### PR TITLE
Implement headingoffset & headingreset attributes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8030,8 +8030,6 @@ imported/w3c/web-platform-tests/css/css-break/table/repeated-section/text-in-nes
 imported/w3c/web-platform-tests/css/css-break/text-indent-and-wide-float.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-break/transform-025.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/html/rendering/sections/headingoffset-and-headingreset.html [ ImageOnlyFailure ]
-
 # Need to add tolerance for local in separate since failure is 0.01% and these tests pass on WPT itself.
 imported/w3c/web-platform-tests/svg/painting/reftests/text-shadow-01.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/text-shadow-02.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has-with-headingoffset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has-with-headingoffset-expected.txt
@@ -1,0 +1,58 @@
+
+PASS Initial colors: #has_heading_1
+PASS Initial colors: #has_heading_2
+PASS Initial colors: #has_heading_3
+PASS Initial colors: #has_heading_1_2
+PASS h1[headingoffset=1]: #has_heading_1
+PASS h1[headingoffset=1]: #has_heading_2
+PASS h1[headingoffset=1]: #has_heading_3
+PASS h1[headingoffset=1]: #has_heading_1_2
+PASS h1[headingoffset=2]: #has_heading_1
+PASS h1[headingoffset=2]: #has_heading_2
+PASS h1[headingoffset=2]: #has_heading_3
+PASS h1[headingoffset=2]: #has_heading_1_2
+PASS h1 with headingoffset removed: #has_heading_1
+PASS h1 with headingoffset removed: #has_heading_2
+PASS h1 with headingoffset removed: #has_heading_3
+PASS h1 with headingoffset removed: #has_heading_1_2
+PASS ancestor[headingoffset=1]: #has_heading_1
+PASS ancestor[headingoffset=1]: #has_heading_2
+PASS ancestor[headingoffset=1]: #has_heading_3
+PASS ancestor[headingoffset=1]: #has_heading_1_2
+PASS ancestor[headingoffset=2]: #has_heading_1
+PASS ancestor[headingoffset=2]: #has_heading_2
+PASS ancestor[headingoffset=2]: #has_heading_3
+PASS ancestor[headingoffset=2]: #has_heading_1_2
+PASS h1[headingreset] (cuts ancestor offset): #has_heading_1
+PASS h1[headingreset] (cuts ancestor offset): #has_heading_2
+PASS h1[headingreset] (cuts ancestor offset): #has_heading_3
+PASS h1[headingreset] (cuts ancestor offset): #has_heading_1_2
+PASS h1 with headingreset removed: #has_heading_1
+PASS h1 with headingreset removed: #has_heading_2
+PASS h1 with headingreset removed: #has_heading_3
+PASS h1 with headingreset removed: #has_heading_1_2
+PASS ancestor with headingoffset removed: #has_heading_1
+PASS ancestor with headingoffset removed: #has_heading_2
+PASS ancestor with headingoffset removed: #has_heading_3
+PASS ancestor with headingoffset removed: #has_heading_1_2
+PASS h1.headingOffset = 1: #has_heading_1
+PASS h1.headingOffset = 1: #has_heading_2
+PASS h1.headingOffset = 1: #has_heading_3
+PASS h1.headingOffset = 1: #has_heading_1_2
+PASS h1.headingOffset = 0: #has_heading_1
+PASS h1.headingOffset = 0: #has_heading_2
+PASS h1.headingOffset = 0: #has_heading_3
+PASS h1.headingOffset = 0: #has_heading_1_2
+PASS ancestor[headingoffset=2] again: #has_heading_1
+PASS ancestor[headingoffset=2] again: #has_heading_2
+PASS ancestor[headingoffset=2] again: #has_heading_3
+PASS ancestor[headingoffset=2] again: #has_heading_1_2
+PASS h1.headingReset = true: #has_heading_1
+PASS h1.headingReset = true: #has_heading_2
+PASS h1.headingReset = true: #has_heading_3
+PASS h1.headingReset = true: #has_heading_1_2
+PASS h1.headingReset = false: #has_heading_1
+PASS h1.headingReset = false: #has_heading_2
+PASS h1.headingReset = false: #has_heading_3
+PASS h1.headingReset = false: #has_heading_1_2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has-with-headingoffset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has-with-headingoffset.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors Invalidation: :heading() pseudo-class in :has() argument with headingoffset/headingreset</title>
+<link rel="help" href="https://drafts.csswg.org/selectors-5/#headings">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  div { color: grey }
+  #ancestor:has(:heading(1)) ~ #has_heading_1 { color: red }
+  #ancestor:has(:heading(2)) ~ #has_heading_2 { color: orange }
+  #ancestor:has(:heading(3)) ~ #has_heading_3 { color: yellow }
+  #ancestor:has(:heading(1, 2)) ~ #has_heading_1_2 { color: green }
+</style>
+<div id="ancestor"><h1 id="h1"></h1></div>
+<div id="has_heading_1"></div>
+<div id="has_heading_2"></div>
+<div id="has_heading_3"></div>
+<div id="has_heading_1_2"></div>
+<script>
+const grey = "rgb(128, 128, 128)";
+const red = "rgb(255, 0, 0)";
+const orange = "rgb(255, 165, 0)";
+const yellow = "rgb(255, 255, 0)";
+const green = "rgb(0, 128, 0)";
+
+function testColors(test_name,
+                    has_heading_1_color,
+                    has_heading_2_color,
+                    has_heading_3_color,
+                    has_heading_1_2_color) {
+  test(function() {
+      assert_equals(getComputedStyle(has_heading_1).color, has_heading_1_color);
+  }, test_name + ": #has_heading_1");
+  test(function() {
+      assert_equals(getComputedStyle(has_heading_2).color, has_heading_2_color);
+  }, test_name + ": #has_heading_2");
+  test(function() {
+      assert_equals(getComputedStyle(has_heading_3).color, has_heading_3_color);
+  }, test_name + ": #has_heading_3");
+  test(function() {
+      assert_equals(getComputedStyle(has_heading_1_2).color, has_heading_1_2_color);
+  }, test_name + ": #has_heading_1_2");
+}
+
+testColors("Initial colors", red, grey, grey, green);
+
+// Set headingoffset on the heading itself: h1 -> level 2
+h1.setAttribute("headingoffset", "1");
+testColors("h1[headingoffset=1]", grey, orange, grey, green);
+
+// Increase offset: h1 -> level 3
+h1.setAttribute("headingoffset", "2");
+testColors("h1[headingoffset=2]", grey, grey, yellow, grey);
+
+// Remove offset: h1 -> level 1
+h1.removeAttribute("headingoffset");
+testColors("h1 with headingoffset removed", red, grey, grey, green);
+
+// Move offset to the ancestor: h1 -> level 2
+ancestor.setAttribute("headingoffset", "1");
+testColors("ancestor[headingoffset=1]", grey, orange, grey, green);
+
+// Increase ancestor offset: h1 -> level 3
+ancestor.setAttribute("headingoffset", "2");
+testColors("ancestor[headingoffset=2]", grey, grey, yellow, grey);
+
+// headingreset on the heading cuts ancestor's offset: h1 -> level 1
+h1.setAttribute("headingreset", "");
+testColors("h1[headingreset] (cuts ancestor offset)", red, grey, grey, green);
+
+// Remove headingreset: h1 -> level 3 again
+h1.removeAttribute("headingreset");
+testColors("h1 with headingreset removed", grey, grey, yellow, grey);
+
+// Clear ancestor offset: h1 -> level 1
+ancestor.removeAttribute("headingoffset");
+testColors("ancestor with headingoffset removed", red, grey, grey, green);
+
+// Set offset via IDL property
+h1.headingOffset = 1;
+testColors("h1.headingOffset = 1", grey, orange, grey, green);
+
+h1.headingOffset = 0;
+testColors("h1.headingOffset = 0", red, grey, grey, green);
+
+// headingreset toggling via IDL property
+ancestor.setAttribute("headingoffset", "2");
+testColors("ancestor[headingoffset=2] again", grey, grey, yellow, grey);
+
+h1.headingReset = true;
+testColors("h1.headingReset = true", red, grey, grey, green);
+
+h1.headingReset = false;
+testColors("h1.headingReset = false", grey, grey, yellow, grey);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has-with-slot-reassignment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has-with-slot-reassignment-expected.txt
@@ -1,0 +1,41 @@
+
+PASS Initial (h1 slotted into slot_a): #has_heading_1
+PASS Initial (h1 slotted into slot_a): #has_heading_3
+PASS Initial (h1 slotted into slot_a): #has_heading_5
+PASS h1.slot = 'b': #has_heading_1
+PASS h1.slot = 'b': #has_heading_3
+PASS h1.slot = 'b': #has_heading_5
+PASS h1.slot = 'nonexistent': #has_heading_1
+PASS h1.slot = 'nonexistent': #has_heading_3
+PASS h1.slot = 'nonexistent': #has_heading_5
+PASS h1.slot = 'a': #has_heading_1
+PASS h1.slot = 'a': #has_heading_3
+PASS h1.slot = 'a': #has_heading_5
+PASS slotA.name = 'c': #has_heading_1
+PASS slotA.name = 'c': #has_heading_3
+PASS slotA.name = 'c': #has_heading_5
+PASS slotB.name = 'a': #has_heading_1
+PASS slotB.name = 'a': #has_heading_3
+PASS slotB.name = 'a': #has_heading_5
+PASS Reset slot names: #has_heading_1
+PASS Reset slot names: #has_heading_3
+PASS Reset slot names: #has_heading_5
+PASS slotA.remove(): #has_heading_1
+PASS slotA.remove(): #has_heading_3
+PASS slotA.remove(): #has_heading_5
+PASS Re-insert slot_a: #has_heading_1
+PASS Re-insert slot_a: #has_heading_3
+PASS Re-insert slot_a: #has_heading_5
+PASS ancestor[headingoffset=2]: #has_heading_1
+PASS ancestor[headingoffset=2]: #has_heading_3
+PASS ancestor[headingoffset=2]: #has_heading_5
+PASS h1.slot = 'b' with ancestor[headingoffset=2]: #has_heading_1
+PASS h1.slot = 'b' with ancestor[headingoffset=2]: #has_heading_3
+PASS h1.slot = 'b' with ancestor[headingoffset=2]: #has_heading_5
+PASS ancestor[headingoffset=4]: #has_heading_1
+PASS ancestor[headingoffset=4]: #has_heading_3
+PASS ancestor[headingoffset=4]: #has_heading_5
+PASS ancestor with headingoffset removed: #has_heading_1
+PASS ancestor with headingoffset removed: #has_heading_3
+PASS ancestor with headingoffset removed: #has_heading_5
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has-with-slot-reassignment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has-with-slot-reassignment.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors Invalidation: :heading() pseudo-class in :has() argument with slot reassignment</title>
+<link rel="help" href="https://drafts.csswg.org/selectors-5/#headings">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  div { color: grey }
+  #ancestor:has(:heading(1)) ~ #has_heading_1 { color: red }
+  #ancestor:has(:heading(3)) ~ #has_heading_3 { color: yellow }
+  #ancestor:has(:heading(5)) ~ #has_heading_5 { color: green }
+</style>
+<div id="ancestor">
+  <template shadowrootmode="open">
+    <div headingoffset="2">
+      <slot id="slot_a" name="a"></slot>
+    </div>
+    <div headingoffset="4">
+      <slot id="slot_b" name="b"></slot>
+    </div>
+  </template>
+  <h1 id="h1" slot="a"></h1>
+</div>
+<div id="has_heading_1"></div>
+<div id="has_heading_3"></div>
+<div id="has_heading_5"></div>
+<script>
+const grey = "rgb(128, 128, 128)";
+const red = "rgb(255, 0, 0)";
+const yellow = "rgb(255, 255, 0)";
+const green = "rgb(0, 128, 0)";
+
+const slotA = ancestor.shadowRoot.getElementById("slot_a");
+const slotB = ancestor.shadowRoot.getElementById("slot_b");
+const slotAContainer = slotA.parentElement;
+
+function testColors(test_name,
+                    has_heading_1_color,
+                    has_heading_3_color,
+                    has_heading_5_color) {
+  test(function() {
+      assert_equals(getComputedStyle(has_heading_1).color, has_heading_1_color);
+  }, test_name + ": #has_heading_1");
+  test(function() {
+      assert_equals(getComputedStyle(has_heading_3).color, has_heading_3_color);
+  }, test_name + ": #has_heading_3");
+  test(function() {
+      assert_equals(getComputedStyle(has_heading_5).color, has_heading_5_color);
+  }, test_name + ": #has_heading_5");
+}
+
+// A slotted heading's level depends on its host chain, not on the shadow-tree
+// slot containers. Slot reassignment must therefore not change its level.
+
+// Initial: h1 slotted into slot_a, ancestor has no headingoffset, level 1.
+testColors("Initial (h1 slotted into slot_a)", red, grey, grey);
+
+// Move h1 to slot_b: still level 1.
+h1.slot = "b";
+testColors("h1.slot = 'b'", red, grey, grey);
+
+// Point h1 at a non-existent slot: unslotted, still level 1.
+h1.slot = "nonexistent";
+testColors("h1.slot = 'nonexistent'", red, grey, grey);
+
+// Back to slot_a: still level 1.
+h1.slot = "a";
+testColors("h1.slot = 'a'", red, grey, grey);
+
+// Rename slot_a so h1 no longer matches: unslotted, still level 1.
+slotA.name = "c";
+testColors("slotA.name = 'c'", red, grey, grey);
+
+// Rename slot_b to 'a' so h1 now slots into it: still level 1.
+slotB.name = "a";
+testColors("slotB.name = 'a'", red, grey, grey);
+
+// Reset names: still level 1.
+slotA.name = "a";
+slotB.name = "b";
+testColors("Reset slot names", red, grey, grey);
+
+// Remove slot_a: still level 1.
+slotA.remove();
+testColors("slotA.remove()", red, grey, grey);
+
+// Re-insert slot_a: still level 1.
+slotAContainer.appendChild(slotA);
+testColors("Re-insert slot_a", red, grey, grey);
+
+// Toggling the host's headingoffset (which IS on the slotted h1's chain) does
+// change the level, and :has() must invalidate.
+ancestor.setAttribute("headingoffset", "2");
+testColors("ancestor[headingoffset=2]", grey, yellow, grey);
+
+// Slot reassignment with a non-zero host offset still doesn't change level.
+h1.slot = "b";
+testColors("h1.slot = 'b' with ancestor[headingoffset=2]", grey, yellow, grey);
+
+ancestor.setAttribute("headingoffset", "4");
+testColors("ancestor[headingoffset=4]", grey, grey, green);
+
+ancestor.removeAttribute("headingoffset");
+testColors("ancestor with headingoffset removed", red, grey, grey);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/w3c-import.log
@@ -40,6 +40,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-css-nesting-shared.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-in-adjacent-position.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-in-ancestor-position.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-in-is-non-subject-compound.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-in-parent-position.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-in-sibling-position.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-invalidation-after-removing-non-first-element.html
@@ -63,6 +64,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-with-nth-child-sibling-remove.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-with-nth-child.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-with-pseudo-class.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has-with-headingoffset.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has-with-slot-reassignment.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-context-pseudo-class-in-has.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-has-shadow-tree-element-at-nonsubject-position.html
@@ -230,6 +233,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/nth-last-child-when-sibling-changes.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/nth-of-namespace-class-invalidation-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/option-disabled-when-ancestor-changes.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/part-dir.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/part-lang.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/part-pseudo-expected.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -149,8 +149,8 @@ PASS HTMLElement interface: operation showPopover(optional ShowPopoverOptions)
 PASS HTMLElement interface: operation hidePopover()
 PASS HTMLElement interface: operation togglePopover(optional (TogglePopoverOptions or boolean))
 PASS HTMLElement interface: attribute popover
-FAIL HTMLElement interface: attribute headingOffset assert_true: The prototype object must have a property "headingOffset" expected true got false
-FAIL HTMLElement interface: attribute headingReset assert_true: The prototype object must have a property "headingReset" expected true got false
+PASS HTMLElement interface: attribute headingOffset
+PASS HTMLElement interface: attribute headingReset
 PASS HTMLElement interface: attribute onabort
 PASS HTMLElement interface: attribute onauxclick
 PASS HTMLElement interface: attribute onbeforeinput
@@ -262,8 +262,8 @@ PASS HTMLElement interface: document.createElement("noscript") must inherit prop
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "togglePopover(optional (TogglePopoverOptions or boolean))" with the proper type
 PASS HTMLElement interface: calling togglePopover(optional (TogglePopoverOptions or boolean)) on document.createElement("noscript") with too few arguments must throw TypeError
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "popover" with the proper type
-FAIL HTMLElement interface: document.createElement("noscript") must inherit property "headingOffset" with the proper type assert_inherits: property "headingOffset" not found in prototype chain
-FAIL HTMLElement interface: document.createElement("noscript") must inherit property "headingReset" with the proper type assert_inherits: property "headingReset" not found in prototype chain
+PASS HTMLElement interface: document.createElement("noscript") must inherit property "headingOffset" with the proper type
+PASS HTMLElement interface: document.createElement("noscript") must inherit property "headingReset" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onabort" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onauxclick" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onbeforeinput" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headingoffset-and-headingreset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headingoffset-and-headingreset-expected.txt
@@ -1,0 +1,101 @@
+
+PASS headingoffset (set via attribute) should change the level a heading matches against
+PASS headingoffset (set via attribute) should change the level when a parent changes offset
+PASS headingoffset (set via property) should change the level a heading matches against
+PASS headingoffset (set via property) should change the level when a parent changes offset
+PASS headingoffset should not impact modals or explicit headingreset containers
+PASS case 1: heading level for <h1 data-expected-offset="2"><!-- Level 2, h1 + 1 = 2 --></h1> should match based on expected document structure
+PASS case 2: heading level for <h2 data-expected-offset="3"><!-- Level 3, h2 + 1 = 3 --></h2> should match based on expected document structure
+PASS case 3: heading level for <h3 data-expected-offset="4"><!-- Level 4, h3 + 1 = 4 --></h3> should match based on expected document structure
+PASS case 4: heading level for <h1 data-expected-offset="4"><!-- Level 4, h1 + 2 + 1 = 4 --></h1> should match based on expected document structure
+PASS case 5: heading level for <h2 data-expected-offset="5"><!-- Level 5, h2 + 2 + 1 = 5 --></h2> should match based on expected document structure
+PASS case 6: heading level for <h1 data-expected-offset="1"><!-- Level 1, h1 (headingreset)--></h1> should match based on expected document structure
+PASS case 7: heading level for <h1 data-expected-offset="4"><!-- Level 4, h1 + 2 + 1 = 4 --></h1> should match based on expected document structure
+PASS case 8: heading level for <h1 data-expected-offset="1" headingreset="">
+        <!-- Level 1, h1 (headingreset) -->
+      </h1> should match based on expected document structure
+PASS case 9: heading level for <h1 data-expected-offset="9"><!-- Level 9, h1 + 8 --></h1> should match based on expected document structure
+PASS case 10: heading level for <h2 data-expected-offset="9"><!-- Level 9, h2 + 8 (clamped) --></h2> should match based on expected document structure
+PASS case 11: heading level for <h3 data-expected-offset="9"><!-- Level 9, h3 + 8 (clamped) --></h3> should match based on expected document structure
+PASS case 12: heading level for <h4 data-expected-offset="9"><!-- Level 9, h4 + 8 (clamped) --></h4> should match based on expected document structure
+PASS case 13: heading level for <h5 data-expected-offset="9"><!-- Level 9, h5 + 8 (clamped) --></h5> should match based on expected document structure
+PASS case 14: heading level for <h6 data-expected-offset="9"><!-- Level 9, h6 + 8 (clamped) --></h6> should match based on expected document structure
+PASS case 15: heading level for <h1 data-expected-offset="1"><!-- Level 1, h1 (headingreset)--></h1> should match based on expected document structure
+PASS case 16: heading level for <h1 data-expected-offset="9"><!-- Level 9, h1 + 8 --></h1> should match based on expected document structure
+PASS case 17: heading level for <h1 data-expected-offset="1"><!-- Level 1, h1 + (-3 clamped to 0) --></h1> should match based on expected document structure
+PASS case 18: heading level for <h2 data-expected-offset="2"><!-- Level 2, h2 + (-3 clamped to 0) --></h2> should match based on expected document structure
+PASS case 19: heading level for <h3 data-expected-offset="3"><!-- Level 3, h3 + (-3 clamped to 0) --></h3> should match based on expected document structure
+PASS case 20: heading level for <h4 data-expected-offset="4"><!-- Level 4, h4 + (-3 clamped to 0) --></h4> should match based on expected document structure
+PASS case 21: heading level for <h5 data-expected-offset="5"><!-- Level 5, h5 + (-3 clamped to 0) --></h5> should match based on expected document structure
+PASS case 22: heading level for <h6 data-expected-offset="6"><!-- Level 6, h6 + (-3 clamped to 0) --></h6> should match based on expected document structure
+PASS case 23: heading level for <h1 data-expected-offset="1"><!-- Level 1, h1 (headingreset)--></h1> should match based on expected document structure
+PASS case 24: heading level for <h1 data-expected-offset="1"><!-- Level 1, h1 + (-3 clamped to 0) --></h1> should match based on expected document structure
+PASS case 25: heading level for <h1 data-expected-offset="5"><!-- Level 5, h1 + 2 + 2 = 5 --></h1> should match based on expected document structure
+PASS case 26: heading level for <h2 data-expected-offset="6"><!-- Level 6, h2 + 2 + 2 = 6 --></h2> should match based on expected document structure
+PASS case 27: heading level for <h3 data-expected-offset="7"><!-- Level 7, h3 + 2 + 2 = 7 --></h3> should match based on expected document structure
+PASS case 28: heading level for <h4 data-expected-offset="8"><!-- Level 8, h4 + 2 + 2 = 8 --></h4> should match based on expected document structure
+PASS case 29: heading level for <h5 data-expected-offset="9"><!-- Level 9, h5 + 2 + 2 = 9 --></h5> should match based on expected document structure
+PASS case 30: heading level for <h6 data-expected-offset="9">
+        <!-- Level 9, h6 + 2 + 2 = (10 clamped to 9) -->
+      </h6> should match based on expected document structure
+PASS case 31: heading level for <h1 data-expected-offset="3" headingoffset="2" headingreset="">
+        <!-- Level 3, h1 + 2 + (headingreset) -->
+      </h1> should match based on expected document structure
+PASS case 32: heading level for <h2 data-expected-offset="4" headingoffset="2" headingreset="">
+        <!-- Level 4, h2 + 2 + (headingreset) -->
+      </h2> should match based on expected document structure
+PASS case 33: heading level for <h2 data-expected-offset="3"><!-- Level 3, h2 + 1 --></h2> should match based on expected document structure
+PASS case 34: heading level for <h4 data-expected-offset="5"><!-- Level 5, h4 + 1 --></h4> should match based on expected document structure
+PASS case 35: heading level for <h4 data-expected-offset="4" headingreset="">
+    <!-- Level 4, h4 (headingreset) -->
+  </h4> should match based on expected document structure
+PASS case 36: heading level for <h2 data-expected-offset="3"><!-- Level 3, h2 + 1 --></h2> should match based on expected document structure
+PASS case 37: heading level for <h1 data-expected-offset="2" headingoffset="1"><!-- Level 2, h1 + 1 --></h1> should match based on expected document structure
+PASS case 38: heading level for <h2 data-expected-offset="3" headingoffset="1"><!-- Level 3, h2 + 1 --></h2> should match based on expected document structure
+PASS case 39: heading level for <h1 data-expected-offset="3" headingoffset="2"><!-- Level 3, h1 + 2--></h1> should match based on expected document structure
+PASS case 40: heading level for <h2 data-expected-offset="4" headingoffset="2"><!-- Level 4, h2 + 2 --></h2> should match based on expected document structure
+PASS case 41: heading level for <h1 data-expected-offset="2" headingoffset="1" headingreset="">
+  <!-- Level 2, h1 + 1 (headingreset) -->
+</h1> should match based on expected document structure
+PASS case 42: heading level for <h2 data-expected-offset="3" headingoffset="1" headingreset="">
+  <!-- Level 3, h2 + 1 (headingreset) -->
+</h2> should match based on expected document structure
+PASS case 43: heading level for <h1 data-expected-offset="3" headingoffset="2" headingreset="">
+  <!-- Level 3, h1 + 2 (headingreset) -->
+</h1> should match based on expected document structure
+PASS case 44: heading level for <h2 data-expected-offset="4" headingoffset="2" headingreset="">
+  <!-- Level 4, h2 + 2 (headingreset) -->
+</h2> should match based on expected document structure
+PASS case 45: heading level for <h1 data-expected-offset="9" headingoffset="20" headingreset="">
+  <!-- Level 9, h1 + 20 (clamped)  -->
+</h1> should match based on expected document structure
+PASS case 46: heading level for <h2 data-expected-offset="9" headingoffset="20" headingreset="">
+  <!-- Level 9, h2 + 20 (clamped) -->
+</h2> should match based on expected document structure
+PASS case 47: heading level for <h1 data-expected-offset="1" headingoffset="0" headingreset="">
+  <!-- Level 1, h1 + 0 -->
+</h1> should match based on expected document structure
+PASS case 48: heading level for <h2 data-expected-offset="2" headingoffset="0" headingreset="">
+  <!-- Level 2, h2 + 0 -->
+</h2> should match based on expected document structure
+PASS case 49: heading level for <h1 data-expected-offset="2" headingoffset="1"><!-- Level 2, h1 + 1 --></h1> should match based on expected document structure
+PASS case 50: heading level for <h2 data-expected-offset="3" headingoffset="1"><!-- Level 3, h2 + 1 --></h2> should match based on expected document structure
+PASS case 51: heading level for <h1 data-expected-offset="2" headingoffset="1" headingreset="">
+    <!-- Level 2, h1 + 1 -->
+  </h1> should match based on expected document structure
+PASS case 52: heading level for <h2 data-expected-offset="3" headingoffset="1" headingreset="">
+    <!-- Level 3, h2 + 1 -->
+  </h2> should match based on expected document structure
+PASS case 53: heading level for <h1 data-expected-offset="1" headingoffset="-1" headingreset="">
+    <!-- Level 1, h1 + (-1 clamped to 0) -->
+  </h1> should match based on expected document structure
+PASS case 54: heading level for <h2 data-expected-offset="2" headingoffset="-1" headingreset="">
+    <!-- Level 2, h2 + (-1 clamped to 0) -->
+  </h2> should match based on expected document structure
+PASS case 55: heading level for <h1 data-expected-offset="5">
+            <!-- Level 5, h1 + 1 + (-6 clamped to 0) + 3 + (-1 clamped to 0) -->
+          </h1> should match based on expected document structure
+PASS case 56: heading level for <h1 data-expected-offset="9" headingoffset="9" aria-level="3">
+  <!-- Level 3 -->
+</h1> should match based on expected document structure
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headingoffset-and-headingreset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headingoffset-and-headingreset.html
@@ -1,0 +1,326 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<link rel="help" href="https://github.com/whatwg/html/pull/11086" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div headingoffset="1" title="container headingoffset=1">
+  <!-- h1s are now h2s and so on -->
+  <h1 data-expected-offset="2"><!-- Level 2, h1 + 1 = 2 --></h1>
+  <h2 data-expected-offset="3"><!-- Level 3, h2 + 1 = 3 --></h2>
+  <h3 data-expected-offset="4"><!-- Level 4, h3 + 1 = 4 --></h3>
+  <div headingoffset="2" title="container headingoffset=2">
+    <!-- h1s are now h4s -->
+    <h1 data-expected-offset="4"><!-- Level 4, h1 + 2 + 1 = 4 --></h1>
+    <h2 data-expected-offset="5"><!-- Level 5, h2 + 2 + 1 = 5 --></h2>
+    <div headingreset title="container headingreset">
+      <!-- h1s are now h1s -->
+      <h1 data-expected-offset="1"><!-- Level 1, h1 (headingreset)--></h1>
+    </div>
+    <dialog open title="container dialog">
+      <!-- non-modal dialogs do not headingreset, h1s are still h4s -->
+      <h1 data-expected-offset="4"><!-- Level 4, h1 + 2 + 1 = 4 --></h1>
+      <h1 data-expected-offset="1" headingreset>
+        <!-- Level 1, h1 (headingreset) -->
+      </h1>
+    </dialog>
+  </div>
+</div>
+<!-- Clamping -->
+<div headingoffset="8" title="container headingoffset=8">
+  <!-- h1s are now h9s -->
+  <h1 data-expected-offset="9"><!-- Level 9, h1 + 8 --></h1>
+  <h2 data-expected-offset="9"><!-- Level 9, h2 + 8 (clamped) --></h2>
+  <h3 data-expected-offset="9"><!-- Level 9, h3 + 8 (clamped) --></h3>
+  <h4 data-expected-offset="9"><!-- Level 9, h4 + 8 (clamped) --></h4>
+  <h5 data-expected-offset="9"><!-- Level 9, h5 + 8 (clamped) --></h5>
+  <h6 data-expected-offset="9"><!-- Level 9, h6 + 8 (clamped) --></h6>
+  <div headingreset title="container headingreset">
+    <!-- h1s are now h1s -->
+    <h1 data-expected-offset="1"><!-- Level 1, h1 (headingreset)--></h1>
+  </div>
+  <dialog open title="container dialog">
+    <!-- non-modal dialogs do not headingreset, h1s are still h4s -->
+    <h1 data-expected-offset="9"><!-- Level 9, h1 + 8 --></h1>
+  </dialog>
+</div>
+<!-- Negative headingoffsets are clamped to `0` -->
+<div headingoffset="-3" title="container headingoffset=-3">
+  <h1 data-expected-offset="1"><!-- Level 1, h1 + (-3 clamped to 0) --></h1>
+  <h2 data-expected-offset="2"><!-- Level 2, h2 + (-3 clamped to 0) --></h2>
+  <h3 data-expected-offset="3"><!-- Level 3, h3 + (-3 clamped to 0) --></h3>
+  <h4 data-expected-offset="4"><!-- Level 4, h4 + (-3 clamped to 0) --></h4>
+  <h5 data-expected-offset="5"><!-- Level 5, h5 + (-3 clamped to 0) --></h5>
+  <h6 data-expected-offset="6"><!-- Level 6, h6 + (-3 clamped to 0) --></h6>
+  <div headingreset title="container headingreset">
+    <!-- h1s are now h1s -->
+    <h1 data-expected-offset="1"><!-- Level 1, h1 (headingreset)--></h1>
+  </div>
+  <dialog open title="container dialog">
+    <!-- non-modal dialogs do not headingreset, h1s are still h1s -->
+    <h1 data-expected-offset="1"><!-- Level 1, h1 + (-3 clamped to 0) --></h1>
+  </dialog>
+</div>
+<!-- Resetting applies after headingOffset -->
+<div headingreset title="container headingreset + headingoffset">
+  <div headingoffset="2" headingreset>
+    <div headingoffset="2">
+      <h1 data-expected-offset="5"><!-- Level 5, h1 + 2 + 2 = 5 --></h1>
+      <h2 data-expected-offset="6"><!-- Level 6, h2 + 2 + 2 = 6 --></h2>
+      <h3 data-expected-offset="7"><!-- Level 7, h3 + 2 + 2 = 7 --></h3>
+      <h4 data-expected-offset="8"><!-- Level 8, h4 + 2 + 2 = 8 --></h4>
+      <h5 data-expected-offset="9"><!-- Level 9, h5 + 2 + 2 = 9 --></h5>
+      <h6 data-expected-offset="9">
+        <!-- Level 9, h6 + 2 + 2 = (10 clamped to 9) -->
+      </h6>
+      <h1 data-expected-offset="3" headingoffset="2" headingreset>
+        <!-- Level 3, h1 + 2 + (headingreset) -->
+      </h1>
+      <h2 data-expected-offset="4" headingoffset="2" headingreset>
+        <!-- Level 4, h2 + 2 + (headingreset) -->
+      </h2>
+    </div>
+  </div>
+</div>
+<!-- Ensure shadow roots work -->
+<div headingoffset="1" title="container shadowroot headingoffset=1">
+  <template shadowrootmode="open">
+    <h1 data-expected-offset="2"><!-- Level 2, h1 + 1 --></h1>
+    <h2 data-expected-offset="2" headingreset>
+      <!-- Level 2, h2 (headingreset) -->
+    </h2>
+  </template>
+</div>
+<!-- Ensure slotted elements are correctly set -->
+<div headingoffset="1" title="container shadowroot slotted headingoffset=1">
+  <template shadowrootmode="open">
+    <h1 data-expected-offset="2"><!-- Level 2, h1 + 1 --></h1>
+    <h2 data-expected-offset="3"><!-- Level 3, h2 + 1 --></h2>
+    <h3 data-expected-offset="3" headingreset>
+      <!-- Level 3, h3 (headingreset) -->
+    </h3>
+    <slot></slot>
+  </template>
+  <h1><!-- Level 2, h1 + 1 --></h1>
+</div>
+<!-- Ensure slotted elements respect their parents -->
+<div
+  headingoffset="1"
+  title="container shadowroot slotted with container headingoffset=1"
+>
+  <template shadowrootmode="open">
+    <h1 data-expected-offset="2"><!-- Level 2, h1 + 1 --></h1>
+    <div headingoffset="1" title="container inside shadowroot headingoffset=1">
+      <slot></slot>
+    </div>
+  </template>
+  <h2 data-expected-offset="3"><!-- Level 3, h2 + 1 --></h2>
+  <h4 data-expected-offset="5"><!-- Level 5, h4 + 1 --></h4>
+  <h4 data-expected-offset="4" headingreset>
+    <!-- Level 4, h4 (headingreset) -->
+  </h4>
+</div>
+<!-- Ensure the slot's headingoffset does not affect slotted content -->
+<div
+  headingoffset="1"
+  title="container shadowroot slot with attr headingoffset=1"
+>
+  <template shadowrootmode="open">
+    <h1 data-expected-offset="2"><!-- Level 2, h1 + 1 --></h1>
+    <slot headingoffset="1"></slot>
+  </template>
+  <h2 data-expected-offset="3"><!-- Level 3, h2 + 1 --></h2>
+</div>
+<h1 data-expected-offset="2" headingoffset="1"><!-- Level 2, h1 + 1 --></h1>
+<h2 data-expected-offset="3" headingoffset="1"><!-- Level 3, h2 + 1 --></h2>
+<h1 data-expected-offset="3" headingoffset="2"><!-- Level 3, h1 + 2--></h1>
+<h2 data-expected-offset="4" headingoffset="2"><!-- Level 4, h2 + 2 --></h2>
+<h1 data-expected-offset="2" headingoffset="1" headingreset>
+  <!-- Level 2, h1 + 1 (headingreset) -->
+</h1>
+<h2 data-expected-offset="3" headingoffset="1" headingreset>
+  <!-- Level 3, h2 + 1 (headingreset) -->
+</h2>
+<h1 data-expected-offset="3" headingoffset="2" headingreset>
+  <!-- Level 3, h1 + 2 (headingreset) -->
+</h1>
+<h2 data-expected-offset="4" headingoffset="2" headingreset>
+  <!-- Level 4, h2 + 2 (headingreset) -->
+</h2>
+<h1 data-expected-offset="9" headingoffset="20" headingreset>
+  <!-- Level 9, h1 + 20 (clamped)  -->
+</h1>
+<h2 data-expected-offset="9" headingoffset="20" headingreset>
+  <!-- Level 9, h2 + 20 (clamped) -->
+</h2>
+<h1 data-expected-offset="1" headingoffset="0" headingreset>
+  <!-- Level 1, h1 + 0 -->
+</h1>
+<h2 data-expected-offset="2" headingoffset="0" headingreset>
+  <!-- Level 2, h2 + 0 -->
+</h2>
+<div title="container with no attr">
+  <h1 data-expected-offset="2" headingoffset="1"><!-- Level 2, h1 + 1 --></h1>
+  <h2 data-expected-offset="3" headingoffset="1"><!-- Level 3, h2 + 1 --></h2>
+  <h1 data-expected-offset="2" headingoffset="1" headingreset>
+    <!-- Level 2, h1 + 1 -->
+  </h1>
+  <h2 data-expected-offset="3" headingoffset="1" headingreset>
+    <!-- Level 3, h2 + 1 -->
+  </h2>
+  <h1 data-expected-offset="1" headingoffset="-1" headingreset>
+    <!-- Level 1, h1 + (-1 clamped to 0) -->
+  </h1>
+  <h2 data-expected-offset="2" headingoffset="-1" headingreset>
+    <!-- Level 2, h2 + (-1 clamped to 0) -->
+  </h2>
+</div>
+<div headingreset title="many nested + and - values">
+  <div headingoffset="-1">
+    <div headingoffset="3">
+      <div headingoffset="-6">
+        <div headingoffset="1">
+          <h1 data-expected-offset="5">
+            <!-- Level 5, h1 + 1 + (-6 clamped to 0) + 3 + (-1 clamped to 0) -->
+          </h1>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<h1 data-expected-offset="9" headingoffset="9" aria-level="3">
+  <!-- Level 3 -->
+</h1>
+
+<div headingoffset="9" id="modalParent">
+  <dialog id="modal">
+    <h1></h1>
+  </dialog>
+</div>
+
+<script>
+  const attribute = (el, val) => el.setAttribute("headingoffset", val);
+  const property = (el, val) => (el.headingOffset = val);
+  const levels = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const matchAllLevels = (el) =>
+    levels.map((l) => el.matches(`:heading(${l})`));
+
+  for (const fn of [attribute, property]) {
+    test(function () {
+      const el = document.createElement("h1");
+      assert_true(el.matches(":heading"), `h1 should match :heading`);
+      assert_true(el.matches(":heading(1)"), `h1 should match :heading(1)`);
+      assert_equals(
+        el.headingOffset,
+        0,
+        `h1 has an initial headingOffset of 0`,
+      );
+      fn(el, 3);
+      assert_equals(el.headingOffset, 3, `h1 now has a headingOffset of 3`);
+      assert_false(
+        el.matches(":heading(1)"),
+        `h1[headingoffset=3] should no longer match :heading(1)`,
+      );
+      assert_true(
+        el.matches(":heading(4)"),
+        `h1[headingoffset=3] should match :heading(4)`,
+      );
+    }, `headingoffset (set via ${fn.name}) should change the level a heading matches against`);
+
+    test(function () {
+      const parent = document.createElement("div");
+      const el = document.createElement("h1");
+      parent.append(el);
+      assert_true(el.matches(":heading"), `h1 should match :heading`);
+      assert_true(el.matches(":heading(1)"), `h1 should match :heading(1)`);
+      assert_equals(
+        parent.headingOffset,
+        0,
+        `parent has an initial headingOffset of 0`,
+      );
+      fn(parent, 3);
+      assert_equals(parent.headingOffset, 3, `h1 now has a headingOffset of 3`);
+      assert_false(
+        el.matches(":heading(1)"),
+        `h1[headingoffset=3] should no longer match :heading(1)`,
+      );
+      assert_true(
+        el.matches(":heading(4)"),
+        `div[headingoffset=3] h1 should match :heading(4)`,
+      );
+      const bools = matchAllLevels(el);
+      const expected_bools = levels.map((l) => l == 4);
+      assert_array_equals(
+        bools,
+        expected_bools,
+        `${el.outerHTML} should match only the expected heading level`,
+      );
+      assert_false(el.headingReset, "h1 has an initial headingReset=false");
+      el.headingReset = true;
+      assert_true(el.headingReset, "h1 now has a headingReset of true");
+      assert_false(
+        el.matches(":heading(4)"),
+        `div[headingoffset=3] h1[headingreset] should not match :heading(4)`,
+      );
+      assert_true(
+        el.matches(":heading(1)"),
+        `div[headingoffset=3] h1[headingreset] should match :heading(1)`,
+      );
+      const reset_bools = matchAllLevels(el);
+      const reset_expected_bools = levels.map((l) => l == 1);
+      assert_array_equals(
+        reset_bools,
+        reset_expected_bools,
+        `${el.outerHTML} should match only the expected heading level`,
+      );
+    }, `headingoffset (set via ${fn.name}) should change the level when a parent changes offset`);
+  }
+
+  test(function (t) {
+    const el = modal.querySelector("h1");
+    assert_false(modal.headingReset, `modal dialog has not set heading reset`);
+    modal.showModal();
+    t.add_cleanup(() => modal.close());
+
+    assert_false(modal.headingReset, `modal dialogs return headingReset false by default`);
+    assert_true(el.matches(":heading"), `h1 inside modal should match :heading`);
+    assert_true(el.matches(":heading(9)"), `h1 inside modal should match :heading(9)`);
+    modal.headingReset = true;
+    assert_true(el.matches(":heading(1)"), `h1 inside modal should match :heading(1) if modal is headingreset`);
+    const bools = matchAllLevels(el);
+    const expected_bools = levels.map((l) => l == 1);
+    assert_array_equals(
+      bools,
+      expected_bools,
+      `${el.outerHTML} should match only the expected heading level`,
+    );
+  }, `headingoffset should not impact modals or explicit headingreset containers`);
+
+  let i = 0;
+  for (const el of document.querySelectorAll("[data-expected-offset]")) {
+    i += 1;
+    test(function () {
+      const expected = parseInt(el.getAttribute("data-expected-offset"));
+      assert_true(
+        expected > 0 && expected < 10,
+        "expected offset should be a level from 1 to 9",
+      );
+      assert_true(
+        el.matches(":heading"),
+        `${el.outerHTML} should match :heading`,
+      );
+      const bools = matchAllLevels(el);
+      const expected_bools = levels.map((l) => l == expected);
+      assert_true(
+        el.matches(`:heading(${expected})`),
+        `${el.outerHTML} should match :heading(${expected})`,
+      );
+      assert_array_equals(
+        bools,
+        expected_bools,
+        `${el.outerHTML} should match only the expected heading level`,
+      );
+    }, `case ${i}: heading level for ${el.outerHTML} should match based on expected document structure`);
+  }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headingoffset-mutations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headingoffset-mutations-expected.txt
@@ -1,0 +1,41 @@
+
+PASS headingoffset property mutations update descendant headings
+PASS nested headingoffset property mutations propagate to descendants
+PASS headingoffset property mutations update all heading types
+PASS headingoffset property mutations propagate to deeply nested desendants
+PASS headingoffset property mutations on shadow host update shadow DOM headings
+PASS headingoffset property mutations on ancestors of shadow host propagate to shadow DOM
+PASS headingoffset property mutations inside shadow DOM update correctly
+PASS headingoffset property mutations on host (not slot) update slotted headings
+PASS headingoffset property mutations propagate via host chain through nested shadow roots
+PASS headingoffset property mutations respect level clamping
+PASS headingoffset property mutations propagate via host chain across two levels of shadow DOM
+PASS headingoffset property propagates only via host chain through three nested shadow DOMs
+PASS headingoffset property mutations update headings at multiple shadow DOM levels independently
+PASS headingoffset attribute mutations update descendant headings
+PASS nested headingoffset attribute mutations propagate to descendants
+PASS headingoffset attribute mutations update all heading types
+PASS headingoffset attribute mutations propagate to deeply nested desendants
+PASS headingoffset attribute mutations on shadow host update shadow DOM headings
+PASS headingoffset attribute mutations on ancestors of shadow host propagate to shadow DOM
+PASS headingoffset attribute mutations inside shadow DOM update correctly
+PASS headingoffset attribute mutations on host (not slot) update slotted headings
+PASS headingoffset attribute mutations propagate via host chain through nested shadow roots
+PASS headingoffset attribute mutations respect level clamping
+PASS headingoffset attribute mutations propagate via host chain across two levels of shadow DOM
+PASS headingoffset attribute propagates only via host chain through three nested shadow DOMs
+PASS headingoffset attribute mutations update headings at multiple shadow DOM levels independently
+PASS headingreset mutations update descendant headings
+PASS headingreset and headingoffset mutations interact correctly
+PASS invalid headingoffset attribute values are handled correctly on mutation
+PASS slot name attribute changes do not change slotted heading levels
+PASS element slot attribute changes do not change heading levels
+PASS slot element removal and addition do not change slotted heading levels
+PASS default-to-named slot transitions do not change heading levels
+PASS swapping slot names does not change slotted heading levels
+PASS manual slot assignment does not change heading levels
+PASS manual slot reassignment between slots does not change heading levels
+PASS non-HTML elements (SVG) slotted with heading descendants get updated via host chain
+PASS non-HTML elements (MathML) slotted with heading descendants get updated via host chain
+PASS manual slot assignment of non-HTML elements does not change heading levels
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headingoffset-mutations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headingoffset-mutations.html
@@ -1,0 +1,721 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<link rel="help" href="https://github.com/whatwg/html/pull/11086" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div>
+  <h1 id="testMutation"></h1>
+</div>
+
+<div id="testNestedOuter">
+  <div id="testNestedInner">
+    <h1 id="testNested"></h1>
+  </div>
+</div>
+
+<div id="testResetMutationContainer" headingoffset="3">
+  <h1 id="testResetMutation"></h1>
+</div>
+
+<div id="testResetInteractionOuter" headingoffset="5">
+  <div id="testResetInteractionInner">
+    <h1 id="testResetInteraction"></h1>
+  </div>
+</div>
+
+<div id="testAllHeadingsContainer">
+  <h1 id="testAllH1"></h1>
+  <h2 id="testAllH2"></h2>
+  <h3 id="testAllH3"></h3>
+  <h4 id="testAllH4"></h4>
+  <h5 id="testAllH5"></h5>
+  <h6 id="testAllH6"></h6>
+</div>
+
+<div id="testDeepNestingContainer">
+  <div>
+    <div>
+      <h1 id="testDeepNesting"></h1>
+    </div>
+  </div>
+</div>
+
+<div id="testShadowHost">
+  <template shadowrootmode="open">
+    <h1 id="testShadowHostH1"></h1>
+  </template>
+</div>
+
+<div id="testShadowAncestor">
+  <div id="testShadowAncestorHost">
+    <template shadowrootmode="open">
+      <h1 id="testShadowAncestorH1"></h1>
+    </template>
+  </div>
+</div>
+
+<div id="testShadowInner">
+  <template shadowrootmode="open">
+    <div id="testShadowInnerContainer">
+      <h1 id="testShadowInnerH1"></h1>
+    </div>
+  </template>
+</div>
+
+<div id="testSlotted">
+  <template shadowrootmode="open">
+    <slot id="testSlottedSlot"></slot>
+  </template>
+  <h1 id="testSlottedH1"></h1>
+</div>
+
+<div id="testSlottedNested">
+  <template shadowrootmode="open">
+    <slot id="testSlottedNestedSlot"></slot>
+  </template>
+  <div id="testSlottedNestedChild">
+    <template shadowrootmode="open">
+      <h1 id="testSlottedNestedH1"></h1>
+    </template>
+  </div>
+</div>
+
+<div>
+  <h1 id="testClamping"></h1>
+</div>
+
+<div>
+  <h1 id="testInvalid"></h1>
+</div>
+
+<div id="testSlotNameChange">
+  <template shadowrootmode="open">
+    <div headingoffset="2">
+      <slot name="a" id="testSlotNameChangeSlotA"></slot>
+    </div>
+    <div headingoffset="4">
+      <slot name="b" id="testSlotNameChangeSlotB"></slot>
+    </div>
+  </template>
+  <h1 slot="a" id="testSlotNameChangeH1"></h1>
+</div>
+
+<div id="testSlotAttrChange">
+  <template shadowrootmode="open">
+    <div headingoffset="1">
+      <slot name="x" id="testSlotAttrChangeSlotX"></slot>
+    </div>
+    <div headingoffset="3">
+      <slot name="y" id="testSlotAttrChangeSlotY"></slot>
+    </div>
+  </template>
+  <h1 slot="x" id="testSlotAttrChangeH1"></h1>
+</div>
+
+<div id="testSlotRemoval">
+  <template shadowrootmode="open">
+    <div headingoffset="5">
+      <slot id="testSlotRemovalSlot"></slot>
+    </div>
+  </template>
+  <h1 id="testSlotRemovalH1"></h1>
+</div>
+
+<div id="testSlotDefault">
+  <template shadowrootmode="open">
+    <div headingoffset="2">
+      <slot id="testSlotDefaultSlot"></slot>
+    </div>
+  </template>
+  <h1 id="testSlotDefaultH1"></h1>
+</div>
+
+<div id="testSlotMultiple">
+  <template shadowrootmode="open">
+    <div headingoffset="1">
+      <slot name="first" id="testSlotMultipleSlotFirst"></slot>
+    </div>
+    <div headingoffset="3">
+      <slot name="second" id="testSlotMultipleSlotSecond"></slot>
+    </div>
+  </template>
+  <h1 slot="first" id="testSlotMultipleH1A"></h1>
+  <h1 slot="second" id="testSlotMultipleH1B"></h1>
+</div>
+
+<div id="testNestedShadow" headingoffset="1">
+  <template shadowrootmode="open">
+    <div headingoffset="2" id="testNestedShadowInner">
+      <slot id="testNestedShadowSlot"></slot>
+    </div>
+  </template>
+  <div id="testNestedShadowChild">
+    <template shadowrootmode="open">
+      <div headingoffset="3" id="testNestedShadowChildInner">
+        <h1 id="testNestedShadowH1"></h1>
+      </div>
+    </template>
+  </div>
+</div>
+
+<div id="testTripleShadow">
+  <template shadowrootmode="open">
+    <div headingoffset="1" id="testTripleShadowL1">
+      <slot id="testTripleShadowSlot1"></slot>
+    </div>
+  </template>
+  <div id="testTripleShadowChild1">
+    <template shadowrootmode="open">
+      <div headingoffset="1" id="testTripleShadowL2">
+        <slot id="testTripleShadowSlot2"></slot>
+      </div>
+    </template>
+    <div id="testTripleShadowChild2">
+      <template shadowrootmode="open">
+        <h1 id="testTripleShadowH1"></h1>
+      </template>
+    </div>
+  </div>
+</div>
+
+<div id="testSvgSlotted">
+  <template shadowrootmode="open">
+    <div headingoffset="2">
+      <slot id="testSvgSlottedSlot"></slot>
+    </div>
+  </template>
+</div>
+
+<div id="testNestedShadowHeadings">
+  <template shadowrootmode="open">
+    <div headingoffset="1" id="testNestedShadowHeadingsL1">
+      <slot id="testNestedShadowHeadingsSlot"></slot>
+      <h1 id="testNestedShadowHeadingsInnerH1"></h1>
+    </div>
+  </template>
+  <div id="testNestedShadowHeadingsChild">
+    <template shadowrootmode="open">
+      <div headingoffset="2" id="testNestedShadowHeadingsL2">
+        <h1 id="testNestedShadowHeadingsChildH1"></h1>
+      </div>
+    </template>
+  </div>
+</div>
+
+<div id="testManualSlot"></div>
+
+<div id="testManualSlotMultiple"></div>
+
+<script>
+  const levels = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const matchAllLevels = (el) => levels.map((l) => el.matches(`:heading(${l})`));
+  const assertLevel = (el, expected, msg) => {
+    const bools = matchAllLevels(el);
+    const expected_bools = levels.map((l) => l == expected);
+    assert_array_equals(bools, expected_bools, msg);
+  };
+
+  for (const style of ["property", "attribute"]) {
+    const set = (el, val) => {
+      if (style === "property") {
+        el.headingOffset = val;
+      } else {
+        el.setAttribute("headingoffset", String(val));
+      }
+    };
+    const clear = (el) => {
+      if (style === "property") {
+        el.headingOffset = 0;
+      } else {
+        el.removeAttribute("headingoffset");
+      }
+    };
+
+    test(t => {
+      const container = testMutation.parentElement;
+      t.add_cleanup(() => clear(container));
+
+      assertLevel(testMutation, 1, "h1 starts at level 1");
+      set(container, 2);
+      assertLevel(testMutation, 3, "h1 becomes level 3 after parent gets headingoffset=2");
+      set(container, 5);
+      assertLevel(testMutation, 6, "h1 becomes level 6 after parent headingoffset changes to 5");
+      clear(container);
+      assertLevel(testMutation, 1, "h1 returns to level 1 after parent headingoffset removed");
+    }, `headingoffset ${style} mutations update descendant headings`);
+
+    test(t => {
+      t.add_cleanup(() => {
+        clear(testNestedOuter);
+        clear(testNestedInner);
+      });
+
+      assertLevel(testNested, 1, "h1 starts at level 1");
+      set(testNestedOuter, 1);
+      assertLevel(testNested, 2, "h1 becomes level 2 after outer headingOffset=1");
+      set(testNestedInner, 2);
+      assertLevel(testNested, 4, "h1 becomes level 4 after inner headingOffset=2 (1+2+1)");
+      set(testNestedOuter, 3);
+      assertLevel(testNested, 6, "h1 becomes level 6 after outer headingOffset changes to 3 (3+2+1)");
+      clear(testNestedInner);
+      assertLevel(testNested, 4, "h1 becomes level 4 after inner headingOffset=0 (3+0+1)");
+    }, `nested headingoffset ${style} mutations propagate to descendants`);
+
+    test(t => {
+      t.add_cleanup(() => { testAllHeadingsContainer.headingOffset = 0; });
+
+      assertLevel(testAllH1, 1, "h1 starts at level 1");
+      assertLevel(testAllH2, 2, "h2 starts at level 2");
+      assertLevel(testAllH3, 3, "h3 starts at level 3");
+      assertLevel(testAllH4, 4, "h4 starts at level 4");
+      assertLevel(testAllH5, 5, "h5 starts at level 5");
+      assertLevel(testAllH6, 6, "h6 starts at level 6");
+
+      set(testAllHeadingsContainer, 2);
+
+      assertLevel(testAllH1, 3, "h1 becomes level 3");
+      assertLevel(testAllH2, 4, "h2 becomes level 4");
+      assertLevel(testAllH3, 5, "h3 becomes level 5");
+      assertLevel(testAllH4, 6, "h4 becomes level 6");
+      assertLevel(testAllH5, 7, "h5 becomes level 7");
+      assertLevel(testAllH6, 8, "h6 becomes level 8");
+    }, `headingoffset ${style} mutations update all heading types`);
+
+    test(t => {
+      t.add_cleanup(() => clear(testDeepNestingContainer));
+
+      assertLevel(testDeepNesting, 1, "deeply nested h1 starts at level 1");
+      set(testDeepNestingContainer, 3);
+      assertLevel(testDeepNesting, 4, "deeply nested h1 becomes level 4 after ancestor mutation");
+    }, `headingoffset ${style} mutations propagate to deeply nested desendants`);
+
+    test(t => {
+      const h1 = testShadowHost.shadowRoot.getElementById("testShadowHostH1");
+      t.add_cleanup(() => clear(testShadowHost));
+
+      assertLevel(h1, 1, "h1 in shadow DOM starts at level 1");
+      set(testShadowHost, 2);
+      assertLevel(h1, 3, "h1 in shadow DOM becomes level 3 after host headingoffset=2");
+      clear(testShadowHost);
+      assertLevel(h1, 1, "h1 in shadow DOM returns to level 1 after host headingoffset=0");
+    }, `headingoffset ${style} mutations on shadow host update shadow DOM headings`);
+
+    test(t => {
+      const h1 = testShadowAncestorHost.shadowRoot.getElementById("testShadowAncestorH1");
+      t.add_cleanup(() => {
+        clear(testShadowAncestor);
+        clear(testShadowAncestorHost);
+      });
+
+      assertLevel(h1, 1, "h1 in shadow DOM starts at level 1");
+      set(testShadowAncestor, 2);
+      assertLevel(h1, 3, "h1 in shadow DOM becomes level 3 after outer headingoffset=2");
+      set(testShadowAncestorHost, 1);
+      assertLevel(h1, 4, "h1 in shadow DOM becomes level 4 after host headingoffset=1 (2+1+1)");
+    }, `headingoffset ${style} mutations on ancestors of shadow host propagate to shadow DOM`);
+
+    test(t => {
+      const innerContainer = testShadowInner.shadowRoot.getElementById("testShadowInnerContainer");
+      const h1 = testShadowInner.shadowRoot.getElementById("testShadowInnerH1");
+      t.add_cleanup(() => {
+        clear(testShadowInner);
+        clear(innerContainer);
+      });
+
+      assertLevel(h1, 1, "h1 starts at level 1");
+      set(innerContainer, 2);
+      assertLevel(h1, 3, "h1 becomes level 3 after shadow DOM container headingoffset=2");
+      set(testShadowInner, 1);
+      assertLevel(h1, 4, "h1 becomes level 4 after host headingoffset=1 (1+2+1)");
+    }, `headingoffset ${style} mutations inside shadow DOM update correctly`);
+
+    test(t => {
+      const slot = testSlotted.shadowRoot.getElementById("testSlottedSlot");
+      t.add_cleanup(() => {
+        clear(testSlotted);
+        clear(slot);
+      });
+
+      assertLevel(testSlottedH1, 1, "slotted h1 starts at level 1");
+      set(slot, 2);
+      assertLevel(testSlottedH1, 1, "slot headingoffset=2 does not affect slotted h1");
+      set(testSlotted, 1);
+      assertLevel(testSlottedH1, 2, "slotted h1 becomes level 2 after host headingoffset=1");
+    }, `headingoffset ${style} mutations on host (not slot) update slotted headings`);
+
+    test(t => {
+      const slot = testSlottedNested.shadowRoot.getElementById("testSlottedNestedSlot");
+      const h1 = testSlottedNestedChild.shadowRoot.getElementById("testSlottedNestedH1");
+      t.add_cleanup(() => {
+        clear(testSlottedNested);
+        clear(slot);
+      });
+
+      assertLevel(h1, 1, "h1 in nested shadow starts at level 1");
+      set(slot, 2);
+      assertLevel(h1, 1, "outer slot headingoffset=2 does not affect h1");
+      set(testSlottedNested, 1);
+      assertLevel(h1, 2, "h1 becomes level 2 after outermost host headingoffset=1");
+    }, `headingoffset ${style} mutations propagate via host chain through nested shadow roots`);
+
+    test(t => {
+      const container = testClamping.parentElement;
+      t.add_cleanup(() => clear(container));
+
+      assertLevel(testClamping, 1, "h1 starts at level 1");
+      set(container, 10);
+      assertLevel(testClamping, 9, "h1 clamped to level 9 with headingoffset=10");
+      set(container, 100);
+      assertLevel(testClamping, 9, "h1 still clamped to level 9 with headingoffset=100");
+    }, `headingoffset ${style} mutations respect level clamping`);
+
+    test(t => {
+      const innerDiv = testNestedShadow.shadowRoot.getElementById("testNestedShadowInner");
+      const innerShadowDiv = testNestedShadowChild.shadowRoot.getElementById("testNestedShadowChildInner");
+      const h1 = testNestedShadowChild.shadowRoot.getElementById("testNestedShadowH1");
+      t.add_cleanup(() => {
+        set(testNestedShadow, 1);
+        set(innerDiv, 2);
+        set(innerShadowDiv, 3);
+      });
+
+      assertLevel(h1, 5, "h1 in nested shadow starts at level 5 (3+1+1)");
+      set(testNestedShadow, 0);
+      assertLevel(h1, 4, "h1 becomes level 4 after outermost headingoffset=0 (3+0+1)");
+      set(innerDiv, 0);
+      assertLevel(h1, 4, "outer shadow's slot wrapper does not affect h1");
+      set(innerShadowDiv, 0);
+      assertLevel(h1, 1, "h1 becomes level 1 after innermost wrapper headingoffset=0");
+      set(testNestedShadow, 2);
+      assertLevel(h1, 3, "h1 becomes level 3 after outermost headingoffset=2 (0+2+1)");
+    }, `headingoffset ${style} mutations propagate via host chain across two levels of shadow DOM`);
+
+    test(t => {
+      const l1 = testTripleShadow.shadowRoot.getElementById("testTripleShadowL1");
+      const l2 = testTripleShadowChild1.shadowRoot.getElementById("testTripleShadowL2");
+      const h1 = testTripleShadowChild2.shadowRoot.getElementById("testTripleShadowH1");
+      t.add_cleanup(() => {
+        set(l1, 1);
+        set(l2, 1);
+        clear(testTripleShadow);
+        clear(testTripleShadowChild1);
+      });
+
+      assertLevel(h1, 1, "h1 in triple shadow starts at level 1");
+      set(l1, 3);
+      assertLevel(h1, 1, "l1 in outer shadow tree does not affect h1");
+      set(l2, 2);
+      assertLevel(h1, 1, "l2 in middle shadow tree does not affect h1");
+      set(testTripleShadow, 2);
+      assertLevel(h1, 3, "h1 becomes level 3 after outermost host headingoffset=2 (2+1)");
+      set(testTripleShadowChild1, 1);
+      assertLevel(h1, 4, "h1 becomes level 4 after middle host headingoffset=1 (2+1+1)");
+      clear(testTripleShadow);
+      assertLevel(h1, 2, "h1 becomes level 2 after outermost cleared (1+1)");
+    }, `headingoffset ${style} propagates only via host chain through three nested shadow DOMs`);
+
+    test(t => {
+      const l1 = testNestedShadowHeadings.shadowRoot.getElementById("testNestedShadowHeadingsL1");
+      const l2 = testNestedShadowHeadingsChild.shadowRoot.getElementById("testNestedShadowHeadingsL2");
+      const innerH1 = testNestedShadowHeadings.shadowRoot.getElementById("testNestedShadowHeadingsInnerH1");
+      const childH1 = testNestedShadowHeadingsChild.shadowRoot.getElementById("testNestedShadowHeadingsChildH1");
+      t.add_cleanup(() => {
+        set(l1, 1);
+        set(l2, 2);
+      });
+
+      assertLevel(innerH1, 2, "inner h1 starts at level 2 (1+1)");
+      assertLevel(childH1, 3, "child h1 starts at level 3 (2+1)");
+      set(l1, 3);
+      assertLevel(innerH1, 4, "inner h1 becomes level 4 after l1 headingoffset=3 (3+1)");
+      assertLevel(childH1, 3, "l1 in outer shadow tree does not affect child h1");
+      set(l2, 0);
+      assertLevel(innerH1, 4, "inner h1 stays at level 4 (l2 change doesn't affect it)");
+      assertLevel(childH1, 1, "child h1 becomes level 1 after l2 headingoffset=0");
+    }, `headingoffset ${style} mutations update headings at multiple shadow DOM levels independently`);
+  }
+
+  test(t => {
+    t.add_cleanup(() => {
+      testResetMutationContainer.headingOffset = 3;
+      testResetMutationContainer.headingReset = false;
+    });
+
+    assertLevel(testResetMutation, 4, "h1 starts at level 4 (3+1)");
+    testResetMutationContainer.headingReset = true;
+    assertLevel(testResetMutation, 4, "h1 stays at level 4 after parent gets headingreset (still 3+1, but now reset)");
+    testResetMutationContainer.headingOffset = 1;
+    assertLevel(testResetMutation, 2, "h1 becomes level 2 after parent headingoffset changes to 1");
+    testResetMutationContainer.headingReset = false;
+    assertLevel(testResetMutation, 2, "h1 stays level 2 after headingreset removed (still 1+1)");
+  }, "headingreset mutations update descendant headings");
+
+  test(t => {
+    t.add_cleanup(() => {
+      testResetInteractionOuter.headingOffset = 5;
+      testResetInteractionInner.headingOffset = 0;
+      testResetInteractionInner.headingReset = false;
+    });
+
+    assertLevel(testResetInteraction, 6, "h1 starts at level 6 (5+1)");
+    testResetInteractionInner.headingReset = true;
+    assertLevel(testResetInteraction, 1, "h1 becomes level 1 after inner gets headingreset");
+    testResetInteractionInner.headingOffset = 2;
+    assertLevel(testResetInteraction, 3, "h1 becomes level 3 after inner headingoffset=2 (2+1, reset blocks outer)");
+    testResetInteractionInner.headingReset = false;
+    assertLevel(testResetInteraction, 8, "h1 becomes level 8 after inner headingreset removed (5+2+1)");
+  }, "headingreset and headingoffset mutations interact correctly");
+
+  test(t => {
+    const container = testInvalid.parentElement;
+    t.add_cleanup(() => container.removeAttribute("headingoffset"));
+
+    container.headingOffset = 2;
+    assertLevel(testInvalid, 3, "h1 at level 3 with headingoffset=2");
+    assert_equals(container.headingOffset, 2, "headingOffset property returns 2");
+
+    container.setAttribute("headingoffset", "invalid");
+    assertLevel(testInvalid, 1, "h1 returns to level 1 with invalid headingoffset");
+    assert_equals(container.headingOffset, 0, "headingOffset proprety returns 0 for invalid value");
+
+    container.setAttribute("headingoffset", "3");
+    assertLevel(testInvalid, 4, "h1 at level 4 with headingoffset=3");
+    assert_equals(container.headingOffset, 3, "headingOffset property returns 3");
+  }, "invalid headingoffset attribute values are handled correctly on mutation");
+
+  test(t => {
+    const slotA = testSlotNameChange.shadowRoot.getElementById("testSlotNameChangeSlotA");
+    const slotB = testSlotNameChange.shadowRoot.getElementById("testSlotNameChangeSlotB");
+    t.add_cleanup(() => {
+      slotA.name = "a";
+      testSlotNameChangeH1.slot = "a";
+      testSlotNameChange.removeAttribute("headingoffset");
+    });
+
+    assertLevel(testSlotNameChangeH1, 1, "h1 slotted into slot a starts at level 1");
+    slotA.name = "c";
+    assertLevel(testSlotNameChangeH1, 1, "h1 stays at level 1 when slot a renamed");
+    slotB.name = "a";
+    assertLevel(testSlotNameChangeH1, 1, "h1 stays at level 1 when reslotted into slot b");
+    testSlotNameChange.setAttribute("headingoffset", "2");
+    assertLevel(testSlotNameChangeH1, 3, "h1 becomes level 3 after host headingoffset=2");
+  }, "slot name attribute changes do not change slotted heading levels");
+
+  test(t => {
+    t.add_cleanup(() => {
+      testSlotAttrChangeH1.slot = "x";
+      testSlotAttrChange.removeAttribute("headingoffset");
+    });
+
+    assertLevel(testSlotAttrChangeH1, 1, "h1 with slot=x starts at level 1");
+    testSlotAttrChangeH1.slot = "y";
+    assertLevel(testSlotAttrChangeH1, 1, "h1 stays at level 1 when moved to slot y");
+    testSlotAttrChangeH1.slot = "nonexistent";
+    assertLevel(testSlotAttrChangeH1, 1, "h1 stays at level 1 when slot points to nonexistent slot");
+    testSlotAttrChangeH1.slot = "x";
+    testSlotAttrChange.setAttribute("headingoffset", "3");
+    assertLevel(testSlotAttrChangeH1, 4, "h1 becomes level 4 after host headingoffset=3");
+  }, "element slot attribute changes do not change heading levels");
+
+  test(t => {
+    const slot = testSlotRemoval.shadowRoot.getElementById("testSlotRemovalSlot");
+    const container = slot.parentElement;
+    t.add_cleanup(() => {
+      container.appendChild(slot);
+      testSlotRemoval.removeAttribute("headingoffset");
+    });
+
+    assertLevel(testSlotRemovalH1, 1, "h1 starts at level 1");
+    slot.remove();
+    assertLevel(testSlotRemovalH1, 1, "h1 stays at level 1 when slot removed");
+    container.appendChild(slot);
+    assertLevel(testSlotRemovalH1, 1, "h1 stays at level 1 when slot re-added");
+    testSlotRemoval.setAttribute("headingoffset", "4");
+    assertLevel(testSlotRemovalH1, 5, "h1 becomes level 5 after host headingoffset=4");
+  }, "slot element removal and addition do not change slotted heading levels");
+
+  test(t => {
+    const slot = testSlotDefault.shadowRoot.getElementById("testSlotDefaultSlot");
+    t.add_cleanup(() => {
+      slot.removeAttribute("name");
+      testSlotDefaultH1.removeAttribute("slot");
+      testSlotDefault.removeAttribute("headingoffset");
+    });
+
+    assertLevel(testSlotDefaultH1, 1, "h1 in default slot starts at level 1");
+    slot.name = "named";
+    assertLevel(testSlotDefaultH1, 1, "h1 stays at level 1 when default slot becomes named");
+    testSlotDefaultH1.slot = "named";
+    assertLevel(testSlotDefaultH1, 1, "h1 stays at level 1 when explicitly assigned to named slot");
+    slot.removeAttribute("name");
+    assertLevel(testSlotDefaultH1, 1, "h1 stays at level 1 when slot becomes default but h1 has explicit slot attr");
+    testSlotDefaultH1.removeAttribute("slot");
+    testSlotDefault.setAttribute("headingoffset", "2");
+    assertLevel(testSlotDefaultH1, 3, "h1 becomes level 3 after host headingoffset=2");
+  }, "default-to-named slot transitions do not change heading levels");
+
+  test(t => {
+    const slotFirst = testSlotMultiple.shadowRoot.getElementById("testSlotMultipleSlotFirst");
+    const slotSecond = testSlotMultiple.shadowRoot.getElementById("testSlotMultipleSlotSecond");
+    t.add_cleanup(() => {
+      slotFirst.name = "first";
+      slotSecond.name = "second";
+      testSlotMultiple.removeAttribute("headingoffset");
+    });
+
+    assertLevel(testSlotMultipleH1A, 1, "h1 A in slot first starts at level 1");
+    assertLevel(testSlotMultipleH1B, 1, "h1 B in slot second starts at level 1");
+
+    slotFirst.name = "second";
+    slotSecond.name = "first";
+
+    assertLevel(testSlotMultipleH1A, 1, "h1 A stays at level 1 after slot swap");
+    assertLevel(testSlotMultipleH1B, 1, "h1 B stays at level 1 after slot swap");
+
+    testSlotMultiple.setAttribute("headingoffset", "2");
+
+    assertLevel(testSlotMultipleH1A, 3, "h1 A becomes level 3 after host headingoffset=2");
+    assertLevel(testSlotMultipleH1B, 3, "h1 B becomes level 3 after host headingoffset=2");
+  }, "swapping slot names does not change slotted heading levels");
+
+  test(t => {
+    const shadow = testManualSlot.attachShadow({ mode: "open", slotAssignment: "manual" });
+    const slotContainer = document.createElement("div");
+    slotContainer.setAttribute("headingoffset", "2");
+    const slot = document.createElement("slot");
+    slotContainer.appendChild(slot);
+    shadow.appendChild(slotContainer);
+    const h1 = document.createElement("h1");
+    const div = document.createElement("div");
+    const divH1 = document.createElement("h1");
+    div.appendChild(divH1);
+    testManualSlot.appendChild(h1);
+    testManualSlot.appendChild(div);
+    t.add_cleanup(() => {
+      slot.assign();
+      h1.remove();
+      div.remove();
+      testManualSlot.removeAttribute("headingoffset");
+    });
+
+    assertLevel(h1, 1, "h1 starts at level 1");
+    assertLevel(divH1, 1, "h1 inside div starts at level 1");
+
+    slot.assign(h1);
+    assertLevel(h1, 1, "h1 stays at level 1 after manual slot assignment");
+
+    slot.assign(div);
+    assertLevel(h1, 1, "h1 stays at level 1 after unassignment");
+    assertLevel(divH1, 1, "h1 inside div stays at level 1 after div manually assigned");
+
+    testManualSlot.setAttribute("headingoffset", "1");
+    assertLevel(divH1, 2, "h1 inside manually-assigned div becomes level 2 after host headingoffset=1");
+
+    slot.assign();
+    assertLevel(divH1, 2, "h1 inside div stays at level 2 after slot cleared");
+  }, "manual slot assignment does not change heading levels");
+
+  test(t => {
+    const shadow = testManualSlotMultiple.attachShadow({ mode: "open", slotAssignment: "manual" });
+    const divA = document.createElement("div");
+    divA.setAttribute("headingoffset", "1");
+    const slotA = document.createElement("slot");
+    divA.appendChild(slotA);
+    shadow.appendChild(divA);
+    const divB = document.createElement("div");
+    divB.setAttribute("headingoffset", "3");
+    const slotB = document.createElement("slot");
+    divB.appendChild(slotB);
+    shadow.appendChild(divB);
+    const h1 = document.createElement("h1");
+    testManualSlotMultiple.appendChild(h1);
+    t.add_cleanup(() => {
+      slotA.assign();
+      slotB.assign();
+      h1.remove();
+      testManualSlotMultiple.removeAttribute("headingoffset");
+    });
+
+    assertLevel(h1, 1, "h1 starts at level 1 (not assigned)");
+    slotA.assign(h1);
+    assertLevel(h1, 1, "h1 stays at level 1 after assigned to slot A");
+    slotB.assign(h1);
+    assertLevel(h1, 1, "h1 stays at level 1 after reassigned to slot B");
+    slotA.assign(h1);
+    assertLevel(h1, 1, "h1 stays at level 1 after reassigned back to slot A");
+    testManualSlotMultiple.setAttribute("headingoffset", "2");
+    assertLevel(h1, 3, "h1 becomes level 3 after host headingoffset=2");
+  }, "manual slot reassignment between slots does not change heading levels");
+
+  test(t => {
+    const slot = testSvgSlotted.shadowRoot.getElementById("testSvgSlottedSlot");
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const foreignObject = document.createElementNS("http://www.w3.org/2000/svg", "foreignObject");
+    const h1 = document.createElement("h1");
+    foreignObject.appendChild(h1);
+    svg.appendChild(foreignObject);
+    testSvgSlotted.appendChild(svg);
+    t.add_cleanup(() => {
+      svg.remove();
+      testSvgSlotted.removeAttribute("headingoffset");
+    });
+
+    assertLevel(h1, 1, "h1 inside SVG foreignObject slotted starts at level 1");
+    slot.parentElement.headingOffset = 4;
+    assertLevel(h1, 1, "slot wrapper headingoffset=4 does not affect slotted SVG content");
+    testSvgSlotted.setAttribute("headingoffset", "2");
+    assertLevel(h1, 3, "h1 becomes level 3 after host headingoffset=2");
+  }, "non-HTML elements (SVG) slotted with heading descendants get updated via host chain");
+
+  test(t => {
+    const host = document.createElement("div");
+    const shadow = host.attachShadow({ mode: "open" });
+    const slotContainer = document.createElement("div");
+    slotContainer.setAttribute("headingoffset", "3");
+    const slot = document.createElement("slot");
+    slotContainer.appendChild(slot);
+    shadow.appendChild(slotContainer);
+
+    const mathml = document.createElementNS("http://www.w3.org/1998/Math/MathML", "math");
+    const h1 = document.createElement("h1");
+    mathml.appendChild(h1);
+    host.appendChild(mathml);
+    document.body.appendChild(host);
+    t.add_cleanup(() => host.remove());
+
+    assertLevel(h1, 1, "h1 inside MathML element slotted starts at level 1");
+    slotContainer.headingOffset = 5;
+    assertLevel(h1, 1, "slot wrapper headingoffset does not affect slotted MathML content");
+    host.headingOffset = 1;
+    assertLevel(h1, 2, "h1 becomes level 2 after host headingoffset=1");
+  }, "non-HTML elements (MathML) slotted with heading descendants get updated via host chain");
+
+  test(t => {
+    const host = document.createElement("div");
+    const shadow = host.attachShadow({ mode: "open", slotAssignment: "manual" });
+    const slotContainer = document.createElement("div");
+    slotContainer.setAttribute("headingoffset", "2");
+    const slot = document.createElement("slot");
+    slotContainer.appendChild(slot);
+    shadow.appendChild(slotContainer);
+
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const foreignObject = document.createElementNS("http://www.w3.org/2000/svg", "foreignObject");
+    const h1 = document.createElement("h1");
+    foreignObject.appendChild(h1);
+    svg.appendChild(foreignObject);
+    host.appendChild(svg);
+    document.body.appendChild(host);
+    t.add_cleanup(() => host.remove());
+
+    assertLevel(h1, 1, "h1 inside SVG starts at level 1 (not manually assigned)");
+    slot.assign(svg);
+    assertLevel(h1, 1, "h1 inside SVG stays at level 1 after SVG manually assigned");
+    host.headingOffset = 2;
+    assertLevel(h1, 3, "h1 becomes level 3 after host headingoffset=2");
+    slot.assign();
+    assertLevel(h1, 3, "h1 stays at level 3 after manual slot cleared");
+  }, "manual slot assignment of non-HTML elements does not change heading levels");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headings-and-sections/contains.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headings-and-sections/contains.json
@@ -1,6 +1,0 @@
-[
-    {
-        "id": "outlines",
-        "original_id": "outlines"
-    }
-]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/w3c-import.log
@@ -1,7 +1,7 @@
 The tests in this directory were imported from the W3C repository.
 Do NOT modify these tests directly in WebKit.
 Instead, create a pull request on the WPT github:
-	https://github.com/w3c/web-platform-tests
+	https://github.com/web-platform-tests/wpt
 
 Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
 
@@ -14,4 +14,5 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
-/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headings-and-sections/contains.json
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headingoffset-and-headingreset.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/sections/headingoffset-mutations.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -149,8 +149,8 @@ PASS HTMLElement interface: operation showPopover(optional ShowPopoverOptions)
 PASS HTMLElement interface: operation hidePopover()
 PASS HTMLElement interface: operation togglePopover(optional (TogglePopoverOptions or boolean))
 PASS HTMLElement interface: attribute popover
-FAIL HTMLElement interface: attribute headingOffset assert_true: The prototype object must have a property "headingOffset" expected true got false
-FAIL HTMLElement interface: attribute headingReset assert_true: The prototype object must have a property "headingReset" expected true got false
+PASS HTMLElement interface: attribute headingOffset
+PASS HTMLElement interface: attribute headingReset
 PASS HTMLElement interface: attribute onabort
 PASS HTMLElement interface: attribute onauxclick
 PASS HTMLElement interface: attribute onbeforeinput
@@ -262,8 +262,8 @@ PASS HTMLElement interface: document.createElement("noscript") must inherit prop
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "togglePopover(optional (TogglePopoverOptions or boolean))" with the proper type
 PASS HTMLElement interface: calling togglePopover(optional (TogglePopoverOptions or boolean)) on document.createElement("noscript") with too few arguments must throw TypeError
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "popover" with the proper type
-FAIL HTMLElement interface: document.createElement("noscript") must inherit property "headingOffset" with the proper type assert_inherits: property "headingOffset" not found in prototype chain
-FAIL HTMLElement interface: document.createElement("noscript") must inherit property "headingReset" with the proper type assert_inherits: property "headingReset" not found in prototype chain
+PASS HTMLElement interface: document.createElement("noscript") must inherit property "headingOffset" with the proper type
+PASS HTMLElement interface: document.createElement("noscript") must inherit property "headingReset" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onabort" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onauxclick" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onbeforeinput" with the proper type

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -149,8 +149,8 @@ PASS HTMLElement interface: operation showPopover(optional ShowPopoverOptions)
 PASS HTMLElement interface: operation hidePopover()
 PASS HTMLElement interface: operation togglePopover(optional (TogglePopoverOptions or boolean))
 PASS HTMLElement interface: attribute popover
-FAIL HTMLElement interface: attribute headingOffset assert_true: The prototype object must have a property "headingOffset" expected true got false
-FAIL HTMLElement interface: attribute headingReset assert_true: The prototype object must have a property "headingReset" expected true got false
+PASS HTMLElement interface: attribute headingOffset
+PASS HTMLElement interface: attribute headingReset
 PASS HTMLElement interface: attribute onabort
 PASS HTMLElement interface: attribute onauxclick
 PASS HTMLElement interface: attribute onbeforeinput
@@ -262,8 +262,8 @@ PASS HTMLElement interface: document.createElement("noscript") must inherit prop
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "togglePopover(optional (TogglePopoverOptions or boolean))" with the proper type
 PASS HTMLElement interface: calling togglePopover(optional (TogglePopoverOptions or boolean)) on document.createElement("noscript") with too few arguments must throw TypeError
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "popover" with the proper type
-FAIL HTMLElement interface: document.createElement("noscript") must inherit property "headingOffset" with the proper type assert_inherits: property "headingOffset" not found in prototype chain
-FAIL HTMLElement interface: document.createElement("noscript") must inherit property "headingReset" with the proper type assert_inherits: property "headingReset" not found in prototype chain
+PASS HTMLElement interface: document.createElement("noscript") must inherit property "headingOffset" with the proper type
+PASS HTMLElement interface: document.createElement("noscript") must inherit property "headingReset" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onabort" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onauxclick" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onbeforeinput" with the proper type

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3727,6 +3727,20 @@ HardwareAccelerationEnabled:
     WebCore:
       default: true
 
+HeadingOffsetEnabled:
+  type: bool
+  status: preview
+  category: html
+  humanReadableName: "HTML headingoffset & headingreset attributes"
+  humanReadableDescription: "Enable HTML headingoffset & headingreset attribute support"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 HiddenPageCSSAnimationSuspensionEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1653,21 +1653,7 @@ unsigned AXCoreObject::headingLevel() const
         if (level > 0)
             return level;
     }
-
-    auto elementName = this->elementName();
-    if (elementName == ElementName::HTML_h1)
-        return 1;
-    if (elementName == ElementName::HTML_h2)
-        return 2;
-    if (elementName == ElementName::HTML_h3)
-        return 3;
-    if (elementName == ElementName::HTML_h4)
-        return 4;
-    if (elementName == ElementName::HTML_h5)
-        return 5;
-    if (elementName == ElementName::HTML_h6)
-        return 6;
-    return 0;
+    return computedHeadingLevel();
 }
 
 unsigned AXCoreObject::hierarchicalLevel() const

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -762,6 +762,7 @@ public:
 
     unsigned blockquoteLevel() const;
     unsigned headingLevel() const;
+    virtual unsigned computedHeadingLevel() const { return 0; }
     virtual AccessibilityButtonState checkboxOrRadioValue() const = 0;
     virtual String valueDescription() const = 0;
     virtual float valueForRange() const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -860,6 +860,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::HasRemoteFrameChild:
         stream << "HasRemoteFrameChild";
         break;
+    case AXProperty::HeadingLevel:
+        stream << "HeadingLevel";
+        break;
     case AXProperty::IsARIAHidden:
         stream << "IsARIAHidden";
         break;

--- a/Source/WebCore/accessibility/AXNotifications.h
+++ b/Source/WebCore/accessibility/AXNotifications.h
@@ -67,6 +67,7 @@ namespace WebCore {
     macro(FrameLoadComplete) \
     macro(GrabbedStateChanged) \
     macro(HasPopupChanged) \
+    macro(HeadingLevelChanged) \
     macro(HiddenStateChanged) \
     macro(IdAttributeChanged) \
     macro(ImageOverlayChanged) \

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5819,6 +5819,9 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
         case AXNotification::LevelChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::ARIALevel });
             break;
+        case AXNotification::HeadingLevelChanged:
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::HeadingLevel });
+            break;
         case AXNotification::MaximumValueChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::MaxValueForRange, AXProperty::ValueForRange } });
             break;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -72,6 +72,7 @@
 #include "HTMLDataListElement.h"
 #include "HTMLDetailsElement.h"
 #include "HTMLFormControlElement.h"
+#include "HTMLHeadingElement.h"
 #include "HTMLInputElement.h"
 #include "HTMLModelElement.h"
 #include "HTMLNames.h"
@@ -1663,6 +1664,13 @@ RenderView* AccessibilityObject::topRenderer() const
 unsigned AccessibilityObject::ariaLevel() const
 {
     return std::max(0, integralAttribute(aria_levelAttr));
+}
+
+unsigned AccessibilityObject::computedHeadingLevel() const
+{
+    if (RefPtr heading = dynamicDowncast<HTMLHeadingElement>(node()))
+        return heading->level();
+    return 0;
 }
 
 String AccessibilityObject::language() const

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -553,6 +553,7 @@ public:
     RenderView* topRenderer() const;
     virtual ScrollView* scrollView() const { return nullptr; }
     unsigned ariaLevel() const final;
+    unsigned computedHeadingLevel() const final;
     String language() const final;
     // 1-based, to match the aria-level spec.
     bool isInlineText() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -414,6 +414,7 @@ private:
 #endif
     std::optional<AccessibilityOrientation> explicitOrientation() const { return optionalAttributeValue<AccessibilityOrientation>(AXProperty::ExplicitOrientation); }
     unsigned ariaLevel() const final { return unsignedAttributeValue(AXProperty::ARIALevel); }
+    unsigned computedHeadingLevel() const final { return unsignedAttributeValue(AXProperty::HeadingLevel); }
     String language() const final { return stringAttributeValue(AXProperty::Language); }
     void setSelectedChildren(const AccessibilityChildrenVector&) final;
     AccessibilityChildrenVector visibleChildren() final { return tree().objectsForIDs(vectorAttributeValue<AXID>(AXProperty::VisibleChildren)); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -666,6 +666,9 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
         case AXProperty::ARIALevel:
             properties.append({ AXProperty::ARIALevel, axObject.ariaLevel() });
             break;
+        case AXProperty::HeadingLevel:
+            properties.append({ AXProperty::HeadingLevel, axObject.computedHeadingLevel() });
+            break;
         case AXProperty::ValueAutofillButtonType:
             properties.append({ AXProperty::ValueAutofillButtonType, static_cast<int>(axObject.valueAutofillButtonType()) });
             properties.append({ AXProperty::IsValueAutofillAvailable, axObject.isValueAutofillAvailable() });
@@ -2510,6 +2513,9 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
 
         if (object.isHeading() || isExposedTableRow || isTreeItem)
             setProperty(AXProperty::ARIALevel, object.ariaLevel());
+
+        if (object.isHeading())
+            setProperty(AXProperty::HeadingLevel, object.computedHeadingLevel());
 
         // These properties are only needed on the AXCoreObject interface due to their use in ATSPI,
         // so only cache them for ATSPI.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -190,6 +190,7 @@ enum class AXProperty : uint16_t {
     HasApplePDFAnnotationAttribute,
     HasLinethrough,
     HasRemoteFrameChild,
+    HeadingLevel,
     InputType,
     IsEditableWebArea,
     IsSubscript,

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -39,6 +39,7 @@
 #include "ElementRareData.h"
 #include "FunctionCall.h"
 #include "HTMLDocument.h"
+#include "HTMLHeadingElement.h"
 #include "HTMLNames.h"
 #include "InspectorInstrumentation.h"
 #include "Namespace.h"
@@ -3946,8 +3947,6 @@ void SelectorCodeGenerator::generateElementMatchesHeading(Assembler::JumpList& f
 
 void SelectorCodeGenerator::generateElementMatchesHeading(Assembler::JumpList& failureCases, const FixedVector<int>* integerList)
 {
-    // FIXME: When HTMLHeadingElement caches an effective offset (headingoffset/headingreset),
-    // load that byte here, add it to the base, and saturate at 9.
     LocalRegister nodeName(m_registerAllocator);
     {
         LocalRegister qualifiedNameImpl(m_registerAllocator);
@@ -3963,10 +3962,16 @@ void SelectorCodeGenerator::generateElementMatchesHeading(Assembler::JumpList& f
     if (!integerList)
         return;
 
-    uint8_t levelMask = 0;
+    LocalRegister offset(m_registerAllocator);
+    m_assembler.load8(Assembler::Address(elementAddressRegister, HTMLHeadingElement::effectiveHeadingOffsetMemoryOffset()), offset);
+    m_assembler.add32(offset, nodeName);
+    m_assembler.add32(Assembler::TrustedImm32(1), nodeName);
+    m_assembler.moveConditionally32(Assembler::Above, nodeName, Assembler::TrustedImm32(9), Assembler::TrustedImm32(9), nodeName, nodeName);
+
+    uint16_t levelMask = 0;
     for (int level : *integerList) {
-        if (level >= 1 && level <= 6)
-            levelMask |= 1u << (level - 1);
+        if (level >= 1 && level <= 9)
+            levelMask |= 1u << level;
     }
     if (!levelMask) {
         failureCases.append(m_assembler.jump());

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2027,6 +2027,9 @@ public:
     void addElementWithPendingUserAgentShadowTreeUpdate(Element&);
     WEBCORE_EXPORT void removeElementWithPendingUserAgentShadowTreeUpdate(Element&);
 
+    bool usesHeadingOffsetAttribute() const { return m_usesHeadingOffsetAttribute; }
+    void setUsesHeadingOffsetAttribute() { m_usesHeadingOffsetAttribute = true; }
+
     std::optional<PAL::SessionID> sessionID() const final;
 
     ReportingScope* reportingScopeIfExists() const { return m_reportingScope.get(); }
@@ -2812,6 +2815,7 @@ private:
     bool m_inHitTesting { false };
 #endif
     bool m_isDirAttributeDirty { false };
+    bool m_usesHeadingOffsetAttribute { false };
 
     bool m_scheduledDeferredAXObjectCacheUpdate { false };
     bool m_wasRemovedLastRefCalled { false };

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -159,6 +159,8 @@ formtarget
 frame
 frameborder
 headers
+headingoffset
+headingreset
 height
 hidden
 high

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -64,6 +64,7 @@
 #include "HTMLElementFactory.h"
 #include "HTMLFieldSetElement.h"
 #include "HTMLFormElement.h"
+#include "HTMLHeadingElement.h"
 #include "HTMLInputElement.h"
 #include "HTMLMaybeFormAssociatedCustomElement.h"
 #include "HTMLNames.h"
@@ -392,6 +393,13 @@ void HTMLElement::attributeChanged(const QualifiedName& name, const AtomString& 
             setTabIndexExplicitly(optionalTabIndex.value());
         else
             setTabIndexExplicitly(std::nullopt);
+        return;
+    case AttributeNames::headingoffsetAttr:
+    case AttributeNames::headingresetAttr:
+        if (document().settings().headingOffsetEnabled()) {
+            document().setUsesHeadingOffsetAttribute();
+            updateEffectiveHeadingOffsetForElementAndDescendants(*this, computedHeadingOffset(*this));
+        }
         return;
     case AttributeNames::inertAttr:
         invalidateStyle();

--- a/Source/WebCore/html/HTMLElement.idl
+++ b/Source/WebCore/html/HTMLElement.idl
@@ -53,6 +53,10 @@
 
     [CEReactions=Needed, Reflect] attribute boolean inert;
 
+    // The headingoffset & headingreset attributes
+    [CEReactions=Needed, EnabledBySetting=HeadingOffsetEnabled, Reflect] attribute unsigned long headingOffset;
+    [CEReactions=Needed, EnabledBySetting=HeadingOffsetEnabled, Reflect] attribute boolean headingReset;
+
     // The popover API
     [EnabledBySetting=PopoverAttributeEnabled] undefined showPopover(optional ShowPopoverOptions options = {});
     [EnabledBySetting=PopoverAttributeEnabled] undefined hidePopover();

--- a/Source/WebCore/html/HTMLHeadingElement.cpp
+++ b/Source/WebCore/html/HTMLHeadingElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -23,7 +23,16 @@
 #include "config.h"
 #include "HTMLHeadingElement.h"
 
+#include "AXNotifications.h"
+#include "AXObjectCache.h"
+#include "CSSSelector.h"
+#include "Document.h"
+#include "ElementChildIteratorInlines.h"
 #include "HTMLNames.h"
+#include "HTMLParserIdioms.h"
+#include "PseudoClassChangeInvalidation.h"
+#include "Settings.h"
+#include "ShadowRoot.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -42,20 +51,93 @@ Ref<HTMLHeadingElement> HTMLHeadingElement::create(const QualifiedName& tagName,
 
 HTMLHeadingElement::~HTMLHeadingElement() = default;
 
-unsigned HTMLHeadingElement::level() const
+static unsigned localHeadingOffset(const HTMLElement& element)
 {
-    if (hasTagName(HTMLNames::h1Tag))
-        return 1;
-    if (hasTagName(HTMLNames::h2Tag))
-        return 2;
-    if (hasTagName(HTMLNames::h3Tag))
-        return 3;
-    if (hasTagName(HTMLNames::h4Tag))
-        return 4;
-    if (hasTagName(HTMLNames::h5Tag))
-        return 5;
-    ASSERT(hasTagName(HTMLNames::h6Tag));
-    return 6;
+    auto& value = element.attributeWithoutSynchronization(HTMLNames::headingoffsetAttr);
+    if (value.isNull())
+        return 0;
+    auto parsed = parseHTMLNonNegativeInteger(value);
+    if (!parsed)
+        return 0;
+    return std::min<unsigned>(9, *parsed);
 }
 
+// https://html.spec.whatwg.org/multipage/sections.html#get-an-element's-computed-heading-offset
+unsigned computedHeadingOffset(const Element& element)
+{
+    unsigned offset = 0;
+    for (RefPtr ancestor = const_cast<Element*>(&element); ancestor; ancestor = ancestor->parentOrShadowHostElement()) {
+        RefPtr htmlAncestor = dynamicDowncast<HTMLElement>(*ancestor);
+        if (!htmlAncestor)
+            continue;
+        offset = std::min<unsigned>(9, offset + localHeadingOffset(*htmlAncestor));
+        if (htmlAncestor->hasAttributeWithoutSynchronization(HTMLNames::headingresetAttr))
+            return offset;
+    }
+    return offset;
 }
+
+unsigned HTMLHeadingElement::level() const
+{
+    unsigned base;
+    if (hasTagName(HTMLNames::h1Tag))
+        base = 1;
+    else if (hasTagName(HTMLNames::h2Tag))
+        base = 2;
+    else if (hasTagName(HTMLNames::h3Tag))
+        base = 3;
+    else if (hasTagName(HTMLNames::h4Tag))
+        base = 4;
+    else if (hasTagName(HTMLNames::h5Tag))
+        base = 5;
+    else {
+        ASSERT(hasTagName(HTMLNames::h6Tag));
+        base = 6;
+    }
+    if (!document().settings().headingOffsetEnabled())
+        return base;
+    return std::min<unsigned>(9, base + m_effectiveHeadingOffset);
+}
+
+Node::NeedsPostConnectionSteps HTMLHeadingElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+{
+    auto result = HTMLElement::insertionSteps(insertionType, parentOfInsertedTree);
+
+    if (insertionType.connectedToDocument && document().settings().headingOffsetEnabled())
+        setEffectiveHeadingOffset(document().usesHeadingOffsetAttribute() ? computedHeadingOffset(*this) : 0);
+
+    return result;
+}
+
+static void setEffectiveHeadingOffsetIfDifferent(HTMLHeadingElement& heading, unsigned offset)
+{
+    if (offset == heading.effectiveHeadingOffset())
+        return;
+    Style::PseudoClassChangeInvalidation styleInvalidation(heading, CSSSelector::PseudoClass::Heading, Style::PseudoClassChangeInvalidation::AnyValue);
+    heading.setEffectiveHeadingOffset(offset);
+    if (CheckedPtr cache = protect(heading.document())->existingAXObjectCache())
+        cache->postNotification(&heading, AXNotification::HeadingLevelChanged);
+}
+
+void updateEffectiveHeadingOffsetForElementAndDescendants(Element& root, unsigned rootOffset)
+{
+    if (RefPtr heading = dynamicDowncast<HTMLHeadingElement>(root))
+        setEffectiveHeadingOffsetIfDifferent(*heading, rootOffset);
+
+    auto recurseInto = [&](ContainerNode& container) {
+        for (Ref child : childrenOfType<Element>(container)) {
+            RefPtr htmlChild = dynamicDowncast<HTMLElement>(child.get());
+            if (htmlChild && htmlChild->hasAttributeWithoutSynchronization(HTMLNames::headingresetAttr))
+                continue;
+            unsigned localOffset = htmlChild ? localHeadingOffset(*htmlChild) : 0;
+            unsigned childOffset = std::min<unsigned>(9, rootOffset + localOffset);
+            updateEffectiveHeadingOffsetForElementAndDescendants(child.get(), childOffset);
+        }
+    };
+
+    recurseInto(root);
+    if (RefPtr shadowRoot = root.shadowRoot())
+        recurseInto(*shadowRoot);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLHeadingElement.h
+++ b/Source/WebCore/html/HTMLHeadingElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -34,11 +34,23 @@ public:
 
     ~HTMLHeadingElement();
 
-    unsigned NODELETE level() const;
+    unsigned level() const;
+
+    unsigned effectiveHeadingOffset() const { return m_effectiveHeadingOffset; }
+    void setEffectiveHeadingOffset(unsigned offset) { m_effectiveHeadingOffset = std::min<unsigned>(9, offset); }
+
+    static constexpr ptrdiff_t effectiveHeadingOffsetMemoryOffset() { return OBJECT_OFFSETOF(HTMLHeadingElement, m_effectiveHeadingOffset); }
 
 private:
     HTMLHeadingElement(const QualifiedName&, Document&);
+
+    Node::NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode& parentOfInsertedTree) final;
+
+    uint8_t m_effectiveHeadingOffset { 0 };
 };
+
+unsigned computedHeadingOffset(const Element&);
+void updateEffectiveHeadingOffsetForElementAndDescendants(Element& root, unsigned rootOffset);
 
 } // namespace WebCore
 

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -472,20 +472,16 @@ void RuleSet::addRuleToBucket(RuleData& ruleData)
     }
 
     if (headingPseudoClassSelector) {
-        std::array<bool, 7> wantedLevel { };
+        unsigned highestMatchableBase = 0;
         if (auto* integerList = headingPseudoClassSelector->integerList()) {
             for (int level : *integerList) {
-                if (level >= 1 && level <= 6)
-                    wantedLevel[level] = true;
+                if (level >= 1 && level <= 9)
+                    highestMatchableBase = std::max(highestMatchableBase, std::min<unsigned>(level, 6));
             }
-        } else {
-            for (unsigned level = 1; level <= 6; ++level)
-                wantedLevel[level] = true;
-        }
-        bool addedToAnyBucket = false;
-        for (unsigned level = 1; level <= 6; ++level) {
-            if (!wantedLevel[level])
-                continue;
+        } else
+            highestMatchableBase = 6;
+
+        for (unsigned level = 1; level <= highestMatchableBase; ++level) {
             auto& tag = [&] -> const HTMLQualifiedName& {
                 switch (level) {
                 case 1: return HTMLNames::h1Tag;
@@ -498,9 +494,8 @@ void RuleSet::addRuleToBucket(RuleData& ruleData)
             }();
             addToRuleSet(tag.localName(), m_tagLocalNameRules, ruleData);
             addToRuleSet(tag.localName(), m_tagLowercaseLocalNameRules, ruleData);
-            addedToAnyBucket = true;
         }
-        if (addedToAnyBucket)
+        if (highestMatchableBase)
             return;
     }
 


### PR DESCRIPTION
#### bb6d1b4a1f91239eed5808209db60ab7cd4081d9
<pre>
Implement headingoffset &amp; headingreset attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=295092">https://bugs.webkit.org/show_bug.cgi?id=295092</a>
<a href="https://rdar.apple.com/155028047">rdar://155028047</a>

Reviewed by Tim Nguyen.

They are implemented behind the HeadingOffsetEnabled feature flag
(preview). The complexity of the feature lies in correctly invalidating
the :heading pseudo-class.

Tests: imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has-with-headingoffset.html
       imported/w3c/web-platform-tests/css/selectors/invalidation/heading-pseudo-class-in-has-with-slot-reassignment.html
       imported/w3c/web-platform-tests/html/semantics/sections/headingoffset-and-headingreset.html
       imported/w3c/web-platform-tests/html/semantics/sections/headingoffset-mutations.html

This includes a fix for a recent (and hopefully last) change for this
feature:

   <a href="https://github.com/whatwg/html/pull/12562">https://github.com/whatwg/html/pull/12562</a>
   <a href="https://github.com/web-platform-tests/wpt/pull/60525">https://github.com/web-platform-tests/wpt/pull/60525</a>

Canonical link: <a href="https://commits.webkit.org/316885@main">https://commits.webkit.org/316885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91384e4296ed271c2ed0348160ac8b88ca911fb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47664 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41445 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183305 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47346 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/de582a9f-ded0-4b8f-b76a-2b3f28756564) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38531 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/115582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49626d50-b8eb-4553-a00c-7f63dd2cf0a9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37172 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31789 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/4399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147596 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185731 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34993 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39730 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47331 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143848 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48010 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113240 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26406 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38769 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46516 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45918 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46149 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45977 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->