### PR TITLE
Simplify DeprecatedCSSOMValue class hierarchy by using virtual functions

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -178,8 +178,6 @@ css/StyleRule.cpp
 css/StyleRuleImport.cpp
 css/StyleRuleImport.h
 css/StyleSheetContents.cpp
-css/deprecated-cssom/DeprecatedCSSOMPrimitiveValue.h
-css/deprecated-cssom/DeprecatedCSSOMRGBColor.h
 css/typedom/DeclaredStylePropertyMap.cpp
 css/typedom/InlineStylePropertyMap.cpp
 css/typedom/numeric/CSSMathMax.cpp
@@ -191,7 +189,6 @@ css/typedom/transform/CSSSkew.cpp
 css/typedom/transform/CSSSkewX.cpp
 css/typedom/transform/CSSSkewY.cpp
 css/typedom/transform/CSSTranslate.cpp
-css/values/primitives/CSSPrimitiveNumericTypes+DeprecatedCSSOMValueCreation.h
 dom/Attr.cpp
 dom/BoundaryPoint.cpp
 dom/BroadcastChannel.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1051,8 +1051,11 @@ css/calc/CSSCalcTree+Simplification.cpp @header:RenderStyleGetters
 css/calc/CSSCalcTree.cpp
 css/calc/CSSCalcType.cpp
 css/calc/CSSCalcValue.cpp
+css/deprecated-cssom/DeprecatedCSSOMCustomValue.cpp
 css/deprecated-cssom/DeprecatedCSSOMLazySerializingCustomValue.cpp
 css/deprecated-cssom/DeprecatedCSSOMPrimitiveValue.cpp
+css/deprecated-cssom/DeprecatedCSSOMRGBColor.cpp
+css/deprecated-cssom/DeprecatedCSSOMRect.cpp
 css/deprecated-cssom/DeprecatedCSSOMValue.cpp
 css/deprecated-cssom/DeprecatedCSSOMValueList.cpp
 css/parser/CSSAtRuleID.cpp

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -104,6 +104,7 @@
 #include "CSSViewValue.h"
 #include "CSSWebkitBoxReflectValue.h"
 #include "ComputedStyleDependencies.h"
+#include "DeprecatedCSSOMCustomValue.h"
 #include "DeprecatedCSSOMPrimitiveValue.h"
 #include "DeprecatedCSSOMValueList.h"
 #include "EventTarget.h"
@@ -450,7 +451,7 @@ Ref<DeprecatedCSSOMValue> CSSValue::createDeprecatedCSSOMWrapper(CSSStyleDeclara
         return uncheckedDowncast<CSSQuotesValue>(*this).createDeprecatedCSSOMWrapper(styleDeclaration);
 
     default:
-        return DeprecatedCSSOMComplexValue::create(*this, styleDeclaration);
+        return DeprecatedCSSOMCustomValue::create(*this, styleDeclaration);
     }
 }
 

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMCounter.h
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMCounter.h
@@ -25,12 +25,10 @@
 
 #pragma once
 
-#include <WebCore/CSSValueKeywords.h>
+#include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-
-enum CSSValueID : uint16_t;
 
 class DeprecatedCSSOMCounter final : public RefCounted<DeprecatedCSSOMCounter> {
 public:

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMCustomValue.cpp
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMCustomValue.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DeprecatedCSSOMCustomValue.h"
+
+#include "CSSKeywordValue.h"
+#include "CSSSerializationContext.h"
+
+namespace WebCore {
+
+Ref<DeprecatedCSSOMCustomValue> DeprecatedCSSOMCustomValue::create(Ref<const CSSValue> value, CSSStyleDeclaration& owner)
+{
+    return adoptRef(*new DeprecatedCSSOMCustomValue(WTF::move(value), owner));
+}
+
+DeprecatedCSSOMCustomValue::DeprecatedCSSOMCustomValue(Ref<const CSSValue> value, CSSStyleDeclaration& owner)
+    : DeprecatedCSSOMValue(owner)
+    , m_value(WTF::move(value))
+{
+}
+
+String DeprecatedCSSOMCustomValue::cssText() const
+{
+    return m_value->cssText(CSS::defaultSerializationContext());
+}
+
+unsigned short DeprecatedCSSOMCustomValue::cssValueType() const
+{
+    return CSS_CUSTOM;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMCustomValue.h
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMCustomValue.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSValue.h"
+#include "DeprecatedCSSOMValue.h"
+
+namespace WebCore {
+
+class DeprecatedCSSOMCustomValue final : public DeprecatedCSSOMValue {
+public:
+    static Ref<DeprecatedCSSOMCustomValue> create(Ref<const CSSValue>, CSSStyleDeclaration&);
+
+    String cssText() const override;
+    unsigned short NODELETE cssValueType() const override;
+    bool isCustomValue() const override { return true; }
+
+private:
+    DeprecatedCSSOMCustomValue(Ref<const CSSValue>, CSSStyleDeclaration&);
+
+    const Ref<const CSSValue> m_value;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSSOM_VALUE(DeprecatedCSSOMCustomValue, isCustomValue())

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMLazySerializingCustomValue.cpp
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMLazySerializingCustomValue.cpp
@@ -35,7 +35,7 @@ Ref<DeprecatedCSSOMLazySerializingCustomValue> DeprecatedCSSOMLazySerializingCus
 }
 
 DeprecatedCSSOMLazySerializingCustomValue::DeprecatedCSSOMLazySerializingCustomValue(SerializationFunctor&& functor, CSSStyleDeclaration& owner)
-    : DeprecatedCSSOMValue(ClassType::LazySerializingCustom, owner)
+    : DeprecatedCSSOMValue(owner)
     , m_serializationFunctor(WTF::move(functor))
 {
 }
@@ -45,6 +45,11 @@ String DeprecatedCSSOMLazySerializingCustomValue::cssText() const
     if (m_cachedSerialization.isNull())
         m_cachedSerialization = m_serializationFunctor(CSS::defaultSerializationContext());
     return m_cachedSerialization;
+}
+
+unsigned short DeprecatedCSSOMLazySerializingCustomValue::cssValueType() const
+{
+    return CSS_CUSTOM;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMLazySerializingCustomValue.h
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMLazySerializingCustomValue.h
@@ -24,14 +24,17 @@
 
 #pragma once
 
-#include "CSSValueTypes.h"
 #include "DeprecatedCSSOMValue.h"
 #include <wtf/Function.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// This type is equivalent to `DeprecatedCSSOMComplexValue`, but is used for values that have no `CSSValue` wrapper.
+namespace CSS {
+struct SerializationContext;
+}
+
+// This type is equivalent to `DeprecatedCSSOMCustomValue`, but is used for values that have no `CSSValue` wrapper.
 // Lazy serialization is used to guard against the case of a user accessing a `DeprecatedCSSOMValue` just to check
 // what its type is. If that is deemed to niche, we can simplify this type by eagerly serializing, avoiding the need
 // to hold onto the serialization functor.
@@ -41,8 +44,9 @@ public:
 
     static Ref<DeprecatedCSSOMLazySerializingCustomValue> create(SerializationFunctor&&, CSSStyleDeclaration&);
 
-    String cssText() const;
-    unsigned short cssValueType() const { return CSS_CUSTOM; }
+    String cssText() const override;
+    unsigned short NODELETE cssValueType() const override;
+    bool isLazySerializingCustomValue() const override { return true; }
 
 private:
     DeprecatedCSSOMLazySerializingCustomValue(SerializationFunctor&&, CSSStyleDeclaration&);

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMPrimitiveValue.cpp
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMPrimitiveValue.cpp
@@ -33,6 +33,8 @@
 #include "CSSCustomIdentValue.h"
 #include "CSSFontFamilyNameValue.h"
 #include "CSSKeywordValue.h"
+#include "CSSParserIdioms.h"
+#include "CSSPrimitiveValue.h"
 #include "CSSRectValue.h"
 #include "CSSSerializationContext.h"
 #include "CSSStringValue.h"
@@ -44,9 +46,45 @@
 
 namespace WebCore {
 
+Ref<DeprecatedCSSOMPrimitiveValue> DeprecatedCSSOMPrimitiveValue::create(Ref<const CSSValue> value, CSSStyleDeclaration& owner)
+{
+    return adoptRef(*new DeprecatedCSSOMPrimitiveValue(WTF::move(value), owner));
+}
+
+DeprecatedCSSOMPrimitiveValue::DeprecatedCSSOMPrimitiveValue(Ref<const CSSValue> value, CSSStyleDeclaration& owner)
+    : DeprecatedCSSOMValue(owner)
+    , m_value(value)
+{
+}
+
 String DeprecatedCSSOMPrimitiveValue::cssText() const
 {
-    return protect(value())->cssText(CSS::defaultSerializationContext());
+    return protect(m_value)->cssText(CSS::defaultSerializationContext());
+}
+
+unsigned short DeprecatedCSSOMPrimitiveValue::cssValueType() const
+{
+    // These values are exposed in the DOM, but constants for them are not.
+    constexpr unsigned short CSS_INITIAL = 4;
+    constexpr unsigned short CSS_UNSET = 5;
+    constexpr unsigned short CSS_REVERT = 6;
+
+    RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(m_value);
+    if (!keywordValue)
+        return CSS_PRIMITIVE_VALUE;
+
+    switch (keywordValue->valueID()) {
+    case CSSValueInherit:
+        return CSS_INHERIT;
+    case CSSValueInitial:
+        return CSS_INITIAL;
+    case CSSValueUnset:
+        return CSS_UNSET;
+    case CSSValueRevert:
+        return CSS_REVERT;
+    default:
+        return CSS_PRIMITIVE_VALUE;
+    }
 }
 
 unsigned short DeprecatedCSSOMPrimitiveValue::primitiveType() const
@@ -255,7 +293,7 @@ ExceptionOr<Ref<DeprecatedCSSOMRGBColor>> DeprecatedCSSOMPrimitiveValue::getRGBC
 {
     if (primitiveType() != CSS_RGBCOLOR)
         return Exception { ExceptionCode::InvalidAccessError };
-    return DeprecatedCSSOMRGBColor::create(m_owner, downcast<CSSColorValue>(m_value.get()).color().absoluteColor());
+    return DeprecatedCSSOMRGBColor::create(downcast<CSSColorValue>(m_value.get()).color().absoluteColor(), m_owner);
 }
 
 bool DeprecatedCSSOMPrimitiveValue::isCSSWideKeyword() const

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMPrimitiveValue.h
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMPrimitiveValue.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,8 +26,6 @@
 
 #pragma once
 
-#include <WebCore/CSSParserIdioms.h>
-#include <WebCore/CSSPrimitiveValue.h>
 #include <WebCore/DeprecatedCSSOMValue.h>
 
 namespace WebCore {
@@ -35,7 +34,7 @@ class DeprecatedCSSOMCounter;
 class DeprecatedCSSOMRGBColor;
 class DeprecatedCSSOMRect;
     
-class DeprecatedCSSOMPrimitiveValue : public DeprecatedCSSOMValue {
+class DeprecatedCSSOMPrimitiveValue final : public DeprecatedCSSOMValue {
 public:
     // Only expose what's in the IDL file.
     enum UnitType {
@@ -68,13 +67,11 @@ public:
         // Do not add new units here; this is deprecated and we shouldn't expose anything not in DOM Level 2 Style.
     };
 
-    static Ref<DeprecatedCSSOMPrimitiveValue> create(const CSSValue& value, CSSStyleDeclaration& owner)
-    {
-        return adoptRef(*new DeprecatedCSSOMPrimitiveValue(value, owner));
-    }
+    static Ref<DeprecatedCSSOMPrimitiveValue> create(Ref<const CSSValue>, CSSStyleDeclaration&);
 
-    bool equals(const DeprecatedCSSOMPrimitiveValue& other) const { return m_value->equals(other.m_value); }
-    String cssText() const;
+    String cssText() const override;
+    unsigned short NODELETE cssValueType() const override;
+    bool isPrimitiveValue() const override { return true; }
 
     WEBCORE_EXPORT unsigned short primitiveType() const;
     WEBCORE_EXPORT ExceptionOr<float> getFloatValue(unsigned short unitType) const;
@@ -88,20 +85,12 @@ public:
 
     bool isCSSWideKeyword() const;
 
-    static unsigned short cssValueType() { return CSS_PRIMITIVE_VALUE; }
-
 private:
-    DeprecatedCSSOMPrimitiveValue(const CSSValue& value, CSSStyleDeclaration& owner)
-        : DeprecatedCSSOMValue(ClassType::Primitive, owner)
-        , m_value(value)
-    {
-    }
-
-    const CSSValue& value() const { return m_value; }
+    DeprecatedCSSOMPrimitiveValue(Ref<const CSSValue>, CSSStyleDeclaration&);
 
     Ref<const CSSValue> m_value;
 };
-    
+
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_CSSOM_VALUE(DeprecatedCSSOMPrimitiveValue, isPrimitiveValue())

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRGBColor.cpp
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRGBColor.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DeprecatedCSSOMRGBColor.h"
+
+#include "CSSPrimitiveValue.h"
+
+namespace WebCore {
+
+static Ref<DeprecatedCSSOMPrimitiveValue> createWrapperForColorComponent(double number, CSSStyleDeclaration& owner)
+{
+    return DeprecatedCSSOMPrimitiveValue::create(CSSPrimitiveValue::create(number), owner);
+}
+
+Ref<DeprecatedCSSOMRGBColor> DeprecatedCSSOMRGBColor::create(const WebCore::Color& color, CSSStyleDeclaration& owner)
+{
+    return adoptRef(*new DeprecatedCSSOMRGBColor(color, owner));
+}
+
+DeprecatedCSSOMRGBColor::DeprecatedCSSOMRGBColor(const WebCore::Color& color, CSSStyleDeclaration& owner)
+    : m_color(color.toColorTypeLossy<SRGBA<uint8_t>>().resolved())
+    , m_red(createWrapperForColorComponent(m_color.red, owner))
+    , m_green(createWrapperForColorComponent(m_color.green, owner))
+    , m_blue(createWrapperForColorComponent(m_color.blue, owner))
+    , m_alpha(createWrapperForColorComponent(color.alphaAsFloat(), owner))
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRGBColor.h
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRGBColor.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -22,16 +23,12 @@
 
 #include <WebCore/Color.h>
 #include <WebCore/DeprecatedCSSOMPrimitiveValue.h>
-#include <wtf/Ref.h>
 
 namespace WebCore {
 
 class DeprecatedCSSOMRGBColor final : public RefCounted<DeprecatedCSSOMRGBColor> {
 public:
-    static Ref<DeprecatedCSSOMRGBColor> create(CSSStyleDeclaration& owner, const WebCore::Color& color)
-    {
-        return adoptRef(*new DeprecatedCSSOMRGBColor(owner, color));
-    }
+    static Ref<DeprecatedCSSOMRGBColor> create(const WebCore::Color&, CSSStyleDeclaration&);
 
     DeprecatedCSSOMPrimitiveValue& red() { return m_red; }
     DeprecatedCSSOMPrimitiveValue& green() { return m_green; }
@@ -41,19 +38,7 @@ public:
     ResolvedColorType<SRGBA<uint8_t>> color() const { return m_color; }
 
 private:
-    template<typename NumberType> static Ref<DeprecatedCSSOMPrimitiveValue> createWrapper(CSSStyleDeclaration& owner, NumberType number)
-    {
-        return DeprecatedCSSOMPrimitiveValue::create(CSSPrimitiveValue::create(number), owner);
-    }
-
-    DeprecatedCSSOMRGBColor(CSSStyleDeclaration& owner, const WebCore::Color& color)
-        : m_color(color.toColorTypeLossy<SRGBA<uint8_t>>().resolved())
-        , m_red(createWrapper(owner, m_color.red))
-        , m_green(createWrapper(owner, m_color.green))
-        , m_blue(createWrapper(owner, m_color.blue))
-        , m_alpha(createWrapper(owner, color.alphaAsFloat()))
-    {
-    }
+    DeprecatedCSSOMRGBColor(const WebCore::Color&, CSSStyleDeclaration&);
 
     ResolvedColorType<SRGBA<uint8_t>> m_color;
     const Ref<DeprecatedCSSOMPrimitiveValue> m_red;

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRect.cpp
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRect.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DeprecatedCSSOMRect.h"
+
+#include "Rect.h"
+
+namespace WebCore {
+
+Ref<DeprecatedCSSOMRect> DeprecatedCSSOMRect::create(const Rect& rect, CSSStyleDeclaration& owner)
+{
+    return adoptRef(*new DeprecatedCSSOMRect(rect, owner));
+}
+
+DeprecatedCSSOMRect::DeprecatedCSSOMRect(const Rect& rect, CSSStyleDeclaration& owner)
+    : m_top(DeprecatedCSSOMPrimitiveValue::create(rect.top(), owner))
+    , m_right(DeprecatedCSSOMPrimitiveValue::create(rect.right(), owner))
+    , m_bottom(DeprecatedCSSOMPrimitiveValue::create(rect.bottom(), owner))
+    , m_left(DeprecatedCSSOMPrimitiveValue::create(rect.left(), owner))
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRect.h
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRect.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,16 +27,14 @@
 #pragma once
 
 #include <WebCore/DeprecatedCSSOMPrimitiveValue.h>
-#include <WebCore/Rect.h>
 
 namespace WebCore {
 
+class Rect;
+
 class DeprecatedCSSOMRect final : public RefCounted<DeprecatedCSSOMRect> {
 public:
-    static Ref<DeprecatedCSSOMRect> create(const Rect& rect, CSSStyleDeclaration& owner)
-    {
-        return adoptRef(*new DeprecatedCSSOMRect(rect, owner));
-    }
+    static Ref<DeprecatedCSSOMRect> create(const Rect&, CSSStyleDeclaration&);
 
     DeprecatedCSSOMPrimitiveValue& top() const { return m_top; }
     DeprecatedCSSOMPrimitiveValue& right() const { return m_right; }
@@ -43,13 +42,7 @@ public:
     DeprecatedCSSOMPrimitiveValue& left() const { return m_left; }
 
 private:
-    DeprecatedCSSOMRect(const Rect& rect, CSSStyleDeclaration& owner)
-        : m_top(DeprecatedCSSOMPrimitiveValue::create(rect.top(), owner))
-        , m_right(DeprecatedCSSOMPrimitiveValue::create(rect.right(), owner))
-        , m_bottom(DeprecatedCSSOMPrimitiveValue::create(rect.bottom(), owner))
-        , m_left(DeprecatedCSSOMPrimitiveValue::create(rect.left(), owner))
-    {
-    }
+    DeprecatedCSSOMRect(const Rect&, CSSStyleDeclaration&);
 
     const Ref<DeprecatedCSSOMPrimitiveValue> m_top;
     const Ref<DeprecatedCSSOMPrimitiveValue> m_right;

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMValue.cpp
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMValue.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,97 +27,8 @@
 #include "config.h"
 #include "DeprecatedCSSOMValue.h"
 
-#include "CSSKeywordValue.h"
-#include "CSSSerializationContext.h"
-#include "DeprecatedCSSOMLazySerializingCustomValue.h"
-#include "DeprecatedCSSOMPrimitiveValue.h"
-#include "DeprecatedCSSOMValueList.h"
-
 namespace WebCore {
 
-void DeprecatedCSSOMValue::operator delete(DeprecatedCSSOMValue* value, std::destroying_delete_t)
-{
-    auto destroyAndFree = [&]<typename ValueType> (ValueType& value) {
-        std::destroy_at(&value);
-        ValueType::freeAfterDestruction(&value);
-    };
+DeprecatedCSSOMValue::~DeprecatedCSSOMValue() = default;
 
-    switch (value->classType()) {
-    case ClassType::LazySerializingCustom:
-        destroyAndFree(uncheckedDowncast<DeprecatedCSSOMLazySerializingCustomValue>(*value));
-        break;
-    case ClassType::Complex:
-        destroyAndFree(uncheckedDowncast<DeprecatedCSSOMComplexValue>(*value));
-        break;
-    case ClassType::Primitive:
-        destroyAndFree(uncheckedDowncast<DeprecatedCSSOMPrimitiveValue>(*value));
-        break;
-    case ClassType::List:
-        destroyAndFree(uncheckedDowncast<DeprecatedCSSOMValueList>(*value));
-        break;
-    }
-}
-
-unsigned short DeprecatedCSSOMValue::cssValueType() const
-{
-    switch (classType()) {
-    case ClassType::LazySerializingCustom:
-        return uncheckedDowncast<DeprecatedCSSOMLazySerializingCustomValue>(*this).cssValueType();
-    case ClassType::Complex:
-        return uncheckedDowncast<DeprecatedCSSOMComplexValue>(*this).cssValueType();
-    case ClassType::Primitive:
-        return uncheckedDowncast<DeprecatedCSSOMPrimitiveValue>(*this).cssValueType();
-    case ClassType::List:
-        return CSS_VALUE_LIST;
-    }
-    ASSERT_NOT_REACHED();
-    return CSS_CUSTOM;
-}
-
-String DeprecatedCSSOMValue::cssText() const
-{
-    switch (classType()) {
-    case ClassType::LazySerializingCustom:
-        return uncheckedDowncast<DeprecatedCSSOMLazySerializingCustomValue>(*this).cssText();
-    case ClassType::Complex:
-        return uncheckedDowncast<DeprecatedCSSOMComplexValue>(*this).cssText();
-    case ClassType::Primitive:
-        return uncheckedDowncast<DeprecatedCSSOMPrimitiveValue>(*this).cssText();
-    case ClassType::List:
-        return uncheckedDowncast<DeprecatedCSSOMValueList>(*this).cssText();
-    }
-    ASSERT_NOT_REACHED();
-    return emptyString();
-}
-
-String DeprecatedCSSOMComplexValue::cssText() const
-{
-    return m_value->cssText(CSS::defaultSerializationContext());
-}
-
-unsigned short DeprecatedCSSOMComplexValue::cssValueType() const
-{
-    // These values are exposed in the DOM, but constants for them are not.
-    constexpr unsigned short CSS_INITIAL = 4;
-    constexpr unsigned short CSS_UNSET = 5;
-    constexpr unsigned short CSS_REVERT = 6;
-
-    RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(m_value);
-    if (!keywordValue)
-        return CSS_CUSTOM;
-
-    switch (keywordValue->valueID()) {
-    case CSSValueInherit:
-        return CSS_INHERIT;
-    case CSSValueInitial:
-        return CSS_INITIAL;
-    case CSSValueUnset:
-        return CSS_UNSET;
-    case CSSValueRevert:
-        return CSS_REVERT;
-    default:
-        return CSS_CUSTOM;
-    }
-}
-
-}
+} // namespace WebCore

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMValue.h
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMValue.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,18 +27,13 @@
 #pragma once
 
 #include <WebCore/CSSStyleDeclaration.h>
-#include <WebCore/CSSValue.h>
 #include <WebCore/ExceptionOr.h>
-#include <wtf/NoVirtualDestructorBase.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
-#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// NOTE: This destructor is non-virtual for memory and performance reasons.
-// Don't go making it virtual again unless you know exactly what you're doing!
-class DeprecatedCSSOMValue : public RefCountedAndCanMakeWeakPtr<DeprecatedCSSOMValue>, public NoVirtualDestructorBase {
+class DeprecatedCSSOMValue : public RefCountedAndCanMakeWeakPtr<DeprecatedCSSOMValue> {
 public:
     // Exactly match the IDL. No reason to add anything if it's not in the IDL.
     enum Type : unsigned short {
@@ -47,64 +43,28 @@ public:
         CSS_CUSTOM = 3
     };
 
-    WEBCORE_EXPORT unsigned short NODELETE cssValueType() const;
+    WEBCORE_EXPORT virtual ~DeprecatedCSSOMValue();
 
-    WEBCORE_EXPORT String cssText() const;
+    WEBCORE_EXPORT virtual unsigned short NODELETE cssValueType() const = 0;
+    WEBCORE_EXPORT virtual String cssText() const = 0;
     ExceptionOr<void> setCssText(const String&) { return { }; } // Will never implement.
 
-    bool isLazySerializingCustomValue() const { return classType() == ClassType::LazySerializingCustom; }
-    bool isComplexValue() const { return classType() == ClassType::Complex; }
-    bool isPrimitiveValue() const { return classType() == ClassType::Primitive; }
-    bool isValueList() const { return classType() == ClassType::List; }
+    virtual bool isLazySerializingCustomValue() const { return false; }
+    virtual bool isCustomValue() const { return false; }
+    virtual bool isPrimitiveValue() const { return false; }
+    virtual bool isValueList() const { return false; }
 
     CSSStyleDeclaration& owner() const { return m_owner; }
 
-    WEBCORE_EXPORT void operator delete(DeprecatedCSSOMValue*, std::destroying_delete_t);
-
 protected:
-    static const size_t ClassTypeBits = 3;
-    enum class ClassType : uint8_t {
-        LazySerializingCustom,
-        Complex,
-        List,
-        Primitive
-    };
-    ClassType classType() const { return static_cast<ClassType>(m_classType); }
-
-    DeprecatedCSSOMValue(ClassType classType, CSSStyleDeclaration& owner)
-        : m_classType(std::to_underlying(classType))
-        , m_owner(owner)
+    DeprecatedCSSOMValue(CSSStyleDeclaration& owner)
+        : m_owner(owner)
     {
     }
 
-protected:
-    unsigned m_valueSeparator : CSSValue::ValueSeparatorBits;
-    unsigned m_classType : ClassTypeBits; // ClassType
-    
     const Ref<CSSStyleDeclaration> m_owner;
 };
 
-class DeprecatedCSSOMComplexValue : public DeprecatedCSSOMValue {
-public:
-    static Ref<DeprecatedCSSOMComplexValue> create(Ref<const CSSValue> value, CSSStyleDeclaration& owner)
-    {
-        return adoptRef(*new DeprecatedCSSOMComplexValue(WTF::move(value), owner));
-    }
-
-    String cssText() const;
-    unsigned short NODELETE cssValueType() const;
-
-protected:
-    DeprecatedCSSOMComplexValue(Ref<const CSSValue> value, CSSStyleDeclaration& owner)
-        : DeprecatedCSSOMValue(ClassType::Complex, owner)
-        , m_value(WTF::move(value))
-    {
-    }
-
-private:
-    const Ref<const CSSValue> m_value;
-};
-    
 } // namespace WebCore
 
 #define SPECIALIZE_TYPE_TRAITS_CSSOM_VALUE(ToValueTypeName, predicate) \
@@ -112,4 +72,3 @@ SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \
 static bool isType(const WebCore::DeprecatedCSSOMValue& value) { return value.predicate; } \
 SPECIALIZE_TYPE_TRAITS_END()
 
-SPECIALIZE_TYPE_TRAITS_CSSOM_VALUE(DeprecatedCSSOMComplexValue, isComplexValue())

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMValueList.cpp
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMValueList.cpp
@@ -26,19 +26,36 @@
 #include "config.h"
 #include "DeprecatedCSSOMValueList.h"
 
-#include <wtf/text/StringBuilder.h>
+#include "CSSValueList.h"
+#include <wtf/text/MakeString.h>
 
 namespace WebCore {
 
-String DeprecatedCSSOMValueList::cssText() const
+Ref<DeprecatedCSSOMValueList> DeprecatedCSSOMValueList::create(DeprecatedCSSOMValueListBuilder&& values, CSSValue::ValueSeparator separator, CSSStyleDeclaration& owner)
 {
-    // FIXME: Clearly wrong for cases like CSSSubgridValue. Change to call cssText on m_value instead.
-    auto prefix = ""_s;
-    auto separator = CSSValueList::separatorCSSText(static_cast<CSSValueList::ValueSeparator>(m_valueSeparator));
-    StringBuilder result;
-    for (auto& value : m_values)
-        result.append(std::exchange(prefix, separator), value.get().cssText());
-    return result.toString();
+    return adoptRef(*new DeprecatedCSSOMValueList(WTF::move(values), separator, owner));
 }
 
+Ref<DeprecatedCSSOMValueList> DeprecatedCSSOMValueList::create(const CSSValueContainingVector& values, CSSStyleDeclaration& owner)
+{
+    return adoptRef(*new DeprecatedCSSOMValueList(WTF::map<4>(values, [&](auto& value) -> Ref<DeprecatedCSSOMValue> { return value.createDeprecatedCSSOMWrapper(owner); }), values.separator(), owner));
 }
+
+DeprecatedCSSOMValueList::DeprecatedCSSOMValueList(DeprecatedCSSOMValueListBuilder&& values, CSSValue::ValueSeparator separator, CSSStyleDeclaration& owner)
+    : DeprecatedCSSOMValue(owner)
+    , m_valueSeparator { separator }
+    , m_values { WTF::move(values) }
+{
+}
+
+String DeprecatedCSSOMValueList::cssText() const
+{
+    return makeString(interleave(m_values, [](auto& value) { return value.get().cssText(); }, CSSValueList::separatorCSSText(m_valueSeparator)));
+}
+
+unsigned short DeprecatedCSSOMValueList::cssValueType() const
+{
+    return CSS_VALUE_LIST;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMValueList.h
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMValueList.h
@@ -25,46 +25,30 @@
 
 #pragma once
 
-#include <WebCore/CSSValueList.h>
 #include <WebCore/DeprecatedCSSOMValue.h>
 
 namespace WebCore {
 
+class CSSValueContainingVector;
 using DeprecatedCSSOMValueListBuilder = Vector<Ref<DeprecatedCSSOMValue>, 4>;
 
-class DeprecatedCSSOMValueList : public DeprecatedCSSOMValue {
+class DeprecatedCSSOMValueList final : public DeprecatedCSSOMValue {
 public:
-    static Ref<DeprecatedCSSOMValueList> create(DeprecatedCSSOMValueListBuilder&& values, CSSValue::ValueSeparator separator, CSSStyleDeclaration& owner)
-    {
-        return adoptRef(*new DeprecatedCSSOMValueList(WTF::move(values), separator, owner));
-    }
+    static Ref<DeprecatedCSSOMValueList> create(DeprecatedCSSOMValueListBuilder&&, CSSValue::ValueSeparator, CSSStyleDeclaration&);
+    static Ref<DeprecatedCSSOMValueList> create(const CSSValueContainingVector&, CSSStyleDeclaration&);
 
-    static Ref<DeprecatedCSSOMValueList> create(const CSSValueContainingVector& values, CSSStyleDeclaration& owner)
-    {
-        return adoptRef(*new DeprecatedCSSOMValueList(values, owner));
-    }
-
-    String cssText() const;
+    String cssText() const override;
+    unsigned short NODELETE cssValueType() const override;
+    bool isValueList() const override { return true; }
 
     size_t length() const { return m_values.size(); }
     DeprecatedCSSOMValue* item(size_t index) { return index < m_values.size() ? m_values[index].ptr() : nullptr; }
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_values.size(); }
 
 private:
-    DeprecatedCSSOMValueList(DeprecatedCSSOMValueListBuilder&& values, CSSValue::ValueSeparator separator, CSSStyleDeclaration& owner)
-        : DeprecatedCSSOMValue(ClassType::List, owner)
-        , m_values { WTF::move(values) }
-    {
-        m_valueSeparator = separator;
-    }
+    DeprecatedCSSOMValueList(DeprecatedCSSOMValueListBuilder&&, CSSValue::ValueSeparator, CSSStyleDeclaration&);
 
-    DeprecatedCSSOMValueList(const CSSValueContainingVector& values, CSSStyleDeclaration& owner)
-        : DeprecatedCSSOMValue(ClassType::List, owner)
-        , m_values(WTF::map(values, [&](auto& value) { return value.createDeprecatedCSSOMWrapper(owner); }))
-    {
-        m_valueSeparator = values.separator();
-    }
-
+    CSSValue::ValueSeparator m_valueSeparator;
     Vector<Ref<DeprecatedCSSOMValue>, 4> m_values;
 };
 

--- a/Source/WebCore/css/values/CSSValueTypes.cpp
+++ b/Source/WebCore/css/values/CSSValueTypes.cpp
@@ -31,6 +31,7 @@
 #include "CSSValueList.h"
 #include "CSSValuePair.h"
 #include "CSSValuePool.h"
+#include "DeprecatedCSSOMCustomValue.h"
 #include "DeprecatedCSSOMPrimitiveValue.h"
 #include "DeprecatedCSSOMValueList.h"
 
@@ -83,7 +84,7 @@ Ref<DeprecatedCSSOMValue> makePrimitiveDeprecatedCSSOMValue(CSSStyleDeclaration&
 
 Ref<DeprecatedCSSOMValue> makeFunctionDeprecatedCSSOMValue(CSSStyleDeclaration& owner, CSSValueID name, Ref<CSSValue>&& value)
 {
-    return DeprecatedCSSOMComplexValue::create(makeFunctionCSSValue(name, WTF::move(value)), owner);
+    return DeprecatedCSSOMCustomValue::create(makeFunctionCSSValue(name, WTF::move(value)), owner);
 }
 
 template<> Ref<DeprecatedCSSOMValue> makeCoalescingPairDeprecatedCSSOMValue<SerializationSeparatorType::Space>(CSSStyleDeclaration& owner, Ref<CSSValue>&& first, Ref<CSSValue>&& second)

--- a/Source/WebCore/style/StyleCustomProperty.cpp
+++ b/Source/WebCore/style/StyleCustomProperty.cpp
@@ -32,6 +32,7 @@
 #include "CSSTokenizer.h"
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
+#include "DeprecatedCSSOMCustomValue.h"
 #include "DeprecatedCSSOMPrimitiveValue.h"
 #include "DeprecatedCSSOMValueList.h"
 #include "RenderStyle.h"
@@ -124,7 +125,7 @@ Ref<DeprecatedCSSOMValue> CustomProperty::propertyValueDeprecatedCSSOMWrapper(CS
             return CSS::createDeprecatedCSSOMValue(pool, owner, CSS::String { emptyString() });
         },
         [&](const Ref<CSSVariableData>& variableData) -> Ref<DeprecatedCSSOMValue> {
-            return DeprecatedCSSOMComplexValue::create(CSSSubstitutionValue::create(variableData.copyRef()), owner);
+            return DeprecatedCSSOMCustomValue::create(CSSSubstitutionValue::create(variableData.copyRef()), owner);
         },
         [&](const Value& value) -> Ref<DeprecatedCSSOMValue> {
             return convertValue(value);


### PR DESCRIPTION
#### 4029f1176cf754142738523efa92957ce3b8ead7
<pre>
Simplify DeprecatedCSSOMValue class hierarchy by using virtual functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=315582">https://bugs.webkit.org/show_bug.cgi?id=315582</a>

Reviewed by Darin Adler.

Replaces bespoke/switch-based virtual dispatch with real virtual functions
in DeprecatedCSSOMValue hierarchy. The switch-base dispatch is an artifact
from when DeprecatedCSSOMValue was extracted from CSSValue, and is only needed
in places where performance is critical.

Also renames DeprecatedCSSOMComplexValue to DeprecatedCSSOMCustomValue,
matching its type enum value CSS_CUSTOM and moved it into its own files.
Also moved a few other functions from being inline to the implementation
file to avoid unnecessary includes in the headers.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSValue.cpp:
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMCounter.h:
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMCustomValue.cpp: Added.
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMCustomValue.h: Added.
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMLazySerializingCustomValue.cpp:
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMLazySerializingCustomValue.h:
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMPrimitiveValue.cpp:
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMPrimitiveValue.h:
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRGBColor.cpp: Added.
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRGBColor.h:
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRect.cpp: Added.
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMRect.h:
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMValue.cpp:
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMValue.h:
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMValueList.cpp:
* Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMValueList.h:
* Source/WebCore/css/values/CSSValueTypes.cpp:
* Source/WebCore/style/StyleCustomProperty.cpp:

Canonical link: <a href="https://commits.webkit.org/313973@main">https://commits.webkit.org/313973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fff2ea28bb0cf439210ee83fe818f9947920fb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164721 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121973 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128012 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148050 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108557 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21515 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176279 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136330 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136294 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36703 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147561 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101160 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31563 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24417 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37472 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110517 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36870 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2482 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37118 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->