### PR TITLE
Cherry-pick 305413.546@safari-7624-branch (1df88b983792). https://bugs.webkit.org/show_bug.cgi?id=310177

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -29,6 +29,7 @@
 #include "CacheStorageDiskStore.h"
 #include "CacheStorageManager.h"
 #include "CacheStorageMemoryStore.h"
+#include "Connection.h"
 #include "Logging.h"
 #include <WebCore/CacheQueryOptions.h>
 #include <WebCore/CrossOriginAccessControl.h>
@@ -40,16 +41,22 @@
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#define MESSAGE_CHECK_COMPLETION(assertion, connection, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, connection, completion)
+
 namespace WebKit {
 
-String CacheStorageCache::computeKeyURL(const URL& url)
+std::optional<String> CacheStorageCache::computeKeyURL(const URL& url)
 {
-    RELEASE_ASSERT(url.isValid());
-    RELEASE_ASSERT(!url.isEmpty());
+    ASSERT(url.isValid());
+    ASSERT(!url.isEmpty());
+    if (!url.isValid() || url.isEmpty())
+        return std::nullopt;
     URL keyURL { url };
     keyURL.removeQueryAndFragmentIdentifier();
     auto keyURLString = keyURL.string();
-    RELEASE_ASSERT(RecordsMap::isValidKey(keyURLString));
+    ASSERT(RecordsMap::isValidKey(keyURLString));
+    if (!RecordsMap::isValidKey(keyURLString))
+        return std::nullopt;
     return keyURLString;
 }
 
@@ -141,7 +148,7 @@ void CacheStorageCache::open(WebCore::DOMCacheEngine::CacheIdentifierCallback&& 
 
         for (auto&& recordInfo : recordInfos) {
             recordInfo.setIdentifier(nextRecordIdentifier());
-            protectedThis->m_records.ensure(computeKeyURL(recordInfo.url()), [] {
+            protectedThis->m_records.ensure(*computeKeyURL(recordInfo.url()), [] {
                 return Vector<CacheStorageRecordInformation> { };
             }).iterator->value.append(WTF::move(recordInfo));
         }
@@ -162,8 +169,11 @@ static CacheStorageRecord toCacheStorageRecord(WebCore::DOMCacheEngine::CrossThr
     return CacheStorageRecord { WTF::move(recordInfo), record.requestHeadersGuard, WTF::move(record.request), record.options, WTF::move(record.referrer), record.responseHeadersGuard, WTF::move(record.response), record.responseBodySize, WTF::move(record.responseBody) };
 }
 
-void CacheStorageCache::retrieveRecords(WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&& callback)
+void CacheStorageCache::retrieveRecords(IPC::Connection& connection, WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&& callback)
 {
+    if (!options.request.url().isNull())
+        MESSAGE_CHECK_COMPLETION(computeKeyURL(options.request.url()), connection, callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal)));
+
     auto targetRecordInfos = findRecords(options);
     retrieveRecords(targetRecordInfos, WTF::move(options), WTF::move(callback));
 }
@@ -186,7 +196,11 @@ Vector<CacheStorageRecordInformation> CacheStorageCache::findRecords(const WebCo
         if (!options.ignoreMethod && options.request.httpMethod() != "GET"_s)
             return { };
 
-        auto iterator = m_records.find(computeKeyURL(url));
+        auto keyURL = computeKeyURL(url);
+        if (!keyURL)
+            return { };
+
+        auto iterator = m_records.find(*keyURL);
         if (iterator == m_records.end())
             return { };
 
@@ -234,15 +248,18 @@ void CacheStorageCache::retrieveRecords(const Vector<CacheStorageRecordInformati
     });
 }
 
-void CacheStorageCache::removeRecords(WebCore::ResourceRequest&& request, WebCore::CacheQueryOptions&& options, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+void CacheStorageCache::removeRecords(IPC::Connection& connection, WebCore::ResourceRequest&& request, WebCore::CacheQueryOptions&& options, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     ASSERT(m_isInitialized);
     assertIsOnCorrectQueue();
-    
+
     if (!options.ignoreMethod && request.httpMethod() != "GET"_s)
         return callback({ });
 
-    auto iterator = m_records.find(computeKeyURL(request.url()));
+    auto keyURL = computeKeyURL(request.url());
+    MESSAGE_CHECK_COMPLETION(keyURL, connection, callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal)));
+
+    auto iterator = m_records.find(*keyURL);
     if (iterator == m_records.end())
         return callback({ });
 
@@ -272,11 +289,15 @@ void CacheStorageCache::removeRecords(WebCore::ResourceRequest&& request, WebCor
     });
 }
 
-CacheStorageRecordInformation* CacheStorageCache::findExistingRecord(const WebCore::ResourceRequest& request, std::optional<uint64_t> identifier)
+Expected<CacheStorageRecordInformation*, WebCore::DOMCacheEngine::Error> CacheStorageCache::findExistingRecord(const WebCore::ResourceRequest& request, std::optional<uint64_t> identifier)
 {
     assertIsOnCorrectQueue();
 
-    auto iterator = m_records.find(computeKeyURL(request.url()));
+    auto keyURL = computeKeyURL(request.url());
+    if (!keyURL)
+        return makeUnexpected(WebCore::DOMCacheEngine::Error::Internal);
+
+    auto iterator = m_records.find(*keyURL);
     if (iterator == m_records.end())
         return nullptr;
 
@@ -291,7 +312,7 @@ CacheStorageRecordInformation* CacheStorageCache::findExistingRecord(const WebCo
     return &iterator->value[index];
 }
 
-void CacheStorageCache::putRecords(Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+void CacheStorageCache::putRecords(IPC::Connection& connection, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     ASSERT(m_isInitialized);
     assertIsOnCorrectQueue();
@@ -303,11 +324,20 @@ void CacheStorageCache::putRecords(Vector<WebCore::DOMCacheEngine::CrossThreadRe
     CheckedUint64 spaceRequested = 0;
     CheckedUint64 spaceAvailable = 0;
     bool isSpaceRequestedValid = true;
-    auto cacheStorageRecords = WTF::map(WTF::move(records), [&](WebCore::DOMCacheEngine::CrossThreadRecord&& record) {
+    std::optional<WebCore::DOMCacheEngine::Error> encounteredError;
+    auto cacheStorageRecords = WTF::compactMap(WTF::move(records), [&](WebCore::DOMCacheEngine::CrossThreadRecord&& record) -> std::optional<CacheStorageRecord> {
+        if (encounteredError)
+            return std::nullopt;
+
         if (isSpaceRequestedValid) {
             spaceRequested += record.responseBodySize;
-            if (auto* existingRecord = findExistingRecord(record.request))
-                spaceAvailable += existingRecord->size();
+            auto existingRecord = findExistingRecord(record.request);
+            if (!existingRecord.has_value()) {
+                encounteredError = existingRecord.error();
+                return std::nullopt;
+            }
+            if (*existingRecord)
+                spaceAvailable += (*existingRecord)->size();
             if (spaceRequested.hasOverflowed() || spaceAvailable.hasOverflowed())
                 isSpaceRequestedValid = false;
             else {
@@ -319,11 +349,13 @@ void CacheStorageCache::putRecords(Vector<WebCore::DOMCacheEngine::CrossThreadRe
         return toCacheStorageRecord(WTF::move(record), manager->salt(), m_uniqueName);
     });
 
+    MESSAGE_CHECK_COMPLETION(!encounteredError, connection, callback(makeUnexpected(*encounteredError)));
+
     // The request still needs to go through quota check to keep ordering.
     if (!isSpaceRequestedValid)
         spaceRequested = 0;
 
-    manager->requestSpace(spaceRequested, [weakThis = WeakPtr { *this }, records = WTF::move(cacheStorageRecords), callback = WTF::move(callback), isSpaceRequestedValid](bool granted) mutable {
+    manager->requestSpace(spaceRequested, [weakThis = WeakPtr { *this }, connection = Ref { connection }, records = WTF::move(cacheStorageRecords), callback = WTF::move(callback), isSpaceRequestedValid](bool granted) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
@@ -336,35 +368,37 @@ void CacheStorageCache::putRecords(Vector<WebCore::DOMCacheEngine::CrossThreadRe
         if (!granted)
             return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::QuotaExceeded));
 
-        protectedThis->putRecordsAfterQuotaCheck(WTF::move(records), WTF::move(callback));
+        protectedThis->putRecordsAfterQuotaCheck(connection, WTF::move(records), WTF::move(callback));
     });
 }
 
-void CacheStorageCache::putRecordsAfterQuotaCheck(Vector<CacheStorageRecord>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+void CacheStorageCache::putRecordsAfterQuotaCheck(IPC::Connection& connection, Vector<CacheStorageRecord>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     ASSERT(m_isInitialized);
     assertIsOnCorrectQueue();
 
     Vector<CacheStorageRecordInformation> targetRecordInfos;
     for (auto& record : records) {
-        if (auto* existingRecord = findExistingRecord(record.request)) {
-            record.info.setIdentifier(existingRecord->identifier());
-            targetRecordInfos.append(*existingRecord);
+        auto existingRecord = findExistingRecord(record.request);
+        MESSAGE_CHECK_COMPLETION(existingRecord.has_value(), connection, callback(makeUnexpected(existingRecord.error())));
+        if (*existingRecord) {
+            record.info.setIdentifier((*existingRecord)->identifier());
+            targetRecordInfos.append(**existingRecord);
         }
     }
 
-    auto readRecordsCallback = [weakThis = WeakPtr { *this }, records = WTF::move(records), callback = WTF::move(callback)](auto existingCacheStorageRecords) mutable {
+    auto readRecordsCallback = [weakThis = WeakPtr { *this }, connection = Ref { connection }, records = WTF::move(records), callback = WTF::move(callback)](auto existingCacheStorageRecords) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
-        protectedThis->putRecordsInStore(WTF::move(records), WTF::move(existingCacheStorageRecords), WTF::move(callback));
+        protectedThis->putRecordsInStore(connection, WTF::move(records), WTF::move(existingCacheStorageRecords), WTF::move(callback));
     };
 
     m_store->readRecords(targetRecordInfos, WTF::move(readRecordsCallback));
 }
 
-void CacheStorageCache::putRecordsInStore(Vector<CacheStorageRecord>&& records, Vector<std::optional<CacheStorageRecord>>&& existingRecords, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+void CacheStorageCache::putRecordsInStore(IPC::Connection& connection, Vector<CacheStorageRecord>&& records, Vector<std::optional<CacheStorageRecord>>&& existingRecords, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     assertIsOnCorrectQueue();
 
@@ -374,7 +408,9 @@ void CacheStorageCache::putRecordsInStore(Vector<CacheStorageRecord>&& records, 
         if (!record.info.identifier()) {
             record.info.setIdentifier(nextRecordIdentifier());
             sizeIncreased += record.info.size();
-            m_records.ensure(computeKeyURL(record.info.url()), [] {
+            auto keyURL = computeKeyURL(record.info.url());
+            MESSAGE_CHECK_COMPLETION(keyURL, connection, callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal)));
+            m_records.ensure(*keyURL, [] {
                 return Vector<CacheStorageRecordInformation> { };
             }).iterator->value.append(record.info);
         } else {
@@ -389,7 +425,9 @@ void CacheStorageCache::putRecordsInStore(Vector<CacheStorageRecord>&& records, 
 
             auto& existingRecord = existingRecords[index];
             // Ensure identifier still exists.
-            auto* existingRecordInfo = findExistingRecord(record.request, record.info.identifier());
+            auto existingRecordInfoOrError = findExistingRecord(record.request, record.info.identifier());
+            MESSAGE_CHECK_COMPLETION(existingRecordInfoOrError.has_value(), connection, callback(makeUnexpected(existingRecordInfoOrError.error())));
+            auto* existingRecordInfo = *existingRecordInfoOrError;
             if (!existingRecordInfo) {
                 record.info.setIdentifier(0);
                 continue;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
@@ -34,6 +34,10 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WorkQueue.h>
 
+namespace IPC {
+class Connection;
+}
+
 namespace WebKit {
 class CacheStorageCache;
 }
@@ -54,9 +58,9 @@ public:
 
     void getSize(CompletionHandler<void(uint64_t)>&&);
     void open(WebCore::DOMCacheEngine::CacheIdentifierCallback&&);
-    void retrieveRecords(WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&&);
-    void removeRecords(WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
-    void putRecords(Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void retrieveRecords(IPC::Connection&, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&&);
+    void removeRecords(IPC::Connection&, WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void putRecords(IPC::Connection&, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
     void removeAllRecords();
     void close();
 
@@ -65,9 +69,9 @@ public:
 
 private:
     CacheStorageCache(CacheStorageManager&, const String& name, const String& uniqueName, const String& path, Ref<WorkQueue>&&);
-    CacheStorageRecordInformation* findExistingRecord(const WebCore::ResourceRequest&, std::optional<uint64_t> = std::nullopt);
-    void putRecordsAfterQuotaCheck(Vector<CacheStorageRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
-    void putRecordsInStore(Vector<CacheStorageRecord>&&, Vector<std::optional<CacheStorageRecord>>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    Expected<CacheStorageRecordInformation*, WebCore::DOMCacheEngine::Error> findExistingRecord(const WebCore::ResourceRequest&, std::optional<uint64_t> = std::nullopt);
+    void putRecordsAfterQuotaCheck(IPC::Connection&, Vector<CacheStorageRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void putRecordsInStore(IPC::Connection&, Vector<CacheStorageRecord>&&, Vector<std::optional<CacheStorageRecord>>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
     void assertIsOnCorrectQueue() const
     {
 #if ASSERT_ENABLED
@@ -75,7 +79,7 @@ private:
 #endif
     }
 
-    static String computeKeyURL(const URL&);
+    static std::optional<String> computeKeyURL(const URL&);
     using RecordsMap = HashMap<String, Vector<CacheStorageRecordInformation>>;
 
     WeakPtr<CacheStorageManager> m_manager;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -2033,22 +2033,22 @@ void NetworkStorageManager::unlockCacheStorage(IPC::Connection& connection, cons
         cacheStorageManager->unlockStorage(connection.uniqueID());
 }
 
-void NetworkStorageManager::cacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&& callback)
+void NetworkStorageManager::cacheStorageRetrieveRecords(IPC::Connection& connection, WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&& callback)
 {
     RefPtr cache = m_cacheStorageRegistry->cache(cacheIdentifier);
     if (!cache)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
-    cache->retrieveRecords(WTF::move(options), WTF::move(callback));
+    cache->retrieveRecords(connection, WTF::move(options), WTF::move(callback));
 }
 
-void NetworkStorageManager::cacheStorageRemoveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::ResourceRequest&& request, WebCore::CacheQueryOptions&& options, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+void NetworkStorageManager::cacheStorageRemoveRecords(IPC::Connection& connection, WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::ResourceRequest&& request, WebCore::CacheQueryOptions&& options, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     RefPtr cache = m_cacheStorageRegistry->cache(cacheIdentifier);
     if (!cache)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
-    cache->removeRecords(WTF::move(request), WTF::move(options), WTF::move(callback));
+    cache->removeRecords(connection, WTF::move(request), WTF::move(options), WTF::move(callback));
 }
 
 void NetworkStorageManager::cacheStoragePutRecords(IPC::Connection& connection, WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
@@ -2060,7 +2060,7 @@ void NetworkStorageManager::cacheStoragePutRecords(IPC::Connection& connection, 
     for (auto& record : records)
         MESSAGE_CHECK_COMPLETION(record.responseBodySize >= CacheStorageDiskStore::computeRealBodySizeForStorage(record.responseBody), connection, callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal)));
 
-    cache->putRecords(WTF::move(records), WTF::move(callback));
+    cache->putRecords(connection, WTF::move(records), WTF::move(callback));
 }
 
 void NetworkStorageManager::cacheStorageClearMemoryRepresentation(const WebCore::ClientOrigin& origin, CompletionHandler<void()>&& callback)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -260,8 +260,8 @@ private:
     void cacheStorageDereference(IPC::Connection&, WebCore::DOMCacheIdentifier);
     void lockCacheStorage(IPC::Connection&, const WebCore::ClientOrigin&);
     void unlockCacheStorage(IPC::Connection&, const WebCore::ClientOrigin&);
-    void cacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&&);
-    void cacheStorageRemoveRecords(WebCore::DOMCacheIdentifier, WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void cacheStorageRetrieveRecords(IPC::Connection&, WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&&);
+    void cacheStorageRemoveRecords(IPC::Connection&, WebCore::DOMCacheIdentifier, WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
     void cacheStoragePutRecords(IPC::Connection&, WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
     void cacheStorageClearMemoryRepresentation(const WebCore::ClientOrigin&, CompletionHandler<void()>&&);
     void cacheStorageRepresentation(CompletionHandler<void(const String&)>&&);


### PR DESCRIPTION
#### 29ec063b656355b971fbb6e1703b44ba221091df
<pre>
Cherry-pick 305413.546@safari-7624-branch (1df88b983792). <a href="https://bugs.webkit.org/show_bug.cgi?id=310177">https://bugs.webkit.org/show_bug.cgi?id=310177</a>

    CacheStorageCache::computeKeyURL() can cause network process to crash on bad IPC
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310177">https://bugs.webkit.org/show_bug.cgi?id=310177</a>
    <a href="https://rdar.apple.com/172058080">rdar://172058080</a>

    Reviewed by Sihui Liu.

    CacheStorageCache::computeKeyURL() can cause network process to crash on
    bad IPC from the WebContent process, due to release assertions.

    To address the issue, replace the debug assertions in
    CacheStorageCache::computeKeyURL() and returning std::nullopt in release
    builds. The call sites then rely on MESSAGE_CHECK when computeKeyURL()
    returns std::nullopt to terminate the process that sent the bad IPC.

    * Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
    (WebKit::CacheStorageCache::computeKeyURL):
    (WebKit::CacheStorageCache::open):
    (WebKit::CacheStorageCache::retrieveRecords):
    (WebKit::CacheStorageCache::removeRecords):
    (WebKit::CacheStorageCache::findExistingRecord):
    (WebKit::CacheStorageCache::putRecords):
    (WebKit::CacheStorageCache::putRecordsAfterQuotaCheck):
    (WebKit::CacheStorageCache::putRecordsInStore):
    * Source/WebKit/NetworkProcess/storage/CacheStorageCache.h:
    * Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
    (WebKit::NetworkStorageManager::cacheStorageRetrieveRecords):
    (WebKit::NetworkStorageManager::cacheStorageRemoveRecords):
    (WebKit::NetworkStorageManager::cacheStoragePutRecords):
    * Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:

    * Tools/TestWebKitAPI/Tests/WebKit/FetchLocalFile.mm:
    (TEST(WebKit, FetchLocalFileFromTempDirectory)):
    Fix flaky test that kept causing issues on EWS.

    Identifier: 305413.546@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.680@webkitglib/2.52">https://commits.webkit.org/305877.680@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42cc5db7ae2f8e32e803acb8795a1c7fa8609457

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164422 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/37906 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/31477 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173451 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121674 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38240 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37908 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127753 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121674 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167381 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38240 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/31477 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108298 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38240 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37908 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21215 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38240 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/31477 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175977 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28800 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31477 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136066 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/37578 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/37908 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136034 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38363 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/31477 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100793 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25026 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38363 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31477 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37173 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110217 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/36570 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/31477 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/36819 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/36719 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->