### PR TITLE
[Skia] Simplify canvas recording in ImageBufferSkiaAcceleratedBackend

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -110,6 +110,9 @@ bool GraphicsContextSkia::makeGLContextCurrentIfNeeded() const
     if (m_renderingMode == RenderingMode::Unaccelerated)
         return true;
 
+    if (m_contextMode != ContextMode::PaintingMode)
+        return true;
+
     if (m_renderingPurpose != RenderingPurpose::Canvas && m_renderingPurpose != RenderingPurpose::DOM)
         return true;
 
@@ -206,7 +209,7 @@ void GraphicsContextSkia::drawNativeImage(const NativeImage& nativeImage, const 
         return;
 
     // Collect raster images for atlas batching during recording.
-    if (m_contextMode == ContextMode::RecordingMode && m_renderingMode == RenderingMode::Accelerated && !image->isTextureBacked()) {
+    if (m_contextMode == ContextMode::TileRecordingMode && m_renderingMode == RenderingMode::Accelerated && !image->isTextureBacked()) {
         ASSERT(m_atlasLayoutBuilder);
         m_atlasLayoutBuilder->collectRasterImage(image);
     }
@@ -1153,39 +1156,50 @@ void GraphicsContextSkia::drawPattern(const NativeImage& nativeImage, const Floa
     m_canvas.drawRect(destRect, paint);
 }
 
-void GraphicsContextSkia::beginRecording()
+void GraphicsContextSkia::beginRecording(RecordingMode recordingMode)
 {
     ASSERT(m_contextMode == ContextMode::PaintingMode);
-    m_contextMode = ContextMode::RecordingMode;
+    switch (recordingMode) {
+    case RecordingMode::Tile:
+        m_contextMode = ContextMode::TileRecordingMode;
+        if (m_renderingMode == RenderingMode::Accelerated)
+            m_atlasLayoutBuilder = makeUnique<SkiaImageAtlasLayoutBuilder>();
+        else
+            ASSERT(!m_atlasLayoutBuilder);
+        break;
+    case RecordingMode::Canvas:
+        m_contextMode = ContextMode::CanvasRecordingMode;
+        if (!m_enableStateReplayTracking) {
+            m_enableStateReplayTracking = true;
 
-    if (m_renderingMode == RenderingMode::Accelerated)
-        m_atlasLayoutBuilder = makeUnique<SkiaImageAtlasLayoutBuilder>();
-    else
-        ASSERT(!m_atlasLayoutBuilder);
+            // Seed a base entry so clips issued before the first save() are tracked.
+            pushSkiaState();
+        }
+        break;
+    }
 }
 
 SkiaRecordingData GraphicsContextSkia::endRecording()
 {
-    ASSERT(m_contextMode == ContextMode::RecordingMode);
-    m_contextMode = ContextMode::PaintingMode;
-
-    Vector<Ref<SkiaImageAtlasLayout>> atlasLayouts;
-    unsigned imageSetFingerprint = 0;
-    if (m_atlasLayoutBuilder) {
-        atlasLayouts = m_atlasLayoutBuilder->finalize();
-        imageSetFingerprint = m_atlasLayoutBuilder->imageSetFingerprint();
-        m_atlasLayoutBuilder = nullptr;
+    auto contextMode = std::exchange(m_contextMode, ContextMode::PaintingMode);
+    switch (contextMode) {
+    case ContextMode::TileRecordingMode: {
+        Vector<Ref<SkiaImageAtlasLayout>> atlasLayouts;
+        unsigned imageSetFingerprint = 0;
+        if (m_atlasLayoutBuilder) {
+            atlasLayouts = m_atlasLayoutBuilder->finalize();
+            imageSetFingerprint = m_atlasLayoutBuilder->imageSetFingerprint();
+            m_atlasLayoutBuilder = nullptr;
+        }
+        return { WTF::move(m_imageToFenceMap), WTF::move(atlasLayouts), imageSetFingerprint };
+    }
+    case ContextMode::CanvasRecordingMode:
+        return { };
+    case ContextMode::PaintingMode:
+        RELEASE_ASSERT_NOT_REACHED();
     }
 
-    return { WTF::move(m_imageToFenceMap), WTF::move(atlasLayouts), imageSetFingerprint };
-}
-
-void GraphicsContextSkia::enableStateReplayTracking()
-{
-    m_enableStateReplayTracking = true;
-
-    // Seed a base entry so clips issued before the first save() are tracked.
-    pushSkiaState();
+    return { };
 }
 
 void GraphicsContextSkia::replayStateOnCanvas(SkCanvas& canvas) const
@@ -1218,7 +1232,7 @@ void GraphicsContextSkia::replayStateOnCanvas(SkCanvas& canvas) const
 
 void GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded(const sk_sp<SkImage>& image, GrDirectContext* grContext)
 {
-    if (m_contextMode != ContextMode::RecordingMode)
+    if (m_contextMode != ContextMode::TileRecordingMode)
         return;
 
     if (!image || !image->isTextureBacked())
@@ -1230,7 +1244,7 @@ void GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded(const sk_sp<SkI
 
 void GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded(Pattern& pattern)
 {
-    if (m_contextMode != ContextMode::RecordingMode)
+    if (m_contextMode != ContextMode::TileRecordingMode)
         return;
 
     auto nativeImage = pattern.tileNativeImage();

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -57,10 +57,10 @@ public:
 
     const DestinationColorSpace& colorSpace() const final;
 
-    void beginRecording();
+    enum class RecordingMode : bool { Tile, Canvas };
+    void beginRecording(RecordingMode);
     SkiaRecordingData endRecording();
 
-    void enableStateReplayTracking();
     void replayStateOnCanvas(SkCanvas&) const;
 
     void didUpdateState(GraphicsContextState&) final;
@@ -124,9 +124,10 @@ public:
     void drawSkiaText(const sk_sp<SkTextBlob>&, SkScalar, SkScalar, bool, bool);
 
 private:
-    enum class ContextMode : bool {
+    enum class ContextMode : uint8_t {
         PaintingMode,
-        RecordingMode
+        TileRecordingMode,
+        CanvasRecordingMode
     };
 
     bool makeGLContextCurrentIfNeeded() const;

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -38,7 +38,6 @@
 #include "PlatformDisplay.h"
 #include "ProcessCapabilities.h"
 #include "SkiaRecordingResult.h"
-#include "SkiaReplayCanvas.h"
 #include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkPixmap.h>
@@ -168,6 +167,12 @@ GraphicsContext& ImageBufferSkiaAcceleratedBackend::context()
     return *m_canvasRecordingContext;
 }
 
+GrDirectContext* ImageBufferSkiaAcceleratedBackend::grContext() const
+{
+    auto* recordingContext = m_surface->recordingContext();
+    return recordingContext ? recordingContext->asDirectContext() : nullptr;
+}
+
 void ImageBufferSkiaAcceleratedBackend::ensureCanvasRecordingContext()
 {
     if (m_canvasRecordingContext)
@@ -181,22 +186,25 @@ void ImageBufferSkiaAcceleratedBackend::ensureCanvasRecordingContext()
     auto* recordingCanvas = m_pictureRecorder.beginRecording(size().width(), size().height());
     m_switchableCanvas->switchToCanvas(recordingCanvas);
 
-    // Dont' use Canvas purpose: SkPictureRecorder is CPU-side, doesn't need GL context.
-    m_canvasRecordingContext = makeUnique<GraphicsContextSkia>(static_cast<SkCanvas&>(*m_switchableCanvas), RenderingMode::Accelerated, RenderingPurpose::LayerBacking);
+    m_canvasRecordingContext = makeUnique<GraphicsContextSkia>(static_cast<SkCanvas&>(*m_switchableCanvas), RenderingMode::Accelerated, RenderingPurpose::Canvas);
     m_canvasRecordingContext->applyDeviceScaleFactor(resolutionScale());
-    m_canvasRecordingContext->enableStateReplayTracking();
-    m_canvasRecordingContext->beginRecording();
+    m_canvasRecordingContext->beginRecording(GraphicsContextSkia::RecordingMode::Canvas);
     m_hasActiveRecording = true;
 }
 
-std::unique_ptr<GLFence> ImageBufferSkiaAcceleratedBackend::flushCanvasRecordingContextIfNeeded()
+void ImageBufferSkiaAcceleratedBackend::replayCanvasRecordingContextIfNeeded()
 {
-    // Only flush if we have an active recording (not already flushed).
     if (!m_canvasRecordingContext || !m_hasActiveRecording)
-        return nullptr;
+        return;
+
+    auto* grContext = this->grContext();
+    if (!grContext)
+        return;
 
     if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
-        return nullptr;
+        return;
+
+    ASSERT(grContext == PlatformDisplay::sharedDisplay().skiaGrContext());
 
     IntRect recordRect(IntPoint(), size());
     auto recordingData = m_canvasRecordingContext->endRecording();
@@ -209,13 +217,8 @@ std::unique_ptr<GLFence> ImageBufferSkiaAcceleratedBackend::flushCanvasRecording
     auto* surfaceCanvas = m_surface->getCanvas();
     auto surfaceSaveCount = surfaceCanvas->getSaveCount();
 
-    if (recording->hasFences()) {
-        auto replayCanvas = SkiaReplayCanvas::create(size(), recording);
-        replayCanvas->addCanvas(surfaceCanvas);
-        replayCanvas->picture()->playback(&replayCanvas.get());
-        replayCanvas->removeCanvas(surfaceCanvas);
-    } else
-        recording->picture()->playback(surfaceCanvas);
+    ASSERT(!recording->hasFences());
+    recording->picture()->playback(surfaceCanvas);
 
     // Undo unbalanced saves from the picture playback on the surface canvas.
     surfaceCanvas->restoreToCount(surfaceSaveCount);
@@ -226,34 +229,21 @@ std::unique_ptr<GLFence> ImageBufferSkiaAcceleratedBackend::flushCanvasRecording
     m_canvasRecordingContext->replayStateOnCanvas(*surfaceCanvas);
 
     m_hasActiveRecording = false;
-
-    auto* recordingContext = m_surface->recordingContext();
-    auto* grContext = recordingContext ? recordingContext->asDirectContext() : nullptr;
-    if (!grContext)
-        return nullptr;
-
-    return SkiaUtilities::flushAndSubmitSurfaceWithFence(grContext, m_surface.get());
 }
 
 void ImageBufferSkiaAcceleratedBackend::flushContext()
 {
-    // For canvas recording, flush the recording and wait for GPU completion.
-    if (auto fence = flushCanvasRecordingContextIfNeeded()) {
-        fence->serverWait();
-        return;
-    }
+    replayCanvasRecordingContextIfNeeded();
 
-    // Normal surface flush.
-    if (!m_surface || !PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
-        return;
-
-    auto* recordingContext = m_surface->recordingContext();
-    auto* grContext = recordingContext ? recordingContext->asDirectContext() : nullptr;
+    auto* grContext = this->grContext();
     if (!grContext)
         return;
 
-    if (auto fence = SkiaUtilities::flushAndSubmitSurfaceWithFence(grContext, m_surface.get()))
-        fence->serverWait();
+    if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
+        return;
+
+    ASSERT(grContext == PlatformDisplay::sharedDisplay().skiaGrContext());
+    grContext->flushAndSubmit(m_surface.get(), GrSyncCpu::kNo);
 }
 
 void ImageBufferSkiaAcceleratedBackend::prepareForDisplay()
@@ -262,18 +252,21 @@ void ImageBufferSkiaAcceleratedBackend::prepareForDisplay()
     if (!m_layerContentsDisplayDelegate)
         return;
 
-    // Flush and get fence for async GPU→display synchronization
-    auto fence = flushCanvasRecordingContextIfNeeded();
-
-    // If not using canvas recording (or recording already flushed), create a fence the traditional way
-    if (!fence)
-        fence = GLFence::create(PlatformDisplay::sharedDisplay().glDisplay());
-
     auto image = createNativeImageReference();
     if (!image)
         return;
 
-    m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferNativeImage::create(image.releaseNonNull(), WTF::move(fence)));
+    auto* grContext = this->grContext();
+    if (!grContext)
+        return;
+
+    if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
+        return;
+
+    ASSERT(grContext == PlatformDisplay::sharedDisplay().skiaGrContext());
+
+    m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferNativeImage::create(image.releaseNonNull(),
+        SkiaUtilities::flushAndSubmitSurfaceWithFence(grContext, m_surface.get())));
 
     // Re-enable recording mode for subsequent drawing operations.
     // This allows batching to occur again after each prepareForDisplay() cycle.
@@ -286,7 +279,7 @@ void ImageBufferSkiaAcceleratedBackend::prepareForDisplay()
 
         // Replay state onto the new recording canvas to give it the exact same save/clip/CTM nesting.
         m_canvasRecordingContext->replayStateOnCanvas(*recordingCanvas);
-        m_canvasRecordingContext->beginRecording();
+        m_canvasRecordingContext->beginRecording(GraphicsContextSkia::RecordingMode::Canvas);
         m_hasActiveRecording = true;
     }
 #endif
@@ -301,16 +294,15 @@ RefPtr<NativeImage> ImageBufferSkiaAcceleratedBackend::copyNativeImage()
 
 RefPtr<NativeImage> ImageBufferSkiaAcceleratedBackend::createNativeImageReference()
 {
-    flushCanvasRecordingContextIfNeeded();
+    replayCanvasRecordingContextIfNeeded();
 
-    auto* recordingContext = m_surface->recordingContext();
-    auto* grContext = recordingContext ? recordingContext->asDirectContext() : nullptr;
+    auto* grContext = this->grContext();
 
     // If we're using MSAA, we need to flush the surface before calling makeImageSnapshot(),
     // because that call doesn't force the MSAA resolution, which can produce outdated results
     // in the resulting SkImage.
     auto& display = PlatformDisplay::sharedDisplay();
-    if (grContext && display.msaaSampleCount() > 0 && display.skiaGLContext()->makeContextCurrent())
+    if (grContext && grContext == display.skiaGrContext() && display.msaaSampleCount() > 0 && display.skiaGLContext()->makeContextCurrent())
         grContext->flush(m_surface.get());
 
     return NativeImage::create(m_surface->makeImageSnapshot(), grContext);
@@ -321,9 +313,8 @@ void ImageBufferSkiaAcceleratedBackend::getPixelBuffer(const IntRect& srcRect, P
     if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
         return;
 
-    // CPU needs to read pixels now, wait for GPU completion.
-    if (auto fence = flushCanvasRecordingContextIfNeeded())
-        fence->serverWait();
+    // CPU needs to read pixels now, replay the recording.
+    replayCanvasRecordingContextIfNeeded();
 
     const IntRect backendRect { { }, size() };
     const auto sourceRectClipped = intersection(backendRect, srcRect);
@@ -364,9 +355,8 @@ void ImageBufferSkiaAcceleratedBackend::putPixelBuffer(const PixelBufferSourceVi
     if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
         return;
 
-    // CPU needs to write pixels now, wait for GPU completion.
-    if (auto fence = flushCanvasRecordingContextIfNeeded())
-        fence->serverWait();
+    // CPU needs to write pixels now, replay the recording.
+    replayCanvasRecordingContextIfNeeded();
 
     UNUSED_PARAM(destFormat);
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
@@ -35,9 +35,10 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 #include <wtf/TZoneMalloc.h>
 
+class GrDirectContext;
+
 namespace WebCore {
 
-class GLFence;
 class GraphicsContextSkia;
 class SkiaSwitchableCanvas;
 
@@ -64,7 +65,8 @@ private:
     void getPixelBuffer(const IntRect&, PixelBuffer&) final;
     void putPixelBuffer(const PixelBufferSourceView&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) final;
 
-    std::unique_ptr<GLFence> flushCanvasRecordingContextIfNeeded();
+    GrDirectContext* grContext() const;
+    void replayCanvasRecordingContextIfNeeded();
     void ensureCanvasRecordingContext();
 
 #if USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -225,7 +225,7 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
     SkPictureRecorder pictureRecorder;
     auto* recordingCanvas = pictureRecorder.beginRecording(recordRect.width(), recordRect.height());
     GraphicsContextSkia recordingContext(*recordingCanvas, renderingMode, RenderingPurpose::LayerBacking);
-    recordingContext.beginRecording();
+    recordingContext.beginRecording(GraphicsContextSkia::RecordingMode::Tile);
     paintIntoGraphicsContext(layer, recordingContext, recordRect, contentsOpaque, contentsScale);
     auto recordingData = recordingContext.endRecording();
 

--- a/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp
@@ -45,6 +45,7 @@ SkiaSerializedImageBuffer::SkiaSerializedImageBuffer(ImageBuffer& imageBuffer)
 
     m_imageBuffer->flushDrawingContext();
     m_image = m_imageBuffer->createNativeImageReference();
+    m_fence = GLFence::create(PlatformDisplay::sharedDisplay().glDisplay());
 }
 
 SkiaSerializedImageBuffer::~SkiaSerializedImageBuffer() = default;
@@ -65,6 +66,11 @@ RefPtr<ImageBuffer> SkiaSerializedImageBuffer::sinkIntoImageBuffer()
         m_imageBuffer->colorSpace(), RenderingMode::Accelerated, std::nullopt, { m_imageBuffer->pixelFormat() });
     if (!copiedImageBuffer)
         return nullptr;
+
+    if (m_fence) {
+        m_fence->serverWait();
+        m_fence = nullptr;
+    }
 
     FloatRect destination({ }, m_imageBuffer->logicalSize());
     FloatRect source = destination;

--- a/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.h
@@ -30,6 +30,7 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+class GLFence;
 class ImageBuffer;
 class Nativeimage;
 
@@ -45,6 +46,7 @@ private:
 
     Ref<ImageBuffer> m_imageBuffer;
     RefPtr<NativeImage> m_image;
+    std::unique_ptr<GLFence> m_fence;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### e099d2f02f229e22fb37df9240f2ca00e2209f0a
<pre>
[Skia] Simplify canvas recording in ImageBufferSkiaAcceleratedBackend
<a href="https://bugs.webkit.org/show_bug.cgi?id=315552">https://bugs.webkit.org/show_bug.cgi?id=315552</a>

Reviewed by Nikolas Zimmermann.

When we record the canvas in ImageBufferSkiaAcceleratedBackend, the
replay is always expected to happen in the same thread where the record
was done. That means we don&apos;t need fences for the accelerated images
recorded. We don&apos;t need to create a fence and wait for it before
reading/writing pixels either, in those cases we don&apos;t even need to
flush the context since read/write operations are done by skia API that
already flushed the context if needed internally. We only need to create
a fence when the surface snapshot is going to be rewrapped in a
different thread. We don&apos;t need to create the atlas layout builder
either, so this patch adds a new ContextMode to indicate we are
recording for the canvas and not for the tiles.

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::makeGLContextCurrentIfNeeded const):
(WebCore::GraphicsContextSkia::drawNativeImage):
(WebCore::GraphicsContextSkia::beginRecording):
(WebCore::GraphicsContextSkia::endRecording):
(WebCore::GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded):
(WebCore::GraphicsContextSkia::enableStateReplayTracking): Deleted.
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::grContext const):
(WebCore::ImageBufferSkiaAcceleratedBackend::ensureCanvasRecordingContext):
(WebCore::ImageBufferSkiaAcceleratedBackend::replayCanvasRecordingContextIfNeeded):
(WebCore::ImageBufferSkiaAcceleratedBackend::flushContext):
(WebCore::ImageBufferSkiaAcceleratedBackend::prepareForDisplay):
(WebCore::ImageBufferSkiaAcceleratedBackend::createNativeImageReference):
(WebCore::ImageBufferSkiaAcceleratedBackend::getPixelBuffer):
(WebCore::ImageBufferSkiaAcceleratedBackend::putPixelBuffer):
(WebCore::ImageBufferSkiaAcceleratedBackend::flushCanvasRecordingContextIfNeeded):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::record):
* Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp:
(WebCore::SkiaSerializedImageBuffer::SkiaSerializedImageBuffer):
(WebCore::SkiaSerializedImageBuffer::sinkIntoImageBuffer):
* Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.h:

Canonical link: <a href="https://commits.webkit.org/313877@main">https://commits.webkit.org/313877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69e3a3c6d0dd2121dd745b3702b1e70f3dcb6486

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121685 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127762 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89936 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147802 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108307 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27736 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21226 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175988 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28811 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27186 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136075 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/37710 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136043 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147313 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100810 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25027 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24169 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37184 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110228 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36581 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2227 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->