### PR TITLE
Cherry-pick(s) cf2e67ecb913. rdar://176061945

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProvokingVertexHelper.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProvokingVertexHelper.mm
@@ -22,15 +22,29 @@ namespace rx
 namespace
 {
 constexpr size_t kInitialIndexBufferSize = 0xFFFF;  // Initial 64k pool.
+<<<<<<< HEAD
 }
 static inline uint32_t primCountForIndexCount(const uint fixIndexBufferKey,
                                               const GLsizei indexCount)
 {
     const uint fixIndexBufferMode =
         (fixIndexBufferKey >> MtlFixIndexBufferKeyModeShift) & MtlFixIndexBufferKeyModeMask;
+=======
+>>>>>>> cf2e67ecb913 (ANGLE: REGRESSION(305413.478@safari-7624-branch) Drawing large amount of indices causes validation failure again)
 
-    switch (fixIndexBufferMode)
+struct IndexedDrawRewriteInfoMtl {
+    uint32_t primitiveCount;
+    size_t newIndexCount;
+    gl::PrimitiveMode newPrimitiveMode;
+};
+
+// Returns counts for Metal indexed draw for GL indexed draw parameters.
+inline IndexedDrawRewriteInfoMtl resolveIndexedDrawRewriteInfo(gl::PrimitiveMode mode, GLsizei count)
+{
+    uint32_t indexCount = static_cast<uint32_t>(count);
+    switch (mode)
     {
+<<<<<<< HEAD
         case MtlFixIndexBufferKeyPoints:
             return indexCount;
         case MtlFixIndexBufferKeyLines:
@@ -48,12 +62,30 @@ static inline uint32_t primCountForIndexCount(const uint fixIndexBufferKey,
         case MtlFixIndexBufferKeyTriangleFan:
             // Prevent underflow with subtraction and avoid casting to a signed type
             return std::max(indexCount - 2, 0);
+=======
+        case gl::PrimitiveMode::Points:
+            return {indexCount, indexCount, gl::PrimitiveMode::Points};
+        case gl::PrimitiveMode::Lines:
+            return {indexCount / 2, indexCount - (indexCount % 2), gl::PrimitiveMode::Lines};
+        case gl::PrimitiveMode::LineLoop:
+            return {indexCount, static_cast<size_t>(indexCount) * 2, gl::PrimitiveMode::Lines};
+        case gl::PrimitiveMode::LineStrip:
+            indexCount = indexCount < 1 ? 0 : indexCount - 1;
+            return {indexCount, static_cast<size_t>(indexCount) * 2, gl::PrimitiveMode::Lines};
+        case gl::PrimitiveMode::Triangles:
+            return {indexCount / 3, indexCount - (indexCount % 3), gl::PrimitiveMode::Triangles};
+        case gl::PrimitiveMode::TriangleStrip:
+        case gl::PrimitiveMode::TriangleFan:
+            indexCount = indexCount < 2 ? 0 : indexCount - 2;
+            return {indexCount, static_cast<size_t>(indexCount) * 3, gl::PrimitiveMode::Triangles};
+>>>>>>> cf2e67ecb913 (ANGLE: REGRESSION(305413.478@safari-7624-branch) Drawing large amount of indices causes validation failure again)
         default:
-            ASSERT(false);
-            return 0;
+            UNREACHABLE();
+            return {0, 0, gl::PrimitiveMode::InvalidEnum};
     }
 }
 
+<<<<<<< HEAD
 static inline bool indexCountForPrimCount(const uint fixIndexBufferKey,
                                           const uint32_t primCount,
                                           uint32_t *outIndexCount)
@@ -113,6 +145,8 @@ static inline gl::PrimitiveMode getNewPrimitiveMode(const uint fixIndexBufferKey
             ASSERT(false);
             return gl::PrimitiveMode::InvalidEnum;
     }
+=======
+>>>>>>> cf2e67ecb913 (ANGLE: REGRESSION(305413.478@safari-7624-branch) Drawing large amount of indices causes validation failure again)
 }
 ProvokingVertexHelper::ProvokingVertexHelper(ContextMtl *context) : mIndexBuffers(false)
 {
@@ -205,6 +239,7 @@ angle::Result ProvokingVertexHelper::preconditionIndexBuffer(ContextMtl *context
     // Upload index buffer
     // dispatch per-primitive?
     uint indexBufferKey = buildIndexBufferKey(elementsType, primitiveRestartEnabled, primitiveMode);
+<<<<<<< HEAD
     uint32_t primCount     = primCountForIndexCount(indexBufferKey, glCount);
     uint32_t newIndexCount = 0;
     ANGLE_CHECK_GL_MATH(context, indexCountForPrimCount(indexBufferKey, primCount, &newIndexCount));
@@ -218,6 +253,16 @@ angle::Result ProvokingVertexHelper::preconditionIndexBuffer(ContextMtl *context
 
     ANGLE_CHECK_GL_MATH(context, checkedBufferSize.IsValid());
     ANGLE_TRY(mIndexBuffers.allocate(context, checkedBufferSize.ValueOrDie(), &newBuffer));
+=======
+    auto [primCount, newIndexCount, newPrimitiveMode] = resolveIndexedDrawRewriteInfo(primitiveMode, count);
+    // We do not support large buffers at the moment.
+    ANGLE_CHECK_GL_MATH(context, newIndexCount <= std::numeric_limits<uint32_t>::max());
+    size_t newIndexBufferSize = newIndexCount << gl::GetDrawElementsTypeShift(elementsType);
+    size_t newOffset          = 0;
+    mtl::BufferRef newBuffer;
+    ANGLE_TRY(mIndexBuffers.allocate(context, newIndexBufferSize + indexOffset, nullptr,
+                                     &newBuffer, &newOffset));
+>>>>>>> cf2e67ecb913 (ANGLE: REGRESSION(305413.478@safari-7624-branch) Drawing large amount of indices causes validation failure again)
     auto threadsPerThreadgroup = MTLSizeMake(MIN(primCount, 64u), 1, 1);
 
     mtl::ComputeCommandEncoder *encoder =
@@ -235,9 +280,15 @@ angle::Result ProvokingVertexHelper::preconditionIndexBuffer(ContextMtl *context
                     1, 1),
         threadsPerThreadgroup);
     outIndexCount    = static_cast<uint32_t>(newIndexCount);
+<<<<<<< HEAD
     outIndexOffset   = newBuffer.offset();
     outPrimitiveMode = getNewPrimitiveMode(indexBufferKey);
     outNewBuffer     = newBuffer.buffer();
+=======
+    outIndexOffset   = newOffset;
+    outPrimitiveMode = newPrimitiveMode;
+    outNewBuffer     = newBuffer;
+>>>>>>> cf2e67ecb913 (ANGLE: REGRESSION(305413.478@safari-7624-branch) Drawing large amount of indices causes validation failure again)
     return angle::Result::Continue;
 }
 
@@ -256,6 +307,7 @@ angle::Result ProvokingVertexHelper::generateIndexBuffer(ContextMtl *context,
     // dispatch per-primitive?
     const bool primitiveRestartEnabled = false;
     uint indexBufferKey = buildIndexBufferKey(elementsType, primitiveRestartEnabled, primitiveMode);
+<<<<<<< HEAD
     uint32_t primCount  = primCountForIndexCount(indexBufferKey, glCount);
 
     uint32_t newIndexCount = 0;
@@ -269,6 +321,16 @@ angle::Result ProvokingVertexHelper::generateIndexBuffer(ContextMtl *context,
 
     ANGLE_CHECK_GL_MATH(context, checkedBufferSize.IsValid());
     ANGLE_TRY(mIndexBuffers.allocate(context, checkedBufferSize.ValueOrDie(), &newBuffer));
+=======
+    auto [primCount, newIndexCount, newPrimitiveMode] = resolveIndexedDrawRewriteInfo(primitiveMode, count);
+    // We do not support large buffers at the moment.
+    ANGLE_CHECK_GL_MATH(context, newIndexCount <= std::numeric_limits<uint32_t>::max());
+    size_t newIndexBufferSize = newIndexCount << gl::GetDrawElementsTypeShift(elementsType);
+    size_t newIndexOffset = 0;
+    mtl::BufferRef newBuffer;
+    ANGLE_TRY(mIndexBuffers.allocate(context, newIndexBufferSize, nullptr, &newBuffer,
+                                     &newIndexOffset));
+>>>>>>> cf2e67ecb913 (ANGLE: REGRESSION(305413.478@safari-7624-branch) Drawing large amount of indices causes validation failure again)
     auto threadsPerThreadgroup = MTLSizeMake(MIN(primCount, 64u), 1, 1);
 
     mtl::ComputeCommandEncoder *encoder =
@@ -286,9 +348,15 @@ angle::Result ProvokingVertexHelper::generateIndexBuffer(ContextMtl *context,
                     1, 1),
         threadsPerThreadgroup);
     outIndexCount    = static_cast<uint32_t>(newIndexCount);
+<<<<<<< HEAD
     outIndexOffset   = newBuffer.offset();
     outPrimitiveMode = getNewPrimitiveMode(indexBufferKey);
     outNewBuffer     = newBuffer.buffer();
+=======
+    outIndexOffset   = newIndexOffset;
+    outPrimitiveMode = newPrimitiveMode;
+    outNewBuffer     = newBuffer;
+>>>>>>> cf2e67ecb913 (ANGLE: REGRESSION(305413.478@safari-7624-branch) Drawing large amount of indices causes validation failure again)
     return angle::Result::Continue;
 }
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176061945 to main. [cf2e67ecb913] caused a merge conflict. 

```ANGLE: REGRESSION(305413.478@safari-7624-branch) Drawing large amount of indices causes validation failure again
https://bugs.webkit.org/show_bug.cgi?id=310527
rdar://171930518

Reviewed by Dan Glastonbury.

Following ANGLE update was incorrect:
    305413.478@safari-7624-branch
    Cherry-pick b8fc3646bc85. rdar://172393738
    Update ANGLE to 2026-01-27 (39dd12fb75bd11328c19faf9b7427723d14c9ed8)

The commit would erase the fix:
    305413.55@safari-7624-branch
    ANGLE: Metal: Drawing large amount of indices causes validation failure
    https://bugs.webkit.org/show_bug.cgi?id=305627
    rdar://166536416

Reintroduce the fix.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProvokingVertexHelper.mm:
(rx::ProvokingVertexHelper::preconditionIndexBuffer):
(rx::ProvokingVertexHelper::generateIndexBuffer):
(rx::primCountForIndexCount): Deleted.
(rx::indexCountForPrimCount): Deleted.
(rx::getNewPrimitiveMode): Deleted.

Originally-landed-as: 305413.564@rapid/safari-7624.2.5.110-branch (cf2e67ecb913). rdar://176061945

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc61e0ac020d9ea35b638a199ddfa4767d3876e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164499 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/37983 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/31554 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/173529 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121751 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38317 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37985 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/173529 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121751 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/167458 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38317 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/31554 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/173529 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38317 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37985 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/21292 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38317 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/31554 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176055 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31554 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/176055 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38052 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/37985 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176055 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38742 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/31554 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100894 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38742 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31554 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37250 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/36648 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/31554 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/36896 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/36796 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->