### PR TITLE
[MSE|Cocoa] currentTime can go beyond duration or gap following a seek.

### DIFF
--- a/LayoutTests/media/media-source/media-source-seek-across-gap-stall-reset-expected.txt
+++ b/LayoutTests/media/media-source/media-source-seek-across-gap-stall-reset-expected.txt
@@ -1,0 +1,30 @@
+
+RUN(video.src = URL.createObjectURL(source))
+RUN(video.muted = true)
+RUN(video.playsInline = true)
+RUN(video.disableRemotePlayback = true)
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+Append every fragment so buffered = [0, 10].
+RUN(source.endOfStream())
+EVENT(sourceended)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+Punch two gaps so buffered = [0, 1] [3, 5] [8, 10].
+RUN(sourceBuffer.remove(1, 3))
+EVENT(update)
+RUN(sourceBuffer.remove(5, 8))
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '3') OK
+Seek into the middle buffered range, past the first gap.
+RUN(video.currentTime = 4)
+EVENT(seeked)
+EXPECTED (video.currentTime >= 3 && video.currentTime <= 5 == 'true') OK
+RUN(video.play())
+EVENT(playing)
+EVENT(waiting)
+EXPECTED (video.currentTime <= 5.1 == 'true') OK
+EXPECTED (video.currentTime < 8 == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-seek-across-gap-stall-reset.html
+++ b/LayoutTests/media/media-source/media-source-seek-across-gap-stall-reset.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>currentTime must not advance past the next buffered-range gap after seeking into a later buffered range</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Regression test for https://bugs.webkit.org/show_bug.cgi?id=315551.
+    var loader;
+    var source;
+    var sourceBuffer;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        try {
+            findMediaElement();
+
+            loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+            await loaderPromise(loader);
+
+            source = new MediaSource();
+            run('video.src = URL.createObjectURL(source)');
+            run('video.muted = true');
+            run('video.playsInline = true');
+            run('video.disableRemotePlayback = true');
+            await waitFor(source, 'sourceopen');
+            waitFor(video, 'error').then(failTest);
+
+            run('sourceBuffer = source.addSourceBuffer(loader.type())');
+            run('sourceBuffer.appendBuffer(loader.initSegment())');
+            await waitFor(sourceBuffer, 'update');
+
+            consoleWrite('Append every fragment so buffered = [0, 10].');
+            for (let i = 0; i < loader.mediaSegmentsLength(); i++) {
+                sourceBuffer.appendBuffer(loader.mediaSegment(i));
+                await waitFor(sourceBuffer, 'update', true);
+            }
+            run('source.endOfStream()');
+            await waitFor(source, 'sourceended');
+            testExpected('sourceBuffer.buffered.length', 1);
+
+            consoleWrite('Punch two gaps so buffered = [0, 1] [3, 5] [8, 10].');
+            run('sourceBuffer.remove(1, 3)');
+            await waitFor(sourceBuffer, 'update');
+            run('sourceBuffer.remove(5, 8)');
+            await waitFor(sourceBuffer, 'update');
+            testExpected('sourceBuffer.buffered.length', 3);
+
+            consoleWrite('Seek into the middle buffered range, past the first gap.');
+            run('video.currentTime = 4');
+            await waitFor(video, 'seeked');
+            testExpected('video.currentTime >= 3 && video.currentTime <= 5', true);
+
+            run('video.play()');
+            await waitFor(video, 'playing');
+
+            // Wait for the renderer to stall at the end of the middle range. With
+            // the fix the boundary observer fires at 5 and the renderer stalls
+            // there. 'waiting' may fire from either the cap or from
+            // MediaSource::monitorSourceBuffers's periodic readyState recheck just
+            // before reaching 5 — both paths fire it in roughly the same wallclock
+            // window, so the event itself does not distinguish the fixed and
+            // unfixed cases. The differentiator is the currentTime check below.
+            //
+            // Bound the wait so the test fails fast if 'waiting' never fires.
+            await waitForEventWithTimeout(video, 'waiting', 3000, "'waiting' did not fire after seeking into a buffered range followed by a gap");
+
+            // Give enough wallclock time for the unfixed case to advance past 5.
+            // With the fix this is a no-op: the cap has already pinned playback
+            // at 5.
+            await sleepFor(500);
+
+            // The defining assertion: currentTime must be at or just past the
+            // start of the [5, 8] gap. The tolerance accounts for
+            // MediaSource::monitorSourceBuffers running on a 250ms timer:
+            // without the fix, playback advances past 5 until the next
+            // monitorSourceBuffers tick fires 'waiting' and pauses, landing
+            // somewhere up to ~5.25.
+            testExpected('video.currentTime <= 5.1', true);
+            testExpected('video.currentTime < 8', true);
+
+            endTest();
+        } catch (e) {
+            failTest(`Caught exception: "${e}"`);
+        }
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -317,6 +317,7 @@ private:
 
     friend class MediaSourcePrivateAVFObjC;
     void bufferedChanged();
+    void resetStallForTime(const MediaTime&);
     void stall();
     void timeChanged();
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -617,6 +617,11 @@ void MediaPlayerPrivateMediaSourceAVFObjC::reenqueueMediaForTimeAndFinishSeek(co
     assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER, seekTime);
 
+    // Refresh the renderer's stall cap before finishSeek, since finishSeek
+    // may resume playback on the GPU side. The cap programmed for the
+    // pre-seek playhead may be stale.
+    resetStallForTime(seekTime);
+
     GenericPromise::all({
         protect(m_mediaSourcePrivate)->reenqueueMediaForTime(seekTime),
         invokeAsync(MediaSourcePrivateAVFObjC::queueSingleton(), [renderer = m_renderer, seekTime] -> Ref<GenericPromise> {
@@ -745,23 +750,27 @@ const PlatformTimeRanges& MediaPlayerPrivateMediaSourceAVFObjC::buffered() const
 
 void MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged()
 {
+    resetStallForTime(currentTime());
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::resetStallForTime(const MediaTime& time)
+{
     assertIsMainThread();
     m_renderer->cancelTimeReachedAction();
 
     auto ranges = protect(m_mediaSourcePrivate)->buffered();
-    auto currentTime = this->currentTime();
-    if (!protect(m_mediaSourcePrivate)->hasFutureTime(currentTime) && shouldBePlaying()) {
-        ALWAYS_LOG(LOGIDENTIFIER, "Not having data to play at currentTime: ", currentTime, " stalling");
+    if (!protect(m_mediaSourcePrivate)->hasFutureTime(time) && shouldBePlaying()) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Not having data to play at time: ", time, " stalling");
         stall();
     }
 
     auto stallAtTime = duration();
-    size_t index = ranges.find(currentTime);
+    size_t index = ranges.find(time);
     if (index != notFound) {
         // Find the next gap (or end of media)
         for (; index < ranges.length(); index++) {
             if ((index < ranges.length() - 1 && ranges.start(index + 1) - ranges.end(index) > m_mediaSourcePrivate->timeFudgeFactor())
-                || (index == ranges.length() - 1 && ranges.end(index) > currentTime)) {
+                || (index == ranges.length() - 1 && ranges.end(index) > time)) {
                 stallAtTime = ranges.end(index);
                 break;
             }
@@ -1037,7 +1046,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::durationChanged()
             player->durationChanged();
     }
     m_duration = duration;
-    bufferedChanged();
+    resetStallForTime(currentTime());
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::effectiveRateChanged()
@@ -1054,7 +1063,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::notifyEndOfMediaIfNeeded()
     assertIsMainThread();
     // Observed: in some runs, playback drains at end of media (the renderer
     // stops producing frames) without the boundary observer programmed in
-    // bufferedChanged() firing. The effective rate still transitions to 0
+    // resetStallForTime() firing. The effective rate still transitions to 0
     // in that case, which gives us a reliable signal: if MediaSource has
     // transitioned to 'ended' and there is no future data past the current
     // time, route a timeChanged() through so HTMLMediaElement's

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -170,6 +170,13 @@ void AudioVideoRendererRemote::TimeProgressEstimator::clearStallCap()
     m_stallCap.reset();
 }
 
+void AudioVideoRendererRemote::TimeProgressEstimator::clearStallCapIfBefore(const MediaTime& time)
+{
+    Locker locker { m_lock };
+    if (m_stallCap && *m_stallCap < time)
+        m_stallCap.reset();
+}
+
 Ref<AudioVideoRendererRemote> AudioVideoRendererRemote::create(LoggerHelper* loggerHelper, HTMLMediaElementIdentifier mediaElementIdentifier, MediaPlayerIdentifier playerIdentifier, GPUProcessConnection& connection)
 {
     assertIsMainThread();
@@ -603,6 +610,11 @@ Ref<MediaTimePromise> AudioVideoRendererRemote::prepareToSeek(const MediaTime& t
 {
     m_timeEstimator.setTime({ time, 0.0, MonotonicTime::now() });
     m_timeEstimator.resetLastReturnedTime();
+    // A forward seek past a previously-installed stall cap leaves the cap
+    // describing a position now behind the playhead. The estimator would
+    // otherwise clamp currentTime() back to that stale boundary. The player
+    // computes a new cap via resetStallForTime() if needed.
+    m_timeEstimator.clearStallCapIfBefore(time);
     m_seeking = true;
     m_lastSeekTime = time;
     return invokeAsync(queueSingleton(), [protectedThis = Ref { *this }, this, time] -> Ref<MediaTimePromise> {

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -115,6 +115,7 @@ public:
         void resetLastReturnedTime();
         void setStallCap(const MediaTime&);
         void clearStallCap();
+        void clearStallCapIfBefore(const MediaTime&);
 
     private:
         static constexpr Seconds kUpdateInterval = remoteAudioVideoRendererUpdateInterval;


### PR DESCRIPTION
#### 49f240763dcf90d9be128418bed0a863343f5f94
<pre>
[MSE|Cocoa] currentTime can go beyond duration or gap following a seek.
<a href="https://bugs.webkit.org/show_bug.cgi?id=315551">https://bugs.webkit.org/show_bug.cgi?id=315551</a>
<a href="https://rdar.apple.com/177926288">rdar://177926288</a>

Reviewed by Youenn Fablet.

MediaPlayerPrivateMediaSourceAVFObjC programs an AVFoundation boundary-time
observer (&quot;stall cap&quot;) on the synchronizer that fires when synchronizer time
crosses the next gap end (or duration). The cap was computed in bufferedChanged()
from the current buffered ranges and the current playhead.

bufferedChanged() is only invoked by MediaSource::updateBufferedIfNeeded when
the aggregated buffered ranges actually change. A seek does NOT change buffered
ranges, so before the fix the cap remained programmed against the pre-seek
playhead. If that boundary lies behind the post-seek synchronizer time, the
synchronizer plays forward and never crosses it, so the renderer kept
advancing past the next gap.

Should the currentTime changed following a seek, this wasn&apos;t reset and the
stall stop would become stale.

A second cache of the stall cap exists in AudioVideoRendererRemote&apos;s
TimeProgressEstimator: it mirrors the boundary so currentTime() can clamp to it
locally without waiting for the GPU stall IPC to round-trip. After a forward
seek past the cap, that cached value describes a position behind the playhead
and the estimator would clamp currentTime() backwards to it.
clearStallCapIfBefore() drops the cached cap when prepareToSeek moves the
playhead past it; the player then computes a fresh cap via resetStallForTime on
the post-seek time, which reprograms both the GPU-side boundary observer and
the WebContent-side cache.

Test added.

* LayoutTests/media/media-source/media-source-seek-across-gap-stall-reset-expected.txt: Added.
* LayoutTests/media/media-source/media-source-seek-across-gap-stall-reset.html: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::reenqueueMediaForTimeAndFinishSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::resetStallForTime):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::durationChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::notifyEndOfMediaIfNeeded):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::clearStallCapIfBefore):
(WebKit::AudioVideoRendererRemote::prepareToSeek):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:

Canonical link: <a href="https://commits.webkit.org/313936@main">https://commits.webkit.org/313936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/457940ec6b273583b269b78b0b6e462117d79da6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173635 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121852 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127900 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e98f99b7-92c2-4879-8e52-af5004802c6b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108444 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27869 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21393 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176158 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28979 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136217 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38153 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136181 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36679 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147456 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100997 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31454 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24312 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37351 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110395 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36749 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2375 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36997 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36897 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->