### PR TITLE
CSS reference filter with `filterUnits="userSpaceOnUse"` should use the border box as the filter region

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-001-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+        margin: 10px;
+    }
+  </style>
+</head>
+<body>
+  <svg width="500" height="400">
+    <filter id="test" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%" primitiveUnits="userSpaceOnUse" filterUnits="userSpaceOnUse">
+      <feFlood flood-color="blue" flood-opacity="0.2" result="wash"/>
+      <feFlood x="0" y="0" width="100" height="100" flood-color="orange" flood-opacity="0.5" result="topleft"/>
+      <feFlood x="400" y="300" width="100" height="100" flood-color="orange" flood-opacity="0.5" result="bottomRight"/>
+      <feMerge>
+        <feMergeNode in="SourceGraphic" />
+        <feMergeNode in="wash" />
+        <feMergeNode in="topleft" />
+        <feMergeNode in="bottomRight" />
+      </feMerge>
+    </filter>
+    <g filter="url(#test)">
+      <rect x="50" y="50" width="400" height="300" fill="green"></rect>
+      <rect x="0" y="0" width="100" height="100" fill="green"></rect>
+      <rect x="400" y="300" width="100" height="100" fill="green"></rect>
+    </g>
+  </svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-001.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/filter-effects/#FilterEffectsRegion">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/13964">
+<link rel="match" href="reference/reference-filter-geometry-001-ref.html">
+<meta name="assert" content="Tests that the SVG filter region is computed relative to the ink overflow bounds of the target element when filterUnits are `objectBoundingBox`">
+<style>
+    body {
+        margin: 0;
+    }
+    .box {
+        margin: 60px;
+        position: relative;
+        width: 400px;
+        height: 300px;
+        background-color: green;
+        filter: url(#test);
+    }
+
+    .child {
+        position: absolute;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+    }
+
+    .topleft {
+        top: -50px;
+        left: -50px;
+    }
+
+    .bottomright {
+        top: 250px;
+        left: 350px;
+    }
+
+    svg {
+        position: absolute;
+    }
+</style>
+</head>
+<body>
+  <svg width="0" height="0">
+    <filter id="test" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%" primitiveUnits="objectBoundingBox" filterUnits="objectBoundingBox">
+      <feFlood flood-color="blue" flood-opacity="0.2" result="wash"/>
+      <feFlood x="0" y="0" width="0.2" height="0.25" flood-color="orange" flood-opacity="0.5" result="topleft"/>
+      <feFlood x="0.8" y="0.75" width="0.3" height="0.3" flood-color="orange" flood-opacity="0.5" result="bottomRight"/>
+      <feMerge>
+        <feMergeNode in="SourceGraphic" />
+        <feMergeNode in="wash" />
+        <feMergeNode in="topleft" />
+        <feMergeNode in="bottomRight" />
+      </feMerge>
+    </filter>
+  </svg>
+  <div class="box">
+    <div class="child topleft"></div>
+    <div class="child bottomright"></div>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-002-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+        margin: 50px;
+    }
+  </style>
+</head>
+<body>
+  <svg width="400" height="300">
+    <filter id="test" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%" primitiveUnits="userSpaceOnUse" filterUnits="userSpaceOnUse">
+      <feFlood flood-color="blue" flood-opacity="0.2" result="wash"/>
+      <feFlood x="0" y="0" width="50" height="50" flood-color="orange" flood-opacity="0.5" result="topleft"/>
+      <feFlood x="350" y="250" width="50" height="50" flood-color="orange" flood-opacity="0.5" result="bottomRight"/>
+      <feMerge>
+        <feMergeNode in="SourceGraphic" />
+        <feMergeNode in="wash" />
+        <feMergeNode in="topleft" />
+        <feMergeNode in="bottomRight" />
+      </feMerge>
+    </filter>
+    <g filter="url(#test)">
+      <rect x="0" y="0" width="400" height="300" fill="green"></rect>
+      <rect x="0" y="0" width="100" height="100" fill="green"></rect>
+      <rect x="530" y="250" width="100" height="100" fill="green"></rect>
+    </g>
+  </svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-002.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/filter-effects/#FilterEffectsRegion">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/13964">
+<link rel="match" href="reference/reference-filter-geometry-002-ref.html">
+<meta name="assert" content="Tests that the SVG filter region is computed relative to the border box of the target element when filterUnits are `userSpaceOnUse`">
+<style>
+    body {
+        margin: 0;
+    }
+    .box {
+        position: relative;
+        margin: 50px;
+        width: 400px;
+        height: 300px;
+        background-color: green;
+        filter: url(#test);
+    }
+
+    .child {
+        position: absolute;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+    }
+
+    .topleft {
+        top: -50px;
+        left: -50px;
+    }
+
+    .bottomright {
+        top: 250px;
+        left: 350px;
+    }
+
+    svg {
+        position: absolute;
+    }
+</style>
+</head>
+<body>
+  <svg width="0" height="0">
+    <filter id="test" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%" primitiveUnits="objectBoundingBox" filterUnits="userSpaceOnUse">
+      <feFlood flood-color="blue" flood-opacity="0.2" result="wash"/>
+      <feFlood x="0" y="0" width="0.2" height="0.25" flood-color="orange" flood-opacity="0.5" result="topleft"/>
+      <feFlood x="0.8" y="0.75" width="0.3" height="0.3" flood-color="orange" flood-opacity="0.5" result="bottomRight"/>
+      <feMerge>
+        <feMergeNode in="SourceGraphic" />
+        <feMergeNode in="wash" />
+        <feMergeNode in="topleft" />
+        <feMergeNode in="bottomRight" />
+      </feMerge>
+    </filter>
+  </svg>
+  <div class="box">
+    <div class="child topleft"></div>
+    <div class="child bottomright"></div>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-003-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+        margin: 50px;
+    }
+  </style>
+</head>
+<body>
+  <svg width="400" height="300">
+    <filter id="test" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%" primitiveUnits="userSpaceOnUse" filterUnits="userSpaceOnUse">
+      <feFlood flood-color="blue" flood-opacity="0.2" result="wash"/>
+      <feFlood x="0" y="0" width="50" height="50" flood-color="orange" flood-opacity="0.5" result="topleft"/>
+      <feFlood x="350" y="250" width="50" height="50" flood-color="orange" flood-opacity="0.5" result="bottomRight"/>
+      <feMerge>
+        <feMergeNode in="SourceGraphic" />
+        <feMergeNode in="wash" />
+        <feMergeNode in="topleft" />
+        <feMergeNode in="bottomRight" />
+      </feMerge>
+    </filter>
+    <g filter="url(#test)">
+      <rect x="0" y="0" width="400" height="300" fill="green"></rect>
+      <rect x="0" y="0" width="100" height="100" fill="green"></rect>
+      <rect x="530" y="250" width="100" height="100" fill="green"></rect>
+    </g>
+  </svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-003.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/filter-effects/#FilterEffectsRegion">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/13964">
+<link rel="match" href="reference/reference-filter-geometry-003-ref.html">
+<meta name="assert" content="Tests that the SVG filter region is computed relative to the border box of the target element when filterUnits are `userSpaceOnUse`">
+<style>
+    body {
+        margin: 0;
+    }
+    .box {
+        position: relative;
+        margin: 50px;
+        width: 400px;
+        height: 300px;
+        background-color: green;
+        filter: url(#test);
+    }
+
+    .child {
+        position: absolute;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+    }
+
+    .topleft {
+        top: -50px;
+        left: -50px;
+    }
+
+    .bottomright {
+        top: 250px;
+        left: 350px;
+    }
+
+    svg {
+        position: absolute;
+    }
+</style>
+</head>
+<body>
+  <svg width="0" height="0">
+    <filter id="test" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%" primitiveUnits="userSpaceOnUse" filterUnits="userSpaceOnUse">
+      <feFlood flood-color="blue" flood-opacity="0.2" result="wash"/>
+      <feFlood x="0" y="0" width="50" height="50" flood-color="orange" flood-opacity="0.5" result="topleft"/>
+      <feFlood x="350" y="250" width="50" height="50" flood-color="orange" flood-opacity="0.5" result="bottomRight"/>
+      <feMerge>
+        <feMergeNode in="SourceGraphic" />
+        <feMergeNode in="wash" />
+        <feMergeNode in="topleft" />
+        <feMergeNode in="bottomRight" />
+      </feMerge>
+    </filter>
+  </svg>
+  <div class="box">
+    <div class="child topleft"></div>
+    <div class="child bottomright"></div>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/reference-filter-geometry-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/reference-filter-geometry-001-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+        margin: 10px;
+    }
+  </style>
+</head>
+<body>
+  <svg width="500" height="400">
+    <filter id="test" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%" primitiveUnits="userSpaceOnUse" filterUnits="userSpaceOnUse">
+      <feFlood flood-color="blue" flood-opacity="0.2" result="wash"/>
+      <feFlood x="0" y="0" width="100" height="100" flood-color="orange" flood-opacity="0.5" result="topleft"/>
+      <feFlood x="400" y="300" width="100" height="100" flood-color="orange" flood-opacity="0.5" result="bottomRight"/>
+      <feMerge>
+        <feMergeNode in="SourceGraphic" />
+        <feMergeNode in="wash" />
+        <feMergeNode in="topleft" />
+        <feMergeNode in="bottomRight" />
+      </feMerge>
+    </filter>
+    <g filter="url(#test)">
+      <rect x="50" y="50" width="400" height="300" fill="green"></rect>
+      <rect x="0" y="0" width="100" height="100" fill="green"></rect>
+      <rect x="400" y="300" width="100" height="100" fill="green"></rect>
+    </g>
+  </svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/reference-filter-geometry-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/reference-filter-geometry-002-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+        margin: 50px;
+    }
+  </style>
+</head>
+<body>
+  <svg width="400" height="300">
+    <filter id="test" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%" primitiveUnits="userSpaceOnUse" filterUnits="userSpaceOnUse">
+      <feFlood flood-color="blue" flood-opacity="0.2" result="wash"/>
+      <feFlood x="0" y="0" width="50" height="50" flood-color="orange" flood-opacity="0.5" result="topleft"/>
+      <feFlood x="350" y="250" width="50" height="50" flood-color="orange" flood-opacity="0.5" result="bottomRight"/>
+      <feMerge>
+        <feMergeNode in="SourceGraphic" />
+        <feMergeNode in="wash" />
+        <feMergeNode in="topleft" />
+        <feMergeNode in="bottomRight" />
+      </feMerge>
+    </filter>
+    <g filter="url(#test)">
+      <rect x="0" y="0" width="400" height="300" fill="green"></rect>
+      <rect x="0" y="0" width="100" height="100" fill="green"></rect>
+      <rect x="530" y="250" width="100" height="100" fill="green"></rect>
+    </g>
+  </svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/reference-filter-geometry-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/reference-filter-geometry-003-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+        margin: 50px;
+    }
+  </style>
+</head>
+<body>
+  <svg width="400" height="300">
+    <filter id="test" color-interpolation-filters="sRGB" x="0%" y="0%" width="100%" height="100%" primitiveUnits="userSpaceOnUse" filterUnits="userSpaceOnUse">
+      <feFlood flood-color="blue" flood-opacity="0.2" result="wash"/>
+      <feFlood x="0" y="0" width="50" height="50" flood-color="orange" flood-opacity="0.5" result="topleft"/>
+      <feFlood x="350" y="250" width="50" height="50" flood-color="orange" flood-opacity="0.5" result="bottomRight"/>
+      <feMerge>
+        <feMergeNode in="SourceGraphic" />
+        <feMergeNode in="wash" />
+        <feMergeNode in="topleft" />
+        <feMergeNode in="bottomRight" />
+      </feMerge>
+    </filter>
+    <g filter="url(#test)">
+      <rect x="0" y="0" width="400" height="300" fill="green"></rect>
+      <rect x="0" y="0" width="100" height="100" fill="green"></rect>
+      <rect x="530" y="250" width="100" height="100" fill="green"></rect>
+    </g>
+  </svg>
+</body>
+</html>

--- a/LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html
+++ b/LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html
@@ -231,6 +231,16 @@ setTimeout(async () => {
                             height : 1.723597111119525e-43
                         }
                     },
+                    objectBoundingBoxReferenceBox : {
+                        location : {
+                            x : -509502506841300.9,
+                            y : -5.566387275235406e-27
+                        },
+                        size : {
+                            width : 1.961817850054744e-44,
+                            height : 1.723597111119525e-43
+                        }
+                    },
                     filterRegion : {
                         location : {
                             x : -509502506841300.9,
@@ -240,6 +250,10 @@ setTimeout(async () => {
                             width : 1.961817850054744e-44,
                             height : 1.723597111119525e-43
                         }
+                    },
+                    primitiveUserSpaceOffset : {
+                        x : 0,
+                        y : 0
                     },
                     scale : {
                         width : 3.2175183536110756e-38,

--- a/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html
+++ b/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html
@@ -109,6 +109,16 @@
                                         height : 1
                                     }
                                 },
+                                objectBoundingBoxReferenceBox : {
+                                    location : {
+                                        x : 0,
+                                        y : 0
+                                    },
+                                    size : {
+                                        width : 1,
+                                        height : 1
+                                    }
+                                },
                                 filterRegion : {
                                     location : {
                                         x : 1,
@@ -118,6 +128,10 @@
                                         width : 1,
                                         height : 1
                                     }
+                                },
+                                primitiveUserSpaceOffset : {
+                                    x : 0,
+                                    y : 0
                                 },
                                 scale : {
                                     width : 1,

--- a/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
+++ b/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
@@ -76,6 +76,16 @@
                                     height : 0
                                 }
                             },
+                            objectBoundingBoxReferenceBox : {
+                                location : {
+                                    x : 0,
+                                    y : 0
+                                },
+                                size : {
+                                    width : 0,
+                                    height : 0
+                                }
+                            },
                             filterRegion : {
                                 location : {
                                     x : 0,
@@ -85,6 +95,10 @@
                                     width : 0,
                                     height : 0
                                 }
+                            },
+                            primitiveUserSpaceOffset : {
+                                x : 0,
+                                y : 0
                             },
                             scale : {
                                 width : 0,

--- a/LayoutTests/ipc/invalid-feConvolveMatrix-crash.html
+++ b/LayoutTests/ipc/invalid-feConvolveMatrix-crash.html
@@ -106,6 +106,16 @@
                                             height: 110
                                         }
                                     },
+                                    objectBoundingBoxReferenceBox : {
+                                        location : {
+                                            x: 39,
+                                            y: 112
+                                        },
+                                        size : {
+                                            width: 32,
+                                            height: 110
+                                        }
+                                    },
                                     filterRegion : {
                                         location : {
                                             x: 39,
@@ -115,6 +125,10 @@
                                             width: 32,
                                             height: 110
                                         }
+                                    },
+                                    primitiveUserSpaceOffset : {
+                                        x : 0,
+                                        y : 0
                                     },
                                     scale : {
                                         width : 68,

--- a/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
+++ b/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
@@ -73,6 +73,16 @@ window.setTimeout(async () => {
                                     height: 0
                                 }
                             },
+                            objectBoundingBoxReferenceBox : {
+                                location : {
+                                    x: 0,
+                                    y: 0
+                                },
+                                size : {
+                                    width: 0,
+                                    height: 0
+                                }
+                            },
                             filterRegion : {
                                 location : {
                                     x: 0,
@@ -82,6 +92,10 @@ window.setTimeout(async () => {
                                     width: 0,
                                     height: 0
                                 }
+                            },
+                            primitiveUserSpaceOffset : {
+                                x : 0,
+                                y : 0
                             },
                             scale : {
                                 width : 0,

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -902,6 +902,8 @@ webkit.org/b/261024 js/cached-window-properties.html [ Pass Timeout ]
 webrtc/vp8-then-h264.html [ Pass ]
 
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-plus-filter.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-002.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-003.html [ ImageOnlyFailure ]
 
 # Flaky tests Nov2023
 webkit.org/b/264680 imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub.html [ Failure Pass ]

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -129,9 +129,11 @@ RefPtr<Filter> CanvasRenderingContext2D::createFilter(const FloatRect& bounds) c
     auto filterRegion = bounds + toFloatBoxExtent(outsets);
 
     auto preferredFilterRenderingModes = page->preferredFilterRenderingModes(*context);
-    auto filter = CSSFilterRenderer::create(*renderer, state().filter, {
+    auto filter = CSSFilterRenderer::create(*renderer, state().filter, FilterGeometry {
             .referenceBox = bounds,
+            .objectBoundingBoxReferenceBox = bounds,
             .filterRegion = filterRegion,
+            .primitiveUserSpaceOffset = { },
             .scale = { 1, 1 },
         }, preferredFilterRenderingModes, { }, *context);
     if (!filter)

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -36,8 +36,18 @@ class FilterImage;
 class FilterResults;
 
 struct FilterGeometry {
+    // Reference box used to resolve SVG filter percentages when filterUnits=userSpaceOnUse:
+    // the filtered element's own bounding box (border box for HTML, objectBoundingBox for SVG).
     FloatRect referenceBox;
+    // Reference box used when filterUnits=objectBoundingBox: the union of the layer's painted
+    // bounds (matches Firefox). May equal referenceBox when no separate value was supplied.
+    FloatRect objectBoundingBoxReferenceBox;
     FloatRect filterRegion;
+    // Offset added to primitive x/y when primitiveUnits=userSpaceOnUse, so primitive
+    // coordinates land in the inner SVGFilterRenderer's coordinate system. Zero for SVG
+    // filters (rendering happens in user space). For CSS-referenced filters on HTML
+    // elements, this is the box origin in body coords.
+    FloatPoint primitiveUserSpaceOffset;
     FloatSize scale;
 };
 
@@ -68,6 +78,8 @@ public:
     void setFilterRegion(const FloatRect& filterRegion) { m_geometry.filterRegion = filterRegion; }
 
     FloatRect referenceBox() const { return m_geometry.referenceBox; }
+    FloatRect objectBoundingBoxReferenceBox() const { return m_geometry.objectBoundingBoxReferenceBox; }
+    FloatPoint primitiveUserSpaceOffset() const { return m_geometry.primitiveUserSpaceOffset; }
 
     virtual FloatSize resolvedSize(const FloatSize& size) const { return size; }
     virtual FloatPoint3D resolvedPoint3D(const FloatPoint3D& point) const { return point; }

--- a/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
@@ -39,7 +39,13 @@ bool SourceGraphicSoftwareApplier::apply(const Filter&, std::span<const Ref<Filt
     if (!resultImage || !sourceImage)
         return false;
 
-    resultImage->context().drawImageBuffer(*sourceImage, IntPoint());
+    // The result buffer's origin is result.absoluteImageRect().location() in absolute
+    // coords; the source buffer's origin is input->absoluteImageRect().location().
+    // When the source extends beyond the result (e.g. CSS-referenced SVG filters where
+    // the source canvas is layer bounds but the result is clipped to filterRegion),
+    // we need to draw the source at this offset to keep pixels in the same coord system.
+    auto offset = input->absoluteImageRect().location() - result.absoluteImageRect().location();
+    resultImage->context().drawImageBuffer(*sourceImage, IntPoint(offset));
     return true;
 }
 

--- a/Source/WebCore/rendering/CSSFilterRenderer.cpp
+++ b/Source/WebCore/rendering/CSSFilterRenderer.cpp
@@ -127,7 +127,25 @@ static RefPtr<SVGFilterRenderer> createReferenceFilter(const CSSFilterRenderer& 
     RefPtr contextElement = dynamicDowncast<SVGElement>(renderer.element());
 
     auto geometry = filter.geometry();
-    geometry.filterRegion = SVGLengthContext::resolveRectangle(contextElement.get(), *filterElement, filterElement->filterUnits(), filter.referenceBox());
+    auto cssBorderBox = geometry.referenceBox;
+    auto cssOverflowBoundsBox = geometry.objectBoundingBoxReferenceBox;
+
+    // Inner SVGFilterRenderer geometry stays in painting coords so it matches the outer
+    // CSSFilterRenderer's source image (which is painted in painting coords).
+    geometry.referenceBox = cssOverflowBoundsBox;
+
+    // For primitiveUnits=userSpaceOnUse, primitive x/y resolved by SVGLengthContext are in
+    // raw user space (origin 0,0). Translate them by the box origin so they match painting
+    // coords (where the inner filter operates).
+    geometry.primitiveUserSpaceOffset = cssBorderBox.location();
+
+    // Resolve filter x/y/w/h per filterUnits, producing a filterRegion in painting coords.
+    if (filterElement->filterUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX)
+        geometry.filterRegion = SVGLengthContext::resolveRectangle(contextElement.get(), *filterElement, filterElement->filterUnits(), cssOverflowBoundsBox);
+    else {
+        geometry.filterRegion = SVGLengthContext::resolveRectangle(contextElement.get(), *filterElement, filterElement->filterUnits(), FloatRect({ }, cssBorderBox.size()));
+        geometry.filterRegion.moveBy(cssBorderBox.location());
+    }
     if (geometry.filterRegion.isEmpty())
         return nullptr;
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3628,7 +3628,25 @@ GraphicsContext* RenderLayer::setupFilters(GraphicsContext& destinationContext, 
     LayoutRect filterRepaintRect = paintingFilters->dirtySourceRect();
     filterRepaintRect.move(offsetFromRoot);
 
-    auto rootRelativeBounds = calculateLayerBounds(paintingInfo.rootLayer, offsetFromRoot, { });
+    // For filterUnits="objectBoundingBox", compute the ink overflow bounds (i.e. the bounds of the element
+    // and its descendants), which is the layer bounds.
+    auto objectBoundingBoxReferenceBox = calculateLayerBounds(paintingInfo.rootLayer, offsetFromRoot, { });
+
+    // The SVG filter reference box (per CSS Filter Effects) is the filtered element's own
+    // bounding box — border box for HTML, object bounding box for SVG. This is used when
+    // resolving SVG filter percentages with filterUnits="userSpaceOnUse".
+    auto rootRelativeBounds = objectBoundingBoxReferenceBox;
+    if (is<RenderBox>(renderer())) {
+        rootRelativeBounds = enclosingLayoutRect(renderer().referenceBoxRect(CSSBoxType::BorderBox));
+        rootRelativeBounds.move(offsetFromRoot);
+    }
+
+    LOG_WITH_STREAM(Filters, stream << "RenderLayer " << this << " setupFilters: objectBoundingBox " << renderer().objectBoundingBox()
+        << " offsetFromRoot " << offsetFromRoot
+        << " rootRelativeBounds " << rootRelativeBounds
+        << " objectBoundingBoxReferenceBox " << objectBoundingBoxReferenceBox
+        << " paintDirtyRect " << paintingInfo.paintDirtyRect
+        << " backgroundRect " << backgroundRect.rect());
 
     // When the filter is applied via a transparency layer directly on the destination context (e.g. CG drop-shadow),
     // the switcher doesn't consult applyFilters's clipToRect path, so the ancestor border-radius clip would be lost.
@@ -3640,7 +3658,7 @@ GraphicsContext* RenderLayer::setupFilters(GraphicsContext& destinationContext, 
         };
     }
 
-    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, paintingInfo.paintBehavior, enclosingIntRect(rootRelativeBounds), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect),
+    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, paintingInfo.paintBehavior, enclosingIntRect(rootRelativeBounds), enclosingIntRect(objectBoundingBoxReferenceBox), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect),
         backgroundRect.rect(), applyAdditionalDestinationClip);
     if (!filterContext)
         return nullptr;

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -157,28 +157,32 @@ IntOutsets RenderLayerFilters::calculateOutsets(RenderElement& renderer, const F
     return CSSFilterRenderer::calculateOutsets(renderer, filter, targetBoundingBox);
 }
 
-GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, OptionSet<PaintBehavior> paintBehavior, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip)
+GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, OptionSet<PaintBehavior> paintBehavior, const LayoutRect& filterBoxRect, const LayoutRect& objectBoundingBoxFilterRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip)
 {
     auto preferredFilterRenderingModes = renderer.page().preferredFilterRenderingModes(context);
     auto outsets = calculateOutsets(renderer, filterBoxRect);
 
-    auto dirtyFilterRegion = dirtyRect;
+    LOG_WITH_STREAM(Filters, stream << "RenderLayerFilters " << this << " beginFilterEffect: filterBoxRect " << filterBoxRect
+        << " objectBoundingBoxFilterRect " << objectBoundingBoxFilterRect
+        << " dirtyRect " << dirtyRect << " layerRepaintRect " << layerRepaintRect
+        << " clipRect " << clipRect << " outsets " << outsets);
+
+    // FIXME: This isn't the "filter region" per spec; this is affeted by dirty rect.
     auto filterRegion = dirtyRect;
+
+    auto dirtyRectPlusOutsets = dirtyRect;
+    if (!outsets.isZero()) {
+        // FIXME: This flipping was added for drop-shadow, but it's not obvious that it's correct.
+        LayoutBoxExtent flippedOutsets { outsets.bottom(), outsets.left(), outsets.top(), outsets.right() };
+        dirtyRectPlusOutsets.expand(flippedOutsets);
+    }
 
     if (auto* shape = dynamicDowncast<RenderSVGShape>(renderer)) {
         // In LBSE, the filter region will be recomputed in createReferenceFilter().
-        // FIXME: The LBSE filter geometry is not correct.
-        filterRegion = dirtyFilterRegion = enclosingLayoutRect(shape->objectBoundingBox());
+        // FIXME: The LBSE filter geometry is not correct. The dirty rect must not impact the filter region here.
+        filterRegion = enclosingLayoutRect(shape->objectBoundingBox());
     } else {
-        if (!outsets.isZero()) {
-            // FIXME: This flipping was added for drop-shadow, but it's not obvious that it's correct.
-            LayoutBoxExtent flippedOutsets { outsets.bottom(), outsets.left(), outsets.top(), outsets.right() };
-            dirtyFilterRegion.expand(flippedOutsets);
-        }
-
-        dirtyFilterRegion = intersection(filterBoxRect, dirtyFilterRegion);
-        filterRegion = dirtyFilterRegion;
-
+        filterRegion = intersection(objectBoundingBoxFilterRect, dirtyRectPlusOutsets);
         if (!outsets.isZero())
             filterRegion.expand(toLayoutBoxExtent(outsets));
     }
@@ -187,7 +191,9 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
         return nullptr;
 
     auto geometryReferenceGeometryChanged = [](auto& existingGeometry, auto& newGeometry) {
-        return existingGeometry.referenceBox != newGeometry.referenceBox || existingGeometry.scale != newGeometry.scale;
+        return existingGeometry.referenceBox != newGeometry.referenceBox
+            || existingGeometry.objectBoundingBoxReferenceBox != newGeometry.objectBoundingBoxReferenceBox
+            || existingGeometry.scale != newGeometry.scale;
     };
 
     auto filterScale = m_filterScale;
@@ -196,9 +202,14 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
 
     auto geometry = FilterGeometry {
         .referenceBox = filterBoxRect,
+        .objectBoundingBoxReferenceBox = objectBoundingBoxFilterRect,
         .filterRegion = filterRegion,
+        .primitiveUserSpaceOffset = { },
         .scale = filterScale,
     };
+
+    LOG_WITH_STREAM(Filters, stream << "RenderLayerFilters " << this << " beginFilterEffect: referenceBox " << geometry.referenceBox << " objectBoundingBoxReferenceBox " << geometry.objectBoundingBoxReferenceBox
+        << " filterRegion " << geometry.filterRegion << " scale " << geometry.scale);
 
     bool hasUpdatedBackingStore = false;
     if (!m_filter || geometryReferenceGeometryChanged(m_filter->geometry(), geometry) || m_preferredFilterRenderingModes != preferredFilterRenderingModes) {
@@ -239,7 +250,9 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
         if (is<RenderSVGShape>(renderer))
             sourceImageRect = renderer.objectBoundingBox();
         else
-            sourceImageRect = dirtyFilterRegion;
+            sourceImageRect = filterRegion;
+        LOG_WITH_STREAM(Filters, stream << "RenderLayerFilters " << this << " beginFilterEffect: sourceImageRect " << sourceImageRect
+            << " m_repaintRect " << m_repaintRect << " filter->filterRegion " << filter->filterRegion());
         m_targetSwitcher = GraphicsContextSwitcher::create(context, sourceImageRect, DestinationColorSpace::SRGB(), { WTF::move(filter) });
     }
 

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -76,7 +76,7 @@ public:
     // Per render
     LayoutRect repaintRect() const { return m_repaintRect; }
 
-    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, OptionSet<PaintBehavior>, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip = { });
+    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, OptionSet<PaintBehavior>, const LayoutRect& filterBoxRect, const LayoutRect& objectBoundingBoxFilterRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip = { });
     void applyFilterEffect(GraphicsContext& destinationContext);
 
 private:

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -458,9 +458,11 @@ void writeSVGResourceContainer(TextStream& ts, const LegacyRenderSVGResourceCont
         ts << '\n';
         // Creating a placeholder filter which is passed to the builder.
         Ref filterElement = filter->filterElement();
-        auto placeholderFilter = SVGFilterRenderer::create(filterElement.ptr(), filterElement, {
+        auto placeholderFilter = SVGFilterRenderer::create(filterElement.ptr(), filterElement, FilterGeometry {
                 .referenceBox = { },
+                .objectBoundingBoxReferenceBox = { },
                 .filterRegion = { },
+                .primitiveUserSpaceOffset = { },
                 .scale = { 1, 1},
             }, FilterRenderingMode::Software, { }, NullGraphicsContext());
         if (placeholderFilter) {

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -131,9 +131,11 @@ auto LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const
     auto renderingOptions(renderer.settings().showDebugBorders() ? std::make_optional(FilterRenderingOption::ShowDebugOverlay) : std::nullopt);
 
     // Create the SVGFilterRenderer object.
-    filterData->filter = SVGFilterRenderer::create(contextElement.get(), filterElement, {
+    filterData->filter = SVGFilterRenderer::create(contextElement.get(), filterElement, FilterGeometry {
         .referenceBox = targetBoundingBox,
+        .objectBoundingBoxReferenceBox = targetBoundingBox,
         .filterRegion = filterRegion,
+        .primitiveUserSpaceOffset = { },
         .scale = filterScale,
     }, preferredFilterModes, renderingOptions, *context, RenderingResourceIdentifier::generate());
 

--- a/Source/WebCore/style/values/images/kinds/StyleFilterImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleFilterImage.cpp
@@ -147,9 +147,11 @@ RefPtr<WebCore::Image> FilterImage::image(const RenderElement* renderElement, co
     auto sourceImageRect = FloatRect { { }, size };
 
     auto renderingOptions(protect(renderer->settings())->showDebugBorders() ? std::make_optional(FilterRenderingOption::ShowDebugOverlay) : std::nullopt);
-    auto cssFilter = CSSFilterRenderer::create(const_cast<RenderElement&>(*renderer), m_filter, {
+    auto cssFilter = CSSFilterRenderer::create(const_cast<RenderElement&>(*renderer), m_filter, FilterGeometry {
             .referenceBox = sourceImageRect,
+            .objectBoundingBoxReferenceBox = sourceImageRect,
             .filterRegion = sourceImageRect,
+            .primitiveUserSpaceOffset = { },
             .scale = { 1, 1 },
         }, preferredFilterRenderingModes, renderingOptions, NullGraphicsContext());
     if (!cssFilter)

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
@@ -108,6 +108,12 @@ static std::optional<std::tuple<SVGFilterEffectGraph, FilterEffectGeometryMap>> 
 
         if (auto flags = effectElement->effectGeometryFlags()) {
             auto effectBoundaries = SVGLengthContext::resolveRectangle(contextElement, effectElement.get(), filter.primitiveUnits(), filter.referenceBox());
+            // For primitiveUnits=userSpaceOnUse, resolveRectangle ignores viewport.location and
+            // returns coordinates in raw user space. Translate into the inner filter's
+            // coordinate system. Zero for SVG-element-applied filters (rendering happens in
+            // user space); equals the box origin for CSS-referenced filters on HTML elements.
+            if (filter.primitiveUnits() == SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE)
+                effectBoundaries.move(toFloatSize(filter.primitiveUserSpaceOffset()));
             effectGeometryMap.add(*effect, FilterEffectGeometry(effectBoundaries, flags));
         }
 
@@ -320,10 +326,9 @@ RefPtr<FilterImage> SVGFilterRenderer::apply(const Filter&, FilterImage& sourceI
 
     // Per the SVG spec, standard inputs (SourceGraphic, SourceAlpha, etc.) use
     // the filter region as their default primitive subregion. The source image
-    // may come from an outer CSSFilterRenderer whose filter region is the
-    // element's bounding box, which is smaller than this SVG filter's region.
-    // Adjust the primitive subregion to match the SVG filter region so that
-    // downstream effects (e.g., feOffset) are not incorrectly clipped.
+    // may come from an outer CSSFilterRenderer whose filter region differs from
+    // this SVG filter's region. Re-tag the source's primitive subregion to
+    // match the SVG filter region so downstream effects aren't incorrectly clipped.
     if (RefPtr input = FilterImage::create(filterRegion(), sourceImage, results.allocator()))
         return apply(input.get(), results);
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7686,7 +7686,9 @@ class WebCore::FilterOperations {
 header: <WebCore/Filter.h>
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::FilterGeometry {
     WebCore::FloatRect referenceBox;
+    WebCore::FloatRect objectBoundingBoxReferenceBox;
     WebCore::FloatRect filterRegion;
+    WebCore::FloatPoint primitiveUserSpaceOffset;
     WebCore::FloatSize scale;
 }
 


### PR DESCRIPTION
#### da09244a3b8495e9b7b5e25dfc430801350d5739
<pre>
CSS reference filter with `filterUnits=&quot;userSpaceOnUse&quot;` should use the border box as the filter region
<a href="https://bugs.webkit.org/show_bug.cgi?id=315518">https://bugs.webkit.org/show_bug.cgi?id=315518</a>
<a href="https://rdar.apple.com/177891626">rdar://177891626</a>

Reviewed by NOBODY (OOPS!).

The geometry of SVG filters referenced from CSS is not well defined[1] in the spec[2] but
the behavior of other browsers is that if `filterUnits` is `userSpaceOnUse`, the reference
box for the SVG is the CSS border box; if it&apos;s `objectBoundingBox`, then the reference box
is the ink overflow bounds (which is WebKit&apos;s current behavior).

Fixing this requires two changes; first, we plumb both the border box, and the ink overflow
bounds through via `FilterGeometry`. Second, we have ensure that the coordinate systems of
the CSS filter chain, and the referenced SVG filters match; this is important, for example,
to get the correct offset for the SVG SourceGraphic. This is done via
`geometry.primitiveUserSpaceOffset`.

[1] <a href="https://github.com/w3c/csswg-drafts/issues/13964">https://github.com/w3c/csswg-drafts/issues/13964</a>
[2] <a href="https://drafts.csswg.org/filter-effects/#filter-region">https://drafts.csswg.org/filter-effects/#filter-region</a>

Tests: imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-001.html
       imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-002.html
       imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-003.html

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/reference-filter-geometry-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/reference-filter-geometry-002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/reference-filter-geometry-003-ref.html: Added.
* LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html:
* LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html:
* LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html:
* LayoutTests/ipc/invalid-feConvolveMatrix-crash.html:
* LayoutTests/ipc/invalid-svgfilter-expression-crash.html:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::createFilter const):
* Source/WebCore/platform/graphics/filters/Filter.h:
(WebCore::Filter::objectBoundingBoxReferenceBox const):
(WebCore::Filter::primitiveUserSpaceOffset const):
* Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp:
(WebCore::SourceGraphicSoftwareApplier::apply const):
* Source/WebCore/rendering/CSSFilterRenderer.cpp:
(WebCore::createReferenceFilter):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::setupFilters):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/RenderLayerFilters.h:
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGResourceContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::applyResource):
* Source/WebCore/style/values/images/kinds/StyleFilterImage.cpp:
(WebCore::Style::FilterImage::image const):
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp:
(WebCore::buildFilterEffectGraph):
(WebCore::SVGFilterRenderer::apply):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da09244a3b8495e9b7b5e25dfc430801350d5739

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174186 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122401 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38636 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128335 "Found 4 new test failures: css3/filters/effect-blur.html css3/filters/reference-filter-outsets.html css3/filters/svg-blur-filter-clipped.html svg/filters/feMerge-nodes-unite-outsets.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90329 "1 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108860 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29694 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28318 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21941 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176709 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29585 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27796 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136653 "Found 6 new test failures: css3/filters/effect-blur.html css3/filters/reference-filter-outsets.html css3/filters/svg-blur-filter-clipped.html imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-002.html imported/w3c/web-platform-tests/css/filter-effects/reference-filter-geometry-003.html svg/filters/feMerge-nodes-unite-outsets.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136595 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147887 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101702 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31877 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Passed layout tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24754 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37903 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110975 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37300 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2831 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37546 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37444 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->