### PR TITLE
[JSC] Fix GC safety for sunk contiguous array materialization in FTL

### DIFF
--- a/JSTests/stress/ftl-materialize-new-array-with-butterfly.js
+++ b/JSTests/stress/ftl-materialize-new-array-with-butterfly.js
@@ -1,0 +1,35 @@
+//@ runDefault("--useConcurrentJIT=false", "--jitPolicyScale=0.1", "--slowPathAllocsBetweenGCs=3")
+
+function opt(escape) {
+    const arr = new Array(2);
+
+    arr[0] = {};
+    arr[1] = {};
+
+    if (escape) {
+        return arr;
+    }
+
+    return 0;
+}
+
+function main() {
+    noInline(opt);
+
+    for (let i = 0; i < 1000; i++) {
+        opt(!(i % 10));
+    }
+
+    for (let i = 0; i < 100; i++) {
+        const arr = opt(true);
+
+        for (let j = 0; j < 5; j++) {
+            const object = {};
+            if (arr[0] === object) {
+                throw new Error("bad");
+            }
+        }
+    }
+}
+
+main();

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -18662,6 +18662,9 @@ IGNORE_CLANG_WARNINGS_END
 
         ObjectMaterializationData& data = m_node->objectMaterializationData();
 
+        // Contiguous element values may be GC cell pointers; keep them live across allocateJSArray
+        // since the butterfly is unowned at allocateCell and the GC won't trace its contents.
+        Vector<LValue> contiguousElementValues;
         for (unsigned i = 0; i < data.m_properties.size(); ++i) {
             // Add two to account for `size` and `butterfly`
             Edge edge = m_graph.varArgChild(m_node, i + 2);
@@ -18670,10 +18673,15 @@ IGNORE_CLANG_WARNINGS_END
             case ALL_DOUBLE_INDEXING_TYPES:
                 m_out.storeDouble(lowDouble(edge), butterfly, m_heaps.indexedDoubleProperties[index]);
                 break;
-            case ALL_INT32_INDEXING_TYPES:
+            case ALL_INT32_INDEXING_TYPES: {
+                LValue value = lowJSValue(edge, ManualOperandSpeculation); // We already speculated it so it is fine.
+                m_out.store64(value, butterfly, m_heaps.forIndexingType(indexingType)->at(index));
+                break;
+            }
             case ALL_CONTIGUOUS_INDEXING_TYPES: {
                 LValue value = lowJSValue(edge, ManualOperandSpeculation); // We already speculated it so it is fine.
                 m_out.store64(value, butterfly, m_heaps.forIndexingType(indexingType)->at(index));
+                contiguousElementValues.append(value);
                 break;
             }
             default:
@@ -18683,6 +18691,8 @@ IGNORE_CLANG_WARNINGS_END
         }
 
         LValue array = allocateJSArray(indexingType, publicLength, butterfly);
+        // Keep contiguous element values live across the GC point in allocateJSArray's slow path.
+        ensureStillAliveHere(contiguousElementValues);
         setJSValue(array);
         mutatorFence();
     }
@@ -26757,15 +26767,21 @@ IGNORE_CLANG_WARNINGS_END
         return true;
     }
 
-    void ensureStillAliveHere(LValue value)
+    void ensureStillAliveHereImpl(const Vector<LValue>& values)
     {
+        if (values.isEmpty())
+            return;
         PatchpointValue* patchpoint = m_out.patchpoint(Void);
         patchpoint->effects = Effects::none();
         patchpoint->effects.writesLocalState = true;
         patchpoint->effects.reads = HeapRange::top();
-        patchpoint->append(value, ValueRep::ColdAny);
+        for (LValue value : values)
+            patchpoint->append(value, ValueRep::ColdAny);
         patchpoint->setGenerator([=] (CCallHelpers&, const StackmapGenerationParams&) { });
     }
+
+    void ensureStillAliveHere(const Vector<LValue>& values) { ensureStillAliveHereImpl(values); }
+    void ensureStillAliveHere(LValue value) { ensureStillAliveHereImpl({ value }); }
 
     LValue toButterfly(LValue immutableButterfly)
     {


### PR DESCRIPTION
#### e638840dd2cdd52550b4078833836974c348adaa
<pre>
[JSC] Fix GC safety for sunk contiguous array materialization in FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=310223">https://bugs.webkit.org/show_bug.cgi?id=310223</a>
<a href="https://rdar.apple.com/172827445">rdar://172827445</a>

Reviewed by Yusuke Suzuki.

compileMaterializeNewArrayWithButterfly writes element values into a raw butterfly before
allocating the JSArray header. For contiguous arrays the element values are GC cell pointers,
but their last B3 use is the store64 into the butterfly. B3 backward liveness therefore marks
them dead at that point, so they are absent from the stack when allocateJSArray&apos;s slow path
triggers a collection — the butterfly is unowned and the GC does not trace its contents.

Fix by collecting contiguous element values and calling ensureStillAliveHere after
allocateJSArray. This inserts a zero-instruction patchpoint that is a formal B3 use of each
value, extending their liveness backward through the allocation slow path and forcing them onto
the stack where the GC conservative scanner can find them.

INT32 and DOUBLE elements are not cell pointers and need no treatment.

Test: JSTests/stress/ftl-materialize-new-array-with-butterfly.js

Originally-landed-as: 305413.530@rapid/safari-7624.2.5.110-branch (ad7a71bb3efe). <a href="https://rdar.apple.com/176062025">rdar://176062025</a>
Canonical link: <a href="https://commits.webkit.org/313923@main">https://commits.webkit.org/313923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1326659263274f6e8523aec19072d86258b872a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121758 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127824 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89986 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108369 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29171 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27798 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21299 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156657 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176062 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25398 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28885 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136142 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136107 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36669 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147384 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100901 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31393 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24240 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196909 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37257 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110301 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51716 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36655 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2301 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->