### PR TITLE
WebGPU+WebXR on visionOS: setScissorRect unusable on XR projection layer

### DIFF
--- a/LayoutTests/http/tests/webgpu/scissor-test.html
+++ b/LayoutTests/http/tests/webgpu/scissor-test.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<!-- WebGPU + WebXR scissor test.
+
+     Draws a fullscreen rectangle directly in clip space (NDC) — no
+     projection, no view matrix, no parallax. The four corners are colored
+     so it's easy to read which part of the rectangle is being clipped:
+
+         red      green
+            +----+
+            |    |
+            +----+
+         blue    yellow
+
+     A scissor is applied to the LEFT HALF of subImage.viewport. With a
+     correctly-working scissor (and no parallax to confuse things), BOTH
+     eyes should see exactly the left half of the rectangle:
+
+         red     |
+            +----|        (green/yellow clipped, blue at bottom-left,
+            |    |         red at top-left)
+            +----|
+         blue    |
+-->
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no'>
+    <title>WebGPU+WebXR Scissor Test</title>
+    <style>
+      body { font-family: system-ui; background: #222; color: #eee; text-align: center; margin: 0; padding: 20px; }
+      button { font-size: 18px; padding: 12px 20px; }
+      pre { text-align: left; background: #111; padding: 10px; max-height: 240px; overflow: auto; }
+    </style>
+  </head>
+  <body>
+    <h1>Scissor Test — left half of screen</h1>
+    <button id='xr-button' disabled>Loading…</button>
+    <pre id='log'></pre>
+    <canvas id='webgpu_canvas' width='600' height='400' style='display:none'></canvas>
+    <script type='module'>
+      const log = (...args) => {
+        document.getElementById('log').textContent += args.join(' ') + '\n';
+        console.log(...args);
+      };
+
+      const SHADER = `
+        struct VertexOut {
+          @builtin(position) pos: vec4f,
+          @location(0) color: vec4f,
+        }
+
+        @vertex
+        fn vsMain(@builtin(vertex_index) i: u32) -> VertexOut {
+          // Fullscreen quad in clip space (NDC). No camera, no parallax.
+          // Two triangles, 6 vertices, triangle-list.
+          var pos = array<vec4f, 6>(
+            vec4f(-0.95,  0.95, 0.5, 1),  // 0 top-left
+            vec4f(-0.95, -0.95, 0.5, 1),  // 1 bottom-left
+            vec4f( 0.95,  0.95, 0.5, 1),  // 2 top-right
+            vec4f( 0.95,  0.95, 0.5, 1),  // 3 top-right
+            vec4f(-0.95, -0.95, 0.5, 1),  // 4 bottom-left
+            vec4f( 0.95, -0.95, 0.5, 1)   // 5 bottom-right
+          );
+          var color = array<vec4f, 6>(
+            vec4f(1, 0, 0, 1),  // top-left:     red
+            vec4f(0, 0, 1, 1),  // bottom-left:  blue
+            vec4f(0, 1, 0, 1),  // top-right:    green
+            vec4f(0, 1, 0, 1),  // top-right:    green
+            vec4f(0, 0, 1, 1),  // bottom-left:  blue
+            vec4f(1, 1, 0, 1)   // bottom-right: yellow
+          );
+          var out: VertexOut;
+          out.pos = pos[i];
+          out.color = color[i];
+          return out;
+        }
+
+        @fragment
+        fn fsMain(in: VertexOut) -> @location(0) vec4f {
+          return in.color;
+        }
+      `;
+
+      let xrButton = document.getElementById('xr-button');
+      let xrSession = null;
+      let xrRefSpace = null;
+      let device = null;
+      let pipeline = null;
+      let xrBinding = null;
+      let projectionLayer = null;
+      const colorFormat = 'bgra8unorm';
+      const depthFormat = 'depth24plus';
+
+      async function init() {
+        if (!navigator.xr) { xrButton.textContent = 'WebXR unavailable'; return; }
+        if (!navigator.gpu) { xrButton.textContent = 'WebGPU unavailable'; return; }
+        if (!('XRGPUBinding' in window)) { xrButton.textContent = 'XRGPUBinding unavailable'; return; }
+        if (!await navigator.xr.isSessionSupported('immersive-vr')) {
+          xrButton.textContent = 'immersive-vr unsupported';
+          return;
+        }
+
+        const adapter = await navigator.gpu.requestAdapter({ xrCompatible: true });
+        device = await adapter.requestDevice();
+        const module = device.createShaderModule({ code: SHADER });
+        pipeline = device.createRenderPipeline({
+          layout: 'auto',
+          vertex: { module, entryPoint: 'vsMain' },
+          fragment: { module, entryPoint: 'fsMain', targets: [{ format: colorFormat }] },
+          primitive: { topology: 'triangle-list' },
+          depthStencil: { format: depthFormat, depthWriteEnabled: true, depthCompare: 'always' },
+        });
+
+        xrButton.textContent = 'Enter VR';
+        xrButton.disabled = false;
+        xrButton.addEventListener('click', async () => {
+          if (!xrSession) {
+            const session = await navigator.xr.requestSession('immersive-vr', { requiredFeatures: ['webgpu'] });
+            await onSessionStarted(session);
+          } else {
+            xrSession.end();
+          }
+        });
+      }
+
+      async function onSessionStarted(session) {
+        xrSession = session;
+        xrButton.textContent = 'Exit VR';
+        session.addEventListener('end', () => { xrSession = null; xrButton.textContent = 'Enter VR'; });
+
+        xrBinding = new XRGPUBinding(session, device);
+        projectionLayer = xrBinding.createProjectionLayer({
+          colorFormat: xrBinding.getPreferredColorFormat(),
+          depthStencilFormat: depthFormat,
+        });
+        session.updateRenderState({ layers: [projectionLayer] });
+
+        xrRefSpace = await session.requestReferenceSpace('local');
+        session.requestAnimationFrame(onXRFrame);
+      }
+
+      let loggedOnce = false;
+      function onXRFrame(time, frame) {
+        const session = frame.session;
+        session.requestAnimationFrame(onXRFrame);
+
+        const pose = frame.getViewerPose(xrRefSpace);
+        if (!pose) return;
+
+        const encoder = device.createCommandEncoder();
+
+        for (let i = 0; i < pose.views.length; ++i) {
+          const view = pose.views[i];
+          const sub = xrBinding.getViewSubImage(projectionLayer, view);
+          const vp = sub.viewport;
+
+          if (!loggedOnce) {
+            log(`eye ${i}: vp=(${vp.x},${vp.y},${vp.width},${vp.height}) tex=${sub.colorTexture.width}x${sub.colorTexture.height}`);
+          }
+
+          const pass = encoder.beginRenderPass({
+            colorAttachments: [{
+              view: sub.colorTexture.createView(sub.getViewDescriptor()),
+              loadOp: 'clear',
+              clearValue: [0.15, 0.15, 0.15, 1],
+              storeOp: 'store',
+            }],
+            depthStencilAttachment: {
+              view: sub.depthStencilTexture.createView(sub.getViewDescriptor()),
+              depthLoadOp: 'clear',
+              depthClearValue: 1.0,
+              depthStoreOp: 'store',
+            },
+          });
+
+          pass.setViewport(vp.x, vp.y, vp.width, vp.height, 0, 1);
+          // SCISSOR TEST: clip to LEFT HALF of the viewport.
+          // With clip-space (NDC) geometry there is no parallax, so both
+          // eyes' composited displays should clip identically at the
+          // screen midpoint. Visible result per eye should be the LEFT
+          // half of the rectangle: red on top-left, blue on bottom-left.
+          //
+          // setViewport is in view space (sub.viewport coordinates).
+          // setScissorRect is in physical pixels of the render target,
+          // i.e. sub.colorTexture.width/.height. Each eye renders to its
+          // own slice that starts at (0,0) in physical pixels.
+          const halfTextureWidth = Math.floor(sub.colorTexture.width / 2);
+          pass.setScissorRect(0, 0, halfTextureWidth, sub.colorTexture.height);
+
+          pass.setPipeline(pipeline);
+          pass.draw(6, 1);
+          pass.end();
+        }
+
+        device.queue.submit([encoder.finish()]);
+        loggedOnce = true;
+      }
+
+      init();
+    </script>
+  </body>
+</html>

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -1575,10 +1575,27 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
 void RenderPassEncoder::setScissorRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height)
 {
     RETURN_IF_FINISHED();
+
     if (sumOverflows<uint32_t>(x, width) || x + width > m_renderTargetWidth || sumOverflows<uint32_t>(y, height) || y + height > m_renderTargetHeight) {
         makeInvalid();
         return;
     }
+
+    if (id<MTLRasterizationRateMap> map = m_rasterizationRateMap) {
+        MTLSize physSize = [map physicalSizeForLayer:0];
+        MTLCoordinate2D scissorStart = [map mapPhysicalToScreenCoordinates:MTLCoordinate2DMake(x, y) forLayer:0];
+        MTLCoordinate2D scissorEnd = [map mapPhysicalToScreenCoordinates:MTLCoordinate2DMake(std::min<float>(physSize.width, x + width), std::min<float>(physSize.height, y + height)) forLayer:0];
+        MTLSize screenSize = [map screenSize];
+        m_scissorRect = MTLScissorRect {
+            static_cast<NSUInteger>(roundf(scissorStart.x)),
+            static_cast<NSUInteger>(roundf(scissorStart.y)),
+            std::min(screenSize.width, static_cast<NSUInteger>(roundf(scissorEnd.x - scissorStart.x))),
+            std::min(screenSize.height, static_cast<NSUInteger>(roundf(scissorEnd.y - scissorStart.y))),
+        };
+
+        return;
+    }
+
     m_scissorRect = MTLScissorRect { x, y, width, height };
 }
 


### PR DESCRIPTION
#### eda478cddb5d40012b333ffcbf0b71eb200c49b0
<pre>
WebGPU+WebXR on visionOS: setScissorRect unusable on XR projection layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=315274">https://bugs.webkit.org/show_bug.cgi?id=315274</a>
<a href="https://rdar.apple.com/177664498">rdar://177664498</a>

Reviewed by Dan Glastonbury.

setScissorRect needs to map from render target dimensions to
screen space.

Test: http/tests/webgpu/scissor-test.html

* LayoutTests/http/tests/webgpu/scissor-test.html: Added.
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setScissorRect):

Canonical link: <a href="https://commits.webkit.org/314005@main">https://commits.webkit.org/314005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92d2b1849884ae00b286d333630d20f4b6d586a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121599 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/752cd376-6327-49b6-899f-708eba200d74) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127692 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89869 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f503e61-31e6-4629-a4b9-1045ccebd4c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108237 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0dd8473d-49b5-437d-9e97-a8183c2dcc7d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29036 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27660 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21140 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138938 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175902 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28724 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136003 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135972 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36719 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147235 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100669 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31282 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24091 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37098 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110142 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36494 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2148 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36744 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36644 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->