### PR TITLE
[macOS Tahoe] imported/w3c/web-platform-tests/url/IdnaTestV2.any.html is a constant text failure.

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2264,8 +2264,6 @@ webkit.org/b/315308 http/tests/inspector/network/cross-origin-iframe-get-respons
 
 webkit.org/b/308165 [ Debug ] scrollingcoordinator/mac/latching/simple-page-rubberbands.html [ Pass Failure ]
 
-webkit.org/b/315578 imported/w3c/web-platform-tests/url/IdnaTestV2.any.html [ Failure ]
-
 webkit.org/b/311759 [ Release arm64 ] imported/w3c/web-platform-tests/event-timing/keydown.html [ Pass Failure ]
 
 webkit.org/b/308325 [ Debug ] http/wpt/cache-storage/cache-in-stopped-context.html [ Pass Failure ]

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/url/IdnaTestV2.any-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/url/IdnaTestV2.any-expected.txt
@@ -1822,8 +1822,8 @@ PASS ToASCII("1꫶Ss𑲥。ᷘ") V6
 PASS ToASCII("１꫶Ss𑲥｡ᷘ") V6
 PASS ToASCII("xn--3j78f.xn--mkb20b") V7
 PASS ToASCII("𲤱⒛⾳．ꡦ⒈") V7
-FAIL ToASCII("𲤱20.音.ꡦ1.") A4_2 (ignored) "https://𲤱20.音.ꡦ1./x" cannot be parsed as a URL.
-FAIL ToASCII("xn--20-9802c.xn--0w5a.xn--1-eg4e.") A4_2 (ignored) "https://xn--20-9802c.xn--0w5a.xn--1-eg4e./x" cannot be parsed as a URL.
+PASS ToASCII("𲤱20.音.ꡦ1.") A4_2 (ignored)
+PASS ToASCII("xn--20-9802c.xn--0w5a.xn--1-eg4e.") A4_2 (ignored)
 PASS ToASCII("xn--dth6033bzbvx.xn--tsh9439b") V7
 PASS ToASCII("Ⴕ。۰≮ß݅")
 PASS ToASCII("Ⴕ。۰≮ß݅")
@@ -1910,9 +1910,9 @@ PASS ToASCII("𲮚９ꍩ៓．‍ß") C2
 PASS ToASCII("𲮚9ꍩ៓.‍ß") C2
 PASS ToASCII("𲮚9ꍩ៓.‍SS") C2
 PASS ToASCII("𲮚9ꍩ៓.‍ss") C2
-FAIL ToASCII("xn--9-i0j5967eg3qz.ss") "https://xn--9-i0j5967eg3qz.ss/x" cannot be parsed as a URL.
-FAIL ToASCII("𲮚9ꍩ៓.ss") "https://𲮚9ꍩ៓.ss/x" cannot be parsed as a URL.
-FAIL ToASCII("𲮚9ꍩ៓.SS") "https://𲮚9ꍩ៓.SS/x" cannot be parsed as a URL.
+PASS ToASCII("xn--9-i0j5967eg3qz.ss")
+PASS ToASCII("𲮚9ꍩ៓.ss")
+PASS ToASCII("𲮚9ꍩ៓.SS")
 PASS ToASCII("xn--9-i0j5967eg3qz.xn--ss-l1t") C2
 PASS ToASCII("xn--9-i0j5967eg3qz.xn--zca770n") C2
 PASS ToASCII("𲮚９ꍩ៓．‍SS") C2


### PR DESCRIPTION
#### 7c873d6423b8e5eca9b34559cb001fe91f711c37
<pre>
[macOS Tahoe] imported/w3c/web-platform-tests/url/IdnaTestV2.any.html is a constant text failure.
<a href="https://rdar.apple.com/177964721">rdar://177964721</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315578">https://bugs.webkit.org/show_bug.cgi?id=315578</a>

Unreviewed rebaseline.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/url/IdnaTestV2.any-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c873d6423b8e5eca9b34559cb001fe91f711c37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173530 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121752 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68148ea8-0401-45d9-960d-c509cdbf0fc1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127818 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89981 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c81c72b0-83f7-4ec7-b1a7-9b127c12ec72) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108363 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2737b8c9-b46e-444a-9d21-0d889f0a2722) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29177 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27796 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21293 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176056 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27241 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136137 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136102 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38743 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147368 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100895 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31389 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24224 "Exiting early after 10 failures. 10 tests run. 1 failures") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37251 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36649 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2285 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36897 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36797 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->