### PR TITLE
Cherry-pick(s) 6b53aa44e133. rdar://176061288

### DIFF
--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -735,6 +735,7 @@ void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::D
     }
 
     if (decoder.messageName() == Messages::WebBackForwardList::BackForwardUpdateItem::name()) {
+<<<<<<< HEAD
         if (RefPtr page = m_page.get()) {
 #if ENABLE(BACK_FORWARD_LIST_SWIFT)
             page->backForwardListMessageReceiver().didReceiveMessage(connection, decoder);
@@ -742,6 +743,10 @@ void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::D
             page->backForwardList().didReceiveProvisionalMessage(connection, decoder);
 #endif
         }
+=======
+        if (RefPtr page = m_page.get())
+            page->backForwardList().didReceiveProvisionalMessage(connection, decoder);
+>>>>>>> 6b53aa44e133 (MESSAGE_CHECK URLs passed in to WebBackForwardListItem backForwardUpdateItem and backForwardSetChildItem)
         return;
     }
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -838,7 +838,17 @@ void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<
     if (RefPtr webPageProxy = m_page.get()) {
         ASSERT(webPageProxy->identifier() == item->pageID() && frameState->itemID == item->identifier());
 
+<<<<<<< HEAD
         auto oldFrameID = frameItem->frameID();
+=======
+        if (!!item->backForwardCacheEntry() != frameState->hasCachedPage) {
+            if (frameState->hasCachedPage)
+            webPageProxy->protectedBackForwardCache()->addEntry(*item, process->coreProcessIdentifier());
+            else if (!item->suspendedPage())
+            webPageProxy->protectedBackForwardCache()->removeEntry(*item);
+        }
+
+>>>>>>> 6b53aa44e133 (MESSAGE_CHECK URLs passed in to WebBackForwardListItem backForwardUpdateItem and backForwardSetChildItem)
         frameItem->setFrameState(WTF::move(frameState));
         auto newFrameID = frameItem->frameID();
 
@@ -959,6 +969,7 @@ void WebBackForwardList::didReceiveProvisionalMessage(IPC::Connection& connectio
     didReceiveMessage(connection, decoder);
 }
 
+<<<<<<< HEAD
 #else // ENABLE(BACK_FORWARD_LIST_SWIFT)
 
 WebBackForwardListWrapper::WebBackForwardListWrapper(WebPageProxy& webPageProxy)
@@ -1035,6 +1046,8 @@ String WebBackForwardListWrapper::loggingString()
 
 #endif // ENABLE(BACK_FORWARD_LIST_SWIFT)
 
+=======
+>>>>>>> 6b53aa44e133 (MESSAGE_CHECK URLs passed in to WebBackForwardListItem backForwardUpdateItem and backForwardSetChildItem)
 } // namespace WebKit
 
 #if ENABLE(BACK_FORWARD_LIST_SWIFT)


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176061288 to main. The following sources [715bc669054b] will still need to be cherry-picked once the conflict is resolved.

```MESSAGE_CHECK URLs passed in to WebBackForwardListItem backForwardUpdateItem and backForwardSetChildItem
rdar://171104801

Reviewed by Ryosuke Niwa and Per Arne Vollan.

We do a MESSAGE_CHECK for unexpected file URLs in backForwardAddItemShared.
These two methods should get the same treatment.

No new tests (The "success" path of the test would be a crash, which we can't add.)

* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::didReceiveMessage):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::messageCheckItemURLs):
(WebKit::WebBackForwardList::backForwardAddItemShared):
(WebKit::WebBackForwardList::backForwardSetChildItem):
(WebKit::WebBackForwardList::backForwardUpdateItem):
(WebKit::WebBackForwardList::didReceiveProvisionalMessage):
* Source/WebKit/UIProcess/WebBackForwardList.h:

Originally-landed-as: 305413.459@rapid/safari-7624.2.5.110-branch (6b53aa44e133). rdar://176061288

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12d23659ffefff8a6719ca37cd58c5bfba5dff51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164457 "5 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37941 "Hash 12d23659 for PR 65676 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31512 "Hash 12d23659 for PR 65676 does not build (failure)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/173487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38275 "Hash 12d23659 for PR 65676 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37943 "Hash 12d23659 for PR 65676 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/173487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167416 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/38275 "Hash 12d23659 for PR 65676 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/31512 "Hash 12d23659 for PR 65676 does not build (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/173487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/38275 "Hash 12d23659 for PR 65676 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/37943 "Hash 12d23659 for PR 65676 does not build (failure)") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/21250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/38275 "Hash 12d23659 for PR 65676 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/31512 "Hash 12d23659 for PR 65676 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25349 "Build is in progress. Recent messages:") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28835 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/31512 "Hash 12d23659 for PR 65676 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/176013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/37943 "Hash 12d23659 for PR 65676 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/31512 "Hash 12d23659 for PR 65676 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/31512 "Hash 12d23659 for PR 65676 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37208 "Hash 12d23659 for PR 65676 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110252 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36606 "Hash 12d23659 for PR 65676 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/31512 "Hash 12d23659 for PR 65676 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36854 "Hash 12d23659 for PR 65676 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36754 "Hash 12d23659 for PR 65676 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->