### PR TITLE
[regression] feGaussianBlur in filter is not applied if the stdDeviation contains a 0 in the pair

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feGaussianBlur-stdDeviation-axis-zero-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feGaussianBlur-stdDeviation-axis-zero-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<title>feGaussianBlur: blur is applied along the non-zero axis when stdDeviation is "0 X" or "X 0" - reference</title>
+<link rel="help" href="https://drafts.csswg.org/filter-effects-1/#element-attrdef-fegaussianblur-stddeviation">
+<style>body { margin: 0; background: white; }</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <defs>
+    <filter id="blurY" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="0.0001 5"/>
+    </filter>
+    <filter id="blurX" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="5 0.0001"/>
+    </filter>
+  </defs>
+  <rect x="20" y="25" width="50" height="50" fill="green" filter="url(#blurY)"/>
+  <rect x="120" y="25" width="50" height="50" fill="green" filter="url(#blurX)"/>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feGaussianBlur-stdDeviation-axis-zero-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feGaussianBlur-stdDeviation-axis-zero-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<title>feGaussianBlur: blur is applied along the non-zero axis when stdDeviation is "0 X" or "X 0" - reference</title>
+<link rel="help" href="https://drafts.csswg.org/filter-effects-1/#element-attrdef-fegaussianblur-stddeviation">
+<style>body { margin: 0; background: white; }</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <defs>
+    <filter id="blurY" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="0.0001 5"/>
+    </filter>
+    <filter id="blurX" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="5 0.0001"/>
+    </filter>
+  </defs>
+  <rect x="20" y="25" width="50" height="50" fill="green" filter="url(#blurY)"/>
+  <rect x="120" y="25" width="50" height="50" fill="green" filter="url(#blurX)"/>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feGaussianBlur-stdDeviation-axis-zero.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feGaussianBlur-stdDeviation-axis-zero.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<title>feGaussianBlur: blur is applied along the non-zero axis when stdDeviation is "0 X" or "X 0"</title>
+<link rel="help" href="https://drafts.csswg.org/filter-effects-1/#element-attrdef-fegaussianblur-stddeviation">
+<link rel="match" href="feGaussianBlur-stdDeviation-axis-zero-ref.html">
+<meta name="assert" content="When stdDeviation has 0 in only one of X or Y, the blur is applied only along the axis with the non-zero value.">
+<meta name="fuzzy" content="maxDifference=0-130;totalPixels=0-1500">
+<style>body { margin: 0; background: white; }</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <defs>
+    <filter id="blurY" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="0 5"/>
+    </filter>
+    <filter id="blurX" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="5 0"/>
+    </filter>
+  </defs>
+  <rect x="20" y="25" width="50" height="50" fill="green" filter="url(#blurY)"/>
+  <rect x="120" y="25" width="50" height="50" fill="green" filter="url(#blurX)"/>
+</svg>
+</html>

--- a/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
@@ -442,7 +442,7 @@ bool FEGaussianBlurSoftwareApplier::apply(const Filter& filter, std::span<const 
     input->copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
 
     auto stdDeviation = m_effect->effectiveStdDeviation(filter.renderingOptions());
-    if (stdDeviation.isEmpty())
+    if (!stdDeviation.width() && !stdDeviation.height())
         return true;
 
     auto kernelSize = m_effect->calculateKernelSize(filter, stdDeviation);


### PR DESCRIPTION
#### 19ba11bf04d0e35a1f9fa887d7608a96b58fefc2
<pre>
[regression] feGaussianBlur in filter is not applied if the stdDeviation contains a 0 in the pair
<a href="https://bugs.webkit.org/show_bug.cgi?id=315522">https://bugs.webkit.org/show_bug.cgi?id=315522</a>
<a href="https://rdar.apple.com/177906905">rdar://177906905</a>

Reviewed by Dan Glastonbury.

Fix a regression introduced by <a href="https://webkit.org/b/315118">https://webkit.org/b/315118</a>
FloatSize::isEmpty() is width &lt;= 0 || height &lt;= 0 (FloatSize.h:73),
so stdDeviation=&quot;0 5&quot; and &quot;5 0&quot; was now bypassing the blur entirely.

Re-introducing the check on width and height and adding a WPT test case
to catch the regression next time.

Tests: imported/w3c/web-platform-tests/css/filter-effects/feGaussianBlur-stdDeviation-axis-zero.html
       imported/w3c/web-platform-tests/css/filter-effects/feGaussianBlur-stdDeviation-axis-zero-ref.html

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feGaussianBlur-stdDeviation-axis-zero-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feGaussianBlur-stdDeviation-axis-zero-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feGaussianBlur-stdDeviation-axis-zero.html: Added.
* Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp:
(WebCore::FEGaussianBlurSoftwareApplier::apply const):

Canonical link: <a href="https://commits.webkit.org/313874@main">https://commits.webkit.org/313874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a228d03a1ecbc853b7d83a0f369b937dc7145562

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173436 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121659 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8a33d31-4cb8-48de-b4d5-3bd128b3ae96) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127741 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89916 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26b0b357-b227-4f1f-883e-dbc5385353ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108286 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0bf9187-67e2-41d1-a8df-89ec24bb2da8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29083 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27711 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21200 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175962 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28785 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136054 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136022 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/36644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147284 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100772 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25024 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31333 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24140 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37158 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110202 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36554 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2198 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36804 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->