### PR TITLE
[AutoFill Debugging] Omit URLs for links that navigate to the current page

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
@@ -19,6 +19,7 @@ root
 		link url=example.com/2 'Plain link (2)'
 		link url=example.com/3 'Plain link (3)'
 		link url=/test/cat.png 'Local file'
+		link 'Self link'
 	section
 		image src=image alt='SVG data URL'
 		image src=image2 alt='PNG data URL'
@@ -50,6 +51,7 @@ root
 [Plain link \(2\)](example.com/2)
 [Plain link \(3\)](example.com/3)
 [Local file](/test/cat.png)
+[Self link](/text-extraction/debug-text-extraction-shorten-urls.html)
 
 ![SVG data URL](image)
 ![PNG data URL](image2)

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
@@ -50,6 +50,7 @@ a, img {
         <a href="https://example.com/7e61b3f7-8d81-4225-8d68-f646f977ce33?cid=63e3d9fb0bf5">Plain link (2)</a>
         <a href="https://example.com/b3029797-1fb8-4edf-97bd-63e3d9fb0bf5?cid=4edf97bd">Plain link (3)</a>
         <a href="file:///Users/test/089bac2e873e45608912886c4e028584/cat.png">Local file</a>
+        <a href="debug-text-extraction-shorten-urls.html">Self link</a>
     </section>
     <section class="test-section" title="Images">
         <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Ccircle cx='50' cy='50' r='40' fill='red'/%3E%3C/svg%3E" alt="SVG data URL">

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -604,6 +604,14 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
                     return { WTF::move(url) };
 
                 auto shortenedString = shortenedURLString(url);
+                bool linksToCurrentURL = [&] {
+                    auto urlAsView = [](const URL& url) -> StringView {
+                        if (url.hasFragmentIdentifier() && url.fragmentIdentifier().isEmpty())
+                            return url.viewWithoutFragmentIdentifier();
+                        return url.string();
+                    };
+                    return urlAsView(url) == urlAsView(protect(element->document())->url());
+                }();
 
                 String target;
                 if (RefPtr anchor = dynamicDowncast<HTMLAnchorElement>(*element))
@@ -612,7 +620,8 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
                 return { LinkItemData {
                     WTF::move(target),
                     WTF::move(url),
-                    WTF::move(shortenedString)
+                    WTF::move(shortenedString),
+                    linksToCurrentURL,
                 } };
             }
         }

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -142,6 +142,7 @@ struct LinkItemData {
     String target;
     URL completedURL;
     String shortenedURLString;
+    bool linksToCurrentURL { false };
 };
 
 struct IFrameData {

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -1544,7 +1544,8 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
                 parts.append("link"_s);
                 parts.appendVector(partsForItem(item, aggregator, includeRectForParentItem));
 
-                if (!linkData.completedURL.isEmpty() && aggregator.includeURLs())
+                bool omitSelfLinkURL = aggregator.useTextTreeOutput() && aggregator.shortenURLs() && linkData.linksToCurrentURL;
+                if (!linkData.completedURL.isEmpty() && aggregator.includeURLs() && !omitSelfLinkURL)
                     parts.append(makeString("url="_s, quoteValue(aggregator.stringForURL(linkData), streamlined)));
             }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6830,6 +6830,7 @@ header: <WebCore/TextExtractionTypes.h>
     String target;
     URL completedURL;
     String shortenedURLString;
+    bool linksToCurrentURL;
 };
 
 header: <WebCore/TextExtractionTypes.h>


### PR DESCRIPTION
#### 7c4e6fd92a2f21eb7ab7e22130ce07ceab3795f7
<pre>
[AutoFill Debugging] Omit URLs for links that navigate to the current page
<a href="https://bugs.webkit.org/show_bug.cgi?id=315523">https://bugs.webkit.org/show_bug.cgi?id=315523</a>
<a href="https://rdar.apple.com/177900186">rdar://177900186</a>

Reviewed by Abrar Rahman Protyasha.

When shortening URLs, omit URLs for links if they simply redirect to the same webpage.

* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::addPartsForItem):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/313866@main">https://commits.webkit.org/313866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f88e27ed0c73f5859e33d69cb4976b87822b5baa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173393 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121616 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc956ef1-e879-4abe-bcb3-43d012f7435e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166233 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127708 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89884 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca23eb68-e678-47f7-9a8e-6ae4a8f32f56) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147739 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108253 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de05ada9-5872-4474-8623-441d891cc749) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29051 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27676 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21157 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175919 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28741 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136019 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37519 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31796 "Found 1 new test failure: http/tests/storage/setItem-and-reload.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135988 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36636 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147250 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100703 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24106 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37115 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110159 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36511 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2164 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36761 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36661 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->