### PR TITLE
[Skia] Parameterize SkiaCompositingLayer paint walk by mode

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -426,7 +426,14 @@ bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& damage
 {
     bool hasRunningAnimations = computeTransformsAndAnimations({ }, { }, MonotonicTime::now());
     PaintContext context(damage);
+
+    context.mode = PaintMode::Paint;
     recursivePaint(canvas, context);
+
+    if (hasDebugIndicators()) {
+        context.mode = PaintMode::DebugIndicators;
+        recursivePaint(canvas, context);
+    }
 
 #if ENABLE(DAMAGE_TRACKING)
     if (damage && frameDamagePropagationEnabled()) {
@@ -441,8 +448,10 @@ bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& damage
 void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
 {
 #if ENABLE(DAMAGE_TRACKING)
+    const bool collectsDamage = context.mode == PaintMode::Paint;
     auto cleanup = WTF::makeScopeExit([&] {
-        m_layerDamage = std::nullopt;
+        if (collectsDamage)
+            m_layerDamage = std::nullopt;
     });
 #endif
 
@@ -455,6 +464,19 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
     canvas.save();
     canvas.concat(SkM44(transform));
 
+    if (context.mode == PaintMode::Paint) {
+        paintContents(canvas, context);
+#if ENABLE(DAMAGE_TRACKING)
+        collectFrameDamage(canvas, context, transform);
+#endif
+    } else
+        paintDebugIndicators(canvas, context);
+
+    canvas.restore();
+}
+
+void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context)
+{
     SkPaint paint;
     paint.setStyle(SkPaint::kFill_Style);
     auto ctm = canvas.getLocalToDeviceAs3x3();
@@ -510,28 +532,35 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
                 SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
         }
     }
+}
 
 #if ENABLE(DAMAGE_TRACKING)
-    if (frameDamagePropagationEnabled() && context.frameDamage) {
-        auto frameDamage = transform.mapRect(effectiveLayerRect());
-        auto clipBounds = FloatRect(this->clipBounds(canvas, context));
-        if (!clipBounds.isEmpty())
-            frameDamage.intersect(clipBounds);
+void SkiaCompositingLayer::collectFrameDamage(SkCanvas& canvas, PaintContext& context, const TransformationMatrix& transform)
+{
+    if (!frameDamagePropagationEnabled() || !context.frameDamage)
+        return;
 
-        m_previousLayerRectInFrameCoordinates.unite(frameDamage);
+    auto frameDamage = transform.mapRect(effectiveLayerRect());
+    auto clipBounds = FloatRect(this->clipBounds(canvas, context));
+    if (!clipBounds.isEmpty())
+        frameDamage.intersect(clipBounds);
 
-        if (m_layerDamage) {
-            for (const auto& rect : *m_layerDamage) {
-                auto damageRect = transform.mapRect(FloatRect(rect));
-                if (!clipBounds.isEmpty())
-                    damageRect.intersect(clipBounds);
-                context.frameDamage->add(damageRect);
-            }
-        } else if ((m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()) || m_contentsBuffer || m_imageBackingStore)
-            context.frameDamage->add(frameDamage);
-    }
+    m_previousLayerRectInFrameCoordinates.unite(frameDamage);
+
+    if (m_layerDamage) {
+        for (const auto& rect : *m_layerDamage) {
+            auto damageRect = transform.mapRect(FloatRect(rect));
+            if (!clipBounds.isEmpty())
+                damageRect.intersect(clipBounds);
+            context.frameDamage->add(damageRect);
+        }
+    } else if ((m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()) || m_contentsBuffer || m_imageBackingStore)
+        context.frameDamage->add(frameDamage);
+}
 #endif
 
+void SkiaCompositingLayer::paintDebugIndicators(SkCanvas& canvas, PaintContext&)
+{
     if (m_debugBorder) {
         SkPaint borderPaint;
         borderPaint.setStyle(SkPaint::kStroke_Style);
@@ -545,53 +574,50 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
             canvas.drawRect(SkRect(m_contentsRect), borderPaint);
     }
 
+    if (!m_repaintCount)
+        return;
+
     // Capture the full canvas-to-device position while the layer transform is still active.
     SkPoint deviceOrigin { 0, 0 };
-    if (m_repaintCount) {
-        auto mapped = canvas.getLocalToDevice().map(0, 0, 0, 1);
-        if (std::abs(mapped.w) > std::numeric_limits<float>::epsilon())
-            deviceOrigin = { mapped.x / mapped.w, mapped.y / mapped.w };
-        else
-            deviceOrigin = { mapped.x, mapped.y };
+    auto mapped = canvas.getLocalToDevice().map(0, 0, 0, 1);
+    if (std::abs(mapped.w) > std::numeric_limits<float>::epsilon())
+        deviceOrigin = { mapped.x / mapped.w, mapped.y / mapped.w };
+    else
+        deviceOrigin = { mapped.x, mapped.y };
+
+    constexpr float pointSize = 14;
+    constexpr float padding = 3;
+
+    static SkFont font = [] {
+        auto typeface = FontCache::forCurrentThread().fontManager().matchFamilyStyle("monospace", SkFontStyle::Bold());
+        SkFont f(typeface, pointSize);
+        f.setEdging(SkFont::Edging::kAntiAlias);
+        f.setSubpixel(true);
+        return f;
+    }();
+
+    if (m_repaintCountOverlay.count != m_repaintCount) {
+        m_repaintCountOverlay.count = m_repaintCount;
+        m_repaintCountOverlay.string = String::number(*m_repaintCount).ascii();
+        SkRect textBounds;
+        font.measureText(m_repaintCountOverlay.string.data(), m_repaintCountOverlay.string.length(), SkTextEncoding::kUTF8, &textBounds);
+        m_repaintCountOverlay.backgroundWidth = textBounds.width() + padding * 2;
+        m_repaintCountOverlay.backgroundHeight = textBounds.height() + padding * 2;
+        m_repaintCountOverlay.baselineOffset = -textBounds.fTop + padding;
     }
 
-    canvas.restore();
+    SkAutoCanvasRestore autoRestore(&canvas, true);
+    canvas.resetMatrix();
 
-    if (m_repaintCount) {
-        constexpr float pointSize = 14;
-        constexpr float padding = 3;
+    SkPaint backgroundPaint;
+    backgroundPaint.setColor(m_debugBorder ? SkColor(m_debugBorder->color) : SK_ColorBLACK);
+    backgroundPaint.setStyle(SkPaint::kFill_Style);
+    canvas.drawRect(SkRect::MakeXYWH(deviceOrigin.x(), deviceOrigin.y(), m_repaintCountOverlay.backgroundWidth, m_repaintCountOverlay.backgroundHeight), backgroundPaint);
 
-        static SkFont font = [] {
-            auto typeface = FontCache::forCurrentThread().fontManager().matchFamilyStyle("monospace", SkFontStyle::Bold());
-            SkFont f(typeface, pointSize);
-            f.setEdging(SkFont::Edging::kAntiAlias);
-            f.setSubpixel(true);
-            return f;
-        }();
-
-        if (m_repaintCountOverlay.count != m_repaintCount) {
-            m_repaintCountOverlay.count = m_repaintCount;
-            m_repaintCountOverlay.string = String::number(*m_repaintCount).ascii();
-            SkRect textBounds;
-            font.measureText(m_repaintCountOverlay.string.data(), m_repaintCountOverlay.string.length(), SkTextEncoding::kUTF8, &textBounds);
-            m_repaintCountOverlay.backgroundWidth = textBounds.width() + padding * 2;
-            m_repaintCountOverlay.backgroundHeight = textBounds.height() + padding * 2;
-            m_repaintCountOverlay.baselineOffset = -textBounds.fTop + padding;
-        }
-
-        SkAutoCanvasRestore autoRestore(&canvas, true);
-        canvas.resetMatrix();
-
-        SkPaint backgroundPaint;
-        backgroundPaint.setColor(m_debugBorder ? SkColor(m_debugBorder->color) : SK_ColorBLACK);
-        backgroundPaint.setStyle(SkPaint::kFill_Style);
-        canvas.drawRect(SkRect::MakeXYWH(deviceOrigin.x(), deviceOrigin.y(), m_repaintCountOverlay.backgroundWidth, m_repaintCountOverlay.backgroundHeight), backgroundPaint);
-
-        SkPaint textPaint;
-        textPaint.setColor(SK_ColorWHITE);
-        textPaint.setAntiAlias(true);
-        canvas.drawString(m_repaintCountOverlay.string.data(), deviceOrigin.x() + padding, deviceOrigin.y() + m_repaintCountOverlay.baselineOffset, font, textPaint);
-    }
+    SkPaint textPaint;
+    textPaint.setColor(SK_ColorWHITE);
+    textPaint.setAntiAlias(true);
+    canvas.drawString(m_repaintCountOverlay.string.data(), deviceOrigin.x() + padding, deviceOrigin.y() + m_repaintCountOverlay.baselineOffset, font, textPaint);
 }
 
 void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& context)
@@ -700,6 +726,11 @@ void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintC
     if (surfaceRect.isEmpty())
         return;
 
+    if (context.mode != PaintMode::Paint) {
+        paintFunction(canvas, context);
+        return;
+    }
+
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
     auto imageInfo = SkImageInfo::Make(surfaceRect.width(), surfaceRect.height(), kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, nullptr);
@@ -752,11 +783,22 @@ void SkiaCompositingLayer::paintBackdrop(SkCanvas& canvas, PaintContext& context
 
 void SkiaCompositingLayer::paintWithMaskAndBackdrop(SkCanvas& canvas, PaintContext& context)
 {
-    const bool shouldClipPath = m_mask && m_mask->m_clipPath.has_value();
-    if (shouldClipPath && m_mask->m_clipPath->isEmpty())
+    // An empty clip path fully clips the layer out, so it isn't painted at all.
+    // Skip it in every mode: there's nothing to paint, to collect damage for, or
+    // to annotate with debug indicators.
+    if (m_mask && m_mask->m_clipPath && m_mask->m_clipPath->isEmpty())
         return;
 
-    sk_sp<SkImage> maskImage = m_mask && !shouldClipPath ? m_mask->maskImage() : nullptr;
+    // Otherwise the mask only affects the painted result, so apply it (clip path
+    // or mask image) only in PaintMode::Paint. Damage collection and debug
+    // indicators walk the tree unmasked.
+    bool shouldClipPath = false;
+    sk_sp<SkImage> maskImage;
+    if (context.mode == PaintMode::Paint && m_mask) {
+        shouldClipPath = m_mask->m_clipPath.has_value();
+        if (!shouldClipPath)
+            maskImage = m_mask->maskImage();
+    }
     SkAutoCanvasRestore autoRestore(&canvas, shouldClipPath || maskImage);
     if (shouldClipPath || maskImage) {
         TransformationMatrix transform(context.accumulatedReplicaTransform);
@@ -802,14 +844,33 @@ void SkiaCompositingLayer::paintWithFilterAndMask(SkCanvas& canvas, PaintContext
 
 #if ENABLE(DAMAGE_TRACKING)
     auto clipBounds = FloatRect(this->clipBounds(canvas, context));
+    const bool collectsDamage = context.mode == PaintMode::Paint;
+    const bool needToProcessFrameDamage = collectsDamage && frameDamagePropagationEnabled() && context.frameDamage;
 #endif
+
+    if (context.mode != PaintMode::Paint) {
+#if ENABLE(DAMAGE_TRACKING)
+        if (needToProcessFrameDamage) {
+            for (const auto& rect : overlapRects) {
+                FloatRect damageRect(rect);
+                if (!clipBounds.isEmpty())
+                    damageRect.intersect(clipBounds);
+                m_accumulatedOverlapRegionFrameDamage.unite(damageRect);
+            }
+            if (!m_accumulatedOverlapRegionFrameDamage.isEmpty())
+                context.frameDamage->add(m_accumulatedOverlapRegionFrameDamage);
+        }
+#endif
+        paintSelfAndChildren(canvas, context);
+        return;
+    }
 
     SkPaint paint;
     paint.setImageFilter(filter->filter);
 
     for (const auto& rect : overlapRects) {
 #if ENABLE(DAMAGE_TRACKING)
-        if (frameDamagePropagationEnabled() && context.frameDamage) {
+        if (needToProcessFrameDamage) {
             FloatRect damageRect(rect);
             if (!clipBounds.isEmpty())
                 damageRect.intersect(clipBounds);
@@ -833,7 +894,7 @@ void SkiaCompositingLayer::paintWithFilterAndMask(SkCanvas& canvas, PaintContext
     }
 
 #if ENABLE(DAMAGE_TRACKING)
-    if (frameDamagePropagationEnabled() && context.frameDamage && !m_accumulatedOverlapRegionFrameDamage.isEmpty())
+    if (needToProcessFrameDamage && !m_accumulatedOverlapRegionFrameDamage.isEmpty())
         context.frameDamage->add(m_accumulatedOverlapRegionFrameDamage);
 #endif
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -109,6 +109,8 @@ public:
 
     bool paint(SkCanvas&, std::optional<Damage>&);
 
+    bool hasDebugIndicators() const { return m_debugBorder.has_value() || m_repaintCount.has_value(); }
+
 private:
     SkiaCompositingLayer() = default;
 
@@ -121,12 +123,18 @@ private:
 
     bool computeTransformsAndAnimations(const TransformationMatrix& parentTransform, const TransformationMatrix& futureParentTransform, MonotonicTime);
 
+    enum class PaintMode : uint8_t {
+        Paint,
+        DebugIndicators,
+    };
+
     struct PaintContext {
         explicit PaintContext(std::optional<Damage>& damage)
             : frameDamage(damage)
         {
         }
 
+        PaintMode mode { PaintMode::Paint };
         float opacity { 1 };
         std::optional<SkBlendMode> blendMode;
         IntSize offset;
@@ -150,6 +158,11 @@ private:
     void paintWithBlendMode(SkCanvas&, PaintContext&);
     void paintWithFilterAndMask(SkCanvas&, PaintContext&);
     void paintSelf(SkCanvas&, PaintContext&);
+    void paintContents(SkCanvas&, PaintContext&);
+    void paintDebugIndicators(SkCanvas&, PaintContext&);
+#if ENABLE(DAMAGE_TRACKING)
+    void collectFrameDamage(SkCanvas&, PaintContext&, const TransformationMatrix&);
+#endif
     void paintSelfAndChildren(SkCanvas&, PaintContext&);
     void paintWithIntermediateSurface(SkCanvas&, PaintContext&, const IntRect&, SkPaint*, PaintFunction&&);
     void paintWith3DRenderingContext(SkCanvas&, PaintContext&);


### PR DESCRIPTION
#### 6811e00c4dcf82c76b4630e16a27355b40daf2f2
<pre>
[Skia] Parameterize SkiaCompositingLayer paint walk by mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=315561">https://bugs.webkit.org/show_bug.cgi?id=315561</a>

Reviewed by Carlos Garcia Campos.

Make recursivePaint addressable by mode so any given walk runs in exactly
one mode at a time. Add a private PaintMode on PaintContext with two
values: Paint (content + damage) and DebugIndicators (overlay only).

The public paint() signature is unchanged. Internally it now drives two
walks: a Paint walk for the prior all-in-one behavior minus debug
indicators, and - if the root layer carries indicators - a follow-up
DebugIndicators walk that recurses against the root canvas in tree
order. In DebugIndicators mode paintWithIntermediateSurface() and
paintSelfAndChildrenWithFilterAndMask() short-circuit: no GPU surfaces,
no mask rasterization, no filter application. This places indicators
above filters, masks, and intermediate surfaces of the content walk.

m_layerDamage is only consumed by the Paint walk - the DebugIndicators
walk has nothing to do with damage state and leaves it alone.

This sets up a follow-up that derives the next frame&apos;s damaged region
by walking the same paint recursion against an SkNoDrawCanvas. No
observable behavior change in this commit.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paint):
(WebCore::SkiaCompositingLayer::paintSelf):
(WebCore::SkiaCompositingLayer::paintContents):
(WebCore::SkiaCompositingLayer::collectFrameDamage):
(WebCore::SkiaCompositingLayer::paintDebugIndicators):
(WebCore::SkiaCompositingLayer::paintWithIntermediateSurface):
(WebCore::SkiaCompositingLayer::paintWithMaskAndBackdrop):
(WebCore::SkiaCompositingLayer::paintWithFilterAndMask):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:

Canonical link: <a href="https://commits.webkit.org/314181@main">https://commits.webkit.org/314181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adf67d9655ad9b2217f13f409cc85b44d6587b78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165278 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174321 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122535 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167146 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running bindings-tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128432 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148493 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108957 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29795 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28412 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22396 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176843 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29733 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136752 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147987 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101862 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25154 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31975 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24854 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38037 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111110 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37434 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2932 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->