### PR TITLE
Introduce SharedTimebase and stop sending time updates every 100ms.

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -3177,6 +3177,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/PlatformScreen.serialization.in
     platform/PlatformWheelEvent.serialization.in
     platform/ScrollTypes.serialization.in
+    platform/SharedTimebase.serialization.in
 
     platform/audio/PlatformMediaSession.serialization.in
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2312,6 +2312,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/SharedBufferChunkReader.h
     platform/SharedMemory.h
     platform/SharedStringHash.h
+    platform/SharedTimebase.h
+    platform/SharedTimebaseHandle.h
     platform/SharedTimer.h
     platform/Site.h
     platform/SleepDisabler.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2450,6 +2450,7 @@ platform/SharedBuffer.cpp
 platform/SharedBufferChunkReader.cpp
 platform/SharedMemory.cpp
 platform/SharedStringHash.cpp
+platform/SharedTimebase.cpp
 platform/SimpleCaretAnimator.cpp @header:RenderStyleGetters
 platform/Site.cpp
 platform/SleepDisabler.cpp

--- a/Source/WebCore/platform/SharedTimebase.cpp
+++ b/Source/WebCore/platform/SharedTimebase.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SharedTimebase.h"
+
+#include <WebCore/SharedMemory.h>
+#include <wtf/MediaTime.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/SequenceLocked.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+namespace {
+using SnapshotBuffer = SequenceLocked<SharedTimebase::Snapshot>;
+
+SnapshotBuffer& snapshotBufferIn(SharedMemory& storage)
+{
+    return spanReinterpretCast<SnapshotBuffer>(storage.mutableSpan().first(sizeof(SnapshotBuffer))).front();
+}
+}
+
+struct SharedTimebase::Impl {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Impl);
+public:
+    Ref<SharedMemory> storage;
+};
+
+void SharedTimebaseHandle::takeOwnershipOfMemory(MemoryLedger ledger)
+{
+    memory.takeOwnershipOfMemory(ledger);
+}
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SharedTimebase);
+std::unique_ptr<SharedTimebase> SharedTimebase::create()
+{
+    RefPtr sharedMemory = SharedMemory::allocate(sizeof(SnapshotBuffer));
+    if (!sharedMemory || sharedMemory->size() < sizeof(SnapshotBuffer))
+        return nullptr;
+    auto timebase = makeUnique<SharedTimebase>(sharedMemory.releaseNonNull());
+    timebase->storeSnapshot({ });
+    return timebase;
+}
+
+SharedTimebase::SharedTimebase(Ref<SharedMemory>&& memory)
+    : m_impl { makeUniqueRef<SharedTimebase::Impl>(SharedTimebase::Impl {
+        .storage = WTF::move(memory)
+    }) }
+{
+}
+
+SharedTimebase::~SharedTimebase() = default;
+
+auto SharedTimebase::createHandle() const -> std::optional<Handle>
+{
+    if (auto handle = protect(m_impl->storage)->createHandle(SharedMemoryProtection::ReadOnly)) {
+        return Handle {
+            .memory = WTF::move(*handle)
+        };
+    }
+    return std::nullopt;
+}
+
+void SharedTimebase::storeSnapshot(Snapshot snapshot)
+{
+    snapshotBufferIn(m_impl->storage).store(snapshot);
+}
+
+struct SharedTimebaseReader::Impl {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Impl);
+public:
+    Ref<SharedMemory> storage;
+};
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SharedTimebaseReader);
+
+std::unique_ptr<SharedTimebaseReader> SharedTimebaseReader::create(SharedTimebase::Handle&& handle, Seconds maxExtrapolation, Function<MonotonicTime()>&& clock)
+{
+    RefPtr sharedMemory = SharedMemory::map(WTF::move(handle.memory), SharedMemoryProtection::ReadOnly);
+    if (!sharedMemory || sharedMemory->size() < sizeof(SnapshotBuffer))
+        return nullptr;
+    return std::unique_ptr<SharedTimebaseReader>(new SharedTimebaseReader(sharedMemory.releaseNonNull(), maxExtrapolation, WTF::move(clock)));
+}
+
+SharedTimebaseReader::SharedTimebaseReader(Ref<SharedMemory>&& storage, Seconds maxExtrapolation, Function<MonotonicTime()>&& clock)
+    : m_impl { makeUniqueRef<SharedTimebaseReader::Impl>(SharedTimebaseReader::Impl {
+        .storage = WTF::move(storage)
+    }) }
+    , m_maxExtrapolation(maxExtrapolation)
+    , m_clock(clock ? WTF::move(clock) : Function<MonotonicTime()> { [] { return MonotonicTime::now(); } })
+{
+}
+
+SharedTimebaseReader::~SharedTimebaseReader() = default;
+
+MediaTime SharedTimebaseReader::currentTime() const
+{
+    auto snapshot = snapshotBufferIn(m_impl->storage).load();
+
+    auto rate = snapshot.playbackRate;
+    MediaTime calculated;
+    if (!rate)
+        calculated = snapshot.currentTime;
+    else {
+        auto elapsed = std::min(m_clock() - snapshot.hostTime, m_maxExtrapolation);
+        calculated = snapshot.currentTime + MediaTime::createWithDouble(rate * elapsed.seconds());
+    }
+
+    if (rate >= 0)
+        calculated = std::max(m_lastReturnedTime.value_or(calculated), calculated);
+    else
+        calculated = std::min(m_lastReturnedTime.value_or(calculated), calculated);
+
+    m_lastReturnedTime = calculated;
+    return calculated;
+}
+
+double SharedTimebaseReader::currentRate() const
+{
+    return snapshotBufferIn(m_impl->storage).load().playbackRate;
+}
+
+void SharedTimebaseReader::resetForTimeDiscontinuity()
+{
+    m_lastReturnedTime.reset();
+}
+
+}

--- a/Source/WebCore/platform/SharedTimebase.h
+++ b/Source/WebCore/platform/SharedTimebase.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/SharedMemory.h>
+#include <wtf/Function.h>
+#include <wtf/MediaTime.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class SharedTimebaseHandle {
+public:
+    SharedMemoryHandle memory;
+    void takeOwnershipOfMemory(MemoryLedger);
+};
+
+class WEBCORE_EXPORT SharedTimebase final {
+    WTF_MAKE_TZONE_ALLOCATED(SharedTimebase);
+public:
+    using Handle = SharedTimebaseHandle;
+
+    struct Snapshot {
+        MediaTime currentTime;
+        double playbackRate { 0 };
+        MonotonicTime hostTime;
+    };
+
+    static std::unique_ptr<SharedTimebase> create();
+    ~SharedTimebase();
+
+    std::optional<Handle> createHandle() const;
+
+    void storeSnapshot(Snapshot);
+
+private:
+    friend constexpr std::unique_ptr<SharedTimebase> std::make_unique<SharedTimebase>(Ref<WebCore::SharedMemory>&&);
+    explicit SharedTimebase(Ref<SharedMemory>&&);
+
+    struct Impl;
+    UniqueRef<Impl> m_impl;
+};
+
+// Reader-side companion to SharedTimebase. Owns its own read-only mapping of
+// the shared memory plus the per-reader state needed to turn the writer's raw
+// snapshot stream into a bounded, monotonic playback time: a forward-monotonic
+// high-water-mark clamp, and rate-based extrapolation from the latest snapshot
+// capped at maxExtrapolation.
+//
+// Not thread-safe: callers must serialize all method invocations on a given
+// instance.
+class WEBCORE_EXPORT SharedTimebaseReader final {
+    WTF_MAKE_TZONE_ALLOCATED(SharedTimebaseReader);
+public:
+    // maxExtrapolation caps rate-based extrapolation from the latest snapshot
+    // to "now" — if the writer has been silent for longer than this, we don't
+    // trust that the published rate held for the entire interval. Pass the
+    // producer's refresh cadence.
+    //
+    // clock is the source of "now" for extrapolation; defaults to
+    // MonotonicTime::now. Override for tests that need deterministic timing.
+    static std::unique_ptr<SharedTimebaseReader> create(SharedTimebase::Handle&&, Seconds maxExtrapolation, Function<MonotonicTime()>&& clock = { });
+    ~SharedTimebaseReader();
+
+    MediaTime currentTime() const;
+    double currentRate() const;
+
+    void resetForTimeDiscontinuity();
+
+private:
+    SharedTimebaseReader(Ref<SharedMemory>&&, Seconds maxExtrapolation, Function<MonotonicTime()>&&);
+
+    struct Impl;
+    UniqueRef<Impl> m_impl;
+    const Seconds m_maxExtrapolation;
+    const Function<MonotonicTime()> m_clock;
+    mutable std::optional<MediaTime> m_lastReturnedTime;
+};
+
+}

--- a/Source/WebCore/platform/SharedTimebase.serialization.in
+++ b/Source/WebCore/platform/SharedTimebase.serialization.in
@@ -1,0 +1,26 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: <WebCore/SharedTimebase.h>
+[CustomHeader, RValue] class WebCore::SharedTimebaseHandle {
+    WebCore::SharedMemoryHandle memory;
+};

--- a/Source/WebCore/platform/SharedTimebaseHandle.h
+++ b/Source/WebCore/platform/SharedTimebaseHandle.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// This forwarding header exists because the IPC message code generator
+// includes <WebCore/SharedTimebaseHandle.h> based on the type name.
+// SharedTimebaseHandle is actually defined in SharedTimebase.h.
+#pragma once
+#include <WebCore/SharedTimebase.h>

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -223,6 +223,9 @@ private:
     // changes. The cached value reflects the rate we set, not the actual
     // timebase rate.
     float synchronizerRate() const { return m_lastSetSyncRate; }
+    void handleEffectiveRateChanged(double);
+    void releaseStartupGateAndForwardRate();
+    void cancelStartupGateObserver();
     bool updateLastPixelBuffer();
     void maybePurgeLastPixelBuffer();
     void setNeedsPlaceholderImage(bool);
@@ -355,6 +358,13 @@ private:
     MonotonicTime m_startupTime;
 
     RefPtr<EffectiveRateChangedListener> m_effectiveRateChangedListener;
+    Function<void(double)> m_effectiveRateChangedCallback;
+    double m_lastForwardedEffectiveRate { 0 };
+    // Set between a 0 → non-zero rate notification and the moment the
+    // synchronizer's timebase is observed to actually move. While set,
+    // effectiveRate() returns 0 — masking AVSampleBufferRenderSynchronizer's
+    // habit of publishing a non-zero rate before its timebase starts moving.
+    RetainPtr<id> m_startupGateObserver;
 
     mutable std::unique_ptr<PixelBufferConformerCV> m_rgbConformer;
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -127,6 +127,7 @@ AudioVideoRendererAVFObjC::~AudioVideoRendererAVFObjC()
 {
     if (RefPtr rateChangeListener = std::exchange(m_effectiveRateChangedListener, { }))
         rateChangeListener->stop();
+    cancelStartupGateObserver();
     cancelSeekingPromiseIfNeeded();
     cancelTimeReachedAction();
     cancelTimeObserver();
@@ -506,6 +507,8 @@ void AudioVideoRendererAVFObjC::setRate(double rate)
 
 double AudioVideoRendererAVFObjC::effectiveRate() const
 {
+    if (m_startupGateObserver)
+        return 0;
     // False positive see webkit.org/b/298024
     SUPPRESS_UNRETAINED_ARG return PAL::CMTimebaseGetRate([m_synchronizer timebase]);
 }
@@ -655,12 +658,61 @@ Ref<GenericPromise> AudioVideoRendererAVFObjC::finishSeek(const MediaTime& seekT
 
 void AudioVideoRendererAVFObjC::notifyEffectiveRateChanged(Function<void(double)>&& callback)
 {
+    m_effectiveRateChangedCallback = WTF::move(callback);
     // False positive see webkit.org/b/298024
-    SUPPRESS_UNRETAINED_ARG m_effectiveRateChangedListener = EffectiveRateChangedListener::create([callback = makeBlockPtr(WTF::move(callback))](double rate) mutable {
-        callOnMainThread([callback, rate] {
-            callback.get()(rate);
+    SUPPRESS_UNRETAINED_ARG m_effectiveRateChangedListener = EffectiveRateChangedListener::create([weakThis = ThreadSafeWeakPtr { *this }](double rate) mutable {
+        callOnMainThread([weakThis, rate] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->handleEffectiveRateChanged(rate);
         });
     }, [m_synchronizer timebase]);
+}
+
+void AudioVideoRendererAVFObjC::handleEffectiveRateChanged(double rate)
+{
+    ASSERT(isMainThread());
+
+    // -> 0, or non-zero -> non-zero (already moving): forward immediately.
+    // The 0 -> non-zero edge is the only one that lies, so it's gated below.
+    if (!rate || m_lastForwardedEffectiveRate) {
+        cancelStartupGateObserver();
+        m_lastForwardedEffectiveRate = rate;
+        if (m_effectiveRateChangedCallback)
+            m_effectiveRateChangedCallback(rate);
+        return;
+    }
+
+    // 0 -> non-zero with a gate already pending: leave it.
+    if (m_startupGateObserver)
+        return;
+
+    // 0 -> non-zero. Hold the rate change until the timebase actually
+    // moves (in either direction).
+    SUPPRESS_UNRETAINED_ARG MediaTime baseTime = PAL::toMediaTime(PAL::CMTimebaseGetTime([m_synchronizer timebase]));
+    m_startupGateObserver = [m_synchronizer addPeriodicTimeObserverForInterval:PAL::CMTimeMake(1, 100) queue:mainDispatchQueueSingleton() usingBlock:makeBlockPtr([weakThis = ThreadSafeWeakPtr { *this }, baseTime](CMTime) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !protectedThis->m_startupGateObserver)
+            return;
+        SUPPRESS_UNRETAINED_ARG MediaTime now = PAL::toMediaTime(PAL::CMTimebaseGetTime([protectedThis->m_synchronizer timebase]));
+        if (now != baseTime)
+            protectedThis->releaseStartupGateAndForwardRate();
+    }).get()];
+}
+
+void AudioVideoRendererAVFObjC::releaseStartupGateAndForwardRate()
+{
+    ASSERT(isMainThread());
+    cancelStartupGateObserver();
+    SUPPRESS_UNRETAINED_ARG double liveRate = PAL::CMTimebaseGetRate([m_synchronizer timebase]);
+    m_lastForwardedEffectiveRate = liveRate;
+    if (m_effectiveRateChangedCallback)
+        m_effectiveRateChangedCallback(liveRate);
+}
+
+void AudioVideoRendererAVFObjC::cancelStartupGateObserver()
+{
+    if (RetainPtr observer = std::exchange(m_startupGateObserver, nullptr))
+        [m_synchronizer removeTimeObserver:observer.get()];
 }
 
 void AudioVideoRendererAVFObjC::setVolume(float volume)

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -754,6 +754,7 @@ set(WebCore_SERIALIZATION_IN_FILES
     PlatformWheelEvent.serialization.in
     ProtectionSpaceBase.serialization.in
     ScrollTypes.serialization.in
+    SharedTimebase.serialization.in
     WebGPU.serialization.in
 )
 

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -777,6 +777,7 @@ $(WEBCORE_PRIVATE_HEADERS_DIR)/PlatformWheelEvent.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/PlaybackSessionModel.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/ProtectionSpaceBase.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/ScrollTypes.serialization.in
+$(WEBCORE_PRIVATE_HEADERS_DIR)/SharedTimebase.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/WebGPU.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/WebModel.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/generate-bindings.pl

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -987,6 +987,7 @@ WEBCORE_SERIALIZATION_DESCRIPTION_FILES = \
 	PlaybackSessionModel.serialization.in \
 	ProtectionSpaceBase.serialization.in \
 	ScrollTypes.serialization.in \
+	SharedTimebase.serialization.in \
 	WebGPU.serialization.in \
 #
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -50,6 +50,7 @@
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/MediaSamplesBlock.h>
 #include <WebCore/PlatformLayer.h>
+#include <WebCore/SharedTimebase.h>
 
 #include <wtf/LoggerHelper.h>
 #if PLATFORM(COCOA)
@@ -67,13 +68,25 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioVideoRendererProxyManager);
 
-static WebCore::MediaTimeUpdateData timeUpdateDataFor(WebCore::AudioVideoRenderer& renderer)
+void RemoteAudioVideoRendererProxyManager::updateContextSharedTimebase(const RendererContext& context)
 {
-    return {
-        .currentTime = renderer.currentTime(),
-        .effectiveRate = renderer.timeIsProgressing() ? renderer.effectiveRate() : 0.0,
-        .wallTime = MonotonicTime::now(),
-    };
+    if (!context.sharedTimebase)
+        return;
+    context.sharedTimebase->storeSnapshot({
+        .currentTime = context.renderer->currentTime(),
+        .playbackRate = context.renderer->effectiveRate(),
+        .hostTime = MonotonicTime::now()
+    });
+}
+
+template<typename Message>
+void RemoteAudioVideoRendererProxyManager::publishAndSend(RemoteAudioVideoRendererIdentifier identifier, Message&& message)
+{
+    auto iterator = m_renderers.find(identifier);
+    if (iterator == m_renderers.end())
+        return;
+    updateContextSharedTimebase(iterator->value);
+    m_gpuConnectionToWebProcess.get()->connection().send(std::forward<Message>(message), identifier);
 }
 
 RefPtr<AudioVideoRenderer> RemoteAudioVideoRendererProxyManager::createRenderer()
@@ -116,37 +129,47 @@ std::optional<SharedPreferencesForWebProcess> RemoteAudioVideoRendererProxyManag
     return std::nullopt;
 }
 
-void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdentifier identifier, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier)
+void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdentifier identifier, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier, CompletionHandler<void(std::optional<WebCore::SharedTimebaseHandle>)>&& completionHandler)
 {
     MESSAGE_CHECK(!m_renderers.contains(identifier));
 
     RefPtr renderer = createRenderer();
     ASSERT(renderer);
-    if (!renderer)
+    if (!renderer) {
+        completionHandler(std::nullopt);
         return;
+    }
+
+    auto sharedTimebase = SharedTimebase::create();
+    std::optional<SharedTimebaseHandle> handle;
+    if (sharedTimebase)
+        handle = sharedTimebase->createHandle();
+
     RendererContext context {
         .renderer = renderer.releaseNonNull(),
         .mediaElementIdentifier = mediaElementIdentifier,
-        .playerIdentifier = playerIdentifier
+        .playerIdentifier = playerIdentifier,
+        .sharedTimebase = WTF::move(sharedTimebase)
     };
 
     context.renderer->notifyWhenErrorOccurs([weakThis = WeakPtr { *this }, identifier](PlatformMediaError error) {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
-            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::ErrorOccurred(error), identifier);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::ErrorOccurred(error));
     });
 
     context.renderer->notifyFirstFrameAvailable([weakThis = WeakPtr { *this }, identifier] {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier)) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !protectedThis->m_renderers.contains(identifier))
+            return;
 #if PLATFORM(COCOA)
-            protectedThis->contextFor(identifier).layerHostingContextManager.setVideoLayerSizeIfPossible();
+        protectedThis->contextFor(identifier).layerHostingContextManager.setVideoLayerSizeIfPossible();
 #endif
-            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::FirstFrameAvailable(protectedThis->stateFor(identifier)), identifier);
-        }
+        protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::FirstFrameAvailable(protectedThis->stateFor(identifier)));
     });
 
     context.renderer->notifyWhenRequiresFlushToResume([weakThis = WeakPtr { *this }, identifier] {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
-            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::RequiresFlushToResume(protectedThis->stateFor(identifier)), identifier);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::RequiresFlushToResume(protectedThis->stateFor(identifier)));
     });
 
     context.renderer->notifyRenderingModeChanged([weakThis = WeakPtr { *this }, identifier] {
@@ -155,13 +178,13 @@ void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdenti
     });
 
     context.renderer->notifySizeChanged([weakThis = WeakPtr { *this }, identifier](const MediaTime& time, FloatSize size) {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
-            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::SizeChanged(time, size, protectedThis->stateFor(identifier)), identifier);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::SizeChanged(time, size, protectedThis->stateFor(identifier)));
     });
 
     context.renderer->notifyEffectiveRateChanged([weakThis = WeakPtr { *this }, identifier](double) {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
-            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::EffectiveRateChanged(protectedThis->stateFor(identifier)), identifier);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::EffectiveRateChanged(protectedThis->stateFor(identifier)));
     });
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
@@ -171,7 +194,10 @@ void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdenti
 
     m_renderers.set(identifier, WTF::move(context));
 
-    m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(stateFor(identifier)), identifier);
+    installTimeObserver(identifier, remoteAudioVideoRendererUpdateInterval);
+
+    publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(stateFor(identifier)));
+    completionHandler(WTF::move(handle));
 }
 
 void RemoteAudioVideoRendererProxyManager::shutdown(RemoteAudioVideoRendererIdentifier identifier)
@@ -231,8 +257,8 @@ void RemoteAudioVideoRendererProxyManager::addTrack(RemoteAudioVideoRendererIden
     }
     if (auto trackIdentifier = renderer->addTrack(type)) {
         renderer->notifyTrackNeedsReenqueuing(*trackIdentifier, [weakThis = WeakPtr { *this }, identifier](TrackIdentifier trackIdentifier, const MediaTime& time) {
-            if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
-                protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::TrackNeedsReenqueuing(trackIdentifier, time, protectedThis->stateFor(identifier)), identifier);
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::TrackNeedsReenqueuing(trackIdentifier, time, protectedThis->stateFor(identifier)));
         });
 
         completionHandler(*trackIdentifier);
@@ -256,11 +282,11 @@ void RemoteAudioVideoRendererProxyManager::requestMediaDataWhenReady(RemoteAudio
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !result)
             return;
-        protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::ReadyForMoreMediaData(trackIdentifier), identifier);
+        protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::ReadyForMoreMediaData(trackIdentifier));
     });
 }
 
-MediaSampleConverter& RemoteAudioVideoRendererProxyManager::converterFor(RemoteAudioVideoRendererProxyManager::RendererContext& context, TrackIdentifier trackIdentifier)
+MediaSampleConverter& RemoteAudioVideoRendererProxyManager::converterFor(RendererContext& context, TrackIdentifier trackIdentifier)
 {
     return context.converters.ensure(trackIdentifier, [] {
         return WebCore::MediaSampleConverter { };
@@ -296,8 +322,8 @@ void RemoteAudioVideoRendererProxyManager::notifyTimeReachedAndStall(RemoteAudio
     if (!renderer)
         return;
     renderer->notifyTimeReachedAndStall(time, [weakThis = WeakPtr { *this }, identifier](auto& time) {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
-            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StallTimeReached(time, protectedThis->stateFor(identifier)), identifier);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::StallTimeReached(time, protectedThis->stateFor(identifier)));
     });
 }
 
@@ -313,8 +339,8 @@ void RemoteAudioVideoRendererProxyManager::performTaskAtTime(RemoteAudioVideoRen
     if (!renderer)
         return;
     renderer->performTaskAtTime(time, [weakThis = WeakPtr { *this }, time, identifier](auto) {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
-            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::TaskTimeReached(time, protectedThis->stateFor(identifier)), identifier);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::TaskTimeReached(time, protectedThis->stateFor(identifier)));
     });
 }
 
@@ -368,52 +394,56 @@ void RemoteAudioVideoRendererProxyManager::installTimeObserver(RemoteAudioVideoR
         if (iterator == protectedThis->m_renderers.end())
             return;
         auto& context = iterator->value;
-        if (context.firstTickAfterPlay) {
-            context.firstTickAfterPlay = false;
-            protectedThis->installTimeObserver(identifier, remoteAudioVideoRendererUpdateInterval);
-        }
         protectedThis->maybeUpdateCachedVideoMetrics(identifier);
-        protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::TimeObserverUpdate(protectedThis->stateFor(identifier)), identifier);
+        protectedThis->updateContextSharedTimebase(context);
     });
 }
 
 // SynchronizerInterface
-void RemoteAudioVideoRendererProxyManager::play(RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&& completionHandler)
+void RemoteAudioVideoRendererProxyManager::play(RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime)
 {
-    if (RefPtr renderer = rendererFor(identifier)) {
-        renderer->play(hostTime);
-        contextFor(identifier).firstTickAfterPlay = true;
-        installTimeObserver(identifier, remoteAudioVideoRendererFirstTickInterval);
-        completionHandler(timeUpdateDataFor(*renderer));
+    auto iterator = m_renderers.find(identifier);
+    MESSAGE_CHECK(iterator != m_renderers.end());
+    if (iterator == m_renderers.end())
         return;
-    }
-    completionHandler({ });
+    auto& context = iterator->value;
+
+    context.renderer->play(hostTime);
+    updateContextSharedTimebase(context);
 }
 
-void RemoteAudioVideoRendererProxyManager::pause(RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&& completionHandler)
+void RemoteAudioVideoRendererProxyManager::pause(RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime)
 {
-    if (RefPtr renderer = rendererFor(identifier)) {
-        renderer->pause(hostTime);
-        completionHandler(timeUpdateDataFor(*renderer));
+    auto iterator = m_renderers.find(identifier);
+    MESSAGE_CHECK(iterator != m_renderers.end());
+    if (iterator == m_renderers.end())
         return;
-    }
-    completionHandler({ });
+    auto& context = iterator->value;
+
+    context.renderer->pause(hostTime);
+    updateContextSharedTimebase(context);
 }
 
-void RemoteAudioVideoRendererProxyManager::setRate(RemoteAudioVideoRendererIdentifier identifier, double rate, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&& completionHandler)
+void RemoteAudioVideoRendererProxyManager::setRate(RemoteAudioVideoRendererIdentifier identifier, double rate)
 {
-    if (RefPtr renderer = rendererFor(identifier)) {
-        renderer->setRate(rate);
-        completionHandler(timeUpdateDataFor(*renderer));
+    auto iterator = m_renderers.find(identifier);
+    MESSAGE_CHECK(iterator != m_renderers.end());
+    if (iterator == m_renderers.end())
         return;
-    }
-    completionHandler({ });
+    auto& context = iterator->value;
+
+    context.renderer->setRate(rate);
+    updateContextSharedTimebase(context);
 }
 
 void RemoteAudioVideoRendererProxyManager::stall(RemoteAudioVideoRendererIdentifier identifier)
 {
-    if (RefPtr renderer = rendererFor(identifier))
-        renderer->stall();
+    auto iterator = m_renderers.find(identifier);
+    MESSAGE_CHECK(iterator != m_renderers.end());
+    auto& context = iterator->value;
+
+    context.renderer->stall();
+    updateContextSharedTimebase(context);
 }
 
 void RemoteAudioVideoRendererProxyManager::prepareToSeek(RemoteAudioVideoRendererIdentifier identifier, const MediaTime& seekTime, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&& completionHandler)
@@ -424,8 +454,8 @@ void RemoteAudioVideoRendererProxyManager::prepareToSeek(RemoteAudioVideoRendere
         return;
     }
     renderer->prepareToSeek(seekTime)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, identifier, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
-            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)), identifier);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)));
         completionHandler(WTF::move(result));
     });
 }
@@ -438,8 +468,8 @@ void RemoteAudioVideoRendererProxyManager::finishSeek(RemoteAudioVideoRendererId
         return;
     }
     renderer->finishSeek(time)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, identifier, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
-            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)), identifier);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)));
         completionHandler(WTF::move(result));
     });
 }
@@ -525,7 +555,7 @@ void RemoteAudioVideoRendererProxyManager::notifyWhenHasAvailableVideoFrame(WebK
         // receiver doesn't have to read a stale shared cache. This path is
         // independent of the cadence-based metrics push.
         auto metrics = protectedThis->contextFor(identifier).renderer->videoPlaybackQualityMetrics();
-        protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::HasAvailableVideoFrame(presentationTime, clockTime, protectedThis->stateFor(identifier), WTF::move(metrics)), identifier);
+        protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::HasAvailableVideoFrame(presentationTime, clockTime, protectedThis->stateFor(identifier), WTF::move(metrics)));
     });
 }
 
@@ -556,11 +586,10 @@ void RemoteAudioVideoRendererProxyManager::setResourceOwner(RemoteAudioVideoRend
 void RemoteAudioVideoRendererProxyManager::setVideoPlaybackMetricsUpdateInterval(RemoteAudioVideoRendererIdentifier identifier, double interval)
 {
     DEBUG_LOG(LOGIDENTIFIER, identifier.loggingString(), " interval=", interval, "s");
-    MESSAGE_CHECK(m_renderers.contains(identifier));
     auto iterator = m_renderers.find(identifier);
-    if (iterator == m_renderers.end())
-        return;
+    MESSAGE_CHECK(iterator != m_renderers.end());
     auto& context = iterator->value;
+
     static const Seconds metricsAdvanceUpdate = 0.25_s;
     updateCachedVideoMetrics(identifier);
     context.videoPlaybackMetricsUpdateInterval = Seconds(interval);
@@ -596,7 +625,7 @@ void RemoteAudioVideoRendererProxyManager::updateCachedVideoMetrics(RemoteAudioV
         return;
     }
     DEBUG_LOG(LOGIDENTIFIER, identifier.loggingString(), " total=", metrics->totalVideoFrames, " dropped=", metrics->droppedVideoFrames, " corrupted=", metrics->corruptedVideoFrames, " displayComposited=", metrics->displayCompositedVideoFrames, " frameDelay=", metrics->totalFrameDelay);
-    m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::UpdatePlaybackQualityMetrics(WTF::move(*metrics)), identifier);
+    publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::UpdatePlaybackQualityMetrics(WTF::move(*metrics)));
 }
 
 void RemoteAudioVideoRendererProxyManager::flushAndRemoveImage(RemoteAudioVideoRendererIdentifier identifier)
@@ -663,13 +692,11 @@ void RemoteAudioVideoRendererProxyManager::syncTextTrackBounds(RemoteAudioVideoR
 
 RemoteAudioVideoRendererState RemoteAudioVideoRendererProxyManager::stateFor(RemoteAudioVideoRendererIdentifier identifier) const
 {
-    RefPtr renderer = rendererFor(identifier);
-    ASSERT(renderer);
-    if (!renderer)
+    auto iterator = m_renderers.find(identifier);
+    if (iterator == m_renderers.end())
         return { };
     return {
-        .timeUpdateData = timeUpdateDataFor(*renderer),
-        .paused = renderer->paused(),
+        .paused = iterator->value.renderer->paused(),
     };
 }
 
@@ -691,9 +718,9 @@ void RemoteAudioVideoRendererProxyManager::rendereringModeChanged(RemoteAudioVid
 
     // See webkit.org/b/299655
     SUPPRESS_FORWARD_DECL_ARG if (auto maybeHostingContext = context.layerHostingContextManager.createHostingContextIfNeeded(context.renderer->platformVideoLayer(), canShowWhileLocked))
-        m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::LayerHostingContextChanged(state, *maybeHostingContext, context.layerHostingContextManager.videoLayerSize()), identifier);
+        publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::LayerHostingContextChanged(state, *maybeHostingContext, context.layerHostingContextManager.videoLayerSize()));
 #endif
-    m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::RenderingModeChanged(state), identifier);
+    publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::RenderingModeChanged(state));
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -43,6 +43,7 @@
 #include <WebCore/MediaPromiseTypes.h>
 #include <WebCore/MediaSampleConverter.h>
 #include <WebCore/ShareableBitmapHandle.h>
+#include <WebCore/SharedTimebase.h>
 #include <wtf/Forward.h>
 #include <wtf/Logger.h>
 #include <wtf/MediaTime.h>
@@ -85,7 +86,7 @@ public:
 
 private:
     // Messages
-    void create(RemoteAudioVideoRendererIdentifier, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier);
+    void create(RemoteAudioVideoRendererIdentifier, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier, CompletionHandler<void(std::optional<WebCore::SharedTimebaseHandle>)>&&);
     void shutdown(RemoteAudioVideoRendererIdentifier);
 
     void setPreferences(RemoteAudioVideoRendererIdentifier, WebCore::VideoRendererPreferences);
@@ -114,9 +115,9 @@ private:
     void notifyWhenErrorOccurs(RemoteAudioVideoRendererIdentifier, CompletionHandler<void(WebCore::PlatformMediaError)>&&);
 
     // SynchronizerInterface
-    void play(RemoteAudioVideoRendererIdentifier, std::optional<MonotonicTime>, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&&);
-    void pause(RemoteAudioVideoRendererIdentifier, std::optional<MonotonicTime>, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&&);
-    void setRate(RemoteAudioVideoRendererIdentifier, double, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&&);
+    void play(RemoteAudioVideoRendererIdentifier, std::optional<MonotonicTime>);
+    void pause(RemoteAudioVideoRendererIdentifier, std::optional<MonotonicTime>);
+    void setRate(RemoteAudioVideoRendererIdentifier, double);
     void stall(RemoteAudioVideoRendererIdentifier);
     void prepareToSeek(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
     void finishSeek(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(GenericPromise::Result&&)>&&);
@@ -167,6 +168,7 @@ private:
         RefPtr<WebCore::AudioVideoRenderer> renderer;
         Markable<WebCore::HTMLMediaElementIdentifier> mediaElementIdentifier;
         Markable<WebCore::MediaPlayerIdentifier> playerIdentifier;
+        std::unique_ptr<WebCore::SharedTimebase> sharedTimebase;
 #if PLATFORM(COCOA)
         LayerHostingContextManager layerHostingContextManager;
 #endif
@@ -174,7 +176,6 @@ private:
         WebCore::VideoRendererPreferences preferences { };
         Seconds videoPlaybackMetricsUpdateInterval { };
         MonotonicTime nextPlaybackQualityMetricsUpdateTime { };
-        bool firstTickAfterPlay { false };
         bool isGatheringVideoFrameMetadata { false };
     };
     RefPtr<WebCore::AudioVideoRenderer> createRenderer();
@@ -188,6 +189,8 @@ private:
     using LayerHostingContextCallback = CompletionHandler<void(WebCore::HostingContext)>;
     void requestHostingContext(RemoteAudioVideoRendererIdentifier, LayerHostingContextCallback&&);
     WebCore::MediaSampleConverter& converterFor(RendererContext&, TrackIdentifier);
+    static void updateContextSharedTimebase(const RendererContext&);
+    template<typename Message> void publishAndSend(RemoteAudioVideoRendererIdentifier, Message&&);
 
 #if PLATFORM(COCOA)
     void setVideoLayerSize(RemoteAudioVideoRendererIdentifier, const WebCore::FloatSize&);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -31,7 +31,7 @@
     DispatchedTo=GPU
 ]
 messages -> RemoteAudioVideoRendererProxyManager {
-    Create(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::MediaPlayerClientIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier)
+    Create(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::MediaPlayerClientIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier) -> (std::optional<WebCore::SharedTimebaseHandle> handle)
     Shutdown(WebKit::RemoteAudioVideoRendererIdentifier identifier)
 
     SetPreferences(WebKit::RemoteAudioVideoRendererIdentifier identifier, OptionSet<WebCore::VideoRendererPreference> preferences)
@@ -54,9 +54,9 @@ messages -> RemoteAudioVideoRendererProxyManager {
     ApplicationWillResignActive(WebKit::RemoteAudioVideoRendererIdentifier identifier)
     SetSpatialTrackingInfo(WebKit::RemoteAudioVideoRendererIdentifier identifier, bool prefersSpatialAudioExperience, enum:uint8_t WebCore::MediaPlayerSoundStageSize soundStageSize, String sceneIdentifier, String defaultLabel, String label)
 
-    Play(WebKit::RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime) -> (struct WebCore::MediaTimeUpdateData timeUpdateData)
-    Pause(WebKit::RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime) -> (struct WebCore::MediaTimeUpdateData timeUpdateData)
-    SetRate(WebKit::RemoteAudioVideoRendererIdentifier identifier, double rate) -> (struct WebCore::MediaTimeUpdateData timeUpdateData)
+    Play(WebKit::RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime)
+    Pause(WebKit::RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime)
+    SetRate(WebKit::RemoteAudioVideoRendererIdentifier identifier, double rate)
     Stall(WebKit::RemoteAudioVideoRendererIdentifier identifier)
     PrepareToSeek(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime seekTime) -> (Expected<MediaTime, WebCore::PlatformMediaError> result)
     FinishSeek(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime seekTime) -> (GenericPromise::Result result)

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -389,6 +389,7 @@
 # Shared Memory
 [SafeWrapper] StructureParam WebCore::ShareableCVPixelBufferBytesHandle.m_handle WebCore::SharedMemoryHandle
 [SafeWrapper] StructureParam WebCore::ShareableBitmapHandle.m_handle WebCore::SharedMemoryHandle
+[NotSentFromWebContent] StructureParam WebCore::SharedTimebaseHandle.memory WebCore::SharedMemoryHandle
 [SafeWrapper] StructureParam IPC::StreamServerConnectionHandle.buffer WebCore::SharedMemoryHandle
 
 [UnsafeWrapper] std::optional<IPC::SharedBufferReference> {
@@ -442,6 +443,8 @@
     [Legacy] StructureParam WebKit::FullScreenMediaDetails.imageHandle
 
     [DebugOnly] MessageParamReply IPCStreamTester.SyncMessageReturningSharedMemory1 handle
+
+    [NotSentFromWebContent] MessageParamReply RemoteAudioVideoRendererProxyManager.Create handle SharedTimebaseHandle
 }
 
 [UnsafeWrapper] WebCore::SharedMemoryHandle {

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -74,109 +74,6 @@ WorkQueue& AudioVideoRendererRemote::queueSingleton()
     return workQueue.get();
 }
 
-MediaTime AudioVideoRendererRemote::TimeProgressEstimator::currentTime() const
-{
-    Locker locker { m_lock };
-    MediaTime calculated;
-    auto rate = m_effectiveRate.load();
-    if (!rate || m_forceUseCachedTime)
-        calculated = m_cachedTime;
-    else {
-        auto elapsed = std::min(MonotonicTime::now() - m_wallTime, kUpdateInterval);
-        calculated = m_cachedTime + MediaTime::createWithDouble(rate * elapsed.seconds());
-    }
-    if (rate >= 0)
-        calculated = std::max(m_lastReturnedTime.value_or(calculated), calculated);
-    else
-        calculated = std::min(m_lastReturnedTime.value_or(calculated), calculated);
-    // Cap at the pending stall boundary. The renderer can't advance past a time
-    // we've explicitly asked the GPU to stall at, even if the GPU's stall IPC
-    // hasn't propagated yet. Applied after the monotonicity clamp so we can clip
-    // back from any prior overshoot.
-    if (m_stallCap)
-        calculated = std::min(calculated, *m_stallCap);
-    m_lastReturnedTime = calculated;
-    return calculated;
-}
-
-bool AudioVideoRendererRemote::TimeProgressEstimator::timeIsProgressing() const
-{
-    return m_effectiveRate.load();
-}
-
-void AudioVideoRendererRemote::TimeProgressEstimator::setTime(const MediaTimeUpdateData& data)
-{
-    Locker locker { m_lock };
-    bool currentTimeChanged = data.currentTime != m_cachedTime;
-    m_cachedTime = data.currentTime;
-    m_wallTime = data.wallTime;
-    m_effectiveRate = data.effectiveRate;
-    // Release the cached-time freeze only when this anchor proves time has
-    // progressed: rate must be non-zero AND currentTime must have changed.
-    // A pause-reply (rate=0, possibly distinct currentTime) re-anchors but
-    // keeps the freeze, so the next play() still waits for forward progress.
-    if (data.effectiveRate && currentTimeChanged) {
-        if (std::exchange(m_forceUseCachedTime, false))
-            RELEASE_LOG(Media, "AudioVideoRendererRemote::TimeProgressEstimator started");
-    } else if (m_forceUseCachedTime)
-        RELEASE_LOG(Media, "AudioVideoRendererRemote::TimeProgressEstimator not starting, held off effectiveRate=%f currentTime=%f", data.effectiveRate, data.currentTime.toDouble());
-}
-
-void AudioVideoRendererRemote::TimeProgressEstimator::setRate(double rate)
-{
-    Locker locker { m_lock };
-    auto currentRate = m_effectiveRate.load();
-    if (currentRate) {
-        auto now = MonotonicTime::now();
-        auto elapsed = std::min(now - m_wallTime, kUpdateInterval);
-        m_cachedTime += MediaTime::createWithDouble(currentRate * elapsed.seconds());
-        m_wallTime = now;
-    }
-    m_effectiveRate = rate;
-    if (!rate)
-        m_lastReturnedTime.reset();
-    m_forceUseCachedTime = true;
-}
-
-void AudioVideoRendererRemote::TimeProgressEstimator::pause()
-{
-    Locker locker { m_lock };
-    m_forceUseCachedTime = true;
-    auto rate = m_effectiveRate.load();
-    if (!rate)
-        return;
-    auto now = MonotonicTime::now();
-    auto elapsed = std::min(now - m_wallTime, kUpdateInterval);
-    m_cachedTime += MediaTime::createWithDouble(rate * elapsed.seconds());
-    m_wallTime = now;
-    m_effectiveRate = 0;
-}
-
-void AudioVideoRendererRemote::TimeProgressEstimator::resetLastReturnedTime()
-{
-    Locker locker { m_lock };
-    m_lastReturnedTime.reset();
-}
-
-void AudioVideoRendererRemote::TimeProgressEstimator::setStallCap(const MediaTime& time)
-{
-    Locker locker { m_lock };
-    m_stallCap = time;
-}
-
-void AudioVideoRendererRemote::TimeProgressEstimator::clearStallCap()
-{
-    Locker locker { m_lock };
-    m_stallCap.reset();
-}
-
-void AudioVideoRendererRemote::TimeProgressEstimator::clearStallCapIfBefore(const MediaTime& time)
-{
-    Locker locker { m_lock };
-    if (m_stallCap && *m_stallCap < time)
-        m_stallCap.reset();
-}
-
 Ref<AudioVideoRendererRemote> AudioVideoRendererRemote::create(LoggerHelper* loggerHelper, HTMLMediaElementIdentifier mediaElementIdentifier, MediaPlayerIdentifier playerIdentifier, GPUProcessConnection& connection)
 {
     assertIsMainThread();
@@ -208,7 +105,30 @@ AudioVideoRendererRemote::AudioVideoRendererRemote(LoggerHelper* loggerHelper, G
     connection.connection().addWorkQueueMessageReceiver(Messages::AudioVideoRendererRemoteMessageReceiver::messageReceiverName(), queueSingleton(), m_receiver, m_identifier.toUInt64());
     connection.addClient(*this);
 
-    connection.connection().send(Messages::RemoteAudioVideoRendererProxyManager::Create(identifier, mediaElementIdentifier, playerIdentifier), 0);
+    connection.connection().sendWithAsyncReply(Messages::RemoteAudioVideoRendererProxyManager::Create(identifier, mediaElementIdentifier, playerIdentifier), [weakThis = ThreadSafeWeakPtr { *this }](auto&& handle) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        if (!handle) {
+            protectedThis->ensureOnDispatcher([protectedThis] {
+                assertIsCurrent(queueSingleton());
+                if (protectedThis->m_errorCallback)
+                    protectedThis->m_errorCallback(PlatformMediaError::MemoryError);
+            });
+            return;
+        }
+        auto reader = SharedTimebaseReader::create(WTF::move(*handle), remoteAudioVideoRendererUpdateInterval);
+        if (!reader) {
+            protectedThis->ensureOnDispatcher([protectedThis] {
+                assertIsCurrent(queueSingleton());
+                if (protectedThis->m_errorCallback)
+                    protectedThis->m_errorCallback(PlatformMediaError::MemoryError);
+            });
+            return;
+        }
+        Locker locker { protectedThis->m_lock };
+        protectedThis->m_sharedTimebaseReader = WTF::move(reader);
+    }, 0);
 }
 
 AudioVideoRendererRemote::~AudioVideoRendererRemote() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
@@ -526,15 +446,8 @@ void AudioVideoRendererRemote::play(std::optional<MonotonicTime> hostTime)
         Locker locker { m_lock };
         m_cachedState.paused = false;
     }
-    // The GPU's reply gives the estimator a chance to release the gate at
-    // IPC-round-trip latency if the synchronizer's timebase has already
-    // advanced past the cached anchor; otherwise the freeze stays engaged
-    // until the first periodic time observer tick (~100 ms later).
     ensureOnDispatcherWithConnection([hostTime](auto& renderer, auto& connection) {
-        connection.sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::Play(renderer.m_identifier, hostTime), queueSingleton(), [weakThis = ThreadSafeWeakPtr { renderer }](WebCore::MediaTimeUpdateData&& timeUpdateData) {
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->m_timeEstimator.setTime(timeUpdateData);
-        });
+        connection.send(Messages::RemoteAudioVideoRendererProxyManager::Play(renderer.m_identifier, hostTime), 0);
     });
 }
 
@@ -544,18 +457,8 @@ void AudioVideoRendererRemote::pause(std::optional<MonotonicTime> hostTime)
         Locker locker { m_lock };
         m_cachedState.paused = true;
     }
-    m_timeEstimator.pause();
-    // The reply re-anchors m_cachedTime to the GPU's authoritative pause
-    // position (which may differ slightly from our local extrapolation due to
-    // IPC latency). The setTime gate keeps m_forceUseCachedTime engaged because
-    // effectiveRate is 0, so the next play() still requires a forward-progress
-    // anchor before interpolation can start.
     ensureOnDispatcherWithConnection([hostTime](auto& renderer, auto& connection) {
-        connection.sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::Pause(renderer.m_identifier, hostTime), queueSingleton(), [weakThis = ThreadSafeWeakPtr { renderer }](WebCore::MediaTimeUpdateData&& timeUpdateData) {
-            ASSERT(!timeUpdateData.effectiveRate);
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->m_timeEstimator.setTime(timeUpdateData);
-        });
+        connection.send(Messages::RemoteAudioVideoRendererProxyManager::Pause(renderer.m_identifier, hostTime), 0);
     });
 }
 
@@ -567,26 +470,19 @@ bool AudioVideoRendererRemote::paused() const
 
 void AudioVideoRendererRemote::setRate(double rate)
 {
-    m_timeEstimator.setRate(rate);
-    // The GPU's reply re-anchors m_cachedTime with the real effective rate. The estimator
-    // remains gated until the next TimeObserverUpdate IPC; this anchor only sets what
-    // currentTime() returns while still gated.
     ensureOnDispatcherWithConnection([rate](auto& renderer, auto& connection) {
-        connection.sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::SetRate(renderer.m_identifier, rate), queueSingleton(), [weakThis = ThreadSafeWeakPtr { renderer }](WebCore::MediaTimeUpdateData&& timeUpdateData) {
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->m_timeEstimator.setTime(timeUpdateData);
-        });
+        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetRate(renderer.m_identifier, rate), 0);
     });
 }
 
 double AudioVideoRendererRemote::effectiveRate() const
 {
-    return m_timeEstimator.effectiveRate();
+    Locker locker { m_lock };
+    return m_sharedTimebaseReader ? m_sharedTimebaseReader->currentRate() : 0.0;
 }
 
 void AudioVideoRendererRemote::stall()
 {
-    m_timeEstimator.setRate(0);
     ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
         connection.send(Messages::RemoteAudioVideoRendererProxyManager::Stall(renderer.m_identifier), 0);
     });
@@ -608,13 +504,20 @@ void AudioVideoRendererRemote::cancelPendingSeek()
 
 Ref<MediaTimePromise> AudioVideoRendererRemote::prepareToSeek(const MediaTime& time)
 {
-    m_timeEstimator.setTime({ time, 0.0, MonotonicTime::now() });
-    m_timeEstimator.resetLastReturnedTime();
-    // A forward seek past a previously-installed stall cap leaves the cap
-    // describing a position now behind the playhead. The estimator would
-    // otherwise clamp currentTime() back to that stale boundary. The player
-    // computes a new cap via resetStallForTime() if needed.
-    m_timeEstimator.clearStallCapIfBefore(time);
+    {
+        Locker locker { m_lock };
+        if (m_sharedTimebaseReader)
+            m_sharedTimebaseReader->resetForTimeDiscontinuity();
+        // A seek that crosses a previously-installed stall cap (forward past it
+        // under positive rate, backward past it under negative) leaves the cap
+        // describing a position now behind the playhead. Drop it; the player
+        // computes a new cap via resetStallForTime() if needed.
+        if (m_stallCap) {
+            double rate = m_sharedTimebaseReader ? m_sharedTimebaseReader->currentRate() : 1.0;
+            if (rate >= 0 ? *m_stallCap < time : *m_stallCap > time)
+                m_stallCap.reset();
+        }
+    }
     m_seeking = true;
     m_lastSeekTime = time;
     return invokeAsync(queueSingleton(), [protectedThis = Ref { *this }, this, time] -> Ref<MediaTimePromise> {
@@ -651,8 +554,8 @@ Ref<MediaTimePromise> AudioVideoRendererRemote::prepareToSeek(const MediaTime& t
 
 Ref<GenericPromise> AudioVideoRendererRemote::finishSeek(const MediaTime& time)
 {
-    m_timeEstimator.setTime({ time, 0.0, MonotonicTime::now() });
-    m_timeEstimator.resetLastReturnedTime();
+    if (!m_seeking)
+        ALWAYS_LOG(LOGIDENTIFIER, "state error");
     ASSERT(m_seeking, "Invalid seeking state, bad API usage");
     return invokeAsync(queueSingleton(), [protectedThis = Ref { *this }, this, time] -> Ref<GenericPromise> {
         cancelPendingSeek();
@@ -817,7 +720,8 @@ void AudioVideoRendererRemote::notifyTrackNeedsReenqueuing(TrackIdentifier track
 
 bool AudioVideoRendererRemote::timeIsProgressing() const
 {
-    return m_timeEstimator.timeIsProgressing();
+    Locker locker { m_lock };
+    return m_sharedTimebaseReader && m_sharedTimebaseReader->currentRate();
 }
 
 void AudioVideoRendererRemote::notifyEffectiveRateChanged(Function<void(double)>&& callback)
@@ -832,16 +736,21 @@ MediaTime AudioVideoRendererRemote::currentTime() const
 {
     if (m_seeking)
         return m_lastSeekTime;
-    return m_timeEstimator.currentTime();
+    Locker locker { m_lock };
+    if (!m_sharedTimebaseReader)
+        return MediaTime::zeroTime();
+    auto t = m_sharedTimebaseReader->currentTime();
+    if (m_stallCap)
+        t = std::min(t, *m_stallCap);
+    return t;
 }
 
 void AudioVideoRendererRemote::notifyTimeReachedAndStall(const MediaTime& time, Function<void(const MediaTime&)>&& callback)
 {
-    // Cap the estimator at the boundary: the renderer cannot advance past a
-    // time we have asked the GPU to stall at, even if the StallTimeReached IPC
-    // hasn't propagated yet. Cleared when cancelTimeReachedAction or the next
-    // notifyTimeReachedAndStall replaces it.
-    m_timeEstimator.setStallCap(time);
+    {
+        Locker locker { m_lock };
+        m_stallCap = time;
+    }
     ensureOnDispatcherWithConnection([time, callback = WTF::move(callback)](auto& renderer, auto& connection) mutable {
         assertIsCurrent(queueSingleton());
         renderer.m_timeReachedAndStallCallback = WTF::move(callback);
@@ -851,7 +760,10 @@ void AudioVideoRendererRemote::notifyTimeReachedAndStall(const MediaTime& time, 
 
 void AudioVideoRendererRemote::cancelTimeReachedAction()
 {
-    m_timeEstimator.clearStallCap();
+    {
+        Locker locker { m_lock };
+        m_stallCap.reset();
+    }
     ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
         assertIsCurrent(queueSingleton());
         renderer.m_timeReachedAndStallCallback = { };
@@ -873,6 +785,11 @@ void AudioVideoRendererRemote::flush()
 {
     ALWAYS_LOG(LOGIDENTIFIER, "seeking:", m_seeking.load());
     m_seeking = false;
+    {
+        Locker locker { m_lock };
+        if (m_sharedTimebaseReader)
+            m_sharedTimebaseReader->resetForTimeDiscontinuity();
+    }
     ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
         renderer.m_keyframeNeeded = true;
         connection.send(Messages::RemoteAudioVideoRendererProxyManager::Flush(renderer.m_identifier), 0);
@@ -947,7 +864,6 @@ WTFLogChannel& AudioVideoRendererRemote::logChannel() const
 void AudioVideoRendererRemote::updateCacheState(const RemoteAudioVideoRendererState& state)
 {
     constexpr Seconds playbackQualityMetricsTimeout = 30_s;
-    m_timeEstimator.setTime(state.timeUpdateData);
     bool shouldDisableMetrics = false;
     {
         Locker locker { m_lock };
@@ -1239,10 +1155,16 @@ void AudioVideoRendererRemote::MessageReceiver::effectiveRateChanged(RemoteAudio
 {
     if (RefPtr parent = m_parent.get()) {
         assertIsCurrent(queueSingleton());
-        auto effectiveRate = state.timeUpdateData.effectiveRate;
         parent->updateCacheState(state);
-        if (parent->m_effectiveRateChangedCallback)
-            parent->m_effectiveRateChangedCallback(effectiveRate);
+        if (!parent->m_effectiveRateChangedCallback)
+            return;
+        double effectiveRate = 0.0;
+        {
+            Locker locker { parent->m_lock };
+            if (parent->m_sharedTimebaseReader)
+                effectiveRate = parent->m_sharedTimebaseReader->currentRate();
+        }
+        parent->m_effectiveRateChangedCallback(effectiveRate);
     }
 }
 
@@ -1292,12 +1214,6 @@ void AudioVideoRendererRemote::MessageReceiver::stateUpdate(RemoteAudioVideoRend
         parent->updateCacheState(state);
 }
 
-void AudioVideoRendererRemote::MessageReceiver::timeObserverUpdate(RemoteAudioVideoRendererState state)
-{
-    if (RefPtr parent = m_parent.get())
-        parent->updateCacheState(state);
-}
-
 void AudioVideoRendererRemote::MessageReceiver::updatePlaybackQualityMetrics(WebCore::VideoPlaybackQualityMetrics metrics)
 {
     if (RefPtr parent = m_parent.get()) {
@@ -1324,8 +1240,15 @@ void AudioVideoRendererRemote::MessageReceiver::layerHostingContextChanged(Remot
         }
         parent->updateCacheState(state);
         parent->setLayerHostingContext(WTF::move(hostingContext));
-        if (parent->m_videoLayerSizeChangedCallback)
-            parent->m_videoLayerSizeChangedCallback(state.timeUpdateData.currentTime, videoLayerSize);
+        if (!parent->m_videoLayerSizeChangedCallback)
+            return;
+        MediaTime currentTime;
+        {
+            Locker locker { parent->m_lock };
+            if (parent->m_sharedTimebaseReader)
+                currentTime = parent->m_sharedTimebaseReader->currentTime();
+        }
+        parent->m_videoLayerSizeChangedCallback(currentTime, videoLayerSize);
     }
 }
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -37,7 +37,7 @@
 #include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/MediaSampleConverter.h>
-#include <WebCore/MediaTimeUpdateData.h>
+#include <WebCore/SharedTimebase.h>
 #include <WebCore/VideoPlaybackQualityMetrics.h>
 #include <wtf/Forward.h>
 #include <wtf/LoggerHelper.h>
@@ -95,37 +95,12 @@ public:
         void errorOccurred(WebCore::PlatformMediaError);
         void readyForMoreMediaData(WebCore::SamplesRendererTrackIdentifier);
         void stateUpdate(RemoteAudioVideoRendererState);
-        void timeObserverUpdate(RemoteAudioVideoRendererState);
         void updatePlaybackQualityMetrics(WebCore::VideoPlaybackQualityMetrics);
 
 #if PLATFORM(COCOA)
         void layerHostingContextChanged(RemoteAudioVideoRendererState, WebCore::HostingContext&&, const WebCore::FloatSize&);
 #endif
         ThreadSafeWeakPtr<AudioVideoRendererRemote> m_parent;
-    };
-
-    class TimeProgressEstimator final {
-    public:
-        MediaTime currentTime() const;
-        bool timeIsProgressing() const;
-        double effectiveRate() const { return m_effectiveRate.load(); }
-        void setTime(const WebCore::MediaTimeUpdateData&);
-        void setRate(double);
-        void pause();
-        void resetLastReturnedTime();
-        void setStallCap(const MediaTime&);
-        void clearStallCap();
-        void clearStallCapIfBefore(const MediaTime&);
-
-    private:
-        static constexpr Seconds kUpdateInterval = remoteAudioVideoRendererUpdateInterval;
-        mutable Lock m_lock;
-        MediaTime m_cachedTime WTF_GUARDED_BY_LOCK(m_lock) { MediaTime::zeroTime() };
-        MonotonicTime m_wallTime WTF_GUARDED_BY_LOCK(m_lock);
-        std::atomic<double> m_effectiveRate { 0 };
-        bool m_forceUseCachedTime WTF_GUARDED_BY_LOCK(m_lock) { true };
-        mutable std::optional<MediaTime> m_lastReturnedTime WTF_GUARDED_BY_LOCK(m_lock);
-        std::optional<MediaTime> m_stallCap WTF_GUARDED_BY_LOCK(m_lock);
     };
 
 private:
@@ -281,7 +256,12 @@ private:
     CachedState m_cachedState WTF_GUARDED_BY_LOCK(m_lock);
     MonotonicTime m_lastPlaybackQualityMetricsQueryTime WTF_GUARDED_BY_LOCK(m_lock);
     Seconds m_videoPlaybackMetricsUpdateInterval WTF_GUARDED_BY_LOCK(m_lock);
-    TimeProgressEstimator m_timeEstimator;
+    std::unique_ptr<WebCore::SharedTimebaseReader> m_sharedTimebaseReader WTF_GUARDED_BY_LOCK(m_lock);
+    // Upper bound on currentTime() so the SharedTimebaseReader's wall-clock
+    // extrapolation can't overshoot a stall boundary (e.g. the start of a
+    // buffered gap). Set by notifyTimeReachedAndStall, cleared by
+    // cancelTimeReachedAction or a seek that crosses it.
+    std::optional<MediaTime> m_stallCap WTF_GUARDED_BY_LOCK(m_lock);
 
     Function<void(WebCore::PlatformMediaError)> m_errorCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Function<void()> m_firstFrameAvailableCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in
@@ -42,7 +42,6 @@ messages -> AudioVideoRendererRemoteMessageReceiver {
     TaskTimeReached(MediaTime time, struct WebKit::RemoteAudioVideoRendererState state)
     ErrorOccurred(WebCore::PlatformMediaError error)
     StateUpdate(struct WebKit::RemoteAudioVideoRendererState state)
-    TimeObserverUpdate(struct WebKit::RemoteAudioVideoRendererState state)
     UpdatePlaybackQualityMetrics(struct WebCore::VideoPlaybackQualityMetrics metrics)
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h
@@ -26,26 +26,17 @@
 #pragma once
 
 #include <WebCore/FloatSize.h>
-#include <WebCore/MediaTimeUpdateData.h>
 #include <wtf/MediaTime.h>
 #include <wtf/Seconds.h>
 
 namespace WebKit {
 
-// Cadence at which the GPU-side proxy throttles outgoing TimeObserverUpdate
-// IPCs to the WebContent process during steady-state playback. The
-// WebContent-side TimeProgressEstimator also caps its between-anchor
-// extrapolation to this interval.
+// Cadence at which the GPU-side proxy refreshes the SharedTimebase anchor
+// during steady-state playback. Also caps SharedTimebaseReader's
+// between-anchor extrapolation to this interval.
 constexpr Seconds remoteAudioVideoRendererUpdateInterval = 250_ms;
 
-// Underlying GPU-side time observer cadence. Set shorter than the steady-state
-// interval so the first tick after each play() lands quickly to confirm that
-// playback has started; subsequent ticks are throttled by the proxy back to
-// remoteAudioVideoRendererUpdateInterval.
-constexpr Seconds remoteAudioVideoRendererFirstTickInterval = 100_ms;
-
 struct RemoteAudioVideoRendererState {
-    WebCore::MediaTimeUpdateData timeUpdateData { };
     bool paused { false };
 };
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.serialization.in
@@ -22,7 +22,6 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 struct WebKit::RemoteAudioVideoRendererState {
-    WebCore::MediaTimeUpdateData timeUpdateData;
     bool paused;
 }
 #endif

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -758,6 +758,7 @@
 				WebCore/RenderStyleChange.cpp,
 				WebCore/RTCRtpSFrameTransformerTests.cpp,
 				WebCore/SampleMap.cpp,
+				WebCore/SharedTimebaseTests.cpp,
 				WebCore/SecurityOrigin.cpp,
 				WebCore/SerializedScriptValue.cpp,
 				WebCore/ServiceWorkerRoutines.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedTimebaseTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedTimebaseTests.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Helpers/Test.h"
+#include <WebCore/SharedTimebase.h>
+#include <wtf/MediaTime.h>
+#include <wtf/MonotonicTime.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+TEST(SharedTimebase, Basic)
+{
+    auto writerTimebase = SharedTimebase::create();
+    ASSERT_TRUE(writerTimebase);
+
+    auto timebaseHandle = writerTimebase->createHandle();
+    ASSERT_TRUE(timebaseHandle);
+
+    auto now = MonotonicTime::now();
+    constexpr Seconds maxExtrapolation = 10_s;
+    auto fakeNow = now;
+    auto reader = SharedTimebaseReader::create(WTF::move(*timebaseHandle), maxExtrapolation, [&fakeNow] { return fakeNow; });
+    ASSERT_TRUE(reader);
+
+    writerTimebase->storeSnapshot({
+        .currentTime = MediaTime::zeroTime(),
+        .playbackRate = 1.0,
+        .hostTime = now
+    });
+
+    fakeNow = now;
+    EXPECT_EQ(reader->currentTime(), MediaTime::zeroTime());
+
+    fakeNow = now + 1_s;
+    EXPECT_EQ(reader->currentTime(), MediaTime::createWithSeconds(1_s));
+
+    // Rate now change to 0.5s at now+1s.
+    writerTimebase->storeSnapshot({
+        .currentTime = MediaTime::createWithSeconds(1_s),
+        .playbackRate = 0.5,
+        .hostTime = now + 1_s
+    });
+
+    fakeNow = now + 2_s;
+    EXPECT_EQ(reader->currentTime().toDouble(), 1.5);
+
+    // Reading with a host time before the writer host time does not apply the playback rate estimation
+    fakeNow = now - 1_s;
+    EXPECT_EQ(reader->currentTime().toDouble(), 1.5);
+
+    // Beyond cap — elapsed clamped to maxExtrapolation taking into account rate.
+    fakeNow = now + 20_s;
+    EXPECT_EQ(reader->currentTime().toDouble(), maxExtrapolation.seconds() * 0.5 + 1); // Time was 1s at now+1 with a rate of 0.5.
+
+    // High-water-mark clamp: a snapshot rewinding to zero must not make
+    // currentTime() go backwards.
+    auto highWater = reader->currentTime();
+    writerTimebase->storeSnapshot({
+        .currentTime = MediaTime::zeroTime(),
+        .playbackRate = 0.0,
+        .hostTime = now
+    });
+    fakeNow = now;
+    EXPECT_EQ(reader->currentTime(), highWater);
+
+    // resetForTiscontinuity drops the high-water-mark; the next read
+    // observes the new (lower) snapshot.
+    reader->resetForTimeDiscontinuity();
+    EXPECT_EQ(reader->currentTime(), MediaTime::zeroTime());
+}
+
+}


### PR DESCRIPTION
#### 1feeb18419beb9b6ecb88bf86708cfd48259572c
<pre>
Introduce SharedTimebase and stop sending time updates every 100ms.
<a href="https://bugs.webkit.org/show_bug.cgi?id=315553">https://bugs.webkit.org/show_bug.cgi?id=315553</a>
<a href="https://rdar.apple.com/177927416">rdar://177927416</a>

Reviewed by Jer Noble.

Background
----------

The remote audio/video renderer in the WebContent process used to
learn playback time by way of a periodic IPC: every ~100ms in the
first second after Play, then every ~250ms during steady-state
playback, the GPU sent a TimeObserverUpdate carrying a
MediaTimeUpdateData anchor (currentTime, effectiveRate, wallTime).
An inner class on the WebContent side, TimeProgressEstimator, cached
the latest anchor and extrapolated forward between IPCs to answer
currentTime() / timeIsProgressing() / effectiveRate() synchronously.

The estimator had also accumulated two pieces of state that don&apos;t
really belong in a generic time extrapolator: a &quot;startup gate&quot; that
held currentTime() at the cached anchor after Play / SetRate /
FinishSeek until the next GPU update was observed (compensating for
AVSampleBufferRenderSynchronizer publishing a non-zero rate before
its timebase actually starts advancing), and a stall cap that
clamped currentTime() to a boundary the client had asked the GPU to
stall at (compensating for the IPC round-trip on
NotifyTimeReachedAndStall).

The two issues with that shape:

- Steady-state IPC traffic. Every active &lt;video&gt; emits a
  cross-process message four times per second purely to refresh a
  cached time. The receiver wakes a dedicated work queue in the
  WebContent process, decodes the message, locks, and stores three
  numbers.

- The estimator quietly accumulated AVFoundation- and
  client-specific quirks. AVF lying about its rate is masked far
  away from where the lie is told; the stall cap is correlated with
  IPCs the renderer issues but lives behind an indirection. Every
  future reader inherits both.

Design steps folded into this commit
------------------------------------

1. Make the AVF rate truthful at the source. In
   AudioVideoRendererAVFObjC, on a 0 -&gt; non-zero rate transition,
   don&apos;t forward the new rate to the consumer (or expose it through
   effectiveRate()) yet. Instead, install a fine-grained periodic
   time observer on the synchronizer; once CMTimebaseGetTime has
   advanced past the value captured at the transition, remove the
   observer and forward the rate. On any non-zero -&gt; 0 transition,
   tear down any pending observer and forward 0 immediately. With
   this in place, the rate the GPU publishes is one that has been
   observed to be in effect, so the WebContent side never needs a
   startup gate to mask the AVF lie.

2. Move the stall cap onto AudioVideoRendererRemote. The cap is a
   client-issued boundary tied to an in-flight
   NotifyTimeReachedAndStall, not a property of the timebase.
   notifyTimeReachedAndStall(time) sets m_stallCap = time directly
   on the renderer (under m_lock); cancelTimeReachedAction clears
   it; cancelPendingSeek clears or keeps it according to the seek
   direction. The renderer&apos;s currentTime() applies the cap as a
   final clamp on top of whatever the time source returns. This
   takes the cap out of the path that any future timebase reader
   would have to carry.

3. Replace the periodic time-update IPC with a shared-memory
   timebase. With (1) and (2) in place, the only remaining job is
   propagating a (currentTime, playbackRate, hostTime) anchor from
   the GPU to the WebContent process. Writes happen on a small
   number of discrete events (Play, Pause, SetRate, Stall,
   PrepareToSeek, FinishSeek); reads happen often (every JS access
   to video.currentTime, every monitorSourceBuffers tick). A small
   shared-memory anchor the writer updates on those events and the
   reader reads cheaply matches that ratio more directly than a
   periodic IPC stream.

The new design
--------------

WebCore::SharedTimebase is a writer-side handle to a small
SharedMemory region; the GPU publishes a (currentTime, playbackRate,
hostTime) Snapshot whenever something changes time (Play / Pause /
SetRate / Stall / PrepareToSeek / FinishSeek), plus once per
existing time-observer tick so the anchor stays fresh enough to
bound extrapolation. Reads are lock-free via SequenceLocked&lt;T&gt;.

The WebContent process opens the same region as a
SharedTimebaseReader. With AVF-quirk handling moved to step 1 and
the stall cap moved to step 2, the reader is small: rate-based
extrapolation from the latest snapshot, capped at maxExtrapolation
so a silent writer can&apos;t extrapolate forever, and a forward-
monotonic high-water-mark clamp on the value it returns. A clock
function is constructor-injectable so tests can drive deterministic
timing; the default is MonotonicTime::now.

The Create message returns the read handle; if SharedMemory
allocation fails, the WebContent side surfaces it through the
existing m_errorCallback as PlatformMediaError::MemoryError.

With the reader handling time and the renderer handling the cap,
the periodic TimeObserverUpdate IPC is no longer load-bearing and
is removed outright. Play / Pause / SetRate stop using async
replies — their only job had been to feed MediaTimeUpdateData back
to the estimator — and become fire-and-forget.
RemoteAudioVideoRendererState loses its timeUpdateData field; only
`bool paused` remains. The GPU&apos;s existing time observer is
preserved (it still drives playback-quality metrics), but its only
effect on the WebContent&apos;s notion of time is now a direct
storeSnapshot() into the shared region — no IPC is sent.

Tests: Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/SharedTimebase.cpp: Added.
(WebCore::SharedTimebaseHandle::takeOwnershipOfMemory):
(WebCore::SharedTimebase::create):
(WebCore::SharedTimebase::SharedTimebase):
(WebCore::SharedTimebase::createHandle const):
(WebCore::SharedTimebase::storeSnapshot):
(WebCore::SharedTimebaseReader::create):
(WebCore::SharedTimebaseReader::SharedTimebaseReader):
(WebCore::SharedTimebaseReader::currentTime const):
(WebCore::SharedTimebaseReader::currentRate const):
(WebCore::SharedTimebaseReader::resetForTimeDiscontinuity):
* Source/WebCore/platform/SharedTimebase.h: Added.
* Source/WebCore/platform/SharedTimebase.serialization.in: Copied from Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.serialization.in.
* Source/WebCore/platform/SharedTimebaseHandle.h: Copied from Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h.
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::~AudioVideoRendererAVFObjC):
(WebCore::AudioVideoRendererAVFObjC::effectiveRate const):
(WebCore::AudioVideoRendererAVFObjC::notifyEffectiveRateChanged):
(WebCore::AudioVideoRendererAVFObjC::handleEffectiveRateChanged):
On 0 -&gt; non-zero rate transitions, install a periodic time
observer on the synchronizer and hold the rate change back from
the consumer / from effectiveRate() until CMTimebaseGetTime has
been observed advancing. On non-zero -&gt; 0 transitions, tear down
any pending observer and forward 0 immediately.
(WebCore::AudioVideoRendererAVFObjC::releaseStartupGateAndForwardRate):
(WebCore::AudioVideoRendererAVFObjC::cancelStartupGateObserver):
* Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::updateContextSharedTimebase):
Publishes (currentTime, effectiveRate, MonotonicTime::now()) into
the per-renderer SharedTimebase. Single point where the writer-
side anchor is refreshed.
(WebKit::RemoteAudioVideoRendererProxyManager::create):
Allocates a SharedTimebase per renderer and returns its handle in
the Create reply. nullopt on allocation failure — the WebContent
side maps that to PlatformMediaError::MemoryError.
(WebKit::RemoteAudioVideoRendererProxyManager::addTrack):
(WebKit::RemoteAudioVideoRendererProxyManager::requestMediaDataWhenReady):
(WebKit::RemoteAudioVideoRendererProxyManager::converterFor):
(WebKit::RemoteAudioVideoRendererProxyManager::notifyTimeReachedAndStall):
(WebKit::RemoteAudioVideoRendererProxyManager::performTaskAtTime):
(WebKit::RemoteAudioVideoRendererProxyManager::installTimeObserver):
Drop the periodic TimeObserverUpdate IPC; the same callback now
refreshes the shared anchor directly via updateContextSharedTimebase.
firstTickAfterPlay and maybeUpdateCachedVideoMetrics are unchanged.
(WebKit::RemoteAudioVideoRendererProxyManager::play):
(WebKit::RemoteAudioVideoRendererProxyManager::pause):
(WebKit::RemoteAudioVideoRendererProxyManager::setRate):
No longer return MediaTimeUpdateData; refresh the SharedTimebase
anchor inline. Use MESSAGE_CHECK with an early return so a
malformed identifier can&apos;t dereference past the find() failure.
(WebKit::RemoteAudioVideoRendererProxyManager::stall):
Refresh the anchor after the renderer transitions to rate=0.
(WebKit::RemoteAudioVideoRendererProxyManager::prepareToSeek):
(WebKit::RemoteAudioVideoRendererProxyManager::finishSeek):
(WebKit::RemoteAudioVideoRendererProxyManager::notifyWhenHasAvailableVideoFrame):
(WebKit::RemoteAudioVideoRendererProxyManager::setVideoPlaybackMetricsUpdateInterval):
(WebKit::RemoteAudioVideoRendererProxyManager::updateCachedVideoMetrics):
(WebKit::RemoteAudioVideoRendererProxyManager::stateFor const):
Refresh the anchor before producing the StateUpdate snapshot;
state itself is now just `paused`.
(WebKit::RemoteAudioVideoRendererProxyManager::rendereringModeChanged):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
(WebKit::RemoteAudioVideoRendererProxyManager::publishAndSend):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
Create now returns std::optional&lt;WebCore::SharedTimebaseHandle&gt;.
Play / Pause / SetRate become fire-and-forget (no async reply).

* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
Register WebCore::SharedTimebaseHandle as a serializable IPC type.

* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
Delete the TimeProgressEstimator inner class entirely; replace
m_timeEstimator with std::unique_ptr&lt;SharedTimebaseReader&gt;
m_sharedTimebaseReader, guarded by m_lock. Add std::optional&lt;MediaTime&gt;
m_stallCap on the renderer itself; the cap no longer lives in the
time source.
(WebKit::AudioVideoRendererRemote::AudioVideoRendererRemote):
Send Create as sendWithAsyncReply. On nullopt handle or null
SharedTimebase, dispatch m_errorCallback(MemoryError) on the work
queue. On success, build the reader.
(WebKit::AudioVideoRendererRemote::play):
(WebKit::AudioVideoRendererRemote::pause):
(WebKit::AudioVideoRendererRemote::setRate):
(WebKit::AudioVideoRendererRemote::effectiveRate const):
Read currentRate from m_sharedTimebaseReader.
(WebKit::AudioVideoRendererRemote::stall):
(WebKit::AudioVideoRendererRemote::cancelPendingSeek):
Conditionally clears m_stallCap based on rate direction.
(WebKit::AudioVideoRendererRemote::timeIsProgressing const):
(WebKit::AudioVideoRendererRemote::currentTime const):
Read from m_sharedTimebaseReader under m_lock, then clamp by
m_stallCap. Preserves the existing m_seeking / m_lastSeekTime
short-circuit.
(WebKit::AudioVideoRendererRemote::notifyTimeReachedAndStall):
Set m_stallCap = time, then send the IPC.
(WebKit::AudioVideoRendererRemote::cancelTimeReachedAction):
Clear m_stallCap, then send the IPC.
(WebKit::AudioVideoRendererRemote::flush):
(WebKit::AudioVideoRendererRemote::updateCacheState):
State struct no longer carries time data.
(WebKit::AudioVideoRendererRemote::MessageReceiver::effectiveRateChanged):
(WebKit::AudioVideoRendererRemote::MessageReceiver::layerHostingContextChanged):
Read currentRate / currentTime from m_sharedTimebaseReader instead
of state.timeUpdateData.
Delete MessageReceiver::timeObserverUpdate.
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::currentTime const): Deleted.
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::timeIsProgressing const): Deleted.
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::setTime): Deleted.
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::setRate): Deleted.
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::pause): Deleted.
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::resetLastReturnedTime): Deleted.
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::setStallCap): Deleted.
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::clearStallCap): Deleted.
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::clearStallCapIfBefore): Deleted.
(WebKit::AudioVideoRendererRemote::MessageReceiver::timeObserverUpdate): Deleted.
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in:
Drop TimeObserverUpdate.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.serialization.in:
Drop timeUpdateData; struct is now just `bool paused`. Comment on
remoteAudioVideoRendererUpdateInterval updated to describe the
shared-anchor refresh cadence rather than the dropped IPC.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/SharedTimebaseTests.cpp: Added.
Unit coverage for the writer/reader pair: anchor publication,
rate-based extrapolation, monotonicity clamp.
(TestWebKitAPI::TEST(SharedTimebase, Basic)):

Canonical link: <a href="https://commits.webkit.org/314135@main">https://commits.webkit.org/314135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bace5963da8e58a820ebd006cfe24dd237ea5b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165180 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122437 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5eb9592-0bc9-4b2e-acd6-739cf25021a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128355 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3fecd4bb-15ba-45e4-917a-ddc5f5d87936) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108880 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3e2921c-2d4e-4f03-b39b-49815d5e3616) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/164500 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29718 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28339 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21977 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176745 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29623 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136674 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136613 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36835 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147909 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101738 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31893 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24776 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37939 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111011 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37336 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2853 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37582 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37480 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->