### PR TITLE
Delegated Apple Pay: Remove bincompat staging code from WebKit

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -406,11 +406,4 @@ NS_ASSUME_NONNULL_END
 #import "PassKitInstallmentsSPI.h"
 #undef PAL_PASSKIT_SPI_GUARD_AGAINST_INDIRECT_INCLUSION
 
-#if HAVE(PASSKIT_DELEGATED_REQUEST)
-// FIXME: <rdar://165836164> (Remove bincompat staging code from WebKit)
-@interface PKPaymentRequest (DelegatedRequest)
-@property (nonatomic, assign) BOOL isDelegatedRequest;
-@end
-#endif // HAVE(PASSKIT_DELEGATED_REQUEST)
-
 #endif // !__has_feature(modules)

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -276,15 +276,6 @@ selectors = [
 ]
 requires = ["ENABLE_WRITING_TOOLS_EXTENDED_PROOFREADING"]
 
-[[staging]]
-request = "rdar://163791929"
-cleanup = "rdar://165836164"
-selectors = [
- { name = "setIsDelegatedRequest:", class = "PKPaymentRequest" },
-]
-requires = ["HAVE_PASSKIT_DELEGATED_REQUEST"]
-requires-sdk = ["iOS < 26.4"]
-
 [[not-web-essential]]
 request = "rdar://165006869"
 selectors = [

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -398,12 +398,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [result setMerchantCategoryCode:toPKMerchantCategoryCode(merchantCategoryCode)];
 #endif
 
-#if ENABLE(APPLE_PAY_DELEGATED_REQUEST)
-    if (auto isDelegatedRequest = paymentRequest.isDelegatedRequest()) {
-        // FIXME: <rdar://165836164> (Remove bincompat staging code from WebKit)
-        if ([result respondsToSelector:@selector(setIsDelegatedRequest:)])
-            [result setIsDelegatedRequest:*isDelegatedRequest];
-    }
+#if HAVE(PASSKIT_DELEGATED_REQUEST)
+    if (auto isDelegatedRequest = paymentRequest.isDelegatedRequest())
+        [result setIsDelegatedRequest:*isDelegatedRequest];
 #endif
 
     return result;


### PR DESCRIPTION
#### 66c073b22627b409d20b0ac96237df6ac89eb6c1
<pre>
Delegated Apple Pay: Remove bincompat staging code from WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=315562">https://bugs.webkit.org/show_bug.cgi?id=315562</a>
<a href="https://rdar.apple.com/165836164">rdar://165836164</a>

Reviewed by Abrar Rahman Protyasha.

When rolling out support for Delegated Apple Pay, temporary staging SPI and a
respondsToSelector check was added to ensure the build process didn&apos;t break. Now that
the delegated payments API is public in the iOS 26.4 SDK, this SPI and selector check can
now be removed.

No new tests are required, existing tests surrounding Delegated Apple Pay will suffice.

* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):

Canonical link: <a href="https://commits.webkit.org/315118@main">https://commits.webkit.org/315118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f39642fda8ad5575d23ed20e06659145f0c6375

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174330 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122544 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a376f06-1144-4698-8cc9-1b4ea707cdf3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128441 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90401 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ecbc4af1-1b94-49fd-9ea0-da74d13f44cc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108966 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5440a5a7-90c5-4c10-b24c-157e19d0d81c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29802 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28422 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22405 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176852 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29744 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136761 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38846 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136700 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37470 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147994 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101875 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31980 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24861 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38046 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111119 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37443 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2939 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37689 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37587 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->