### PR TITLE
[JSC] Allow RISCV64 offlineasm local labels for pcrtoaddr and call

### DIFF
--- a/Source/JavaScriptCore/offlineasm/riscv64.rb
+++ b/Source/JavaScriptCore/offlineasm/riscv64.rb
@@ -467,7 +467,7 @@ def riscv64LowerAddressLoads(list)
                 riscv64ValidateOperands(node.operands, [LabelReference, RegisterID])
                 newList << Instruction.new(node.codeOrigin, "rv_la", node.operands)
             when "pcrtoaddr"
-                riscv64ValidateOperands(node.operands, [LabelReference, RegisterID])
+                riscv64ValidateOperands(node.operands, [LabelReference, RegisterID], [LocalLabelReference, RegisterID])
                 newList << Instruction.new(node.codeOrigin, "rv_lla", node.operands)
             else
                 newList << node
@@ -600,7 +600,7 @@ def riscv64LowerOperation(list)
         case riscv64OperandTypes(node.operands)
         when [RegisterID]
             callOpcode = "jalr"
-        when [LabelReference]
+        when [LabelReference], [LocalLabelReference]
             callOpcode = "call"
         else
             riscv64RaiseMismatchedOperands(node.operands)
@@ -1589,7 +1589,7 @@ class Instruction
             riscv64ValidateOperands(operands, [LabelReference], [LocalLabelReference])
             $asm.puts "#{rvop(opcode)} #{operands[0].asmLabel}"
         when /^rv_(la|lla)$/
-            riscv64ValidateOperands(operands, [LabelReference, RegisterID])
+            riscv64ValidateOperands(operands, [LabelReference, RegisterID], [LocalLabelReference, RegisterID])
             $asm.puts "#{rvop(opcode)} #{operands[1].riscv64Operand}, #{operands[0].asmLabel}"
         when "rv_mv"
             riscv64ValidateOperands(operands, [RegisterID, RegisterID])


### PR DESCRIPTION
#### 7c85338f10b6da6a6dfc77c32e5360170c058808
<pre>
[JSC] Allow RISCV64 offlineasm local labels for pcrtoaddr and call
<a href="https://bugs.webkit.org/show_bug.cgi?id=315539">https://bugs.webkit.org/show_bug.cgi?id=315539</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=271371">https://bugs.webkit.org/show_bug.cgi?id=271371</a>

Reviewed by NOBODY (OOPS!).

RISCV64 already supports emitting local labels for generated branch-like operations, but some earlier lowering checks only accepted ordinary LabelReference operands. Allow LocalLabelReference through pcrtoaddr, call, and rv_lla validation so lowering and emission agree for local control-flow labels.

No new tests. Verified with a Ruby lowering probe for LocalLabelReference operands passed to pcrtoaddr and call.

* Source/JavaScriptCore/offlineasm/riscv64.rb:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c85338f10b6da6a6dfc77c32e5360170c058808

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121626 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127718 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89893 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108263 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29061 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27686 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21167 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156525 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175929 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25266 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136029 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135998 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147260 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100718 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31312 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24116 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196777 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110169 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51684 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36521 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2174 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36771 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->