### PR TITLE
[CMake] Declare WebCore-migrated headers textual in WebKitLegacy private modulemap on iOS

### DIFF
--- a/Source/WebKitLegacy/PlatformIOS.cmake
+++ b/Source/WebKitLegacy/PlatformIOS.cmake
@@ -1099,13 +1099,39 @@ endif ()
 
 configure_file(${WEBKITLEGACY_DIR}/Modules/WebKitLegacy.modulemap
                ${_wkl_fw}/Modules/module.modulemap COPYONLY)
+# WebCore-migrated headers: declare textual so WebKitLegacy doesn't compete
+# with WebCore_Private.Core for @interface ownership (WAKView, WebEvent, ...).
+# Mirrors MigratedHeaders-input.xcfilelist.
+set(_wkl_textual_for_ios
+    AbstractPasteboard.h
+    KeyEventCodesIOS.h
+    WAKAppKitStubs.h
+    WAKResponder.h
+    WAKView.h
+    WAKWindow.h
+    WKContentObservation.h
+    WKGraphics.h
+    WKTypes.h
+    WebCoreThread.h
+    WebCoreThreadMessage.h
+    WebCoreThreadRun.h
+    WebEvent.h
+    WebEventRegion.h
+    WebItemProviderPasteboard.h
+    WebKitAvailability.h
+    WebScriptObject.h
+)
 set(_wkl_modulemap_body "")
 foreach (_file ${WebKitLegacy_LEGACY_FORWARDING_HEADERS_FILES})
     get_filename_component(_name "${_file}" NAME)
     if (_name IN_LIST _wkl_excluded_for_ios)
         continue ()
     endif ()
-    string(APPEND _wkl_modulemap_body "    header \"${_name}\"\n")
+    if (_name IN_LIST _wkl_textual_for_ios)
+        string(APPEND _wkl_modulemap_body "    textual header \"${_name}\"\n")
+    else ()
+        string(APPEND _wkl_modulemap_body "    header \"${_name}\"\n")
+    endif ()
 endforeach ()
 string(APPEND _wkl_modulemap_body "    header \"WorkAround173516139.h\"\n")
 file(WRITE ${_wkl_fw}/Modules/module.private.modulemap


### PR DESCRIPTION
#### 20a731667528ca37ce046d8ca70c922b2e57409e
<pre>
[CMake] Declare WebCore-migrated headers textual in WebKitLegacy private modulemap on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=315574">https://bugs.webkit.org/show_bug.cgi?id=315574</a>
<a href="https://rdar.apple.com/177959268">rdar://177959268</a>

Reviewed by NOBODY (OOPS!).

The cmake-generated WebKitLegacy.framework/Modules/module.private.modulemap
listed every staged header as `header`, including the WebCore-migrated set
(WAKView.h, WebEvent.h, WebCoreThread.h, ...). WebCore_Private.Core
already owns those @interfaces, so under -explicit-module-build the
WebKitLegacy PCM compile failed with:

  WebFrameView.h:45:27: error: definition of &apos;WAKView&apos; must be imported
  from module &apos;WebCore_Private.Core.WAKView&apos; before it is required

Emit the migrated headers as `textual header` so WebKitLegacy stops
claiming ownership. The staged copies remain reachable via
`&lt;WebKitLegacy/X.h&gt;`.

* Source/WebKitLegacy/PlatformIOS.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20a731667528ca37ce046d8ca70c922b2e57409e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173511 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37967 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30102 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108348 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21274 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139051 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/25555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176037 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28860 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/27223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/136121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/136086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/147350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100873 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110276 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36630 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/2267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36878 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36778 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->