### PR TITLE
Safari "open safe files" turns .tgz files into tarballs without a file extension (should be .tar; works for .tar.gz)

### DIFF
--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -758,6 +758,32 @@ static String NODELETE normalizedImageMIMEType(const String& mimeType)
 #endif
 }
 
+static String canonicalMIMEType(const String& mimeType)
+{
+    static constexpr SortedArrayMap aliasMap { WTF::toArray<std::pair<ComparableLettersLiteral, ASCIILiteral>>({
+        { "application/x-gzip"_s, "application/gzip"_s },
+        { "application/x-zip-compressed"_s, "application/zip"_s },
+    }) };
+    auto canonical = aliasMap.tryGet(mimeType);
+    return canonical ? *canonical : mimeType;
+}
+
+static bool isArchiveMIMEType(const String& canonicalizedMIMEType)
+{
+    static constexpr SortedArraySet archiveMIMETypes { WTF::toArray<ComparableLettersLiteral>({
+        "application/gzip"_s,
+        "application/java-archive"_s,
+        "application/vnd.rar"_s,
+        "application/x-7z-compressed"_s,
+        "application/x-bzip2"_s,
+        "application/x-compressed-tar"_s,
+        "application/x-tar"_s,
+        "application/x-xz"_s,
+        "application/zip"_s,
+    }) };
+    return archiveMIMETypes.contains(canonicalizedMIMEType);
+}
+
 String MIMETypeRegistry::appendFileExtensionIfNecessary(const String& filename, const String& mimeType)
 {
     if (filename.isEmpty() || filename.contains('.') || equalIgnoringASCIICase(mimeType, defaultMIMEType()))
@@ -785,8 +811,13 @@ String MIMETypeRegistry::correctExtensionForMIMEType(const String& suggestedFile
         return makeString(suggestedFilename, '.', preferredExtension);
 
     auto currentExtension = suggestedFilename.substring(dotPosition + 1);
-    if (!equalIgnoringASCIICase(mimeTypeForExtension(currentExtension), mimeType))
+    auto extensionMIMEType = canonicalMIMEType(mimeTypeForExtension(currentExtension));
+    auto responseMIMEType = canonicalMIMEType(mimeType);
+    if (!equalIgnoringASCIICase(extensionMIMEType, responseMIMEType)) {
+        if (isArchiveMIMEType(extensionMIMEType) && isArchiveMIMEType(responseMIMEType))
+            return suggestedFilename;
         return makeString(suggestedFilename.left(dotPosition), '.', preferredExtension);
+    }
 
     // Only strip the middle extension if it belongs to a different major MIME type to preserve compound extensions (e.g. ".tar.gz").
     auto basePart = suggestedFilename.left(dotPosition);

--- a/Tools/TestWebKitAPI/Tests/WebCore/MIMETypeRegistry.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MIMETypeRegistry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,6 +88,42 @@ TEST(MIMETypeRegistry, PreferredExtensionForMIMEType)
 TEST(MIMETypeRegistry, ExtensionsForMIMEType)
 {
     EXPECT_EQ(MIMETypeRegistry::extensionsForMIMEType({ }).size(), 0U);
+}
+
+TEST(MIMETypeRegistry, CorrectExtensionForMIMEType)
+{
+    EXPECT_TRUE(MIMETypeRegistry::correctExtensionForMIMEType({ }, "image/png"_s).isEmpty());
+    EXPECT_STREQ("file.png", MIMETypeRegistry::correctExtensionForMIMEType("file.png"_s, { }).utf8().data());
+    EXPECT_STREQ("file.png", MIMETypeRegistry::correctExtensionForMIMEType("file.png"_s, "application/octet-stream"_s).utf8().data());
+    EXPECT_STREQ("file.html", MIMETypeRegistry::correctExtensionForMIMEType("file.html"_s, "text/plain"_s).utf8().data());
+
+    EXPECT_STREQ("image.png", MIMETypeRegistry::correctExtensionForMIMEType("image.png"_s, "image/png"_s).utf8().data());
+
+    EXPECT_STREQ("video.mp4", MIMETypeRegistry::correctExtensionForMIMEType("video.gif"_s, "video/mp4"_s).utf8().data());
+    EXPECT_STREQ("file.png", MIMETypeRegistry::correctExtensionForMIMEType("file.gif"_s, "image/png"_s).utf8().data());
+
+    EXPECT_STREQ("file.png", MIMETypeRegistry::correctExtensionForMIMEType("file"_s, "image/png"_s).utf8().data());
+
+#if PLATFORM(COCOA)
+    EXPECT_STREQ("archive.tar.gz", MIMETypeRegistry::correctExtensionForMIMEType("archive.tar.gz"_s, "application/gzip"_s).utf8().data());
+
+    EXPECT_STREQ("resource.tgz", MIMETypeRegistry::correctExtensionForMIMEType("resource.tgz"_s, "application/gzip"_s).utf8().data());
+
+    EXPECT_STREQ("resource.tgz", MIMETypeRegistry::correctExtensionForMIMEType("resource.tgz"_s, "application/x-gzip"_s).utf8().data());
+    EXPECT_STREQ("file.zip", MIMETypeRegistry::correctExtensionForMIMEType("file.zip"_s, "application/x-zip-compressed"_s).utf8().data());
+    EXPECT_STREQ("file.gz", MIMETypeRegistry::correctExtensionForMIMEType("file.gz"_s, "application/gzip"_s).utf8().data());
+    EXPECT_STREQ("file.gz", MIMETypeRegistry::correctExtensionForMIMEType("file.gz"_s, "application/x-gzip"_s).utf8().data());
+
+    EXPECT_STREQ("resource.TGZ", MIMETypeRegistry::correctExtensionForMIMEType("resource.TGZ"_s, "application/gzip"_s).utf8().data());
+    EXPECT_STREQ("resource.tgz", MIMETypeRegistry::correctExtensionForMIMEType("resource.tgz"_s, "Application/X-Gzip"_s).utf8().data());
+
+    EXPECT_STREQ("archive.cpgz", MIMETypeRegistry::correctExtensionForMIMEType("archive.cpgz"_s, "application/zip"_s).utf8().data());
+    EXPECT_STREQ("archive.cpgz", MIMETypeRegistry::correctExtensionForMIMEType("archive.cpgz"_s, "application/gzip"_s).utf8().data());
+    EXPECT_STREQ("data.tar", MIMETypeRegistry::correctExtensionForMIMEType("data.tar"_s, "application/gzip"_s).utf8().data());
+    EXPECT_STREQ("data.tgz", MIMETypeRegistry::correctExtensionForMIMEType("data.tgz"_s, "application/zip"_s).utf8().data());
+    EXPECT_STREQ("file.gz", MIMETypeRegistry::correctExtensionForMIMEType("file.gz"_s, "application/zip"_s).utf8().data());
+    EXPECT_STREQ("app.jar", MIMETypeRegistry::correctExtensionForMIMEType("app.jar"_s, "application/zip"_s).utf8().data());
+#endif
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### aa5783f948506ce7056c3b37e68d31ee78da1d6d
<pre>
Safari &quot;open safe files&quot; turns .tgz files into tarballs without a file extension (should be .tar; works for .tar.gz)
<a href="https://bugs.webkit.org/show_bug.cgi?id=315604">https://bugs.webkit.org/show_bug.cgi?id=315604</a>
<a href="https://rdar.apple.com/175291256">rdar://175291256</a>

Reviewed by Sihui Liu.

The problem: .tgz/.cpgz files were being renamed to .gz/.zip because it
compared the URL extension&apos;s MIME type to the server&apos;s Content-Type as
plain strings. This ignores the fact that application/x-gzip / application/gzip
(and more) are aliases and that compressed archive shorthands are different
compared to server side. Server side usually labels with just the outer
compression in Content-Type.

The fix: Treat known MIME aliases as equal.
application/x-gzip is normalized to application/gzip (and application/x-zip-compressed
to application/zip) before comparison to not trigger a false mismatch.
If the URL extension&apos;s MIME and the server&apos;s MIME are both compressed archive
formats, but are different, we keep the URL extension instead of overwriting it
since the URL is more specfic than the server&apos;s label.

Test: Tools/TestWebKitAPI/Tests/WebCore/MIMETypeRegistry.cpp

* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::canonicalMIMEType):
(WebCore::isArchiveMIMEType):
(WebCore::MIMETypeRegistry::correctExtensionForMIMEType):
* Tools/TestWebKitAPI/Tests/WebCore/MIMETypeRegistry.cpp:
(TestWebKitAPI::TEST(MIMETypeRegistry, CorrectExtensionForMIMEType)):

Canonical link: <a href="https://commits.webkit.org/314104@main">https://commits.webkit.org/314104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfb700ce64061c3cb3dc456e6de21a59e01df317

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173872 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72b4e287-9cff-4fbf-abe2-0a3b1e8350fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128088 "Passed tests") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66d29077-2a9c-489b-9ef1-4637ba875852) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108634 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45216ef0-8dcc-4c6c-9a57-b812a2c16063) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29456 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21631 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176395 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136408 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38390 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136372 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36813 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147644 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101299 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31644 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37588 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36986 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2567 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37234 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37134 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->