### PR TITLE
Cherry-pick 305413.565@safari-7624-branch (f49e83162fdd). https://bugs.webkit.org/show_bug.cgi?id=310544

### DIFF
--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event-expected.txt
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event-expected.txt
@@ -1,0 +1,11 @@
+Test that changing the input type during an input event does not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.type is "text"
+PASS Did not crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input id="input" type="date">
+
+<script>
+
+jsTestIsAsync = true;
+
+description("Test that changing the input type during an input event does not crash.");
+
+input.addEventListener("input", () => {
+    input.type = "text";
+});
+
+addEventListener("load", async () => {
+    input.focus();                                         // [mm]/dd/yyyy
+    UIHelper.keyDown("9");                                 // -> [09]/dd/yyyy
+    UIHelper.keyDown("rightArrow");                        // -> 09/[dd]/yyyy
+    UIHelper.keyDown("2");                                 // -> 09/[02]/yyyy
+    UIHelper.keyDown("rightArrow");                        // -> 09/02/[yyyy]
+    UIHelper.keyDown("2");                                 // -> 09/02/[0002]
+    UIHelper.keyDown("0");                                 // -> 09/02/[0020]
+    UIHelper.keyDown("1");                                 // -> 09/02/[0201]
+    UIHelper.keyDown("2");                                 // -> 09/02/[2012] -> input event fires -> type changes to text
+
+    shouldBeEqualToString("input.type", "text");
+
+    testPassed("Did not crash.");
+    finishJSTest();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -34,6 +34,8 @@ webkit.org/b/289926 imported/w3c/web-platform-tests/css/css-position/position-ab
 
 imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/image-orientation/drawImage-from-blob.tentative.html [ Pass ]
 
+fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event.html [ Pass ]
+
 fast/forms/month/month-editable-components/month-editable-components-input-and-change-events.html [ Pass ]
 fast/forms/month/month-editable-components/month-editable-components-user-invalid.html [ Pass ]
 fast/forms/month/month-editable-components/month-editable-components-user-valid.html [ Pass ]

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -89,7 +89,8 @@ typedef struct _WebKitGstIceAgentPrivate {
     RefPtr<SocketProvider> socketProvider;
     GRefPtr<RiceAgent> agent;
 
-    StreamHashMap streams;
+    Lock streamsLock;
+    StreamHashMap streams WTF_GUARDED_BY_LOCK(streamsLock);
 
     RefPtr<RunLoop> runLoop;
 
@@ -395,6 +396,7 @@ static GstWebRTCICEStream* webkitGstWebRTCIceAgentAddStream(GstWebRTCICE* ice, g
     if (!backend->priv->iceBackend)
         return nullptr;
 
+    Locker locker { backend->priv->streamsLock };
     if (backend->priv->streams.contains(sessionId)) {
         GST_ERROR_OBJECT(ice, "Stream already added for session %u", sessionId);
         return nullptr;
@@ -642,7 +644,10 @@ void webkitGstWebRTCIceAgentClosed(WebKitGstIceAgent* agent)
     Locker locker { priv->stateLock };
     priv->state = AgentState::Closed;
 
-    priv->streams.clear();
+    {
+        Locker locker { priv->streamsLock };
+        priv->streams.clear();
+    }
 
     if (!priv->closePromise)
         return;
@@ -723,13 +728,16 @@ static void webkitGstWebRTCIceAgentConstructed(GObject* object)
     priv->agent = adoptGRef(rice_agent_new(true, true));
 }
 
-static void findStreamAndApply(const StreamHashMap& streams, unsigned streamId, Function<void(const WebKitGstIceStream*)> callback)
+static void findStreamAndApply(WebKitGstIceAgent* agent, unsigned streamId, Function<void(const WebKitGstIceStream*)> callback)
 {
-    for (auto& riceStream : streams.values()) {
+    Locker locker { agent->priv->streamsLock };
+    for (auto& riceStream : agent->priv->streams.values()) {
         if (riceStream->riceStreamId != streamId)
             continue;
 
-        callback(WEBKIT_GST_WEBRTC_ICE_STREAM(riceStream->stream.get()));
+        GRefPtr stream = riceStream->stream;
+        locker.unlockEarly();
+        callback(WEBKIT_GST_WEBRTC_ICE_STREAM(stream.get()));
         return;
     }
 }
@@ -748,7 +756,7 @@ static bool webkitGstWebRTCIceAgentConfigure(WebKitGstIceAgent* backend, RefPtr<
         auto self = weakThis.get();
         if (!self)
             return;
-        findStreamAndApply(self->priv->streams, streamId, [protocol, from = WTF::move(from), to = WTF::move(to), data = WTF::move(data)](const auto* stream) mutable {
+        findStreamAndApply(self.get(), streamId, [protocol, from = WTF::move(from), to = WTF::move(to), data = WTF::move(data)](const auto* stream) mutable {
             webkitGstWebRTCIceStreamHandleIncomingData(stream, protocol, WTF::move(from), WTF::move(to), WTF::move(data));
         });
     });
@@ -874,7 +882,7 @@ void webkitGstWebRTCIceAgentWakeup(WebKitGstIceAgent* agent)
 
 void webkitGstWebRTCIceAgentGatheringDoneForStream(WebKitGstIceAgent* agent, unsigned streamId)
 {
-    findStreamAndApply(agent->priv->streams, streamId, [](const auto* stream) {
+    findStreamAndApply(agent, streamId, [](const auto* stream) {
         webkitGstWebRTCIceStreamGatheringDone(stream);
     });
 }
@@ -891,7 +899,7 @@ void webkitGstWebRTCIceAgentLocalCandidateGatheredForStream(WebKitGstIceAgent* a
         }
     }
 
-    findStreamAndApply(agent->priv->streams, streamId, [&](const auto* stream) {
+    findStreamAndApply(agent, streamId, [&](const auto* stream) {
         Locker locker { priv->stateLock };
         if (priv->state >= AgentState::Closing) {
             GST_DEBUG_OBJECT(agent, "Agent %s, no need to notify gathered candidate anymore", priv->state == AgentState::Closed ? "was closed" : "is closing");
@@ -913,14 +921,14 @@ void webkitGstWebRTCIceAgentLocalCandidateGatheredForStream(WebKitGstIceAgent* a
 
 void webkitGstWebRTCIceAgentNewSelectedPairForStream(WebKitGstIceAgent* agent, unsigned streamId, RiceAgentSelectedPair& selectedPair)
 {
-    findStreamAndApply(agent->priv->streams, streamId, [&](const auto* stream) {
+    findStreamAndApply(agent, streamId, [&](const auto* stream) {
         webkitGstWebRTCIceStreamNewSelectedPair(stream, selectedPair);
     });
 }
 
 void webkitGstWebRTCIceAgentComponentStateChangedForStream(WebKitGstIceAgent* agent, unsigned streamId, RiceAgentComponentStateChange& change)
 {
-    findStreamAndApply(agent->priv->streams, streamId, [&](const auto* stream) {
+    findStreamAndApply(agent, streamId, [&](const auto* stream) {
         webkitGstWebRTCIceStreamComponentStateChanged(stream, change);
     });
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -65,6 +65,12 @@ using WebKitGstRiceStream = struct _WebKitGstRiceStream {
 
 using StreamHashMap = HashMap<unsigned, std::unique_ptr<WebKitGstRiceStream>, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>;
 
+enum class AgentState : uint8_t {
+    Open,
+    Closing,
+    Closed
+};
+
 typedef struct _WebKitGstIceAgentPrivate {
     ~_WebKitGstIceAgentPrivate()
     {
@@ -87,8 +93,9 @@ typedef struct _WebKitGstIceAgentPrivate {
 
     RefPtr<RunLoop> runLoop;
 
-    Atomic<bool> agentIsClosed;
-    GRefPtr<GstPromise> closePromise;
+    Lock stateLock;
+    AgentState state WTF_GUARDED_BY_LOCK(stateLock) { AgentState::Open };
+    GRefPtr<GstPromise> closePromise WTF_GUARDED_BY_LOCK(stateLock);
 
     GstWebRTCICEOnCandidateFunc onCandidate;
     gpointer onCandidateData;
@@ -396,6 +403,7 @@ static GstWebRTCICEStream* webkitGstWebRTCIceAgentAddStream(GstWebRTCICE* ice, g
     auto riceStream = adoptGRef(rice_agent_add_stream(backend->priv->agent.get()));
     auto streamId = static_cast<unsigned>(rice_stream_get_id(riceStream.get()));
     [[maybe_unused]] auto component = adoptGRef(rice_stream_add_component(riceStream.get()));
+    GST_DEBUG_OBJECT(ice, "Component %zu added for stream %u", rice_component_get_id(component.get()), streamId);
 
     auto stream = adoptGRef(GST_WEBRTC_ICE_STREAM(webkitGstWebRTCCreateIceStream(backend, WTF::move(riceStream))));
     backend->priv->streams.add(sessionId, WTF::makeUnique<WebKitGstRiceStream>(streamId, WTF::move(stream)));
@@ -628,14 +636,19 @@ static gboolean webkitGstWebRTCIceAgentGetSelectedPair(GstWebRTCICE* ice, GstWeb
 
 void webkitGstWebRTCIceAgentClosed(WebKitGstIceAgent* agent)
 {
-    agent->priv->agentIsClosed.exchange(true);
-    agent->priv->streams.clear();
+    GST_DEBUG_OBJECT(agent, "Agent successfully closed");
+    auto priv = agent->priv;
 
-    if (!agent->priv->closePromise)
+    Locker locker { priv->stateLock };
+    priv->state = AgentState::Closed;
+
+    priv->streams.clear();
+
+    if (!priv->closePromise)
         return;
 
-    gst_promise_reply(agent->priv->closePromise.get(), nullptr);
-    agent->priv->closePromise.clear();
+    gst_promise_reply(priv->closePromise.get(), nullptr);
+    priv->closePromise.clear();
 }
 
 #if GST_CHECK_VERSION(1, 27, 0)
@@ -643,24 +656,48 @@ static void webkitGstWebRTCIceAgentClose(GstWebRTCICE* ice, GstPromise* promise)
 {
     auto backend = WEBKIT_GST_WEBRTC_ICE_BACKEND(ice);
 
-    auto isClosed = backend->priv->agentIsClosed.load();
-    if (isClosed)
-        return;
+    {
+        Locker locker { backend->priv->stateLock };
 
-    bool shouldWait = promise == nullptr;
-    backend->priv->closePromise = promise;
-    auto now = WTF::MonotonicTime::now().secondsSinceEpoch();
-    rice_agent_close(backend->priv->agent.get(), now.nanoseconds());
+        GST_DEBUG_OBJECT(ice, "Attempting to close connection");
+        if (backend->priv->state >= AgentState::Closing) {
+            GST_DEBUG_OBJECT(ice, "Agent %s, no need to close again", backend->priv->state == AgentState::Closed ? "was closed" : "is closing");
+            return;
+        }
+
+        backend->priv->closePromise = promise;
+        backend->priv->state = AgentState::Closing;
+        auto now = WTF::MonotonicTime::now().secondsSinceEpoch();
+        rice_agent_close(backend->priv->agent.get(), now.nanoseconds());
+    }
+
+    {
+        Locker locker { backend->priv->stateLock };
+
+        bool shouldWait = promise == nullptr;
+        auto isClosed = backend->priv->state == AgentState::Closed;
+        if (!shouldWait || isClosed) {
+            GST_DEBUG_OBJECT(ice, "No need to wait close procedure completion");
+            backend->priv->state = AgentState::Closed;
+            return;
+        }
+    }
+
+    GST_DEBUG_OBJECT(ice, "Waiting close procedure completion");
     webkitGstWebRTCIceAgentWakeup(backend);
 
-    isClosed = backend->priv->agentIsClosed.load();
-    if (!shouldWait || isClosed)
-        return;
-
-    while (!isClosed) {
+    auto timeout = WTF::MonotonicTime::now().secondsSinceEpoch() + 2_s;
+    while (WTF::MonotonicTime::now().secondsSinceEpoch() < timeout) {
+        bool isClosed = false;
+        {
+            Locker locker { backend->priv->stateLock };
+            isClosed = backend->priv->state == AgentState::Closed;
+        }
+        if (isClosed)
+            return;
         g_main_context_iteration(backend->priv->runLoop->mainContext(), FALSE);
-        isClosed = backend->priv->agentIsClosed.load();
     }
+    GST_DEBUG_OBJECT(ice, "Agent failed to properly close connections");
 }
 #endif
 
@@ -670,8 +707,6 @@ static void webkitGstWebRTCIceAgentConstructed(GObject* object)
 
     auto backend = WEBKIT_GST_WEBRTC_ICE_BACKEND(object);
     auto priv = backend->priv;
-
-    priv->agentIsClosed.exchange(false);
 
     static Atomic<uint32_t> counter = 0;
     auto id = counter.load();
@@ -846,17 +881,32 @@ void webkitGstWebRTCIceAgentGatheringDoneForStream(WebKitGstIceAgent* agent, uns
 
 void webkitGstWebRTCIceAgentLocalCandidateGatheredForStream(WebKitGstIceAgent* agent, unsigned streamId, RiceAgentGatheredCandidate& candidate)
 {
+    auto priv = agent->priv;
+    {
+        Locker locker { priv->stateLock };
+
+        if (priv->state >= AgentState::Closing) {
+            GST_DEBUG_OBJECT(agent, "Agent %s, no need to notify gathered candidate anymore", priv->state == AgentState::Closed ? "was closed" : "is closing");
+            return;
+        }
+    }
+
     findStreamAndApply(agent->priv->streams, streamId, [&](const auto* stream) {
+        Locker locker { priv->stateLock };
+        if (priv->state >= AgentState::Closing) {
+            GST_DEBUG_OBJECT(agent, "Agent %s, no need to notify gathered candidate anymore", priv->state == AgentState::Closed ? "was closed" : "is closing");
+            return;
+        }
         auto sdp = GMallocString::unsafeAdoptFromUTF8(rice_candidate_to_sdp_string(&candidate.gathered.candidate));
 
-        if (agent->priv->forceRelay && candidate.gathered.candidate.candidate_type != RICE_CANDIDATE_TYPE_RELAYED) {
+        if (priv->forceRelay && candidate.gathered.candidate.candidate_type != RICE_CANDIDATE_TYPE_RELAYED) {
             GST_DEBUG_OBJECT(agent, "Ignoring non-relay ICE candidate %s", sdp.utf8());
             return;
         }
 
         ASSERT(startsWith(sdp.span(), "a="_s));
         String strippedSdp(sdp.span().subspan(2));
-        agent->priv->onCandidate(GST_WEBRTC_ICE(agent), streamId, strippedSdp.utf8().data(), agent->priv->onCandidateData);
+        priv->onCandidate(GST_WEBRTC_ICE(agent), streamId, strippedSdp.utf8().data(), priv->onCandidateData);
         webkitGstWebRTCIceStreamAddLocalGatheredCandidate(stream, candidate.gathered);
     });
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp
@@ -104,6 +104,7 @@ void webkitGstWebRTCIceStreamGatheringDone(const WebKitGstIceStream* ice)
 void webkitGstWebRTCIceStreamAddLocalGatheredCandidate(const WebKitGstIceStream* ice, RiceGatheredCandidate& candidate)
 {
     auto stream = WEBKIT_GST_WEBRTC_ICE_STREAM(ice);
+    GST_DEBUG_OBJECT(ice, "Local candidate gathered for stream %u on component %zu", stream->priv->streamId, candidate.candidate.component_id);
     rice_stream_add_local_gathered_candidate(stream->priv->riceStream.get(), &candidate);
 }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -179,13 +179,15 @@ RTCRtpSendParameters GStreamerRtpSenderBackend::getParameters() const
         m_currentParameters = source->parameters();
     }, [&](const Ref<RealtimeOutgoingVideoSourceGStreamer>& source) {
         m_currentParameters = source->parameters();
-    }, [](const std::nullptr_t&) {
+    }, [&](const std::nullptr_t&) {
+        GST_DEBUG_OBJECT(m_rtcSender.get(), "No outgoing source yet, unable to retrieve parameters");
     });
 
     GST_DEBUG_OBJECT(m_rtcSender.get(), "Current parameters: %" GST_PTR_FORMAT, m_currentParameters.get());
-    if (!m_currentParameters)
+    if (!m_currentParameters) {
+        GST_DEBUG_OBJECT(m_rtcSender.get(), "Using init data: %" GST_PTR_FORMAT, m_initData.get());
         return toRTCRtpSendParameters(m_initData.get());
-
+    }
     return toRTCRtpSendParameters(m_currentParameters.get());
 }
 

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -173,13 +173,8 @@ ReadableStreamBYOBRequest* ReadableByteStreamController::getByobRequest() const
 {
     if (!m_byobRequest && !m_pendingPullIntos.isEmpty()) {
         auto& firstDescriptor = m_pendingPullIntos.first();
-        auto view = JSC::Uint8Array::create(firstDescriptor.buffer.ptr(), firstDescriptor.byteOffset + firstDescriptor.bytesFilled, firstDescriptor.byteLength - firstDescriptor.bytesFilled);
-        Ref byobRequest = ReadableStreamBYOBRequest::create();
-
-        byobRequest->setController(const_cast<ReadableByteStreamController*>(this));
-        byobRequest->setView(view.ptr());
-
-        m_byobRequest = WTF::move(byobRequest);
+        Ref view = JSC::Uint8Array::create(firstDescriptor.buffer.ptr(), firstDescriptor.byteOffset + firstDescriptor.bytesFilled, firstDescriptor.byteLength - firstDescriptor.bytesFilled);
+        m_byobRequest = ReadableStreamBYOBRequest::create(*const_cast<ReadableByteStreamController*>(this), WTF::move(view));
     }
 
     return m_byobRequest.get();
@@ -424,8 +419,8 @@ void ReadableByteStreamController::invalidateByobRequest()
     if (!byobRequest)
         return;
 
-    byobRequest->setController(nullptr);
-    byobRequest->setView(nullptr);
+    byobRequest->clearController();
+    byobRequest->clearView();
     m_byobRequest = nullptr;
 }
 

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ReadableStreamBYOBRequest.h"
 
+#include "JSReadableStream.h"
 #include "JSReadableStreamBYOBRequest.h"
 #include "ReadableByteStreamController.h"
 #include "ReadableStream.h"
@@ -33,12 +34,23 @@
 
 namespace WebCore {
 
-Ref<ReadableStreamBYOBRequest> ReadableStreamBYOBRequest::create()
+Ref<ReadableStreamBYOBRequest> ReadableStreamBYOBRequest::create(ReadableByteStreamController& controller, Ref<JSC::ArrayBufferView>&& view)
 {
-    return adoptRef(*new ReadableStreamBYOBRequest);
+    return adoptRef(*new ReadableStreamBYOBRequest(controller, WTF::move(view)));
 }
 
-ReadableStreamBYOBRequest::ReadableStreamBYOBRequest() = default;
+ReadableStreamBYOBRequest::ReadableStreamBYOBRequest(ReadableByteStreamController& controller, Ref<JSC::ArrayBufferView>&& view)
+    : m_controller(controller)
+    , m_view(WTF::move(view))
+{
+    Ref stream = controller.stream();
+    auto* globalObject = stream->globalObject();
+    ASSERT(globalObject);
+    if (!globalObject)
+        return;
+
+    m_streamWrapperForGC.set(globalObject->vm(), globalObject, toJS(globalObject, globalObject, stream.get()));
+}
 
 JSC::ArrayBufferView* ReadableStreamBYOBRequest::view() const
 {
@@ -72,21 +84,21 @@ ExceptionOr<void> ReadableStreamBYOBRequest::respondWithNewView(JSDOMGlobalObjec
     return controller->respondWithNewView(globalObject, view);
 }
 
-void ReadableStreamBYOBRequest::setController(ReadableByteStreamController* controller)
+void ReadableStreamBYOBRequest::clearController()
 {
-    m_controller = controller;
+    m_controller = nullptr;
+    m_streamWrapperForGC.clear();
 }
 
-void ReadableStreamBYOBRequest::setView(JSC::ArrayBufferView* view)
+void ReadableStreamBYOBRequest::clearView()
 {
-    m_view = view;
+    m_view = nullptr;
 }
 
 template<typename Visitor>
 void ReadableStreamBYOBRequest::visitAdditionalChildren(Visitor& visitor)
 {
-    if (m_controller)
-        SUPPRESS_UNCOUNTED_ARG m_controller->stream().visitAdditionalChildren(visitor);
+    m_streamWrapperForGC.visit(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(ReadableStreamBYOBRequest);

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ExceptionOr.h"
+#include "JSValueInWrappedObject.h"
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
@@ -40,22 +41,23 @@ class ReadableByteStreamController;
 
 class ReadableStreamBYOBRequest : public RefCounted<ReadableStreamBYOBRequest> {
 public:
-    static Ref<ReadableStreamBYOBRequest> create();
+    static Ref<ReadableStreamBYOBRequest> create(ReadableByteStreamController&, Ref<JSC::ArrayBufferView>&&);
 
     JSC::ArrayBufferView* view() const;
     ExceptionOr<void> respond(JSDOMGlobalObject&, size_t);
     ExceptionOr<void> respondWithNewView(JSDOMGlobalObject&, JSC::ArrayBufferView&);
 
-    void setController(ReadableByteStreamController*);
-    void setView(JSC::ArrayBufferView*);
+    void clearController();
+    void clearView();
 
     template<typename Visitor> void visitAdditionalChildren(Visitor&);
 
 private:
-    ReadableStreamBYOBRequest();
+    ReadableStreamBYOBRequest(ReadableByteStreamController&, Ref<JSC::ArrayBufferView>&&);
 
     WeakPtr<ReadableByteStreamController> m_controller;
     RefPtr<JSC::ArrayBufferView> m_view;
+    JSValueInWrappedObject m_streamWrapperForGC;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -646,9 +646,10 @@ void BaseDateAndTimeInputType::didEndChooser()
 
 bool BaseDateAndTimeInputType::setupDateTimeChooserParameters(DateTimeChooserParameters& parameters)
 {
-    ASSERT(element());
+    RefPtr element = this->element();
+    if (!element)
+        return false;
 
-    Ref element = *this->element();
     Ref document = element->document();
 
     if (!document->view())

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -55,6 +55,9 @@ public:
     bool typeMismatch() const final;
     bool hasBadInput() const final;
 
+    void ref() const final { InputType::ref(); }
+    void deref() const final { InputType::deref(); }
+
 protected:
     enum class DateTimeFormatValidationResults : uint8_t {
         HasYear = 1 << 0,

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -236,9 +236,10 @@ size_t DateTimeEditElement::fieldIndexOf(const DateTimeFieldElement& fieldToFind
 void DateTimeEditElement::defaultEventHandler(Event& event)
 {
     if (RefPtr keyboardEvent = dynamicDowncast<KeyboardEvent>(event)) {
-        if (keyboardEvent->keyIdentifier() == "U+0020"_s && m_editControlOwner) {
+        RefPtr editControlOwner = m_editControlOwner.get();
+        if (editControlOwner && keyboardEvent->keyIdentifier() == "U+0020"_s) {
             // Forward space keypresses to the owner to activate the date picker.
-            m_editControlOwner->didReceiveSpaceKeyFromControl();
+            editControlOwner->didReceiveSpaceKeyFromControl();
             // We want to mark the event as handled to avoid scrolling the page.
             event.setDefaultHandled();
             return;
@@ -314,7 +315,8 @@ void DateTimeEditElement::layout(const LayoutParameters& layoutParameters)
 
 void DateTimeEditElement::didBlurFromField(Event& event)
 {
-    if (!m_editControlOwner)
+    RefPtr editControlOwner = m_editControlOwner.get();
+    if (!editControlOwner)
         return;
 
     if (RefPtr newFocusedElement = event.relatedTarget()) {
@@ -326,13 +328,13 @@ void DateTimeEditElement::didBlurFromField(Event& event)
             return;
     }
 
-    m_editControlOwner->didBlurFromControl();
+    editControlOwner->didBlurFromControl();
 }
 
 void DateTimeEditElement::fieldValueChanged()
 {
-    if (m_editControlOwner)
-        m_editControlOwner->didChangeValueFromControl();
+    if (RefPtr editControlOwner = m_editControlOwner.get())
+        editControlOwner->didChangeValueFromControl();
 }
 
 bool DateTimeEditElement::focusOnNextFocusableField(size_t startIndex)
@@ -382,12 +384,16 @@ bool DateTimeEditElement::focusOnPreviousField(const DateTimeFieldElement& field
 
 bool DateTimeEditElement::isFieldOwnerDisabled() const
 {
-    return m_editControlOwner && m_editControlOwner->isEditControlOwnerDisabled();
+    if (RefPtr editControlOwner = m_editControlOwner.get())
+        return editControlOwner->isEditControlOwnerDisabled();
+    return false;
 }
 
 bool DateTimeEditElement::isFieldOwnerReadOnly() const
 {
-    return m_editControlOwner && m_editControlOwner->isEditControlOwnerReadOnly();
+    if (RefPtr editControlOwner = m_editControlOwner.get())
+        return editControlOwner->isEditControlOwnerReadOnly();
+    return false;
 }
 
 bool DateTimeEditElement::isFieldOwnerHorizontal() const
@@ -399,18 +405,22 @@ bool DateTimeEditElement::isFieldOwnerHorizontal() const
 
 bool DateTimeEditElement::didFieldOwnerTransferFocusToPicker()
 {
-    return m_editControlOwner && m_editControlOwner->didEditControlOwnerTransferFocusToPicker();
+    if (RefPtr editControlOwner = m_editControlOwner.get())
+        return editControlOwner->didEditControlOwnerTransferFocusToPicker();
+    return false;
 }
 
 void DateTimeEditElement::didSuppressBlurDueToPickerFocusTransfer()
 {
-    if (m_editControlOwner)
-        m_editControlOwner->didSuppressBlurDueToPickerFocusTransfer();
+    if (RefPtr editControlOwner = m_editControlOwner.get())
+        editControlOwner->didSuppressBlurDueToPickerFocusTransfer();
 }
 
 AtomString DateTimeEditElement::localeIdentifier() const
 {
-    return m_editControlOwner ? m_editControlOwner->localeIdentifier() : nullAtom();
+    if (RefPtr editControlOwner = m_editControlOwner.get())
+        return editControlOwner->localeIdentifier();
+    return nullAtom();
 }
 
 const GregorianDateTime& DateTimeEditElement::placeholderDate() const
@@ -439,12 +449,16 @@ void DateTimeEditElement::setEmptyValue(const LayoutParameters& layoutParameters
 
 String DateTimeEditElement::value() const
 {
-    return m_editControlOwner ? m_editControlOwner->formatDateTimeFieldsState(valueAsDateTimeFieldsState()) : emptyString();
+    if (RefPtr editControlOwner = m_editControlOwner.get())
+        return editControlOwner->formatDateTimeFieldsState(valueAsDateTimeFieldsState());
+    return emptyString();
 }
 
 String DateTimeEditElement::placeholderValue() const
 {
-    return m_editControlOwner ? m_editControlOwner->formatDateTimeFieldsState(valueAsDateTimeFieldsState(DateTimePlaceholderIfNoValue::Yes)) : emptyString();
+    if (RefPtr editControlOwner = m_editControlOwner.get())
+        return editControlOwner->formatDateTimeFieldsState(valueAsDateTimeFieldsState(DateTimePlaceholderIfNoValue::Yes));
+    return emptyString();
 }
 
 DateTimeFieldsState DateTimeEditElement::valueAsDateTimeFieldsState(DateTimePlaceholderIfNoValue placeholderIfNoValue) const

--- a/Source/WebCore/html/shadow/DateTimeEditElement.h
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.h
@@ -28,23 +28,13 @@
 
 #include "DateComponents.h"
 #include "DateTimeFieldElement.h"
-
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class DateTimeEditElementEditControlOwner;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::DateTimeEditElementEditControlOwner> : std::true_type { };
-}
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
 class Locale;
 
-class DateTimeEditElementEditControlOwner : public CanMakeWeakPtr<DateTimeEditElementEditControlOwner> {
+class DateTimeEditElementEditControlOwner : public AbstractRefCountedAndCanMakeWeakPtr<DateTimeEditElementEditControlOwner> {
 public:
     virtual ~DateTimeEditElementEditControlOwner();
     virtual void didBlurFromControl() = 0;


### PR DESCRIPTION
#### d859d3f7bc1206fcded3b464780e459342cd47d3
<pre>
Cherry-pick 305413.565@safari-7624-branch (f49e83162fdd). <a href="https://bugs.webkit.org/show_bug.cgi?id=310544">https://bugs.webkit.org/show_bug.cgi?id=310544</a>

    Use-After-Free in `BaseDateAndTimeInputType::didChangeValueFromControl`
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310544">https://bugs.webkit.org/show_bug.cgi?id=310544</a>
    <a href="https://rdar.apple.com/173012873">rdar://173012873</a>

    Reviewed by Abrar Rahman Protyasha and Lily Spiniolas.

    `BaseDateAndTimeInputType::didChangeValueFromControl()` dispatches `input`
    events without protecting itself. An event handler can change the input&apos;s type
    (e.g., from `date` to `text`), which replaces `HTMLInputElement::m_inputType`
    and destroys the `BaseDateAndTimeInputType` instance. After the event handler
    returns, the function continues executing `setupDateTimeChooserParameters()`
    and `showDateTimeChooser()` on the freed object, resulting in a use-after-free.

    Fix by holding a `RefPtr` to the input type on the stack prior to calling
    `didChangeValueFromControl()`.

    Test: fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event.html

    * LayoutTests/fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event-expected.txt: Added.
    * LayoutTests/fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event.html: Added.
    * Source/WebCore/html/BaseDateAndTimeInputType.cpp:
    (WebCore::BaseDateAndTimeInputType::setupDateTimeChooserParameters):

    Fix `setupDateTimeChooserParameters` to null-check element() instead of
    of asserting, since the element may be gone after the type change.

    * Source/WebCore/html/BaseDateAndTimeInputType.h:
    * Source/WebCore/html/shadow/DateTimeEditElement.cpp:
    (WebCore::DateTimeEditElement::defaultEventHandler):
    (WebCore::DateTimeEditElement::didBlurFromField):
    (WebCore::DateTimeEditElement::fieldValueChanged):
    (WebCore::DateTimeEditElement::isFieldOwnerDisabled const):
    (WebCore::DateTimeEditElement::isFieldOwnerReadOnly const):
    (WebCore::DateTimeEditElement::didFieldOwnerTransferFocusToPicker):
    (WebCore::DateTimeEditElement::didSuppressBlurDueToPickerFocusTransfer):
    (WebCore::DateTimeEditElement::localeIdentifier const):
    (WebCore::DateTimeEditElement::value const):
    (WebCore::DateTimeEditElement::placeholderValue const):
    * Source/WebCore/html/shadow/DateTimeEditElement.h:

    Change the base class of `DateTimeEditElementEditControlOwner` from
    `CanMakeWeakPtr&lt;DateTimeEditElementEditControlOwner&gt;` to
    `AbstractRefCountedAndCanMakeWeakPtr&lt;DateTimeEditElementEditControlOwner&gt;`,
    so that the object may be ref-counted.

    Remove the `IsDeprecatedWeakRefSmartPointerException` exception, since
    `DateTimeEditElementEditControlOwner` needs to be ref-counted to avoid
    use-after-free.

    Identifier: 305413.565@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.684@webkitglib/2.52">https://commits.webkit.org/305877.684@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e2cc88b2940e0ac40426e1ee026785b7b55096b9
<pre>
Cherry-pick 313836@main (f9a8c97fce94). <a href="https://bugs.webkit.org/show_bug.cgi?id=315469">https://bugs.webkit.org/show_bug.cgi?id=315469</a>

    [GStreamer][WebRTC][Rice] imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer.window.html flaky crashes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315469">https://bugs.webkit.org/show_bug.cgi?id=315469</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Protect access to the streams hashmap using a mutex, otherwise we might crash when being notified of
    incoming data while a close procedure is on-going.

    * Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
    (webkitGstWebRTCIceAgentAddStream):
    (webkitGstWebRTCIceAgentSetTos):
    (webkitGstWebRTCIceAgentClosed):
    (findStreamAndApply):
    (webkitGstWebRTCIceAgentConfigure):
    (webkitGstWebRTCIceAgentGatheringDoneForStream):
    (webkitGstWebRTCIceAgentLocalCandidateGatheredForStream):
    (webkitGstWebRTCIceAgentNewSelectedPairForStream):
    (webkitGstWebRTCIceAgentComponentStateChangedForStream):

    Canonical link: <a href="https://commits.webkit.org/313836@main">https://commits.webkit.org/313836@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.683@webkitglib/2.52">https://commits.webkit.org/305877.683@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 2c8d7528b97f9c206242cb52088b3721b7e8d167
<pre>
Cherry-pick 312189@main (6ff991b88b5f). <a href="https://bugs.webkit.org/show_bug.cgi?id=312269">https://bugs.webkit.org/show_bug.cgi?id=312269</a>

    [GStreamer][Rice] Flaky crash in `rice_proto::conncheck::ConnCheckList::add_local_candidate_internal()`
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312269">https://bugs.webkit.org/show_bug.cgi?id=312269</a>

    Reviewed by Xabier Rodriguez-Calvar.

    There was a race condition where the agent would start closing, wake-up it main loop and that would
    trigger a local candidate notification after rice_agent_close() was called. We now distinguish the
    &quot;closing&quot; case from the &quot;closed&quot; case using an enum that can be checked before processing local
    candidate notifications.

    * LayoutTests/platform/gtk/TestExpectations:
    * Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
    (_WebKitGstIceAgentPrivate::WTF_GUARDED_BY_LOCK):
    (webkitGstWebRTCIceAgentAddStream):
    (webkitGstWebRTCIceAgentClosed):
    (webkitGstWebRTCIceAgentClose):
    (webkitGstWebRTCIceAgentConstructed):
    (webkitGstWebRTCIceAgentLocalCandidateGatheredForStream):
    * Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp:
    (webkitGstWebRTCIceStreamAddLocalGatheredCandidate):
    * Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
    (WebCore::GStreamerRtpSenderBackend::getParameters const):

    Canonical link: <a href="https://commits.webkit.org/312189@main">https://commits.webkit.org/312189@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.682@webkitglib/2.52">https://commits.webkit.org/305877.682@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### ba2cb3ccac962cb8440ec2a1b268769eb30b0734
<pre>
Cherry-pick 305413.480@safari-7624-branch (5d62bc6b2841). <a href="https://bugs.webkit.org/show_bug.cgi?id=312938">https://bugs.webkit.org/show_bug.cgi?id=312938</a>

    Potential use after free of m_controller under ReadableStreamBYOBRequest::visitAdditionalChildren()
    <a href="https://rdar.apple.com/172462937">rdar://172462937</a>

    Reviewed by Chris Dumez.

    m_controller can be nullified while being used in GC thread.
    We remove usage of m_controller in the GC thread.
    Instead, request will store its stream as a JSValueInWrappedObject, and we will use this JSValueInWrappedObject in the GC thread.
    We make sure to clear the JSValueInWrappedObject when the request gets invalidated.

    Identifier: 305413.480@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.681@webkitglib/2.52">https://commits.webkit.org/305877.681@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dffe2f288d848e779664229cf757efaa3574c1ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164540 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38024 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/31595 "The change is no longer eligible for processing.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/173570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121792 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166409 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38358 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38026 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/173570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121792 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167499 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38358 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/31595 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/173570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38358 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38026 "The change is no longer eligible for processing.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/21333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38358 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/31595 "The change is no longer eligible for processing.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176096 "Failed to checkout and rebase branch from PR 65668") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28919 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31595 "The change is no longer eligible for processing.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/176096 "Failed to checkout and rebase branch from PR 65668") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38093 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/38026 "The change is no longer eligible for processing.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/176096 "Failed to checkout and rebase branch from PR 65668") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38783 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/31595 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100935 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25046 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38783 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31595 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37291 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110335 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/36689 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/31595 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/36937 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/36837 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->