### PR TITLE
Web Inspector: [SI] route Cmd+Z through the per-frame undo stack of the edited iframe

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target-expected.txt
@@ -1,0 +1,32 @@
+Tests WI.DOMUndoCoordinator routes undo/redo/markUndoableState to the most recently edited target.
+
+
+
+== Running test suite: SiteIsolation.DOM.UndoCoordinator
+-- Running test case: Setup
+PASS: Should find the main frame target.
+PASS: Should find a cross-origin child frame target.
+PASS: WI.domUndoCoordinator should exist.
+
+-- Running test case: DefaultsToMainWhenNoEdits
+PASS: page target undo called once.
+PASS: page target redo called once.
+PASS: main frame undo NOT called.
+PASS: child frame undo NOT called.
+PASS: child frame redo NOT called.
+
+-- Running test case: MarkUndoableStateRoutesToFrameTarget
+PASS: child frame markUndoableState called.
+PASS: main frame markUndoableState NOT called.
+PASS: Subsequent undo routes to child frame.
+PASS: Subsequent undo did NOT hit main frame.
+
+-- Running test case: DidEditSwitchesRouting
+PASS: undo routes to child frame after didEdit(childFrameTarget).
+PASS: redo routes to main frame after didEdit(mainFrameTarget).
+PASS: redo did NOT hit child frame after switching to main frame.
+
+-- Running test case: NullTargetIsNoop
+PASS: undo still routes to child frame after didEdit(null).
+PASS: didEdit(null) did NOT reset routing to main frame.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target.html
@@ -1,0 +1,143 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.UndoCoordinator");
+
+    let mainFrameTarget = null;
+    let childFrameTarget = null;
+
+    function spyAgent(target) {
+        let calls = {undo: 0, redo: 0, markUndoableState: 0};
+        let agent = target.DOMAgent;
+        let originals = {
+            undo: agent.undo.bind(agent),
+            redo: agent.redo.bind(agent),
+            markUndoableState: agent.markUndoableState.bind(agent),
+        };
+        agent.undo = (...args) => { calls.undo++; return originals.undo(...args); };
+        agent.redo = (...args) => { calls.redo++; return originals.redo(...args); };
+        agent.markUndoableState = (...args) => { calls.markUndoableState++; return originals.markUndoableState(...args); };
+        calls.restore = () => {
+            agent.undo = originals.undo;
+            agent.redo = originals.redo;
+            agent.markUndoableState = originals.markUndoableState;
+        };
+        return calls;
+    }
+
+    suite.addTestCase({
+        name: "Setup",
+        async test() {
+            let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+            let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+            mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+            InspectorTest.expectNotNull(mainFrameTarget, "Should find the main frame target.");
+
+            childFrameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+            InspectorTest.expectNotNull(childFrameTarget, "Should find a cross-origin child frame target.");
+
+            if (childFrameTarget.isProvisional) {
+                let committedEvent = await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+                childFrameTarget = committedEvent.data.target;
+            }
+            await childFrameTarget.ensureTargetExecutionContext();
+
+            InspectorTest.expectNotNull(WI.domUndoCoordinator, "WI.domUndoCoordinator should exist.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "DefaultsToMainWhenNoEdits",
+        description: "With no edits recorded, undo/redo fall back to the main (page) target, not a frame target.",
+        async test() {
+            // The fallback target is WI.assumingMainTarget() (the page target), which is a distinct object
+            // from the main frame target. Spy on it directly and assert neither frame target is touched.
+            let pageCalls = spyAgent(WI.assumingMainTarget());
+            let mainFrameCalls = spyAgent(mainFrameTarget);
+            let childCalls = spyAgent(childFrameTarget);
+
+            WI.domUndoCoordinator.undo();
+            WI.domUndoCoordinator.redo();
+
+            InspectorTest.expectEqual(pageCalls.undo, 1, "page target undo called once.");
+            InspectorTest.expectEqual(pageCalls.redo, 1, "page target redo called once.");
+            InspectorTest.expectEqual(mainFrameCalls.undo, 0, "main frame undo NOT called.");
+            InspectorTest.expectEqual(childCalls.undo, 0, "child frame undo NOT called.");
+            InspectorTest.expectEqual(childCalls.redo, 0, "child frame redo NOT called.");
+
+            pageCalls.restore();
+            mainFrameCalls.restore();
+            childCalls.restore();
+        }
+    });
+
+    suite.addTestCase({
+        name: "MarkUndoableStateRoutesToFrameTarget",
+        description: "markUndoableState(childFrameTarget) dispatches to the child frame agent and sets it as last-edit target.",
+        async test() {
+            let mainCalls = spyAgent(mainFrameTarget);
+            let childCalls = spyAgent(childFrameTarget);
+
+            WI.domUndoCoordinator.markUndoableState(childFrameTarget);
+            InspectorTest.expectEqual(childCalls.markUndoableState, 1, "child frame markUndoableState called.");
+            InspectorTest.expectEqual(mainCalls.markUndoableState, 0, "main frame markUndoableState NOT called.");
+
+            WI.domUndoCoordinator.undo();
+            InspectorTest.expectEqual(childCalls.undo, 1, "Subsequent undo routes to child frame.");
+            InspectorTest.expectEqual(mainCalls.undo, 0, "Subsequent undo did NOT hit main frame.");
+
+            mainCalls.restore();
+            childCalls.restore();
+        }
+    });
+
+    suite.addTestCase({
+        name: "DidEditSwitchesRouting",
+        description: "didEdit(childFrameTarget) then didEdit(mainFrameTarget) — undo follows the latest target.",
+        async test() {
+            let mainCalls = spyAgent(mainFrameTarget);
+            let childCalls = spyAgent(childFrameTarget);
+
+            WI.domUndoCoordinator.didEdit(childFrameTarget);
+            WI.domUndoCoordinator.undo();
+            InspectorTest.expectEqual(childCalls.undo, 1, "undo routes to child frame after didEdit(childFrameTarget).");
+
+            WI.domUndoCoordinator.didEdit(mainFrameTarget);
+            WI.domUndoCoordinator.redo();
+            InspectorTest.expectEqual(mainCalls.redo, 1, "redo routes to main frame after didEdit(mainFrameTarget).");
+            InspectorTest.expectEqual(childCalls.redo, 0, "redo did NOT hit child frame after switching to main frame.");
+
+            mainCalls.restore();
+            childCalls.restore();
+        }
+    });
+
+    suite.addTestCase({
+        name: "NullTargetIsNoop",
+        description: "didEdit(null) preserves the prior last-edit target.",
+        async test() {
+            WI.domUndoCoordinator.didEdit(childFrameTarget);
+            WI.domUndoCoordinator.didEdit(null);
+
+            let mainCalls = spyAgent(mainFrameTarget);
+            let childCalls = spyAgent(childFrameTarget);
+
+            WI.domUndoCoordinator.undo();
+            InspectorTest.expectEqual(childCalls.undo, 1, "undo still routes to child frame after didEdit(null).");
+            InspectorTest.expectEqual(mainCalls.undo, 0, "didEdit(null) did NOT reset routing to main frame.");
+
+            mainCalls.restore();
+            childCalls.restore();
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests WI.DOMUndoCoordinator routes undo/redo/markUndoableState to the most recently edited target.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/dom-frame.html"></iframe>
+</body>

--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -131,6 +131,8 @@ WI.loaded = function()
         WI.deviceSettingsManager = new WI.DeviceSettingsManager,
     ];
 
+    WI.domUndoCoordinator = new WI.DOMUndoCoordinator;
+
     // Register for events.
     WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.Paused, WI._debuggerDidPause, WI);
     WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.Resumed, WI._debuggerDidResume, WI);
@@ -2984,16 +2986,12 @@ WI._redoKeyboardShortcut = function(event)
 
 WI.undo = function()
 {
-    let target = WI.assumingMainTarget();
-    if (target.hasCommand("DOM.undo"))
-        target.DOMAgent.undo();
+    WI.domUndoCoordinator.undo();
 };
 
 WI.redo = function()
 {
-    let target = WI.assumingMainTarget();
-    if (target.hasCommand("DOM.redo"))
-        target.DOMAgent.redo();
+    WI.domUndoCoordinator.redo();
 };
 
 WI.highlightRangesWithStyleClass = function(element, resultRanges, styleClass, changes)

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMUndoCoordinator.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMUndoCoordinator.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.DOMUndoCoordinator = class DOMUndoCoordinator
+{
+    constructor()
+    {
+        // Most recently edited target. Cmd+Z dispatches here. Stays valid until that target is removed.
+        this._lastEditTarget = null;
+
+        WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, this._handleTargetRemoved, this);
+    }
+
+    // Public
+
+    didEdit(target)
+    {
+        // A null target means "the edit's target is unknown," not "the edit belongs to main." Defaulting to
+        // main here would clobber a previously-recorded frame target and misroute the next Cmd+Z, so no-op
+        // and keep the existing routing. markUndoableState() is what supplies the concrete target.
+        if (!target)
+            return;
+        this._lastEditTarget = target;
+    }
+
+    markUndoableState(target)
+    {
+        // Unlike didEdit(), a missing target here is a real page-level edit (e.g. a DOMNode with no owning
+        // frame target, or a CSS edit while FrameCSSAgent does not yet exist), which genuinely belongs to
+        // main. Resolve it so the edit is both recorded and dispatched against a concrete target.
+        target ||= WI.assumingMainTarget();
+        this.didEdit(target);
+        if (target.hasCommand("DOM.markUndoableState"))
+            target.DOMAgent.markUndoableState();
+    }
+
+    undo()
+    {
+        let target = this._lastEditTarget || WI.assumingMainTarget();
+        if (target.hasCommand("DOM.undo"))
+            target.DOMAgent.undo();
+    }
+
+    redo()
+    {
+        let target = this._lastEditTarget || WI.assumingMainTarget();
+        if (target.hasCommand("DOM.redo"))
+            target.DOMAgent.redo();
+    }
+
+    // Private
+
+    _handleTargetRemoved(event)
+    {
+        if (this._lastEditTarget === event.data.target)
+            this._lastEditTarget = null;
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -943,6 +943,7 @@
     <script src="Controllers/DOMDebuggerManager.js"></script>
     <script src="Controllers/DOMManager.js"></script>
     <script src="Controllers/DOMStorageManager.js"></script>
+    <script src="Controllers/DOMUndoCoordinator.js"></script>
     <script src="Controllers/DebuggerManager.js"></script>
     <script src="Controllers/DeviceSettingsManager.js"></script>
     <script src="Controllers/DragToAdjustController.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Models/CSSGrouping.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSGrouping.js
@@ -81,7 +81,7 @@ WI.CSSGrouping = class CSSGrouping extends WI.Object
         let target = WI.assumingMainTarget();
         let {grouping: groupingPayload} = await target.CSSAgent.setGroupingHeaderText(this._id, newText);
 
-        target.DOMAgent.markUndoableState();
+        WI.domUndoCoordinator.markUndoableState(target);
         await this._nodeStyles.refresh();
 
         console.assert(groupingPayload.type == this._type);

--- a/Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js
@@ -180,8 +180,7 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
             if (error)
                 return;
 
-            if (target.hasCommand("DOM.markUndoableState"))
-                target.DOMAgent.markUndoableState();
+            WI.domUndoCoordinator.markUndoableState(target);
 
             this.dispatchEventToListeners(WI.CSSStyleSheet.Event.ContentDidChange);
         }

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -1376,9 +1376,7 @@ WI.DOMNode = class DOMNode extends WI.Object
 
     _markUndoableState()
     {
-        let target = WI.assumingMainTarget();
-        if (target.hasCommand("DOM.markUndoableState"))
-            target.DOMAgent.markUndoableState();
+        WI.domUndoCoordinator.markUndoableState(this.owningTarget);
     }
 
     _makeUndoableCallback(callback)

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
@@ -382,7 +382,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
 
         function completed()
         {
-            target.DOMAgent.markUndoableState();
+            WI.domUndoCoordinator.markUndoableState(target);
 
             // Wait for the refresh promise caused by injecting an empty inspector stylesheet to resolve
             // (another call will be ignored while one is still pending),
@@ -475,7 +475,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
                 return;
             }
 
-            target.DOMAgent.markUndoableState();
+            WI.domUndoCoordinator.markUndoableState(target);
 
             // Do a full refresh incase the rule no longer matches the node or the
             // matched selector indices changed.

--- a/Source/WebInspectorUI/UserInterface/Test.html
+++ b/Source/WebInspectorUI/UserInterface/Test.html
@@ -277,6 +277,7 @@
     <script src="Controllers/DOMDebuggerManager.js"></script>
     <script src="Controllers/DOMManager.js"></script>
     <script src="Controllers/DOMStorageManager.js"></script>
+    <script src="Controllers/DOMUndoCoordinator.js"></script>
     <script src="Controllers/DebuggerManager.js"></script>
     <script src="Controllers/DeviceSettingsManager.js"></script>
     <script src="Controllers/FormatterSourceMap.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Test/Test.js
+++ b/Source/WebInspectorUI/UserInterface/Test/Test.js
@@ -71,6 +71,8 @@ WI.loaded = function()
         WI.animationManager = new WI.AnimationManager,
     ];
 
+    WI.domUndoCoordinator = new WI.DOMUndoCoordinator;
+
     // Register for events.
     document.addEventListener("DOMContentLoaded", WI.contentLoaded);
     WI.browserManager.enable();

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
@@ -454,8 +454,7 @@ WI.SpreadsheetStyleProperty = class SpreadsheetStyleProperty extends WI.Object
 
         if (changed) {
             let target = WI.assumingMainTarget();
-            if (target.hasCommand("DOM.markUndoableState"))
-                target.DOMAgent.markUndoableState();
+            WI.domUndoCoordinator.markUndoableState(target);
         }
     }
 


### PR DESCRIPTION
#### cd558dee60c1f73e2aebdd7d2b038fb697862e78
<pre>
Web Inspector: [SI] route Cmd+Z through the per-frame undo stack of the edited iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=315199">https://bugs.webkit.org/show_bug.cgi?id=315199</a>
<a href="https://rdar.apple.com/177529260">rdar://177529260</a>

Reviewed by Qianlang Chen.

Add WI.DOMUndoCoordinator, a single-slot frontend coordinator that
remembers the most recently edited target. Every successful DOM edit
funnels through DOMNode._markUndoableState, which now records
node.owningTarget as the last-edit target via the coordinator. CSS edit
completions (CSSGrouping, CSSStyleSheet, DOMNodeStyles, and
SpreadsheetStyleProperty) route through the coordinator with the main
target, since FrameCSSAgent does not yet exist. WI.undo() and WI.redo()
dispatch through the coordinator, falling back to main when nothing has
been edited. A TargetRemoved listener clears the slot when a frame
target is torn down.

Follow up work will fix cross frame ordering (&quot;edit A, edit B, undo twice&quot;).

Test: http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/undo-coordinator-frame-target.html: Added.
* Source/WebInspectorUI/UserInterface/Base/Main.js:
(WI.loaded):
* Source/WebInspectorUI/UserInterface/Controllers/DOMUndoCoordinator.js: Added.
(WI.DOMUndoCoordinator):
(WI.DOMUndoCoordinator.prototype.didEdit):
(WI.DOMUndoCoordinator.prototype.markUndoableState):
(WI.DOMUndoCoordinator.prototype.undo):
(WI.DOMUndoCoordinator.prototype.redo):
(WI.DOMUndoCoordinator.prototype._handleTargetRemoved):
* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Models/CSSGrouping.js:
(WI.CSSGrouping.prototype.async setText):
* Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js:
(WI.CSSStyleSheet.prototype.handleCurrentRevisionContentChange.contentDidChange):
(WI.CSSStyleSheet.prototype.handleCurrentRevisionContentChange):
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype._markUndoableState):
* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles.prototype.addRule.completed):
(WI.DOMNodeStyles.prototype.changeRuleSelector.ruleSelectorChanged):
(WI.DOMNodeStyles.prototype.changeRuleSelector):
* Source/WebInspectorUI/UserInterface/Test.html:
* Source/WebInspectorUI/UserInterface/Test/Test.js:
(WI.loaded):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js:
(WI.SpreadsheetStyleProperty.prototype.spreadsheetTextFieldDidBlur):

Canonical link: <a href="https://commits.webkit.org/315392@main">https://commits.webkit.org/315392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/288533216ef601b2d1a6822ece9fc102818cafc5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126592 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86231beb-159c-4f16-8b08-abf12f545334) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131499 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4dcc220b-6bad-4e16-9840-3a68782df4a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112003 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bf51bad-d8f5-4f41-af99-7d59e0f600a6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26937 "Built successfully") | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142932 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; 4 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180836 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139947 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139791 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37639 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43148 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106958 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35076 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114913 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41657 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6237 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41051 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41306 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41194 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->