### PR TITLE
[GLIB] Add XRDeviceIdentifier to serialized_identifiers()

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -572,6 +572,7 @@ def serialized_identifiers():
         'WebKit::WebTransportSessionIdentifier',
         'WebKit::WebURLSchemeHandlerIdentifier',
         'WebKit::WebUndoStepID',
+        'WebKit::XRDeviceIdentifier',
     ]
 
 

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -638,6 +638,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebKit::WebTransportSessionIdentifier"_s,
         "WebKit::WebURLSchemeHandlerIdentifier"_s,
         "WebKit::WebUndoStepID"_s,
+        "WebKit::XRDeviceIdentifier"_s,
     };
 }
 


### PR DESCRIPTION
#### 432bc10c950699e0b10f36c3390cff021047a2e6
<pre>
[GLIB] Add XRDeviceIdentifier to serialized_identifiers()
<a href="https://bugs.webkit.org/show_bug.cgi?id=315569">https://bugs.webkit.org/show_bug.cgi?id=315569</a>

Reviewed by Patrick Griffis.

XRDeviceIdentifier is an ObjectIdentifier, so it belongs in the list that feeds
IPC.objectIdentifiers. Only ports that enable WEBXR compile XRDeviceInfo, which
is why ipc/serialized-type-info.html reports it as lacking IPC metadata on GLib
and visionOS but not on macOS.

* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:

Canonical link: <a href="https://commits.webkit.org/319892@main">https://commits.webkit.org/319892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7729379b1ca3d7b1b676c79e21ce8120b2d1b25e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193220 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147291 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142835 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/99193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123262 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/182329 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45249 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43496 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155645 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43128 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4393 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195161 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56595 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152303 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57300 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151999 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27789 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46559 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129569 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125681 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55808 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18139 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55416 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->