### PR TITLE
Cherry-pick(s) f76d6df54e60. rdar://176062450

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2077,6 +2077,12 @@ webkit.org/b/185859 imported/w3c/web-platform-tests/css/selectors/focus-visible-
 webkit.org/b/217904 imported/w3c/web-platform-tests/css/selectors/is-where-visited.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/selectors/xml-class-selector.xml [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/selectors/case-insensitive-parent.html [ ImageOnlyFailure ]
+<<<<<<< HEAD
+=======
+imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-017.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-018.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020.html [ ImageOnlyFailure ]
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
 # This test is bit heavy for debug
 [ Debug ] imported/w3c/web-platform-tests/css/selectors/invalidation/has-complexity.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt
@@ -3,5 +3,9 @@ details
 
 PASS The dialog element should support :open.
 PASS The details element should support :open.
+<<<<<<< HEAD
 PASS The select element should support :open.
+=======
+FAIL The select element should support :open. assert_true: :open should match when the select is open. expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional-expected.txt
@@ -15,6 +15,17 @@ Chimpanzee
 Ostrich
 Wolf
 
+<<<<<<< HEAD
 FAIL In dialog mode the first focusable element should get focus. assert_equals: The anchor should be focused. expected Element node <a id="interactive1" href="https://www.example.com/">Elep... but got Element node <option id="option1">Tiger</option>
 FAIL In dialog mode tab should not close the picker. assert_false: The select should initially be closed. expected false got true
+=======
+FAIL In dialog mode the first focusable element should get focus. assert_equals: The anchor should be focused. expected Element node <a id="interactive1" href="https://www.example.com/">Elep... but got Element node <select id="target">
+  <div></div>
+  <span></span>
+  <a i...
+FAIL In dialog mode tab should not close the picker. assert_equals: The anchor should be focused. expected Element node <a id="interactive1" href="https://www.example.com/">Elep... but got Element node <select id="target">
+  <div></div>
+  <span></span>
+  <a i...
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional-expected.txt
@@ -3,10 +3,19 @@ one
 select0-button              select7-button
 
 PASS Button controller code should not run if the mousedown event is preventDefaulted.
+<<<<<<< HEAD
 PASS Listbox controller code should not run if the mousedown event is preventDefaulted.
 PASS <select> should fire input and change events when new option is selected.
 PASS <select> should not fire input and change events when new selected option has the same value as the old.
 PASS <select> should fire input and change events when option in listbox is clicked
 PASS Check that <Space> opens <select>.
 PASS Check that <Space> opens <select> when <select> specifies tabindex
+=======
+FAIL Listbox controller code should not run if the mousedown event is preventDefaulted. assert_true: expected true got false
+FAIL <select> should fire input and change events when new option is selected. assert_true: expected true got false
+FAIL <select> should not fire input and change events when new selected option has the same value as the old. assert_true: expected true got false
+FAIL <select> should fire input and change events when option in listbox is clicked assert_true: expected true got false
+FAIL Check that <Space> opens <select>. assert_true: <Space> should open select expected true got false
+FAIL Check that <Space> opens <select> when <select> specifies tabindex assert_true: <Space> should open select expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events.optional-expected.txt
@@ -1,6 +1,11 @@
 
 Click
 
+<<<<<<< HEAD
 FAIL Events, implicit button assert_array_equals: after showing, events from test_driver.click lengths differ, expected array ["pointerdown on select at select. open: false.", "pointerdown on select at wrapper. open: false.", "mousedown on select at select. open: false.", "mousedown on select at wrapper. open: false.", "focusin on option1 at select. open: true.", "focusin on option1 at wrapper. open: true.", "pointerup on select at select. open: true.", "pointerup on select at wrapper. open: true.", "mouseup on select at select. open: true.", "mouseup on select at wrapper. open: true.", "click on select at select. open: true.", "click on select at wrapper. open: true."] length 12, got ["pointerdown on select at select. open: false.", "pointerdown on select at wrapper. open: false.", "mousedown on select at select. open: false.", "mousedown on select at wrapper. open: false.", "focusin on select at select. open: false.", "focusin on select at wrapper. open: false.", "focusout on select at select. open: true.", "focusout on select at wrapper. open: true.", "focusin on option1 at select. open: true.", "focusin on option1 at wrapper. open: true.", "pointerup on select at select. open: true.", "pointerup on select at wrapper. open: true.", "mouseup on select at select. open: true.", "mouseup on select at wrapper. open: true.", "click on select at select. open: true.", "click on select at wrapper. open: true."] length 16
+=======
+
+FAIL Events, implicit button assert_true: expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 FAIL Events, explicit button assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-focus-visible-with-mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-focus-visible-with-mouse-expected.txt
@@ -1,6 +1,10 @@
 
 
+<<<<<<< HEAD
 FAIL Select should not match :focus-visible when using mouse. assert_equals: Nothing should be :focus-visible after picking an option. expected null but got Element node <select>
   <option>option</option>
 </select>
+=======
+FAIL Select should not match :focus-visible when using mouse. assert_true: select should open after clicking it. expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional-expected.txt
@@ -1000,8 +1000,15 @@ Option #998
 Option #999
 Option #1000
 
+<<<<<<< HEAD
 PASS Behavior of Home and End for customizable-<select>
 PASS Behavior of Home and End for customizable-<select>, starting at the top
 PASS Behavior of Home and End for customizable-<select>, starting at the bottom
 FAIL Behavior of PageUp and PageDown for customizable-<select> assert_equals: First page down should not scroll expected 305.390625 but got -240.609375
+=======
+FAIL Behavior of Home and End for customizable-<select> assert_true: expected true got false
+FAIL Behavior of Home and End for customizable-<select>, starting at the top assert_true: expected true got false
+FAIL Behavior of Home and End for customizable-<select>, starting at the bottom assert_true: expected true got false
+FAIL Behavior of PageUp and PageDown for customizable-<select> assert_true: expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional-expected.txt
@@ -1,7 +1,14 @@
 
 
+<<<<<<< HEAD
 PASS Behavior of Home for customizable-<select>
 PASS Behavior of End for customizable-<select>
 PASS Behavior of PageUp for customizable-<select>
 PASS Behavior of PageDown for customizable-<select>
+=======
+FAIL Behavior of Home for customizable-<select> assert_true: expected true got false
+FAIL Behavior of End for customizable-<select> assert_true: expected true got false
+FAIL Behavior of PageUp for customizable-<select> assert_true: expected true got false
+FAIL Behavior of PageDown for customizable-<select> assert_true: expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-inside-top-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-inside-top-layer-expected.txt
@@ -1,6 +1,13 @@
 
+<<<<<<< HEAD
 PASS select can be nested inside a popover
 PASS a popover can be nested inside select
 PASS select can be nested inside a modal dialog
 PASS a modal dialog can be nested inside select
+=======
+FAIL select can be nested inside a popover assert_true: the select should be showing expected true got false
+FAIL a popover can be nested inside select assert_true: the select should be showing expected true got false
+FAIL select can be nested inside a modal dialog assert_true: the select should be showing expected true got false
+FAIL a modal dialog can be nested inside select assert_true: the select should be showing expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt
@@ -1,5 +1,6 @@
 custom button
 
+<<<<<<< HEAD
 PASS defaultbutton: When the listbox is closed, spacebar should open the listbox.
 FAIL defaultbutton: When the listbox is closed, all arrow keys should open the listbox. assert_true: Arrow left should open the listbox. expected true got false
 PASS defaultbutton: When the listbox is closed, the enter key should not trigger form submission.
@@ -10,4 +11,17 @@ FAIL custombutton: When the listbox is closed, all arrow keys should open the li
 PASS custombutton: When the listbox is closed, the enter key should not trigger form submission.
 FAIL custombutton: When the listbox is open, the enter key should commit the selected option. assert_equals: The first option should remain focused after pressing the right arrow key. expected Element node <option class="one">one</option> but got Element node <option class="two">two</option>
 PASS custombutton: When the listbox is open, the tab key should close the listbox.
+=======
+
+FAIL defaultbutton: When the listbox is closed, spacebar should open the listbox. assert_true: The select should be open after pressing space. expected true got false
+FAIL defaultbutton: When the listbox is closed, all arrow keys should open the listbox. assert_true: Arrow left should open the listbox. expected true got false
+PASS defaultbutton: When the listbox is closed, the enter key should not trigger form submission.
+FAIL defaultbutton: When the listbox is open, the enter key should commit the selected option. assert_true: The select should open when clicked. expected true got false
+FAIL defaultbutton: When the listbox is open, the tab key should close the listbox. assert_true: Space should open the listbox. expected true got false
+FAIL custombutton: When the listbox is closed, spacebar should open the listbox. assert_true: The select should be open after pressing space. expected true got false
+FAIL custombutton: When the listbox is closed, all arrow keys should open the listbox. assert_true: Arrow left should open the listbox. expected true got false
+FAIL custombutton: When the listbox is closed, the enter key should not trigger form submission. assert_false: Enter should not submit the form when the listbox is closed. expected false got true
+FAIL custombutton: When the listbox is open, the enter key should commit the selected option. assert_true: The select should open when clicked. expected true got false
+FAIL custombutton: When the listbox is open, the tab key should close the listbox. assert_true: Space should open the listbox. expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-focus-change-for-hidden-options.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-focus-change-for-hidden-options.optional-expected.txt
@@ -3,5 +3,9 @@ alpha
 charlie
 foxtrot
 
+<<<<<<< HEAD
 PASS Hidden options should be skipped when changing focus using the up and down keys.
+=======
+FAIL Hidden options should be skipped when changing focus using the up and down keys. assert_true: The select should be open after pressing space. expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt
@@ -1,12 +1,21 @@
 light dismiss
 custom button button fallback button
 
+<<<<<<< HEAD
 PASS fallbackbutton: Select with appearance:base-select should open and close when clicking the button.
 PASS fallbackbutton: Clicking an option in an appearance:base-select select should choose the option and close the popover.
 PASS fallbackbutton: Clicking the label should focus the select button without opening the picker.
 FAIL fallbackbutton: Touch input should work the same as mouse input. assert_true: Select should open after touching button. expected true got false
 PASS custombutton: Select with appearance:base-select should open and close when clicking the button.
 PASS custombutton: Clicking an option in an appearance:base-select select should choose the option and close the popover.
+=======
+FAIL fallbackbutton: Select with appearance:base-select should open and close when clicking the button. assert_true: Select should be open after clicking the button. expected true got false
+FAIL fallbackbutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_true: Select should be open after clicking the button. expected true got false
+PASS fallbackbutton: Clicking the label should focus the select button without opening the picker.
+FAIL fallbackbutton: Touch input should work the same as mouse input. assert_true: Select should open after touching button. expected true got false
+FAIL custombutton: Select with appearance:base-select should open and close when clicking the button. assert_true: Select should be open after clicking the button. expected true got false
+FAIL custombutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_true: Select should be open after clicking the button. expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 PASS custombutton: Clicking the label should focus the select button without opening the picker.
 FAIL custombutton: Touch input should work the same as mouse input. assert_true: Select should open after touching button. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-exit-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-exit-animation-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Top layer exit animations should work on ::picker(select) just like a popover. assert_equals: color should transition based on the exit animation. expected "rgb(128, 128, 128)" but got "rgb(0, 0, 0)"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-interactive-element-focus.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-interactive-element-focus.optional-expected.txt
@@ -2,7 +2,11 @@ invokerbutton
 option
 
 
+<<<<<<< HEAD
 FAIL Clicking interactive elements inside the select picker should focus them. assert_equals: button expected Element node <button id="button">button</button> but got Element node <select>
   <button>invoker</button>
   <button id="button"...
+=======
+FAIL Clicking interactive elements inside the select picker should focus them. assert_true: select should open after being clicked. expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-starting-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-starting-style-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL @starting-style should work on ::picker(select) just like a popover. assert_equals: color should transition based on @starting-style. expected "rgb(128, 128, 128)" but got "rgb(0, 0, 0)"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-light-dismiss-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-light-dismiss-invalidation-expected.txt
@@ -1,4 +1,8 @@
   option
 
+<<<<<<< HEAD
 PASS select should not match :open when light dismissed.
+=======
+FAIL select should not match :open when light dismissed. assert_equals: The select should match :open when opened. expected "rgb(255, 0, 0)" but got "rgb(0, 255, 0)"
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-synthetic-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-synthetic-events-expected.txt
@@ -2,6 +2,12 @@
 one
 two
 
+<<<<<<< HEAD
 PASS defaultbutton: Synthetic events should not trigger behaviors of select element.
 PASS custombutton: Synthetic events should not trigger behaviors of select element.
+=======
+
+FAIL defaultbutton: Synthetic events should not trigger behaviors of select element. assert_true: Select should open after a real click occurs. expected true got false
+FAIL custombutton: Synthetic events should not trigger behaviors of select element. assert_false: Synthetic mouse/pointer events should not open the picker. expected false got true
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-type-to-search.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-type-to-search.tentative-expected.txt
@@ -1,4 +1,8 @@
 
 
+<<<<<<< HEAD
 PASS Type to search should focus but not select an option until selection is confirmed.
+=======
+FAIL Type to search should focus but not select an option until selection is confirmed. assert_true: The select should be open after pressing space. expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance-expected.txt
@@ -4,6 +4,7 @@ option one
 option two
 option three
 
+<<<<<<< HEAD
 PASS Basic functionality of select picker and appearance
 PASS Basic functionality of select picker with appearance:auto
 PASS Basic functionality of select picker with appearance:none
@@ -13,4 +14,15 @@ PASS Test of the test harness
 PASS The select picker is closed if the <select> appearance value is changed via CSS while the picker is open
 PASS The select picker is closed if the ::picker() appearance value is changed via CSS while the picker is open
 PASS The select picker is closed if the <select> inline appearance value is changed while the picker is open
+=======
+FAIL Basic functionality of select picker and appearance assert_equals: expected "none" but got ""
+FAIL Basic functionality of select picker with appearance:auto assert_equals: expected "none" but got ""
+FAIL Basic functionality of select picker with appearance:none assert_equals: expected "none" but got ""
+FAIL Switching appearance in popover-open should close the picker assert_equals: expected "none" but got ""
+FAIL Switching appearance in JS after picker is open should close the picker assert_equals: expected "none" but got ""
+FAIL Test of the test harness assert_equals: expected "base-select" but got "auto"
+FAIL The select picker is closed if the <select> appearance value is changed via CSS while the picker is open assert_equals: expected "base-select" but got "auto"
+FAIL The select picker is closed if the ::picker() appearance value is changed via CSS while the picker is open assert_equals: expected "base-select" but got "auto"
+FAIL The select picker is closed if the <select> inline appearance value is changed while the picker is open assert_equals: expected "base-select" but got "auto"
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-option-focusable.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-option-focusable.tentative-expected.txt
@@ -1,4 +1,8 @@
 
 
+<<<<<<< HEAD
 PASS Validate <option> is focusable when is a descendant of <select>
+=======
+FAIL Validate <option> is focusable when is a descendant of <select> assert_true: expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4059,6 +4059,11 @@ imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of
 imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/grouped-kind-of-widget-fallback-border-top-left-radius-001.html [ ImageOnlyFailure ]
 
 # Customizable select feature.
+<<<<<<< HEAD
+=======
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-in-page/customizable-select-in-page-keyboard-behavior.tentative.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-in-page/customizable-select-in-page-mouse-behavior.tentative.html [ Skip ]
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-listbox-touch.optional.html [ Skip ]
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-option-focusable.tentative-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-option-focusable.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+
+FAIL Validate <option> is focusable when is a descendant of <select> assert_equals: expected Element node <option id="select0-option2">two</option> but got Element node <select id="select0">
+  <option>one</option>
+  <option id...
+

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -5690,6 +5690,7 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-arrow-scroll.optional.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-tabindex-order.html [ Skip ]
+<<<<<<< HEAD
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events.optional.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional.html [ Skip ]
@@ -5712,6 +5713,9 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 
 # Newly imported WPT tests that are timing out on iOS.
 imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-activate-keyup-prevented.html [ Skip ]
+=======
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional.html [ Skip ]
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-tab-navigation.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/click/auxclick_event.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/click/click_event_target_child_parent.html [ Skip ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt
@@ -1,5 +1,10 @@
 invoker
 
+<<<<<<< HEAD
 PASS Buttons in the popover should be rendered and should not close the popover when clicked.
 FAIL Non-interactive content in the popover should not close the popover when clicked. assert_true: Clicking non-interactive, non-option content should not close the popover. expected true got false
+=======
+FAIL Buttons in the popover should be rendered and should not close the popover when clicked. promise_test: Unhandled rejection with value: object "Error: element click intercepted error"
+FAIL Non-interactive content in the popover should not close the popover when clicked. assert_false: Select should be closed at the start of the test. expected false got true
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-iterate-before-beginning.optional-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-iterate-before-beginning.optional-expected.txt
@@ -1,7 +1,15 @@
 button
+<<<<<<< HEAD
 one
 two
 
 PASS Attempting to focus the previous option while focused on the first option should not crash.
 FAIL Keyboard navigating backwards over an <hr> and <optgroup> should not crash. assert_equals: second option should be focused after arrow down. expected Element node <option class="two">two</option> but got Element node <option class="one">one</option>
+=======
+
+FAIL Attempting to focus the previous option while focused on the first option should not crash. assert_equals: The first option should be focused after opening the select. expected Element node <option class="one">one</option> but got Element node <select id="s1">
+  <button>button</button>
+  <option clas...
+FAIL Keyboard navigating backwards over an <hr> and <optgroup> should not crash. assert_true: select should open after clicking it. expected true got false
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 custom button
+=======
+
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
 FAIL defaultbutton: When the listbox is closed, spacebar should open the listbox. assert_true: The select should be open after pressing space. expected true got false
 FAIL defaultbutton: When the listbox is closed, all arrow keys should open the listbox. assert_true: Arrow left should open the listbox. expected true got false

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt
@@ -1,4 +1,5 @@
 light dismiss
+<<<<<<< HEAD
 custom button button
  fallback button
 
@@ -10,4 +11,16 @@ PASS custombutton: Select with appearance:base-select should open and close when
 FAIL custombutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_false: Select should be closed after clicking an option. expected false got true
 FAIL custombutton: Clicking the label should focus the select button without opening the picker. assert_false: select picker should be closed after clicking the label. expected false got true
 FAIL custombutton: Touch input should work the same as mouse input. assert_true: Select should open after touching button. expected true got false
+=======
+custom button button fallback button
+
+FAIL fallbackbutton: Select with appearance:base-select should open and close when clicking the button. assert_false: Select should be closed after clicking the button a second time. expected false got true
+FAIL fallbackbutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_false: Select should be closed at the start of the test. expected false got true
+FAIL fallbackbutton: Clicking the label should focus the select button without opening the picker. assert_false: select picker should be closed after clicking the label. expected false got true
+FAIL fallbackbutton: Touch input should work the same as mouse input. assert_equals: select.value should be updated after touching another option. expected "two" but got "one"
+FAIL custombutton: Select with appearance:base-select should open and close when clicking the button. assert_false: Select should be closed after clicking the button a second time. expected false got true
+FAIL custombutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_false: Select should be closed at the start of the test. expected false got true
+FAIL custombutton: Clicking the label should focus the select button without opening the picker. assert_false: select picker should be closed after clicking the label. expected false got true
+FAIL custombutton: Touch input should work the same as mouse input. assert_equals: select.value should be updated after touching another option. expected "two" but got "one"
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Hover styles should be present for appearance:base-select options. assert_true: dropdown should open after calling showPicker(). expected true got false
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-open-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-open-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS select should support :open pseudo selector.
+FAIL select :open and :not(:open) should invalidate correctly. assert_equals: The style rules from :open should apply when the select is open. expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -173,6 +173,8 @@ html/LazyLoadFrameObserver.cpp
 html/LazyLoadImageObserver.cpp
 html/MediaElementSession.cpp
 html/ModelDocument.cpp
+[ Mac ] html/RangeInputType.cpp
+[ Mac ] html/ResetInputType.cpp
 html/ValidatedFormListedElement.cpp
 html/ValidationMessage.cpp
 html/canvas/CanvasRenderingContext2D.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -297,6 +297,12 @@ html/MediaController.cpp
 html/MediaElementSession.cpp
 html/ModelDocument.cpp
 html/OffscreenCanvas.cpp
+<<<<<<< HEAD
+=======
+[ iOS ] html/TextFieldInputType.cpp
+[ Mac ] html/RangeInputType.cpp
+[ Mac ] html/ResetInputType.cpp
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 html/ValidatedFormListedElement.cpp
 html/ValidationMessage.cpp
 html/canvas/CanvasFilterContextSwitcher.cpp

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -34,6 +34,10 @@
 #include "AccessibilityMenuListPopup.h"
 #include "FrameDestructionObserverInlines.h"
 #include "HTMLSelectElement.h"
+<<<<<<< HEAD
+=======
+#include "RenderMenuList.h"
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 #include "RenderObjectDocument.h"
 #include <wtf/Scope.h>
 
@@ -65,12 +69,18 @@ bool AccessibilityMenuList::press()
     RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(element());
     auto notification = AXNotification::PressDidFail;
     if (selectElement && !selectElement->isDisabledFormControl()) {
+<<<<<<< HEAD
         // Note that hiding or showing the popup could trigger JS.
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
         if (selectElement->popupIsVisible())
             selectElement->hidePopup();
         else
             selectElement->showPopup();
+<<<<<<< HEAD
 
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
         notification = AXNotification::PressDidSucceed;
     }
     if (CheckedPtr cache = axObjectCache())

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -197,9 +197,12 @@
         "open": {
             "settings-flag": "openPseudoClassEnabled"
         },
+<<<<<<< HEAD
         "optimum": {
             "settings-flag": "cssAppearanceBaseEnabled"
         },
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
         "optional": {},
         "out-of-range": {},
         "past": {

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1286,12 +1286,15 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
         case CSSSelector::PseudoClass::InternalMediaDocument:
             return isMediaDocument(element);
 
+<<<<<<< HEAD
         case CSSSelector::PseudoClass::InternalSelectPopover:
             return matchesSelectPopoverPseudoClass(element);
 
         case CSSSelector::PseudoClass::InternalUsesMenulist:
             return matchesUsesMenulistPseudoClass(element);
 
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
         case CSSSelector::PseudoClass::Open:
             return matchesOpenPseudoClass(element);
 

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -125,7 +125,10 @@ CSSParserContext::CSSParserContext(const Settings& settings)
     , cssInternalAutoBaseParsingEnabled { settings.cssInternalAutoBaseParsingEnabled() }
     , cssMathDepthEnabled { settings.cssMathDepthEnabled() }
     , openPseudoClassEnabled { settings.openPseudoClassEnabled() }
+<<<<<<< HEAD
     , cssAttrSubstitutionFunctionEnabled { settings.cssAttrSubstitutionFunctionEnabled() }
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
     , propertySettings { CSSPropertySettings { settings } }
 {
 }
@@ -152,6 +155,7 @@ void add(Hasher& hasher, const CSSParserContext& context)
 #if ENABLE(SERVICE_CONTROLS)
         context.imageControlsEnabled,
 #endif
+<<<<<<< HEAD
         context.colorLayersEnabled,
         context.cssPickerPseudoElementEnabled,
         context.targetTextPseudoElementEnabled,
@@ -174,6 +178,26 @@ void add(Hasher& hasher, const CSSParserContext& context)
         context.cssAttrSubstitutionFunctionEnabled
     );
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, context.enclosingRuleType, bits);
+=======
+        | context.colorLayersEnabled                        << 17
+        | context.contrastColorEnabled                      << 18
+        | context.targetTextPseudoElementEnabled            << 19
+        | context.cssProgressFunctionEnabled                << 20
+        | context.cssRandomFunctionEnabled                  << 21
+        | context.cssTreeCountingFunctionsEnabled           << 22
+        | context.cssURLModifiersEnabled                    << 23
+        | context.cssURLIntegrityModifierEnabled            << 24
+        | context.cssAxisRelativePositionKeywordsEnabled    << 25
+        | context.cssDynamicRangeLimitMixEnabled            << 26
+        | context.cssConstrainedDynamicRangeLimitEnabled    << 27
+        | context.cssTextDecorationLineErrorValues          << 28
+        | context.cssTextTransformMathAutoEnabled           << 29
+        | context.cssInternalAutoBaseParsingEnabled         << 30
+        | context.cssTextTransformMathAutoEnabled           << 31;
+    uint32_t bits2 = context.cssMathDepthEnabled            << 0
+        | context.openPseudoClassEnabled                    << 1;
+    add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits, bits2);
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 }
 
 void CSSParserContext::setUASheetMode()

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -88,7 +88,10 @@ struct CSSParserContext {
     bool webkitMediaTextTrackDisplayQuirkEnabled : 1 { false };
     bool cssMathDepthEnabled : 1 { false };
     bool openPseudoClassEnabled : 1 { false };
+<<<<<<< HEAD
     bool cssAttrSubstitutionFunctionEnabled : 1 { false };
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -73,7 +73,12 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
         context.cssPickerPseudoElementEnabled,
         context.htmlEnhancedSelectEnabled,
         context.targetTextPseudoElementEnabled,
+<<<<<<< HEAD
         context.cssAppearanceBaseEnabled,
+=======
+        context.thumbAndTrackPseudoElementsEnabled,
+        context.viewTransitionsEnabled,
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
         context.webkitMediaTextTrackDisplayQuirkEnabled,
         context.openPseudoClassEnabled
     );

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -271,7 +271,11 @@ ValueOrReference<String> BaseDateAndTimeInputType::sanitizeValue(const String& p
     return proposedValue;
 }
 
+<<<<<<< HEAD
 bool BaseDateAndTimeInputType::valueMissing(StringView value) const
+=======
+bool BaseDateAndTimeInputType::valueMissing(const String& value) const
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 {
     ASSERT(element());
     return protect(element())->isMutable() && element()->isRequired() && value.isEmpty();
@@ -640,6 +644,12 @@ void BaseDateAndTimeInputType::didChooseValue(StringView value)
 {
     ASSERT(element());
     protect(element())->setValue(value.toString(), DispatchInputAndChangeEvent);
+}
+
+void BaseDateAndTimeInputType::didEndChooser()
+{
+    m_dateTimeChooser = nullptr;
+    setPopupIsVisible(false);
 }
 
 void BaseDateAndTimeInputType::didEndChooser()

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -48,7 +48,10 @@
 #include "HTMLInputElement.h"
 #include "HTMLOptionElement.h"
 #include "InputTypeNames.h"
+<<<<<<< HEAD
 #include "PlatformRenderTheme.h"
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 #include "PseudoClassChangeInvalidation.h"
 #include "RenderTheme.h"
 #include "RenderView.h"

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -35,7 +35,10 @@
 #include "LocalizedStrings.h"
 #include "MouseEvent.h"
 #include "PseudoClassChangeInvalidation.h"
+<<<<<<< HEAD
 #include "ScriptDisallowedScope.h"
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 #include "ShadowRoot.h"
 #include "ShouldNotFireMutationEventsScope.h"
 #include "SlotAssignment.h"

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -41,7 +41,11 @@ public:
 
     void queueDetailsToggleEventTask(ToggleState oldState, ToggleState newState);
 
+<<<<<<< HEAD
     bool NODELETE isOpen() const;
+=======
+    bool isOpen() const;
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
 private:
     HTMLDetailsElement(const QualifiedName&, Document&);
@@ -61,7 +65,10 @@ private:
     WeakPtr<HTMLSummaryElement, WeakPtrImplWithEventTargetData> m_defaultSummary;
     RefPtr<HTMLSlotElement> m_defaultSlot;
     bool m_isOpen { false };
+<<<<<<< HEAD
     bool m_shouldCloseElementAfterInsertion { false };
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
     RefPtr<ToggleEventTask> m_toggleEventTask;
 };

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -377,11 +377,15 @@ void HTMLDialogElement::removingSteps(RemovalType removalType, ContainerNode& ol
 void HTMLDialogElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
+<<<<<<< HEAD
     Ref document = this->document();
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
     if (name == openAttr) {
         auto isOpen = !newValue.isNull();
         Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Open, isOpen);
         m_isOpen = isOpen;
+<<<<<<< HEAD
 
         if (document->settings().closedbyAttributeEnabled()) {
             if (!document->isFullyActive())
@@ -426,6 +430,11 @@ void HTMLDialogElement::cleanupSteps()
 #endif
 }
 
+=======
+    }
+}
+
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 void HTMLDialogElement::setIsModal(bool newValue)
 {
     if (m_isModal == newValue)
@@ -442,4 +451,12 @@ void HTMLDialogElement::queueDialogToggleEventTask(ToggleState oldState, ToggleS
     RefPtr { m_toggleEventTask }->queue(oldState, newState, source);
 }
 
+<<<<<<< HEAD
+=======
+bool HTMLDialogElement::isOpen() const
+{
+    return m_isOpen;
+}
+
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 }

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -75,6 +75,7 @@ private:
     void setIsModal(bool newValue);
     bool supportsFocus() const final;
 
+<<<<<<< HEAD
     NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
     void postConnectionSteps() final;
 
@@ -87,6 +88,13 @@ private:
     bool m_isModal { false };
     bool m_isOpen { false };
     bool m_isRequestingToClose { false };
+=======
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
+
+    String m_returnValue;
+    bool m_isModal { false };
+    bool m_isOpen { false };
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_previouslyFocusedElement;
 
     RefPtr<ToggleEventTask> m_toggleEventTask;

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -66,7 +66,10 @@
 #include "MouseEvent.h"
 #include "NodeName.h"
 #include "NodeRareData.h"
+<<<<<<< HEAD
 #include "PlatformRenderTheme.h"
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 #include "PseudoClassChangeInvalidation.h"
 #include "RenderListBox.h"
 #include "RenderMenuList.h"
@@ -82,6 +85,10 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
+
+#if !PLATFORM(IOS_FAMILY)
+#include <WebCore/PopupMenu.h>
+#endif
 
 #if !PLATFORM(IOS_FAMILY)
 #include <WebCore/PopupMenu.h>
@@ -200,6 +207,19 @@ void HTMLSelectElement::didAddUserAgentShadowRoot(ShadowRoot& root)
 
     root.appendChild(popover);
     m_popover = WTF::move(popover);
+}
+
+HTMLSelectElement::~HTMLSelectElement() = default;
+
+void HTMLSelectElement::didDetachRenderers()
+{
+#if !PLATFORM(IOS_FAMILY)
+    if (RefPtr popup = m_popup)
+        popup->hide();
+    m_popup = nullptr;
+    setPopupIsVisible(false);
+#endif
+    HTMLFormControlElement::didDetachRenderers();
 }
 
 HTMLSelectElement* HTMLSelectElement::findOwnerSelect(ContainerNode* startNode, ExcludeOptGroup excludeOptGroup)
@@ -1166,6 +1186,10 @@ void HTMLSelectElement::setOptionsChangedOnRenderer()
             downcast<RenderListBox>(*renderer).setOptionsChanged(true);
     }
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 #if !PLATFORM(IOS_FAMILY)
     if (!m_popupIsVisible)
         return;
@@ -1594,11 +1618,23 @@ bool HTMLSelectElement::platformHandleKeydownEvent(KeyboardEvent* event)
             // Calling focus() may cause us to lose our renderer. Return true so
             // that our caller doesn't process the event further, but don't set
             // the event as handled.
+<<<<<<< HEAD
             if (!renderer() || !usesMenuList())
                 return true;
 
             openPickerForUserInteraction();
 
+=======
+            if (!is<RenderMenuList>(renderer()))
+                return true;
+
+            // Save the selection so it can be compared to the new selection
+            // when dispatching change events during selectOption, which
+            // gets called from RenderMenuList::valueChanged, which gets called
+            // after the user makes a selection from the menu.
+            saveLastSelection();
+            showPopup(); // showPopup() may run JS and cause the renderer to get destroyed.
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
             event->setDefaultHandled();
         }
         return true;
@@ -1709,11 +1745,23 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
                 protect(document())->updateStyleIfNeeded();
 
                 // Calling focus() may remove the renderer or change the renderer type.
+<<<<<<< HEAD
                 if (!renderer() || !usesMenuList())
                     return;
 
                 openPickerForUserInteraction();
 
+=======
+                if (!is<RenderMenuList>(renderer()))
+                    return;
+
+                // Save the selection so it can be compared to the new selection
+                // when dispatching change events during selectOption, which
+                // gets called from RenderMenuList::valueChanged, which gets called
+                // after the user makes a selection from the menu.
+                saveLastSelection();
+                showPopup(); // showPopup() may run JS and cause the renderer to get destroyed.
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
                 handled = true;
             }
         } else if (RenderTheme::singleton().popsMenuByArrowKeys()) {
@@ -1722,11 +1770,23 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
                 protect(document())->updateStyleIfNeeded();
 
                 // Calling focus() may remove the renderer or change the renderer type.
+<<<<<<< HEAD
                 if (!renderer() || !usesMenuList())
                     return;
 
                 openPickerForUserInteraction();
 
+=======
+                if (!is<RenderMenuList>(renderer()))
+                    return;
+
+                // Save the selection so it can be compared to the new selection
+                // when dispatching change events during selectOption, which
+                // gets called from RenderMenuList::valueChanged, which gets called
+                // after the user makes a selection from the menu.
+                saveLastSelection();
+                showPopup(); // showPopup() may run JS and cause the renderer to get destroyed.
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
                 handled = true;
             } else if (keyCode == '\r') {
                 if (RefPtr form = this->form())
@@ -1745,9 +1805,24 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
         focus();
         protect(document())->updateStyleIfNeeded();
 #if !PLATFORM(IOS_FAMILY)
+<<<<<<< HEAD
         if (!renderer() || !usesMenuList()) {
 #else
         if (!usesBaseAppearancePicker()) {
+=======
+        protectedDocument()->updateStyleIfNeeded();
+
+        if (is<RenderMenuList>(renderer())) {
+            ASSERT(!m_popupIsVisible);
+            // Save the selection so it can be compared to the new
+            // selection when we call onChange during selectOption,
+            // which gets called from RenderMenuList::valueChanged,
+            // which gets called after the user makes a selection from
+            // the menu.
+            saveLastSelection();
+            showPopup(); // showPopup() may run JS and cause the renderer to get destroyed.
+        }
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 #endif
             event.setDefaultHandled();
             return;
@@ -1769,6 +1844,10 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
 
 #if !PLATFORM(IOS_FAMILY)
     if (event.type() == eventNames.blurEvent && !focused()) {
+<<<<<<< HEAD
+=======
+        CheckedRef menuList = downcast<RenderMenuList>(*renderer());
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
         if (m_popupIsVisible)
             hidePopup();
     }
@@ -2153,8 +2232,13 @@ void HTMLSelectElement::showPopup()
     if (m_popupIsVisible)
         return;
 
+<<<<<<< HEAD
     CheckedPtr renderer = this->renderer();
     if (!renderer || !usesMenuList())
+=======
+    CheckedPtr renderer = dynamicDowncast<RenderMenuList>(this->renderer());
+    if (!renderer)
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
         return;
 
     RefPtr frame = document().frame();
@@ -2169,6 +2253,7 @@ void HTMLSelectElement::showPopup()
         m_popup = document().page()->chrome().createPopupMenu(*this);
     setPopupIsVisible(true);
 
+<<<<<<< HEAD
     // Ensure layout is up-to-date before computing the element location.
     protect(document())->updateLayout();
 
@@ -2180,6 +2265,13 @@ void HTMLSelectElement::showPopup()
     IntRect absBounds = renderer->absoluteBoundingBoxRectIgnoringTransforms();
     absBounds.setLocation(roundedIntPoint(absTopLeft));
 
+=======
+    // Compute the top left taking transforms into account, but use
+    // the actual width of the element to size the popup.
+    FloatPoint absTopLeft = renderer->localToAbsolute(FloatPoint(), UseTransforms);
+    IntRect absBounds = renderer->absoluteBoundingBoxRectIgnoringTransforms();
+    absBounds.setLocation(roundedIntPoint(absTopLeft));
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
     protect(m_popup)->show(absBounds, *frameView, optionToListIndex(selectedIndex())); // May run JS.
 }
 
@@ -2201,6 +2293,7 @@ bool HTMLSelectElement::isOpen() const
     return m_popupIsVisible;
 }
 
+<<<<<<< HEAD
 void HTMLSelectElement::showPickerInternal()
 {
     if (!usesBaseAppearancePicker()) {
@@ -2273,6 +2366,8 @@ void HTMLSelectElement::focusOptionAtIndex(int listIndex, std::optional<bool> fo
     }
 }
 
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 ExceptionOr<void> HTMLSelectElement::showPicker()
 {
     RefPtr frame = document().frame();
@@ -2291,6 +2386,7 @@ ExceptionOr<void> HTMLSelectElement::showPicker()
     if (!window || !window->consumeTransientActivation())
         return Exception { ExceptionCode::NotAllowedError, "Select showPicker() requires a user gesture."_s };
 
+<<<<<<< HEAD
     protect(document())->updateStyleIfNeeded();
     bool openedBaseAppearancePicker = usesBaseAppearancePicker();
     showPickerInternal(); // showPickerInternal() may run JS and cause the renderer to get destroyed.
@@ -2302,6 +2398,11 @@ ExceptionOr<void> HTMLSelectElement::showPicker()
         if (!usesBaseAppearancePicker())
             hidePickerPopoverElement();
     }
+=======
+#if !PLATFORM(IOS_FAMILY)
+    showPopup(); // showPopup() may run JS and cause the renderer to get destroyed.
+#endif
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
     return { };
 }
@@ -2453,6 +2554,7 @@ PopupMenuStyle HTMLSelectElement::itemStyle(unsigned listIndex) const
 
 PopupMenuStyle HTMLSelectElement::menuStyle() const
 {
+<<<<<<< HEAD
     CheckedPtr renderer = this->renderer();
     ASSERT(renderer);
     if (!renderer) {
@@ -2473,6 +2575,12 @@ PopupMenuStyle HTMLSelectElement::menuStyle() const
     }
 
     CheckedRef outerStyle = renderer->style();
+=======
+    auto defaultStyle = RenderStyle::create();
+    CheckedPtr renderer = dynamicDowncast<RenderMenuList>(this->renderer());
+    CheckedRef outerStyle = renderer ? renderer->style() : defaultStyle;
+    CheckedRef<const RenderStyle> innerStyle = (renderer && renderer->innerRenderer()) ? renderer->innerRenderer()->style() : outerStyle.get();
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
     auto bounds = renderer->absoluteBoundingBoxRectIgnoringTransforms();
     auto popupSize = RenderTheme::singleton().popupMenuSize(outerStyle, bounds);
     return PopupMenuStyle(

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -125,11 +125,16 @@ public:
 
     bool popupIsVisible() const { return m_popupIsVisible; }
     WEBCORE_EXPORT void setPopupIsVisible(bool);
+<<<<<<< HEAD
     std::optional<FloatPoint> lastPopupLocationForTesting() const { return m_lastPopupLocationForTesting; }
 
     bool NODELETE isOpen() const;
 
     void didUpdateActiveOption(int optionIndex);
+=======
+
+    bool isOpen() const;
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
     // PopupMenuClient methods
     void valueChanged(unsigned listIndex, bool fireOnChange = true) override;
@@ -291,10 +296,13 @@ private:
 
     void didDetachRenderers() final;
 
+<<<<<<< HEAD
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
 
     void showPickerInternal();
 
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
     // TypeAheadDataSource functions.
     int indexOfSelectedOption() const final;
     int optionCount() const final;
@@ -315,19 +323,26 @@ private:
     bool m_allowsNonContiguousSelection;
     bool m_isCapturingMouseEvents { false };
     mutable bool m_shouldRecalcListItems;
+<<<<<<< HEAD
     unsigned m_selectedContentDescendantCount { 0 };
 
     std::optional<int> m_lastActiveIndex;
 
     WeakPtr<HTMLSlotElement, WeakPtrImplWithEventTargetData> m_buttonSlot;
     WeakPtr<SelectPopoverElement, WeakPtrImplWithEventTargetData> m_popover;
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
 #if !PLATFORM(IOS_FAMILY)
     RefPtr<PopupMenu> m_popup;
 #endif
+<<<<<<< HEAD
     std::optional<FloatPoint> m_lastPopupLocationForTesting;
     bool m_popupIsVisible { false };
     bool m_wasBaseAppearance { false };
+=======
+    bool m_popupIsVisible { false };
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 };
 
 } // namespace

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -58,7 +58,10 @@
 #include "LocalizedStrings.h"
 #include "NodeRenderStyle.h"
 #include "PlatformKeyboardEvent.h"
+<<<<<<< HEAD
 #include "PlatformRenderTheme.h"
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 #include "PseudoClassChangeInvalidation.h"
 #include "RenderLayer.h"
 #include "RenderLayerScrollableArea.h"
@@ -311,7 +314,11 @@ RenderPtr<RenderElement> TextFieldInputType::createInputRenderer(RenderStyle&& s
 {
     ASSERT(element());
     // FIXME: https://github.com/llvm/llvm-project/pull/142471 Moving style is not unsafe.
+<<<<<<< HEAD
     SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderTextControlSingleLine>(RenderObject::Type::TextControlSingleLine, *protect(element()), WTF::move(style));
+=======
+    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderTextControlSingleLine>(RenderObject::Type::TextControlSingleLine, *protectedElement(), WTF::move(style));
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 }
 
 bool TextFieldInputType::shouldHaveSpinButton() const

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -58,9 +58,89 @@ RenderMenuList::RenderMenuList(HTMLSelectElement& element, RenderStyle&& style)
     ASSERT(isRenderMenuList());
 }
 
+<<<<<<< HEAD
 RenderMenuList::~RenderMenuList() = default;
 
 HTMLSelectElement& NODELETE RenderMenuList::selectElement() const
+=======
+void RenderMenuList::setInnerRenderer(RenderBlock& innerRenderer)
+{
+    ASSERT(!m_innerBlock.get());
+    m_innerBlock = innerRenderer;
+    adjustInnerStyle();
+}
+
+void RenderMenuList::adjustInnerStyle()
+{
+    auto& innerStyle = m_innerBlock->mutableStyle();
+    innerStyle.setFlexGrow(1);
+    innerStyle.setFlexShrink(1);
+    // min-width: 0; is needed for correct shrinking.
+    innerStyle.setLogicalMinWidth(0_css_px);
+    // Use margin:auto instead of align-items:center to get safe centering, i.e.
+    // when the content overflows, treat it the same as align-items: flex-start.
+    // But we only do that for the cases where html.css would otherwise use center.
+    if (style().alignItems().isCenter()) {
+        innerStyle.setMarginBefore(CSS::Keyword::Auto { });
+        innerStyle.setMarginAfter(CSS::Keyword::Auto { });
+        innerStyle.setAlignSelf(CSS::Keyword::FlexStart { });
+    }
+
+    auto paddingBox = theme().popupInternalPaddingBox(style());
+    if (!writingMode().isHorizontal())
+        paddingBox = { paddingBox.left(), paddingBox.top(), paddingBox.right(), paddingBox.bottom() };
+
+    innerStyle.setPaddingBox(WTF::move(paddingBox));
+
+    if (document().page()->chrome().selectItemWritingDirectionIsNatural()) {
+        // Items in the popup will not respect the CSS text-align and direction properties,
+        // so we must adjust our own style to match.
+        innerStyle.setTextAlign(Style::TextAlign::Left);
+        TextDirection direction = (m_buttonText && m_buttonText->text().defaultWritingDirection() == U_RIGHT_TO_LEFT) ? TextDirection::RTL : TextDirection::LTR;
+        innerStyle.setDirection(direction);
+#if PLATFORM(IOS_FAMILY)
+    } else if (document().page()->chrome().selectItemAlignmentFollowsMenuWritingDirection()) {
+        innerStyle.setTextAlign(writingMode().isBidiLTR() ? Style::TextAlign::Left : Style::TextAlign::Right);
+        TextDirection direction;
+        UnicodeBidi unicodeBidi;
+        if (selectElement().multiple() && selectedOptionCount(*this) != 1) {
+            direction = (m_buttonText && m_buttonText->text().defaultWritingDirection() == U_RIGHT_TO_LEFT) ? TextDirection::RTL : TextDirection::LTR;
+            unicodeBidi = UnicodeBidi::Normal;
+        } else if (m_optionStyle) {
+            direction = m_optionStyle->writingMode().bidiDirection();
+            unicodeBidi = m_optionStyle->unicodeBidi();
+        } else {
+            direction = style().writingMode().bidiDirection();
+            unicodeBidi = style().unicodeBidi();
+        }
+
+        innerStyle.setDirection(direction);
+        innerStyle.setUnicodeBidi(unicodeBidi);
+    }
+#else
+    } else if (m_optionStyle && document().page()->chrome().selectItemAlignmentFollowsMenuWritingDirection()) {
+        if ((m_optionStyle->writingMode().bidiDirection() != innerStyle.writingMode().bidiDirection()
+            || m_optionStyle->unicodeBidi() != innerStyle.unicodeBidi()))
+            m_innerBlock->setNeedsLayoutAndPreferredWidthsUpdate();
+        innerStyle.setTextAlign(writingMode().isBidiLTR() ? Style::TextAlign::Left : Style::TextAlign::Right);
+        innerStyle.setDirection(m_optionStyle->writingMode().bidiDirection());
+        innerStyle.setUnicodeBidi(m_optionStyle->unicodeBidi());
+    }
+#endif // !PLATFORM(IOS_FAMILY)
+
+    if (m_innerBlock && m_innerBlock->layoutBox()) {
+        if (auto* inlineFormattingContextRoot = dynamicDowncast<RenderBlockFlow>(*m_innerBlock); inlineFormattingContextRoot && inlineFormattingContextRoot->inlineLayout())
+            inlineFormattingContextRoot->inlineLayout()->rootStyleWillChange(*inlineFormattingContextRoot, innerStyle);
+        if (auto* lineLayout = LayoutIntegration::LineLayout::containing(*m_innerBlock))
+            lineLayout->styleWillChange(*m_innerBlock, innerStyle, Style::DifferenceResult::Layout);
+        LayoutIntegration::LineLayout::updateStyle(*m_innerBlock);
+        for (auto& child : childrenOfType<RenderText>(*m_innerBlock))
+            LayoutIntegration::LineLayout::updateStyle(child);
+    }
+}
+
+HTMLSelectElement& RenderMenuList::selectElement() const
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 {
     return downcast<HTMLSelectElement>(nodeForNonAnonymous());
 }
@@ -111,6 +191,31 @@ void RenderMenuList::updateFromElement()
         updateOptionsWidth();
         m_needsOptionsWidthUpdate = false;
     }
+<<<<<<< HEAD
+=======
+
+#if !PLATFORM(IOS_FAMILY)
+    if (!selectElement().popupIsVisible())
+#endif
+        setTextFromOption(selectElement().selectedIndex());
+}
+
+void RenderMenuList::setTextFromOption(int optionIndex)
+{
+    const auto& listItems = selectElement().listItems();
+    int size = listItems.size();
+
+    int i = selectElement().optionToListIndex(optionIndex);
+    String text = emptyString();
+    if (i >= 0 && i < size) {
+        if (RefPtr option = dynamicDowncast<HTMLOptionElement>(*listItems[i])) {
+            text = option->textIndentedToRespectGroupLabel();
+            auto* style = option->computedStyleForEditability();
+            m_optionStyle = style ? RenderStyle::clonePtr(*style) : nullptr;
+        }
+    }
+
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 #if PLATFORM(IOS_FAMILY)
     // iOS border-radius hack.
     setNeedsLayout();
@@ -189,6 +294,34 @@ void RenderMenuList::computePreferredLogicalWidths()
     clearNeedsPreferredWidthsUpdate();
 }
 
+<<<<<<< HEAD
+=======
+void RenderMenuList::didSetSelectedIndex(int listIndex)
+{
+    didUpdateActiveOption(selectElement().listToOptionIndex(listIndex));
+}
+
+void RenderMenuList::didUpdateActiveOption(int optionIndex)
+{
+    if (!AXObjectCache::accessibilityEnabled())
+        return;
+
+    CheckedPtr axCache = document().existingAXObjectCache();
+    if (!axCache)
+        return;
+
+    if (m_lastActiveIndex == optionIndex)
+        return;
+    m_lastActiveIndex = optionIndex;
+
+    int listIndex = selectElement().optionToListIndex(optionIndex);
+    if (listIndex < 0 || listIndex >= static_cast<int>(selectElement().listItems().size()))
+        return;
+
+    axCache->onSelectedOptionChanged(*this, optionIndex);
+}
+
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 void RenderMenuList::getItemBackgroundColor(unsigned listIndex, Color& itemBackgroundColor, bool& itemHasCustomBackgroundColor) const
 {
     const auto& listItems = selectElement().listItems();
@@ -245,7 +378,10 @@ LayoutUnit RenderMenuList::clientPaddingRight() const
 
     return paddingRight();
 }
+<<<<<<< HEAD
 #endif
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
 #if PLATFORM(IOS_FAMILY)
 void RenderMenuList::layout()

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -35,7 +35,6 @@ class RenderMenuList final : public RenderFlexibleBox {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMenuList);
 public:
     RenderMenuList(HTMLSelectElement&, RenderStyle&&);
-    virtual ~RenderMenuList();
 
     HTMLSelectElement& NODELETE selectElement() const;
 
@@ -54,12 +53,19 @@ public:
 
     void getItemBackgroundColor(unsigned listIndex, Color&, bool& itemHasCustomBackgroundColor) const;
 
+<<<<<<< HEAD
 #if PLATFORM(WIN)
+=======
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
     LayoutUnit clientPaddingLeft() const;
     LayoutUnit clientPaddingRight() const;
 #endif
 
+<<<<<<< HEAD
     void updateFromElement() final;
+=======
+    void setTextFromOption(int optionIndex);
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
 private:
     void element() const = delete;
@@ -85,6 +91,13 @@ private:
 
     bool m_needsOptionsWidthUpdate;
     int m_optionsWidth;
+<<<<<<< HEAD
+=======
+
+    std::optional<int> m_lastActiveIndex;
+
+    std::unique_ptr<RenderStyle> m_optionStyle;
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1250,9 +1250,15 @@ public:
     void performActionOnElements(uint32_t action, Vector<WebCore::ElementContext>&&);
     void saveImageToLibrary(IPC::Connection&, WebCore::SharedMemoryHandle&& imageHandle, const String& authorizationToken);
     void focusNextFocusedElement(bool isForward, CompletionHandler<void()>&&);
+<<<<<<< HEAD
     void setFocusedElementValue(std::optional<WebCore::FrameIdentifier>, const WebCore::ElementContext&, const String&);
     void setFocusedElementSelectedIndex(std::optional<WebCore::FrameIdentifier>, const WebCore::ElementContext&, uint32_t index, bool allowMultipleSelection = false);
     void setSelectElementIsOpen(std::optional<WebCore::FrameIdentifier>, const WebCore::ElementContext&, bool isOpen);
+=======
+    void setFocusedElementValue(const WebCore::ElementContext&, const String&);
+    void setFocusedElementSelectedIndex(const WebCore::ElementContext&, uint32_t index, bool allowMultipleSelection = false);
+    void setSelectElementIsOpen(const WebCore::ElementContext&, bool isOpen);
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
     void applicationDidEnterBackground();
     void applicationDidFinishSnapshottingAfterEnteringBackground();
     void applicationWillEnterForeground();

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1093,6 +1093,11 @@ void WebPageProxy::setSelectElementIsOpen(std::optional<WebCore::FrameIdentifier
     sendToProcessContainingFrame(frameID, Messages::WebPage::SetSelectElementIsOpen(context, isOpen));
 }
 
+void WebPageProxy::setSelectElementIsOpen(const WebCore::ElementContext& context, bool isOpen)
+{
+    protect(legacyMainFrameProcess())->send(Messages::WebPage::SetSelectElementIsOpen(context, isOpen), webPageIDInMainFrameProcess());
+}
+
 void WebPageProxy::didPerformDictionaryLookup(const DictionaryPopupInfo& dictionaryPopupInfo)
 {
     if (RefPtr pageClient = this->pageClient())

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -697,11 +697,17 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
 
 - (void)contextMenuInteraction:(UIContextMenuInteraction *)interaction willDisplayMenuForConfiguration:(UIContextMenuConfiguration *)configuration animator:(id <UIContextMenuInteractionAnimating>)animator
 {
+<<<<<<< HEAD
     RetainPtr view = _view.get();
     if (RefPtr page = [view page]) {
         auto& focusedInfo = [view focusedElementInformation];
         page->setSelectElementIsOpen(focusedInfo.frameID(), focusedInfo.elementContext, true);
     }
+=======
+    RetainPtr view = _view;
+    if (RefPtr page = [view page])
+        page->setSelectElementIsOpen([view focusedElementInformation].elementContext, true);
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
     [animator addCompletion:[weakSelf = WeakObjCPtr<WKSelectPicker>(self)] {
         auto strongSelf = weakSelf.get();
@@ -712,11 +718,18 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
 
 - (void)contextMenuInteraction:(UIContextMenuInteraction *)interaction willEndForConfiguration:(UIContextMenuConfiguration *)configuration animator:(id <UIContextMenuInteractionAnimating>)animator
 {
+<<<<<<< HEAD
     RetainPtr view = _view.get();
     auto& focusedInfo = [view focusedElementInformation];
     auto elementContext = focusedInfo.elementContext;
     if (RefPtr page = [view page])
         page->setSelectElementIsOpen(focusedInfo.frameID(), elementContext, false);
+=======
+    RetainPtr view = _view;
+    auto elementContext = [view focusedElementInformation].elementContext;
+    if (RefPtr page = [view page])
+        page->setSelectElementIsOpen(elementContext, false);
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
     _isAnimatingContextMenuDismissal = YES;
     [animator addCompletion:[weakSelf = WeakObjCPtr<WKSelectPicker>(self), elementContext] {
@@ -736,12 +749,19 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
         return;
 
     _selectContextMenuPresenter = nullptr;
+<<<<<<< HEAD
     RetainPtr view = _view.get();
     [view _removeContextMenuHintContainerIfPossible];
     if (RefPtr page = [view page]) {
         auto& focusedInfo = [view focusedElementInformation];
         page->setSelectElementIsOpen(focusedInfo.frameID(), focusedInfo.elementContext, false);
     }
+=======
+    RetainPtr view = _view;
+    [view _removeContextMenuHintContainerIfPossible];
+    if (RefPtr page = [view page])
+        page->setSelectElementIsOpen([view focusedElementInformation].elementContext, false);
+>>>>>>> f76d6df54e60 (Implement CSS :open pseudo-class)
 
     if (!_isAnimatingContextMenuDismissal)
         [[view webView] _didDismissContextMenu];


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176062450 to main. [f76d6df54e60] caused a merge conflict. 

```Implement CSS :open pseudo-class
rdar://173253012

Reviewed by Ryosuke Niwa, Anne van Kesteren, Aditya Keerthi and Simon Fraser.

Cherry-pick 305917@main (842e79a7f433). https://bugs.webkit.org/show_bug.cgi?id=284398
Cherry-pick 306546@main (c74593b7f29a). rdar://169307251
Cherry-pick 307253@main (af169a2af053). rdar://170088926
Cherry-pick 307294@main (6e1bf0271cf0). rdar://170091970
Cherry-pick 308148@main (1fc35e3d7b6a). https://bugs.webkit.org/show_bug.cgi?id=307798
Cherry-pick 307295@main (2e0a18f). rdar://170108337

Co-authored-by: Luke Warlow <lwarlow@igalia.com>
Co-authored-by: Anne van Kesteren <annevk@annevk.nl>

* LayoutTests/TestExpectations:
* LayoutTests/fast/forms/ios/select-open-pseudo-class-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-open-pseudo-class.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/input-element-pseudo-open-click.optional-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/input-element-pseudo-open-click.optional.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/input-element-pseudo-open.optional.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/input-element-pseudo-open.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/input-element-pseudo-open.optional.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-accessibility-minimum-target-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-events.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-focus-visible-with-mouse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-inside-top-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-focus-change-for-hidden-options.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-exit-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-interactive-element-focus.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-starting-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-light-dismiss-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-synthetic-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-type-to-search.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-many-options.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-option-focusable.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-popover-position-with-zoom.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-cross-origin-iframe-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-option-focusable.tentative-expected.txt: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-pseudo/input-element-pseudo-open.optional-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-iterate-before-beginning.optional-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-open-expected.txt: Added.
* LayoutTests/platform/win/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::press):
(WebCore::AccessibilityMenuList::isCollapsed const):
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesOpenPseudoClass):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
(WebCore::SelectorCompiler::addPseudoClassType):
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::showPicker):
(WebCore::BaseDateAndTimeInputType::setPopupIsVisible):
(WebCore::BaseDateAndTimeInputType::showDateTimeChooser):
(WebCore::BaseDateAndTimeInputType::didChangeValueFromControl):
(WebCore::BaseDateAndTimeInputType::didReceiveSpaceKeyFromControl):
(WebCore::BaseDateAndTimeInputType::didEndChooser):
(WebCore::BaseDateAndTimeInputType::closeDateTimeChooser):
(WebCore::BaseDateAndTimeInputType::supportsReadOnly const): Deleted.
(WebCore::BaseDateAndTimeInputType::shouldRespectListAttribute): Deleted.
(WebCore::BaseDateAndTimeInputType::isPresentingAttachedView const): Deleted.
* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::setPopupIsVisible):
(WebCore::ColorInputType::showPicker):
(WebCore::ColorInputType::didEndChooser):
(WebCore::ColorInputType::endColorChooser):
(WebCore::ColorInputType::isPresentingAttachedView const): Deleted.
(WebCore::ColorInputType::supportsRequired const): Deleted.
(WebCore::ColorInputType::allowsShowPickerAcrossFrames): Deleted.
(WebCore::ColorInputType::shouldRespectListAttribute): Deleted.
(WebCore::ColorInputType::shouldResetOnDocumentActivation): Deleted.
* Source/WebCore/html/ColorInputType.h:
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::attributeChanged):
(WebCore::HTMLDetailsElement::isOpen const):
* Source/WebCore/html/HTMLDetailsElement.h:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::attributeChanged):
(WebCore::HTMLDialogElement::isOpen const):
* Source/WebCore/html/HTMLDialogElement.h:
* Source/WebCore/html/HTMLOptGroupElement.cpp:
* Source/WebCore/html/HTMLOptionElement.cpp:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::didDetachRenderers):
(WebCore::HTMLSelectElement::setOptionsChangedOnRenderer):
(WebCore::HTMLSelectElement::platformHandleKeydownEvent):
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
(WebCore::HTMLSelectElement::showPopup):
(WebCore::HTMLSelectElement::hidePopup):
(WebCore::HTMLSelectElement::setPopupIsVisible):
(WebCore::HTMLSelectElement::isOpen const):
(WebCore::HTMLSelectElement::showPicker):
(WebCore::HTMLSelectElement::itemStyle const):
(WebCore::HTMLSelectElement::menuStyle const):
(WebCore::HTMLSelectElement::popupDidHide):
* Source/WebCore/html/HTMLSelectElement.h:
(WebCore::HTMLSelectElement::size const): Deleted.
(WebCore::HTMLSelectElement::multiple const): Deleted.
(WebCore::HTMLSelectElement::allowsNonContiguousSelection const): Deleted.
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::isKeyboardFocusable const):
(WebCore::TextFieldInputType::didCloseSuggestions):
(WebCore::TextFieldInputType::displaySuggestions):
(WebCore::TextFieldInputType::closeSuggestions):
(WebCore::TextFieldInputType::setPopupIsVisible):
(WebCore::TextFieldInputType::needsContainer const): Deleted.
(WebCore::TextFieldInputType::supportsReadOnly const): Deleted.
(WebCore::TextFieldInputType::shouldUseInputMethod const): Deleted.
(WebCore::TextFieldInputType::isPresentingAttachedView const): Deleted.
(WebCore::TextFieldInputType::isFocusingWithDataListDropdown const): Deleted.
* Source/WebCore/html/TextFieldInputType.h:
(WebCore::TextFieldInputType::needsContainer const):
* Source/WebCore/rendering/RenderMenuList.cpp:
(WebCore::RenderMenuList::RenderMenuList):
(RenderMenuList::updateFromElement):
(WebCore::RenderMenuList::willBeDestroyed): Deleted.
(WebCore::RenderMenuList::popupMenuSize): Deleted.
(WebCore::RenderMenuList::hostWindow const): Deleted.
(RenderMenuList::showPopup): Deleted.
(RenderMenuList::hidePopup): Deleted.
(RenderMenuList::popupDidHide): Deleted.
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isSelectPopupVisible):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::setSelectElementIsOpen):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPicker contextMenuInteraction:willDisplayMenuForConfiguration:animator:]):
(-[WKSelectPicker contextMenuInteraction:willEndForConfiguration:animator:]):
(-[WKSelectPicker resetContextMenuPresenter]):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::setSelectElementIsOpen):

Originally-landed-as: 305413.571@rapid/safari-7624.2.5.110-branch (f76d6df54e60). rdar://176062450

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1cef23490dbfe541860f6ba751933d1efc0ce77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164340 "91 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37824 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31395 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173369 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121592 "Hash b1cef234 for PR 65627 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166209 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38158 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37825 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/173369 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/121592 "Hash b1cef234 for PR 65627 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167299 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/38158 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/31395 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/173369 "Hash b1cef234 for PR 65627 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/38158 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/37825 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21133 "Hash b1cef234 for PR 65627 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/38158 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/31395 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175895 "Hash b1cef234 for PR 65627 does not build (failure)") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28717 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/31395 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/175895 "Hash b1cef234 for PR 65627 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37495 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/37825 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/175895 "Hash b1cef234 for PR 65627 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38281 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/31395 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100661 "Hash b1cef234 for PR 65627 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/38281 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/31395 "Hash b1cef234 for PR 65627 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37091 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110135 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36487 "Hash b1cef234 for PR 65627 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/31395 "Hash b1cef234 for PR 65627 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36737 "Hash b1cef234 for PR 65627 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36637 "Hash b1cef234 for PR 65627 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->