### PR TITLE
Text fragment can match a prefix that isn't word-bounded on left near start of document

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/prefix-word-bounded-at-doc-start-expected.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/prefix-word-bounded-at-doc-start-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - prefix near document start must be word-bounded</title>
+<style>
+  span {
+    background-color: pink;
+  }
+</style>
+
+<p>Pass condition: only the word in the final sentence below is highlighted; the heading is not.</p>
+<h2>II</h2>
+<p>The Pool of Tears</p>
+<p>Let me think: was I <span>the</span> same when I got up this morning?</p>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/prefix-word-bounded-at-doc-start.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/prefix-word-bounded-at-doc-start.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to text fragment - prefix near document start must be word-bounded</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<meta name="assert" content="A text directive prefix that is not at a word boundary must not match. The target should resolve to the later occurrence whose prefix is word-bounded, not the one at the start of the document.">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-1500" />
+<style>
+  ::target-text { background-color: pink; }
+</style>
+
+<p>Pass condition: only the word in the final sentence below is highlighted; the heading is not.</p>
+<h2>II</h2>
+<p>The Pool of Tears</p>
+<p>Let me think: was I the same when I got up this morning?</p>
+
+<script>
+  location.href = "#:~:text=i-,the";
+</script>
+</html>

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1898,6 +1898,16 @@ inline bool NODELETE SearchBuffer::needsMoreContext() const
     return m_needsMoreContext;
 }
 
+static void prepend(Vector<char16_t>& buffer, StringView text)
+{
+    size_t length = text.length();
+    size_t oldSize = buffer.size();
+    buffer.grow(oldSize + length);
+    if (oldSize)
+        WTF::memmoveSpan(buffer.mutableSpan().subspan(length), buffer.span().first(oldSize));
+    text.getCharacters(buffer.mutableSpan().first(length));
+}
+
 inline void SearchBuffer::prependContext(StringView text)
 {
     ASSERT(m_needsMoreContext);
@@ -1915,7 +1925,8 @@ inline void SearchBuffer::prependContext(StringView text)
     }
 
     size_t usableLength = std::min(m_buffer.capacity() - m_prefixLength, text.length() - wordBoundaryContextStart);
-    WTF::append(m_buffer, text.substring(text.length() - usableLength, usableLength));
+    auto suffix = text.substring(text.length() - usableLength, usableLength);
+    prepend(m_buffer, suffix);
     m_prefixLength += usableLength;
 
     if (wordBoundaryContextStart || m_prefixLength == m_buffer.capacity())


### PR DESCRIPTION
#### 208745c0c095eda0e5fa99542804b712d4fd26da
<pre>
Text fragment can match a prefix that isn&apos;t word-bounded on left near start of document
<a href="https://bugs.webkit.org/show_bug.cgi?id=315536">https://bugs.webkit.org/show_bug.cgi?id=315536</a>

Reviewed by Darin Adler.

The change makes the SearchBuffer::prependContext function live up to its name and prepend context instead of appending context. Prior to the change, that appending could leave the buffer sent to isWordStartMatch in the wrong order. That resulted in the wrong character being examined for a word boundary, which caused acceptance of a match that should&apos;ve been rejected. The fix properly inserts into the front of the buffer so that the characters sent to isWordStartMatch are in the correct order, and that fixes the boundary check so that it properly rejects that non-bounded pattern.

Test: http/tests/scroll-to-text-fragment/prefix-word-bounded-at-doc-start.html

* LayoutTests/http/tests/scroll-to-text-fragment/prefix-word-bounded-at-doc-start-expected.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/prefix-word-bounded-at-doc-start.html: Added.
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::prepend):
(WebCore::SearchBuffer::prependContext): Insert the gathered context at front of buffer instead of appending to end.

Canonical link: <a href="https://commits.webkit.org/314323@main">https://commits.webkit.org/314323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7a1d006f2ffbcf2881c24807d084006454ddf54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174037 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122251 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128215 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90254 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108741 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29573 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28187 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21792 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139468 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176560 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29412 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27662 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136536 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136481 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36943 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147754 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101543 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31755 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24619 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37754 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110825 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37151 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2694 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->