### PR TITLE
Skip SVGResourcesCache invalidation walk when nothing depends on the element

### DIFF
--- a/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
@@ -24,6 +24,7 @@
 #include "LegacyRenderSVGModelObjectInlines.h"
 #include "LegacyRenderSVGResourceContainer.h"
 #include "RenderElementInlines.h"
+#include "SVGElement.h"
 #include "SVGResources.h"
 #include "SVGResourcesCycleSolver.h"
 #include "Settings.h"
@@ -201,10 +202,17 @@ void SVGResourcesCache::clientStyleChanged(RenderElement& renderer, Style::Diffe
         return false;
     };
 
-    if (hasStyleDifferencesAffectingResources()) {
+    bool resourceAffectingChange = hasStyleDifferencesAffectingResources();
+    if (resourceAffectingChange) {
         auto& cache = resourcesCacheFromRenderer(renderer);
         cache.removeResourcesFromRenderer(renderer);
         cache.addResourcesFromRenderer(renderer, newStyle);
+    }
+
+    if (!resourceAffectingChange && !renderer.isLegacyRenderSVGResourceContainer()) {
+        RefPtr svgElement = dynamicDowncast<SVGElement>(renderer.element());
+        if (svgElement && !svgElement->hasReferencingDependents())
+            return;
     }
 
     LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation(renderer, false);

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -303,6 +303,14 @@ Vector<WeakPtr<SVGResourceElementClient>> SVGElement::referencingCSSClients() co
     return copyToVector(m_svgRareData->referencingCSSClients());
 }
 
+bool SVGElement::hasReferencingDependents() const
+{
+    if (!m_svgRareData)
+        return false;
+    return !m_svgRareData->referencingElements().isEmptyIgnoringNullReferences()
+        || !m_svgRareData->referencingCSSClients().isEmptyIgnoringNullReferences();
+}
+
 void SVGElement::addReferencingCSSClient(SVGResourceElementClient& client)
 {
     if (CheckedPtr container = dynamicDowncast<RenderSVGResourceContainer>(this->renderer()))

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -125,6 +125,8 @@ public:
     void removeReferencingElement(SVGElement&);
     void removeElementReference();
 
+    bool hasReferencingDependents() const;
+
     Vector<WeakPtr<SVGResourceElementClient>> referencingCSSClients() const;
     void addReferencingCSSClient(SVGResourceElementClient&);
     void removeReferencingCSSClient(SVGResourceElementClient&);


### PR DESCRIPTION
#### c01e4c1311bf9da68e78c6bfa0768443feb99a95
<pre>
Skip SVGResourcesCache invalidation walk when nothing depends on the element
<a href="https://bugs.webkit.org/show_bug.cgi?id=315596">https://bugs.webkit.org/show_bug.cgi?id=315596</a>

Reviewed by NOBODY (OOPS!).

SVGResourcesCache::clientStyleChanged() unconditionally calls
markForLayoutAndParentResourceInvalidation() even when the style change
doesn&apos;t affect resource bindings and no other element references this
one. For workloads that mutate many SVG elements together, this
work multiplies across N elements and shows up as a measurable slice
of render tree update time.

* Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::clientStyleChanged):
(WebCore::SVGResourcesCache::clientWasAddedToTree):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::hasReferencingDependents const):
* Source/WebCore/svg/SVGElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c01e4c1311bf9da68e78c6bfa0768443feb99a95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173584 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121806 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/24d276dd-07cf-4911-99e3-a3b87e0db895) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38040 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127866 "Found 5 new test failures: css3/masking/reference-clip-path-change-repaint.html imported/mozilla/svg/pattern-live-01b.svg imported/mozilla/svg/text/dynamic-font-size-4.svg imported/w3c/web-platform-tests/css/filter-effects/svg-sourcegraphic-currentcolor-dynamic-001.html imported/w3c/web-platform-tests/svg/pservers/reftests/pattern-inheritance-template-pattern-removed.svg (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90008 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f235c37f-dc65-4cfd-a73e-e54e1b90b359) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167513 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30166 "Found 5 new test failures: css3/masking/reference-clip-path-change-repaint.html imported/mozilla/svg/dynamic-mask-contents-01.svg imported/mozilla/svg/dynamic-pattern-contents-01.svg imported/mozilla/svg/pattern-live-01b.svg imported/mozilla/svg/text/dynamic-font-size-4.svg (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108411 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e94929ef-3c3c-4068-8867-237c15bcf751) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29213 "Found 2 new test failures: imported/w3c/web-platform-tests/css/filter-effects/svg-sourcegraphic-currentcolor-dynamic-001.html imported/w3c/web-platform-tests/svg/pservers/reftests/pattern-inheritance-template-pattern-removed.svg (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27834 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21347 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176110 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28933 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27284 "Found 7 new test failures: css3/masking/reference-clip-path-change-repaint.html imported/mozilla/svg/dynamic-mask-contents-01.svg imported/mozilla/svg/dynamic-pattern-contents-01.svg imported/mozilla/svg/pattern-live-01b.svg imported/mozilla/svg/text/dynamic-font-size-4.svg imported/w3c/web-platform-tests/css/filter-effects/svg-sourcegraphic-currentcolor-dynamic-001.html imported/w3c/web-platform-tests/svg/pservers/reftests/pattern-inheritance-template-pattern-removed.svg (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136185 "Found 4 new test failures: css3/masking/reference-clip-path-change-repaint.html imported/mozilla/svg/text/dynamic-font-size-4.svg imported/w3c/web-platform-tests/css/filter-effects/svg-sourcegraphic-currentcolor-dynamic-001.html imported/w3c/web-platform-tests/svg/pservers/reftests/pattern-inheritance-template-pattern-removed.svg (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38107 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31956 "Found 7 new test failures: css3/masking/reference-clip-path-change-repaint.html imported/mozilla/svg/dynamic-mask-contents-01.svg imported/mozilla/svg/dynamic-pattern-contents-01.svg imported/mozilla/svg/pattern-live-01b.svg imported/mozilla/svg/text/dynamic-font-size-4.svg imported/w3c/web-platform-tests/css/filter-effects/svg-sourcegraphic-currentcolor-dynamic-001.html imported/w3c/web-platform-tests/svg/pservers/reftests/pattern-inheritance-template-pattern-removed.svg (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136150 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147411 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100949 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31425 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24267 "Found 7 new test failures: css3/masking/reference-clip-path-change-repaint.html imported/mozilla/svg/dynamic-mask-contents-01.svg imported/mozilla/svg/dynamic-pattern-contents-01.svg imported/mozilla/svg/pattern-live-01b.svg imported/mozilla/svg/text/dynamic-font-size-4.svg imported/w3c/web-platform-tests/css/filter-effects/svg-sourcegraphic-currentcolor-dynamic-001.html imported/w3c/web-platform-tests/svg/pservers/reftests/pattern-inheritance-template-pattern-removed.svg (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37305 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110349 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36703 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2328 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36951 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36851 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->