### PR TITLE
[CMake][iOS] Stage WebCore-sourced WebKitLegacy headers as forwarding stubs

### DIFF
--- a/Source/WebKitLegacy/PlatformIOS.cmake
+++ b/Source/WebKitLegacy/PlatformIOS.cmake
@@ -973,13 +973,14 @@ set(_wkl_excluded_for_ios
     WebWindowAnimation.h
 )
 
-# Apply the same exclusion to WebKitLegacy_PUBLIC_FRAMEWORK_HEADERS, which is
-# what WEBKIT_COPY_FILES(WebKitLegacy_CopyHeaders) in CMakeLists.txt actually
-# stages. (The foreach below adds forwarding stubs in addition to the copies.)
+# Apply the same exclusion to WebKitLegacy_PUBLIC_FRAMEWORK_HEADERS so
+# WEBKIT_COPY_FILES doesn't stage them. Also drop ${WEBCORE_DIR} entries: the
+# foreach below stages forwarding stubs instead.
 set(_wkl_filtered "")
 foreach (_path IN LISTS WebKitLegacy_PUBLIC_FRAMEWORK_HEADERS)
     get_filename_component(_pathname "${_path}" NAME)
-    if (NOT _pathname IN_LIST _wkl_excluded_for_ios)
+    cmake_path(IS_PREFIX WEBCORE_DIR "${_path}" NORMALIZE _is_from_webcore)
+    if (NOT _pathname IN_LIST _wkl_excluded_for_ios AND NOT _is_from_webcore)
         list(APPEND _wkl_filtered "${_path}")
     endif ()
 endforeach ()
@@ -1030,6 +1031,12 @@ foreach (_file ${WebKitLegacy_LEGACY_FORWARDING_HEADERS_FILES})
     else ()
         set(_src_path "${CMAKE_CURRENT_SOURCE_DIR}/${_file}")
     endif ()
+    # WebCore-sourced headers (WAKView.h etc.) are owned by WebCore_Private.Core.*.
+    # Stage a forwarding stub so WebKitLegacy re-exports that submodule.
+    cmake_path(IS_PREFIX WEBCORE_DIR "${_src_path}" NORMALIZE _is_from_webcore)
+    if (_is_from_webcore)
+        set(_migrated "#import <WebCore/${_name}>\n")
+    else ()
     # Stage 1 -- migrate-header-rule:
     #   sed -E -e 's/<WebCore\//<WebKitLegacy\//' -e 's/(^ *)WEBCORE_EXPORT /\1/'
     # Mac-only `<WebCore/...>` imports become `<WebKitLegacy/...>` because Xcode
@@ -1071,6 +1078,7 @@ foreach (_file ${WebKitLegacy_LEGACY_FORWARDING_HEADERS_FILES})
     endif ()
     file(READ "${_unifdef_output}" _migrated)
     file(REMOVE "${_unifdef_input}" "${_unifdef_output}")
+    endif ()
 
     set(_existing "")
     if (EXISTS "${_target_filename}")


### PR DESCRIPTION
#### 867c4d50c4e5f1a93b4aba4448966496ae13a7ca
<pre>
[CMake][iOS] Stage WebCore-sourced WebKitLegacy headers as forwarding stubs
<a href="https://bugs.webkit.org/show_bug.cgi?id=315605">https://bugs.webkit.org/show_bug.cgi?id=315605</a>
&lt;<a href="https://rdar.apple.com/problem/177985077">rdar://problem/177985077</a>&gt;

Reviewed by Pascoe.

WebKit symlinks WAKView.h and related headers from WebCore. With
explicit-module-build enabled on iOS, this looks like
a conflict (same type defined in two modules), and the build fails.

Use #import &lt;WebCore/...&gt; in forwarding stub instead of a symlink.
Modules are perfectly compatible with importing things.

* Source/WebKitLegacy/PlatformIOS.cmake:

Canonical link: <a href="https://commits.webkit.org/313925@main">https://commits.webkit.org/313925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1af41ec1c4e78fc21114b984bd05f0bff159b024

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173607 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38062 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127880 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167535 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/30182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108425 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21369 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176134 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/27304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136201 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38129 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136165 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147430 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100973 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25052 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31441 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37327 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110371 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36725 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2349 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36973 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36873 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->