### PR TITLE
[GLIB] Replace uses of Ref/RefPtr with protect() in WebCore

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
@@ -63,7 +63,7 @@ void GStreamerDtlsTransportBackendObserver::stateChanged()
     if (!m_client)
         return;
 
-    callOnMainThread([this, protectedThis = Ref { *this }]() mutable {
+    callOnMainThread([this, protectedThis = protect(*this)]() mutable {
         if (!m_client || !m_backend)
             return;
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
@@ -98,7 +98,7 @@ void GStreamerIceTransportBackendObserver::onIceTransportStateChanged()
     GST_DEBUG_OBJECT(m_iceTransport.get(), "ICE transport state changed to %s", desc.utf8());
 #endif
 
-    callOnMainThread([protectedThis = Ref { *this }, transportState] {
+    callOnMainThread([protectedThis = protect(*this), transportState] {
         if (RefPtr client = protectedThis->m_client.get())
             client->onStateChanged(toRTCIceTransportState(transportState));
     });
@@ -111,7 +111,7 @@ void GStreamerIceTransportBackendObserver::onGatheringStateChanged()
 
     GstWebRTCICEGatheringState gatheringState;
     g_object_get(m_iceTransport.get(), "gathering-state", &gatheringState, nullptr);
-    callOnMainThread([protectedThis = Ref { *this }, gatheringState] {
+    callOnMainThread([protectedThis = protect(*this), gatheringState] {
         if (RefPtr client = protectedThis->m_client.get())
             client->onGatheringStateChanged(toRTCIceGatheringState(gatheringState));
     });
@@ -174,7 +174,7 @@ void GStreamerIceTransportBackendObserver::onSelectedCandidatePairChanged()
 
     auto localCandidate = candidateFromGstWebRTC(selectedPair->local);
     auto remoteCandidate = candidateFromGstWebRTC(selectedPair->remote);
-    WTF::callOnMainThreadAndWait([protectedThis = Ref { *this }, localCandidate = WTF::move(localCandidate), remoteCandidate = WTF::move(remoteCandidate)] mutable {
+    WTF::callOnMainThreadAndWait([protectedThis = protect(*this), localCandidate = WTF::move(localCandidate), remoteCandidate = WTF::move(remoteCandidate)] mutable {
         if (RefPtr client = protectedThis->m_client.get())
             client->onSelectedCandidatePairChanged(WTF::move(localCandidate), WTF::move(remoteCandidate));
     });

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -126,11 +126,11 @@ void GStreamerRtpSenderBackend::stopSource()
 {
     GST_DEBUG_OBJECT(m_rtcSender.get(), "Stopping source");
     switchOn(m_source, [&](Ref<RealtimeOutgoingAudioSourceGStreamer>& source) {
-        source->stop([self = RefPtr { this }] {
+        source->stop([self = protect(this)] {
             self->clearSource();
         });
     }, [&](Ref<RealtimeOutgoingVideoSourceGStreamer>& source) {
-        source->stop([self = RefPtr { this }] {
+        source->stop([self = protect(this)] {
             self->clearSource();
         });
     }, [&](std::nullptr_t&) {

--- a/Source/WebCore/platform/graphics/gstreamer/MainThreadNotifier.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MainThreadNotifier.h
@@ -57,7 +57,7 @@ public:
         if (!addPendingNotification(notificationType))
             return;
 
-        RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }, notificationType, callback = Function<void()>(WTF::move(callbackFunctor))] {
+        RunLoop::mainSingleton().dispatch([this, protectedThis = protect(*this), notificationType, callback = Function<void()>(WTF::move(callbackFunctor))] {
             if (!m_isValid.load())
                 return;
             if (removePendingNotification(notificationType))

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4338,7 +4338,7 @@ void MediaPlayerPrivateGStreamer::pushNextHolePunchBuffer()
 {
     ASSERT(isHolePunchRenderingEnabled());
 #if USE(COORDINATED_GRAPHICS)
-    m_contentsBufferProxy->setDisplayBuffer(CoordinatedPlatformLayerBufferHolePunch::create(m_size, m_videoSink.get(), m_quirksManagerForTesting ? m_quirksManagerForTesting.copyRef() : RefPtr { &GStreamerQuirksManager::singleton() }));
+    m_contentsBufferProxy->setDisplayBuffer(CoordinatedPlatformLayerBufferHolePunch::create(m_size, m_videoSink.get(), m_quirksManagerForTesting ? m_quirksManagerForTesting.copyRef() : protect(&GStreamerQuirksManager::singleton())));
 #endif
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -414,7 +414,7 @@ void GStreamerIncomingTrackProcessor::trackReady()
 
     m_isReady = true;
     GST_DEBUG_OBJECT(m_bin.get(), "MediaStream %s track %s on pad %" GST_PTR_FORMAT " is ready", m_data.mediaStreamId.utf8().data(), m_data.trackId.utf8().data(), m_pad.get());
-    callOnMainThread([endPoint = Ref { *endPoint }, this] {
+    callOnMainThread([endPoint = protect(*endPoint), this] {
         if (endPoint->isStopped())
             return;
         endPoint->connectIncomingTrack(m_data);
@@ -428,7 +428,7 @@ void GStreamerIncomingTrackProcessor::trackHasReceivedFirstPacket()
         return;
 
     GST_DEBUG_OBJECT(m_bin.get(), "MediaStream %s track %s on pad %" GST_PTR_FORMAT " has received its first packet", m_data.mediaStreamId.utf8().data(), m_data.trackId.utf8().data(), m_pad.get());
-    callOnMainThread([endPoint = Ref { *endPoint }, this] {
+    callOnMainThread([endPoint = protect(*endPoint), this] {
         if (endPoint->isStopped())
             return;
         endPoint->notifyFirstPacketReceived(m_data);

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp
@@ -101,7 +101,7 @@ void RealtimeOutgoingAudioSourceLibWebRTC::audioSamplesAvailable(const MediaTime
         auto* buffer = gst_sample_get_buffer(sample.get());
         gst_adapter_push(m_adapter.get(), gst_buffer_ref(buffer));
     }
-    LibWebRTCProvider::callOnWebRTCSignalingThread([protectedThis = Ref { *this }] {
+    LibWebRTCProvider::callOnWebRTCSignalingThread([protectedThis = protect(*this)] {
         protectedThis->pullAudioData();
     });
 }


### PR DESCRIPTION
#### e82c450e3d7cf1bf51a82cc9f735ee1d5fb4e656
<pre>
[GLIB] Replace uses of Ref/RefPtr with protect() in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=315563">https://bugs.webkit.org/show_bug.cgi?id=315563</a>

Reviewed by Philippe Normand.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp:
(WebCore::GStreamerDtlsTransportBackendObserver::stateChanged):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp:
(WebCore::GStreamerIceTransportBackendObserver::onIceTransportStateChanged):
(WebCore::GStreamerIceTransportBackendObserver::onGatheringStateChanged):
(WebCore::GStreamerIceTransportBackendObserver::onSelectedCandidatePairChanged):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
(WebCore::GStreamerRtpSenderBackend::stopSource):
* Source/WebCore/platform/graphics/gstreamer/MainThreadNotifier.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pushNextHolePunchBuffer):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::trackReady):
(WebCore::GStreamerIncomingTrackProcessor::trackHasReceivedFirstPacket):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp:
(WebCore::RealtimeOutgoingAudioSourceLibWebRTC::audioSamplesAvailable):

Canonical link: <a href="https://commits.webkit.org/313884@main">https://commits.webkit.org/313884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/436b7eae51f813ca17c4017dceb5f30749708287

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121691 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127768 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89940 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108313 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29117 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27742 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21232 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175994 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28817 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136081 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/37907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31862 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136049 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147315 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100833 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25030 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24171 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37190 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110234 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36587 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2229 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36736 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->