### PR TITLE
[libpas] Add MTE tag-policy tests for bmalloc heap

### DIFF
--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -596,6 +596,7 @@
 		E3096D4C2A82357800BC4CA0 /* pas_allocation_result.c in Sources */ = {isa = PBXBuildFile; fileRef = E3096D4B2A82357800BC4CA0 /* pas_allocation_result.c */; };
 		E3AA9B8328C724D8005DF9D6 /* pas_darwin_spi.h in Headers */ = {isa = PBXBuildFile; fileRef = E3AA9B8228C724D8005DF9D6 /* pas_darwin_spi.h */; };
 		F30C5BE42E8F33E4006CA1E9 /* MARTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F30C5BE32E8F33E4006CA1E9 /* MARTests.cpp */; };
+		F30C5BE42E8F33E4006CA1F9 /* MTETests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F30C5BE32E8F33E4006CA1F9 /* MTETests.cpp */; };
 		F3EFAABC2E90316400A1EDE0 /* pas_mar_registry.c in Sources */ = {isa = PBXBuildFile; fileRef = F3EFAAB92E90316400A1EDE0 /* pas_mar_registry.c */; };
 		F3EFAABD2E90316400A1EDE0 /* pas_mar_report_crash.c in Sources */ = {isa = PBXBuildFile; fileRef = F3EFAABB2E90316400A1EDE0 /* pas_mar_report_crash.c */; };
 		F3EFAABE2E90316400A1EDE0 /* pas_mar_crash_reporter_report.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EFAAB72E90316400A1EDE0 /* pas_mar_crash_reporter_report.h */; };
@@ -1116,6 +1117,7 @@
 		0FC681C9210F7C9F003C6A13 /* pas_thread_local_cache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_thread_local_cache.c; sourceTree = "<group>"; };
 		0FC681CA210F7C9F003C6A13 /* pas_thread_local_cache_layout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_thread_local_cache_layout.h; sourceTree = "<group>"; };
 		0FC681DB210FAC4B003C6A13 /* test_pas */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = test_pas; sourceTree = BUILT_PRODUCTS_DIR; };
+		0FC681E2210FAC4B003C6A13 /* test_pas.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = test_pas.entitlements; sourceTree = "<group>"; };
 		0FC681EA210FEDB5003C6A13 /* TestHarness.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestHarness.h; sourceTree = "<group>"; };
 		0FC681EB21127A16003C6A13 /* TestHarness.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TestHarness.cpp; sourceTree = "<group>"; };
 		0FC681EE2114D983003C6A13 /* pas_all_heaps.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_all_heaps.c; sourceTree = "<group>"; };
@@ -1319,6 +1321,7 @@
 		E3096D4B2A82357800BC4CA0 /* pas_allocation_result.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_allocation_result.c; sourceTree = "<group>"; };
 		E3AA9B8228C724D8005DF9D6 /* pas_darwin_spi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_darwin_spi.h; sourceTree = "<group>"; };
 		F30C5BE32E8F33E4006CA1E9 /* MARTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MARTests.cpp; sourceTree = "<group>"; };
+		F30C5BE32E8F33E4006CA1F9 /* MTETests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MTETests.cpp; sourceTree = "<group>"; };
 		F3EFAAB72E90316400A1EDE0 /* pas_mar_crash_reporter_report.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pas_mar_crash_reporter_report.h; sourceTree = "<group>"; };
 		F3EFAAB82E90316400A1EDE0 /* pas_mar_registry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pas_mar_registry.h; sourceTree = "<group>"; };
 		F3EFAAB92E90316400A1EDE0 /* pas_mar_registry.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pas_mar_registry.c; sourceTree = "<group>"; };
@@ -1440,6 +1443,7 @@
 				0FEA45BE236CDAED00B5A375 /* LockFreeReadPtrPtrHashtableTests.cpp */,
 				2CB9B15C278F861B003A8C1B /* LotsOfHeapsAndThreads.cpp */,
 				F30C5BE32E8F33E4006CA1E9 /* MARTests.cpp */,
+				F30C5BE32E8F33E4006CA1F9 /* MTETests.cpp */,
 				2C734C8F277680EF0017BFFE /* MemalignTests.cpp */,
 				0FD22D0722CD8A7500B21841 /* MinHeapTests.cpp */,
 				2B2A589B2742D815005EE07C /* PGMTests.cpp */,
@@ -2001,6 +2005,7 @@
 		3A6CA64E21012895003EFDBF = {
 			isa = PBXGroup;
 			children = (
+				0FC681E2210FAC4B003C6A13 /* test_pas.entitlements */,
 				3A6CA65921012895003EFDBF /* src */,
 				3A6CA65821012895003EFDBF /* Products */,
 				3A6CA66621012BAB003EFDBF /* Frameworks */,
@@ -2713,6 +2718,7 @@
 				0FEA45BF236CDAED00B5A375 /* LockFreeReadPtrPtrHashtableTests.cpp in Sources */,
 				2CB9B15D278F861B003A8C1B /* LotsOfHeapsAndThreads.cpp in Sources */,
 				F30C5BE42E8F33E4006CA1E9 /* MARTests.cpp in Sources */,
+				F30C5BE42E8F33E4006CA1F9 /* MTETests.cpp in Sources */,
 				2C734C90277680EF0017BFFE /* MemalignTests.cpp in Sources */,
 				0FD22D0822CD8A7500B21841 /* MinHeapTests.cpp in Sources */,
 				2B2A589C2742D815005EE07C /* PGMTests.cpp in Sources */,
@@ -3241,6 +3247,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++23";
 				CLANG_ENABLE_MODULES = NO;
 				CLANG_ENABLE_MODULE_DEBUGGING = NO;
+				CODE_SIGN_ENTITLEMENTS = test_pas.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -3259,6 +3266,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++23";
 				CLANG_ENABLE_MODULES = NO;
 				CLANG_ENABLE_MODULE_DEBUGGING = NO;
+				CODE_SIGN_ENTITLEMENTS = test_pas.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"OS_UNFAIR_LOCK_INLINE=1",

--- a/Source/bmalloc/libpas/src/test/MTETests.cpp
+++ b/Source/bmalloc/libpas/src/test/MTETests.cpp
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "TestHarness.h"
+#include "bmalloc_heap.h"
+#include "bmalloc_heap_config.h"
+#include "pas_internal_config.h"
+#include "pas_mte.h"
+#include "pas_mte_config.h"
+#include "pas_scavenger.h"
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+using namespace std;
+
+#if defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
+#if PAS_ENABLE_MTE
+
+namespace {
+
+// Extracts the 4-bit MTE tag from a tagged pointer (bits [59:56]).
+static uint8_t logicalTagOf(uintptr_t ptr)
+{
+    return static_cast<uint8_t>((ptr >> PAS_MTE_TAG_SHIFT) & 0xf);
+}
+
+// Reads the tag stored in MTE tag memory for the granule at `ptr` via the LDG instruction.
+// Operates on the canonical address (tag bits stripped) so it works with any pointer value,
+// including ones that have been freed (the tag storage persists until the page is decommitted).
+static uint8_t allocationTagOf(uintptr_t ptr)
+{
+    uintptr_t canonical = ptr & PAS_MTE_CANONICAL_MASK;
+    PAS_MTE_GET_MTAG(canonical);
+    return logicalTagOf(canonical);
+}
+
+// Non-compact allocations get a nonzero MTE tag for all sizes up to PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE
+void testMTETagsNonCompactObjectsAreTagged()
+{
+    static const size_t sizes[] = {
+        16, 32, 48, 64, 128, 256, 512, 1024, 2048, 4096,
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE / 2,
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE,
+    };
+    for (auto size : sizes) {
+        void* mem = bmalloc_try_allocate(size, pas_non_compact_allocation_mode);
+        CHECK(mem);
+        uintptr_t ptr = reinterpret_cast<uintptr_t>(mem);
+        uint8_t tag = logicalTagOf(ptr);
+        CHECK_NOT_EQUAL(tag, static_cast<uint8_t>(0));
+        CHECK_EQUAL(tag, allocationTagOf(ptr));
+        bmalloc_deallocate(mem);
+    }
+}
+
+// Compact allocations always return a zero-tagged pointer
+void testMTETagsCompactObjectsAreZeroTagged()
+{
+    static const size_t sizes[] = {
+        16, 64, 256, 1024, 4096,
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE - 1,
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE,
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE * 2,
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE * 200,
+    };
+    static const pas_allocation_mode modes[] = {
+        pas_always_compact_allocation_mode,
+        pas_maybe_compact_allocation_mode,
+    };
+    for (auto mode : modes) {
+        for (auto size : sizes) {
+            void* mem = bmalloc_try_allocate(size, mode);
+            CHECK(mem);
+            CHECK_EQUAL(logicalTagOf(reinterpret_cast<uintptr_t>(mem)), static_cast<uint8_t>(0));
+            bmalloc_deallocate(mem);
+        }
+    }
+}
+
+// Calling pas_mte_force_nontaggable_user_allocations_into_large_heap() should
+// still let objects <=32k be allocated from MTE-tagged heaps.
+void testMTETagsAtAndBelowCeilingAreTagged()
+{
+    pas_mte_force_nontaggable_user_allocations_into_large_heap();
+
+    static const size_t sizes[] = {
+        16,
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE / 4,
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE / 2,
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE,
+    };
+    for (auto size : sizes) {
+        void* mem = bmalloc_try_allocate(size, pas_non_compact_allocation_mode);
+        CHECK(mem);
+        CHECK_NOT_EQUAL(logicalTagOf(reinterpret_cast<uintptr_t>(mem)), static_cast<uint8_t>(0));
+        bmalloc_deallocate(mem);
+    }
+}
+
+void testMTETagsAboveCeilingAreUntagged()
+{
+    pas_mte_force_nontaggable_user_allocations_into_large_heap();
+
+    static const size_t sizes[] = {
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE + 16,
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE * 2,
+        PAS_MAX_MTE_TAGGABLE_OBJECT_SIZE * 4,
+    };
+    for (auto size : sizes) {
+        void* mem = bmalloc_try_allocate(size, pas_non_compact_allocation_mode);
+        CHECK(mem);
+        // Large allocations are protected by guard objects and thus untagged
+        CHECK_EQUAL(logicalTagOf(reinterpret_cast<uintptr_t>(mem)), static_cast<uint8_t>(0));
+        bmalloc_deallocate(mem);
+    }
+}
+
+void testMTESegregatedAdjacentObjectsHaveDifferentTags()
+{
+    // Allocate enough 32-byte objects to populate several segregated pages and yield
+    // a large sample of truly adjacent (contiguous) pairs to check.
+    const size_t objSize = 32;
+    const size_t count = 512;
+    vector<void*> objs(count);
+
+    for (size_t i = 0; i < count; i++) {
+        objs[i] = bmalloc_try_allocate(objSize, pas_non_compact_allocation_mode);
+        CHECK(objs[i]);
+    }
+
+    sort(objs.begin(), objs.end());
+
+    size_t adjacentPairsChecked = 0;
+    for (size_t i = 0; i + 1 < count; i++) {
+        uintptr_t a = reinterpret_cast<uintptr_t>(objs[i]);
+        uintptr_t b = reinterpret_cast<uintptr_t>(objs[i + 1]);
+        if (b - a == objSize) {
+            ++adjacentPairsChecked;
+            CHECK_NOT_EQUAL(logicalTagOf(a), logicalTagOf(b));
+        }
+    }
+    // Sanity: we must have found enough adjacent pairs to make the test meaningful.
+    CHECK_GREATER(adjacentPairsChecked, static_cast<size_t>(64));
+
+    for (auto* p : objs)
+        bmalloc_deallocate(p);
+}
+
+void testMTEBitfitAdjacentObjectsHaveDifferentTags()
+{
+    // Use a mix of sizes to exercise the nonhomogeneous (ldg-based) tagging path.
+    static const size_t sizes[] = { 32, 48, 64, 80, 96, 112, 128 };
+    const size_t count = 512;
+    vector<pair<size_t, void*>> objs;
+    objs.reserve(count);
+
+    for (size_t i = 0; i < count; i++) {
+        size_t sz = sizes[i % (sizeof(sizes) / sizeof(*sizes))];
+        void* mem = bmalloc_try_allocate(sz, pas_non_compact_allocation_mode);
+        CHECK(mem);
+        objs.push_back({ sz, mem });
+    }
+
+    sort(objs.begin(), objs.end(), [](const auto& a, const auto& b) {
+        return a.second < b.second;
+    });
+
+    size_t adjacentPairsChecked = 0;
+    for (size_t i = 0; i + 1 < objs.size(); i++) {
+        uintptr_t a = reinterpret_cast<uintptr_t>(objs[i].second);
+        uintptr_t b = reinterpret_cast<uintptr_t>(objs[i + 1].second);
+        size_t sza = objs[i].first;
+        // Only check pairs that are truly adjacent (b starts exactly where a ends).
+        if (a + sza == b) {
+            ++adjacentPairsChecked;
+            CHECK_NOT_EQUAL(logicalTagOf(a), logicalTagOf(b));
+        }
+    }
+
+    // Sanity: we must have found enough adjacent pairs to make the test meaningful.
+    CHECK_GREATER(adjacentPairsChecked, static_cast<size_t>(64));
+
+    for (auto& [sz, p] : objs)
+        bmalloc_deallocate(p);
+}
+
+// Reallocating a non-compact object to a larger non-compact size should return a pointer
+// with a nonzero tag, and all data written to the original buffer is preserved at the new
+// address
+void testMTEReallocPreservesDataAndUsesNonzeroTag()
+{
+    const size_t oldSize = 64;
+    const size_t newSize = 256;
+    const uint8_t pattern = 0xAB;
+
+    void* mem = bmalloc_try_allocate(oldSize, pas_non_compact_allocation_mode);
+    CHECK(mem);
+    CHECK_NOT_EQUAL(logicalTagOf(reinterpret_cast<uintptr_t>(mem)), static_cast<uint8_t>(0));
+
+    memset(mem, pattern, oldSize);
+
+    void* newMem = bmalloc_try_reallocate(mem, newSize,
+        pas_non_compact_allocation_mode, pas_reallocate_free_if_successful);
+    CHECK(newMem);
+    CHECK_NOT_EQUAL(logicalTagOf(reinterpret_cast<uintptr_t>(newMem)), static_cast<uint8_t>(0));
+
+    const auto* bytes = static_cast<const uint8_t*>(newMem);
+    for (size_t i = 0; i < oldSize; i++)
+        CHECK_EQUAL(bytes[i], pattern);
+
+    bmalloc_deallocate(newMem);
+}
+
+// Reallocating to a compact allocation mode always returns a zero-tagged pointer,
+// regardless of the original allocation's tag.
+void testMTEReallocToCompactGivesZeroTag()
+{
+    void* mem = bmalloc_try_allocate(64, pas_non_compact_allocation_mode);
+    CHECK(mem);
+    CHECK_NOT_EQUAL(logicalTagOf(reinterpret_cast<uintptr_t>(mem)), static_cast<uint8_t>(0));
+
+    void* newMem = bmalloc_try_reallocate(mem, 128,
+        pas_always_compact_allocation_mode, pas_reallocate_free_if_successful);
+    CHECK(newMem);
+    CHECK_EQUAL(logicalTagOf(reinterpret_cast<uintptr_t>(newMem)), static_cast<uint8_t>(0));
+
+    bmalloc_deallocate(newMem);
+}
+
+void testMTEBitfitObjectsGetRetaggedOnFreeManyIterations()
+{
+    // Scavenger is already suspended by SuspendScavengerScope before this function runs.
+    const size_t objSize = 64;
+    const size_t count = 256;
+    const size_t iterations = 16;
+    vector<uintptr_t> ptrs(count);
+
+    for (size_t iter = 0; iter < iterations; iter++) {
+        for (size_t i = 0; i < count; i++) {
+            void* mem = bmalloc_try_allocate(objSize, pas_non_compact_allocation_mode);
+            CHECK(mem);
+            ptrs[i] = reinterpret_cast<uintptr_t>(mem);
+            CHECK_NOT_EQUAL(logicalTagOf(ptrs[i]), static_cast<uint8_t>(0));
+        }
+
+        size_t tagChanged = 0;
+        for (size_t i = 0; i < count; i++) {
+            uint8_t tagBefore = logicalTagOf(ptrs[i]);
+            bmalloc_deallocate(reinterpret_cast<void*>(ptrs[i]));
+
+            uint8_t tagAfter = allocationTagOf(ptrs[i]);
+            CHECK_NOT_EQUAL(tagAfter, static_cast<uint8_t>(0));
+
+            if (tagAfter != tagBefore)
+                ++tagChanged;
+        }
+
+        // This is technically a flaky check: individual slots may get retagged to
+        // the same value (prior to PTE). But with 1024 allocations being freed,
+        // the chance that >20% of them end up with the same tag is ~1 in 1.16 million
+        // even for the segregated case, where there are only 7 tags -- even less
+        // likely for bitfit.
+        // FIXME: once we have PTE, remove the 80% bar
+        CHECK_GREATER_EQUAL(tagChanged, static_cast<size_t>(count * 8 / 10));
+    }
+}
+
+// Segregated objects are retagged when the scavenger flushes the deallocation log.
+// Unlike bitfit, bmalloc_deallocate for segregated objects only enqueues the
+// slot into the deallocation-log; tagging thus only happens when the log is
+// actually emptied.
+void testMTESegregatedObjectsGetRetaggedOnScavenge()
+{
+    const size_t baseObjSize = 8;
+    const size_t objSizeScaleFactor = 8;
+    const size_t count = 2048; // total allocations; half freed, half held live
+
+    vector<uintptr_t> allPtrs(count);
+    for (size_t i = 0; i < count; i++) {
+        // Allocate varying sizes
+        void* mem = bmalloc_try_allocate(baseObjSize + (objSizeScaleFactor * i), pas_non_compact_allocation_mode);
+        CHECK(mem);
+        allPtrs[i] = reinterpret_cast<uintptr_t>(mem);
+        CHECK_NOT_EQUAL(logicalTagOf(allPtrs[i]), static_cast<uint8_t>(0));
+    }
+
+    // Free the even-indexed objects; odd-indexed objects stay live to pin the pages in memory.
+    const size_t freedCount = count / 2;
+    vector<uintptr_t> freedPtrs;
+    vector<uint8_t> tagsBefore;
+    freedPtrs.reserve(freedCount);
+    tagsBefore.reserve(freedCount);
+
+    for (size_t i = 0; i < count; i += 2) {
+        freedPtrs.push_back(allPtrs[i]);
+        tagsBefore.push_back(logicalTagOf(allPtrs[i]));
+        bmalloc_deallocate(reinterpret_cast<void*>(allPtrs[i]));
+    }
+
+    pas_scavenger_run_synchronously_now();
+
+    size_t tagChanged = 0;
+    for (size_t i = 0; i < freedCount; i++) {
+        uint8_t tagAfter = allocationTagOf(freedPtrs[i]);
+        CHECK_NOT_EQUAL(tagAfter, static_cast<uint8_t>(0));
+        if (tagAfter != tagsBefore[i])
+            ++tagChanged;
+    }
+    // FIXME: once we have PTE, remove the 80% bar
+    CHECK_GREATER_EQUAL(tagChanged, static_cast<size_t>(freedCount * 8 / 10));
+
+    // Release the live half.
+    for (size_t i = 1; i < count; i += 2)
+        bmalloc_deallocate(reinterpret_cast<void*>(allPtrs[i]));
+}
+
+} // anonymous namespace
+
+#endif // PAS_ENABLE_MTE
+#endif // defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
+
+void addMTETests()
+{
+#if defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
+#if PAS_ENABLE_MTE
+    {
+        // Basic tag-presence / tagging-ceiling tests (use segregated heap).
+        ADD_TEST(testMTETagsNonCompactObjectsAreTagged());
+        ADD_TEST(testMTETagsCompactObjectsAreZeroTagged());
+        ADD_TEST(testMTETagsAtAndBelowCeilingAreTagged());
+        ADD_TEST(testMTETagsAboveCeilingAreUntagged());
+
+        // Segregated-heap adjacent-tag exclusion.
+        ADD_TEST(testMTESegregatedAdjacentObjectsHaveDifferentTags());
+
+        // Realloc tests (exercise the TCO-guarded copy path).
+        ADD_TEST(testMTEReallocPreservesDataAndUsesNonzeroTag());
+        ADD_TEST(testMTEReallocToCompactGivesZeroTag());
+
+        // Bitfit-heap tests (force all bmalloc allocations through the bitfit path).
+        {
+            ForceBitfit bitfit;
+
+            ADD_TEST(testMTEBitfitAdjacentObjectsHaveDifferentTags());
+
+            // Bitfit retag-on-free requires the scavenger to be quiescent so we can read
+            // the freshly retagged granule before the page is potentially decommitted.
+            {
+                SuspendScavengerScope noScav;
+                ADD_TEST(testMTEBitfitObjectsGetRetaggedOnFreeManyIterations());
+            }
+        }
+
+        // Segregated-heap retag-on-scavenge: free objects, then verify retagged
+        // after pas_scavenger_run_synchronously_now().
+        {
+            ForceSegregated seg;
+            SuspendScavengerScope noScav;
+            ADD_TEST(testMTESegregatedObjectsGetRetaggedOnScavenge());
+        }
+    }
+#endif // PAS_ENABLE_MTE
+#endif // defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
+}

--- a/Source/bmalloc/libpas/src/test/TestHarness.cpp
+++ b/Source/bmalloc/libpas/src/test/TestHarness.cpp
@@ -38,6 +38,7 @@
 #include "pas_epoch.h"
 #include "pas_fd_stream.h"
 #include "pas_heap.h"
+#include "pas_mte_config.h"
 #include "pas_segregated_page.h"
 #include "pas_segregated_page_config.h"
 #include "pas_segregated_size_directory.h"
@@ -141,6 +142,18 @@ DisableBitfit::DisableBitfit()
         "disable-bitfit",
         [] (pas_heap_runtime_config& runtimeConfig) {
             runtimeConfig.max_bitfit_object_size = 0;
+        })
+{
+}
+
+ForceSegregated::ForceSegregated()
+    : RuntimeConfigTestScope(
+        "force-segregated",
+        [] (pas_heap_runtime_config& runtimeConfig) {
+            if (&runtimeConfig != &pas_utility_heap_runtime_config) {
+                runtimeConfig.max_segregated_object_size = UINT_MAX;
+                runtimeConfig.max_bitfit_object_size = 0;
+            }
         })
 {
 }
@@ -377,6 +390,7 @@ void addLockFreeReadPtrPtrHashtableTests();
 void addLotsOfHeapsAndThreadsTests();
 void addMARTests();
 void addMemalignTests();
+void addMTETests();
 void addMinHeapTests();
 void addPGMTests();
 void addRaceTests();
@@ -873,6 +887,13 @@ int main(int argc, char** argv)
     ADD_SUITE(TSD);
     ADD_SUITE(Utils);
     ADD_SUITE(ViewCache);
+#if defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
+#if PAS_ENABLE_MTE
+    pas_mte_ensure_initialized();
+    if (PAS_USE_MTE)
+        ADD_SUITE(MTE);
+#endif
+#endif
 
     ParsedArguments args = parseArguments(argc, argv);
 

--- a/Source/bmalloc/libpas/src/test/TestHarness.h
+++ b/Source/bmalloc/libpas/src/test/TestHarness.h
@@ -239,6 +239,11 @@ public:
     DisableBitfit();
 };
 
+class ForceSegregated : public RuntimeConfigTestScope {
+public:
+    ForceSegregated();
+};
+
 class ForceBaselines : public RuntimeConfigTestScope {
 public:
     ForceBaselines();

--- a/Source/bmalloc/libpas/test_pas.entitlements
+++ b/Source/bmalloc/libpas/test_pas.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.hardened-process</key>
+	<true/>
+	<key>com.apple.security.hardened-process.checked-allocations</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
#### cd1a4c3024409449296cb9021fbdea49d8926e97
<pre>
[libpas] Add MTE tag-policy tests for bmalloc heap
<a href="https://bugs.webkit.org/show_bug.cgi?id=315385">https://bugs.webkit.org/show_bug.cgi?id=315385</a>
<a href="https://rdar.apple.com/177738834">rdar://177738834</a>

Reviewed by NOBODY (OOPS!).

These tests ensure that we tag objects we expect to be tagged (and vice
versa), correctly enforce tag-selection hardening policies (ATE, PTE,
etc.), and retag objects as appropriate (on free/scavenge).
Not all of these are stressed in production builds, so this is the only
place where some behaviors are enforced.

At present, the retagging tests require probabilistic checks,
as we cannot guarantee that all objects will be retagged with a
tag distinct from the previous one, and thus have to allow for a
certain number of temporal collisions. Once PTE is implemented, we
will be able to get rid of this if we so choose.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd1a4c3024409449296cb9021fbdea49d8926e97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122016 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6089f92a-94f8-4861-96fe-f0c0ed38bc0c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128046 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90156 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0820a1fb-feec-4414-b8e0-8305c09e319e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108592 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e76764d0-4013-4d36-b352-16460ccc50a0) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29397 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Running layout-tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28019 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21558 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156915 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176322 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25656 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27468 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136366 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32143 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136329 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147594 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101218 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31599 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24450 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197167 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37515 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51796 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36913 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2516 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37061 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->