### PR TITLE
[GTK][WPE] Skia Compositor: css3/filters/backdrop/backdrop-filter-with-composited-blend-mode.html fails

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1265,7 +1265,6 @@ imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-pl
 
 webkit.org/b/310417 compositing/masks/become-tiled-mask.html [ ImageOnlyFailure Pass ]
 
-webkit.org/b/314308 css3/filters/backdrop/backdrop-filter-with-composited-blend-mode.html [ ImageOnlyFailure ]
 webkit.org/b/314309 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-behavior.html [ ImageOnlyFailure ]
 webkit.org/b/314310 imported/w3c/web-platform-tests/css/filter-effects/drop-shadow-currentcolor-dynamic-003.html [ ImageOnlyFailure ]
 webkit.org/b/314312 media/media-sources-selection.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -601,36 +601,6 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
         return;
     }
 
-    if (m_backdrop.filter && !context.paintingBackdropForLayer) {
-        SkAutoCanvasRestore autoRestore(&canvas, true);
-        SkPathBuilder builder;
-        builder.addRRect(SkRRect(m_backdrop.clipRect));
-        TransformationMatrix clipTransform(context.accumulatedReplicaTransform);
-        clipTransform.multiply(m_transforms.combined);
-        canvas.clipPath(builder.detach().makeTransform(SkM44(clipTransform).asM33()), true);
-
-        // Paint the backdrop root's subtree into a fresh surface (spec step 1),
-        // apply the backdrop filter (step 2), and composite via SrcOver so the
-        // filtered result blends onto the canvas without destroying ancestor
-        // backgrounds that aren't part of the backdrop root's subtree.
-        //
-        // Use paintSelfAndChildren (not recursivePaint) on the backdrop root to
-        // exclude the root's own effects (replica, filter, mask) per the CSS spec.
-        SkPaint paint;
-        paint.setImageFilter(m_backdrop.filter);
-        paint.setAlphaf(context.opacity);
-        if (context.blendMode)
-            paint.setBlendMode(*context.blendMode);
-        paintWithIntermediateSurface(canvas, context, enclosingIntRect(clipTransform.mapRect(m_backdrop.clipRect.rect())), &paint, [&](SkCanvas& canvas, PaintContext& context) {
-            SetForScope scopedPaintBackdropForLayer(context.paintingBackdropForLayer, this);
-            SetForScope scopedOpacity(context.opacity, 1.f);
-            SetForScope scopedBlendMode(context.blendMode, std::nullopt);
-            SetForScope scopedReplicaTransform(context.accumulatedReplicaTransform, TransformationMatrix());
-            SetForScope scopedSkipAfterBackdrop(context.skipAfterBackdrop, false);
-            backdropRoot()->paintSelfAndChildren(canvas, context);
-        });
-    }
-
     paintSelf(canvas, context);
 
     if (m_children.isEmpty())
@@ -749,7 +719,38 @@ void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintC
     canvas.drawImageRect(surface->makeImageSnapshot(), SkRect::MakeWH(surfaceRect.width(), surfaceRect.height()), SkRect::Make(surfaceRect), SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), paint, SkCanvas::kFast_SrcRectConstraint);
 }
 
-void SkiaCompositingLayer::paintSelfAndChildrenWithFilterAndMask(SkCanvas& canvas, PaintContext& context)
+void SkiaCompositingLayer::paintBackdrop(SkCanvas& canvas, PaintContext& context)
+{
+    SkAutoCanvasRestore autoRestore(&canvas, true);
+    SkPathBuilder builder;
+    builder.addRRect(SkRRect(m_backdrop.clipRect));
+    TransformationMatrix clipTransform(context.accumulatedReplicaTransform);
+    clipTransform.multiply(m_transforms.combined);
+    canvas.clipPath(builder.detach().makeTransform(SkM44(clipTransform).asM33()), true);
+
+    // Paint the backdrop root's subtree into a fresh surface (spec step 1),
+    // apply the backdrop filter (step 2), and composite via SrcOver so the
+    // filtered result blends onto the canvas without destroying ancestor
+    // backgrounds that aren't part of the backdrop root's subtree.
+    //
+    // Use paintSelfAndChildren (not recursivePaint) on the backdrop root to
+    // exclude the root's own effects (replica, filter, mask) per the CSS spec.
+    SkPaint paint;
+    paint.setImageFilter(m_backdrop.filter);
+    paint.setAlphaf(context.opacity);
+    if (context.blendMode)
+        paint.setBlendMode(*context.blendMode);
+    paintWithIntermediateSurface(canvas, context, enclosingIntRect(clipTransform.mapRect(m_backdrop.clipRect.rect())), &paint, [&](SkCanvas& canvas, PaintContext& context) {
+        SetForScope scopedPaintBackdropForLayer(context.paintingBackdropForLayer, this);
+        SetForScope scopedOpacity(context.opacity, 1.f);
+        SetForScope scopedBlendMode(context.blendMode, std::nullopt);
+        SetForScope scopedReplicaTransform(context.accumulatedReplicaTransform, TransformationMatrix());
+        SetForScope scopedSkipAfterBackdrop(context.skipAfterBackdrop, false);
+        backdropRoot()->paintSelfAndChildren(canvas, context);
+    });
+}
+
+void SkiaCompositingLayer::paintWithMaskAndBackdrop(SkCanvas& canvas, PaintContext& context)
 {
     const bool shouldClipPath = m_mask && m_mask->m_clipPath.has_value();
     if (shouldClipPath && m_mask->m_clipPath->isEmpty())
@@ -770,6 +771,14 @@ void SkiaCompositingLayer::paintSelfAndChildrenWithFilterAndMask(SkCanvas& canva
             canvas.clipShader(maskShader);
     }
 
+    if (m_backdrop.filter && !context.paintingBackdropForLayer)
+        paintBackdrop(canvas, context);
+
+    paintWithBlendMode(canvas, context);
+}
+
+void SkiaCompositingLayer::paintWithFilterAndMask(SkCanvas& canvas, PaintContext& context)
+{
     auto filter = this->filter();
     if (!filter) {
         paintSelfAndChildren(canvas, context);
@@ -848,15 +857,15 @@ Vector<IntRect, 1> SkiaCompositingLayer::computeConsolidatedOverlapRegionRects(c
     return rects;
 }
 
-void SkiaCompositingLayer::paintSelfAndChildrenWithReplicaFilterAndMask(SkCanvas& canvas, PaintContext& context)
+void SkiaCompositingLayer::paintWithReplica(SkCanvas& canvas, PaintContext& context)
 {
     if (m_replica) {
         auto newAccumulatedReplicaTransform = TransformationMatrix(context.accumulatedReplicaTransform).multiply(replicaTransform());
         SetForScope scopedReplicaTransform(context.accumulatedReplicaTransform, newAccumulatedReplicaTransform);
-        paintSelfAndChildrenWithFilterAndMask(canvas, context);
+        paintWithMaskAndBackdrop(canvas, context);
     }
 
-    paintSelfAndChildrenWithFilterAndMask(canvas, context);
+    paintWithMaskAndBackdrop(canvas, context);
 }
 
 void SkiaCompositingLayer::recursivePaint(SkCanvas& canvas, PaintContext& context)
@@ -866,21 +875,14 @@ void SkiaCompositingLayer::recursivePaint(SkCanvas& canvas, PaintContext& contex
     if (!isVisible())
         return;
 
-    auto blendMode = m_blendMode;
-    if (!blendMode && m_shouldBlend)
-        blendMode = SkBlendMode::kSrcOver;
     SetForScope scopedOpacity(context.opacity, context.opacity * opacity());
-    SetForScope scopedBlendMode(context.blendMode, context.blendMode ? context.blendMode : blendMode);
 
     if (m_preserves3D) {
-        paintUsing3DRenderingContext(canvas, context);
+        paintWith3DRenderingContext(canvas, context);
         return;
     }
 
-    if (opacity() < 1 || m_shouldBlend)
-        paintUsingOverlapRegions(canvas, context);
-    else
-        paintSelfAndChildrenWithReplicaFilterAndMask(canvas, context);
+    paintWithOpacity(canvas, context);
 }
 
 void SkiaCompositingLayer::computeOverlapRegions(ComputeOverlapRegionData& data, const TransformationMatrix& accumulatedReplicaTransform, IncludesReplica includesReplica)
@@ -928,8 +930,13 @@ void SkiaCompositingLayer::computeOverlapRegions(ComputeOverlapRegionData& data,
     }
 }
 
-void SkiaCompositingLayer::paintUsingOverlapRegions(SkCanvas& canvas, PaintContext& context)
+void SkiaCompositingLayer::paintWithOpacity(SkCanvas& canvas, PaintContext& context)
 {
+    if (opacity() == 1) {
+        paintWithReplica(canvas, context);
+        return;
+    }
+
     ComputeOverlapRegionData data {
         .mode = ComputeOverlapRegionMode::Intersection,
         .clipBounds = clipBounds(canvas, context),
@@ -939,7 +946,7 @@ void SkiaCompositingLayer::paintUsingOverlapRegions(SkCanvas& canvas, PaintConte
     computeOverlapRegions(data, context.accumulatedReplicaTransform);
 
     if (data.overlapRegion.isEmpty()) {
-        paintSelfAndChildrenWithReplicaFilterAndMask(canvas, context);
+        paintWithReplica(canvas, context);
         return;
     }
 
@@ -953,7 +960,7 @@ void SkiaCompositingLayer::paintUsingOverlapRegions(SkCanvas& canvas, PaintConte
     for (const auto& rect : data.nonOverlapRegion.rects()) {
         SkAutoCanvasRestore autoRestore(&canvas, true);
         canvas.clipIRect(SkIRect::MakeLTRB(rect.x(), rect.y(), rect.maxX(), rect.maxY()));
-        paintSelfAndChildrenWithReplicaFilterAndMask(canvas, context);
+        paintWithReplica(canvas, context);
     }
 
     auto overlapRects = data.overlapRegion.rects();
@@ -964,14 +971,67 @@ void SkiaCompositingLayer::paintUsingOverlapRegions(SkCanvas& canvas, PaintConte
 
     SkPaint layerPaint;
     layerPaint.setAlphaf(context.opacity);
+    for (const auto& rect : overlapRects) {
+        SkAutoCanvasRestore autoRestore(&canvas, true);
+        paintWithIntermediateSurface(canvas, context, rect, &layerPaint, [&](SkCanvas& canvas, PaintContext& context) {
+            SetForScope scopedOpacity(context.opacity, 1);
+            paintWithReplica(canvas, context);
+        });
+    }
+}
+
+void SkiaCompositingLayer::paintWithBlendMode(SkCanvas& canvas, PaintContext& context)
+{
+    if (!m_shouldBlend) {
+        paintWithFilterAndMask(canvas, context);
+        return;
+    }
+
+    auto blendMode = m_blendMode;
+    if (!blendMode && m_shouldBlend)
+        blendMode = SkBlendMode::kSrcOver;
+    SetForScope scopedBlendMode(context.blendMode, context.blendMode ? context.blendMode : blendMode);
+
+    ComputeOverlapRegionData data {
+        .mode = ComputeOverlapRegionMode::Intersection,
+        .clipBounds = clipBounds(canvas, context),
+        .overlapRegion = { },
+        .nonOverlapRegion = { }
+    };
+    computeOverlapRegions(data, context.accumulatedReplicaTransform);
+
+    if (data.overlapRegion.isEmpty()) {
+        paintWithFilterAndMask(canvas, context);
+        return;
+    }
+
+    // Having both overlap and non-overlap regions carries some overhead.
+    // Avoid it if the overlap area is big anyway.
+    if (data.overlapRegion.totalArea() > data.nonOverlapRegion.totalArea()) {
+        data.overlapRegion.unite(data.nonOverlapRegion);
+        data.nonOverlapRegion = Region();
+    }
+
+    for (const auto& rect : data.nonOverlapRegion.rects()) {
+        SkAutoCanvasRestore autoRestore(&canvas, true);
+        canvas.clipIRect(SkIRect::MakeLTRB(rect.x(), rect.y(), rect.maxX(), rect.maxY()));
+        paintWithFilterAndMask(canvas, context);
+    }
+
+    auto overlapRects = data.overlapRegion.rects();
+    if (data.nonOverlapRegion.isEmpty() && overlapRects.size() > cOverlapRegionConsolidationThreshold) {
+        overlapRects.clear();
+        overlapRects.append(data.overlapRegion.bounds());
+    }
+
+    SkPaint layerPaint;
     if (context.blendMode)
         layerPaint.setBlendMode(*context.blendMode);
     for (const auto& rect : overlapRects) {
         SkAutoCanvasRestore autoRestore(&canvas, true);
         paintWithIntermediateSurface(canvas, context, rect, &layerPaint, [&](SkCanvas& canvas, PaintContext& context) {
-            SetForScope scopedOpacity(context.opacity, 1);
             SetForScope scopedBlendMode(context.blendMode, std::nullopt);
-            paintSelfAndChildrenWithReplicaFilterAndMask(canvas, context);
+            paintWithFilterAndMask(canvas, context);
         });
     }
 }
@@ -999,7 +1059,7 @@ void SkiaCompositingLayer::collect3DRenderingContextLayers(Vector<Ref<SkiaCompos
         child->collect3DRenderingContextLayers(layers);
 }
 
-void SkiaCompositingLayer::paintUsing3DRenderingContext(SkCanvas& canvas, PaintContext& context)
+void SkiaCompositingLayer::paintWith3DRenderingContext(SkCanvas& canvas, PaintContext& context)
 {
     Vector<Ref<SkiaCompositingLayer>> layers;
     collect3DRenderingContextLayers(layers);

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -144,13 +144,16 @@ private:
     using PaintFunction = Function<void(SkCanvas&, PaintContext&)>;
 
     void recursivePaint(SkCanvas&, PaintContext&);
+    void paintWithOpacity(SkCanvas&, PaintContext&);
+    void paintWithReplica(SkCanvas&, PaintContext&);
+    void paintWithMaskAndBackdrop(SkCanvas&, PaintContext&);
+    void paintWithBlendMode(SkCanvas&, PaintContext&);
+    void paintWithFilterAndMask(SkCanvas&, PaintContext&);
     void paintSelf(SkCanvas&, PaintContext&);
     void paintSelfAndChildren(SkCanvas&, PaintContext&);
-    void paintSelfAndChildrenWithReplicaFilterAndMask(SkCanvas&, PaintContext&);
-    void paintSelfAndChildrenWithFilterAndMask(SkCanvas&, PaintContext&);
     void paintWithIntermediateSurface(SkCanvas&, PaintContext&, const IntRect&, SkPaint*, PaintFunction&&);
-    void paintUsingOverlapRegions(SkCanvas&, PaintContext&);
-    void paintUsing3DRenderingContext(SkCanvas&, PaintContext&);
+    void paintWith3DRenderingContext(SkCanvas&, PaintContext&);
+    void paintBackdrop(SkCanvas&, PaintContext&);
     Vector<IntRect, 1> computeConsolidatedOverlapRegionRects(const SkCanvas&, const PaintContext&, ComputeOverlapRegionMode);
     TransformationMatrix replicaTransform() const;
     IntRect clipBounds(const SkCanvas&, const PaintContext&) const;


### PR DESCRIPTION
#### 9cc4f352ea8c9e832dbb3436f4cba5e00ca48ddc
<pre>
[GTK][WPE] Skia Compositor: css3/filters/backdrop/backdrop-filter-with-composited-blend-mode.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=314308">https://bugs.webkit.org/show_bug.cgi?id=314308</a>

Reviewed by Carlos Garcia Campos.

Child layer&apos;s mix blend mode shouldn&apos;t affect the parent layer&apos;s backdrop
filter. Changed the painting order of backdrop and blend mode.

opacity → replica → mask &amp; backdrop filter → blend mode → filter &amp; mask

Renamed some long paint method names.

Tests: css3/filters/backdrop/backdrop-filter-with-composited-blend-mode.html

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintSelfAndChildren):
(WebCore::SkiaCompositingLayer::paintBackdrop):
(WebCore::SkiaCompositingLayer::paintWithMaskAndBackdrop):
(WebCore::SkiaCompositingLayer::paintWithFilterAndMask):
(WebCore::SkiaCompositingLayer::paintWithReplica):
(WebCore::SkiaCompositingLayer::recursivePaint):
(WebCore::SkiaCompositingLayer::paintWithOpacity):
(WebCore::SkiaCompositingLayer::paintWithBlendMode):
(WebCore::SkiaCompositingLayer::paintWith3DRenderingContext):
(WebCore::SkiaCompositingLayer::paintSelfAndChildrenWithFilterAndMask):
(WebCore::SkiaCompositingLayer::paintSelfAndChildrenWithReplicaFilterAndMask):
(WebCore::SkiaCompositingLayer::paintUsingOverlapRegions):
(WebCore::SkiaCompositingLayer::paintUsing3DRenderingContext): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:

Canonical link: <a href="https://commits.webkit.org/313958@main">https://commits.webkit.org/313958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d84e1746aa8834c6803759f8385d97ecdee5d62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121951 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127990 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108535 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27962 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21492 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139243 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176257 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29081 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136308 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136270 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147543 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101131 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25063 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31540 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24399 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37450 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110494 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36848 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2464 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->