### PR TITLE
Cherry-pick 305413.614@safari-7624-branch (ffdd4a695d15). https://bugs.webkit.org/show_bug.cgi?id=311420

### DIFF
--- a/JSTests/stress/stringProtoFuncAt-GCOwnedDataScope-atomstring-swap.js
+++ b/JSTests/stress/stringProtoFuncAt-GCOwnedDataScope-atomstring-swap.js
@@ -1,0 +1,25 @@
+const target = "A".repeat(128);
+const dummy = {};
+Reflect.set(dummy, target, 1);
+
+const freshRope = "A".repeat(128);
+
+let nonAtom = "D".repeat(64) + "D".repeat(64);
+String.prototype.at.call(nonAtom, 0);
+
+let thatObj = {
+    [Symbol.toPrimitive]() {
+        // Trigger atomization via Reflect.set to avoid Inline Cache holding the string
+        Reflect.set(dummy, freshRope, 1);
+
+        // Overwrite the VM's lastAtomizedIdentifierStringImpl cache
+        Reflect.set(dummy, nonAtom, 1);
+
+        gc();
+
+        return 0;
+    }
+};
+
+// Verify that GCOwnedDataScope/Heap keeps the StringImpl alive across the callback
+String.prototype.at.call(freshRope, thatObj);

--- a/JSTests/stress/stringProtoFuncEndsWith-GCOwnedDataScope-atomstring-swap.js
+++ b/JSTests/stress/stringProtoFuncEndsWith-GCOwnedDataScope-atomstring-swap.js
@@ -1,0 +1,23 @@
+const target = "A".repeat(128);
+const dummy = {};
+Reflect.set(dummy, target, 1);
+
+const freshRope = "A".repeat(128);
+
+let nonAtom = "D".repeat(64) + "D".repeat(64);
+String.prototype.endsWith.call(nonAtom, "E");
+
+let thatObj = {
+    toString() {
+        // Trigger atomization via Reflect.set to avoid Inline Cache holding the string
+        Reflect.set(dummy, freshRope, 1);
+        // Overwrite the VM's lastAtomizedIdentifierStringImpl cache
+        Reflect.set(dummy, nonAtom, 1);
+
+        gc();
+        return "B";
+    }
+};
+
+// Verify that GCOwnedDataScope/Heap keeps the StringImpl alive across the callback
+String.prototype.endsWith.call(freshRope, thatObj);

--- a/JSTests/stress/stringProtoFuncLocaleCompare-GCOwnedDataScope-atomstring-swap.js
+++ b/JSTests/stress/stringProtoFuncLocaleCompare-GCOwnedDataScope-atomstring-swap.js
@@ -1,0 +1,23 @@
+const target = "A".repeat(128);
+const dummy = {};
+Reflect.set(dummy, target, 1);
+
+const freshRope = "A".repeat(128);
+
+let nonAtom = "D".repeat(64) + "D".repeat(64);
+String.prototype.localeCompare.call(nonAtom, "E");
+
+let thatObj = {
+    toString() {
+        // Trigger atomization via Reflect.set to avoid Inline Cache holding the string
+        Reflect.set(dummy, freshRope, 1);
+        // Overwrite the VM's lastAtomizedIdentifierStringImpl cache
+        Reflect.set(dummy, nonAtom, 1);
+
+        gc();
+        return "B";
+    }
+};
+
+// Verify that GCOwnedDataScope/Heap keeps the StringImpl alive across the callback
+String.prototype.localeCompare.call(freshRope, thatObj);

--- a/JSTests/stress/stringProtoFuncStartsWith-GCOwnedDataScope-atomstring-swap.js
+++ b/JSTests/stress/stringProtoFuncStartsWith-GCOwnedDataScope-atomstring-swap.js
@@ -1,0 +1,23 @@
+const target = "A".repeat(128);
+const dummy = {};
+Reflect.set(dummy, target, 1);
+
+const freshRope = "A".repeat(128);
+
+let nonAtom = "D".repeat(64) + "D".repeat(64);
+String.prototype.startsWith.call(nonAtom, "E");
+
+let thatObj = {
+    toString() {
+        // Trigger atomization via Reflect.set to avoid Inline Cache holding the string
+        Reflect.set(dummy, freshRope, 1);
+        // Overwrite the VM's lastAtomizedIdentifierStringImpl cache
+        Reflect.set(dummy, nonAtom, 1);
+
+        gc();
+        return "B";
+    }
+};
+
+// Verify that GCOwnedDataScope/Heap keeps the StringImpl alive across the callback
+String.prototype.startsWith.call(freshRope, thatObj);

--- a/Source/JavaScriptCore/heap/ConservativeRoots.cpp
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.cpp
@@ -33,6 +33,7 @@
 #include "JITStubRoutineSet.h"
 #include "JSCast.h"
 #include "JSCellInlines.h"
+#include "JSString.h"
 #include "MarkedBlockInlines.h"
 #include "WasmCallee.h"
 #include <wtf/OSAllocator.h>
@@ -193,7 +194,15 @@ inline void ConservativeRoots::genericAddPointer(char* pointer, HeapVersion mark
         // Only return early if we are marking a non-butterfly, since butterflies without indexed properties could point past the end of their allocation.
         // If we do, and there is another live butterfly immediately following the first, we will mark the latter one here but we still need to
         // mark the former.
-        return isLive && !mayHaveIndexingHeader(cellKind);
+        if (isLive && !mayHaveIndexingHeader(cellKind)) {
+            static_assert(!JSString::numberOfLowerTierPreciseCells && !JSRopeString::numberOfLowerTierPreciseCells, "We only check for strings in MarkedBlocks so Strings better not have precise allocations");
+            // Since we're looking for strings we only need to check if we know we're not looking at an allocation with an IndexingHeader.
+            // FIXME: If we wanted to make this more performant we could have a JSString HeapCell::Kind or embed the JSType in the MarkedBlock::Handle.
+            if (auto* string = jsDynamicCast<const JSString*>(std::bit_cast<const JSCell*>(pointer)))
+                m_heap.m_discoveredAccessedStringsFromGCOwnedDataScope.add(string);
+            return true;
+        }
+        return false;
     };
 
     if (isJSCellKind(cellKind)) {

--- a/Source/JavaScriptCore/heap/GCOwnedDataScope.h
+++ b/Source/JavaScriptCore/heap/GCOwnedDataScope.h
@@ -26,11 +26,11 @@
 #pragma once
 
 #include <JavaScriptCore/EnsureStillAliveHere.h>
+#include <JavaScriptCore/JSCell.h>
+#include <JavaScriptCore/VM.h>
 #include <wtf/text/StringView.h>
 
 namespace JSC {
-
-class JSCell;
 
 // This class is used return data owned by a JSCell. Consider:
 // int foo(JSString* jsString)
@@ -74,9 +74,21 @@ public:
     GCOwnedDataScope(const JSCell* cell, T value)
         : owner(cell)
         , data(value)
-    { }
+    {
+#if ASSERT_ENABLED
+        if (!owner->vm().heap.m_topGCOwnedDataScope)
+            owner->vm().heap.m_topGCOwnedDataScope = this;
+#endif
+    }
 
-    ~GCOwnedDataScope() { ensureStillAliveHere(owner); }
+    ~GCOwnedDataScope()
+    {
+#if ASSERT_ENABLED
+        if (owner && owner->vm().heap.m_topGCOwnedDataScope == this)
+            owner->vm().heap.m_topGCOwnedDataScope = nullptr;
+#endif
+        ensureStillAliveHere(owner);
+    }
 
     operator const T() const LIFETIME_BOUND { return data; }
     operator T() LIFETIME_BOUND { return data; }

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1221,6 +1221,33 @@ void Heap::addToRememberedSet(const JSCell* constCell)
     m_mutatorMarkStack->append(cell);
 }
 
+void Heap::clearConcurrentRetainedDataIfPossible()
+{
+    // It wouldn't be safe to clear the list if it's possible to have a GCOwnedDataScope on the stack since
+    // m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope
+    // is what's keeping the backing bytes alive.
+#if ASSERT_ENABLED
+    if (!m_topGCOwnedDataScope) [[unlikely]]
+        return;
+#endif
+    if (!vm().entryScope) [[unlikely]]
+        return;
+
+    if (!m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope.size())
+        return;
+#if ENABLE(JIT)
+    auto* worklist = JITWorklist::existingGlobalWorklistOrNull();
+    // We need to make sure no JIT thread could be looking at one of our old strings. Any thread that starts after
+    // this check will load the new StringImpl rather than the one in this list so we're safe to delete these as
+    // long as none were running at the time of this check.
+    if (!worklist || !worklist->totalOngoingCompilations()) {
+#else
+    {
+#endif
+        m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope.clear();
+    }
+}
+
 void Heap::sweepSynchronously()
 {
     if (!Options::useGC()) [[unlikely]]
@@ -2296,7 +2323,10 @@ void Heap::finalize()
     vm().keyAtomStringCache.clear();
     vm().stringSplitCache.clear();
 
-    m_possiblyAccessedStringsFromConcurrentThreads.clear();
+    m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope.removeAllMatching([&](const auto& iter) {
+        return !m_discoveredAccessedStringsFromGCOwnedDataScope.contains(iter.first);
+    });
+    m_discoveredAccessedStringsFromGCOwnedDataScope.clear();
 
     immutableButterflyToStringCache.clear();
     
@@ -3002,7 +3032,6 @@ void Heap::addCoreConstraints()
                 // If we tried to scan while not under a safepoint we could stop a thread that's in the process of calling
                 // one of the callees we are looking for.
                 // FIXME: Should we have two constraints for this? One for concurrent and one under safepoint at the bitter end.
-                // TODO: Verify this part only runs on one thread.
                 ASSERT(worldIsStopped());
                 ConservativeRoots conservativeRoots(*this);
 

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -57,6 +57,7 @@
 #include <wtf/Markable.h>
 #include <wtf/NotFound.h>
 #include <wtf/ParallelHelperPool.h>
+#include <wtf/SegmentedVector.h>
 #include <wtf/Threading.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -608,10 +609,12 @@ public:
     void setKeepVerifierSlotVisitor();
     void clearVerifierSlotVisitor();
 
-    void appendPossiblyAccessedStringFromConcurrentThreads(String&& string)
+    void appendPossiblyAccessedStringFromConcurrentThreadsOrGCOwnedDataScope(const JSString* owner, String&& string)
     {
-        m_possiblyAccessedStringsFromConcurrentThreads.append(WTF::move(string));
+        m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope.append({ owner, WTF::move(string) });
     }
+
+    void clearConcurrentRetainedDataIfPossible();
 
     bool isInPhase(CollectorPhase phase) const { return m_currentPhase == phase; }
 
@@ -902,7 +905,15 @@ private:
     Vector<WeakBlock*> m_logicallyEmptyWeakBlocks;
     size_t m_indexOfNextLogicallyEmptyWeakBlockToSweep { WTF::notFound };
 
-    Vector<String> m_possiblyAccessedStringsFromConcurrentThreads;
+#if ASSERT_ENABLED
+    template<typename> friend struct GCOwnedDataScope;
+    const void* m_topGCOwnedDataScope { nullptr };
+#endif
+    // Use a SegmentedVector rather than a Vector because we don't want to have to copy in order to grow the buffer.
+    // Since this list is walked once to deref all the strings
+    // We don't need fast access.
+    SegmentedVector<std::pair<const JSString*, String>, 256, 10, SegmentedVectorGrowthPolicy::Doubling> m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope;
+   UncheckedKeyHashSet<const JSString*> m_discoveredAccessedStringsFromGCOwnedDataScope;
     
     RefPtr<GCActivityCallback> m_fullActivityCallback;
     RefPtr<GCActivityCallback> m_edenActivityCallback;

--- a/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
@@ -73,6 +73,8 @@ void IncrementalSweeper::doSweep(VM& vm, MonotonicTime deadline, SweepTrigger tr
     if (Options::useTracePoints()) [[unlikely]]
         traceScope.emplace(IncrementalSweepStart, IncrementalSweepEnd, vm.heap.size(), vm.heap.capacity());
 
+    vm.heap.clearConcurrentRetainedDataIfPossible();
+
     while (sweepNextBlock(vm, trigger)) {
         if (MonotonicTime::now() < deadline)
             continue;

--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -195,6 +195,12 @@ size_t JITWorklist::queueLength(const AbstractLocker&) const
     return queueLength;
 }
 
+size_t JITWorklist::totalOngoingCompilations() const
+{
+    Locker locker { *m_lock };
+    return totalOngoingCompilations(locker);
+}
+
 size_t JITWorklist::totalOngoingCompilations(const AbstractLocker&) const
 {
     size_t total = 0;

--- a/Source/JavaScriptCore/jit/JITWorklist.h
+++ b/Source/JavaScriptCore/jit/JITWorklist.h
@@ -85,6 +85,8 @@ public:
 
     void dump(PrintStream&) const;
 
+    size_t totalOngoingCompilations() const;
+
 private:
     JITWorklist();
 

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -842,15 +842,19 @@ ALWAYS_INLINE Identifier JSRopeString::toIdentifier(JSGlobalObject* globalObject
 
 ALWAYS_INLINE void JSString::swapToAtomString(VM& vm, RefPtr<AtomStringImpl>&& atom) const
 {
-    // We replace currently held string with new AtomString. But the old string can be accessed from concurrent compilers and GC threads at any time.
-    // So, we keep the old string alive by appending it to Heap::m_possiblyAccessedStringsFromConcurrentThreads. And GC clears that list when GC finishes.
-    // This is OK since (1) when finishing GC concurrent compiler threads and GC threads are stopped, and (2) AtomString is already held in the atom table,
-    // and we anyway keep this old string until this JSString* is GC-ed. So it does not increase any memory pressure, we release at the same timing.
+    // When we swap a JSString's value to an AtomString, the old StringImpl can still be accessed
+    // by concurrent JIT compiler threads, GC threads, or via GCOwnedDataScope references on the stack.
+    // We keep the old string alive by appending it (paired with its owning JSString*) to
+    // Heap::m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope.
+    // During GC, conservative root scanning discovers which JSStrings are still on the stack; at GC
+    // end we prune entries whose JSString was not discovered. Between GCs,
+    // Heap::clearConcurrentRetainedDataIfPossible clears the vector entirely when no JS is executing
+    // and no JIT compilations are in progress.
     ASSERT(!isCompilationThread() && !Thread::mayBeGCThread());
     String target(WTF::move(atom));
     WTF::storeStoreFence(); // Ensure AtomStringImpl's string is fully initialized when it is exposed to concurrent threads.
     valueInternal().swap(target);
-    vm.heap.appendPossiblyAccessedStringFromConcurrentThreads(WTF::move(target));
+    vm.heap.appendPossiblyAccessedStringFromConcurrentThreadsOrGCOwnedDataScope(this, WTF::move(target));
 }
 
 ALWAYS_INLINE Identifier JSString::toIdentifier(JSGlobalObject* globalObject) const

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -122,7 +122,8 @@ template<typename, size_t = 0> class Deque;
 template<typename Key, typename, Key> class EnumeratedArray;
 template<typename> class EnumSet;
 template<typename, typename = EmbeddedFixedVectorMalloc> class FixedVector;
-template<typename, size_t = 8, typename = SegmentedVectorMalloc> class SegmentedVector;
+enum class SegmentedVectorGrowthPolicy : uint8_t { Constant, Doubling };
+template<typename, size_t = 8, size_t = 0, SegmentedVectorGrowthPolicy = SegmentedVectorGrowthPolicy::Constant, typename = SegmentedVectorMalloc> class SegmentedVector;
 template<typename> class Function;
 template<typename> struct FlatteningVariantTraits;
 template<typename> struct IsSmartPtr;
@@ -161,7 +162,7 @@ template<typename, typename = DefaultWeakPtrImpl> class WeakRef;
 template<typename T> class InlineWeakPtr;
 
 template <typename T>
-using SaSegmentedVector = SegmentedVector<T, 8, SequesteredArenaMalloc>;
+using SaSegmentedVector = SegmentedVector<T, 8, 0, SegmentedVectorGrowthPolicy::Constant, SequesteredArenaMalloc>;
 template <typename T>
 using SaFixedVector = FixedVector<T, SequesteredArenaMalloc>;
 template <typename T>

--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -35,13 +35,13 @@ namespace WTF {
     DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SegmentedVector);
 
     // An iterator for SegmentedVector. It supports only the pre ++ operator
-    template <typename T, size_t SegmentSize, typename Malloc> class SegmentedVector;
-    template <typename T, size_t SegmentSize = 8, typename Malloc = SegmentedVectorMalloc> class SegmentedVectorIterator {
+    template <typename T, size_t SegmentSize, size_t InlineCapacity, SegmentedVectorGrowthPolicy GrowthPolicy, typename Malloc> class SegmentedVector;
+    template <typename T, size_t SegmentSize = 8, size_t InlineCapacity = 0, SegmentedVectorGrowthPolicy GrowthPolicy = SegmentedVectorGrowthPolicy::Constant, typename Malloc = SegmentedVectorMalloc> class SegmentedVectorIterator {
         WTF_MAKE_CONFIGURABLE_ALLOCATED(FastMalloc);
     private:
-        friend class SegmentedVector<T, SegmentSize, Malloc>;
+        friend class SegmentedVector<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc>;
     public:
-        typedef SegmentedVectorIterator<T, SegmentSize, Malloc> Iterator;
+        typedef SegmentedVectorIterator<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc> Iterator;
 
         using iterator_category = std::forward_iterator_tag;
         using value_type = T;
@@ -66,7 +66,7 @@ namespace WTF {
             return m_index == other.m_index && &m_vector == &other.m_vector;
         }
 
-        SegmentedVectorIterator& operator=(const SegmentedVectorIterator<T, SegmentSize, Malloc>& other)
+        SegmentedVectorIterator& operator=(const SegmentedVectorIterator<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc>& other)
         {
             m_vector = other.m_vector;
             m_index = other.m_index;
@@ -74,13 +74,13 @@ namespace WTF {
         }
 
     private:
-        SegmentedVectorIterator(SegmentedVector<T, SegmentSize, Malloc>& vector, size_t index)
+        SegmentedVectorIterator(SegmentedVector<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc>& vector, size_t index)
             : m_vector(vector)
             , m_index(index)
         {
         }
 
-        SegmentedVector<T, SegmentSize, Malloc>& m_vector;
+        SegmentedVector<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc>& m_vector;
         size_t m_index;
     };
 
@@ -88,15 +88,23 @@ namespace WTF {
     // stored in its buffer when it grows. Therefore, it is safe to keep
     // pointers into a SegmentedVector. The default tuning values are
     // optimized for segmented vectors that get large; you may want to use
-    // SegmentedVector<thingy, 1> if you don't expect a lot of entries.
-    template <typename T, size_t SegmentSize, typename Malloc>
+    // the inline storage option if you don't expect a lot of entries.
+    //
+    // When InlineCapacity > 0, the first InlineCapacity elements are stored
+    // inline within the vector object itself, avoiding heap allocation for
+    // small vectors. Additional elements are stored in heap-allocated segments
+    // of SegmentSize elements each. Vectors with inline storage are not
+    // movable, as moving would invalidate pointers to elements stored inline.
+    template <typename T, size_t SegmentSize, size_t InlineCapacity, SegmentedVectorGrowthPolicy GrowthPolicy, typename Malloc>
     class SegmentedVector final {
-        friend class SegmentedVectorIterator<T, SegmentSize, Malloc>;
+        friend class SegmentedVectorIterator<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc>;
         WTF_MAKE_NONCOPYABLE(SegmentedVector);
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SegmentedVector);
 
+        static constexpr bool hasInlineStorage = InlineCapacity > 0;
+
     public:
-        using Iterator = SegmentedVectorIterator<T, SegmentSize, Malloc>;
+        using Iterator = SegmentedVectorIterator<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc>;
 
         using value_type = T;
         using iterator = Iterator;
@@ -114,12 +122,12 @@ namespace WTF {
         T& at(size_t index) LIFETIME_BOUND
         {
             ASSERT_WITH_SECURITY_IMPLICATION(index < m_size);
-            return segmentFor(index)->entries()[subscriptFor(index)];
+            return *addressAt(index);
         }
 
         const T& at(size_t index) const LIFETIME_BOUND
         {
-            return const_cast<SegmentedVector<T, SegmentSize, Malloc>*>(this)->at(index);
+            return const_cast<SegmentedVector*>(this)->at(index);
         }
 
         T& operator[](size_t index) LIFETIME_BOUND
@@ -162,25 +170,32 @@ namespace WTF {
         }
 
         template<typename... Args>
-        void append(Args&&... args)
+        ALWAYS_INLINE T& alloc(Args&&... args)
         {
             ++m_size;
             if (!segmentExistsFor(m_size - 1))
-                allocateSegment();
-            new (NotNull, &last()) T(std::forward<Args>(args)...);
+                ensureSegmentsFor(m_size);
+            T* ptr = addressAt(m_size - 1);
+            new (NotNull, ptr) T(std::forward<Args>(args)...);
+            return *ptr;
         }
 
         template<typename... Args>
-        T& alloc(Args&&... args)
+        ALWAYS_INLINE void append(Args&&... args)
         {
-            append(std::forward<Args>(args)...);
-            return last();
+            alloc(std::forward<Args>(args)...);
         }
 
-        void removeLast()
+        ALWAYS_INLINE void append(value_type&& value)
         {
-            last().~T();
+            alloc(WTF::move(value));
+        }
+
+        ALWAYS_INLINE void removeLast()
+        {
+            ASSERT_WITH_SECURITY_IMPLICATION(!isEmpty());
             --m_size;
+            std::destroy_at(addressAt(m_size));
         }
 
         void grow(size_t size)
@@ -190,7 +205,7 @@ namespace WTF {
             size_t oldSize = m_size;
             m_size = size;
             for (size_t i = oldSize; i < m_size; ++i)
-                new (NotNull, &at(i)) T();
+                new (NotNull, addressAt(i)) T();
         }
 
         void clear()
@@ -209,16 +224,67 @@ namespace WTF {
         {
             return Iterator(*this, m_size);
         }
-        
+
         void shrinkToFit()
         {
             m_segments.shrinkToFit();
         }
 
+        unsigned removeAllMatching(NOESCAPE const Invocable<bool(T&)> auto& matches)
+        {
+            unsigned writeIndex = 0;
+            unsigned matchCount = 0;
+            for (unsigned readIndex = 0; readIndex < m_size; ++readIndex) {
+                T* readPtr = addressAt(readIndex);
+                if (matches(*readPtr)) {
+                    std::destroy_at(readPtr);
+                    ++matchCount;
+                } else {
+                    if (writeIndex != readIndex) {
+                        T* writePtr = addressAt(writeIndex);
+                        new (NotNull, writePtr) T(WTF::move(*readPtr));
+                        std::destroy_at(readPtr);
+                    }
+                    ++writeIndex;
+                }
+            }
+            m_size = writeIndex;
+            shrinkToFit();
+            return matchCount;
+        }
+
     private:
+        struct SegmentLocation {
+            size_t segmentIndex;
+            size_t offsetInSegment;
+        };
+
+        ALWAYS_INLINE static SegmentLocation segmentLocationFor(size_t index)
+        {
+            if constexpr (GrowthPolicy == SegmentedVectorGrowthPolicy::Doubling) {
+                size_t n = index / SegmentSize + 1;
+                size_t segmentIndex = (sizeof(size_t) * CHAR_BIT - 1) - WTF::clz(n);
+                size_t offset = index - (SegmentSize * ((static_cast<size_t>(1) << segmentIndex) - 1));
+                return { segmentIndex, offset };
+            } else
+                return { index / SegmentSize, index % SegmentSize };
+        }
+
+        ALWAYS_INLINE static size_t sizeOfSegment(size_t segmentIndex)
+        {
+            if constexpr (GrowthPolicy == SegmentedVectorGrowthPolicy::Doubling)
+                return SegmentSize << segmentIndex;
+            else
+                return SegmentSize;
+        }
+
         class Segment {
         public:
-            std::span<T, SegmentSize> entries() { return unsafeMakeSpan<T, SegmentSize>(m_entries, SegmentSize); }
+            std::span<T, SegmentSize> entries() requires (GrowthPolicy == SegmentedVectorGrowthPolicy::Constant)
+            {
+                return unsafeMakeSpan<T, SegmentSize>(m_entries, SegmentSize);
+            }
+            T* data() { return m_entries; }
 
         private:
             T m_entries[0];
@@ -226,34 +292,78 @@ namespace WTF {
 
         using SegmentPtr = std::unique_ptr<Segment, NonDestructingDeleter<Segment, Malloc>>;
 
+        struct EmptyInlineStorage { };
+        struct InlineStorageData {
+            AlignedStorage<T> m_data[InlineCapacity];
+        };
+
+        ALWAYS_INLINE T* inlineStorage() LIFETIME_BOUND
+        {
+            static_assert(hasInlineStorage);
+            return m_inlineStorageMember.m_data[0].get();
+        }
+
+        ALWAYS_INLINE const T* inlineStorage() const LIFETIME_BOUND
+        {
+            static_assert(hasInlineStorage);
+            return m_inlineStorageMember.m_data[0].get();
+        }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+        ALWAYS_INLINE T* addressAt(size_t index) LIFETIME_BOUND
+        {
+            if constexpr (hasInlineStorage) {
+                if (index < InlineCapacity) [[likely]]
+                    return &inlineStorage()[index];
+                index -= InlineCapacity;
+            }
+            auto [segmentIndex, offset] = segmentLocationFor(index);
+            return &m_segments[segmentIndex].get()->data()[offset];
+        }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
         void destroyAllItems()
         {
             for (size_t i = 0; i < m_size; ++i)
-                at(i).~T();
+                std::destroy_at(addressAt(i));
         }
 
         bool segmentExistsFor(size_t index)
         {
-            return index / SegmentSize < m_segments.size();
+            if constexpr (hasInlineStorage) {
+                if (index < InlineCapacity)
+                    return true;
+                return heapSegmentExistsFor(index);
+            } else
+                return segmentLocationFor(index).segmentIndex < m_segments.size();
         }
 
-        Segment* segmentFor(size_t index) LIFETIME_BOUND
+        ALWAYS_INLINE bool heapSegmentExistsFor(size_t index)
         {
-            return m_segments[index / SegmentSize].get();
-        }
-
-        static size_t subscriptFor(size_t index)
-        {
-            return index % SegmentSize;
+            if constexpr (hasInlineStorage) {
+                ASSERT(index >= InlineCapacity);
+                return segmentLocationFor(index - InlineCapacity).segmentIndex < m_segments.size();
+            } else
+                return segmentLocationFor(index).segmentIndex < m_segments.size();
         }
 
         void ensureSegmentsFor(size_t size)
         {
-            size_t segmentCount = (m_size + SegmentSize - 1) / SegmentSize;
-            size_t neededSegmentCount = (size + SegmentSize - 1) / SegmentSize;
-
-            for (size_t i = segmentCount ? segmentCount - 1 : 0; i < neededSegmentCount; ++i)
-                ensureSegment(i);
+            if constexpr (hasInlineStorage) {
+                if (size <= InlineCapacity)
+                    return;
+                size_t currentSegmentCount = m_segments.size();
+                size_t requiredSegmentCount = segmentLocationFor(size - InlineCapacity - 1).segmentIndex + 1;
+                for (size_t i = currentSegmentCount; i < requiredSegmentCount; ++i)
+                    allocateSegment();
+            } else {
+                size_t segmentCount = m_size ? segmentLocationFor(m_size - 1).segmentIndex + 1 : 0;
+                size_t requiredSegmentCount = segmentLocationFor(size - 1).segmentIndex + 1;
+                for (size_t i = segmentCount ? segmentCount - 1 : 0; i < requiredSegmentCount; ++i)
+                    ensureSegment(i);
+            }
         }
 
         void ensureSegment(size_t segmentIndex)
@@ -265,14 +375,17 @@ namespace WTF {
 
         void allocateSegment()
         {
-            auto* ptr = static_cast<Segment*>(Malloc::malloc(sizeof(T) * SegmentSize));
+            size_t segSize = sizeOfSegment(m_segments.size());
+            auto* ptr = static_cast<Segment*>(Malloc::malloc(sizeof(T) * segSize));
             m_segments.append(SegmentPtr(ptr, { }));
         }
 
         size_t m_size { 0 };
         Vector<SegmentPtr, 0, CrashOnOverflow, 16, Malloc> m_segments;
+        [[no_unique_address]] std::conditional_t<hasInlineStorage, InlineStorageData, EmptyInlineStorage> m_inlineStorageMember;
     };
 
 } // namespace WTF
 
 using WTF::SegmentedVector;
+using WTF::SegmentedVectorGrowthPolicy;


### PR DESCRIPTION
#### 5428ad1ad2f246f5b61fce4a7b6a9ba7a5c491e9
<pre>
Cherry-pick 305413.614@safari-7624-branch (ffdd4a695d15). <a href="https://bugs.webkit.org/show_bug.cgi?id=311420">https://bugs.webkit.org/show_bug.cgi?id=311420</a>

    Heap needs to protect swaped JSString Impls for GCOwnedDataScope
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311420">https://bugs.webkit.org/show_bug.cgi?id=311420</a>
    <a href="https://rdar.apple.com/172467032">rdar://172467032</a>

    Reviewed by Yusuke Suzuki and Dan Hecht.

    When JSString::swapToAtomString replaces a StringImpl with its atomized
    equivalent, the old StringImpl was kept alive only until the next GC
    via
    Heap::m_possiblyAccessedStringsFromConcurrentThreads. However if a
    GCOwnedDataScope is on the stack it&apos;s possible for the buffer to get
    freed before the ~GCOwnedDataScope runs, leaving the buffer as a
    dangling pointer.

    Fix this by:

     1. Renaming m_possiblyAccessedStringsFromConcurrentThreads to
        m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope and
        storing (JSString*, String) pairs so we can track ownership.

     2. During conservative root scanning, discover all JSStrings that are
        still referenced on the stack and record them in
        m_discoveredAccessedStringsFromGCOwnedDataScope.

     3. At GC finalize, pruning entries whose JSString was not discovered on
        the stack rather than clearing the list entirely.

     4. Between GCs, clearing the retained list in IncrementalSweeper when
        no JS is executing and no JIT compilations are in progress.
        Previously the list was only cleared during GC finalize, so it could
        grow unboundedly between collections. Without this Speedometer
        appeared to be regressed, with this it seems like a .2% progression.

     5. Switching from Vector to SegmentedVector with a new doubling growth
        policy to avoid copying entries when resizing the Vector. Since this
        list gets very big 200,000+ entries, avoiding copies is valuable.

    Tests: JSTests/stress/stringProtoFuncAt-GCOwnedDataScope-atomstring-swap.js
           JSTests/stress/stringProtoFuncEndsWith-GCOwnedDataScope-atomstring-swap.js
           JSTests/stress/stringProtoFuncLocaleCompare-GCOwnedDataScope-atomstring-swap.js
           JSTests/stress/stringProtoFuncStartsWith-GCOwnedDataScope-atomstring-swap.js

    Identifier: 305413.614@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.694@webkitglib/2.52">https://commits.webkit.org/305877.694@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5559955eb9def05cd72f2ef8536311988e34ee30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165710 "4 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/39200 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32781 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174752 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122965 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39536 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39204 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128776 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122965 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168669 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39536 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/32781 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109300 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39536 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39204 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22833 "Built successfully") | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/157867 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39536 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/32781 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177276 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/26603 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30192 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32781 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137106 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/165112 "Build is in progress. Recent messages:") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/39269 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/39204 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137035 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/39957 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/32781 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102474 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25223 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/39957 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32781 "The change is no longer eligible for processing.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/38468 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/111541 "The change is no longer eligible for processing.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/37864 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/32781 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/38110 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/38008 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->