### PR TITLE
Web Inspector: [SI] implement DOM editing commands for FrameDOMAgent

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/editing-commands-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/editing-commands-frame-target-expected.txt
@@ -1,0 +1,64 @@
+Tests FrameDOMAgent DOM editing commands: setAttributeValue, setAttributesAsText, removeAttribute, setNodeValue, setNodeName, removeNode, insertAdjacentHTML, setOuterHTML (subtree + whole document via DOMPatchSupport), and moveTo. Each command verifies the edit, undo, and where applicable redo, against a cross-origin iframe.
+
+
+
+== Running test suite: SiteIsolation.DOM.FrameDOMAgent.Editing
+-- Running test case: Setup
+PASS: Should find a cross-origin frame target.
+PASS: Frame target should have a document.
+PASS: Should find #container in the frame document.
+
+-- Running test case: SetAttributeValue
+PASS: Attribute should be set.
+PASS: Attribute should be removed after undo.
+PASS: Attribute should be restored after redo.
+
+-- Running test case: SetAttributesAsText
+PASS: data-a should be set.
+PASS: data-b should be set.
+PASS: Both attributes should be removed after undo.
+
+-- Running test case: RemoveAttribute
+PASS: data-role should be removed.
+PASS: data-role should be restored after undo.
+
+-- Running test case: SetNodeValue
+PASS: #text-node should have a text child.
+PASS: Text content should be replaced.
+PASS: Text content should be restored after undo.
+
+-- Running test case: SetNodeName
+PASS: setNodeName should return a new backend nodeId.
+PASS: Renamed node should resolve in the frame target.
+PASS: New node should be H2.
+PASS: Attribute should be preserved.
+PASS: Node should revert to H1 after undo.
+
+-- Running test case: RemoveNode
+PASS: Should find first LI.
+PASS: First LI should be removed.
+PASS: Second LI should remain.
+PASS: First LI should be restored after undo.
+
+-- Running test case: InsertAdjacentHTML
+PASS: Injected span should appear in container.
+PASS: Injected span should be removed after undo.
+PASS: Injected span should be reinserted after redo.
+
+-- Running test case: InsertAdjacentHTML.InvalidPosition
+PASS: Should produce an exception.
+Error: SyntaxError
+
+-- Running test case: SetOuterHTML
+PASS: Outer HTML should be replaced.
+PASS: Original text should be restored after undo.
+
+-- Running test case: MoveTo
+PASS: Heading should now be inside #list.
+
+-- Running test case: FrontendDOMNode.SetAttributeAsText
+PASS: Frontend setAttribute should succeed for frame-target node.
+
+-- Running test case: SetOuterHTML.WholeDocument
+PASS: Patched element should exist after whole-document setOuterHTML.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/editing-commands-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/editing-commands-frame-target.html
@@ -1,0 +1,289 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameDOMAgent.Editing");
+
+    let frameTarget = null;
+    let frameDoc = null;
+    let containerNode = null;
+
+    // Backend commands take frame-local integer nodeIds; the frontend's `node.id` is a
+    // scoped string for frame-target nodes ("frame-<uuid>:<n>"). `backendNodeId` returns
+    // the raw integer.
+    function bid(node) { return node.backendNodeId; }
+
+    async function getOuterHTMLOf(node) {
+        let {outerHTML} = await frameTarget.DOMAgent.getOuterHTML(bid(node));
+        return outerHTML;
+    }
+
+    async function findChildElement(parent, predicate) {
+        await new Promise((resolve) => parent.getChildNodes(resolve));
+        return parent.children.find(predicate);
+    }
+
+    async function querySelectorBackend(parent, selector) {
+        // containerNode.querySelector returns a raw frame-local id; nodeForIdInFrameTarget
+        // scopes it and resolves the underlying DOMNode so we can read backendNodeId.
+        let rawId = await parent.querySelector(selector);
+        if (!rawId) return null;
+        return WI.domManager.nodeForIdInFrameTarget(rawId, frameTarget);
+    }
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Find the cross-origin frame target and locate #container.",
+        async test() {
+            let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+            let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+            let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+            frameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+            InspectorTest.expectNotNull(frameTarget, "Should find a cross-origin frame target.");
+
+            if (frameTarget.isProvisional) {
+                let committedEvent = await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+                frameTarget = committedEvent.data.target;
+            }
+            await frameTarget.ensureTargetExecutionContext();
+
+            frameDoc = WI.domManager.frameTargetDocumentForTarget(frameTarget);
+            if (!frameDoc) {
+                let docEvent = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+                frameDoc = docEvent.data.document;
+            }
+            InspectorTest.expectNotNull(frameDoc, "Frame target should have a document.");
+
+            let htmlNode = await findChildElement(frameDoc, (n) => n.nodeName() === "HTML");
+            let bodyNode = await findChildElement(htmlNode, (n) => n.nodeName() === "BODY");
+            containerNode = await findChildElement(bodyNode, (n) => n.getAttribute && n.getAttribute("id") === "container");
+            InspectorTest.expectNotNull(containerNode, "Should find #container in the frame document.");
+            await new Promise((resolve) => containerNode.getChildNodes(resolve));
+        }
+    });
+
+    suite.addTestCase({
+        name: "SetAttributeValue",
+        description: "setAttributeValue on a frame-target node, undo, redo.",
+        async test() {
+            await frameTarget.DOMAgent.setAttributeValue(bid(containerNode), "data-edited", "yes");
+            let after = await getOuterHTMLOf(containerNode);
+            InspectorTest.expectThat(after.includes(`data-edited="yes"`), "Attribute should be set.");
+
+            await frameTarget.DOMAgent.undo();
+            let undone = await getOuterHTMLOf(containerNode);
+            InspectorTest.expectThat(!undone.includes(`data-edited="yes"`), "Attribute should be removed after undo.");
+
+            await frameTarget.DOMAgent.redo();
+            let redone = await getOuterHTMLOf(containerNode);
+            InspectorTest.expectThat(redone.includes(`data-edited="yes"`), "Attribute should be restored after redo.");
+
+            await frameTarget.DOMAgent.removeAttribute(bid(containerNode), "data-edited");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SetAttributesAsText",
+        description: "setAttributesAsText parses and applies multiple attributes in one call.",
+        async test() {
+            await frameTarget.DOMAgent.setAttributesAsText(bid(containerNode), `data-a="1" data-b="two"`, "");
+            let after = await getOuterHTMLOf(containerNode);
+            InspectorTest.expectThat(after.includes(`data-a="1"`), "data-a should be set.");
+            InspectorTest.expectThat(after.includes(`data-b="two"`), "data-b should be set.");
+
+            await frameTarget.DOMAgent.undo();
+            let undone = await getOuterHTMLOf(containerNode);
+            InspectorTest.expectThat(!undone.includes(`data-a`) && !undone.includes(`data-b`), "Both attributes should be removed after undo.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "RemoveAttribute",
+        description: "removeAttribute drops an existing attribute and undo restores it.",
+        async test() {
+            await frameTarget.DOMAgent.removeAttribute(bid(containerNode), "data-role");
+            let after = await getOuterHTMLOf(containerNode);
+            InspectorTest.expectThat(!after.includes(`data-role`), "data-role should be removed.");
+
+            await frameTarget.DOMAgent.undo();
+            let undone = await getOuterHTMLOf(containerNode);
+            InspectorTest.expectThat(undone.includes(`data-role="frame-root"`), "data-role should be restored after undo.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SetNodeValue",
+        description: "setNodeValue replaces the text content of a text node.",
+        async test() {
+            let textPara = await querySelectorBackend(containerNode, "#text-node");
+            await new Promise((resolve) => textPara.getChildNodes(resolve));
+
+            let textNode = textPara.children.find((n) => n.nodeType() === Node.TEXT_NODE);
+            InspectorTest.expectNotNull(textNode, "#text-node should have a text child.");
+
+            await frameTarget.DOMAgent.setNodeValue(bid(textNode), "Replaced text.");
+            let after = await getOuterHTMLOf(textPara);
+            InspectorTest.expectThat(after.includes("Replaced text."), "Text content should be replaced.");
+
+            await frameTarget.DOMAgent.undo();
+            let undone = await getOuterHTMLOf(textPara);
+            InspectorTest.expectThat(undone.includes("Hello from cross-origin frame."), "Text content should be restored after undo.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SetNodeName",
+        description: "setNodeName replaces the element with a new tag, preserving children and attributes.",
+        async test() {
+            let heading = await querySelectorBackend(containerNode, "#heading");
+
+            let {nodeId: newBackendId} = await frameTarget.DOMAgent.setNodeName(bid(heading), "h2");
+            InspectorTest.expectNotNull(newBackendId, "setNodeName should return a new backend nodeId.");
+
+            // Re-query to find the new node via frontend resolution (frontend gets a scoped id).
+            let renamed = await querySelectorBackend(containerNode, "#heading");
+            InspectorTest.expectNotNull(renamed, "Renamed node should resolve in the frame target.");
+            InspectorTest.expectEqual(renamed.nodeName(), "H2", "New node should be H2.");
+            InspectorTest.expectEqual(renamed.getAttribute("id"), "heading", "Attribute should be preserved.");
+
+            await frameTarget.DOMAgent.undo();
+            let restored = await querySelectorBackend(containerNode, "#heading");
+            InspectorTest.expectEqual(restored.nodeName(), "H1", "Node should revert to H1 after undo.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "RemoveNode",
+        description: "removeNode detaches a node and undo reattaches it.",
+        async test() {
+            let list = await querySelectorBackend(containerNode, "#list");
+            await new Promise((resolve) => list.getChildNodes(resolve));
+            let firstItem = list.children.find((n) => n.nodeName() === "LI");
+            InspectorTest.expectNotNull(firstItem, "Should find first LI.");
+
+            await frameTarget.DOMAgent.removeNode(bid(firstItem));
+            let after = await getOuterHTMLOf(list);
+            InspectorTest.expectThat(!after.includes("Item one"), "First LI should be removed.");
+            InspectorTest.expectThat(after.includes("Item two"), "Second LI should remain.");
+
+            await frameTarget.DOMAgent.undo();
+            let undone = await getOuterHTMLOf(list);
+            InspectorTest.expectThat(undone.includes("Item one"), "First LI should be restored after undo.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "InsertAdjacentHTML",
+        description: "insertAdjacentHTML at a position; undo removes; redo re-inserts.",
+        async test() {
+            let html = `<span class="injected">marker</span>`;
+            await frameTarget.DOMAgent.insertAdjacentHTML(bid(containerNode), "beforeend", html);
+            let after = await getOuterHTMLOf(containerNode);
+            InspectorTest.expectThat(after.includes(`class="injected"`), "Injected span should appear in container.");
+
+            await frameTarget.DOMAgent.undo();
+            let undone = await getOuterHTMLOf(containerNode);
+            InspectorTest.expectThat(!undone.includes(`class="injected"`), "Injected span should be removed after undo.");
+
+            await frameTarget.DOMAgent.redo();
+            let redone = await getOuterHTMLOf(containerNode);
+            InspectorTest.expectThat(redone.includes(`class="injected"`), "Injected span should be reinserted after redo.");
+
+            await frameTarget.DOMAgent.undo();
+        }
+    });
+
+    suite.addTestCase({
+        name: "InsertAdjacentHTML.InvalidPosition",
+        description: "insertAdjacentHTML with an invalid position should reject.",
+        async test() {
+            await InspectorTest.expectException(async () => {
+                await frameTarget.DOMAgent.insertAdjacentHTML(bid(containerNode), "INVALID_POSITION", "");
+            });
+        }
+    });
+
+    suite.addTestCase({
+        name: "SetOuterHTML",
+        description: "setOuterHTML replaces a subtree; undo restores it.",
+        async test() {
+            let textPara = await querySelectorBackend(containerNode, "#text-node");
+            let replacement = `<p id="text-node">After outer HTML.</p>`;
+            await frameTarget.DOMAgent.setOuterHTML(bid(textPara), replacement);
+
+            let newPara = await querySelectorBackend(containerNode, "#text-node");
+            let after = await getOuterHTMLOf(newPara);
+            InspectorTest.expectEqual(after, replacement, "Outer HTML should be replaced.");
+
+            await frameTarget.DOMAgent.undo();
+            let restored = await querySelectorBackend(containerNode, "#text-node");
+            let restoredHTML = await getOuterHTMLOf(restored);
+            InspectorTest.expectThat(restoredHTML.includes("Hello from cross-origin frame."), "Original text should be restored after undo.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "MoveTo",
+        description: "moveTo relocates a node within the frame document; undo returns it.",
+        async test() {
+            let list = await querySelectorBackend(containerNode, "#list");
+            let heading = await querySelectorBackend(containerNode, "#heading");
+
+            await frameTarget.DOMAgent.moveTo(bid(heading), bid(list));
+            let listHTML = await getOuterHTMLOf(list);
+            InspectorTest.expectThat(listHTML.includes(`id="heading"`), "Heading should now be inside #list.");
+
+            await frameTarget.DOMAgent.undo();
+        }
+    });
+
+    suite.addTestCase({
+        name: "FrontendDOMNode.SetAttributeAsText",
+        description: "WI.DOMNode.setAttribute on a cross-origin frame node should route through the frame's agent (not throw).",
+        async test() {
+            await new Promise((resolve, reject) => {
+                containerNode.setAttribute("data-role", `data-role="frame-root" data-frontend="ok"`, (error) => {
+                    if (error) reject(error);
+                    else resolve();
+                });
+            });
+            let after = await getOuterHTMLOf(containerNode);
+            InspectorTest.expectThat(after.includes(`data-frontend="ok"`), "Frontend setAttribute should succeed for frame-target node.");
+
+            await frameTarget.DOMAgent.undo();
+        }
+    });
+
+    // Whole-document patch destroys cached node references (containerNode, etc.), so it
+    // must run last.
+    suite.addTestCase({
+        name: "SetOuterHTML.WholeDocument",
+        description: "setOuterHTML with nodeId == 0 should patch the frame's whole document via DOMPatchSupport.",
+        async test() {
+            let documentNodeId = 0;
+            let newDocument = `<!DOCTYPE html><html><head><title>Patched</title></head><body><div id="patched-root">patched body</div></body></html>`;
+            await frameTarget.DOMAgent.setOuterHTML(documentNodeId, newDocument);
+
+            let newFrameDoc = WI.domManager.frameTargetDocumentForTarget(frameTarget);
+            if (!newFrameDoc) {
+                let docEvent = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+                newFrameDoc = docEvent.data.document;
+            }
+            let htmlNode = await findChildElement(newFrameDoc, (n) => n.nodeName() === "HTML");
+            let bodyNode = await findChildElement(htmlNode, (n) => n.nodeName() === "BODY");
+            let patched = await findChildElement(bodyNode, (n) => n.getAttribute && n.getAttribute("id") === "patched-root");
+            InspectorTest.expectNotNull(patched, "Patched element should exist after whole-document setOuterHTML.");
+
+            await frameTarget.DOMAgent.undo();
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests FrameDOMAgent DOM editing commands: setAttributeValue, setAttributesAsText, removeAttribute, setNodeValue, setNodeName, removeNode, insertAdjacentHTML, setOuterHTML (subtree + whole document via DOMPatchSupport), and moveTo. Each command verifies the edit, undo, and where applicable redo, against a cross-origin iframe.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/dom-frame.html"></iframe>
+</body>

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -356,7 +356,7 @@
         {
             "name": "setNodeName",
             "description": "Sets node name for a node with given id.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set name for." },
                 { "name": "name", "type": "string", "description": "New node's name." }
@@ -368,6 +368,7 @@
         {
             "name": "setNodeValue",
             "description": "Sets node value for a node with given id.",
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set value for." },
                 { "name": "value", "type": "string", "description": "New node's value." }
@@ -376,6 +377,7 @@
         {
             "name": "removeNode",
             "description": "Removes node with given id.",
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to remove." }
             ]
@@ -383,6 +385,7 @@
         {
             "name": "setAttributeValue",
             "description": "Sets attribute for an element with given id.",
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attribute for." },
                 { "name": "name", "type": "string", "description": "Attribute name." },
@@ -392,6 +395,7 @@
         {
             "name": "setAttributesAsText",
             "description": "Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs.",
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attributes for." },
                 { "name": "text", "type": "string", "description": "Text with a number of attributes. Will parse this text using HTML parser." },
@@ -401,6 +405,7 @@
         {
             "name": "removeAttribute",
             "description": "Removes attribute with given name from an element with given id.",
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to remove attribute from." },
                 { "name": "name", "type": "string", "description": "Name of the attribute to remove." }
@@ -498,6 +503,7 @@
         {
             "name": "setOuterHTML",
             "description": "Sets node HTML markup, returns new node id.",
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set markup for." },
                 { "name": "outerHTML", "type": "string", "description": "Outer HTML markup to set." }
@@ -505,7 +511,7 @@
         },
         {
             "name": "insertAdjacentHTML",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId" },
                 { "name": "position", "type": "string" },
@@ -762,6 +768,7 @@
         {
             "name": "moveTo",
             "description": "Moves node into the new container, places it before the given anchor.",
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to drop." },
                 { "name": "targetNodeId", "$ref": "NodeId", "description": "Id of the element to drop into." },

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
@@ -30,9 +30,11 @@
 #include "CharacterData.h"
 #include "ContainerNode.h"
 #include "DOMEditor.h"
+#include "DOMPatchSupport.h"
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "DocumentType.h"
+#include "Editing.h"
 #include "ElementInlines.h"
 #include "Event.h"
 #include "EventListener.h"
@@ -249,6 +251,33 @@ RefPtr<Node> FrameDOMAgent::assertNode(Inspector::Protocol::ErrorString& errorSt
 RefPtr<Element> FrameDOMAgent::assertElement(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
 {
     RefPtr node = assertNode(errorString, nodeId);
+    if (!node)
+        return nullptr;
+    RefPtr element = dynamicDowncast<Element>(*node);
+    if (!element)
+        errorString = "Node for given nodeId is not an element"_s;
+    return element;
+}
+
+RefPtr<Node> FrameDOMAgent::assertEditableNode(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
+{
+    RefPtr node = assertNode(errorString, nodeId);
+    if (!node)
+        return nullptr;
+    if (node->isInUserAgentShadowTree() && !m_allowEditingUserAgentShadowTrees) {
+        errorString = "Node for given nodeId is in a shadow tree"_s;
+        return nullptr;
+    }
+    if (node->isPseudoElement()) {
+        errorString = "Node for given nodeId is a pseudo-element"_s;
+        return nullptr;
+    }
+    return node;
+}
+
+RefPtr<Element> FrameDOMAgent::assertEditableElement(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
+{
+    RefPtr node = assertEditableNode(errorString, nodeId);
     if (!node)
         return nullptr;
     RefPtr element = dynamicDowncast<Element>(*node);
@@ -1170,6 +1199,227 @@ Ref<Inspector::Protocol::DOM::EventListener> FrameDOMAgent::buildObjectForEventL
     if (disabled)
         value->setDisabled(disabled);
     return value;
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setAttributeValue(int nodeId, const String& name, const String& value)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr element = assertEditableElement(errorString, nodeId);
+    if (!element)
+        return makeUnexpected(errorString);
+
+    if (!m_domEditor->setAttribute(*element, AtomString { name }, AtomString { value }, errorString))
+        return makeUnexpected(errorString);
+
+    return { };
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setAttributesAsText(int nodeId, const String& text, const String& name)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr element = assertEditableElement(errorString, nodeId);
+    if (!element)
+        return makeUnexpected(errorString);
+
+    Ref parsedElement = createHTMLElement(protect(element->document()), HTMLNames::spanTag);
+    auto result = parsedElement.get().setInnerHTML(makeString("<span "_s, text, "></span>"_s));
+    if (result.hasException())
+        return makeUnexpected(InspectorDOMAgent::toErrorString(result.releaseException()));
+
+    RefPtr child = parsedElement->firstChild();
+    if (!child)
+        return makeUnexpected("Could not parse given text"_s);
+
+    RefPtr childElement = dynamicDowncast<Element>(*child);
+    if (!childElement)
+        return makeUnexpected("Could not parse given text"_s);
+
+    if (!childElement->hasAttributes() && !!name) {
+        if (!m_domEditor->removeAttribute(*element, AtomString { name }, errorString))
+            return makeUnexpected(errorString);
+        return { };
+    }
+
+    bool foundOriginalAttribute = false;
+    for (auto& attribute : childElement->attributes()) {
+        auto attributeName = attribute.name().toAtomString();
+        foundOriginalAttribute = foundOriginalAttribute || attributeName == name;
+        if (!m_domEditor->setAttribute(*element, attributeName, attribute.value(), errorString))
+            return makeUnexpected(errorString);
+    }
+
+    if (!foundOriginalAttribute && name.find(deprecatedIsNotSpaceOrNewline) != notFound) {
+        if (!m_domEditor->removeAttribute(*element, AtomString { name }, errorString))
+            return makeUnexpected(errorString);
+    }
+
+    return { };
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::removeAttribute(int nodeId, const String& name)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr element = assertEditableElement(errorString, nodeId);
+    if (!element)
+        return makeUnexpected(errorString);
+
+    if (!m_domEditor->removeAttribute(*element, AtomString { name }, errorString))
+        return makeUnexpected(errorString);
+
+    return { };
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::removeNode(int nodeId)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertEditableNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    RefPtr parentNode = node->parentNode();
+    if (!parentNode)
+        return makeUnexpected("Cannot remove detached node"_s);
+
+    if (!m_domEditor->removeChild(*parentNode, *node, errorString))
+        return makeUnexpected(errorString);
+
+    return { };
+}
+
+Inspector::CommandResult<int> FrameDOMAgent::setNodeName(int nodeId, const String& tagName)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr oldNode = assertElement(errorString, nodeId);
+    if (!oldNode)
+        return makeUnexpected(errorString);
+
+    auto createElementResult = protect(oldNode->document())->createElementForBindings(AtomString { tagName });
+    if (createElementResult.hasException())
+        return makeUnexpected(InspectorDOMAgent::toErrorString(createElementResult.releaseException()));
+
+    auto newElement = createElementResult.releaseReturnValue();
+
+    newElement->cloneAttributesFromElement(*oldNode);
+
+    RefPtr<Node> child;
+    while ((child = oldNode->firstChild())) {
+        if (!m_domEditor->insertBefore(newElement, *child, 0, errorString))
+            return makeUnexpected(errorString);
+    }
+
+    RefPtr<ContainerNode> parent = oldNode->parentNode();
+    if (!m_domEditor->insertBefore(*parent, newElement.copyRef(), protect(oldNode->nextSibling()).get(), errorString))
+        return makeUnexpected(errorString);
+    if (!m_domEditor->removeChild(*parent, *oldNode, errorString))
+        return makeUnexpected(errorString);
+
+    auto resultNodeId = pushNodePathToFrontend(errorString, newElement.ptr());
+    if (m_childrenRequested.contains(nodeId))
+        pushChildNodesToFrontend(resultNodeId);
+
+    return resultNodeId;
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setOuterHTML(int nodeId, const String& outerHTML)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    if (!nodeId) {
+        if (!m_document)
+            return makeUnexpected("Internal error: missing document"_s);
+        DOMPatchSupport { *m_domEditor, *m_document }.patchDocument(outerHTML);
+        return { };
+    }
+
+    RefPtr node = assertEditableNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    Ref document = node->document();
+    if (!document->isHTMLDocument() && !document->isXMLDocument())
+        return makeUnexpected("Document of node for given nodeId is not HTML/XML"_s);
+
+    Node* newNode = nullptr;
+    if (!m_domEditor->setOuterHTML(*node, outerHTML, newNode, errorString))
+        return makeUnexpected(errorString);
+
+    if (!newNode)
+        return { };
+
+    auto newId = pushNodePathToFrontend(errorString, newNode);
+
+    if (m_childrenRequested.contains(nodeId))
+        pushChildNodesToFrontend(newId);
+
+    return { };
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::insertAdjacentHTML(int nodeId, const String& position, const String& html)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertEditableNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    RefPtr element = dynamicDowncast<Element>(*node);
+    if (!element)
+        return makeUnexpected("Node for given nodeId is not an element"_s);
+
+    if (!m_domEditor->insertAdjacentHTML(*element, position, html, errorString))
+        return makeUnexpected(errorString);
+
+    return { };
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setNodeValue(int nodeId, const String& value)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertEditableNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    RefPtr text = dynamicDowncast<Text>(*node);
+    if (!text)
+        return makeUnexpected("Node for given nodeId is not text"_s);
+
+    if (!m_domEditor->replaceWholeText(*text, value, errorString))
+        return makeUnexpected(errorString);
+
+    return { };
+}
+
+Inspector::CommandResult<int> FrameDOMAgent::moveTo(int nodeId, int targetNodeId, std::optional<int>&& insertBeforeNodeId)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertEditableNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    RefPtr targetElement = assertEditableElement(errorString, targetNodeId);
+    if (!targetElement)
+        return makeUnexpected(errorString);
+
+    RefPtr<Node> anchorNode;
+    if (insertBeforeNodeId && *insertBeforeNodeId) {
+        anchorNode = assertEditableNode(errorString, *insertBeforeNodeId);
+        if (!anchorNode)
+            return makeUnexpected(errorString);
+        if (anchorNode->parentNode() != targetElement)
+            return makeUnexpected("Given insertBeforeNodeId must be a child of given targetNodeId"_s);
+    }
+
+    if (!m_domEditor->insertBefore(*targetElement, *node, anchorNode.get(), errorString))
+        return makeUnexpected(errorString);
+
+    return pushNodePathToFrontend(errorString, node.get());
 }
 
 Inspector::CommandResult<void> FrameDOMAgent::undo()

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
@@ -160,6 +160,8 @@ private:
 
     RefPtr<Node> assertNode(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);
     RefPtr<Element> assertElement(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);
+    RefPtr<Node> assertEditableNode(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);
+    RefPtr<Element> assertEditableElement(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);
 
     Ref<Inspector::Protocol::DOM::Node> buildObjectForNode(Node*, int depth);
     Ref<JSON::ArrayOf<String>> buildArrayForElementAttributes(Element*);

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
@@ -30,36 +30,6 @@ namespace WebCore {
 
 using namespace Inspector;
 
-Inspector::CommandResult<int> FrameDOMAgent::setNodeName(int, const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::setNodeValue(int, const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::removeNode(int)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::setAttributeValue(int, const String&, const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::setAttributesAsText(int, const String&, const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::removeAttribute(int, const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::DataBinding>>> FrameDOMAgent::getDataBindingsForNode(int)
 {
@@ -83,16 +53,6 @@ Inspector::CommandResult<void> FrameDOMAgent::removeBreakpointForEventListener(i
 }
 
 Inspector::CommandResult<Ref<Inspector::Protocol::DOM::AccessibilityProperties>> FrameDOMAgent::getAccessibilityPropertiesForNode(int)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::setOuterHTML(int, const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::insertAdjacentHTML(int, const String&, const String&)
 {
     return makeUnexpected("Not yet implemented for frame targets"_s);
 }
@@ -187,11 +147,6 @@ Inspector::CommandResult<void> FrameDOMAgent::hideFlexOverlay(std::optional<int>
 }
 
 Inspector::CommandResult<Ref<Inspector::Protocol::Runtime::RemoteObject>> FrameDOMAgent::resolveNode(int, const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<int> FrameDOMAgent::moveTo(int, int, std::optional<int>&&)
 {
     return makeUnexpected("Not yet implemented for frame targets"_s);
 }

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -445,14 +445,8 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
-        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
-        if (this.owningTarget) {
-            callback("ERROR: not supported on cross-origin frame nodes");
-            return;
-        }
-
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.setNodeName(this.id, name, this._makeUndoableCallback(callback));
+        let target = this.owningTarget || WI.assumingMainTarget();
+        target.DOMAgent.setNodeName(this.backendNodeId, name, this._makeUndoableCallback(callback));
     }
 
     localName()
@@ -513,14 +507,8 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
-        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
-        if (this.owningTarget) {
-            callback("ERROR: not supported on cross-origin frame nodes");
-            return;
-        }
-
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.setNodeValue(this.id, value, this._makeUndoableCallback(callback));
+        let target = this.owningTarget || WI.assumingMainTarget();
+        target.DOMAgent.setNodeValue(this.backendNodeId, value, this._makeUndoableCallback(callback));
     }
 
     getAttribute(name)
@@ -537,14 +525,8 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
-        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
-        if (this.owningTarget) {
-            callback("ERROR: not supported on cross-origin frame nodes");
-            return;
-        }
-
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.setAttributesAsText(this.id, text, name, this._makeUndoableCallback(callback));
+        let target = this.owningTarget || WI.assumingMainTarget();
+        target.DOMAgent.setAttributesAsText(this.backendNodeId, text, name, this._makeUndoableCallback(callback));
     }
 
     setAttributeValue(name, value, callback)
@@ -558,23 +540,15 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
-        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
-        if (this.owningTarget) {
-            if (!callback)
-                return Promise.reject("ERROR: not supported on cross-origin frame nodes");
-            callback("ERROR: not supported on cross-origin frame nodes");
-            return;
-        }
-
-        let target = WI.assumingMainTarget();
+        let target = this.owningTarget || WI.assumingMainTarget();
 
         if (!callback) {
-            return target.DOMAgent.setAttributeValue(this.id, name, value).then(() => {
+            return target.DOMAgent.setAttributeValue(this.backendNodeId, name, value).then(() => {
                 this._markUndoableState();
             });
         }
 
-        target.DOMAgent.setAttributeValue(this.id, name, value, this._makeUndoableCallback(callback));
+        target.DOMAgent.setAttributeValue(this.backendNodeId, name, value, this._makeUndoableCallback(callback));
     }
 
     attributes()
@@ -587,12 +561,6 @@ WI.DOMNode = class DOMNode extends WI.Object
         console.assert(!this._destroyed, this);
         if (this._destroyed) {
             callback("ERROR: node is destroyed");
-            return;
-        }
-
-        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
-        if (this.owningTarget) {
-            callback("ERROR: not supported on cross-origin frame nodes");
             return;
         }
 
@@ -611,8 +579,8 @@ WI.DOMNode = class DOMNode extends WI.Object
             this._makeUndoableCallback(callback)(error);
         }
 
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.removeAttribute(this.id, name, mycallback.bind(this));
+        let target = this.owningTarget || WI.assumingMainTarget();
+        target.DOMAgent.removeAttribute(this.backendNodeId, name, mycallback.bind(this));
     }
 
     toggleClass(className, flag)
@@ -947,14 +915,8 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
-        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
-        if (this.owningTarget) {
-            callback("ERROR: not supported on cross-origin frame nodes");
-            return;
-        }
-
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.setOuterHTML(this.id, html, this._makeUndoableCallback(callback));
+        let target = this.owningTarget || WI.assumingMainTarget();
+        target.DOMAgent.setOuterHTML(this.backendNodeId, html, this._makeUndoableCallback(callback));
     }
 
     insertAdjacentHTML(position, html)
@@ -966,12 +928,8 @@ WI.DOMNode = class DOMNode extends WI.Object
         if (this.nodeType() !== Node.ELEMENT_NODE)
             return;
 
-        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
-        if (this.owningTarget)
-            return;
-
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.insertAdjacentHTML(this.id, position, html, this._makeUndoableCallback());
+        let target = this.owningTarget || WI.assumingMainTarget();
+        target.DOMAgent.insertAdjacentHTML(this.backendNodeId, position, html, this._makeUndoableCallback());
     }
 
     removeNode(callback)
@@ -982,14 +940,8 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
-        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
-        if (this.owningTarget) {
-            callback("ERROR: not supported on cross-origin frame nodes");
-            return;
-        }
-
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.removeNode(this.id, this._makeUndoableCallback(callback));
+        let target = this.owningTarget || WI.assumingMainTarget();
+        target.DOMAgent.removeNode(this.backendNodeId, this._makeUndoableCallback(callback));
     }
 
     getEventListeners({includeAncestors} = {})
@@ -1327,14 +1279,15 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
-        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
-        if (this.owningTarget || targetNode.owningTarget || (anchorNode && anchorNode.owningTarget)) {
-            callback("ERROR: not supported on cross-origin frame nodes");
+        // moveTo requires source, target, and anchor to live in the same agent. Cross-target
+        // moves cannot resolve nodeIds across processes; reject up front.
+        if (this.owningTarget !== targetNode.owningTarget || (anchorNode && anchorNode.owningTarget !== this.owningTarget)) {
+            callback("ERROR: cannot move nodes across frame targets");
             return;
         }
 
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.moveTo(this.id, targetNode.id, anchorNode ? anchorNode.id : undefined, this._makeUndoableCallback(callback));
+        let target = this.owningTarget || WI.assumingMainTarget();
+        target.DOMAgent.moveTo(this.backendNodeId, targetNode.backendNodeId, anchorNode ? anchorNode.backendNodeId : undefined, this._makeUndoableCallback(callback));
     }
 
     isXMLNode()


### PR DESCRIPTION
#### d46f6b0d75a462477d10ccff33b3efa6aa27db6c
<pre>
Web Inspector: [SI] implement DOM editing commands for FrameDOMAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=315590">https://bugs.webkit.org/show_bug.cgi?id=315590</a>
<a href="https://rdar.apple.com/177974230">rdar://177974230</a>

Reviewed by Qianlang Chen.

Port nine DOM editing commands from InspectorDOMAgent onto FrameDOMAgent
— setNodeName, setNodeValue, removeNode, setAttributeValue,
setAttributesAsText, removeAttribute, setOuterHTML, insertAdjacentHTML,
and moveTo. Each operates on the frame&apos;s local Document via the DOMEditor
+ InspectorHistory, so cross-origin iframe edits
are recorded on the frame&apos;s per-process undo stack and reversed by the
existing undo/redo commands. setOuterHTML with nodeId == 0 patches the
frame&apos;s whole document via DOMPatchSupport. CSS notifications after
attribute edits are skipped until FrameCSSAgent exists.

On the frontend, the cross-origin guards are removed
from the editing methods on DOMNode. Each routes through `owningTarget
|| WI.assumingMainTarget()` with `backendNodeId`, matching the pattern
used for querySelector. moveTo rejects cross-target moves up front since
nodeIds cannot resolve across processes.

Test: http/tests/site-isolation/inspector/dom/editing-commands-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/dom/editing-commands-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/editing-commands-frame-target.html: Added.
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp:
(WebCore::FrameDOMAgent::assertEditableNode):
(WebCore::FrameDOMAgent::assertEditableElement):
(WebCore::FrameDOMAgent::setAttributeValue):
(WebCore::FrameDOMAgent::setAttributesAsText):
(WebCore::FrameDOMAgent::removeAttribute):
(WebCore::FrameDOMAgent::removeNode):
(WebCore::FrameDOMAgent::setNodeName):
(WebCore::FrameDOMAgent::setOuterHTML):
(WebCore::FrameDOMAgent::insertAdjacentHTML):
(WebCore::FrameDOMAgent::setNodeValue):
(WebCore::FrameDOMAgent::moveTo):
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.h:
* Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp:
(WebCore::FrameDOMAgent::setNodeName): Deleted.
(WebCore::FrameDOMAgent::setNodeValue): Deleted.
(WebCore::FrameDOMAgent::removeNode): Deleted.
(WebCore::FrameDOMAgent::setAttributeValue): Deleted.
(WebCore::FrameDOMAgent::setAttributesAsText): Deleted.
(WebCore::FrameDOMAgent::removeAttribute): Deleted.
(WebCore::FrameDOMAgent::setOuterHTML): Deleted.
(WebCore::FrameDOMAgent::insertAdjacentHTML): Deleted.
(WebCore::FrameDOMAgent::moveTo): Deleted.
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.setNodeName):
(WI.DOMNode.prototype.setNodeValue):
(WI.DOMNode.prototype.setAttribute):
(WI.DOMNode.prototype.setAttributeValue):
(WI.DOMNode.prototype.removeAttribute):
(WI.DOMNode.prototype.setOuterHTML):
(WI.DOMNode.prototype.insertAdjacentHTML):
(WI.DOMNode.prototype.removeNode):
(WI.DOMNode.prototype.moveTo):

Canonical link: <a href="https://commits.webkit.org/315698@main">https://commits.webkit.org/315698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/613caf7cb8bc09d671788e34447e9d380be5505c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179148 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f529cb7-9782-40e7-8f8b-b3ece1ab2b16) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171655 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43341 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e28f4466-d2b1-40d0-ae38-913a7fb88a33) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172748 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/44775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112828 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbd9cb13-d991-472e-921c-5da038c88662) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27845 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1144 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/44775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181747 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31044 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140607 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44056 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108346 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25868 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35873 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202468 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42567 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/54271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41959 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42102 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->