### PR TITLE
REGRESSION(310262@main): [lldb] dump_class_layout_unittest.serial_test_InheritsFromClassWithPaddedBitfields fails constantly across all platforms.

### DIFF
--- a/Tools/lldb/dump_class_layout_unittest.py
+++ b/Tools/lldb/dump_class_layout_unittest.py
@@ -29,6 +29,8 @@ import importlib.machinery
 import importlib.util
 import lldb
 import os
+import platform
+import subprocess
 import sys
 import unittest
 from unittest.mock import call, MagicMock, patch
@@ -48,7 +50,6 @@ _spec = importlib.util.spec_from_file_location(
 dump_class_layout_script = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(dump_class_layout_script)
 
-# Build for x86_64.
 # Run these tests with xcrun python3 Tools/Scripts/test-lldb-webkit
 # Run a single test with e.g. xcrun python3 Tools/Scripts/test-lldb-webkit --debug  --no-build --verbose dump_class_layout_unittest.TestDumpClassLayout.serial_test_MemberHasBitfieldPadding
 # Compare with clang's output: clang++ -Xclang -fdump-record-layouts DumpClassLayoutTesting.cpp
@@ -61,6 +62,27 @@ def destroy_cached_debug_session():
     debugger_instance = None
 
 
+def _select_architecture(binary_path):
+    """Return the architecture slice to load for layout inspection.
+    Prefer the host architecture so the test exercises the binary's primary
+    slice; fall back to whatever is present in the universal binary."""
+    try:
+        archs = subprocess.check_output(
+            ['/usr/bin/lipo', '-archs', binary_path],
+            stderr=subprocess.DEVNULL,
+        ).decode('utf-8', errors='replace').split()
+    except (OSError, subprocess.CalledProcessError):
+        return 'x86_64'
+    host_machine = platform.machine()
+    if host_machine == 'arm64':
+        for arch in ('arm64e', 'arm64'):
+            if arch in archs:
+                return arch
+    if host_machine in archs:
+        return host_machine
+    return archs[0] if archs else 'x86_64'
+
+
 @unittest.skipUnless(SystemHost.get_default().platform.is_mac(), "macOS only")
 class TestDumpClassLayout(unittest.TestCase):
     @classmethod
@@ -69,7 +91,7 @@ class TestDumpClassLayout(unittest.TestCase):
         if not debugger_instance:
             lldbWebKitTesterExecutable = str(os.environ['LLDB_WEBKIT_TESTER_EXECUTABLE'])
 
-            architecture = 'x86_64'
+            architecture = _select_architecture(lldbWebKitTesterExecutable)
             debugger_instance = LLDBDebuggerInstance(lldbWebKitTesterExecutable, architecture)
             if not debugger_instance:
                 print('Failed to create lldb debugger instance for %s' % (lldbWebKitTesterExecutable))
@@ -371,7 +393,35 @@ Padding percentage: 61.98 %"""
         self.assertEqual(EXPECTED_RESULT, actual_layout.as_string())
 
     def serial_test_InheritsFromClassWithPaddedBitfields(self):
-        EXPECTED_RESULT = """  +0 < 24> InheritsFromClassWithPaddedBitfields
+        # x86_64 reports `dsize=10` for ClassWithPaddedBitfields and the
+        # derived bitfield reuses the base's tail padding at +10, giving a
+        # 16-byte layout.  arm64/arm64e report `dsize=16` (no exposed tail
+        # padding), so `derivedBitfield` lands at +16 and the class is
+        # 24 bytes.
+        if debugger_instance.architecture == 'x86_64':
+            EXPECTED_RESULT = """  +0 < 16> InheritsFromClassWithPaddedBitfields
+  +0 < 16>     ClassWithPaddedBitfields ClassWithPaddedBitfields
+  +0 <  1>         bool boolMember
+  +1 < :1>         unsigned int bitfield1 : 1
+  +1 < :1>         bool bitfield2 : 1
+  +1 < :2>         unsigned int bitfield3 : 2
+  +1 < :1>         unsigned int bitfield4 : 1
+  +1 < :2>         unsigned long bitfield5 : 2
+  +1 < :1>         <UNUSED BITS: 1 bit>
+  +2 <  1>         <PADDING: 1 bytes>
+  +4 <  4>         int intMember
+  +8 < :1>         unsigned int bitfield7 : 1
+  +8 < :9>         unsigned int bitfield8 : 9
+  +9 < :1>         bool bitfield9 : 1
+  +9 < :5>         <UNUSED BITS: 5 bits>
+ +10 < :1>     bool derivedBitfield : 1
+ +10 < :7>     <UNUSED BITS: 7 bits>
+ +11 <  5>     <PADDING: 5 bytes>
+Total byte size: 16
+Total pad bytes: 6
+Padding percentage: 42.97 %"""
+        else:
+            EXPECTED_RESULT = """  +0 < 24> InheritsFromClassWithPaddedBitfields
   +0 < 16>     ClassWithPaddedBitfields ClassWithPaddedBitfields
   +0 <  1>         bool boolMember
   +1 < :1>         unsigned int bitfield1 : 1

--- a/Tools/lldb/lldbWebKitTester/DumpClassLayoutTesting.cpp
+++ b/Tools/lldb/lldbWebKitTester/DumpClassLayoutTesting.cpp
@@ -492,7 +492,24 @@ class MemberHasBitfieldPadding {
 };
 
 /*
-*** Dumping AST Record Layout
+*** Dumping AST Record Layout (x86_64)
+         0 | class InheritsFromClassWithPaddedBitfields
+         0 |   class ClassWithPaddedBitfields (base)
+         0 |     _Bool boolMember
+     1:0-0 |     unsigned int bitfield1
+     1:1-1 |     _Bool bitfield2
+     1:2-3 |     unsigned int bitfield3
+     1:4-4 |     unsigned int bitfield4
+     1:5-6 |     unsigned long bitfield5
+         4 |     int intMember
+     8:0-0 |     unsigned int bitfield7
+     8:1-9 |     unsigned int bitfield8
+     9:2-2 |     _Bool bitfield9
+    10:0-0 |   _Bool derivedBitfield
+           | [sizeof=16, dsize=11, align=8,
+           |  nvsize=11, nvalign=8]
+
+*** Dumping AST Record Layout (arm64/arm64e)
          0 | class InheritsFromClassWithPaddedBitfields
          0 |   class ClassWithPaddedBitfields (base)
          0 |     _Bool boolMember


### PR DESCRIPTION
#### 80c1e5f70b782e8dbd5c190e9b90e91fc81e4579
<pre>
REGRESSION(310262@main): [lldb] dump_class_layout_unittest.serial_test_InheritsFromClassWithPaddedBitfields fails constantly across all platforms.
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=315215">https://bugs.webkit.org/show_bug.cgi?id=315215</a>&gt;
&lt;<a href="https://rdar.apple.com/177546068">rdar://177546068</a>&gt;

Reviewed by Simon Fraser.

`ClassWithPaddedBitfields` has a different exposed tail-padding profile
between architectures: x86_64 reports `dsize=10` and lets
`derivedBitfield` reuse six bytes of the base&apos;s tail padding at +10
(16-byte derived class), while arm64/arm64e report `dsize=16` and place
`derivedBitfield` at +16 (24-byte derived class).  The previous expected
output assumed the arm64 layout, but `setUpClass` pinned `&apos;x86_64&apos;`, so
EWS bots loaded the x86_64 slice of the universal `lldbWebKitTester`
binary and saw the 16-byte layout.  Local engineering builds using
`ONLY_ACTIVE_ARCH=YES` produced an arm64-only binary, which let lldb
fall back to arm64 and report the 24-byte layout that matched the
hardcoded expected output.

Detect the host architecture via `/usr/bin/lipo -archs` and prefer
`arm64e` on Apple silicon, falling back to whatever slice is present.
Branch the expected output for
`serial_test_InheritsFromClassWithPaddedBitfields` on the selected
architecture.  The other padded-bitfield tests need no change because
their layouts are identical across architectures.

* Tools/lldb/dump_class_layout_unittest.py:
(_select_architecture): Add.
(TestDumpClassLayout.setUpClass):
- Pick the architecture to use for the tests.
(TestDumpClassLayout.serial_test_InheritsFromClassWithPaddedBitfields):
- Check the expected results based on the architecture.
* Tools/lldb/lldbWebKitTester/DumpClassLayoutTesting.cpp:
(InheritsFromClassWithPaddedBitfields):
- Add comment about layouts on different architectures.

Canonical link: <a href="https://commits.webkit.org/313939@main">https://commits.webkit.org/313939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43a41ee3a4f2b99fcd2ee8e6037426a2cf84d8b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121618 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127710 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89886 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167325 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30006 "Found 1 new test failure: media/track/track-in-band-chapters.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108255 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29053 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27678 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21159 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175921 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136020 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37521 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31798 "Found 1 new test failure: http/tests/storageAccess/aggregate-sorted-data-with-storage-access.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135989 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147251 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100705 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25056 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31302 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24107 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37117 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36513 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2165 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36763 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36663 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->