### PR TITLE
[Win] Garden seven new layout-test failures on main

### DIFF
--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -439,6 +439,14 @@ fast/text/user-installed-fonts/shadow-postscript-family.html [ Skip ]
 fast/text/user-installed-fonts/shadow-postscript.html [ Skip ]
 fast/text/user-installed-fonts/shadow.html [ Skip ]
 
+# Relies on local(Helvetica) / local(Helvetica Bold) / local(Helvetica Italic) resolving synchronously
+# to drive a re-entrant CSSFontFace status transition. Helvetica is not installed on Windows by default,
+# so the synchronous local() resolution path that exercises the UAF regression doesn't execute as
+# intended; the test is unreliable on the Windows port (see also fast/css/font-face-multiple-faces.html
+# which is flaky on Windows for the same Helvetica-availability reason). Skip rather than mark as
+# Failure so a potential crash on the Windows font path cannot take down the whole test run.
+fast/text/fontface-setstatus-crash.html [ Skip ]
+
 # testRunner.dumpPolicyDelegateCallbacks is not a function
 loader/navigation-policy/should-open-external-urls [ Skip ]
 
@@ -760,6 +768,12 @@ http/tests/inspector/network/xhr-response-body.html [ Failure ]
 
 http/tests/inspector/network/intercept-request-main-resource.html [ Skip ] # Timeout
 
+# Cross-origin iframe response-body retrieval relies on Site Isolation (separate
+# WebProcess per origin) and the BackendResourceDataStore IPC path added in
+# 313753@main. The Windows port does not yet support Site Isolation
+# (see http/tests/site-isolation skip below), so these tests cannot pass.
+http/tests/inspector/network/cross-origin-iframe-get-response-body-subresources.html [ Skip ]
+
 http/tests/loading/hidpi-preload-picture-sizes.html [ Failure ]
 http/tests/loading/oauth.html [ Failure ]
 http/tests/loading/post-in-iframe-with-back-navigation.html [ Failure ]
@@ -987,6 +1001,10 @@ webkit.org/b/185254 http/tests/xmlhttprequest/onloadend-event-after-error.html [
 webkit.org/b/185254 http/tests/xmlhttprequest/onloadend-event-after-sync-requests.html [ DumpJSConsoleLogInStdErr ]
 webkit.org/b/185254 http/tests/xmlhttprequest/response-access-on-error.html [ DumpJSConsoleLogInStdErr ]
 webkit.org/b/185254 http/tests/xmlhttprequest/state-after-network-error.html [ DumpJSConsoleLogInStdErr ]
+
+# Authorization header is not preserved on same-origin redirects on the Windows curl/Apache port.
+# Same underlying issue as the xmlhttprequest auth tests below (basic-auth-*, cross-origin-authorization, re-login, logout, ...).
+http/tests/fetch/fetch-redirect-same-origin-authorization.html [ Skip ]
 
 http/tests/xmlhttprequest/abort-should-cancel-load.html [ Failure ]
 http/tests/xmlhttprequest/access-control-basic-allow-list-request-headers.html [ Failure ]
@@ -1340,6 +1358,11 @@ webkit.org/b/227753 fast/dom/Window/post-message-large-array-buffer-should-not-c
 fast/editing/recursive-reapply-edit-command-crash.html [ Pass Failure ]
 
 fast/dom/HTMLLinkElement/link-stylesheet-load-once.html [ Failure ]
+# Same root cause as link-stylesheet-load-once above: introduced by 313704@main, which
+# replaced testRunner.dumpResourceLoadCallbacks with a UI-process WKPageResourceLoadClient.
+# The Windows curl-based network stack produces different resource-load callback output
+# (URL formatting / event ordering) than the expected mac-style NSURLRequest output.
+fast/dom/HTMLLinkElement/link-preload-load-once.html [ Failure ]
 fast/dom/Window/window-focus-self.html [ Failure ]
 fast/dom/Window/window-resize-and-move-arguments.html [ Failure ]
 fast/dom/Window/window-resize.html [ Failure ]
@@ -4340,6 +4363,10 @@ css3/blending/blend-mode-parent-of-composited-blended-has-layer.html [ Skip ]
 css3/blending/blend-mode-with-accelerated-sibling.html [ Skip ]
 css3/blending/blend-mode-with-composited-descendant-should-have-layer.html [ Skip ]
 css3/filters/backdrop/resource-use-change-size-from-zero.html [ Skip ]
+# Backdrop Root subtree painting fix at 313560@main was only landed in SkiaCompositingLayer
+# (USE(COORDINATED_GRAPHICS) && USE(SKIA)); the Windows WC compositor (USE_GRAPHICS_LAYER_WC)
+# still paints subsequent elements into the Backdrop Root Image, so this ref test fails.
+css3/filters/backdrop/backdrop-blur-and-subsequent-elements.html [ Skip ]
 css3/filters/filtered-compositing-descendant.html [ Skip ]
 
 
@@ -4691,3 +4718,10 @@ webkit.org/b/312135 fast/animation/request-video-frame-callback-in-isolated-worl
 webkit.org/b/312924 fast/webcodecs/resetting-audio-decoder-with-zero-size-crash.html [ Skip ]
 
 fast/message-channel/transfer-mediastreamtrack.html [ Skip ]
+
+# Cross-origin isolation (COOP/COEP) is not fully implemented on the Windows port,
+# so SharedArrayBuffer / WebAssembly.Memory{shared:true} is not exposed in
+# cross-origin-isolated contexts. The glib ports skip the same wasm/serialization/memory
+# tests for the same reason (see webkit.org/b/268068).
+imported/w3c/web-platform-tests/wasm/serialization/memory/messageport-via-sharedworker-success.tentative.https.html [ Skip ]
+imported/w3c/web-platform-tests/wasm/serialization/memory/window-success.tentative.https.html [ Skip ]


### PR DESCRIPTION
#### c605ad5f9d94b76ed95090bdd17d05e945ca9f0d
<pre>
[Win] Garden seven new layout-test failures on main
<a href="https://bugs.webkit.org/show_bug.cgi?id=315520">https://bugs.webkit.org/show_bug.cgi?id=315520</a>

Unreviewed test gardening.

Each of these tests was recently introduced or recently changed in a way
that interacts poorly with the Windows port&apos;s current capabilities. Adding
TestExpectations entries with the investigated root cause for each, so a
follow-up can file bugs and (where applicable) implement the underlying
support.

* LayoutTests/platform/win/TestExpectations:

  - css3/filters/backdrop/backdrop-blur-and-subsequent-elements.html [ Skip ]
    Introduced by 313560@main, which fixed BackdropRoot subtree painting only
    in SkiaCompositingLayer (USE(COORDINATED_GRAPHICS) &amp;&amp; USE(SKIA)). The
    Windows port uses Skia + WC (USE_GRAPHICS_LAYER_WC), which never received
    the analogous fix.

  - fast/dom/HTMLLinkElement/link-preload-load-once.html [ Failure ]
    Same root cause as the sibling link-stylesheet-load-once.html (already
    [ Failure ] on Win): 313704@main rewrote dumpResourceLoadCallbacks to use
    mac-style NSURLRequest/NSURLResponse formatting via a UI-process
    WKPageResourceLoadClient. The Windows curl-based stack produces different
    callback output. Failure (not Skip) so crash/timeout detection stays live.

  - fast/text/fontface-setstatus-crash.html [ Skip ]
    Added by 1-day-old security cherry-pick. Relies on local(Helvetica)
    resolving synchronously to drive a re-entrant CSSFontFace status
    transition; Helvetica is not installed on Windows. Skip rather than
    Failure so a potential crash through the same path doesn&apos;t break the run.

  - http/tests/inspector/network/cross-origin-iframe-get-response-body-subresources.html [ Skip ]
    Introduced by 313753@main alongside Site Isolation&apos;s
    BackendResourceDataStore IPC path. The Windows port does not yet support
    Site Isolation (http/tests/site-isolation is already Skipped).

  - http/tests/fetch/fetch-redirect-same-origin-authorization.html [ Skip ]
    Authorization header is not preserved on same-origin redirects on the
    Windows curl/Apache port. Same underlying issue as the existing
    xmlhttprequest auth-tests cluster (basic-auth-*, cross-origin-authorization,
    re-login, logout, ...).

  - imported/.../wasm/serialization/memory/messageport-via-sharedworker-success.tentative.https.html [ Skip ]
  - imported/.../wasm/serialization/memory/window-success.tentative.https.html [ Skip ]
    Cross-origin isolation (COOP/COEP) is not fully implemented on the
    Windows port, so SharedArrayBuffer / WebAssembly.Memory{shared:true}
    is not exposed in cross-origin-isolated contexts. The glib ports skip
    the same wasm/serialization/memory tests for the same reason
    (see webkit.org/b/268068).

Canonical link: <a href="https://commits.webkit.org/313853@main">https://commits.webkit.org/313853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2856037243f6050319835e9d4abfd3b4c1dbcf7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121603 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37836 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89872 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29992 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147728 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108242 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29039 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27664 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21144 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138941 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175906 "Built successfully") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/27112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/136008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37506 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135977 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36627 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147239 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100677 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31291 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24095 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37102 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36498 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2152 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->