### PR TITLE
Fix dominance analysis in B3CanonicalizePrePostIncrements

### DIFF
--- a/JSTests/stress/b3cppi-ssa-dominance.js
+++ b/JSTests/stress/b3cppi-ssa-dominance.js
@@ -1,0 +1,24 @@
+//@ requireOptions("--useConcurrentJIT=0", "--useB3CanonicalizePrePostIncrements=1")
+
+const arr1 = new Int32Array(256);
+arr1.fill(0x1337)
+const arr2 = new Int32Array(256);
+arr2.fill(0x1337)
+
+function trigger(arr, cond) {
+    if (arr.length !== 256) return 0; // Eliminate bounds check side-exits
+
+    let res = 0;
+    for (let j = 0; j < 2; j++) {
+        if (cond) {
+            Atomics.add(arr, 1, 1337);
+        }
+
+        res = arr[1];
+    }
+    return res;
+}
+
+for (let i = 0; i < 100000; i++) {
+    let ret = trigger(i % 2 === 0 ? arr1 : arr2, i % 2 === 0);
+}

--- a/Source/JavaScriptCore/b3/B3CanonicalizePrePostIncrements.cpp
+++ b/Source/JavaScriptCore/b3/B3CanonicalizePrePostIncrements.cpp
@@ -176,10 +176,15 @@ bool canonicalizePrePostIncrements(Procedure& proc)
                     // which is located just before the memory.
                     auto uses = addressUses.find(address);
                     ASSERT(uses != addressUses.end() && uses->value.size());
+                    bool allUsesDominated = true;
                     for (Value* use : uses->value) {
-                        if (!dominators.dominates(memory->owner, use->owner))
-                            continue;
+                        if (!dominators.dominates(memory->owner, use->owner)) {
+                            allUsesDominated = false;
+                            break;
+                        }
                     }
+                    if (!allUsesDominated)
+                        continue;
 
                     unsigned index = memoryToIndex.get(memory);
                     Value* newAddress = insertionSet.insert<Value>(index, Add, memory->origin(), address->child(0), address->child(1));


### PR DESCRIPTION
#### 81aa535db3c9c340cbbeef9aa8880d95715b39b7
<pre>
Fix dominance analysis in B3CanonicalizePrePostIncrements
<a href="https://bugs.webkit.org/show_bug.cgi?id=310055">https://bugs.webkit.org/show_bug.cgi?id=310055</a>
<a href="https://rdar.apple.com/172282220">rdar://172282220</a>

Reviewed by Yusuke Suzuki and Yijia Huang.

B3CanonicalizePrePostIncrements moves an add to generate an address for
a memory operation, and needs to check that the current block dominates
all uses of the add&apos;s result. If the current block does not dominate all
uses the compiler must cancel the optimization for the current block but
right now the loop does nothing.

Test: JSTests/stress/b3cppi-ssa-dominance.js

* JSTests/stress/b3cppi-ssa-dominance.js: Added.
(arr2.fill.0x1337.trigger):
* Source/JavaScriptCore/b3/B3CanonicalizePrePostIncrements.cpp:
(JSC::B3::canonicalizePrePostIncrements):

Originally-landed-as: 305413.504@rapid/safari-7624.2.5.110-branch (783f58da6e75). <a href="https://rdar.apple.com/176062203">rdar://176062203</a>
Canonical link: <a href="https://commits.webkit.org/313913@main">https://commits.webkit.org/313913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f988a3002f46466d4d648bc3c709b1c4568b752

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121740 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127809 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89973 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29159 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27785 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21281 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156639 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176044 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25380 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28867 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136127 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136092 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36666 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147358 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100880 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31381 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24214 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196891 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110283 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51709 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36637 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2275 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->