### PR TITLE
Cherry-pick(s) 293e2d766d11. rdar://176062499

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
@@ -62,11 +62,20 @@ public:
 
     WEBCORE_EXPORT ~UniqueIDBDatabaseTransaction();
 
+<<<<<<< HEAD
     WEBCORE_EXPORT UniqueIDBDatabaseConnection* NODELETE databaseConnection() const;
     UniqueIDBDatabase* NODELETE database() const;
     const IDBTransactionInfo& info() const LIFETIME_BOUND { return m_transactionInfo; }
     WEBCORE_EXPORT bool NODELETE isVersionChange() const;
     bool NODELETE isReadOnly() const;
+=======
+    WEBCORE_EXPORT UniqueIDBDatabaseConnection* databaseConnection() const;
+    UniqueIDBDatabase* database() const;
+    CheckedPtr<UniqueIDBDatabase> checkedDatabase() const;
+    const IDBTransactionInfo& info() const { return m_transactionInfo; }
+    WEBCORE_EXPORT bool isVersionChange() const;
+    bool isReadOnly() const;
+>>>>>>> 293e2d766d11 (IndexedDB Connection/Transaction Identifier Confusion)
 
     IDBDatabaseInfo* NODELETE originalDatabaseInfo() const;
 

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
@@ -107,7 +107,11 @@ bool IDBStorageRegistry::isValidConnectionForIPC(WebCore::IDBServer::UniqueIDBDa
     return it->value->ipcConnection() == ipcConnection.uniqueID();
 }
 
+<<<<<<< HEAD
 SUPPRESS_NODELETE RefPtr<WebCore::IDBServer::UniqueIDBDatabaseConnection> IDBStorageRegistry::connection(WebCore::IDBDatabaseConnectionIdentifier identifier, IPC::Connection& ipcConnection)
+=======
+RefPtr<WebCore::IDBServer::UniqueIDBDatabaseConnection> IDBStorageRegistry::connection(WebCore::IDBDatabaseConnectionIdentifier identifier, IPC::Connection& ipcConnection)
+>>>>>>> 293e2d766d11 (IndexedDB Connection/Transaction Identifier Confusion)
 {
     RefPtr databaseConnection = m_connections.get(identifier);
     if (!databaseConnection)
@@ -118,7 +122,11 @@ SUPPRESS_NODELETE RefPtr<WebCore::IDBServer::UniqueIDBDatabaseConnection> IDBSto
     return databaseConnection;
 }
 
+<<<<<<< HEAD
 SUPPRESS_NODELETE RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> IDBStorageRegistry::transaction(WebCore::IDBResourceIdentifier identifier, IPC::Connection& ipcConnection)
+=======
+RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> IDBStorageRegistry::transaction(WebCore::IDBResourceIdentifier identifier, IPC::Connection& ipcConnection)
+>>>>>>> 293e2d766d11 (IndexedDB Connection/Transaction Identifier Confusion)
 {
     MESSAGE_CHECK_WITH_RETURN_VALUE(identifier.connectionIdentifier(), ipcConnection, nullptr);
     if (identifier.isEmpty())

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
@@ -53,10 +53,17 @@ public:
     void removeConnectionToClient(IPC::Connection::UniqueID);
     void registerConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection&);
     void unregisterConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection&);
+<<<<<<< HEAD
     RefPtr<WebCore::IDBServer::UniqueIDBDatabaseConnection> NODELETE connection(WebCore::IDBDatabaseConnectionIdentifier, IPC::Connection&);
     void registerTransaction(WebCore::IDBServer::UniqueIDBDatabaseTransaction&);
     void unregisterTransaction(WebCore::IDBServer::UniqueIDBDatabaseTransaction&);
     RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> NODELETE transaction(WebCore::IDBResourceIdentifier, IPC::Connection&);
+=======
+    RefPtr<WebCore::IDBServer::UniqueIDBDatabaseConnection> connection(WebCore::IDBDatabaseConnectionIdentifier, IPC::Connection&);
+    void registerTransaction(WebCore::IDBServer::UniqueIDBDatabaseTransaction&);
+    void unregisterTransaction(WebCore::IDBServer::UniqueIDBDatabaseTransaction&);
+    RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> transaction(WebCore::IDBResourceIdentifier, IPC::Connection&);
+>>>>>>> 293e2d766d11 (IndexedDB Connection/Transaction Identifier Confusion)
 
 private:
     bool isValidConnectionForIPC(WebCore::IDBServer::UniqueIDBDatabaseConnection&, IPC::Connection&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1978,6 +1978,7 @@ void NetworkStorageManager::clear(IPC::Connection& connection, StorageAreaIdenti
 
 void NetworkStorageManager::openDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
 {
+<<<<<<< HEAD
     auto origin = requestData.databaseIdentifier().origin();
     MESSAGE_CHECK(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection);
     MESSAGE_CHECK(requestData.requestIdentifier().connectionIdentifier(), connection);
@@ -1987,6 +1988,12 @@ void NetworkStorageManager::openDatabase(IPC::Connection& connection, const WebC
         return;
 
     protect(originStorageManager(origin)->idbStorageManager(*m_idbStorageRegistry, useSQLiteMemoryBackingStore()))->openDatabase(*connectionToClient, requestData);
+=======
+    RefPtr connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection, requestData.requestIdentifier());
+    if (!connectionToClient)
+        return;
+    checkedOriginStorageManager(requestData.databaseIdentifier().origin())->checkedIDBStorageManager(*m_idbStorageRegistry)->openDatabase(*connectionToClient, requestData);
+>>>>>>> 293e2d766d11 (IndexedDB Connection/Transaction Identifier Confusion)
 }
 
 void NetworkStorageManager::openDBRequestCancelled(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
@@ -1999,6 +2006,7 @@ void NetworkStorageManager::openDBRequestCancelled(IPC::Connection& connection, 
 
 void NetworkStorageManager::deleteDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
 {
+<<<<<<< HEAD
     auto origin = requestData.databaseIdentifier().origin();
     MESSAGE_CHECK(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection);
     MESSAGE_CHECK(requestData.requestIdentifier().connectionIdentifier(), connection);
@@ -2008,6 +2016,12 @@ void NetworkStorageManager::deleteDatabase(IPC::Connection& connection, const We
         return;
 
     protect(originStorageManager(origin)->idbStorageManager(*m_idbStorageRegistry, useSQLiteMemoryBackingStore()))->deleteDatabase(*connectionToClient, requestData);
+=======
+    RefPtr connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection, requestData.requestIdentifier());
+    if (!connectionToClient)
+        return;
+    checkedOriginStorageManager(requestData.databaseIdentifier().origin())->checkedIDBStorageManager(*m_idbStorageRegistry)->deleteDatabase(*connectionToClient, requestData);
+>>>>>>> 293e2d766d11 (IndexedDB Connection/Transaction Identifier Confusion)
 }
 
 void NetworkStorageManager::establishTransaction(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBTransactionInfo& transactionInfo)
@@ -2080,7 +2094,11 @@ void NetworkStorageManager::didFinishHandlingVersionChangeTransaction(IPC::Conne
         databaseConnection->didFinishHandlingVersionChange(transactionIdentifier);
 }
 
+<<<<<<< HEAD
 SUPPRESS_NODELETE RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> NetworkStorageManager::idbTransaction(const WebCore::IDBRequestData& requestData, IPC::Connection& connection)
+=======
+RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> NetworkStorageManager::idbTransaction(const WebCore::IDBRequestData& requestData, IPC::Connection& connection)
+>>>>>>> 293e2d766d11 (IndexedDB Connection/Transaction Identifier Confusion)
 {
     return m_idbStorageRegistry->transaction(requestData.transactionIdentifier(), connection);
 }
@@ -2225,6 +2243,7 @@ void NetworkStorageManager::iterateCursor(IPC::Connection& connection, const Web
 
 void NetworkStorageManager::getAllDatabaseNamesAndVersions(IPC::Connection& connection, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::ClientOrigin& origin)
 {
+<<<<<<< HEAD
     MESSAGE_CHECK(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection);
     MESSAGE_CHECK(requestIdentifier.connectionIdentifier(), connection);
 
@@ -2233,6 +2252,12 @@ void NetworkStorageManager::getAllDatabaseNamesAndVersions(IPC::Connection& conn
         return;
 
     auto result = protect(originStorageManager(origin)->idbStorageManager(*m_idbStorageRegistry, useSQLiteMemoryBackingStore()))->getAllDatabaseNamesAndVersions();
+=======
+    RefPtr connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection, requestIdentifier);
+    if (!connectionToClient)
+        return;
+    auto result = checkedOriginStorageManager(origin)->checkedIDBStorageManager(*m_idbStorageRegistry)->getAllDatabaseNamesAndVersions();
+>>>>>>> 293e2d766d11 (IndexedDB Connection/Transaction Identifier Confusion)
     connectionToClient->didGetAllDatabaseNamesAndVersions(requestIdentifier, WTF::move(result));
 }
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -304,7 +304,11 @@ private:
     const SuspendableWorkQueue& workQueue() const WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
     SuspendableWorkQueue& workQueue() WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
     OriginQuotaManager::Parameters originQuotaManagerParameters(const WebCore::ClientOrigin&);
+<<<<<<< HEAD
     RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> NODELETE idbTransaction(const WebCore::IDBRequestData&, IPC::Connection&);
+=======
+    RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> idbTransaction(const WebCore::IDBRequestData&, IPC::Connection&);
+>>>>>>> 293e2d766d11 (IndexedDB Connection/Transaction Identifier Confusion)
     void setStorageSiteValidationEnabledInternal(bool);
     void updateAllowedSitesForConnectionInternal(IPC::Connection::UniqueID, std::optional<HashSet<WebCore::RegistrableDomain>>&&);
     bool isSiteAllowedForConnection(IPC::Connection::UniqueID, const WebCore::RegistrableDomain&) const;


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176062499 to main. The following sources [d85455322dae] will still need to be cherry-picked once the conflict is resolved.

```IndexedDB Connection/Transaction Identifier Confusion
https://bugs.webkit.org/show_bug.cgi?id=310076
rdar://172392524

Reviewed by Brady Eidson.

NetworkStorageManager fails to validate that Connection/Transaction
identifiers belong to the IPC connection that sent the IPC. This could
lead to data leakage.

I added the MESSAGE_CHECK calls inside the IDBStorageRegistry::connection()
and IDBStorageRegistry::transaction() getter. Those are convenient
choke-points and it makes it way less likely we forget to add such
MESSAGE_CHECK when introducing new IPC.

* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp:
(WebKit::IDBStorageRegistry::ensureConnectionToClient):
(WebKit::IDBStorageRegistry::isValidConnectionForIPC):
(WebKit::IDBStorageRegistry::connection):
(WebKit::IDBStorageRegistry::transaction):
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::openDatabase):
(WebKit::NetworkStorageManager::deleteDatabase):
(WebKit::NetworkStorageManager::establishTransaction):
(WebKit::NetworkStorageManager::databaseConnectionPendingClose):
(WebKit::NetworkStorageManager::databaseConnectionClosed):
(WebKit::NetworkStorageManager::abortOpenAndUpgradeNeeded):
(WebKit::NetworkStorageManager::didFireVersionChangeEvent):
(WebKit::NetworkStorageManager::didGenerateIndexKeyForRecord):
(WebKit::NetworkStorageManager::abortTransaction):
(WebKit::NetworkStorageManager::commitTransaction):
(WebKit::NetworkStorageManager::didFinishHandlingVersionChangeTransaction):
(WebKit::NetworkStorageManager::idbTransaction):
(WebKit::NetworkStorageManager::createObjectStore):
(WebKit::NetworkStorageManager::deleteObjectStore):
(WebKit::NetworkStorageManager::renameObjectStore):
(WebKit::NetworkStorageManager::clearObjectStore):
(WebKit::NetworkStorageManager::createIndex):
(WebKit::NetworkStorageManager::deleteIndex):
(WebKit::NetworkStorageManager::renameIndex):
(WebKit::NetworkStorageManager::putOrAdd):
(WebKit::NetworkStorageManager::getRecord):
(WebKit::NetworkStorageManager::getAllRecords):
(WebKit::NetworkStorageManager::getCount):
(WebKit::NetworkStorageManager::deleteRecord):
(WebKit::NetworkStorageManager::openCursor):
(WebKit::NetworkStorageManager::iterateCursor):
(WebKit::NetworkStorageManager::getAllDatabaseNamesAndVersions):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:

Originally-landed-as: 305413.515@rapid/safari-7624.2.5.110-branch (293e2d766d11). rdar://176062499

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b62366a05a2b4118f5bb8edb82b70a211fe959a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164452 "19 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37936 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31507 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173482 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121704 "Hash 0b62366a for PR 65673 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166321 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38270 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37938 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/173482 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/121704 "Hash 0b62366a for PR 65673 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167411 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/38270 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/31507 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/173482 "Hash 0b62366a for PR 65673 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/38270 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/37938 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21245 "Hash 0b62366a for PR 65673 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/38270 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/31507 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176008 "Hash 0b62366a for PR 65673 does not build (failure)") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28830 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/31507 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/176008 "Hash 0b62366a for PR 65673 does not build (failure)") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/37938 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/176008 "Hash 0b62366a for PR 65673 does not build (failure)") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/31507 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100835 "Hash 0b62366a for PR 65673 does not build (failure)") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/31507 "Hash 0b62366a for PR 65673 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37203 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110247 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36601 "Hash 0b62366a for PR 65673 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/31507 "Hash 0b62366a for PR 65673 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36849 "Hash 0b62366a for PR 65673 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36749 "Hash 0b62366a for PR 65673 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->