### PR TITLE
[libpas] pas_enumerator_create should check validity of compact heap bump

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_enumerator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerator.c
@@ -152,8 +152,10 @@ pas_enumerator* pas_enumerator_create(pas_root* remote_root_address,
 
     if (!compact_heap_base)
         goto fail;
-
-    PAS_ASSERT(compact_heap_reservation_bump >= compact_heap_guard_size);
+    if (compact_heap_reservation_bump < compact_heap_guard_size)
+        goto fail;
+    if (compact_heap_reservation_bump > compact_heap_size)
+        goto fail;
 
     compact_heap_copy_base = pas_enumerator_allocate(result, compact_heap_size);
     if (!pas_enumerator_copy_remote(

--- a/Source/bmalloc/libpas/src/test/EnumerationTests.cpp
+++ b/Source/bmalloc/libpas/src/test/EnumerationTests.cpp
@@ -26,6 +26,7 @@
 #include "TestHarness.h"
 #include "pas_root.h"
 #include "bmalloc_heap.h"
+#include "pas_compact_heap_reservation.h"
 #include "pas_probabilistic_guard_malloc_allocator.h"
 #include "pas_heap.h"
 #include "iso_heap.h"
@@ -280,6 +281,38 @@ void testPGMEnumerationAddAndFree() {
 
 }
 
+void testEnumerationInvalidCompactHeapBump()
+{
+    pas_heap_lock_lock();
+    pas_root* root = pas_root_create();
+    pas_heap_lock_unlock();
+
+    // Do an allocation to ensure the compact heap is initialized.
+    void* p = bmalloc_try_allocate(16, pas_non_compact_allocation_mode);
+    PAS_ASSERT(p);
+
+    size_t saved_bump = pas_compact_heap_reservation_bump;
+    // Set invalid bump size
+    pas_compact_heap_reservation_bump = pas_compact_heap_reservation_size + 1;
+
+    pas_enumerator* enumerator = pas_enumerator_create(
+        root, enumeratorReader, nullptr, enumeratorRecorder, nullptr,
+        pas_enumerator_do_not_record_meta_records,
+        pas_enumerator_do_not_record_payload_records,
+        pas_enumerator_do_not_record_object_records);
+    CHECK(!enumerator);
+
+    // Restore and verify normal creation still works.
+    pas_compact_heap_reservation_bump = saved_bump;
+
+    enumerator = pas_enumerator_create(
+        root, enumeratorReader, nullptr, enumeratorRecorder, nullptr,
+        pas_enumerator_do_not_record_meta_records,
+        pas_enumerator_do_not_record_payload_records,
+        pas_enumerator_do_not_record_object_records);
+    CHECK(enumerator);
+    pas_enumerator_destroy(enumerator);
+}
 
 } // end namespace
 
@@ -287,4 +320,5 @@ void addEnumerationTests() {
     ADD_TEST(testBasicEnumeration());
     ADD_TEST(testPGMEnumerationBasic());
     ADD_TEST(testPGMEnumerationAddAndFree());
+    ADD_TEST(testEnumerationInvalidCompactHeapBump());
 }


### PR DESCRIPTION
#### ed57dc0915ee05990f6c1684695ba0d757f722d8
<pre>
[libpas] pas_enumerator_create should check validity of compact heap bump
<a href="https://bugs.webkit.org/show_bug.cgi?id=311232">https://bugs.webkit.org/show_bug.cgi?id=311232</a>
<a href="https://rdar.apple.com/173763464">rdar://173763464</a>

Reviewed by Marcus Plutowski.

In case the pas root is corrupted, let&apos;s be defensive and check
the consistency of the compact heap parameters.

Added test case to EnumerationTests.cpp to verify this path.

* Source/bmalloc/libpas/src/libpas/pas_enumerator.c:
(pas_enumerator_create):
* Source/bmalloc/libpas/src/test/EnumerationTests.cpp:
(std::testEnumerationInvalidCompactHeapBump):
(addEnumerationTests):

Originally-landed-as: 305413.604@rapid/safari-7624.2.5.110-branch (0c474e5f1172). <a href="https://rdar.apple.com/176061751">rdar://176061751</a>
Canonical link: <a href="https://commits.webkit.org/313934@main">https://commits.webkit.org/313934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/580ded7fac89f557c737720d08594e96a2de0e71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173554 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121776 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127840 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89995 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108385 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29191 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27813 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21317 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156675 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176080 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25416 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136159 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136124 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36677 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100919 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31404 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24244 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196927 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37275 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51723 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36673 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2305 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36921 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->