### PR TITLE
[EME][OCDM] Prevent spurious keystatuses event when all keys expired

### DIFF
--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -175,6 +175,7 @@ public:
     }
 
     unsigned numKeys() const { return m_keys.size(); }
+    bool isEmpty() const { return m_keys.isEmpty(); }
     auto values() const { return m_keys.values(); }
     KeyStoreIDType id() const { return m_id; }
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
@@ -56,8 +56,15 @@ BoxPtr<OpenCDMSession> CDMProxyThunder::getDecryptionSession(DecryptionContext& 
     auto keyID = mappedKeyID.createVector();
 
     auto keyHandle = getOrWaitForKeyHandle(keyID, WTF::move(in.cdmProxyDecryptionClient));
-    if (!keyHandle.has_value() || !keyHandle.value()->isStatusCurrentlyValid())
+    if (!keyHandle) {
+        GST_ERROR("No key handle");
         return nullptr;
+    }
+
+    if (!keyHandle.value()->isStatusCurrentlyValid()) {
+        GST_ERROR("Key handle has no usable key");
+        return nullptr;
+    }
 
     KeyHandleValueVariant keyData = keyHandle.value()->value();
     ASSERT(std::holds_alternative<BoxPtr<OpenCDMSession>>(keyData));

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -571,10 +571,16 @@ void CDMInstanceSessionThunder::updateLicense(const String& sessionID, LicenseTy
     m_sessionChangedCallbacks.append([this, callback = WTF::move(callback)](bool success, RefPtr<SharedBuffer>&& responseMessage) mutable {
         ASSERT(isMainThread());
         if (success) {
-            if (!responseMessage)
-                callback(false, m_keyStore.convertToJSKeyStatusVector(), std::nullopt, std::nullopt, SuccessValue::Succeeded);
-            else {
-                // FIXME: Using JSON reponse messages is much cleaner than using string prefixes, I believe there
+            if (!responseMessage) {
+                GST_DEBUG("Empty response message");
+                std::optional<KeyStatusVector> keyStatus;
+                // If the keystore is empty, generating an empty status vector would trigger a new
+                // keystatuses event potentially overriding the previous one.
+                if (!m_keyStore.isEmpty())
+                    keyStatus = m_keyStore.convertToJSKeyStatusVector();
+                callback(false, WTF::move(keyStatus), std::nullopt, std::nullopt, SuccessValue::Succeeded);
+            } else {
+                // FIXME: Using JSON response messages is much cleaner than using string prefixes, I believe there
                 // will even be other parts of the spec where not having structured data will be bad.
                 ParsedResponseMessage parsedResponseMessage(responseMessage);
                 ASSERT(parsedResponseMessage);


### PR DESCRIPTION
#### 4c861668911872d44c7eba9436922cad3cacdcc7
<pre>
[EME][OCDM] Prevent spurious keystatuses event when all keys expired
<a href="https://bugs.webkit.org/show_bug.cgi?id=315558">https://bugs.webkit.org/show_bug.cgi?id=315558</a>

Reviewed by Xabier Rodriguez-Calvar.

If the keystore is empty, generating an empty status vector would trigger a new keystatuses event
potentially overriding the previous one. Manually tested with a Widevine L3 CDM. This is sadly not
testable because there&apos;s no notion of key expiration in ClearKey.

Driving-by, improve GStreamer logging a bit in CDMProxyThunder.

* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
(WebCore::KeyStoreBase::isEmpty const):
* Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp:
(WebCore::CDMProxyThunder::getDecryptionSession const):
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
(WebCore::CDMInstanceSessionThunder::updateLicense):

Canonical link: <a href="https://commits.webkit.org/313876@main">https://commits.webkit.org/313876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9a339e21a5b5de1863c006018189490eff80395

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121679 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127757 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89931 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108302 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27730 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21220 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175982 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28805 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136070 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/37712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136038 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36643 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38476 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147303 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100798 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/38476 "Build is in progress. Recent messages:") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24159 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37178 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110222 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36575 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2217 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->