### PR TITLE
[Gamepad] Add GamepadButton.type support

### DIFF
--- a/LayoutTests/gamepad/gamepad-button-type-expected.txt
+++ b/LayoutTests/gamepad/gamepad-button-type-expected.txt
@@ -1,0 +1,14 @@
+Tests GamepadButton.type for standard and non-standard buttons.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS gamepad.buttons.length is 18
+PASS gamepad.buttons[0].type is "standard"
+PASS gamepad.buttons[16].type is "standard"
+PASS gamepad.buttons[17].type is "non-standard"
+PASS gamepad.buttons.every(button => button.type === 'standard' || button.type === 'non-standard') is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/gamepad/gamepad-button-type.html
+++ b/LayoutTests/gamepad/gamepad-button-type.html
@@ -1,0 +1,32 @@
+<head>
+<script src="../resources/js-test.js"></script>
+<body>
+<script>
+description("Tests GamepadButton.type for standard and non-standard buttons.");
+jsTestIsAsync = true;
+
+if (window.internals)
+    internals.settings.setGamepadButtonTypeEnabled(true);
+
+function runTest()
+{
+    addEventListener("gamepadconnected", event => {
+        gamepad = event.gamepad;
+
+        shouldBe("gamepad.buttons.length", "18");
+        shouldBeEqualToString("gamepad.buttons[0].type", "standard");
+        shouldBeEqualToString("gamepad.buttons[16].type", "standard");
+        shouldBeEqualToString("gamepad.buttons[17].type", "non-standard");
+        shouldBeTrue("gamepad.buttons.every(button => button.type === 'standard' || button.type === 'non-standard')");
+
+        finishJSTest();
+    }, { once: true });
+
+    const supportsDualRumble = false;
+    testRunner.setMockGamepadDetails(0, "Test Gamepad", "standard", 4, 18, supportsDualRumble);
+    testRunner.connectMockGamepad(0);
+}
+
+onload = runTest;
+</script>
+</body>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3392,6 +3392,21 @@ GStreamerEnabled:
     WebKit:
       default: true
 
+GamepadButtonTypeEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "GamepadButton.type support"
+  humanReadableDescription: "Support for GamepadButton.type"
+  condition: ENABLE(GAMEPAD)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 GamepadTriggerRumbleEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1681,6 +1681,7 @@ list(APPEND WebCore_IDL_INCLUDES
 list(APPEND WebCore_NON_SVG_IDL_FILES
     Modules/gamepad/Gamepad.idl
     Modules/gamepad/GamepadButton.idl
+    Modules/gamepad/GamepadButtonType.idl
     Modules/gamepad/GamepadEffectParameters.idl
     Modules/gamepad/GamepadEvent.idl
     Modules/gamepad/GamepadHapticActuator.idl
@@ -1698,6 +1699,7 @@ if (ENABLE_GAMEPAD)
 
         platform/gamepad/EmptyGamepadProvider.cpp
         platform/gamepad/GamepadProvider.cpp
+        platform/gamepad/PlatformGamepad.cpp
     )
 endif ()
 

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -496,6 +496,7 @@ $(PROJECT_DIR)/Modules/filesystem/FileSystemWritableFileStream.idl
 $(PROJECT_DIR)/Modules/filesystem/StorageManager+FileSystem.idl
 $(PROJECT_DIR)/Modules/gamepad/Gamepad.idl
 $(PROJECT_DIR)/Modules/gamepad/GamepadButton.idl
+$(PROJECT_DIR)/Modules/gamepad/GamepadButtonType.idl
 $(PROJECT_DIR)/Modules/gamepad/GamepadEffectParameters.idl
 $(PROJECT_DIR)/Modules/gamepad/GamepadEvent.idl
 $(PROJECT_DIR)/Modules/gamepad/GamepadHapticActuator.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1481,6 +1481,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepad.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepad.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadButton.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadButton.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadButtonType.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadButtonType.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadEffectParameters.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadEffectParameters.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadEvent.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -361,6 +361,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/filesystem/StorageManager+FileSystem.idl \
     $(WebCore)/Modules/gamepad/Gamepad.idl \
     $(WebCore)/Modules/gamepad/GamepadButton.idl \
+    $(WebCore)/Modules/gamepad/GamepadButtonType.idl \
     $(WebCore)/Modules/gamepad/GamepadEffectParameters.idl \
     $(WebCore)/Modules/gamepad/GamepadEvent.idl \
     $(WebCore)/Modules/gamepad/GamepadHapticActuator.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -443,6 +443,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/filesystem/WorkerFileSystemStorageConnection.h
     Modules/filesystem/WorkerFileSystemStorageConnectionCallbackIdentifier.h
 
+    Modules/gamepad/GamepadButtonType.h
     Modules/gamepad/GamepadEffectParameters.h
     Modules/gamepad/GamepadHapticEffectType.h
     Modules/gamepad/NavigatorGamepad.h

--- a/Source/WebCore/Modules/gamepad/Gamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/Gamepad.cpp
@@ -28,14 +28,31 @@
 
 #if ENABLE(GAMEPAD)
 
+#include "Document.h"
 #include "GamepadButton.h"
+#include "GamepadButtonType.h"
+#include "GamepadConstants.h"
 #include "GamepadHapticActuator.h"
 #include "PlatformGamepad.h"
 #include "ScriptExecutionContext.h"
+#include "Settings.h"
 #include "SharedGamepadValue.h"
+#include <algorithm>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+static size_t exposedButtonCount(Document* document, const PlatformGamepad& platformGamepad)
+{
+    auto buttonCount = platformGamepad.buttonValues().size();
+    if (document && document->settings().gamepadButtonTypeEnabled())
+        return buttonCount;
+
+    if (platformGamepad.mapping() == standardGamepadMappingString())
+        return std::min(buttonCount, numberOfStandardGamepadButtonsWithHomeButton);
+
+    return buttonCount;
+}
 
 Gamepad::Gamepad(Document* document, const PlatformGamepad& platformGamepad)
     : m_id(platformGamepad.id())
@@ -47,9 +64,11 @@ Gamepad::Gamepad(Document* document, const PlatformGamepad& platformGamepad)
     , m_axes(FillWith { }, platformGamepad.axisValues().size(), 0.0)
     , m_vibrationActuator(platformGamepad.supportedEffectTypes().contains(GamepadHapticEffectType::DualRumble) ? RefPtr { GamepadHapticActuator::create(document, GamepadHapticActuator::Type::DualRumble, *this) } : nullptr)
 {
-    unsigned buttonCount = platformGamepad.buttonValues().size();
-    m_buttons = Vector<Ref<GamepadButton>>(buttonCount, [](size_t) {
-        return GamepadButton::create();
+    auto buttonCount = exposedButtonCount(document, platformGamepad);
+    const auto& buttonTypes = platformGamepad.buttonTypes();
+    m_buttons = Vector<Ref<GamepadButton>>(buttonCount, [&](size_t index) {
+        auto type = index < buttonTypes.size() ? buttonTypes[index] : GamepadButtonType::NonStandard;
+        return GamepadButton::create(type);
     });
 }
 

--- a/Source/WebCore/Modules/gamepad/GamepadButton.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadButton.cpp
@@ -30,7 +30,10 @@
 
 namespace WebCore {
 
-GamepadButton::GamepadButton() = default;
+GamepadButton::GamepadButton(GamepadButtonType type)
+    : m_type(type)
+{
+}
 
 bool GamepadButton::pressed() const
 {

--- a/Source/WebCore/Modules/gamepad/GamepadButton.h
+++ b/Source/WebCore/Modules/gamepad/GamepadButton.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GAMEPAD)
 
+#include "GamepadButtonType.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
@@ -34,19 +35,21 @@ namespace WebCore {
 
 class GamepadButton : public RefCounted<GamepadButton> {
 public:
-    static Ref<GamepadButton> create()
+    static Ref<GamepadButton> create(GamepadButtonType type = GamepadButtonType::NonStandard)
     {
-        return adoptRef(*new GamepadButton);
+        return adoptRef(*new GamepadButton(type));
     }
 
     bool NODELETE pressed() const;
     double value() const { return m_value; }
     void setValue(double value) { m_value = value; }
+    GamepadButtonType type() const { return m_type; }
 
 private:
-    GamepadButton();
+    explicit GamepadButton(GamepadButtonType);
 
     double m_value { 0.0 };
+    GamepadButtonType m_type { GamepadButtonType::NonStandard };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/GamepadButtonType.h
+++ b/Source/WebCore/Modules/gamepad/GamepadButtonType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 NVIDIA Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,13 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=GAMEPAD,
-    EnabledBySetting=GamepadsEnabled,
-    Exposed=Window
-] interface GamepadButton {
-    readonly attribute boolean pressed;
-    readonly attribute double value;
-    [EnabledBySetting=GamepadButtonTypeEnabled] readonly attribute GamepadButtonType type;
-};
+#pragma once
 
+#if ENABLE(GAMEPAD)
+
+#include <cstdint>
+
+namespace WebCore {
+
+enum class GamepadButtonType : uint8_t { NonStandard, Standard, Trackpad };
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/Modules/gamepad/GamepadButtonType.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadButtonType.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 NVIDIA Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,11 +25,9 @@
 
 [
     Conditional=GAMEPAD,
-    EnabledBySetting=GamepadsEnabled,
-    Exposed=Window
-] interface GamepadButton {
-    readonly attribute boolean pressed;
-    readonly attribute double value;
-    [EnabledBySetting=GamepadButtonTypeEnabled] readonly attribute GamepadButtonType type;
+    EnabledBySetting=GamepadButtonTypeEnabled
+] enum GamepadButtonType {
+    "non-standard",
+    "standard",
+    "trackpad",
 };
-

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2561,6 +2561,7 @@ platform/encryptedmedia/clearkey/CDMClearKey.cpp
 platform/gamepad/EmptyGamepadProvider.cpp
 platform/gamepad/GamepadConstants.cpp
 platform/gamepad/GamepadProvider.cpp
+platform/gamepad/PlatformGamepad.cpp
 platform/graphics/AV1Utilities.cpp
 platform/graphics/AlphaPremultiplication.cpp
 platform/graphics/AnimationFrameRate.cpp
@@ -4402,6 +4403,7 @@ JSGainNode.cpp
 JSGainOptions.cpp
 JSGamepad.cpp
 JSGamepadButton.cpp
+JSGamepadButtonType.cpp
 JSGamepadEffectParameters.cpp
 JSGamepadEvent.cpp
 JSGamepadHapticActuator.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2235,6 +2235,7 @@
 		518F4FF6194CA4E60081BAAE /* GamepadButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 518F4FED194CA4E60081BAAE /* GamepadButton.cpp */; };
 		518F5002194CAC3A0081BAAE /* JSGamepad.h in Headers */ = {isa = PBXBuildFile; fileRef = 518F4FFE194CAC3A0081BAAE /* JSGamepad.h */; };
 		518F5004194CAC3A0081BAAE /* JSGamepadButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 518F5000194CAC3A0081BAAE /* JSGamepadButton.h */; };
+		5A72B8002F2A000100000001 /* GamepadButtonType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A72B8012F2A000100000001 /* GamepadButtonType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		518F97031BE94C630023187C /* MemoryIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = 518F97011BE94C5B0023187C /* MemoryIndex.h */; };
 		519755FA1BFD7DC3003DE980 /* MemoryIndexCursor.h in Headers */ = {isa = PBXBuildFile; fileRef = 519755F81BFD7DBC003DE980 /* MemoryIndexCursor.h */; };
 		5198F7A51BBDB79300E2CC5F /* UniqueIDBDatabaseConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 5198F7A31BBDAA2900E2CC5F /* UniqueIDBDatabaseConnection.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -12684,6 +12685,7 @@
 		515BE18B1D54F5F600DD7C68 /* GamepadProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GamepadProvider.h; sourceTree = "<group>"; };
 		515BE18C1D54F5F600DD7C68 /* GamepadProviderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GamepadProviderClient.h; sourceTree = "<group>"; };
 		515BE18E1D54F5F600DD7C68 /* PlatformGamepad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformGamepad.h; sourceTree = "<group>"; };
+		5A72B8032F2A000100000001 /* PlatformGamepad.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformGamepad.cpp; sourceTree = "<group>"; };
 		515BE1971D54F6BD00DD7C68 /* HIDGamepad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HIDGamepad.cpp; sourceTree = "<group>"; };
 		515BE1981D54F6BD00DD7C68 /* HIDGamepad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HIDGamepad.h; sourceTree = "<group>"; };
 		515BE1991D54F6BD00DD7C68 /* HIDGamepadProvider.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = HIDGamepadProvider.mm; sourceTree = "<group>"; };
@@ -12818,6 +12820,8 @@
 		518F4FED194CA4E60081BAAE /* GamepadButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GamepadButton.cpp; sourceTree = "<group>"; };
 		518F4FEE194CA4E60081BAAE /* GamepadButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GamepadButton.h; sourceTree = "<group>"; };
 		518F4FEF194CA4E60081BAAE /* GamepadButton.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = GamepadButton.idl; sourceTree = "<group>"; };
+		5A72B8012F2A000100000001 /* GamepadButtonType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GamepadButtonType.h; sourceTree = "<group>"; };
+		5A72B8022F2A000100000001 /* GamepadButtonType.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = GamepadButtonType.idl; sourceTree = "<group>"; };
 		518F4FFD194CAC3A0081BAAE /* JSGamepad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSGamepad.cpp; sourceTree = "<group>"; };
 		518F4FFE194CAC3A0081BAAE /* JSGamepad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGamepad.h; sourceTree = "<group>"; };
 		518F4FFF194CAC3A0081BAAE /* JSGamepadButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSGamepadButton.cpp; sourceTree = "<group>"; };
@@ -28919,6 +28923,7 @@
 				515BE18B1D54F5F600DD7C68 /* GamepadProvider.h */,
 				515BE18C1D54F5F600DD7C68 /* GamepadProviderClient.h */,
 				510A91F224D324C600BFD89C /* KnownGamepads.h */,
+				5A72B8032F2A000100000001 /* PlatformGamepad.cpp */,
 				515BE18E1D54F5F600DD7C68 /* PlatformGamepad.h */,
 				510A91DB24CF441800BFD89C /* SharedGamepadValue.h */,
 				522373E42C4FE8E300F1FA0C /* ShouldRequireExplicitConsentForGamepadAccess.h */,
@@ -29070,6 +29075,8 @@
 				518F4FED194CA4E60081BAAE /* GamepadButton.cpp */,
 				518F4FEE194CA4E60081BAAE /* GamepadButton.h */,
 				518F4FEF194CA4E60081BAAE /* GamepadButton.idl */,
+				5A72B8012F2A000100000001 /* GamepadButtonType.h */,
+				5A72B8022F2A000100000001 /* GamepadButtonType.idl */,
 				4664D1A42964FCD5006FE0C5 /* GamepadEffectParameters.h */,
 				4664D1A52964FCD5006FE0C5 /* GamepadEffectParameters.idl */,
 				516C621D1950D48700337E75 /* GamepadEvent.cpp */,
@@ -45565,6 +45572,7 @@
 				46FE73D22968E52000B8064C /* GameControllerHapticEngines.h in Headers */,
 				51A644B5292895C9001A6691 /* GameControllerSoftLink.h in Headers */,
 				51A644B629296E44001A6691 /* GameControllerSPI.h in Headers */,
+				5A72B8002F2A000100000001 /* GamepadButtonType.h in Headers */,
 				510A91FD24D3C16200BFD89C /* GamepadConstants.h in Headers */,
 				510A91FE24D3C16700BFD89C /* GamepadConstantsMac.h in Headers */,
 				4664D1A72964FCF0006FE0C5 /* GamepadEffectParameters.h in Headers */,

--- a/Source/WebCore/platform/gamepad/KnownGamepads.h
+++ b/Source/WebCore/platform/gamepad/KnownGamepads.h
@@ -33,6 +33,8 @@ enum KnownGamepad {
     Dualshock3 = 0x054c0268,
     Dualshock4_1 = 0x054c05c4,
     Dualshock4_2 = 0x054c09cc,
+    DualSense = 0x054c0ce6,
+    DualSenseEdge = 0x054c0df2,
     GamesirM2 = 0x0ec20475,
     HoripadUltimate = 0x0f0d0090,
     LogitechF310 = 0x046dc216,

--- a/Source/WebCore/platform/gamepad/PlatformGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/PlatformGamepad.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 NVIDIA Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,13 +23,31 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=GAMEPAD,
-    EnabledBySetting=GamepadsEnabled,
-    Exposed=Window
-] interface GamepadButton {
-    readonly attribute boolean pressed;
-    readonly attribute double value;
-    [EnabledBySetting=GamepadButtonTypeEnabled] readonly attribute GamepadButtonType type;
-};
+#include "config.h"
+#include "PlatformGamepad.h"
 
+#if ENABLE(GAMEPAD)
+
+#include "GamepadConstants.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PlatformGamepad);
+
+void PlatformGamepad::setNonStandardButtonTypes(size_t buttonCount)
+{
+    m_buttonTypes = Vector<GamepadButtonType>(FillWith { }, buttonCount, GamepadButtonType::NonStandard);
+}
+
+void PlatformGamepad::setButtonTypesForStandardMapping(size_t buttonCount)
+{
+    setNonStandardButtonTypes(buttonCount);
+
+    for (size_t i = 0; i < buttonCount && i < numberOfStandardGamepadButtonsWithHomeButton; ++i)
+        m_buttonTypes[i] = GamepadButtonType::Standard;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/platform/gamepad/PlatformGamepad.h
+++ b/Source/WebCore/platform/gamepad/PlatformGamepad.h
@@ -27,12 +27,13 @@
 
 #if ENABLE(GAMEPAD)
 
+#include <WebCore/GamepadButtonType.h>
 #include <WebCore/GamepadHapticEffectType.h>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/MonotonicTime.h>
-#include <wtf/TZoneMallocInlines.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -41,7 +42,7 @@ class SharedGamepadValue;
 struct GamepadEffectParameters;
 
 class PlatformGamepad : public CanMakeWeakPtr<PlatformGamepad>, public CanMakeCheckedPtr<PlatformGamepad> {
-    WTF_MAKE_TZONE_ALLOCATED_INLINE(PlatformGamepad);
+    WTF_MAKE_TZONE_ALLOCATED(PlatformGamepad);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlatformGamepad);
 public:
     virtual ~PlatformGamepad() = default;
@@ -52,9 +53,10 @@ public:
     virtual MonotonicTime lastUpdateTime() const { return m_lastUpdateTime; }
     MonotonicTime connectTime() const { return m_connectTime; }
     const GamepadHapticEffectTypeSet& supportedEffectTypes() const LIFETIME_BOUND { return m_supportedEffectTypes; }
-    
+
     virtual const Vector<SharedGamepadValue>& axisValues() const = 0;
     virtual const Vector<SharedGamepadValue>& buttonValues() const = 0;
+    virtual const Vector<GamepadButtonType>& buttonTypes() const LIFETIME_BOUND { return m_buttonTypes; }
     virtual void playEffect(GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler) { completionHandler(false); }
     virtual void stopEffects(CompletionHandler<void()>&& completionHandler) { completionHandler(); }
 
@@ -66,12 +68,16 @@ protected:
     {
     }
 
+    void setNonStandardButtonTypes(size_t);
+    void setButtonTypesForStandardMapping(size_t);
+
     String m_id;
     String m_mapping;
     unsigned m_index;
     MonotonicTime m_lastUpdateTime;
     MonotonicTime m_connectTime;
     GamepadHapticEffectTypeSet m_supportedEffectTypes;
+    Vector<GamepadButtonType> m_buttonTypes;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
@@ -98,11 +98,14 @@ void GameControllerGamepad::setupElements()
     }
 #endif
 
-    if (m_gcController.get().extendedGamepad)
+    if (m_gcController.get().extendedGamepad) {
         m_mapping = standardGamepadMappingString();
+        setButtonTypesForStandardMapping(m_buttonValues.size());
+    } else
+        setNonStandardButtonTypes(m_buttonValues.size());
 
-    auto bindButton = ^(GCControllerButtonInput *button, GamepadButtonRole index) {
-        m_buttonValues[(size_t)index].setValue(button.value);
+    auto bindButtonAtIndex = ^(GCControllerButtonInput *button, size_t index) {
+        m_buttonValues[index].setValue(button.value);
         if (!button)
             return;
 
@@ -115,10 +118,14 @@ void GameControllerGamepad::setupElements()
                 return;
             if (!weakThis)
                 return;
-            weakThis->m_buttonValues[(size_t)index].setValue(value);
+            weakThis->m_buttonValues[index].setValue(value);
             weakThis->m_lastUpdateTime = MonotonicTime::now();
             GameControllerGamepadProvider::singleton().gamepadHadInput(*weakThis, pressed);
         };
+    };
+
+    auto bindButton = ^(GCControllerButtonInput *button, GamepadButtonRole index) {
+        bindButtonAtIndex(button, static_cast<size_t>(index));
     };
 
     // Button Pad
@@ -138,7 +145,7 @@ void GameControllerGamepad::setupElements()
     bindButton(profile.get().dpads[GCInputDirectionPad].down, GamepadButtonRole::LeftClusterBottom);
     bindButton(profile.get().dpads[GCInputDirectionPad].left, GamepadButtonRole::LeftClusterLeft);
     bindButton(profile.get().dpads[GCInputDirectionPad].right, GamepadButtonRole::LeftClusterRight);
-    
+
     // Home, Select, Start
     if (homeButton) {
         bindButton(homeButton.get(), GamepadButtonRole::CenterClusterCenter);
@@ -154,6 +161,20 @@ void GameControllerGamepad::setupElements()
     // L3, R3
     bindButton(profile.get().buttons[GCInputLeftThumbstickButton], GamepadButtonRole::LeftStick);
     bindButton(profile.get().buttons[GCInputRightThumbstickButton], GamepadButtonRole::RightStick);
+
+    // GCDualShockGamepad and GCDualSenseGamepad expose the clickable trackpad
+    // as touchpadButton. It is not part of the standard 17-button mapping.
+    NSObject *extendedGamepad = m_gcController.get().extendedGamepad;
+    if ([extendedGamepad respondsToSelector:@selector(touchpadButton)]) {
+        GCControllerButtonInput *touchpadButton = [extendedGamepad performSelector:@selector(touchpadButton)];
+        if ([touchpadButton isKindOfClass:getGCControllerButtonInputClassSingleton()]) {
+            ASSERT(m_buttonValues.size() == m_buttonTypes.size());
+            size_t buttonIndex = m_buttonValues.size();
+            m_buttonValues.append(0.0);
+            m_buttonTypes.append(GamepadButtonType::Trackpad);
+            bindButtonAtIndex(touchpadButton, buttonIndex);
+        }
+    }
 
     m_axisValues.resize(4);
     m_axisValues[0].setValue(profile.get().dpads[GCInputLeftThumbstick].xAxis.value);

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
@@ -63,6 +63,8 @@ bool GameControllerGamepadProvider::willHandleVendorAndProduct(uint16_t vendorID
     switch ((static_cast<uint32_t>(vendorID) << 16) | productID) {
     case Dualshock4_1:
     case Dualshock4_2:
+    case DualSense:
+    case DualSenseEdge:
     case GamesirM2:
     case HoripadUltimate:
     case Nimbus1:
@@ -109,8 +111,8 @@ void GameControllerGamepadProvider::controllerDidConnect(GCController *controlle
         if (!serviceInfo.service)
             continue;
 
-        auto cfVendorID = adoptCF((CFNumberRef)IOHIDServiceClientCopyProperty(serviceInfo.service, CFSTR(kIOHIDVendorIDKey)));
-        auto cfProductID = adoptCF((CFNumberRef)IOHIDServiceClientCopyProperty(serviceInfo.service, CFSTR(kIOHIDProductIDKey)));
+        RetainPtr<CFNumberRef> cfVendorID = adoptCF((CFNumberRef)IOHIDServiceClientCopyProperty(serviceInfo.service, CFSTR(kIOHIDVendorIDKey)));
+        RetainPtr<CFNumberRef> cfProductID = adoptCF((CFNumberRef)IOHIDServiceClientCopyProperty(serviceInfo.service, CFSTR(kIOHIDProductIDKey)));
 
         int vendorID, productID;
         CFNumberGetValue(cfVendorID.get(), kCFNumberIntType, &vendorID);
@@ -202,7 +204,7 @@ void GameControllerGamepadProvider::prewarmGameControllerDevicesIfNecessary()
     init_GameController_GCInputRightTrigger();
     init_GameController_GCInputRightThumbstick();
     init_GameController_GCInputRightThumbstickButton();
-    
+
     prewarmed = true;
 }
 

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp
@@ -51,6 +51,7 @@ GamepadLibWPE::GamepadLibWPE(struct wpe_gamepad_provider* provider, uintptr_t ga
 
     m_id = String::fromUTF8(wpe_gamepad_get_id(m_gamepad.get()));
     m_mapping = String::fromUTF8("standard");
+    setButtonTypesForStandardMapping(m_buttonValues.size());
 
     static const struct wpe_gamepad_client_interface s_client = {
         // button_event

--- a/Source/WebCore/platform/gamepad/mac/Dualshock3HIDGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/mac/Dualshock3HIDGamepad.cpp
@@ -47,6 +47,7 @@ Dualshock3HIDGamepad::Dualshock3HIDGamepad(HIDDevice&& device, unsigned index)
     m_mapping = standardGamepadMappingString();
 
     m_buttonValues = Vector<SharedGamepadValue>(FillWith { }, numberOfStandardGamepadButtonsWithHomeButton, SharedGamepadValue { 0.0 });
+    setButtonTypesForStandardMapping(m_buttonValues.size());
 
     constexpr size_t axisCount = 4;
     m_axisValues = Vector<SharedGamepadValue>(FillWith { }, axisCount, SharedGamepadValue { 0.0 });

--- a/Source/WebCore/platform/gamepad/mac/GenericHIDGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/mac/GenericHIDGamepad.cpp
@@ -75,6 +75,7 @@ void GenericHIDGamepad::maybeAddGenericDesktopElement(HIDElement& element)
     case kHIDUsage_GD_DPadRight:
     case kHIDUsage_GD_DPadLeft:
         m_buttonValues.append(0.0);
+        m_buttonTypes.append(GamepadButtonType::NonStandard);
         m_elementMap.set(element.cookie(), makeUnique<HIDGamepadButton>(element, m_buttonValues.last()));
         break;
     default:
@@ -86,6 +87,7 @@ void GenericHIDGamepad::maybeAddButtonElement(HIDElement& element)
 {
     // If it's in the button page, we assume it's actually a button.
     m_buttonValues.append(0.0);
+    m_buttonTypes.append(GamepadButtonType::NonStandard);
     m_elementMap.set(element.cookie(), makeUnique<HIDGamepadButton>(element, m_buttonValues.last()));
 }
 

--- a/Source/WebCore/platform/gamepad/mac/LogitechGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/mac/LogitechGamepad.cpp
@@ -47,6 +47,7 @@ LogitechGamepad::LogitechGamepad(HIDDevice&& device, unsigned index)
     m_mapping = standardGamepadMappingString();
 
     m_buttonValues = Vector<SharedGamepadValue>(FillWith { }, numberOfStandardGamepadButtonsWithHomeButton, SharedGamepadValue { 0.0 });
+    setButtonTypesForStandardMapping(m_buttonValues.size());
 
     constexpr size_t axisCount = 4;
     m_axisValues = Vector<SharedGamepadValue>(FillWith { }, axisCount, SharedGamepadValue { 0.0 });

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
@@ -87,6 +87,7 @@ private:
             m_id = wrapped->id();
             m_mapping = wrapped->mapping();
             m_connectTime = wrapped->connectTime();
+            m_buttonTypes = wrapped->buttonTypes();
         }
 
         MonotonicTime lastUpdateTime() const final { return protect(platformGamepad())->lastUpdateTime(); }

--- a/Source/WebCore/platform/gamepad/mac/StadiaHIDGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/mac/StadiaHIDGamepad.cpp
@@ -45,6 +45,7 @@ StadiaHIDGamepad::StadiaHIDGamepad(HIDDevice&& device, unsigned index)
     m_mapping = standardGamepadMappingString();
 
     m_buttonValues = Vector<SharedGamepadValue>(FillWith { }, 19, SharedGamepadValue { 0.0 });
+    setButtonTypesForStandardMapping(m_buttonValues.size());
 
     constexpr size_t axisCount = 4;
     m_axisValues = Vector<SharedGamepadValue>(FillWith { }, axisCount, SharedGamepadValue { 0.0 });

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
@@ -154,6 +154,7 @@ ManetteGamepad::ManetteGamepad(ManetteDevice* device, unsigned index)
     m_buttonValues.resize(static_cast<size_t>(standardGamepadButtonCount));
     for (auto& value : m_buttonValues)
         value.setValue(0.0);
+    setButtonTypesForStandardMapping(m_buttonValues.size());
 
     if (manette_device_has_rumble(m_device.get()))
         m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);

--- a/Source/WebCore/testing/MockGamepad.cpp
+++ b/Source/WebCore/testing/MockGamepad.cpp
@@ -27,11 +27,24 @@
 #include "MockGamepad.h"
 
 #if ENABLE(GAMEPAD)
+
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MockGamepad);
+
+static Vector<GamepadButtonType> mockButtonTypes(const String& mapping, size_t buttonCount)
+{
+    auto buttonTypes = Vector<GamepadButtonType>(FillWith { }, buttonCount, GamepadButtonType::NonStandard);
+    if (mapping == "standard"_s) {
+        constexpr size_t standardButtonCount = 17;
+        for (size_t i = 0; i < buttonCount && i < standardButtonCount; ++i)
+            buttonTypes[i] = GamepadButtonType::Standard;
+    }
+
+    return buttonTypes;
+}
 
 MockGamepad::MockGamepad(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected)
     : PlatformGamepad(index)
@@ -50,6 +63,7 @@ void MockGamepad::updateDetails(const String& gamepadID, const String& mapping, 
     m_buttonValues.clear();
     for (size_t i = 0; i < buttonCount; ++i)
         m_buttonValues.append({ });
+    m_buttonTypes = mockButtonTypes(m_mapping, m_buttonValues.size());
     m_lastUpdateTime = MonotonicTime::now();
     if (supportsDualRumble)
         m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);

--- a/Source/WebKit/Shared/Gamepad/GamepadData.cpp
+++ b/Source/WebKit/Shared/Gamepad/GamepadData.cpp
@@ -31,27 +31,51 @@
 #include "ArgumentCoders.h"
 #include <wtf/text/StringBuilder.h>
 
+using WebCore::GamepadButtonType;
 using WebCore::SharedGamepadValue;
 
 namespace WebKit {
 
-GamepadData::GamepadData(unsigned index, const String& id, const String& mapping, const Vector<SharedGamepadValue>& axisValues, const Vector<SharedGamepadValue>& buttonValues, MonotonicTime lastUpdateTime, const WebCore::GamepadHapticEffectTypeSet& supportedEffectTypes)
+static Vector<double> sharedGamepadValuesToDoubles(const Vector<SharedGamepadValue>& values)
+{
+    return WTF::map(values, [](const auto& value) {
+        return value.value();
+    });
+}
+
+static Vector<GamepadButtonType> normalizedButtonTypes(size_t buttonCount, const Vector<GamepadButtonType>& buttonTypes)
+{
+    if (buttonTypes.size() == buttonCount)
+        return buttonTypes;
+    return Vector<GamepadButtonType>(FillWith { }, buttonCount, GamepadButtonType::NonStandard);
+}
+
+static Vector<GamepadButtonType> normalizedButtonTypes(size_t buttonCount, Vector<GamepadButtonType>&& buttonTypes)
+{
+    if (buttonTypes.size() == buttonCount)
+        return WTF::move(buttonTypes);
+    return Vector<GamepadButtonType>(FillWith { }, buttonCount, GamepadButtonType::NonStandard);
+}
+
+GamepadData::GamepadData(unsigned index, const String& id, const String& mapping, const Vector<SharedGamepadValue>& axisValues, const Vector<SharedGamepadValue>& buttonValues, const Vector<GamepadButtonType>& buttonTypes, MonotonicTime lastUpdateTime, const WebCore::GamepadHapticEffectTypeSet& supportedEffectTypes)
     : m_index(index)
     , m_id(id)
     , m_mapping(mapping)
-    , m_axisValues(WTF::map(axisValues, [](const auto& value) { return value.value(); }))
-    , m_buttonValues(WTF::map(buttonValues, [](const auto& value) { return value.value(); }))
+    , m_axisValues(sharedGamepadValuesToDoubles(axisValues))
+    , m_buttonValues(sharedGamepadValuesToDoubles(buttonValues))
+    , m_buttonTypes(normalizedButtonTypes(m_buttonValues.size(), buttonTypes))
     , m_lastUpdateTime(lastUpdateTime)
     , m_supportedEffectTypes(supportedEffectTypes)
 {
 }
 
-GamepadData::GamepadData(unsigned index, String&& id, String&& mapping, Vector<double>&& axisValues, Vector<double>&& buttonValues, MonotonicTime lastUpdateTime, WebCore::GamepadHapticEffectTypeSet&& supportedEffectTypes)
+GamepadData::GamepadData(unsigned index, String&& id, String&& mapping, Vector<double>&& axisValues, Vector<double>&& buttonValues, Vector<GamepadButtonType>&& buttonTypes, MonotonicTime lastUpdateTime, WebCore::GamepadHapticEffectTypeSet&& supportedEffectTypes)
     : m_index(index)
     , m_id(WTF::move(id))
     , m_mapping(WTF::move(mapping))
     , m_axisValues(WTF::move(axisValues))
     , m_buttonValues(WTF::move(buttonValues))
+    , m_buttonTypes(normalizedButtonTypes(m_buttonValues.size(), WTF::move(buttonTypes)))
     , m_lastUpdateTime(lastUpdateTime)
     , m_supportedEffectTypes(WTF::move(supportedEffectTypes))
 {

--- a/Source/WebKit/Shared/Gamepad/GamepadData.h
+++ b/Source/WebKit/Shared/Gamepad/GamepadData.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GAMEPAD)
 
+#include <WebCore/GamepadButtonType.h>
 #include <WebCore/GamepadHapticEffectType.h>
 #include <WebCore/SharedGamepadValue.h>
 #include <wtf/MonotonicTime.h>
@@ -37,9 +38,9 @@ namespace WebKit {
 
 class GamepadData {
 public:
-    GamepadData(unsigned index, const String& id, const String& mapping, const Vector<WebCore::SharedGamepadValue>& axisValues, const Vector<WebCore::SharedGamepadValue>& buttonValues, MonotonicTime lastUpdateTime, const WebCore::GamepadHapticEffectTypeSet& supportedEffectTypes);
-    
-    GamepadData(unsigned index, String&& id, String&& mapping, Vector<double>&& axisValues, Vector<double>&& buttonValues, MonotonicTime lastUpdateTime, WebCore::GamepadHapticEffectTypeSet&& supportedEffectTypes);
+    GamepadData(unsigned index, const String& id, const String& mapping, const Vector<WebCore::SharedGamepadValue>& axisValues, const Vector<WebCore::SharedGamepadValue>& buttonValues, const Vector<WebCore::GamepadButtonType>& buttonTypes, MonotonicTime lastUpdateTime, const WebCore::GamepadHapticEffectTypeSet& supportedEffectTypes);
+
+    GamepadData(unsigned index, String&& id, String&& mapping, Vector<double>&& axisValues, Vector<double>&& buttonValues, Vector<WebCore::GamepadButtonType>&& buttonTypes, MonotonicTime lastUpdateTime, WebCore::GamepadHapticEffectTypeSet&& supportedEffectTypes);
 
     MonotonicTime lastUpdateTime() const { return m_lastUpdateTime; }
     unsigned index() const { return m_index; }
@@ -47,6 +48,7 @@ public:
     const String& mapping() const LIFETIME_BOUND { return m_mapping; }
     const Vector<double>& axisValues() const LIFETIME_BOUND { return m_axisValues; }
     const Vector<double>& buttonValues() const LIFETIME_BOUND { return m_buttonValues; }
+    const Vector<WebCore::GamepadButtonType>& buttonTypes() const LIFETIME_BOUND { return m_buttonTypes; }
     const WebCore::GamepadHapticEffectTypeSet& supportedEffectTypes() const LIFETIME_BOUND { return m_supportedEffectTypes; }
 
 private:
@@ -55,6 +57,7 @@ private:
     String m_mapping;
     Vector<double> m_axisValues;
     Vector<double> m_buttonValues;
+    Vector<WebCore::GamepadButtonType> m_buttonTypes;
     MonotonicTime m_lastUpdateTime;
     WebCore::GamepadHapticEffectTypeSet m_supportedEffectTypes;
 

--- a/Source/WebKit/Shared/Gamepad/GamepadData.serialization.in
+++ b/Source/WebKit/Shared/Gamepad/GamepadData.serialization.in
@@ -28,6 +28,7 @@ class WebKit::GamepadData {
     String mapping();
     Vector<double> axisValues();
     Vector<double> buttonValues();
+    Vector<WebCore::GamepadButtonType> buttonTypes();
     MonotonicTime lastUpdateTime();
     HashSet<WebCore::GamepadHapticEffectType, IntHash<WebCore::GamepadHapticEffectType>, WTF::StrongEnumHashTraits<WebCore::GamepadHapticEffectType>> supportedEffectTypes();
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1391,6 +1391,13 @@ struct WebCore::GamepadEffectParameters {
     double rightTrigger;
 };
 
+header: <WebCore/GamepadButtonType.h>
+enum class WebCore::GamepadButtonType : uint8_t {
+    NonStandard,
+    Standard,
+    Trackpad
+};
+
 header: <WebCore/GamepadHapticEffectType.h>
 enum class WebCore::GamepadHapticEffectType : uint8_t {
     DualRumble,

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp
@@ -43,6 +43,7 @@ UIGamepad::UIGamepad(WebCore::PlatformGamepad& platformGamepad)
     , m_mapping(platformGamepad.mapping())
     , m_axisValues(platformGamepad.axisValues().size())
     , m_buttonValues(platformGamepad.buttonValues().size())
+    , m_buttonTypes(platformGamepad.buttonTypes())
     , m_lastUpdateTime(platformGamepad.lastUpdateTime())
     , m_supportedEffectTypes(platformGamepad.supportedEffectTypes())
 {
@@ -54,15 +55,17 @@ void UIGamepad::updateFromPlatformGamepad(WebCore::PlatformGamepad& platformGame
     ASSERT(m_index == platformGamepad.index());
     ASSERT(m_axisValues.size() == platformGamepad.axisValues().size());
     ASSERT(m_buttonValues.size() == platformGamepad.buttonValues().size());
+    ASSERT(platformGamepad.buttonTypes().isEmpty() || m_buttonValues.size() == platformGamepad.buttonTypes().size());
 
     m_axisValues = platformGamepad.axisValues();
     m_buttonValues = platformGamepad.buttonValues();
+    m_buttonTypes = platformGamepad.buttonTypes();
     m_lastUpdateTime = platformGamepad.lastUpdateTime();
 }
 
 GamepadData UIGamepad::gamepadData() const
 {
-    return { m_index, m_id, m_mapping, m_axisValues, m_buttonValues, m_lastUpdateTime, m_supportedEffectTypes };
+    return { m_index, m_id, m_mapping, m_axisValues, m_buttonValues, m_buttonTypes, m_lastUpdateTime, m_supportedEffectTypes };
 }
 
 }

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepad.h
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepad.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GAMEPAD)
 
+#include <WebCore/GamepadButtonType.h>
 #include <WebCore/GamepadHapticEffectType.h>
 #include <WebCore/SharedGamepadValue.h>
 #include <wtf/MonotonicTime.h>
@@ -59,6 +60,7 @@ private:
     String m_mapping;
     Vector<WebCore::SharedGamepadValue> m_axisValues;
     Vector<WebCore::SharedGamepadValue> m_buttonValues;
+    Vector<WebCore::GamepadButtonType> m_buttonTypes;
     MonotonicTime m_lastUpdateTime;
     WebCore::GamepadHapticEffectTypeSet m_supportedEffectTypes;
 };

--- a/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp
@@ -52,6 +52,7 @@ PlatformGamepadWPE::PlatformGamepadWPE(WPEGamepad* gamepad, unsigned index)
     m_buttonValues.resize(WPE_GAMEPAD_BUTTON_CENTER_CLUSTER_CENTER + 1);
     for (auto& value : m_buttonValues)
         value.setValue(0.0);
+    setButtonTypesForStandardMapping(m_buttonValues.size());
 
     m_axisValues.resize(WPE_GAMEPAD_AXIS_RIGHT_Y + 1);
     for (auto& value : m_axisValues)

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp
@@ -67,10 +67,15 @@ void WebGamepad::updateValues(const GamepadData& gamepadData)
     ASSERT(gamepadData.index() == index());
     ASSERT(m_axisValues.size() == gamepadData.axisValues().size());
     ASSERT(m_buttonValues.size() == gamepadData.buttonValues().size());
+    ASSERT(gamepadData.buttonTypes().size() == gamepadData.buttonValues().size());
 
-
-    m_axisValues = WTF::map(gamepadData.axisValues(), [](auto value) { return SharedGamepadValue(value); });
-    m_buttonValues = WTF::map(gamepadData.buttonValues(), [](auto value) { return SharedGamepadValue(value); });
+    m_axisValues = WTF::map(gamepadData.axisValues(), [](auto value) {
+        return SharedGamepadValue(value);
+    });
+    m_buttonValues = WTF::map(gamepadData.buttonValues(), [](auto value) {
+        return SharedGamepadValue(value);
+    });
+    m_buttonTypes = gamepadData.buttonTypes();
     m_lastUpdateTime = gamepadData.lastUpdateTime();
 }
 


### PR DESCRIPTION
#### 6488015d7509e973ed7a92f3e7cddd3dba5cbecc
<pre>
[Gamepad] Add GamepadButton.type support

<a href="https://bugs.webkit.org/show_bug.cgi?id=266293">https://bugs.webkit.org/show_bug.cgi?id=266293</a>

Reviewed by NOBODY (OOPS!).

[Gamepad] Add GamepadButton.type support

Implement the GamepadButton.type attribute and propagate button type
metadata from platform gamepad providers through WebKit IPC to WebCore
GamepadButton objects.

Expose GamepadButton.type behind the GamepadButtonTypeEnabled preference, so
the new API surface can remain disabled by default while the implementation is
reviewed and tested.

For standard gamepad mappings, mark only the 17 buttons defined by the
standard gamepad layout as &quot;standard&quot;; additional buttons remain
&quot;non-standard&quot; unless a platform provider identifies a more specific type.

On Cocoa GameController devices, append an exposed touchpadButton as an
additional button and mark it as &quot;trackpad&quot;. This lets devices such as
DualShock 4 and DualSense expose their clickable touchpad as button index
17 while keeping the standard 17-button mapping unchanged.

Also add DualSense and DualSense Edge product IDs to the GameController
allow-list and cover the standard/non-standard button typing behavior with
a layout test.

Spec: <a href="https://github.com/w3c/gamepad/pull/196">https://github.com/w3c/gamepad/pull/196</a>

Test: LayoutTests/gamepad/gamepad-button-type.html

* LayoutTests/gamepad/gamepad-button-type-expected.txt: Added.
* LayoutTests/gamepad/gamepad-button-type.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/gamepad/Gamepad.cpp:
(WebCore::exposedButtonCount):
* Source/WebCore/Modules/gamepad/GamepadButton.cpp:
(WebCore::GamepadButton::GamepadButton):
* Source/WebCore/Modules/gamepad/GamepadButton.h:
(WebCore::GamepadButton::create):
(WebCore::GamepadButton::type const):
* Source/WebCore/Modules/gamepad/GamepadButton.idl:
* Source/WebCore/Modules/gamepad/GamepadButtonType.h: Copied from Source/WebCore/Modules/gamepad/GamepadButton.h.
* Source/WebCore/Modules/gamepad/GamepadButtonType.idl: Copied from Source/WebCore/Modules/gamepad/GamepadButton.idl.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/gamepad/KnownGamepads.h:
* Source/WebCore/platform/gamepad/PlatformGamepad.cpp: Copied from Source/WebCore/Modules/gamepad/GamepadButton.cpp.
(WebCore::PlatformGamepad::setNonStandardButtonTypes):
(WebCore::PlatformGamepad::setButtonTypesForStandardMapping):
* Source/WebCore/platform/gamepad/PlatformGamepad.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm:
(WebCore::GameControllerGamepad::setupElements):
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm:
(WebCore::GameControllerGamepadProvider::willHandleVendorAndProduct):
(WebCore::GameControllerGamepadProvider::controllerDidConnect):
(WebCore::GameControllerGamepadProvider::prewarmGameControllerDevicesIfNecessary):
* Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp:
(WebCore::GamepadLibWPE::GamepadLibWPE):
* Source/WebCore/platform/gamepad/mac/Dualshock3HIDGamepad.cpp:
(WebCore::Dualshock3HIDGamepad::Dualshock3HIDGamepad):
* Source/WebCore/platform/gamepad/mac/GenericHIDGamepad.cpp:
(WebCore::GenericHIDGamepad::maybeAddGenericDesktopElement):
(WebCore::GenericHIDGamepad::maybeAddButtonElement):
* Source/WebCore/platform/gamepad/mac/LogitechGamepad.cpp:
(WebCore::LogitechGamepad::LogitechGamepad):
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h:
* Source/WebCore/platform/gamepad/mac/StadiaHIDGamepad.cpp:
(WebCore::StadiaHIDGamepad::StadiaHIDGamepad):
* Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp:
(WebCore::ManetteGamepad::ManetteGamepad):
* Source/WebCore/testing/MockGamepad.cpp:
(WebCore::mockButtonTypes):
(WebCore::MockGamepad::updateDetails):
* Source/WebKit/Shared/Gamepad/GamepadData.cpp:
(WebKit::sharedGamepadValuesToDoubles):
(WebKit::normalizedButtonTypes):
(WebKit::GamepadData::GamepadData):
(WebKit::m_buttonValues): Deleted.
(WebKit::m_supportedEffectTypes): Deleted.
* Source/WebKit/Shared/Gamepad/GamepadData.h:
* Source/WebKit/Shared/Gamepad/GamepadData.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp:
(WebKit::UIGamepad::UIGamepad):
(WebKit::UIGamepad::updateFromPlatformGamepad):
(WebKit::UIGamepad::gamepadData const):
* Source/WebKit/UIProcess/Gamepad/UIGamepad.h:
* Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp:
(WebKit::PlatformGamepadWPE::PlatformGamepadWPE):
* Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp:
(WebKit::WebGamepad::updateValues):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6488015d7509e973ed7a92f3e7cddd3dba5cbecc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134173 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94658 "1 flakes 21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114645 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36210 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34516 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30555 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3229 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146639 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184488 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33759 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142946 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142824 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46766 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31044 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111567 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37853 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118517 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205176 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45283 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9148 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54782 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44915 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->