### PR TITLE
[JSC] Lower RISCV64 offlineasm transfer instructions

### DIFF
--- a/Source/JavaScriptCore/offlineasm/riscv64.rb
+++ b/Source/JavaScriptCore/offlineasm/riscv64.rb
@@ -570,6 +570,25 @@ def riscv64LowerOperation(list)
         newList << Instruction.new(node.codeOrigin, "rv_s#{suffix}", node.operands)
     end
 
+    def emitTransferOperation(newList, node, size)
+        riscv64ValidateOperands(node.operands, [Address, Address])
+
+        case size
+        when :i
+            loadSuffix = "wu"
+            storeSuffix = "w"
+        when :p, :q
+            loadSuffix = "d"
+            storeSuffix = "d"
+        else
+            raise "Invalid size #{size}"
+        end
+
+        tmp = Tmp.new(node.codeOrigin, :gpr)
+        newList << Instruction.new(node.codeOrigin, "rv_l#{loadSuffix}", [node.operands[0], tmp])
+        newList << Instruction.new(node.codeOrigin, "rv_s#{storeSuffix}", [tmp, node.operands[1]])
+    end
+
     def emitMove(newList, node)
         case riscv64OperandTypes(node.operands)
         when [RegisterID, RegisterID]
@@ -852,6 +871,8 @@ def riscv64LowerOperation(list)
                 emitLoadOperation(newList, node, $1.to_sym)
             when /^store(b|h|i|p|q)$/
                 emitStoreOperation(newList, node, $1.to_sym)
+            when /^transfer(i|p|q)$/
+                emitTransferOperation(newList, node, $1.to_sym)
             when "move"
                 emitMove(newList, node)
             when "jmp"


### PR DESCRIPTION
#### f15e518aaa85fbb85d7852b2c629f2c3efe60c64
<pre>
[JSC] Lower RISCV64 offlineasm transfer instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=315540">https://bugs.webkit.org/show_bug.cgi?id=315540</a>

Reviewed by NOBODY (OOPS!).

RISCV64 lowers load and store operations, but does not lower the transfer instructions used by shared LLInt/IPInt offlineasm. Lower transferi, transferp, and transferq as memory-to-memory copies through a temporary GPR, matching the other native backends.

transferi copies a 32-bit slot with lwu followed by sw. transferp and transferq both copy 64-bit slots on RISCV64, so they use ld followed by sd.

No new tests. Verified with this Ruby lowering probe:

    ruby -I Source/JavaScriptCore/offlineasm -e &apos;require &quot;ast&quot;; require &quot;opt&quot;; require &quot;riscv64&quot;; CodeOrigin = Struct.new(:labelStringExtension); co = CodeOrigin.new(&quot;probe_1&quot;); base = RegisterID.forName(co, &quot;t0&quot;); src = Address.new(co, base, Immediate.new(co, 0)); dst = Address.new(co, base, Immediate.new(co, 8)); expected = {&quot;transferi&quot; =&gt; [&quot;rv_lwu&quot;, &quot;rv_sw&quot;], &quot;transferp&quot; =&gt; [&quot;rv_ld&quot;, &quot;rv_sd&quot;], &quot;transferq&quot; =&gt; [&quot;rv_ld&quot;, &quot;rv_sd&quot;]}; expected.each { |opcode, opcodes| lowered = riscv64LowerOperation([Instruction.new(co, opcode, [src, dst])]); abort &quot;#{opcode}: #{lowered.map(&amp;:opcode).inspect}&quot; unless lowered.map(&amp;:opcode) == opcodes }&apos;

* Source/JavaScriptCore/offlineasm/riscv64.rb:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f15e518aaa85fbb85d7852b2c629f2c3efe60c64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121627 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127719 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89894 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29062 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27688 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21168 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156526 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175930 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25267 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28752 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136030 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135999 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147261 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100719 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31313 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24117 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196778 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37126 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110170 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51685 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36522 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2175 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->