### PR TITLE
Implement WebCodecsImageDecoder

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL idl_test setup promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
+PASS idl_test setup
 PASS idl_test validation
 PASS AudioDecoder interface: existence and properties of interface object
 PASS AudioDecoder interface object length
@@ -16,6 +16,20 @@ PASS AudioDecoder interface: operation flush()
 PASS AudioDecoder interface: operation reset()
 PASS AudioDecoder interface: operation close()
 PASS AudioDecoder interface: operation isConfigSupported(AudioDecoderConfig)
+PASS AudioDecoder must be primary interface of new AudioDecoder(defaultCodecInit)
+PASS Stringification of new AudioDecoder(defaultCodecInit)
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "state" with the proper type
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "decodeQueueSize" with the proper type
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "ondequeue" with the proper type
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "configure(AudioDecoderConfig)" with the proper type
+PASS AudioDecoder interface: calling configure(AudioDecoderConfig) on new AudioDecoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "decode(EncodedAudioChunk)" with the proper type
+PASS AudioDecoder interface: calling decode(EncodedAudioChunk) on new AudioDecoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "flush()" with the proper type
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "reset()" with the proper type
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "close()" with the proper type
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "isConfigSupported(AudioDecoderConfig)" with the proper type
+PASS AudioDecoder interface: calling isConfigSupported(AudioDecoderConfig) on new AudioDecoder(defaultCodecInit) with too few arguments must throw TypeError
 PASS VideoDecoder interface: existence and properties of interface object
 PASS VideoDecoder interface object length
 PASS VideoDecoder interface object name
@@ -31,6 +45,20 @@ PASS VideoDecoder interface: operation flush()
 PASS VideoDecoder interface: operation reset()
 PASS VideoDecoder interface: operation close()
 PASS VideoDecoder interface: operation isConfigSupported(VideoDecoderConfig)
+PASS VideoDecoder must be primary interface of new VideoDecoder(defaultCodecInit)
+PASS Stringification of new VideoDecoder(defaultCodecInit)
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "state" with the proper type
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "decodeQueueSize" with the proper type
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "ondequeue" with the proper type
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "configure(VideoDecoderConfig)" with the proper type
+PASS VideoDecoder interface: calling configure(VideoDecoderConfig) on new VideoDecoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "decode(EncodedVideoChunk)" with the proper type
+PASS VideoDecoder interface: calling decode(EncodedVideoChunk) on new VideoDecoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "flush()" with the proper type
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "reset()" with the proper type
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "close()" with the proper type
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "isConfigSupported(VideoDecoderConfig)" with the proper type
+PASS VideoDecoder interface: calling isConfigSupported(VideoDecoderConfig) on new VideoDecoder(defaultCodecInit) with too few arguments must throw TypeError
 PASS AudioEncoder interface: existence and properties of interface object
 PASS AudioEncoder interface object length
 PASS AudioEncoder interface object name
@@ -46,6 +74,20 @@ PASS AudioEncoder interface: operation flush()
 PASS AudioEncoder interface: operation reset()
 PASS AudioEncoder interface: operation close()
 PASS AudioEncoder interface: operation isConfigSupported(AudioEncoderConfig)
+PASS AudioEncoder must be primary interface of new AudioEncoder(defaultCodecInit)
+PASS Stringification of new AudioEncoder(defaultCodecInit)
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "state" with the proper type
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "encodeQueueSize" with the proper type
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "ondequeue" with the proper type
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "configure(AudioEncoderConfig)" with the proper type
+PASS AudioEncoder interface: calling configure(AudioEncoderConfig) on new AudioEncoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "encode(AudioData)" with the proper type
+PASS AudioEncoder interface: calling encode(AudioData) on new AudioEncoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "flush()" with the proper type
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "reset()" with the proper type
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "close()" with the proper type
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "isConfigSupported(AudioEncoderConfig)" with the proper type
+PASS AudioEncoder interface: calling isConfigSupported(AudioEncoderConfig) on new AudioEncoder(defaultCodecInit) with too few arguments must throw TypeError
 PASS VideoEncoder interface: existence and properties of interface object
 PASS VideoEncoder interface object length
 PASS VideoEncoder interface object name
@@ -61,6 +103,20 @@ PASS VideoEncoder interface: operation flush()
 PASS VideoEncoder interface: operation reset()
 PASS VideoEncoder interface: operation close()
 PASS VideoEncoder interface: operation isConfigSupported(VideoEncoderConfig)
+PASS VideoEncoder must be primary interface of new VideoEncoder(defaultCodecInit)
+PASS Stringification of new VideoEncoder(defaultCodecInit)
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "state" with the proper type
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "encodeQueueSize" with the proper type
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "ondequeue" with the proper type
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "configure(VideoEncoderConfig)" with the proper type
+PASS VideoEncoder interface: calling configure(VideoEncoderConfig) on new VideoEncoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "encode(VideoFrame, optional VideoEncoderEncodeOptions)" with the proper type
+PASS VideoEncoder interface: calling encode(VideoFrame, optional VideoEncoderEncodeOptions) on new VideoEncoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "flush()" with the proper type
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "reset()" with the proper type
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "close()" with the proper type
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "isConfigSupported(VideoEncoderConfig)" with the proper type
+PASS VideoEncoder interface: calling isConfigSupported(VideoEncoderConfig) on new VideoEncoder(defaultCodecInit) with too few arguments must throw TypeError
 PASS EncodedAudioChunk interface: existence and properties of interface object
 PASS EncodedAudioChunk interface object length
 PASS EncodedAudioChunk interface object name
@@ -72,6 +128,14 @@ PASS EncodedAudioChunk interface: attribute timestamp
 PASS EncodedAudioChunk interface: attribute duration
 PASS EncodedAudioChunk interface: attribute byteLength
 PASS EncodedAudioChunk interface: operation copyTo(AllowSharedBufferSource)
+PASS EncodedAudioChunk must be primary interface of new EncodedAudioChunk(defaultAudioChunkInit)
+PASS Stringification of new EncodedAudioChunk(defaultAudioChunkInit)
+PASS EncodedAudioChunk interface: new EncodedAudioChunk(defaultAudioChunkInit) must inherit property "type" with the proper type
+PASS EncodedAudioChunk interface: new EncodedAudioChunk(defaultAudioChunkInit) must inherit property "timestamp" with the proper type
+PASS EncodedAudioChunk interface: new EncodedAudioChunk(defaultAudioChunkInit) must inherit property "duration" with the proper type
+PASS EncodedAudioChunk interface: new EncodedAudioChunk(defaultAudioChunkInit) must inherit property "byteLength" with the proper type
+PASS EncodedAudioChunk interface: new EncodedAudioChunk(defaultAudioChunkInit) must inherit property "copyTo(AllowSharedBufferSource)" with the proper type
+PASS EncodedAudioChunk interface: calling copyTo(AllowSharedBufferSource) on new EncodedAudioChunk(defaultAudioChunkInit) with too few arguments must throw TypeError
 PASS EncodedVideoChunk interface: existence and properties of interface object
 PASS EncodedVideoChunk interface object length
 PASS EncodedVideoChunk interface object name
@@ -83,6 +147,14 @@ PASS EncodedVideoChunk interface: attribute timestamp
 PASS EncodedVideoChunk interface: attribute duration
 PASS EncodedVideoChunk interface: attribute byteLength
 PASS EncodedVideoChunk interface: operation copyTo(AllowSharedBufferSource)
+PASS EncodedVideoChunk must be primary interface of new EncodedVideoChunk(defaultVideoChunkInit)
+PASS Stringification of new EncodedVideoChunk(defaultVideoChunkInit)
+PASS EncodedVideoChunk interface: new EncodedVideoChunk(defaultVideoChunkInit) must inherit property "type" with the proper type
+PASS EncodedVideoChunk interface: new EncodedVideoChunk(defaultVideoChunkInit) must inherit property "timestamp" with the proper type
+PASS EncodedVideoChunk interface: new EncodedVideoChunk(defaultVideoChunkInit) must inherit property "duration" with the proper type
+PASS EncodedVideoChunk interface: new EncodedVideoChunk(defaultVideoChunkInit) must inherit property "byteLength" with the proper type
+PASS EncodedVideoChunk interface: new EncodedVideoChunk(defaultVideoChunkInit) must inherit property "copyTo(AllowSharedBufferSource)" with the proper type
+PASS EncodedVideoChunk interface: calling copyTo(AllowSharedBufferSource) on new EncodedVideoChunk(defaultVideoChunkInit) with too few arguments must throw TypeError
 PASS AudioData interface: existence and properties of interface object
 PASS AudioData interface object length
 PASS AudioData interface object name
@@ -99,6 +171,22 @@ FAIL AudioData interface: operation allocationSize(AudioDataCopyToOptions) asser
 PASS AudioData interface: operation copyTo(AllowSharedBufferSource, AudioDataCopyToOptions)
 PASS AudioData interface: operation clone()
 PASS AudioData interface: operation close()
+PASS AudioData must be primary interface of make_audio_data(1234, 2, 8000, 100)
+PASS Stringification of make_audio_data(1234, 2, 8000, 100)
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "format" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "sampleRate" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "numberOfFrames" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "numberOfChannels" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "duration" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "timestamp" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "allocationSize(AudioDataCopyToOptions)" with the proper type
+FAIL AudioData interface: calling allocationSize(AudioDataCopyToOptions) on make_audio_data(1234, 2, 8000, 100) with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function() {
+            fn.apply(obj, args);
+        }" did not throw
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "copyTo(AllowSharedBufferSource, AudioDataCopyToOptions)" with the proper type
+PASS AudioData interface: calling copyTo(AllowSharedBufferSource, AudioDataCopyToOptions) on make_audio_data(1234, 2, 8000, 100) with too few arguments must throw TypeError
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "clone()" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "close()" with the proper type
 PASS VideoFrame interface: existence and properties of interface object
 PASS VideoFrame interface object length
 PASS VideoFrame interface object name
@@ -122,6 +210,27 @@ PASS VideoFrame interface: operation allocationSize(optional VideoFrameCopyToOpt
 PASS VideoFrame interface: operation copyTo(AllowSharedBufferSource, optional VideoFrameCopyToOptions)
 PASS VideoFrame interface: operation clone()
 PASS VideoFrame interface: operation close()
+PASS VideoFrame must be primary interface of new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33})
+PASS Stringification of new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33})
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "format" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "codedWidth" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "codedHeight" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "codedRect" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "visibleRect" with the proper type
+FAIL VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "rotation" with the proper type assert_inherits: property "rotation" not found in prototype chain
+FAIL VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "flip" with the proper type assert_inherits: property "flip" not found in prototype chain
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "displayWidth" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "displayHeight" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "duration" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "timestamp" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "colorSpace" with the proper type
+FAIL VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "metadata()" with the proper type assert_inherits: property "metadata" not found in prototype chain
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "allocationSize(optional VideoFrameCopyToOptions)" with the proper type
+PASS VideoFrame interface: calling allocationSize(optional VideoFrameCopyToOptions) on new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) with too few arguments must throw TypeError
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "copyTo(AllowSharedBufferSource, optional VideoFrameCopyToOptions)" with the proper type
+PASS VideoFrame interface: calling copyTo(AllowSharedBufferSource, optional VideoFrameCopyToOptions) on new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) with too few arguments must throw TypeError
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "clone()" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "close()" with the proper type
 PASS VideoColorSpace interface: existence and properties of interface object
 PASS VideoColorSpace interface object length
 PASS VideoColorSpace interface object name
@@ -133,38 +242,82 @@ PASS VideoColorSpace interface: attribute transfer
 PASS VideoColorSpace interface: attribute matrix
 PASS VideoColorSpace interface: attribute fullRange
 PASS VideoColorSpace interface: operation toJSON()
-FAIL ImageDecoder interface: existence and properties of interface object assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface object length assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface object name assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: attribute type assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: attribute complete assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: attribute completed assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: attribute tracks assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: operation decode(optional ImageDecodeOptions) assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: operation reset() assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: operation close() assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: operation isTypeSupported(DOMString) assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageTrackList interface: existence and properties of interface object assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface object length assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface object name assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: attribute ready assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: attribute length assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: attribute selectedIndex assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: attribute selectedTrack assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrack interface: existence and properties of interface object assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface object length assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface object name assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: attribute animated assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: attribute frameCount assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: attribute repetitionCount assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: attribute selected assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
+PASS VideoColorSpace must be primary interface of new VideoColorSpace()
+PASS Stringification of new VideoColorSpace()
+PASS VideoColorSpace interface: new VideoColorSpace() must inherit property "primaries" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace() must inherit property "transfer" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace() must inherit property "matrix" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace() must inherit property "fullRange" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace() must inherit property "toJSON()" with the proper type
+PASS VideoColorSpace interface: default toJSON operation on new VideoColorSpace()
+PASS VideoColorSpace must be primary interface of new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true})
+PASS Stringification of new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true})
+PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "primaries" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "transfer" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "matrix" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "fullRange" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "toJSON()" with the proper type
+PASS VideoColorSpace interface: default toJSON operation on new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true})
+FAIL ImageDecoder interface: existence and properties of interface object assert_equals: prototype of self's property "ImageDecoder" is not Function.prototype expected function "function () {
+    [native code]
+}" but got function "function EventTarget() {
+    [native code]
+}"
+PASS ImageDecoder interface object length
+PASS ImageDecoder interface object name
+FAIL ImageDecoder interface: existence and properties of interface prototype object assert_equals: prototype of ImageDecoder.prototype is not Object.prototype expected object "[object Object]" but got object "[object EventTarget]"
+PASS ImageDecoder interface: existence and properties of interface prototype object's "constructor" property
+PASS ImageDecoder interface: existence and properties of interface prototype object's @@unscopables property
+PASS ImageDecoder interface: attribute type
+PASS ImageDecoder interface: attribute complete
+PASS ImageDecoder interface: attribute completed
+PASS ImageDecoder interface: attribute tracks
+PASS ImageDecoder interface: operation decode(optional ImageDecodeOptions)
+PASS ImageDecoder interface: operation reset()
+PASS ImageDecoder interface: operation close()
+PASS ImageDecoder interface: operation isTypeSupported(DOMString)
+PASS ImageDecoder must be primary interface of new ImageDecoder({data: self.imageBody, type: 'image/png'})
+PASS Stringification of new ImageDecoder({data: self.imageBody, type: 'image/png'})
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "type" with the proper type
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "complete" with the proper type
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "completed" with the proper type
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "tracks" with the proper type
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "decode(optional ImageDecodeOptions)" with the proper type
+PASS ImageDecoder interface: calling decode(optional ImageDecodeOptions) on new ImageDecoder({data: self.imageBody, type: 'image/png'}) with too few arguments must throw TypeError
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "reset()" with the proper type
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "close()" with the proper type
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "isTypeSupported(DOMString)" with the proper type
+PASS ImageDecoder interface: calling isTypeSupported(DOMString) on new ImageDecoder({data: self.imageBody, type: 'image/png'}) with too few arguments must throw TypeError
+PASS ImageTrackList interface: existence and properties of interface object
+PASS ImageTrackList interface object length
+PASS ImageTrackList interface object name
+PASS ImageTrackList interface: existence and properties of interface prototype object
+PASS ImageTrackList interface: existence and properties of interface prototype object's "constructor" property
+PASS ImageTrackList interface: existence and properties of interface prototype object's @@unscopables property
+PASS ImageTrackList interface: attribute ready
+PASS ImageTrackList interface: attribute length
+PASS ImageTrackList interface: attribute selectedIndex
+PASS ImageTrackList interface: attribute selectedTrack
+PASS ImageTrackList must be primary interface of new ImageDecoder({data: self.imageBody, type: 'image/png'}).tracks
+PASS Stringification of new ImageDecoder({data: self.imageBody, type: 'image/png'}).tracks
+PASS ImageTrackList interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}).tracks must inherit property "ready" with the proper type
+PASS ImageTrackList interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}).tracks must inherit property "length" with the proper type
+PASS ImageTrackList interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}).tracks must inherit property "selectedIndex" with the proper type
+PASS ImageTrackList interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}).tracks must inherit property "selectedTrack" with the proper type
+PASS ImageTrack interface: existence and properties of interface object
+PASS ImageTrack interface object length
+PASS ImageTrack interface object name
+PASS ImageTrack interface: existence and properties of interface prototype object
+PASS ImageTrack interface: existence and properties of interface prototype object's "constructor" property
+PASS ImageTrack interface: existence and properties of interface prototype object's @@unscopables property
+PASS ImageTrack interface: attribute animated
+PASS ImageTrack interface: attribute frameCount
+PASS ImageTrack interface: attribute repetitionCount
+PASS ImageTrack interface: attribute selected
+PASS ImageTrack must be primary interface of self.imageTracks
+PASS Stringification of self.imageTracks
+PASS ImageTrack interface: self.imageTracks must inherit property "animated" with the proper type
+PASS ImageTrack interface: self.imageTracks must inherit property "frameCount" with the proper type
+PASS ImageTrack interface: self.imageTracks must inherit property "repetitionCount" with the proper type
+PASS ImageTrack interface: self.imageTracks must inherit property "selected" with the proper type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any.worker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL idl_test setup promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
+PASS idl_test setup
 PASS idl_test validation
 PASS AudioDecoder interface: existence and properties of interface object
 PASS AudioDecoder interface object length
@@ -16,6 +16,20 @@ PASS AudioDecoder interface: operation flush()
 PASS AudioDecoder interface: operation reset()
 PASS AudioDecoder interface: operation close()
 PASS AudioDecoder interface: operation isConfigSupported(AudioDecoderConfig)
+PASS AudioDecoder must be primary interface of new AudioDecoder(defaultCodecInit)
+PASS Stringification of new AudioDecoder(defaultCodecInit)
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "state" with the proper type
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "decodeQueueSize" with the proper type
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "ondequeue" with the proper type
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "configure(AudioDecoderConfig)" with the proper type
+PASS AudioDecoder interface: calling configure(AudioDecoderConfig) on new AudioDecoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "decode(EncodedAudioChunk)" with the proper type
+PASS AudioDecoder interface: calling decode(EncodedAudioChunk) on new AudioDecoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "flush()" with the proper type
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "reset()" with the proper type
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "close()" with the proper type
+PASS AudioDecoder interface: new AudioDecoder(defaultCodecInit) must inherit property "isConfigSupported(AudioDecoderConfig)" with the proper type
+PASS AudioDecoder interface: calling isConfigSupported(AudioDecoderConfig) on new AudioDecoder(defaultCodecInit) with too few arguments must throw TypeError
 PASS VideoDecoder interface: existence and properties of interface object
 PASS VideoDecoder interface object length
 PASS VideoDecoder interface object name
@@ -31,6 +45,20 @@ PASS VideoDecoder interface: operation flush()
 PASS VideoDecoder interface: operation reset()
 PASS VideoDecoder interface: operation close()
 PASS VideoDecoder interface: operation isConfigSupported(VideoDecoderConfig)
+PASS VideoDecoder must be primary interface of new VideoDecoder(defaultCodecInit)
+PASS Stringification of new VideoDecoder(defaultCodecInit)
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "state" with the proper type
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "decodeQueueSize" with the proper type
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "ondequeue" with the proper type
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "configure(VideoDecoderConfig)" with the proper type
+PASS VideoDecoder interface: calling configure(VideoDecoderConfig) on new VideoDecoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "decode(EncodedVideoChunk)" with the proper type
+PASS VideoDecoder interface: calling decode(EncodedVideoChunk) on new VideoDecoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "flush()" with the proper type
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "reset()" with the proper type
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "close()" with the proper type
+PASS VideoDecoder interface: new VideoDecoder(defaultCodecInit) must inherit property "isConfigSupported(VideoDecoderConfig)" with the proper type
+PASS VideoDecoder interface: calling isConfigSupported(VideoDecoderConfig) on new VideoDecoder(defaultCodecInit) with too few arguments must throw TypeError
 PASS AudioEncoder interface: existence and properties of interface object
 PASS AudioEncoder interface object length
 PASS AudioEncoder interface object name
@@ -46,6 +74,20 @@ PASS AudioEncoder interface: operation flush()
 PASS AudioEncoder interface: operation reset()
 PASS AudioEncoder interface: operation close()
 PASS AudioEncoder interface: operation isConfigSupported(AudioEncoderConfig)
+PASS AudioEncoder must be primary interface of new AudioEncoder(defaultCodecInit)
+PASS Stringification of new AudioEncoder(defaultCodecInit)
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "state" with the proper type
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "encodeQueueSize" with the proper type
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "ondequeue" with the proper type
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "configure(AudioEncoderConfig)" with the proper type
+PASS AudioEncoder interface: calling configure(AudioEncoderConfig) on new AudioEncoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "encode(AudioData)" with the proper type
+PASS AudioEncoder interface: calling encode(AudioData) on new AudioEncoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "flush()" with the proper type
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "reset()" with the proper type
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "close()" with the proper type
+PASS AudioEncoder interface: new AudioEncoder(defaultCodecInit) must inherit property "isConfigSupported(AudioEncoderConfig)" with the proper type
+PASS AudioEncoder interface: calling isConfigSupported(AudioEncoderConfig) on new AudioEncoder(defaultCodecInit) with too few arguments must throw TypeError
 PASS VideoEncoder interface: existence and properties of interface object
 PASS VideoEncoder interface object length
 PASS VideoEncoder interface object name
@@ -61,6 +103,20 @@ PASS VideoEncoder interface: operation flush()
 PASS VideoEncoder interface: operation reset()
 PASS VideoEncoder interface: operation close()
 PASS VideoEncoder interface: operation isConfigSupported(VideoEncoderConfig)
+PASS VideoEncoder must be primary interface of new VideoEncoder(defaultCodecInit)
+PASS Stringification of new VideoEncoder(defaultCodecInit)
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "state" with the proper type
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "encodeQueueSize" with the proper type
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "ondequeue" with the proper type
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "configure(VideoEncoderConfig)" with the proper type
+PASS VideoEncoder interface: calling configure(VideoEncoderConfig) on new VideoEncoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "encode(VideoFrame, optional VideoEncoderEncodeOptions)" with the proper type
+PASS VideoEncoder interface: calling encode(VideoFrame, optional VideoEncoderEncodeOptions) on new VideoEncoder(defaultCodecInit) with too few arguments must throw TypeError
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "flush()" with the proper type
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "reset()" with the proper type
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "close()" with the proper type
+PASS VideoEncoder interface: new VideoEncoder(defaultCodecInit) must inherit property "isConfigSupported(VideoEncoderConfig)" with the proper type
+PASS VideoEncoder interface: calling isConfigSupported(VideoEncoderConfig) on new VideoEncoder(defaultCodecInit) with too few arguments must throw TypeError
 PASS EncodedAudioChunk interface: existence and properties of interface object
 PASS EncodedAudioChunk interface object length
 PASS EncodedAudioChunk interface object name
@@ -72,6 +128,14 @@ PASS EncodedAudioChunk interface: attribute timestamp
 PASS EncodedAudioChunk interface: attribute duration
 PASS EncodedAudioChunk interface: attribute byteLength
 PASS EncodedAudioChunk interface: operation copyTo(AllowSharedBufferSource)
+PASS EncodedAudioChunk must be primary interface of new EncodedAudioChunk(defaultAudioChunkInit)
+PASS Stringification of new EncodedAudioChunk(defaultAudioChunkInit)
+PASS EncodedAudioChunk interface: new EncodedAudioChunk(defaultAudioChunkInit) must inherit property "type" with the proper type
+PASS EncodedAudioChunk interface: new EncodedAudioChunk(defaultAudioChunkInit) must inherit property "timestamp" with the proper type
+PASS EncodedAudioChunk interface: new EncodedAudioChunk(defaultAudioChunkInit) must inherit property "duration" with the proper type
+PASS EncodedAudioChunk interface: new EncodedAudioChunk(defaultAudioChunkInit) must inherit property "byteLength" with the proper type
+PASS EncodedAudioChunk interface: new EncodedAudioChunk(defaultAudioChunkInit) must inherit property "copyTo(AllowSharedBufferSource)" with the proper type
+PASS EncodedAudioChunk interface: calling copyTo(AllowSharedBufferSource) on new EncodedAudioChunk(defaultAudioChunkInit) with too few arguments must throw TypeError
 PASS EncodedVideoChunk interface: existence and properties of interface object
 PASS EncodedVideoChunk interface object length
 PASS EncodedVideoChunk interface object name
@@ -83,6 +147,14 @@ PASS EncodedVideoChunk interface: attribute timestamp
 PASS EncodedVideoChunk interface: attribute duration
 PASS EncodedVideoChunk interface: attribute byteLength
 PASS EncodedVideoChunk interface: operation copyTo(AllowSharedBufferSource)
+PASS EncodedVideoChunk must be primary interface of new EncodedVideoChunk(defaultVideoChunkInit)
+PASS Stringification of new EncodedVideoChunk(defaultVideoChunkInit)
+PASS EncodedVideoChunk interface: new EncodedVideoChunk(defaultVideoChunkInit) must inherit property "type" with the proper type
+PASS EncodedVideoChunk interface: new EncodedVideoChunk(defaultVideoChunkInit) must inherit property "timestamp" with the proper type
+PASS EncodedVideoChunk interface: new EncodedVideoChunk(defaultVideoChunkInit) must inherit property "duration" with the proper type
+PASS EncodedVideoChunk interface: new EncodedVideoChunk(defaultVideoChunkInit) must inherit property "byteLength" with the proper type
+PASS EncodedVideoChunk interface: new EncodedVideoChunk(defaultVideoChunkInit) must inherit property "copyTo(AllowSharedBufferSource)" with the proper type
+PASS EncodedVideoChunk interface: calling copyTo(AllowSharedBufferSource) on new EncodedVideoChunk(defaultVideoChunkInit) with too few arguments must throw TypeError
 PASS AudioData interface: existence and properties of interface object
 PASS AudioData interface object length
 PASS AudioData interface object name
@@ -99,6 +171,22 @@ FAIL AudioData interface: operation allocationSize(AudioDataCopyToOptions) asser
 PASS AudioData interface: operation copyTo(AllowSharedBufferSource, AudioDataCopyToOptions)
 PASS AudioData interface: operation clone()
 PASS AudioData interface: operation close()
+PASS AudioData must be primary interface of make_audio_data(1234, 2, 8000, 100)
+PASS Stringification of make_audio_data(1234, 2, 8000, 100)
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "format" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "sampleRate" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "numberOfFrames" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "numberOfChannels" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "duration" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "timestamp" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "allocationSize(AudioDataCopyToOptions)" with the proper type
+FAIL AudioData interface: calling allocationSize(AudioDataCopyToOptions) on make_audio_data(1234, 2, 8000, 100) with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function() {
+            fn.apply(obj, args);
+        }" did not throw
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "copyTo(AllowSharedBufferSource, AudioDataCopyToOptions)" with the proper type
+PASS AudioData interface: calling copyTo(AllowSharedBufferSource, AudioDataCopyToOptions) on make_audio_data(1234, 2, 8000, 100) with too few arguments must throw TypeError
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "clone()" with the proper type
+PASS AudioData interface: make_audio_data(1234, 2, 8000, 100) must inherit property "close()" with the proper type
 PASS VideoFrame interface: existence and properties of interface object
 PASS VideoFrame interface object length
 PASS VideoFrame interface object name
@@ -122,6 +210,27 @@ PASS VideoFrame interface: operation allocationSize(optional VideoFrameCopyToOpt
 PASS VideoFrame interface: operation copyTo(AllowSharedBufferSource, optional VideoFrameCopyToOptions)
 PASS VideoFrame interface: operation clone()
 PASS VideoFrame interface: operation close()
+PASS VideoFrame must be primary interface of new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33})
+PASS Stringification of new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33})
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "format" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "codedWidth" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "codedHeight" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "codedRect" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "visibleRect" with the proper type
+FAIL VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "rotation" with the proper type assert_inherits: property "rotation" not found in prototype chain
+FAIL VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "flip" with the proper type assert_inherits: property "flip" not found in prototype chain
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "displayWidth" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "displayHeight" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "duration" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "timestamp" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "colorSpace" with the proper type
+FAIL VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "metadata()" with the proper type assert_inherits: property "metadata" not found in prototype chain
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "allocationSize(optional VideoFrameCopyToOptions)" with the proper type
+PASS VideoFrame interface: calling allocationSize(optional VideoFrameCopyToOptions) on new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) with too few arguments must throw TypeError
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "copyTo(AllowSharedBufferSource, optional VideoFrameCopyToOptions)" with the proper type
+PASS VideoFrame interface: calling copyTo(AllowSharedBufferSource, optional VideoFrameCopyToOptions) on new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) with too few arguments must throw TypeError
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "clone()" with the proper type
+PASS VideoFrame interface: new VideoFrame(makeImageBitmap(32, 16), {timestamp: 100, duration: 33}) must inherit property "close()" with the proper type
 PASS VideoColorSpace interface: existence and properties of interface object
 PASS VideoColorSpace interface object length
 PASS VideoColorSpace interface object name
@@ -133,38 +242,82 @@ PASS VideoColorSpace interface: attribute transfer
 PASS VideoColorSpace interface: attribute matrix
 PASS VideoColorSpace interface: attribute fullRange
 PASS VideoColorSpace interface: operation toJSON()
-FAIL ImageDecoder interface: existence and properties of interface object assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface object length assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface object name assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: attribute type assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: attribute complete assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: attribute completed assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: attribute tracks assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: operation decode(optional ImageDecodeOptions) assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: operation reset() assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: operation close() assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageDecoder interface: operation isTypeSupported(DOMString) assert_own_property: self does not have own property "ImageDecoder" expected property "ImageDecoder" missing
-FAIL ImageTrackList interface: existence and properties of interface object assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface object length assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface object name assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: attribute ready assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: attribute length assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: attribute selectedIndex assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrackList interface: attribute selectedTrack assert_own_property: self does not have own property "ImageTrackList" expected property "ImageTrackList" missing
-FAIL ImageTrack interface: existence and properties of interface object assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface object length assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface object name assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: attribute animated assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: attribute frameCount assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: attribute repetitionCount assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
-FAIL ImageTrack interface: attribute selected assert_own_property: self does not have own property "ImageTrack" expected property "ImageTrack" missing
+PASS VideoColorSpace must be primary interface of new VideoColorSpace()
+PASS Stringification of new VideoColorSpace()
+PASS VideoColorSpace interface: new VideoColorSpace() must inherit property "primaries" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace() must inherit property "transfer" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace() must inherit property "matrix" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace() must inherit property "fullRange" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace() must inherit property "toJSON()" with the proper type
+PASS VideoColorSpace interface: default toJSON operation on new VideoColorSpace()
+PASS VideoColorSpace must be primary interface of new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true})
+PASS Stringification of new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true})
+PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "primaries" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "transfer" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "matrix" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "fullRange" with the proper type
+PASS VideoColorSpace interface: new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true}) must inherit property "toJSON()" with the proper type
+PASS VideoColorSpace interface: default toJSON operation on new VideoColorSpace({primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: true})
+FAIL ImageDecoder interface: existence and properties of interface object assert_equals: prototype of self's property "ImageDecoder" is not Function.prototype expected function "function () {
+    [native code]
+}" but got function "function EventTarget() {
+    [native code]
+}"
+PASS ImageDecoder interface object length
+PASS ImageDecoder interface object name
+FAIL ImageDecoder interface: existence and properties of interface prototype object assert_equals: prototype of ImageDecoder.prototype is not Object.prototype expected object "[object Object]" but got object "[object EventTarget]"
+PASS ImageDecoder interface: existence and properties of interface prototype object's "constructor" property
+PASS ImageDecoder interface: existence and properties of interface prototype object's @@unscopables property
+PASS ImageDecoder interface: attribute type
+PASS ImageDecoder interface: attribute complete
+PASS ImageDecoder interface: attribute completed
+PASS ImageDecoder interface: attribute tracks
+PASS ImageDecoder interface: operation decode(optional ImageDecodeOptions)
+PASS ImageDecoder interface: operation reset()
+PASS ImageDecoder interface: operation close()
+PASS ImageDecoder interface: operation isTypeSupported(DOMString)
+PASS ImageDecoder must be primary interface of new ImageDecoder({data: self.imageBody, type: 'image/png'})
+PASS Stringification of new ImageDecoder({data: self.imageBody, type: 'image/png'})
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "type" with the proper type
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "complete" with the proper type
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "completed" with the proper type
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "tracks" with the proper type
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "decode(optional ImageDecodeOptions)" with the proper type
+PASS ImageDecoder interface: calling decode(optional ImageDecodeOptions) on new ImageDecoder({data: self.imageBody, type: 'image/png'}) with too few arguments must throw TypeError
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "reset()" with the proper type
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "close()" with the proper type
+PASS ImageDecoder interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}) must inherit property "isTypeSupported(DOMString)" with the proper type
+PASS ImageDecoder interface: calling isTypeSupported(DOMString) on new ImageDecoder({data: self.imageBody, type: 'image/png'}) with too few arguments must throw TypeError
+PASS ImageTrackList interface: existence and properties of interface object
+PASS ImageTrackList interface object length
+PASS ImageTrackList interface object name
+PASS ImageTrackList interface: existence and properties of interface prototype object
+PASS ImageTrackList interface: existence and properties of interface prototype object's "constructor" property
+PASS ImageTrackList interface: existence and properties of interface prototype object's @@unscopables property
+PASS ImageTrackList interface: attribute ready
+PASS ImageTrackList interface: attribute length
+PASS ImageTrackList interface: attribute selectedIndex
+PASS ImageTrackList interface: attribute selectedTrack
+PASS ImageTrackList must be primary interface of new ImageDecoder({data: self.imageBody, type: 'image/png'}).tracks
+PASS Stringification of new ImageDecoder({data: self.imageBody, type: 'image/png'}).tracks
+PASS ImageTrackList interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}).tracks must inherit property "ready" with the proper type
+PASS ImageTrackList interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}).tracks must inherit property "length" with the proper type
+PASS ImageTrackList interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}).tracks must inherit property "selectedIndex" with the proper type
+PASS ImageTrackList interface: new ImageDecoder({data: self.imageBody, type: 'image/png'}).tracks must inherit property "selectedTrack" with the proper type
+PASS ImageTrack interface: existence and properties of interface object
+PASS ImageTrack interface object length
+PASS ImageTrack interface object name
+PASS ImageTrack interface: existence and properties of interface prototype object
+PASS ImageTrack interface: existence and properties of interface prototype object's "constructor" property
+PASS ImageTrack interface: existence and properties of interface prototype object's @@unscopables property
+PASS ImageTrack interface: attribute animated
+PASS ImageTrack interface: attribute frameCount
+PASS ImageTrack interface: attribute repetitionCount
+PASS ImageTrack interface: attribute selected
+PASS ImageTrack must be primary interface of self.imageTracks
+PASS Stringification of self.imageTracks
+PASS ImageTrack interface: self.imageTracks must inherit property "animated" with the proper type
+PASS ImageTrack interface: self.imageTracks must inherit property "frameCount" with the proper type
+PASS ImageTrack interface: self.imageTracks must inherit property "repetitionCount" with the proper type
+PASS ImageTrack interface: self.imageTracks must inherit property "selected" with the proper type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.crossOriginIsolated.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.crossOriginIsolated.https.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test ImageDecoder decoding with a SharedArrayBuffer source Can't find variable: ImageDecoder
-FAIL Test ImageDecoder decoding with a Uint8Array(SharedArrayBuffer) source Can't find variable: ImageDecoder
+FAIL Test ImageDecoder decoding with a SharedArrayBuffer source promise_test: Unhandled rejection with value: object "TypeError: SharedArrayBuffer is not allowed"
+PASS Test ImageDecoder decoding with a Uint8Array(SharedArrayBuffer) source
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.crossOriginIsolated.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.crossOriginIsolated.https.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test ImageDecoder decoding with a SharedArrayBuffer source Can't find variable: ImageDecoder
-FAIL Test ImageDecoder decoding with a Uint8Array(SharedArrayBuffer) source Can't find variable: ImageDecoder
+FAIL Test ImageDecoder decoding with a SharedArrayBuffer source promise_test: Unhandled rejection with value: object "TypeError: SharedArrayBuffer is not allowed"
+PASS Test ImageDecoder decoding with a Uint8Array(SharedArrayBuffer) source
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any.worker-expected.txt
@@ -1,43 +1,47 @@
 
-FAIL Test JPEG image decoding. Can't find variable: ImageDecoder
-FAIL Test JPEG w/ EXIF orientation top-left. Can't find variable: ImageDecoder
-FAIL Test JPEG w/ EXIF orientation top-right. Can't find variable: ImageDecoder
-FAIL Test JPEG w/ EXIF orientation bottom-right. Can't find variable: ImageDecoder
-FAIL Test JPEG w/ EXIF orientation bottom-left. Can't find variable: ImageDecoder
-FAIL Test JPEG w/ EXIF orientation left-top. Can't find variable: ImageDecoder
-FAIL Test JPEG w/ EXIF orientation right-top. Can't find variable: ImageDecoder
-FAIL Test JPEG w/ EXIF orientation right-bottom. Can't find variable: ImageDecoder
-FAIL Test JPEG w/ EXIF orientation left-bottom. Can't find variable: ImageDecoder
-FAIL Test 4:2:0 JPEG w/ EXIF orientation top-left. Can't find variable: ImageDecoder
-FAIL Test 4:2:0 JPEG w/ EXIF orientation top-right. Can't find variable: ImageDecoder
-FAIL Test 4:2:0 JPEG w/ EXIF orientation bottom-right. Can't find variable: ImageDecoder
-FAIL Test 4:2:0 JPEG w/ EXIF orientation bottom-left. Can't find variable: ImageDecoder
-FAIL Test 4:2:0 JPEG w/ EXIF orientation left-top. Can't find variable: ImageDecoder
-FAIL Test 4:2:0 JPEG w/ EXIF orientation right-top. Can't find variable: ImageDecoder
-FAIL Test 4:2:0 JPEG w/ EXIF orientation right-bottom. Can't find variable: ImageDecoder
-FAIL Test 4:2:0 JPEG w/ EXIF orientation left-bottom. Can't find variable: ImageDecoder
-FAIL Test PNG image decoding. Can't find variable: ImageDecoder
-FAIL Test AVIF image decoding. Can't find variable: ImageDecoder
-FAIL Test high bit depth HDR AVIF image decoding. Can't find variable: ImageDecoder
-FAIL Test multi-track AVIF image decoding w/ preferAnimation=false. Can't find variable: ImageDecoder
-FAIL Test multi-track AVIF image decoding w/ preferAnimation=true. Can't find variable: ImageDecoder
-FAIL Test WEBP image decoding. Can't find variable: ImageDecoder
-FAIL Test GIF image decoding. Can't find variable: ImageDecoder
-FAIL Test JPEG image YUV 4:2:0 decoding. Can't find variable: ImageDecoder
-FAIL Test AVIF image YUV 4:2:0 decoding. Can't find variable: ImageDecoder
-FAIL Test AVIF image YUV 4:2:2 decoding. Can't find variable: ImageDecoder
-FAIL Test AVIF image YUV 4:4:4 decoding. Can't find variable: ImageDecoder
-FAIL Test WEBP image YUV 4:2:0 decoding. Can't find variable: ImageDecoder
-FAIL Test invalid mime type rejects decode() requests promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
-FAIL Test invalid mime type rejects decodeMetadata() requests promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
-FAIL Test out of range index returns RangeError Can't find variable: ImageDecoder
-FAIL Test decoding a partial ArrayBuffer results in EncodingError Can't find variable: ImageDecoder
-FAIL Test completed property on fully buffered decode Can't find variable: ImageDecoder
-FAIL Test decode, decodeMetadata after no track selected. Can't find variable: ImageDecoder
-FAIL Test track selection in multi track image. Can't find variable: ImageDecoder
-FAIL Test ReadableStream of gif promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
-FAIL Test that decode requests are serialized. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
-FAIL Test ReadableStream aborts promises on track change promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
-FAIL Test ReadableStream aborts completed on close promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
-FAIL Test ReadableStream resolves completed promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
+Harness Error (TIMEOUT), message = null
+
+FAIL Test JPEG image decoding. assert_array_approx_equals: top left corner is yellow property 2, expected 0 +/- 0, expected 0 but got 1
+FAIL Test JPEG w/ EXIF orientation top-left. assert_equals: top left corner expected "Yellow" but got "#ffff01ff"
+FAIL Test JPEG w/ EXIF orientation top-right. assert_equals: top left corner expected "Red" but got "#ffff01ff"
+FAIL Test JPEG w/ EXIF orientation bottom-right. assert_equals: top left corner expected "Green" but got "#ffff01ff"
+FAIL Test JPEG w/ EXIF orientation bottom-left. assert_equals: top left corner expected "Blue" but got "#ffff01ff"
+FAIL Test JPEG w/ EXIF orientation left-top. assert_equals: expected 240 but got 320
+FAIL Test JPEG w/ EXIF orientation right-top. assert_equals: expected 240 but got 320
+FAIL Test JPEG w/ EXIF orientation right-bottom. assert_equals: expected 240 but got 320
+FAIL Test JPEG w/ EXIF orientation left-bottom. assert_equals: expected 240 but got 320
+PASS Test 4:2:0 JPEG w/ EXIF orientation top-left.
+FAIL Test 4:2:0 JPEG w/ EXIF orientation top-right. assert_equals: top left corner expected "Red" but got "Yellow"
+FAIL Test 4:2:0 JPEG w/ EXIF orientation bottom-right. assert_equals: top left corner expected "Green" but got "Yellow"
+FAIL Test 4:2:0 JPEG w/ EXIF orientation bottom-left. assert_equals: top left corner expected "Blue" but got "Yellow"
+FAIL Test 4:2:0 JPEG w/ EXIF orientation left-top. assert_equals: expected 240 but got 320
+FAIL Test 4:2:0 JPEG w/ EXIF orientation right-top. assert_equals: expected 240 but got 320
+FAIL Test 4:2:0 JPEG w/ EXIF orientation right-bottom. assert_equals: expected 240 but got 320
+FAIL Test 4:2:0 JPEG w/ EXIF orientation left-bottom. assert_equals: expected 240 but got 320
+PASS Test PNG image decoding.
+PASS Test AVIF image decoding.
+PASS Test high bit depth HDR AVIF image decoding.
+FAIL Test multi-track AVIF image decoding w/ preferAnimation=false. assert_greater_than: expected a number greater than 1 but got 1
+FAIL Test multi-track AVIF image decoding w/ preferAnimation=true. assert_greater_than: expected a number greater than 1 but got 1
+PASS Test WEBP image decoding.
+PASS Test GIF image decoding.
+FAIL Test JPEG image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "RGBA"
+FAIL Test AVIF image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "RGBA"
+FAIL Test AVIF image YUV 4:2:2 decoding. assert_equals: expected "I422" but got "RGBA"
+FAIL Test AVIF image YUV 4:4:4 decoding. assert_equals: expected "I444" but got "RGBA"
+FAIL Test WEBP image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "RGBA"
+FAIL Test invalid mime type rejects decode() requests assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test invalid mime type rejects decodeMetadata() requests assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test out of range index returns RangeError promise_rejects_js: function "function() { throw e; }" threw object "DataError: Decoding error" ("DataError") expected instance of function "function RangeError() {
+    [native code]
+}" ("RangeError")
+FAIL Test decoding a partial ArrayBuffer results in EncodingError promise_rejects_dom: function "function() { throw e; }" threw object "DataError: Decoding error" that is not a DOMException EncodingError: property "name" is equal to "DataError", expected "EncodingError"
+PASS Test completed property on fully buffered decode
+FAIL Test decode, decodeMetadata after no track selected. assert_equals: expected -1 but got 0
+FAIL Test track selection in multi track image. assert_equals: expected 2 but got 1
+TIMEOUT Test ReadableStream of gif Test timed out
+NOTRUN Test that decode requests are serialized.
+NOTRUN Test ReadableStream aborts promises on track change
+NOTRUN Test ReadableStream aborts completed on close
+NOTRUN Test ReadableStream resolves completed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt
@@ -8,5 +8,5 @@ FAIL Test transfering ArrayBuffer to EncodedAudioChunk assert_equals: data.lengt
 FAIL Test transfering ArrayBuffer to EncodedVideoChunk assert_equals: data.length after detach expected 0 but got 10
 FAIL Test transfering ArrayBuffer to AudioData assert_equals: data.length after detach expected 0 but got 10
 FAIL Encoding from AudioData with transferred buffer assert_equals: buffer.length after detach expected 0 but got 9600
-FAIL Test transfering ArrayBuffer to ImageDecoder. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
+FAIL Test transfering ArrayBuffer to ImageDecoder. assert_equals: buffer.byteLength after detach expected 0 but got 1442
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt
@@ -8,5 +8,5 @@ FAIL Test transfering ArrayBuffer to EncodedAudioChunk assert_equals: data.lengt
 FAIL Test transfering ArrayBuffer to EncodedVideoChunk assert_equals: data.length after detach expected 0 but got 10
 FAIL Test transfering ArrayBuffer to AudioData assert_equals: data.length after detach expected 0 but got 10
 FAIL Encoding from AudioData with transferred buffer assert_equals: buffer.length after detach expected 0 but got 9600
-FAIL Test transfering ArrayBuffer to ImageDecoder. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
+FAIL Test transfering ArrayBuffer to ImageDecoder. assert_equals: buffer.byteLength after detach expected 0 but got 1442
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder-image-orientation-none.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder-image-orientation-none.https-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Test JPEG w/ EXIF orientation top-left on canvas w/o orientation assert_equals: top left corner expected "Yellow" but got "#ffff01ff"
-FAIL Test JPEG w/ EXIF orientation top-right on canvas w/o orientation. assert_equals: top left corner expected "Yellow" but got "#ffff01ff"
-FAIL Test JPEG w/ EXIF orientation bottom-right on canvas w/o orientation. assert_equals: top left corner expected "Yellow" but got "#ffff01ff"
-FAIL Test JPEG w/ EXIF orientation bottom-left on canvas w/o orientation. assert_equals: top left corner expected "Yellow" but got "#ffff01ff"
+PASS Test JPEG w/ EXIF orientation top-left on canvas w/o orientation
+PASS Test JPEG w/ EXIF orientation top-right on canvas w/o orientation.
+PASS Test JPEG w/ EXIF orientation bottom-right on canvas w/o orientation.
+PASS Test JPEG w/ EXIF orientation bottom-left on canvas w/o orientation.
 FAIL Test JPEG w/ EXIF orientation left-top on canvas w/o orientation. assert_equals: expected 320 but got 240
 FAIL Test JPEG w/ EXIF orientation right-top on canvas w/o orientation. assert_equals: expected 320 but got 240
 FAIL Test JPEG w/ EXIF orientation right-bottom on canvas w/o orientation. assert_equals: expected 320 but got 240

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.crossOriginIsolated.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.crossOriginIsolated.https.any-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Test ImageDecoder decoding with a SharedArrayBuffer source promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: SharedArrayBuffer"
+FAIL Test ImageDecoder decoding with a Uint8Array(SharedArrayBuffer) source promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: SharedArrayBuffer"
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.crossOriginIsolated.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.crossOriginIsolated.https.any.worker-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Test ImageDecoder decoding with a SharedArrayBuffer source promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: SharedArrayBuffer"
+FAIL Test ImageDecoder decoding with a Uint8Array(SharedArrayBuffer) source promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: SharedArrayBuffer"
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any-expected.txt
@@ -1,0 +1,89 @@
+
+Harness Error (FAIL), message = Unhandled rejection: Decoding error
+
+PASS Test JPEG image decoding.
+PASS Test JPEG w/ EXIF orientation top-left.
+FAIL Test JPEG w/ EXIF orientation top-right. assert_equals: top left corner expected "Red" but got "Yellow"
+FAIL Test JPEG w/ EXIF orientation bottom-right. assert_equals: top left corner expected "Green" but got "Yellow"
+FAIL Test JPEG w/ EXIF orientation bottom-left. assert_equals: top left corner expected "Blue" but got "Yellow"
+FAIL Test JPEG w/ EXIF orientation left-top. assert_equals: expected 240 but got 320
+FAIL Test JPEG w/ EXIF orientation right-top. assert_equals: expected 240 but got 320
+FAIL Test JPEG w/ EXIF orientation right-bottom. assert_equals: expected 240 but got 320
+FAIL Test JPEG w/ EXIF orientation left-bottom. assert_equals: expected 240 but got 320
+PASS Test 4:2:0 JPEG w/ EXIF orientation top-left.
+FAIL Test 4:2:0 JPEG w/ EXIF orientation top-right. assert_equals: top left corner expected "Red" but got "Yellow"
+FAIL Test 4:2:0 JPEG w/ EXIF orientation bottom-right. assert_equals: top left corner expected "Green" but got "Yellow"
+FAIL Test 4:2:0 JPEG w/ EXIF orientation bottom-left. assert_equals: top left corner expected "Blue" but got "Yellow"
+FAIL Test 4:2:0 JPEG w/ EXIF orientation left-top. assert_equals: expected 240 but got 320
+FAIL Test 4:2:0 JPEG w/ EXIF orientation right-top. assert_equals: expected 240 but got 320
+FAIL Test 4:2:0 JPEG w/ EXIF orientation right-bottom. assert_equals: expected 240 but got 320
+FAIL Test 4:2:0 JPEG w/ EXIF orientation left-bottom. assert_equals: expected 240 but got 320
+PASS Test PNG image decoding.
+PASS Test AVIF image decoding.
+PASS Test high bit depth HDR AVIF image decoding.
+FAIL Test multi-track AVIF image decoding w/ preferAnimation=false. assert_greater_than: expected a number greater than 1 but got 1
+FAIL Test multi-track AVIF image decoding w/ preferAnimation=true. assert_greater_than: expected a number greater than 1 but got 1
+PASS Test WEBP image decoding.
+PASS Test GIF image decoding.
+FAIL Test JPEG image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "BGRA"
+FAIL Test AVIF image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "BGRA"
+FAIL Test AVIF image YUV 4:2:2 decoding. assert_equals: expected "I422" but got "BGRA"
+FAIL Test AVIF image YUV 4:4:4 decoding. assert_equals: expected "I444" but got "BGRA"
+FAIL Test WEBP image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "BGRA"
+FAIL Test invalid mime type rejects decode() requests assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test invalid mime type rejects decodeMetadata() requests assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test out of range index returns RangeError assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test decoding a partial ArrayBuffer results in EncodingError promise_rejects_dom: function "function() { throw e; }" threw object "DataError: Decoding error" that is not a DOMException EncodingError: property "name" is equal to "DataError", expected "EncodingError"
+PASS Test completed property on fully buffered decode
+FAIL Test decode, decodeMetadata after no track selected. assert_equals: expected -1 but got 0
+FAIL Test track selection in multi track image. assert_equals: expected 2 but got 1
+TIMEOUT Test ReadableStream of gif Test timed out
+NOTRUN Test that decode requests are serialized.
+NOTRUN Test ReadableStream aborts promises on track change
+NOTRUN Test ReadableStream aborts completed on close
+NOTRUN Test ReadableStream resolves completed
+
+Harness Error (FAIL), message = Unhandled rejection: Decoding error
+
+PASS Test JPEG image decoding.
+PASS Test JPEG w/ EXIF orientation top-left.
+FAIL Test JPEG w/ EXIF orientation top-right. assert_equals: top left corner expected "Red" but got "Yellow"
+FAIL Test JPEG w/ EXIF orientation bottom-right. assert_equals: top left corner expected "Green" but got "Yellow"
+FAIL Test JPEG w/ EXIF orientation bottom-left. assert_equals: top left corner expected "Blue" but got "Yellow"
+FAIL Test JPEG w/ EXIF orientation left-top. assert_equals: expected 240 but got 320
+FAIL Test JPEG w/ EXIF orientation right-top. assert_equals: expected 240 but got 320
+FAIL Test JPEG w/ EXIF orientation right-bottom. assert_equals: expected 240 but got 320
+FAIL Test JPEG w/ EXIF orientation left-bottom. assert_equals: expected 240 but got 320
+PASS Test 4:2:0 JPEG w/ EXIF orientation top-left.
+FAIL Test 4:2:0 JPEG w/ EXIF orientation top-right. assert_equals: top left corner expected "Red" but got "Yellow"
+FAIL Test 4:2:0 JPEG w/ EXIF orientation bottom-right. assert_equals: top left corner expected "Green" but got "Yellow"
+FAIL Test 4:2:0 JPEG w/ EXIF orientation bottom-left. assert_equals: top left corner expected "Blue" but got "Yellow"
+FAIL Test 4:2:0 JPEG w/ EXIF orientation left-top. assert_equals: expected 240 but got 320
+FAIL Test 4:2:0 JPEG w/ EXIF orientation right-top. assert_equals: expected 240 but got 320
+FAIL Test 4:2:0 JPEG w/ EXIF orientation right-bottom. assert_equals: expected 240 but got 320
+FAIL Test 4:2:0 JPEG w/ EXIF orientation left-bottom. assert_equals: expected 240 but got 320
+PASS Test PNG image decoding.
+PASS Test AVIF image decoding.
+PASS Test high bit depth HDR AVIF image decoding.
+FAIL Test multi-track AVIF image decoding w/ preferAnimation=false. assert_greater_than: expected a number greater than 1 but got 1
+FAIL Test multi-track AVIF image decoding w/ preferAnimation=true. assert_greater_than: expected a number greater than 1 but got 1
+PASS Test WEBP image decoding.
+PASS Test GIF image decoding.
+FAIL Test JPEG image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "BGRA"
+FAIL Test AVIF image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "BGRA"
+FAIL Test AVIF image YUV 4:2:2 decoding. assert_equals: expected "I422" but got "BGRA"
+FAIL Test AVIF image YUV 4:4:4 decoding. assert_equals: expected "I444" but got "BGRA"
+FAIL Test WEBP image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "BGRA"
+FAIL Test invalid mime type rejects decode() requests assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test invalid mime type rejects decodeMetadata() requests assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test out of range index returns RangeError assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test decoding a partial ArrayBuffer results in EncodingError promise_rejects_dom: function "function() { throw e; }" threw object "DataError: Decoding error" that is not a DOMException EncodingError: property "name" is equal to "DataError", expected "EncodingError"
+PASS Test completed property on fully buffered decode
+FAIL Test decode, decodeMetadata after no track selected. assert_equals: expected -1 but got 0
+FAIL Test track selection in multi track image. assert_equals: expected 2 but got 1
+TIMEOUT Test ReadableStream of gif Test timed out
+NOTRUN Test that decode requests are serialized.
+NOTRUN Test ReadableStream aborts promises on track change
+NOTRUN Test ReadableStream aborts completed on close
+NOTRUN Test ReadableStream resolves completed
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any.worker-expected.txt
@@ -1,11 +1,11 @@
 
 Harness Error (TIMEOUT), message = null
 
-FAIL Test JPEG image decoding. assert_array_approx_equals: top left corner is yellow property 2, expected 0 +/- 0, expected 0 but got 1
-FAIL Test JPEG w/ EXIF orientation top-left. assert_equals: top left corner expected "Yellow" but got "#ffff01ff"
-FAIL Test JPEG w/ EXIF orientation top-right. assert_equals: top left corner expected "Red" but got "#ffff01ff"
-FAIL Test JPEG w/ EXIF orientation bottom-right. assert_equals: top left corner expected "Green" but got "#ffff01ff"
-FAIL Test JPEG w/ EXIF orientation bottom-left. assert_equals: top left corner expected "Blue" but got "#ffff01ff"
+PASS Test JPEG image decoding.
+PASS Test JPEG w/ EXIF orientation top-left.
+FAIL Test JPEG w/ EXIF orientation top-right. assert_equals: top left corner expected "Red" but got "Yellow"
+FAIL Test JPEG w/ EXIF orientation bottom-right. assert_equals: top left corner expected "Green" but got "Yellow"
+FAIL Test JPEG w/ EXIF orientation bottom-left. assert_equals: top left corner expected "Blue" but got "Yellow"
 FAIL Test JPEG w/ EXIF orientation left-top. assert_equals: expected 240 but got 320
 FAIL Test JPEG w/ EXIF orientation right-top. assert_equals: expected 240 but got 320
 FAIL Test JPEG w/ EXIF orientation right-bottom. assert_equals: expected 240 but got 320
@@ -25,16 +25,14 @@ FAIL Test multi-track AVIF image decoding w/ preferAnimation=false. assert_great
 FAIL Test multi-track AVIF image decoding w/ preferAnimation=true. assert_greater_than: expected a number greater than 1 but got 1
 PASS Test WEBP image decoding.
 PASS Test GIF image decoding.
-FAIL Test JPEG image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "RGBA"
-FAIL Test AVIF image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "RGBA"
-FAIL Test AVIF image YUV 4:2:2 decoding. assert_equals: expected "I422" but got "RGBA"
-FAIL Test AVIF image YUV 4:4:4 decoding. assert_equals: expected "I444" but got "RGBA"
-FAIL Test WEBP image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "RGBA"
+FAIL Test JPEG image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "BGRA"
+FAIL Test AVIF image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "BGRA"
+FAIL Test AVIF image YUV 4:2:2 decoding. assert_equals: expected "I422" but got "BGRA"
+FAIL Test AVIF image YUV 4:4:4 decoding. assert_equals: expected "I444" but got "BGRA"
+FAIL Test WEBP image YUV 4:2:0 decoding. assert_equals: expected "I420" but got "BGRA"
 FAIL Test invalid mime type rejects decode() requests assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test invalid mime type rejects decodeMetadata() requests assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Test out of range index returns RangeError promise_rejects_js: function "function() { throw e; }" threw object "DataError: Decoding error" ("DataError") expected instance of function "function RangeError() {
-    [native code]
-}" ("RangeError")
+FAIL Test out of range index returns RangeError assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test decoding a partial ArrayBuffer results in EncodingError promise_rejects_dom: function "function() { throw e; }" threw object "DataError: Decoding error" that is not a DOMException EncodingError: property "name" is equal to "DataError", expected "EncodingError"
 PASS Test completed property on fully buffered decode
 FAIL Test decode, decodeMetadata after no track selected. assert_equals: expected -1 but got 0

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -10210,9 +10210,8 @@ WebCodecsHEVCEnabled:
 
 WebCodecsImageEnabled:
   type: bool
-  status: unstable
+  status: testable
   category: media
-  webcoreOnChange: setNeedsRelayoutAllFrames
   humanReadableName: "WebCodecs Image API"
   humanReadableDescription: "Enable WebCodecs Image API"
   condition: ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp
@@ -28,12 +28,25 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "ImageDecoder.h"
+#include "JSDOMConvertBoolean.h"
 #include "JSDOMConvertDictionary.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebCodecsImageDecodeResult.h"
+#include "MIMETypeRegistry.h"
+#include "NativeImage.h"
+#include "ReadableStreamToSharedBufferSink.h"
+#include "ScriptExecutionContext.h"
+#include "ScriptExecutionContextInlines.h"
+#include "WebCodecsControlMessage.h"
 #include "WebCodecsImageDecodeResult.h"
 #include "WebCodecsVideoFrame.h"
 #include <wtf/TZoneMallocInlines.h>
+
+#if USE(CG)
+#include "UTIRegistry.h"
+#include "UTIUtilities.h"
+#endif
 
 namespace WebCore {
 
@@ -46,39 +59,277 @@ Ref<WebCodecsImageDecoder> WebCodecsImageDecoder::create(ScriptExecutionContext&
     return decoder;
 }
 
-WebCodecsImageDecoder::WebCodecsImageDecoder(ScriptExecutionContext& context, Init&&)
+WebCodecsImageDecoder::WebCodecsImageDecoder(ScriptExecutionContext& context, Init&& init)
     : WebCodecsBase(context)
     , m_completedPromise(makeUniqueRef<CompletedPromise>())
+    , m_tracks(WebCodecsImageTrackList::create())
 {
+    RefPtr<SharedBuffer> buffer;
+
+    // FIXME: Support SharedArrayBuffer.
+    WTF::switchOn(init.data,
+        [&](const Ref<JSC::ArrayBuffer>& data) {
+            if (RefPtr buffer = SharedBuffer::create(data->span()))
+                setInternalDecoderData(*buffer, init.type, true);
+        },
+        [&](const Ref<JSC::ArrayBufferView>& data) {
+            if (RefPtr buffer = SharedBuffer::create(data->span()))
+                setInternalDecoderData(*buffer, init.type, true);
+        },
+        [&](const Ref<ReadableStream>& stream) {
+            sinkStreamToInternalDecoder(stream, init.type);
+        }
+    );
 }
 
 WebCodecsImageDecoder::~WebCodecsImageDecoder() = default;
 
-Ref<WebCodecsImageTrackList> WebCodecsImageDecoder::tracks() const
+void WebCodecsImageDecoder::sinkStreamToInternalDecoder(const Ref<ReadableStream>& stream, const String& type)
 {
-    if (!m_tracks)
-        m_tracks = WebCodecsImageTrackList::create({ WebCodecsImageTrack::create() });
-
-    return *m_tracks;
+    m_sink = ReadableStreamToSharedBufferSink::create([weakThis = ThreadSafeWeakPtr { *this }, type](auto&& result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        WTF::switchOn(WTF::move(result),
+            [&](std::nullptr_t) {
+                if (RefPtr buffer = protectedThis->m_bufferBuilder.copyBuffer())
+                    protectedThis->setInternalDecoderData(*buffer, type, true);
+            },
+            [&](std::span<const uint8_t>&& chunk) {
+                protectedThis->m_bufferBuilder.append(chunk);
+                if (RefPtr buffer = protectedThis->m_bufferBuilder.copyBuffer())
+                    protectedThis->setInternalDecoderData(*buffer, type, false);
+            },
+            [&](JSC::JSValue) {
+                protectedThis->closeDecoder(Exception { ExceptionCode::AbortError, "ReadableStream cancelled"_s });
+            },
+            [&](Exception&& exception) {
+                protectedThis->closeDecoder(WTF::move(exception));
+            }
+        );
+    });
+    protect(m_sink)->pipeFrom(stream);
 }
 
-ExceptionOr<void> WebCodecsImageDecoder::decode(std::optional<DecodeOptions>&&, Ref<DeferredPromise>&&)
+void WebCodecsImageDecoder::setInternalDecoderData(FragmentedSharedBuffer& buffer, const String& type, bool allDataReceived)
 {
-    return Exception { ExceptionCode::NotSupportedError };
+    if (state() == WebCodecsCodecState::Closed)
+        return;
+
+    if (!m_internalDecoder)
+        m_internalDecoder = ImageDecoder::create(buffer, type, AlphaOption::Premultiplied, GammaAndColorProfileOption::Applied);
+
+    if (!m_internalDecoder)
+        return;
+
+    // Set all accumulated encoded data in m_internalDecoder.
+    protect(m_internalDecoder)->setData(buffer, allDataReceived);
+    if (!allDataReceived)
+        return;
+
+    // Now m_internalDecoder has received all data, finish configuring
+    // the state of WebCodecsImageDecoder.
+    establishTrackList();
+    setState(WebCodecsCodecState::Configured);
+    m_completedPromise->resolve();
+
+    // Begin queuing the pending decode requests which were received while
+    // the encoded data was being received.
+    queuePendingDecodeRequests();
+}
+
+void WebCodecsImageDecoder::establishTrackList()
+{
+    ASSERT(m_internalDecoder);
+    ASSERT(!m_tracks->isEstablished());
+
+    // FIXME: Can images can have more than one track?
+    auto frameCount = protect(m_internalDecoder)->frameCount();
+    auto repetitionCount = protect(m_internalDecoder)->repetitionCount();
+    Ref track = WebCodecsImageTrack::create(repetitionCount, frameCount, frameCount > 1, true);
+
+    protect(m_tracks)->setTrackList({ WTF::move(track) });
+}
+
+WorkQueue& WebCodecsImageDecoder::queueSingleton()
+{
+    static NeverDestroyed<Ref<WorkQueue>> workQueue = WorkQueue::create("WebCodecsImageDecoder Work Queue"_s);
+    return workQueue.get();
+}
+
+Ref<WebCodecsImageDecoder::DecodePromise> WebCodecsImageDecoder::createNativeImageAtIndex(size_t frameIndex)
+{
+    if (state() == WebCodecsCodecState::Closed)
+        return DecodePromise::createAndReject();
+
+    ASSERT(m_internalDecoder);
+    return invokeAsync(WebCodecsImageDecoder::queueSingleton(), [decoder = m_internalDecoder, frameIndex] {
+        if (auto result = decoder->createNativeImageAtIndex(frameIndex, SubsamplingLevel::Default, { }))
+            return DecodePromise::createAndResolve(WTF::move(std::get<Ref<NativeImage>>(*result)));
+        return DecodePromise::createAndReject();
+    });
+}
+
+void WebCodecsImageDecoder::fulfillPendingDecodePromises(size_t frameIndex, RefPtr<NativeImage>&& nativeImage)
+{
+    if (state() == WebCodecsCodecState::Closed) {
+        rejectPendingDecodePromises(frameIndex, Exception { ExceptionCode::DataError, "ImageDecoder is closed"_s });
+        return;
+    }
+
+    if (!nativeImage) {
+        rejectPendingDecodePromises(frameIndex, Exception { ExceptionCode::DataError, "Decoding error"_s });
+        return;
+    }
+
+    ASSERT(m_internalDecoder);
+    Ref internalDecoder = *m_internalDecoder;
+
+    IntSize frameSize = internalDecoder->frameSizeAtIndex(frameIndex);
+
+    WebCodecsVideoFrame::Init init {
+        .duration = static_cast<uint64_t>(internalDecoder->frameDurationAtIndex(frameIndex).value()),
+        .timestamp = std::nullopt,
+        .alpha = WebCodecsAlphaOption::Keep,
+        .visibleRect = std::nullopt,
+        .displayWidth = static_cast<size_t>(frameSize.width()),
+        .displayHeight = static_cast<size_t>(frameSize.height())
+    };
+
+    // FIXME: nativeImage should be rotated based on the frame ImageOrientation.
+    auto videoFrame = WebCodecsVideoFrame::create(*protect(scriptExecutionContext()), nativeImage.releaseNonNull(), WTF::move(init));
+    if (videoFrame.hasException()) {
+        rejectPendingDecodePromises(frameIndex, videoFrame.releaseException());
+        return;
+    }
+
+    auto decodeResult = WebCodecsImageDecodeResult { videoFrame.releaseReturnValue(), true };
+    for (auto& promise : m_pendingDecodePromises.take(frameIndex + 1))
+        promise->resolve<IDLDictionary<WebCodecsImageDecodeResult>>(decodeResult);
+}
+
+void WebCodecsImageDecoder::rejectPendingDecodePromises(size_t frameIndex, const Exception& exception)
+{
+    for (auto& promise : m_pendingDecodePromises.take(frameIndex + 1))
+        promise->reject(exception);
+}
+
+void WebCodecsImageDecoder::queueDecodeRequest(std::optional<DecodeOptions>&& options)
+{
+    queueControlMessageAndProcess({ *this, [this, protectedThis = Ref { *this }, options = WTF::move(options)]() mutable {
+        protect(scriptExecutionContext())->enqueueTaskWhenSettled(
+            createNativeImageAtIndex(options->frameIndex),
+            TaskSource::MediaElement,
+            [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this), options = WTF::move(options)](auto&& result) {
+                if (RefPtr protectedThis = weakThis.get()) {
+                    if (result.has_value())
+                        protectedThis->fulfillPendingDecodePromises(options->frameIndex, WTF::move(result.value()));
+                    else
+                        protectedThis->fulfillPendingDecodePromises(options->frameIndex, nullptr);
+                }
+        });
+        return WebCodecsControlMessageOutcome::Processed;
+    } });
+}
+
+void WebCodecsImageDecoder::queuePendingDecodeRequests()
+{
+    for (auto frameIndex : m_pendingDecodePromises.keys())
+        queueDecodeRequest(DecodeOptions { frameIndex - 1, true });
+}
+
+void WebCodecsImageDecoder::decode(std::optional<DecodeOptions>&& options, Ref<DeferredPromise>&& promise)
+{
+    // If state is closed, return a Promise rejected.
+    if (state() == WebCodecsCodecState::Closed) {
+        promise->reject(Exception { ExceptionCode::InvalidStateError, "ImageDecoder is closed"_s });
+        return;
+    }
+
+    // If options is undefined, assign a new ImageDecodeOptions to options.
+    if (!options)
+        options = DecodeOptions { };
+
+    // Append promise to the pendingDecodePromises.
+    auto addResult = m_pendingDecodePromises.ensure(options->frameIndex + 1, [] -> Vector<Ref<DeferredPromise>> {
+        return { };
+    });
+
+    addResult.iterator->value.append(WTF::move(promise));
+
+    if (!addResult.isNewEntry)
+        return;
+
+    // Wait for the tracks to be established.
+    if (!m_tracks->isEstablished())
+        return;
+
+    queueDecodeRequest(WTF::move(options));
+}
+
+ExceptionOr<void> WebCodecsImageDecoder::resetDecoder(const Exception& exception)
+{
+    if (state() == WebCodecsCodecState::Closed)
+        return Exception { ExceptionCode::InvalidStateError, "ImageDecoder is closed"_s };
+
+    // Abort any active decoding operation.
+    clearControlMessageQueueAndMaybeScheduleDequeueEvent();
+
+    // Reject pendding decoding promises with exception.
+    auto pendingDecodePromises = std::exchange(m_pendingDecodePromises, { });
+    for (auto& framePromises : pendingDecodePromises.values()) {
+        for (auto& promise : framePromises)
+            promise->reject(exception);
+    }
+
+    return { };
+}
+
+ExceptionOr<void> WebCodecsImageDecoder::closeDecoder(const Exception& exception)
+{
+    // Run Reset ImageDecoder algorithm with exception
+    auto result = resetDecoder(exception);
+    if (result.hasException())
+        return result;
+
+    // Set state to closed.
+    setState(WebCodecsCodecState::Closed);
+
+    // Clear the internal decoder and release associated system resources.
+    m_internalDecoder = nullptr;
+    m_sink = nullptr;
+
+    // Clear the ImageTrackList;
+    protect(m_tracks)->clearTrackList(exception);
+
+    // If completed is not resolved, reject it with exception.
+    if (!m_completedPromise->isFulfilled())
+        m_completedPromise->reject(exception);
+    return { };
 }
 
 ExceptionOr<void> WebCodecsImageDecoder::reset()
 {
-    return Exception { ExceptionCode::NotSupportedError };
+    return resetDecoder(Exception { ExceptionCode::AbortError, "Reset called"_s });
 }
 
 ExceptionOr<void> WebCodecsImageDecoder::close()
 {
-    return Exception { ExceptionCode::NotSupportedError };
+    return closeDecoder(Exception { ExceptionCode::AbortError, "Close called"_s });
 }
 
-void WebCodecsImageDecoder::isTypeSupported(ScriptExecutionContext&, String&&, Ref<DeferredPromise>&&)
+void WebCodecsImageDecoder::isTypeSupported(ScriptExecutionContext&, String&& mimeType, DOMPromiseDeferred<IDLBoolean>&& promise)
 {
+#if USE(CG)
+    bool isTypeSupported = isSupportedImageType(UTIFromMIMEType(mimeType));
+#else
+    bool isTypeSupported = MIMETypeRegistry::isSupportedImageMIMEType(mimeType);
+#endif
+
+    if (isTypeSupported)
+        promise.resolve(true);
+    else
+        promise.reject(Exception { ExceptionCode::TypeError, "Image type is not supported"_s });
 }
 
 void WebCodecsImageDecoder::suspend(ReasonForSuspension)
@@ -87,6 +338,11 @@ void WebCodecsImageDecoder::suspend(ReasonForSuspension)
 
 void WebCodecsImageDecoder::stop()
 {
+    setState(WebCodecsCodecState::Closed);
+    m_internalDecoder = nullptr;
+    m_sink = nullptr;
+    clearControlMessageQueue();
+    m_pendingDecodePromises.clear();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.h
@@ -32,15 +32,22 @@
 #include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include "JSDOMPromiseDeferredForward.h"
+#include "SharedBuffer.h"
 #include "WebCodecsBase.h"
 #include "WebCodecsImageTrackList.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/ArrayBufferView.h>
+#include <wtf/NativePromise.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/WorkQueue.h>
 
 namespace WebCore {
 
+class ImageDecoder;
+class NativeImage;
 class ReadableStream;
+class ReadableStreamToSharedBufferSink;
+class SharedBuffer;
 class WebCodecsVideoFrame;
 
 using ImageBufferSource = Variant
@@ -73,32 +80,57 @@ public:
     static Ref<WebCodecsImageDecoder> create(ScriptExecutionContext&, Init&&);
 
     String type() const { return m_type; }
-    bool complete() const { return true; }
+    bool complete() const { return m_completedPromise->isFulfilled(); }
 
     using CompletedPromise = DOMPromiseProxy<IDLUndefined>;
     CompletedPromise& completed() { return m_completedPromise.get(); }
 
-    Ref<WebCodecsImageTrackList> tracks() const;
+    Ref<WebCodecsImageTrackList> tracks() const { return m_tracks; }
 
-    ExceptionOr<void> decode(std::optional<DecodeOptions>&&, Ref<DeferredPromise>&&);
+    void decode(std::optional<DecodeOptions>&&, Ref<DeferredPromise>&&);
+
     ExceptionOr<void> reset();
     ExceptionOr<void> close();
 
-    static void isTypeSupported(ScriptExecutionContext&, String&& type, Ref<DeferredPromise>&&);
+    static void isTypeSupported(ScriptExecutionContext&, String&& type, DOMPromiseDeferred<IDLBoolean>&&);
 
 private:
     WebCodecsImageDecoder(ScriptExecutionContext&, Init&&);
 
     // ActiveDOMObject.
-    void stop() final;
     void NODELETE suspend(ReasonForSuspension) final;
+    void stop() final;
 
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsImageDecoder; }
 
+    void sinkStreamToInternalDecoder(const Ref<ReadableStream>&, const String& type);
+    void setInternalDecoderData(FragmentedSharedBuffer&, const String& type, bool allDataReceived);
+    void establishTrackList();
+
+    static WorkQueue& queueSingleton();
+
+    using DecodePromise = NativePromise<RefPtr<NativeImage>, void>;
+    Ref<DecodePromise> createNativeImageAtIndex(size_t frameIndex);
+
+    void fulfillPendingDecodePromises(size_t frameIndex, RefPtr<NativeImage>&&);
+    void rejectPendingDecodePromises(size_t frameIndex, const Exception&);
+
+    void queueDecodeRequest(std::optional<DecodeOptions>&&);
+    void queuePendingDecodeRequests();
+
+    ExceptionOr<void> resetDecoder(const Exception&);
+    ExceptionOr<void> closeDecoder(const Exception&);
+
     String m_type;
     UniqueRef<CompletedPromise> m_completedPromise;
-    mutable RefPtr<WebCodecsImageTrackList> m_tracks;
+    mutable Ref<WebCodecsImageTrackList> m_tracks;
+
+    RefPtr<ImageDecoder> m_internalDecoder;
+    HashMap<size_t, Vector<Ref<DeferredPromise>>> m_pendingDecodePromises;
+
+    RefPtr<ReadableStreamToSharedBufferSink> m_sink;
+    SharedBufferBuilder m_bufferBuilder;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.cpp
@@ -34,15 +34,36 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCodecsImageTrackList);
 
-Ref<WebCodecsImageTrackList> WebCodecsImageTrackList::create(Vector<Ref<WebCodecsImageTrack>>&& list)
+Ref<WebCodecsImageTrackList> WebCodecsImageTrackList::create()
 {
-    return adoptRef(*new WebCodecsImageTrackList(WTF::move(list)));
+    return adoptRef(*new WebCodecsImageTrackList());
 }
 
-WebCodecsImageTrackList::WebCodecsImageTrackList(Vector<Ref<WebCodecsImageTrack>>&& list)
+WebCodecsImageTrackList::WebCodecsImageTrackList()
     : m_readyPromise(makeUniqueRef<ReadyPromise>())
-    , m_list(WTF::move(list))
 {
+}
+
+void WebCodecsImageTrackList::setTrackList(Vector<Ref<WebCodecsImageTrack>>&& list)
+{
+    if (list.isEmpty())
+        return;
+    m_list = WTF::move(list);
+    m_selectedIndex = 0;
+    m_readyPromise->resolve();
+}
+
+void WebCodecsImageTrackList::clearTrackList(const Exception& exception)
+{
+    // If readyPromise is not fulfilled, reject it with exception.
+    if (!m_readyPromise->isFulfilled()) {
+        m_readyPromise->reject(exception);
+        return;
+    }
+
+    // Remove all entries from the list and set the selected index to -1.
+    m_list.clear();
+    m_selectedIndex = -1;
 }
 
 RefPtr<WebCodecsImageTrack> WebCodecsImageTrackList::selectedTrack() const

--- a/Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.h
@@ -39,7 +39,11 @@ namespace WebCore {
 class WebCodecsImageTrackList final : public RefCounted<WebCodecsImageTrackList> {
     WTF_MAKE_TZONE_ALLOCATED(WebCodecsImageTrackList);
 public:
-    static Ref<WebCodecsImageTrackList> create(Vector<Ref<WebCodecsImageTrack>>&&);
+    static Ref<WebCodecsImageTrackList> create();
+
+    void setTrackList(Vector<Ref<WebCodecsImageTrack>>&&);
+    void clearTrackList(const Exception&);
+    bool isEstablished() const { return length() > 0; }
 
     using ReadyPromise = DOMPromiseProxy<IDLUndefined>;
     ReadyPromise& ready() { return m_readyPromise.get(); }
@@ -52,7 +56,7 @@ public:
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
 
 private:
-    WebCodecsImageTrackList(Vector<Ref<WebCodecsImageTrack>>&&);
+    WebCodecsImageTrackList();
 
     UniqueRef<ReadyPromise> m_readyPromise;
     int m_selectedIndex { -1 };

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -331,9 +331,9 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
     return WebCodecsVideoFrame::create(context, videoFrame.releaseNonNull(), WTF::move(init));
 }
 
-ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutionContext& context, Ref<NativeImage>&& image)
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutionContext& context, Ref<NativeImage>&& image, Init&& init)
 {
-    return initializeFrameWithResourceAndSize(context, WTF::move(image), { });
+    return initializeFrameWithResourceAndSize(context, WTF::move(image), WTF::move(init));
 }
 
 Ref<WebCodecsVideoFrame> WebCodecsVideoFrame::create(ScriptExecutionContext& context, Ref<VideoFrame>&& videoFrame, BufferInit&& init)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -106,7 +106,7 @@ public:
     static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, Ref<WebCodecsVideoFrame>&&, Init&&);
     static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, BufferSource&&, BufferInit&&);
     static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, ImageBuffer&, IntSize, Init&&);
-    WEBCORE_EXPORT static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, Ref<NativeImage>&&);
+    WEBCORE_EXPORT static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, Ref<NativeImage>&&, Init&&);
     static Ref<WebCodecsVideoFrame> create(ScriptExecutionContext&, Ref<VideoFrame>&&, BufferInit&&);
     static Ref<WebCodecsVideoFrame> create(ScriptExecutionContext& context, WebCodecsVideoFrameData&& data) { return adoptRef(*new WebCodecsVideoFrame(context, WTF::move(data))); }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -8128,7 +8128,7 @@ void Internals::loadArtworkImage(String&& url, ArtworkImagePromise&& promise)
             promise->reject(Exception { ExceptionCode::InvalidAccessError, "No image retrieved."_s });
             return;
         }
-        promise->settle(WebCodecsVideoFrame::create(*document, *nativeImage));
+        promise->settle(WebCodecsVideoFrame::create(*document, *nativeImage, { }));
     });
     m_artworkLoader->requestImageResource();
 }


### PR DESCRIPTION
#### 7040d58fe3bd1070a1d68477d0fb3a397f2d2d05
<pre>
Implement WebCodecsImageDecoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=315546">https://bugs.webkit.org/show_bug.cgi?id=315546</a>
<a href="https://rdar.apple.com/177922841">rdar://177922841</a>

Reviewed by Jean-Yves Avenard.

WebCodecsImageDecoder[1] allows treating animated formats as temporal tracks. It
enables seeking to and decoding individual frames directly into VideoFrame objects.

Decoded image frames can be routed directly into WebGPU textures using the same
high-efficiency path we provide for VideoDecoder, rather than relying on DOM-based
fall-backs.

WebCodecsImageTrackList[2] retrieves the tracks in the image. Currently the image
APIs do not have provide any track information. For now a single track is assumed
per image.

This change implements the basics of this Web API. Following changes will fix the
reset of the ImageDecoder WPT failures.

[1] <a href="https://w3c.github.io/webcodecs/#imagedecoder-interface">https://w3c.github.io/webcodecs/#imagedecoder-interface</a>
[2] <a href="https://w3c.github.io/webcodecs/#imagetracklist-interface">https://w3c.github.io/webcodecs/#imagetracklist-interface</a>

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder-image-orientation-none.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.crossOriginIsolated.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.crossOriginIsolated.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.cpp:
(WebCore::WebCodecsImageDecoder::WebCodecsImageDecoder):
(WebCore::WebCodecsImageDecoder::setInternalDecoder):
(WebCore::WebCodecsImageDecoder::buildTrackList):
(WebCore::WebCodecsImageDecoder::queueSingleton):
(WebCore::WebCodecsImageDecoder::createNativeImageAtIndex):
(WebCore::WebCodecsImageDecoder::resolvePendingDecodePromises):
(WebCore::WebCodecsImageDecoder::rejectPendingDecodePromises):
(WebCore::WebCodecsImageDecoder::decode):
(WebCore::WebCodecsImageDecoder::resetDecoder):
(WebCore::WebCodecsImageDecoder::closeDecoder):
(WebCore::WebCodecsImageDecoder::reset):
(WebCore::WebCodecsImageDecoder::close):
(WebCore::WebCodecsImageDecoder::isTypeSupported):
(WebCore::WebCodecsImageDecoder::stop):
(WebCore::WebCodecsImageDecoder::tracks const): Deleted.
(WebCore::WebCodecsImageDecoder::createInternalDecoder):
(WebCore::WebCodecsImageDecoder::setInternalDecoderData):
(WebCore::WebCodecsImageDecoder::sinkStreamToInternalDecoder):
(WebCore::WebCodecsImageDecoder::establishTrackList):
(WebCore::WebCodecsImageDecoder::settlePendingDecodePromises):
(WebCore::WebCodecsImageDecoder::queueDecodeRequest):
(WebCore::WebCodecsImageDecoder::queuePendingDecodeRequests):
(WebCore::WebCodecsImageDecoder::fulfillPendingDecodePromises):
* Source/WebCore/Modules/webcodecs/WebCodecsImageDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.cpp:
(WebCore::WebCodecsImageTrackList::create):
(WebCore::WebCodecsImageTrackList::WebCodecsImageTrackList):
(WebCore::WebCodecsImageTrackList::setTrackList):
(WebCore::WebCodecsImageTrackList::closeTrackList):
(WebCore::WebCodecsImageTrackList::clearTrackList):
* Source/WebCore/Modules/webcodecs/WebCodecsImageTrackList.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::loadArtworkImage):
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder-image-orientation-none.https-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.crossOriginIsolated.https.any-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.crossOriginIsolated.https.any.worker-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/image-decoder.https.any.worker-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/319040@main">https://commits.webkit.org/319040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfa2e050859aec1668b507f83d51f65f1cebe7e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144530 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53872 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140556 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121008 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42881 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41191 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/2975 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Passed JSC tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/9824 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153285 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40868 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1581 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41485 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192357 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53822 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149900 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40152 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54510 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149629 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44271 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126773 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121918 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53027 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15857 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52409 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52646 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52474 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->