### PR TITLE
Use ElementNames::SVG::foreignObject in Style::ContainmentChecker instead of hasTagName with QualifiedName cast

### DIFF
--- a/Source/WebCore/style/StyleContainmentCheckerInlines.h
+++ b/Source/WebCore/style/StyleContainmentCheckerInlines.h
@@ -26,8 +26,8 @@
 #pragma once
 
 #include <WebCore/Element.h>
+#include <WebCore/NodeName.h>
 #include <WebCore/RenderStyle+GettersInlines.h>
-#include <WebCore/SVGNames.h>
 #include <WebCore/StyleContainmentChecker.h>
 
 namespace WebCore {
@@ -94,7 +94,7 @@ inline bool ContainmentChecker::shouldApplySizeContainment() const
 
     // https://drafts.csswg.org/css-conditional-5/#size-container
     // SVG foreignObject elements are not eligible to be size query containers.
-    if (m_element->hasTagName(static_cast<const QualifiedName&>(SVGNames::foreignObjectTag)))
+    if (m_element->elementName() == ElementNames::SVG::foreignObject)
         return false;
 
     return true;
@@ -124,7 +124,7 @@ inline bool ContainmentChecker::shouldApplyInlineSizeContainment() const
 
     // https://drafts.csswg.org/css-conditional-5/#size-container
     // SVG foreignObject elements are not eligible to be size query containers.
-    if (m_element->hasTagName(static_cast<const QualifiedName&>(SVGNames::foreignObjectTag)))
+    if (m_element->elementName() == ElementNames::SVG::foreignObject)
         return false;
 
     return true;


### PR DESCRIPTION
#### 887cf9723b12a4a596aafcbc7f93c59178327532
<pre>
Use ElementNames::SVG::foreignObject in Style::ContainmentChecker instead of hasTagName with QualifiedName cast
<a href="https://bugs.webkit.org/show_bug.cgi?id=315592">https://bugs.webkit.org/show_bug.cgi?id=315592</a>
<a href="https://rdar.apple.com/177977239">rdar://177977239</a>

Reviewed by Darin Adler.

Follow-up to 313859@main. Replace `hasTagName(static_cast&lt;const QualifiedName&amp;&gt;(
SVGNames::foreignObjectTag))` with `elementName() == ElementNames::SVG::foreignObject`.

Using elementName() might be slightly faster: a single uint16_t compare on the cached
NodeName, vs. QualifiedName::matches which compares three AtomStringImpl pointers.
Matches the idiom already used in SVGElement.cpp, SVGUseElement.cpp, and the HTML
tree builder.

* Source/WebCore/style/StyleContainmentCheckerInlines.h:
(WebCore::Style::ContainmentChecker::shouldApplySizeContainment const):
(WebCore::Style::ContainmentChecker::shouldApplyInlineSizeContainment const):

Canonical link: <a href="https://commits.webkit.org/313941@main">https://commits.webkit.org/313941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8ff94281946f1e848f60394aae751a6d20b052d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121789 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f1fcb82-05dd-41e3-ac31-23bec8041e10) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127853 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90001 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87b38efc-eceb-4701-af41-d086cca337f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108398 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/50a9894f-a579-44fd-a84e-fd9a6baa5a1f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29203 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27826 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21330 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176093 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28916 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136186 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136139 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36682 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147402 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100932 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31414 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24258 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110332 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36686 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2319 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36934 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36834 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->