### PR TITLE
[WebRTC] Heap-use-after-free in `DtlsTransportInternalImpl` when RTCP-mux is negotiated after initial non-mux session

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/packet_transport_internal.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/packet_transport_internal.cc
@@ -112,6 +112,12 @@ void PacketTransportInternal::SubscribeReceivingState(
   RTC_DCHECK_RUN_ON(&network_checker_);
   receiving_state_callbacks_.AddReceiver(tag, std::move(callback));
 }
+#if WEBRTC_WEBKIT_BUILD
+void PacketTransportInternal::UnsubscribeReceivingState(void* tag)
+{
+    receiving_state_callbacks_.RemoveReceivers(tag);
+}
+#endif
 void PacketTransportInternal::NotifyReceivingState(
     PacketTransportInternal* packet_transport) {
   RTC_DCHECK_RUN_ON(&network_checker_);

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/packet_transport_internal.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/packet_transport_internal.h
@@ -92,6 +92,9 @@ class RTC_EXPORT PacketTransportInternal {
   void SubscribeReceivingState(
       void* tag,
       absl::AnyInvocable<void(PacketTransportInternal*)> callback);
+#if WEBRTC_WEBKIT_BUILD
+  void UnsubscribeReceivingState(void* tag);
+#endif
   void NotifyReceivingState(PacketTransportInternal* packet_transport);
 
   // Callback is invoked each time a packet is received on this channel.

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/dtls/dtls_transport.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/dtls/dtls_transport.cc
@@ -288,6 +288,10 @@ DtlsTransportInternalImpl::DtlsTransportInternalImpl(
 DtlsTransportInternalImpl::~DtlsTransportInternalImpl() {
   ice_transport()->ResetDtlsStunPiggybackCallbacks();
   ice_transport()->DeregisterReceivedPacketCallback(this);
+#if WEBRTC_WEBKIT_BUILD
+  ice_transport()->UnsubscribeReceivingState(this);
+  ice_transport()->UnsubscribeWritableState(this);
+#endif
 }
 
 DtlsTransportState DtlsTransportInternalImpl::dtls_state() const {


### PR DESCRIPTION
#### c458fe1b1cc2ad4e829eee311226fc057508d2d6
<pre>
[WebRTC] Heap-use-after-free in `DtlsTransportInternalImpl` when RTCP-mux is negotiated after initial non-mux session
<a href="https://rdar.apple.com/173510839">rdar://173510839</a>

Reviewed by Jer Noble.

DTLSTransport is not unregistering itself from receive/send callbacks, which can trigger a a UAF.
We fix this by adding API to register/unregister a specific listener, and use that API in DtlsTransportInternalImpl destructor and in DtlsTransportInternalImpl::ConnectToIceTransport
We manually validated the fix using a specific STUN server.
We should upgrade our testing infra to support running the test with the STUN server.

Originally-landed-as: 305413.603@rapid/safari-7624.2.5.110-branch (5112c9dc3525). <a href="https://rdar.apple.com/176062217">rdar://176062217</a>
Canonical link: <a href="https://commits.webkit.org/315000@main">https://commits.webkit.org/315000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63569734c0443531b1473910e1fc08c41def847d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176672 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130412 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32828 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110929 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31810 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25405 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141797 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179212 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30019 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138696 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37346 "Failed to push commit to Webkit repository") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41872 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105032 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33957 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40376 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39773 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5073 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40024 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39918 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->