### PR TITLE
[re-land] Support time zone change notifications on linux

### DIFF
--- a/JSTests/stress/intl-datetimeformat-cache-dst-transition.js
+++ b/JSTests/stress/intl-datetimeformat-cache-dst-transition.js
@@ -1,0 +1,205 @@
+//@ skip if $hostOS == "playstation"
+
+// Verifies that every DateCache cache entry returns spec-correct values for
+// dates straddling a DST transition in the same time zone. After bug 314414,
+// these caches persist across VM entries on non-Cocoa platforms, so they must
+// answer correctly on both sides of a DST boundary without being flushed.
+//
+// America/Los_Angeles 2024:
+//   - Spring forward: 2024-03-10 02:00 PST -> 03:00 PDT (UTC-8 -> UTC-7)
+//   - Fall back:      2024-11-03 02:00 PDT -> 01:00 PST (UTC-7 -> UTC-8)
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+
+function expectContains(label, haystack, needle)
+{
+    if (typeof haystack !== "string" || haystack.indexOf(needle) < 0)
+        throw new Error(`${label}: expected ${JSON.stringify(haystack)} to contain ${JSON.stringify(needle)}`);
+}
+
+if (!$vm.setHostTimeZone("America/Los_Angeles"))
+    throw new Error("Failed to set host time zone to America/Los_Angeles");
+
+// Reach a new VMEntryScope so the time zone change takes effect.
+setTimeout(() => {
+    expect("tz applied",
+        new Intl.DateTimeFormat().resolvedOptions().timeZone,
+        "America/Los_Angeles");
+
+    // UTC instants either side of the spring-forward transition.
+    const pstUTC = new Date(Date.UTC(2024, 2, 10,  9, 30)); // -> 01:30 PST
+    const pdtUTC = new Date(Date.UTC(2024, 2, 10, 11, 30)); // -> 04:30 PDT
+
+    // --- DSTCache (m_caches[UTCTime]) ---
+    // Either side of the transition should give the spec-correct local offset,
+    // both on cache miss and on cache hit.
+    expect("PST offset",       pstUTC.getTimezoneOffset(), 480);
+    expect("PDT offset",       pdtUTC.getTimezoneOffset(), 420);
+    expect("PST offset (hit)", pstUTC.getTimezoneOffset(), 480);
+    expect("PDT offset (hit)", pdtUTC.getTimezoneOffset(), 420);
+
+    // --- DateInstanceCache (m_dateInstanceCache) ---
+    // Re-querying the same Date should be consistent.
+    expect("PST hours",        pstUTC.getHours(), 1);
+    expect("PST hours (hit)",  pstUTC.getHours(), 1);
+    expect("PDT hours",        pdtUTC.getHours(), 4);
+    expect("PDT hours (hit)",  pdtUTC.getHours(), 4);
+    // A fresh Date object with the same ms hits the cache directly.
+    expect("PDT hours (new instance hit)",
+        new Date(pdtUTC.getTime()).getHours(), 4);
+
+    // --- YearMonthDayCache (m_yearMonthDayCache) ---
+    // Three distinct Dates, all 16:00 UTC, on consecutive local days bracketing
+    // the DST transition. The cache stores (days, year, month, day); querying
+    // adjacent days exercises the +/-1 fast path.
+    const day9  = new Date(Date.UTC(2024, 2,  9, 16, 0)); // 2024-03-09 08:00 PST
+    const day10 = new Date(Date.UTC(2024, 2, 10, 16, 0)); // 2024-03-10 09:00 PDT
+    const day11 = new Date(Date.UTC(2024, 2, 11, 16, 0)); // 2024-03-11 09:00 PDT
+    expect("day9  year",  day9.getFullYear(),  2024);
+    expect("day10 year",  day10.getFullYear(), 2024);
+    expect("day11 year",  day11.getFullYear(), 2024);
+    expect("day9  month", day9.getMonth(),  2);
+    expect("day10 month", day10.getMonth(),  2);
+    expect("day11 month", day11.getMonth(),  2);
+    expect("day9  date",  day9.getDate(),   9);
+    expect("day10 date",  day10.getDate(), 10);
+    expect("day11 date",  day11.getDate(), 11);
+    expect("day9  hours PST", day9.getHours(),   8);
+    expect("day10 hours PDT", day10.getHours(),  9);
+    expect("day11 hours PDT", day11.getHours(),  9);
+
+    // --- parseDate cache (m_cachedDateString / m_cachedDateStringValue) ---
+    // ES2015+ : ISO date-time strings without a tz designator are local time.
+    // The parser subtracts the local offset, so DST must be respected.
+    expect("parse PST",       Date.parse("2024-03-10T01:30:00"),
+        Date.UTC(2024, 2, 10,  9, 30));
+    expect("parse PDT",       Date.parse("2024-03-10T04:30:00"),
+        Date.UTC(2024, 2, 10, 11, 30));
+    // Cache hit (same string twice in a row should bypass parsing).
+    expect("parse PDT (hit)", Date.parse("2024-03-10T04:30:00"),
+        Date.UTC(2024, 2, 10, 11, 30));
+    expect("parse PST (hit)", Date.parse("2024-03-10T01:30:00"),
+        Date.UTC(2024, 2, 10,  9, 30));
+
+    // --- m_timeZoneStandardDisplayNameCache / m_timeZoneDSTDisplayNameCache ---
+    // Date#toString embeds "(Pacific Standard Time)" or "(Pacific Daylight
+    // Time)" depending on whether the instant is in DST. Both caches are
+    // populated on the first call; subsequent calls hit the cache.
+    const stdStr1 = pstUTC.toString();
+    const dstStr1 = pdtUTC.toString();
+    expectContains("PST display name", stdStr1, "(Pacific Standard Time)");
+    expectContains("PDT display name", dstStr1, "(Pacific Daylight Time)");
+    expectContains("PST GMT offset",   stdStr1, "GMT-0800");
+    expectContains("PDT GMT offset",   dstStr1, "GMT-0700");
+    // Cache hits.
+    expectContains("PST display name (hit)",
+        new Date(pstUTC.getTime()).toString(), "(Pacific Standard Time)");
+    expectContains("PDT display name (hit)",
+        new Date(pdtUTC.getTime()).toString(), "(Pacific Daylight Time)");
+
+    // --- DSTCache (m_caches[LocalTime]) ---
+    // Constructing a Date from local components uses the LocalTime cache. Pick
+    // dates well away from the discontinuity so the local->UTC mapping is
+    // unambiguous.
+    const winterLocal = new Date(2024, 0, 15, 12, 0); // 2024-01-15 12:00 PST
+    const summerLocal = new Date(2024, 5, 15, 12, 0); // 2024-06-15 12:00 PDT
+    expect("local PST -> UTC ms",
+        winterLocal.getTime(), Date.UTC(2024, 0, 15, 20, 0));
+    expect("local PDT -> UTC ms",
+        summerLocal.getTime(), Date.UTC(2024, 5, 15, 19, 0));
+    expect("local PST offset",  winterLocal.getTimezoneOffset(), 480);
+    expect("local PDT offset",  summerLocal.getTimezoneOffset(), 420);
+
+    // --- Intl.DateTimeFormat (separate code path from Date#toString) ---
+    // The IntlDateTimeFormat instance caches its resolved time zone; it relies
+    // on ICU's per-instant DST awareness, not on DateCache's display-name caches.
+    const dtfShort = new Intl.DateTimeFormat("en-US", {
+        timeZone: "America/Los_Angeles", hour: "2-digit", minute: "2-digit",
+        hour12: false, timeZoneName: "short",
+    });
+    const dtfLong = new Intl.DateTimeFormat("en-US", {
+        timeZone: "America/Los_Angeles", hour: "2-digit", minute: "2-digit",
+        hour12: false, timeZoneName: "long",
+    });
+    expectContains("DTF short PST", dtfShort.format(pstUTC), "PST");
+    expectContains("DTF short PDT", dtfShort.format(pdtUTC), "PDT");
+    expectContains("DTF long PST",  dtfLong.format(pstUTC),  "Pacific Standard Time");
+    expectContains("DTF long PDT",  dtfLong.format(pdtUTC),  "Pacific Daylight Time");
+
+    // formatToParts surfaces the timeZoneName as a discrete part.
+    const findPart = (parts, type) => parts.find(p => p.type === type)?.value;
+    const partsPST = dtfShort.formatToParts(pstUTC);
+    const partsPDT = dtfShort.formatToParts(pdtUTC);
+    expect("DTF parts PST", findPart(partsPST, "timeZoneName"), "PST");
+    expect("DTF parts PDT", findPart(partsPDT, "timeZoneName"), "PDT");
+
+    // --- Date#toLocaleString (Intl pathway reached via the Date API) ---
+    const localePST = pstUTC.toLocaleString("en-US", { timeZoneName: "short" });
+    const localePDT = pdtUTC.toLocaleString("en-US", { timeZoneName: "short" });
+    expectContains("toLocaleString PST", localePST, "PST");
+    expectContains("toLocaleString PDT", localePDT, "PDT");
+
+    // --- setters: read-local-modify-write-back-to-UTC roundtrip ---
+    // Date#setHours decodes the receiver's ms to local components (UTCTime
+    // cache), mutates one field, then re-encodes (LocalTime cache). A single
+    // call exercises both directions in one step.
+    const pstSetter = new Date(Date.UTC(2024, 2, 10,  9, 30)); // 01:30 PST
+    pstSetter.setHours(0); // 00:30 PST -> UTC 08:30
+    expect("setHours PST roundtrip",
+        pstSetter.getTime(), Date.UTC(2024, 2, 10, 8, 30));
+
+    const pdtSetter = new Date(Date.UTC(2024, 2, 10, 11, 30)); // 04:30 PDT
+    pdtSetter.setHours(6); // 06:30 PDT -> UTC 13:30
+    expect("setHours PDT roundtrip",
+        pdtSetter.getTime(), Date.UTC(2024, 2, 10, 13, 30));
+
+    // setDate that walks the receiver across the spring-forward boundary: the
+    // local time-of-day must be preserved (10:00 local) while UTC ms shifts by
+    // 23h, not 24h, because the day in between is only 23 wall-clock hours.
+    const walker = new Date(Date.UTC(2024, 2,  9, 18, 0)); // 2024-03-09 10:00 PST
+    expect("walker pre hours",    walker.getHours(), 10);
+    expect("walker pre offset",   walker.getTimezoneOffset(), 480);
+    walker.setDate(10);                                   // 2024-03-10 10:00 PDT
+    expect("walker post hours",   walker.getHours(), 10);
+    expect("walker post offset",  walker.getTimezoneOffset(), 420);
+    expect("walker post UTC ms",  walker.getTime(), Date.UTC(2024, 2, 10, 17, 0));
+
+    // setMonth across DST: jump from a PST instant to a PDT month, preserving
+    // local time-of-day.
+    const jumper = new Date(Date.UTC(2024, 0, 15, 20, 0)); // 2024-01-15 12:00 PST
+    jumper.setMonth(5);                                    // 2024-06-15 12:00 PDT
+    expect("setMonth hours preserved", jumper.getHours(), 12);
+    expect("setMonth offset PDT",      jumper.getTimezoneOffset(), 420);
+    expect("setMonth UTC ms",          jumper.getTime(), Date.UTC(2024, 5, 15, 19, 0));
+
+    // --- getDay (day-of-week sentinel) ---
+    // Across DST, day-of-week must reflect the local day. Pick instants whose
+    // UTC day differs from their local day to make the assertion meaningful.
+    //   2024-03-10 06:00 UTC = 2024-03-09 22:00 PST -> Saturday (6)
+    //   2024-03-10 08:00 UTC = 2024-03-10 00:00 PST -> Sunday   (0)
+    //   2024-03-10 11:00 UTC = 2024-03-10 04:00 PDT -> Sunday   (0)
+    expect("getDay Sat PST",
+        new Date(Date.UTC(2024, 2, 10,  6, 0)).getDay(), 6);
+    expect("getDay Sun PST",
+        new Date(Date.UTC(2024, 2, 10,  8, 0)).getDay(), 0);
+    expect("getDay Sun PDT",
+        new Date(Date.UTC(2024, 2, 10, 11, 0)).getDay(), 0);
+
+    // --- Fall back: DST -> standard transition in the same direction ---
+    // 2024-11-03 08:30 UTC = 01:30 PDT (still summer time)
+    // 2024-11-03 10:30 UTC = 02:30 PST (after fall back)
+    const fbPDT = new Date(Date.UTC(2024, 10, 3,  8, 30));
+    const fbPST = new Date(Date.UTC(2024, 10, 3, 10, 30));
+    expect("fallBack PDT offset", fbPDT.getTimezoneOffset(), 420);
+    expect("fallBack PST offset", fbPST.getTimezoneOffset(), 480);
+    expect("fallBack PDT hours",  fbPDT.getHours(), 1);
+    expect("fallBack PST hours",  fbPST.getHours(), 2);
+    expectContains("fallBack PDT display name",
+        fbPDT.toString(), "(Pacific Daylight Time)");
+    expectContains("fallBack PST display name",
+        fbPST.toString(), "(Pacific Standard Time)");
+}, 0);

--- a/JSTests/stress/intl-datetimeformat-cache-tz-hit.js
+++ b/JSTests/stress/intl-datetimeformat-cache-tz-hit.js
@@ -1,0 +1,48 @@
+//@ skip if $hostOS == "playstation"
+
+// Verifies that an Intl.DateTimeFormat host time zone change is observed
+//
+// ECMA-262 leaves the *timing* of when a host zone change becomes observable
+// implementation-defined, and ECMA-402 only requires that observations stay
+// consistent.
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected "${want}", got "${got}"`);
+}
+
+function cacheableTZ()
+{
+    return new Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+function slowTZ()
+{
+    // Passing an options object (even an empty one) bypasses the fast cache
+    // path, so this resolves the zone through the slow path.
+    return new Intl.DateTimeFormat(undefined, {}).resolvedOptions().timeZone;
+}
+
+function testTZ(timezones, index)
+{
+    if (index >= timezones.length)
+        return;
+
+    const tz = timezones[index];
+    const before = cacheableTZ();
+    expect("baseline: cacheable matches slow", before, slowTZ());
+
+    if (!$vm.setHostTimeZone(tz))
+        throw new Error("Failed to set host time zone to " + tz);
+
+    // Get outside the VMEntryScope so clearForTimeZoneChange() runs.
+    setTimeout(() => {
+        const afterInvalidate = cacheableTZ();
+        const afterInvalidateSlow = slowTZ();
+        expect("after notification fires: cacheable matches slow", afterInvalidate, afterInvalidateSlow);
+        expect("after notification fires: new TZ in effect", afterInvalidate, tz);
+        testTZ(timezones, index + 1);
+    }, 0);
+}
+
+testTZ(["UTC", "Pacific/Kiritimati", "America/Los_Angeles"], 0);

--- a/JSTests/stress/intl-datetimeformat-stale-data-across-tz-change.js
+++ b/JSTests/stress/intl-datetimeformat-stale-data-across-tz-change.js
@@ -1,0 +1,67 @@
+//@ skip if $hostOS == "playstation"
+
+// Regression coverage for stale-cached-GregorianDateTime on a DateInstance
+// across a time zone change.
+//
+// DateInstance lazily fetches a DateInstanceData from m_dateInstanceCache on
+// the first accessor call and stores it in m_data. Subsequent accessors (in
+// both the C++ slow path and the DFG/FTL inline fast paths) only re-compute
+// when the receiver's ms changes (`m_gregorianDateTimeCachedForMS != milli`).
+// After a TZ change, DateCache::clearForTimeZoneChange poisons that sentinel on
+// the DateInstanceData still resident in the cache slots, so a DateInstance
+// pointing at one of them takes a forced miss and recomputes against the new
+// local zone.
+
+// Spec: ECMA-262 LocalTime(t) uses "the LocalTZA of the current host
+// environment", so the same Date must reflect the new TZ after the change.
+// SpiderMonkey 115 agrees on every assertion below.
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+
+if (!$vm.setHostTimeZone("America/Los_Angeles"))
+    throw new Error("Failed to set host time zone to America/Los_Angeles");
+
+setTimeout(() => {
+    expect("initial tz",
+        new Intl.DateTimeFormat().resolvedOptions().timeZone,
+        "America/Los_Angeles");
+
+    // 2024-06-15 00:00 UTC.
+    //   In LA  (PDT, UTC-7): 2024-06-14 17:00 PDT.
+    //   In JST (UTC+9):      2024-06-15 09:00 JST.
+    const heldDate = new Date(Date.UTC(2024, 5, 15, 0, 0));
+
+    // Populate the DateInstance's m_data with LA-relative cached values.
+    expect("LA hours",  heldDate.getHours(), 17);
+    expect("LA offset", heldDate.getTimezoneOffset(), 420);
+    expect("LA date",   heldDate.getDate(), 14);
+    expect("LA day",    heldDate.getDay(), 5); // Friday
+
+    // Flip TZ.
+    if (!$vm.setHostTimeZone("Asia/Tokyo"))
+        throw new Error("Failed to set host time zone to Asia/Tokyo");
+
+    setTimeout(() => {
+        expect("post-change tz",
+            new Intl.DateTimeFormat().resolvedOptions().timeZone,
+            "Asia/Tokyo");
+
+        // A *fresh* Date with the same ms correctly reflects Tokyo.
+        const freshDate = new Date(Date.UTC(2024, 5, 15, 0, 0));
+        expect("fresh JST hours",  freshDate.getHours(), 9);
+        expect("fresh JST offset", freshDate.getTimezoneOffset(), -540);
+        expect("fresh JST date",   freshDate.getDate(), 15);
+        expect("fresh JST day",    freshDate.getDay(), 6); // Saturday
+
+        // The held Date must agree (spec-correct), even though its m_data was
+        // populated under LA TZ.
+        expect("held JST hours",  heldDate.getHours(), 9);
+        expect("held JST offset", heldDate.getTimezoneOffset(), -540);
+        expect("held JST date",   heldDate.getDate(), 15);
+        expect("held JST day",    heldDate.getDay(), 6);
+    }, 0);
+}, 0);

--- a/JSTests/stress/intl-datetimeformat-stale-data-evicted-across-tz-change.js
+++ b/JSTests/stress/intl-datetimeformat-stale-data-evicted-across-tz-change.js
@@ -1,0 +1,62 @@
+//@ skip
+// FIXME: https://bugs.webkit.org/show_bug.cgi?id=318362
+// Skipped: exposes a known, deferred bug (see the FIXME in
+// DateInstanceCache::reset). Companion to
+// intl-datetimeformat-stale-data-across-tz-change.js, which covers the case
+// where the DateInstance's DateInstanceData is still resident in a cache slot
+// when the time zone changes. This one covers the eviction case: the
+// DateInstanceData is evicted from its slot (its slot overwritten by another
+// ms) but stays alive via DateInstance::m_data, so DateCache::reset() never
+// reaches it and the held Date keeps its stale local time.
+//
+// Remove the //@ skip (and add the "skip if $hostOS == playstation" guard the
+// sibling tests use) once the eviction case is fixed.
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+
+if (!$vm.setHostTimeZone("America/Los_Angeles"))
+    throw new Error("Failed to set host time zone to America/Los_Angeles");
+
+setTimeout(() => {
+    // 2024-06-15 00:00 UTC.
+    //   In LA  (PDT, UTC-7): 2024-06-14 17:00 PDT.
+    //   In JST (UTC+9):      2024-06-15 09:00 JST.
+    const heldMs = Date.UTC(2024, 5, 15, 0, 0);
+    const heldDate = new Date(heldMs);
+
+    // Populate heldDate.m_data with LA-relative cached values.
+    expect("LA hours",  heldDate.getHours(), 17);
+    expect("LA offset", heldDate.getTimezoneOffset(), 420);
+    expect("LA date",   heldDate.getDate(), 14);
+    expect("LA day",    heldDate.getDay(), 5); // Friday
+
+    // Flood the 16-slot direct-mapped DateInstanceCache with distinct ms so
+    // heldDate's slot is overwritten. Its DateInstanceData is now evicted from
+    // the cache but still referenced by heldDate.m_data.
+    for (let i = 1; i <= 256; i++)
+        new Date(heldMs + i * 86400000).getHours();
+
+    if (!$vm.setHostTimeZone("Asia/Tokyo"))
+        throw new Error("Failed to set host time zone to Asia/Tokyo");
+
+    setTimeout(() => {
+        expect("post-change tz",
+            new Intl.DateTimeFormat().resolvedOptions().timeZone, "Asia/Tokyo");
+
+        // A fresh Date with the same ms correctly reflects Tokyo.
+        const freshDate = new Date(heldMs);
+        expect("fresh JST hours",  freshDate.getHours(), 9);
+        expect("fresh JST offset", freshDate.getTimezoneOffset(), -540);
+
+        // The held Date must agree (spec-correct), even though its evicted
+        // m_data was populated under LA TZ.
+        expect("held JST hours",  heldDate.getHours(), 9);
+        expect("held JST offset", heldDate.getTimezoneOffset(), -540);
+        expect("held JST date",   heldDate.getDate(), 15);
+        expect("held JST day",    heldDate.getDay(), 6); // Saturday
+    }, 0);
+}, 0);

--- a/JSTests/stress/temporal-cache-dst-transition.js
+++ b/JSTests/stress/temporal-cache-dst-transition.js
@@ -1,0 +1,84 @@
+//@ requireOptions("--useTemporal=1")
+//@ skip if $hostOS == "playstation"
+
+// Companion to intl-datetimeformat-cache-dst-transition.js for Temporal.
+// JSC only exposes a subset of Temporal to JS: there is no
+// Temporal.ZonedDateTime, and Temporal.TimeZone exposes only toString/toJSON
+// (no getOffsetNanosecondsFor), so nothing here can observe a time-zone offset
+// directly. We therefore cover the two cache paths Temporal actually reaches:
+//
+//   1. Temporal.Now.timeZoneId() -> DateCache::defaultTimeZone()
+//      -> timeZoneCache, which must invalidate after timeZoneDidChange().
+//
+//   2. Temporal.PlainDate.prototype.add -> TemporalCalendar::isoDateAdd
+//      -> balanceISODate -> DateCache::yearMonthDayFromDaysWithCache, the same
+//      year/month/day cache Date methods use, reached from a separate code
+//      path. (PlainDate.from(isostring) parses directly and does not hit it.)
+
+function expect(label, got, want)
+{
+    if (got !== want)
+        throw new Error(`${label}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+}
+
+if (!$vm.setHostTimeZone("America/Los_Angeles"))
+    throw new Error("Failed to set host time zone to America/Los_Angeles");
+
+setTimeout(() => {
+    // --- Temporal.Now.timeZoneId tracks the system TZ ---
+    expect("Temporal.Now.timeZoneId", Temporal.Now.timeZoneId(), "America/Los_Angeles");
+
+    // --- PlainDate arithmetic across the DST boundary ---
+    // PlainDate is a wall-calendar object with no time zone, so DST cannot
+    // change its arithmetic; what we are testing is that the shared
+    // yearMonthDayFromDaysWithCache returns spec-correct values from the
+    // Temporal code path. Walk a day at a time across spring-forward.
+    const dayBefore = Temporal.PlainDate.from("2024-03-09");
+    const dayOf     = dayBefore.add({ days: 1 });
+    const dayAfter  = dayOf.add({ days: 1 });
+    expect("PlainDate dayBefore", dayBefore.toString(), "2024-03-09");
+    expect("PlainDate dayOf",     dayOf.toString(),     "2024-03-10");
+    expect("PlainDate dayAfter",  dayAfter.toString(),  "2024-03-11");
+    expect("PlainDate dayOf year",  dayOf.year,  2024);
+    expect("PlainDate dayOf month", dayOf.month, 3);
+    expect("PlainDate dayOf day",   dayOf.day,   10);
+
+    // Larger jumps fall outside the adjacent-day fast path (it only fires when
+    // the resulting day-of-month stays within 1..28), forcing the full
+    // day->year/month/day conversion.
+    const winter = Temporal.PlainDate.from("2024-01-15");
+    const summer = winter.add({ months: 5 });    // -> 2024-06-15
+    const nextWinter = summer.add({ months: 7 }); // -> 2025-01-15
+    expect("PlainDate winter -> summer", summer.toString(), "2024-06-15");
+    expect("PlainDate summer -> next winter", nextWinter.toString(), "2025-01-15");
+
+    // Crossing the fall-back date in single-day steps.
+    const fbBefore = Temporal.PlainDate.from("2024-11-02");
+    const fbOf     = fbBefore.add({ days: 1 });
+    const fbAfter  = fbOf.add({ days: 1 });
+    expect("PlainDate fbBefore", fbBefore.toString(), "2024-11-02");
+    expect("PlainDate fbOf",     fbOf.toString(),     "2024-11-03");
+    expect("PlainDate fbAfter",  fbAfter.toString(),  "2024-11-04");
+    expect("PlainDate fbOf dayOfWeek", fbOf.dayOfWeek, 7); // Sunday in ISO
+
+    // --- Cross-API consistency ---
+    // PlainDate and Date should agree on the calendar date of an instant in LA.
+    // Date.UTC(2024, 10, 3, 10, 30) = 02:30 PST -> 2024-11-03 in LA.
+    const d = new Date(Date.UTC(2024, 10, 3, 10, 30));
+    expect("Date getDate matches PlainDate", d.getDate(), fbOf.day);
+    expect("Date getMonth+1 matches PlainDate", d.getMonth() + 1, fbOf.month);
+    expect("Date getFullYear matches PlainDate", d.getFullYear(), fbOf.year);
+
+    // Flip TZ to verify Temporal.Now picks up the change.
+    if (!$vm.setHostTimeZone("Asia/Tokyo"))
+        throw new Error("Failed to set host time zone to Asia/Tokyo");
+
+    setTimeout(() => {
+        expect("Temporal.Now.timeZoneId after change",
+            Temporal.Now.timeZoneId(), "Asia/Tokyo");
+
+        // PlainDate arithmetic is TZ-independent, so it stays consistent.
+        const stillDayOf = Temporal.PlainDate.from("2024-03-09").add({ days: 1 });
+        expect("PlainDate post-change", stillDayOf.toString(), "2024-03-10");
+    }, 0);
+}, 0);

--- a/Source/JavaScriptCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -3,5 +3,4 @@ API/JSValue.mm
 API/JSVirtualMachine.mm
 API/JSWrapperMap.mm
 API/tests/Regress141275.mm
-runtime/JSDateMath.cpp
 [ iOS ] runtime/ObjectPrototype.cpp

--- a/Source/JavaScriptCore/runtime/DateInstanceCache.h
+++ b/Source/JavaScriptCore/runtime/DateInstanceCache.h
@@ -60,8 +60,17 @@ public:
 
     void reset()
     {
-        for (size_t i = 0; i < cacheSize; ++i)
+        for (size_t i = 0; i < cacheSize; ++i) {
             m_cache[i].key = PNaN;
+            // FIXME: This only reaches DateInstanceData still occupying a slot.
+            // One that was evicted (its slot overwritten by another ms) but is
+            // still referenced by a live DateInstance is missed and keeps its
+            // stale local GregorianDateTime for that DateInstance's lifetime.
+            if (auto* value = m_cache[i].value.get()) {
+                value->m_gregorianDateTimeCachedForMS = PNaN;
+                value->m_gregorianDateTimeUTCCachedForMS = PNaN;
+            }
+        }
     }
 
     DateInstanceData* add(double d)

--- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -80,6 +80,7 @@
 #include <wtf/DateMath.h>
 #include <wtf/Language.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/TimeZone.h>
 #include <wtf/unicode/CharacterNames.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
@@ -93,10 +94,6 @@ namespace JSC {
 namespace JSDateMathInternal {
 static constexpr bool verbose = false;
 }
-
-#if PLATFORM(COCOA)
-std::atomic<uint64_t> lastTimeZoneID { 1 };
-#endif
 
 class OpaqueICUTimeZone {
     WTF_MAKE_TZONE_ALLOCATED(OpaqueICUTimeZone);
@@ -457,38 +454,24 @@ String DateCache::timeZoneDisplayName(bool isDST)
 
 static Lock timeZoneCacheLock;
 
-#if PLATFORM(COCOA)
-static void timeZoneChangeNotification(CFNotificationCenterRef, void*, CFStringRef, const void*, CFDictionaryRef)
-{
-    Locker locker { timeZoneCacheLock };
-    ASSERT(isMainThread());
-    ++lastTimeZoneID;
-}
-#endif
-
 // To confine icu::TimeZone destructor invocation in this file.
 DateCache::DateCache()
 {
-#if PLATFORM(COCOA)
-    static std::once_flag onceKey;
-    std::call_once(onceKey, [&] {
-        CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(), nullptr, timeZoneChangeNotification, kCFTimeZoneSystemTimeZoneDidChangeNotification, nullptr, CFNotificationSuspensionBehaviorDeliverImmediately);
-    });
-#endif
+    WTF::listenForTimeZoneChangeNotifications();
 }
+
+struct CachedHostTimeZone {
+    TimeZone timeZone;
+    uint64_t timeZoneID { 0 };
+};
 
 static TimeZone retrieveTimeZoneInformation()
 {
     Locker locker { timeZoneCacheLock };
-    static NeverDestroyed<std::tuple<TimeZone, uint64_t>> globalCache;
+    static NeverDestroyed<CachedHostTimeZone> globalCache;
 
-    bool isCacheStale = true;
-    uint64_t currentID = 0;
-#if PLATFORM(COCOA)
-    currentID = lastTimeZoneID.load();
-    isCacheStale = std::get<1>(globalCache.get()) != currentID;
-#endif
-    if (isCacheStale) {
+    uint64_t currentID = WTF::lastTimeZoneID();
+    if (globalCache->timeZoneID != currentID) {
         Vector<char16_t, 32> timeZoneID;
         getTimeZoneOverride(timeZoneID);
         TimeZone canonical;
@@ -506,9 +489,9 @@ static TimeZone retrieveTimeZoneInformation()
                 canonical = TimeZone::fromID(id.value());
         }
 
-        globalCache.get() = std::tuple { canonical, currentID };
+        globalCache.get() = CachedHostTimeZone { canonical, currentID };
     }
-    return std::get<0>(globalCache.get());
+    return globalCache->timeZone;
 }
 
 DateCache::~DateCache() = default;
@@ -549,10 +532,8 @@ void DateCache::timeZoneCacheSlow()
     m_timeZoneCache = std::unique_ptr<OpaqueICUTimeZone, OpaqueICUTimeZoneDeleter>(cache);
 }
 
-void DateCache::resetIfNecessarySlow()
+void DateCache::clearForTimeZoneChange()
 {
-    // FIXME: We should clear it only when we know the timezone has been changed on Non-Cocoa platforms.
-    // https://bugs.webkit.org/show_bug.cgi?id=218365
     m_timeZoneCache.reset();
     for (auto& cache : m_caches)
         cache.reset();
@@ -562,6 +543,7 @@ void DateCache::resetIfNecessarySlow()
     m_dateInstanceCache.reset();
     m_timeZoneStandardDisplayNameCache = String();
     m_timeZoneDSTDisplayNameCache = String();
+    m_cachedTimeZoneID = WTF::lastTimeZoneID();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -51,6 +51,7 @@
 #include <wtf/GregorianDateTime.h>
 #include <wtf/Platform.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/TimeZone.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -62,10 +63,6 @@ class OpaqueICUTimeZone;
 class VM;
 
 static constexpr double minECMAScriptTime = -8.64E15;
-
-#if PLATFORM(COCOA)
-extern JS_EXPORT_PRIVATE std::atomic<uint64_t> lastTimeZoneID;
-#endif
 
 // We do not expose icu::TimeZone in this header file. And we cannot use icu::TimeZone forward declaration
 // because icu namespace can be an alias to icu$verNum namespace.
@@ -93,24 +90,10 @@ public:
 
     bool hasTimeZoneChange()
     {
-#if PLATFORM(COCOA)
-        return m_cachedTimezoneID != lastTimeZoneID;
-#else
-        return true; // always force a time zone check.
-#endif
+        return m_cachedTimeZoneID != WTF::lastTimeZoneID();
     }
 
-    void resetIfNecessary()
-    {
-#if PLATFORM(COCOA)
-        if (!hasTimeZoneChange()) [[likely]]
-            return;
-        m_cachedTimezoneID = lastTimeZoneID;
-#endif
-        resetIfNecessarySlow();
-    }
-
-    JS_EXPORT_PRIVATE void resetIfNecessarySlow();
+    JS_EXPORT_PRIVATE void clearForTimeZoneChange();
 
     TimeZone defaultTimeZone();
     String timeZoneDisplayName(bool isDST);
@@ -121,8 +104,6 @@ public:
     double localTimeToMS(double milliseconds, TimeType);
     JS_EXPORT_PRIVATE double parseDate(JSGlobalObject*, VM&, const WTF::String&);
     std::tuple<int32_t, int32_t, int32_t> yearMonthDayFromDaysWithCache(int32_t days);
-
-    static void timeZoneChanged();
 
 private:
     class DSTCache {
@@ -188,7 +169,7 @@ private:
     String m_cachedDateString;
     double m_cachedDateStringValue;
     DateInstanceCache m_dateInstanceCache;
-    uint64_t m_cachedTimezoneID { 0 };
+    uint64_t m_cachedTimeZoneID { 0 };
     String m_timeZoneStandardDisplayNameCache;
     String m_timeZoneDSTDisplayNameCache;
 };

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1741,9 +1741,8 @@ void VM::executeEntryScopeServicesOnEntry()
         clearEntryScopeService(EntryScopeService::FirePrimitiveGigacageEnabled);
     }
 
-    // Reset the date cache between JS invocations to force the VM to
-    // observe time zone changes.
-    dateCache.resetIfNecessary();
+    if (dateCache.hasTimeZoneChange()) [[unlikely]]
+        dateCache.clearForTimeZoneChange();
 
     RefPtr watchdog = this->watchdog();
     if (watchdog) [[unlikely]]

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -83,6 +83,7 @@
 #include <wtf/ProcessID.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/TimeZone.h>
 #include <wtf/WTFProcess.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
@@ -2229,6 +2230,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionSetUserPreferredLanguages);
 static JSC_DECLARE_HOST_FUNCTION(functionICUVersion);
 static JSC_DECLARE_HOST_FUNCTION(functionICUMinorVersion);
 static JSC_DECLARE_HOST_FUNCTION(functionICUHeaderVersion);
+static JSC_DECLARE_HOST_FUNCTION(functionSetHostTimeZone);
 static JSC_DECLARE_HOST_FUNCTION(functionAssertEnabled);
 static JSC_DECLARE_HOST_FUNCTION(functionSecurityAssertEnabled);
 static JSC_DECLARE_HOST_FUNCTION(functionAsanEnabled);
@@ -4125,6 +4127,21 @@ JSC_DEFINE_HOST_FUNCTION(functionICUHeaderVersion, (JSGlobalObject*, CallFrame*)
     return JSValue::encode(jsNumber(U_ICU_VERSION_MAJOR_NUM));
 }
 
+// Usage: $vm.setHostTimeZone("Asia/Tokyo")
+// Overrides the host time zone process-wide and invalidates dependent caches.
+// Returns false (changing nothing) for an invalid identifier.
+JSC_DEFINE_HOST_FUNCTION(functionSetHostTimeZone, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    String tz { callFrame->argument(0).toWTFString(globalObject) };
+    RETURN_IF_EXCEPTION(scope, { });
+
+    return JSValue::encode(jsBoolean(WTF::setHostTimeZoneForTesting(tz)));
+}
+
 // Returns true if Debug ASSERTs are enabled.
 // Usage: $vm.assertEnabled()
 JSC_DEFINE_HOST_FUNCTION(functionAssertEnabled, (JSGlobalObject*, CallFrame*))
@@ -4649,6 +4666,7 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, allowIfNotFuzz, "icuVersion"_s, functionICUVersion, 0);
     addFunction(vm, allowIfNotFuzz, "icuMinorVersion"_s, functionICUMinorVersion, 0);
     addFunction(vm, allowIfNotFuzz, "icuHeaderVersion"_s, functionICUHeaderVersion, 0);
+    addFunction(vm, alwaysAllow, "setHostTimeZone"_s, functionSetHostTimeZone, 1);
 
     addFunction(vm, alwaysAllow, "assertEnabled"_s, functionAssertEnabled, 0);
     addFunction(vm, alwaysAllow, "securityAssertEnabled"_s, functionSecurityAssertEnabled, 0);

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -80,6 +80,9 @@
 		1C2BA32628E6C19B00FA6E17 /* TextBreakIteratorCFCharacterCluster.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C2BA32528E6C19500FA6E17 /* TextBreakIteratorCFCharacterCluster.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C2BA32828E6C24900FA6E17 /* TextBreakIteratorCFStringTokenizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C2BA32728E6C24400FA6E17 /* TextBreakIteratorCFStringTokenizer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C503BE623AAE0AE0072E66B /* LanguageCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C503BE523AAE0AE0072E66B /* LanguageCocoa.mm */; };
+		1A2B3C4D5E6F7A8B9C0D1E21 /* TimeZone.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7A8B9C0D1E20 /* TimeZone.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1A2B3C4D5E6F7A8B9C0D1E23 /* TimeZone.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7A8B9C0D1E22 /* TimeZone.cpp */; };
+		1A2B3C4D5E6F7A8B9C0D1E25 /* TimeZoneCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7A8B9C0D1E24 /* TimeZoneCocoa.cpp */; };
 		1C867D772A254F08000DE93D /* ContextualizedCFString.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C867D752A254F08000DE93D /* ContextualizedCFString.mm */; };
 		1C867D782A254F08000DE93D /* ContextualizedCFString.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C867D762A254F08000DE93D /* ContextualizedCFString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C96836426BE74DF00A2A2F9 /* LogInitialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C96836226BE74DF00A2A2F9 /* LogInitialization.cpp */; };
@@ -1311,6 +1314,9 @@
 		1C2BA32528E6C19500FA6E17 /* TextBreakIteratorCFCharacterCluster.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextBreakIteratorCFCharacterCluster.h; sourceTree = "<group>"; };
 		1C2BA32728E6C24400FA6E17 /* TextBreakIteratorCFStringTokenizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextBreakIteratorCFStringTokenizer.h; sourceTree = "<group>"; };
 		1C503BE523AAE0AE0072E66B /* LanguageCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LanguageCocoa.mm; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7A8B9C0D1E20 /* TimeZone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TimeZone.h; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7A8B9C0D1E22 /* TimeZone.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TimeZone.cpp; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7A8B9C0D1E24 /* TimeZoneCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TimeZoneCocoa.cpp; sourceTree = "<group>"; };
 		1C867D752A254F08000DE93D /* ContextualizedCFString.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContextualizedCFString.mm; sourceTree = "<group>"; };
 		1C867D762A254F08000DE93D /* ContextualizedCFString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContextualizedCFString.h; sourceTree = "<group>"; };
 		1C96836226BE74DF00A2A2F9 /* LogInitialization.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LogInitialization.cpp; sourceTree = "<group>"; };
@@ -2844,6 +2850,8 @@
 				A8A4733F151A825B004123FF /* ThreadSpecific.h */,
 				0F66B2861DC97BAB004A1D3F /* TimeWithDynamicClockType.cpp */,
 				0F66B2871DC97BAB004A1D3F /* TimeWithDynamicClockType.h */,
+				1A2B3C4D5E6F7A8B9C0D1E22 /* TimeZone.cpp */,
+				1A2B3C4D5E6F7A8B9C0D1E20 /* TimeZone.h */,
 				0F7075F41FBF537A00489AF0 /* TimingScope.cpp */,
 				0F7075F31FBF537A00489AF0 /* TimingScope.h */,
 				553071C91C40427200384898 /* TinyLRUCache.h */,
@@ -3472,6 +3480,7 @@
 				466D69102BA4E433005D43F4 /* SpanCocoa.h */,
 				46CEA3F92CC2D39B00FE325C /* SpanCocoa.mm */,
 				EB61EDC62409CCC0001EFE36 /* SystemTracingCocoa.cpp */,
+				1A2B3C4D5E6F7A8B9C0D1E24 /* TimeZoneCocoa.cpp */,
 				4434F91B27948A65007E3E8A /* TollFreeBridging.h */,
 				44CDE4D226EE6CDA009F6ACB /* TypeCastsCocoa.h */,
 				5CC0EE862162BC2200A1A842 /* URLCocoa.mm */,
@@ -4031,6 +4040,7 @@
 				DD3DC90F27A4BF8E007E5B61 /* ThreadSanitizerSupport.h in Headers */,
 				DD3DC99327A4BF8E007E5B61 /* ThreadSpecific.h in Headers */,
 				DD3DC8CE27A4BF8E007E5B61 /* TimeWithDynamicClockType.h in Headers */,
+				1A2B3C4D5E6F7A8B9C0D1E21 /* TimeZone.h in Headers */,
 				DD3DC8F227A4BF8E007E5B61 /* TimingScope.h in Headers */,
 				DD3DC95A27A4BF8E007E5B61 /* TinyLRUCache.h in Headers */,
 				DD3DC98F27A4BF8E007E5B61 /* TinyPtrSet.h in Headers */,
@@ -4723,6 +4733,8 @@
 				A32D8FA521FFFAB400780662 /* ThreadingPOSIX.cpp in Sources */,
 				5311BD5C1EA822F900525281 /* ThreadMessage.cpp in Sources */,
 				0F66B2901DC97BAB004A1D3F /* TimeWithDynamicClockType.cpp in Sources */,
+				1A2B3C4D5E6F7A8B9C0D1E23 /* TimeZone.cpp in Sources */,
+				1A2B3C4D5E6F7A8B9C0D1E25 /* TimeZoneCocoa.cpp in Sources */,
 				0F7075F51FBF53CD00489AF0 /* TimingScope.cpp in Sources */,
 				521CC6B424A27809004377D6 /* TranslatedProcess.cpp in Sources */,
 				FE69838E2F9F1FD0004EA0A7 /* UnbarrieredMonotonicTime.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -378,6 +378,7 @@ set(WTF_PUBLIC_HEADERS
     ThreadingEnums.h
     ThreadingPrimitives.h
     TimeWithDynamicClockType.h
+    TimeZone.h
     TimingScope.h
     TinyLRUCache.h
     TinyPtrSet.h
@@ -631,6 +632,7 @@ set(WTF_SOURCES
     ThreadMessage.cpp
     Threading.cpp
     TimeWithDynamicClockType.cpp
+    TimeZone.cpp
     TimingScope.cpp
     URL.cpp
     URLHelpers.cpp

--- a/Source/WTF/wtf/PlatformCocoa.cmake
+++ b/Source/WTF/wtf/PlatformCocoa.cmake
@@ -39,6 +39,7 @@ list(APPEND WTF_SOURCES
     cocoa/SchedulePairCocoa.mm
     cocoa/SpanCocoa.mm
     cocoa/SystemTracingCocoa.cpp
+    cocoa/TimeZoneCocoa.cpp
     cocoa/URLCocoa.mm
     cocoa/UUIDCocoa.mm
     cocoa/WorkQueueCocoa.cpp

--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -6,6 +6,7 @@ list(APPEND WTF_SOURCES
 
     glib/Application.cpp
     glib/ChassisType.cpp
+    glib/FilePathWatcher.cpp
     glib/FileSystemGlib.cpp
     glib/GMallocString.cpp
     glib/GRefPtr.cpp
@@ -14,6 +15,7 @@ list(APPEND WTF_SOURCES
     glib/RunLoopGLib.cpp
     glib/Sandbox.cpp
     glib/SocketConnection.cpp
+    glib/TimeZoneGLib.cpp
     glib/URLGLib.cpp
 
     posix/CPUTimePOSIX.cpp
@@ -36,6 +38,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     glib/ActivityObserver.h
     glib/Application.h
     glib/ChassisType.h
+    glib/FilePathWatcher.h
     glib/GMallocString.h
     glib/GRefPtr.h
     glib/GSocketMonitor.h

--- a/Source/WTF/wtf/PlatformJSCOnly.cmake
+++ b/Source/WTF/wtf/PlatformJSCOnly.cmake
@@ -55,8 +55,10 @@ else ()
 
     if (LOWERCASE_EVENT_LOOP_TYPE STREQUAL "glib")
         list(APPEND WTF_SOURCES
+            glib/FilePathWatcher.cpp
             glib/FileSystemGlib.cpp
             glib/Sandbox.cpp
+            glib/TimeZoneGLib.cpp
         )
     endif ()
 
@@ -91,6 +93,7 @@ elseif (APPLE)
         VERBATIM)
     list(APPEND WTF_SOURCES
         cocoa/MemoryFootprintCocoa.cpp
+        cocoa/TimeZoneCocoa.cpp
 
         generic/MemoryPressureHandlerGeneric.cpp
 
@@ -120,6 +123,7 @@ endif ()
 
 if (LOWERCASE_EVENT_LOOP_TYPE STREQUAL "glib")
     list(APPEND WTF_PUBLIC_HEADERS
+        glib/FilePathWatcher.h
         glib/GRefPtr.h
         glib/GSpanExtras.h
         glib/GTypedefs.h

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -7,6 +7,7 @@ list(APPEND WTF_SOURCES
 
     glib/Application.cpp
     glib/ChassisType.cpp
+    glib/FilePathWatcher.cpp
     glib/FileSystemGlib.cpp
     glib/GMallocString.cpp
     glib/GRefPtr.cpp
@@ -16,6 +17,7 @@ list(APPEND WTF_SOURCES
     glib/RunLoopGLib.cpp
     glib/Sandbox.cpp
     glib/SocketConnection.cpp
+    glib/TimeZoneGLib.cpp
     glib/URLGLib.cpp
 
     linux/CurrentProcessMemoryStatus.cpp
@@ -56,6 +58,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     glib/ActivityObserver.h
     glib/Application.h
     glib/ChassisType.h
+    glib/FilePathWatcher.h
     glib/GMallocString.h
     glib/GRefPtr.h
     glib/GResources.h

--- a/Source/WTF/wtf/TimeZone.cpp
+++ b/Source/WTF/wtf/TimeZone.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/TimeZone.h>
+
+#include <atomic>
+#include <wtf/DateMath.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+
+static std::atomic<uint64_t> g_lastTimeZoneID { 1 };
+
+uint64_t lastTimeZoneID()
+{
+    return g_lastTimeZoneID.load(std::memory_order_relaxed);
+}
+
+void timeZoneDidChange()
+{
+    g_lastTimeZoneID.fetch_add(1, std::memory_order_relaxed);
+}
+
+#if !PLATFORM(COCOA) && !USE(GLIB)
+void listenForTimeZoneChangeNotifications() { }
+#endif
+
+bool setHostTimeZoneForTesting(const String& timeZone)
+{
+    if (!setTimeZoneOverride(timeZone))
+        return false;
+    timeZoneDidChange();
+    return true;
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/TimeZone.h
+++ b/Source/WTF/wtf/TimeZone.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ExportMacros.h>
+#include <wtf/Forward.h>
+#include <wtf/Platform.h>
+
+namespace WTF {
+
+// Process-global, monotonically increasing counter. It is bumped whenever the
+// host time zone might have changed.
+WTF_EXPORT_PRIVATE uint64_t lastTimeZoneID();
+
+// Bumps lastTimeZoneID(). Call after any time-zone change that the platform
+// notifier does not observe, such as a process-local override.
+WTF_EXPORT_PRIVATE void timeZoneDidChange();
+WTF_EXPORT_PRIVATE void listenForTimeZoneChangeNotifications();
+
+WTF_EXPORT_PRIVATE bool setHostTimeZoneForTesting(const String&);
+
+} // namespace WTF

--- a/Source/WTF/wtf/cocoa/TimeZoneCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/TimeZoneCocoa.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/TimeZone.h>
+
+#include <CoreFoundation/CFTimeZone.h>
+#include <mutex>
+#include <wtf/cf/NotificationCenterCF.h>
+
+namespace WTF {
+
+static void timeZoneChangeNotification(CFNotificationCenterRef, void*, CFStringRef, const void*, CFDictionaryRef)
+{
+    timeZoneDidChange();
+}
+
+void listenForTimeZoneChangeNotifications()
+{
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [] {
+        CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenterSingleton(), nullptr,
+            timeZoneChangeNotification, kCFTimeZoneSystemTimeZoneDidChangeNotification,
+            nullptr, CFNotificationSuspensionBehaviorDeliverImmediately);
+    });
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/glib/FilePathWatcher.cpp
+++ b/Source/WTF/wtf/glib/FilePathWatcher.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FilePathWatcher.h"
+
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FilePathWatcher);
+
+FilePathWatcher::FilePathWatcher(const String& path, Function<void()>&& handler)
+    : m_handler(WTF::move(handler))
+{
+    if (path.isEmpty() || !m_handler)
+        return;
+
+    auto pathUtf8 = path.utf8();
+    GRefPtr file = adoptGRef(g_file_new_for_path(pathUtf8.data()));
+    GUniqueOutPtr<GError> error;
+    m_monitor = adoptGRef(g_file_monitor_file(file.get(), G_FILE_MONITOR_WATCH_HARD_LINKS, nullptr, &error.outPtr()));
+    if (!m_monitor) {
+        LOG_ERROR("FilePathWatcher: failed to monitor %s: %s", pathUtf8.data(), error.get() ? error->message : "unknown error");
+        return;
+    }
+    // GFileMonitor coalesces events within a rate-limit window that defaults to
+    // 800 ms; the local (inotify) backend honors this property. Tighten it so a
+    // rare change is reported promptly instead of after the default delay.
+    g_file_monitor_set_rate_limit(m_monitor.get(), 50);
+    m_changedHandlerID = g_signal_connect(m_monitor.get(), "changed", G_CALLBACK(fileChangedCallback), this);
+}
+
+FilePathWatcher::~FilePathWatcher()
+{
+    if (!m_monitor)
+        return;
+    if (m_changedHandlerID)
+        g_signal_handler_disconnect(m_monitor.get(), m_changedHandlerID);
+    g_file_monitor_cancel(m_monitor.get());
+}
+
+void FilePathWatcher::fileChangedCallback(GFileMonitor*, GFile*, GFile*, GFileMonitorEvent event, FilePathWatcher* watcher)
+{
+    // Without G_FILE_MONITOR_WATCH_MOVES, GIO terminates every observable mutation
+    // (rename, symlink swap, in-place write) with CREATED or CHANGES_DONE_HINT —
+    // a bare DELETED is never the tail of an atomic update, so suppressing it
+    // avoids reacting to the transient mid-rename state.
+    switch (event) {
+    case G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT:
+    case G_FILE_MONITOR_EVENT_CREATED:
+        watcher->m_handler();
+        break;
+    default:
+        break;
+    }
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/glib/FilePathWatcher.h
+++ b/Source/WTF/wtf/glib/FilePathWatcher.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <wtf/Forward.h>
+#include <wtf/Function.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+
+// Watches a single filesystem path and runs a handler when the file is created
+// or finishes changing. Rename, symlink swap, and in-place rewrite are each
+// reported as one call; a bare deletion is not
+class FilePathWatcher {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(FilePathWatcher, WTF_EXPORT_PRIVATE);
+    WTF_MAKE_NONCOPYABLE(FilePathWatcher);
+public:
+    WTF_EXPORT_PRIVATE FilePathWatcher(const String& path, Function<void()>&& handler);
+    WTF_EXPORT_PRIVATE ~FilePathWatcher();
+
+    bool isActive() const { return !!m_monitor; }
+
+private:
+    static void fileChangedCallback(GFileMonitor*, GFile*, GFile*, GFileMonitorEvent, FilePathWatcher*);
+
+    GRefPtr<GFileMonitor> m_monitor;
+    Function<void()> m_handler;
+    gulong m_changedHandlerID { 0 };
+};
+
+} // namespace WTF
+
+using WTF::FilePathWatcher;

--- a/Source/WTF/wtf/glib/TimeZoneGLib.cpp
+++ b/Source/WTF/wtf/glib/TimeZoneGLib.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/TimeZone.h>
+
+#include <gio/gio.h>
+#include <mutex>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/glib/FilePathWatcher.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
+
+namespace WTF {
+
+// /etc/localtime is the canonical location of the host time-zone binary on
+// glibc/musl-based systems (localtime(5):
+// https://man7.org/linux/man-pages/man5/localtime.5.html). The time-conversion
+// functions implicitly call tzset(), which re-reads this file, so any change
+// that takes effect for libc consumers necessarily mutates the path we watch
+// here. See tzset(3):
+//   https://man7.org/linux/man-pages/man3/tzset.3.html
+// FilePathWatcher catches symlink swap, replacement, and in-place rewrite —
+// see the CHANGES_DONE_HINT / CREATED filter in FilePathWatcher.cpp.
+static std::unique_ptr<FilePathWatcher>& localtimeWatcher()
+{
+    static NeverDestroyed<std::unique_ptr<FilePathWatcher>> watcher;
+    return watcher.get();
+}
+
+// Listener for the "Timezone" property of org.freedesktop.timedate1, which
+// systemd-timedated (and a few API-compatible reimplementations) emit on
+// PropertiesChanged whenever timedatectl set-timezone (or any client of the
+// same D-Bus method) succeeds. Spec:
+//   https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.timedate1.html
+//   https://github.com/systemd/systemd/blob/main/src/timedate/timedated.c
+//
+// Coverage:
+//   * Caught by the file watcher AND this listener: any tool that changes the
+//     TZ via timedatectl / GNOME / KDE / SetTimezone() — these always go
+//     through timedated, which rewrites /etc/localtime.
+//   * Caught by the file watcher only: a direct symlink swap of /etc/localtime
+//     by a privileged process that bypasses timedated.
+//   * Caught by this listener only: a TZ change inside a container/sandbox
+//     where /etc/localtime is bind-mounted from the host (so inotify on the
+//     guest path never fires) but the system bus is forwarded.
+//   * Not caught by either: a process-local TZ override applied to the
+//     calling process via setenv("TZ", ...) — there is no kernel notifier
+//     for environment changes, and tzset(3) defines TZ as a per-process
+//     override (https://man7.org/linux/man-pages/man3/tzset.3.html). Callers
+//     that need that path should call timeZoneDidChange() themselves (this is
+//     what setHostTimeZoneForTesting() does).
+static GRefPtr<GDBusProxy>& timedate1Proxy()
+{
+    static NeverDestroyed<GRefPtr<GDBusProxy>> proxy;
+    return proxy.get();
+}
+
+static void timedate1PropertiesChanged(GDBusProxy*, GVariant* changedProperties, char** invalidatedProperties, gpointer)
+{
+    // "&s" points into changedProperties without allocating; we only need to
+    // know whether Timezone is present, not its value.
+    const char* timeZone = nullptr;
+    if (g_variant_lookup(changedProperties, "Timezone", "&s", &timeZone))
+        timeZoneDidChange();
+    else if (invalidatedProperties && g_strv_contains(invalidatedProperties, "Timezone"))
+        timeZoneDidChange();
+}
+
+static void onTimedate1ProxyReady(GObject*, GAsyncResult* result, gpointer)
+{
+    // g_dbus_proxy_new_for_bus_finish returns null if the system bus is
+    // unreachable (e.g. sandboxed without bus forwarding) or proxy setup
+    // failed; in that case we fall back to the file watcher.
+    GUniqueOutPtr<GError> error;
+    GRefPtr<GDBusProxy> proxy = adoptGRef(g_dbus_proxy_new_for_bus_finish(result, &error.outPtr()));
+    if (!proxy) {
+        g_debug("TimeZone: timedate1 proxy unavailable, relying on the /etc/localtime watcher: %s", error.get() ? error->message : "unknown error");
+        return;
+    }
+
+    timedate1Proxy() = proxy;
+    g_signal_connect(proxy.get(), "g-properties-changed", G_CALLBACK(timedate1PropertiesChanged), nullptr);
+}
+
+void listenForTimeZoneChangeNotifications()
+{
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [] {
+        // Both the file monitor and the D-Bus proxy attach to the GMainContext
+        // that is thread-default when this first runs (the first DateCache
+        // construction drives it), so this must be reached on the main thread
+        // for its run loop to dispatch the notifications.
+        localtimeWatcher() = makeUnique<FilePathWatcher>("/etc/localtime"_s, [] {
+            timeZoneDidChange();
+        });
+        // Async proxy construction so we don't block on timedated being
+        // present; DO_NOT_AUTO_START avoids spuriously activating it just to
+        // observe its absence. If the service has no owner now, the proxy's
+        // NameOwnerChanged subscription will pick it up later.
+        g_dbus_proxy_new_for_bus(G_BUS_TYPE_SYSTEM,
+            G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+            nullptr,
+            "org.freedesktop.timedate1",
+            "/org/freedesktop/timedate1",
+            "org.freedesktop.timedate1",
+            nullptr, onTimedate1ProxyReady, nullptr);
+    });
+}
+
+} // namespace WTF

--- a/Source/cmake/FindGLib.cmake
+++ b/Source/cmake/FindGLib.cmake
@@ -161,6 +161,10 @@ function(GLib_HandleComponent name)
         return()
     endif ()
 
+    if (name STREQUAL "GLib")
+        message(FATAL_ERROR "glib-2.0 is required")
+    endif ()
+
     set(module "${GLib_${name}__module}")
     set(library "${GLib_${name}__library}")
     set(dependencies "${GLib_${name}__dependencies}")

--- a/Tools/Scripts/run-gtk-tests
+++ b/Tools/Scripts/run-gtk-tests
@@ -109,4 +109,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     runner = GtkTestRunner(options, args)
-    sys.exit(runner.run_tests())
+    api_test_rc = runner.run_tests()
+    e2e_rc = runner.run_glib_companion_e2e_tests()
+    # Both suites report their own results; exit non-zero if either failed.
+    sys.exit(0 if api_test_rc == 0 and e2e_rc == 0 else 1)

--- a/Tools/Scripts/run-timezone-glib-e2e-test
+++ b/Tools/Scripts/run-timezone-glib-e2e-test
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+"""End-to-end driver for WTF/glib/TimeZoneGLib.cpp: spawns a private bus,
+owns timedate1 on it, and drives WTF_TimeZoneGLib_External.* across a real
+process boundary. See TEST_FILTER."""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+import gi
+gi.require_version('Gio', '2.0')
+from gi.repository import Gio, GLib  # noqa: E402
+
+
+TIMEDATE1_NAME = 'org.freedesktop.timedate1'
+TIMEDATE1_PATH = '/org/freedesktop/timedate1'
+PROPERTIES_IFACE = 'org.freedesktop.DBus.Properties'
+
+TEST_FILTER = 'WTF_TimeZoneGLib_External.*'
+EMIT_INTERVAL_SECONDS = 0.2
+# Keep below the gtest-side timeout (30s) so the test's own deadline is the
+# one reported on failure.
+OVERALL_TIMEOUT_SECONDS = 60
+
+
+def find_testwtf(explicit_path):
+    if explicit_path:
+        if not os.path.isfile(explicit_path):
+            sys.exit(f'TestWTF not found at {explicit_path}')
+        return explicit_path
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    webkit_root = os.path.abspath(os.path.join(script_dir, '..', '..'))
+    candidates = [
+        os.path.join(webkit_root, 'WebKitBuild', 'GTK', 'Release', 'bin', 'TestWebKitAPI', 'TestWTF'),
+        os.path.join(webkit_root, 'WebKitBuild', 'GTK', 'Debug', 'bin', 'TestWebKitAPI', 'TestWTF'),
+        os.path.join(webkit_root, 'WebKitBuild', 'WPE', 'Release', 'bin', 'TestWebKitAPI', 'TestWTF'),
+        os.path.join(webkit_root, 'WebKitBuild', 'WPE', 'Debug', 'bin', 'TestWebKitAPI', 'TestWTF'),
+    ]
+    for c in candidates:
+        if os.path.isfile(c):
+            return c
+    sys.exit('Could not locate TestWTF; pass --testwtf <path> or build the GTK/WPE port first.\n'
+             'Searched:\n  ' + '\n  '.join(candidates))
+
+
+def spawn_private_bus():
+    if not shutil.which('dbus-daemon'):
+        sys.exit('dbus-daemon not found in PATH; install dbus or run inside the wkdev-sdk container.')
+
+    daemon = subprocess.Popen(
+        ['dbus-daemon', '--session', '--nofork', '--print-address'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+    line = daemon.stdout.readline()
+    if not line:
+        stderr = daemon.stderr.read().decode(errors='replace') if daemon.stderr else ''
+        daemon.kill()
+        sys.exit(f'dbus-daemon failed to print bus address. stderr:\n{stderr}')
+    return daemon, line.decode().strip()
+
+
+def own_timedate1(address):
+    flags = Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT | Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION
+    connection = Gio.DBusConnection.new_for_address_sync(address, flags, None, None)
+    reply = connection.call_sync(
+        'org.freedesktop.DBus',
+        '/org/freedesktop/DBus',
+        'org.freedesktop.DBus',
+        'RequestName',
+        GLib.Variant('(su)', (TIMEDATE1_NAME, 0)),
+        GLib.VariantType('(u)'),
+        Gio.DBusCallFlags.NONE,
+        -1,
+        None)
+    code = reply.unpack()[0]
+    # DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER == 1; any other value on a fresh
+    # private bus means our setup is wrong, not a flake worth retrying.
+    if code != 1:
+        sys.exit(f'RequestName({TIMEDATE1_NAME}) returned {code}, expected 1 (PRIMARY_OWNER)')
+    return connection
+
+
+def emit_timezone_changed(connection, timezone):
+    # The '@' format placeholder is C-only; PyGObject auto-wraps a Python
+    # dict/list into a{sv}/as as long as dict values are already GLib.Variant.
+    params = GLib.Variant(
+        '(sa{sv}as)',
+        (TIMEDATE1_NAME, {'Timezone': GLib.Variant('s', timezone)}, []))
+    connection.emit_signal(None, TIMEDATE1_PATH, PROPERTIES_IFACE, 'PropertiesChanged', params)
+    connection.flush_sync(None)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--testwtf', help='Path to the TestWTF binary')
+    parser.add_argument('--timezone', default='Europe/Madrid',
+                        help='Timezone value to send in PropertiesChanged (default: Europe/Madrid)')
+    parser.add_argument('--verbose', action='store_true')
+    args = parser.parse_args()
+
+    testwtf = find_testwtf(args.testwtf)
+    if args.verbose:
+        print(f'[driver] TestWTF: {testwtf}')
+
+    daemon, bus_address = spawn_private_bus()
+    if args.verbose:
+        print(f'[driver] bus address: {bus_address}')
+
+    try:
+        owner_connection = own_timedate1(bus_address)
+        if args.verbose:
+            print(f'[driver] owning {TIMEDATE1_NAME}')
+
+        env = os.environ.copy()
+        env['WEBKIT_TIMEDATE1_TEST_BUS'] = bus_address
+        child = subprocess.Popen(
+            [testwtf, f'--gtest_filter={TEST_FILTER}'],
+            env=env)
+
+        deadline = time.monotonic() + OVERALL_TIMEOUT_SECONDS
+        while True:
+            rc = child.poll()
+            if rc is not None:
+                if args.verbose:
+                    print(f'[driver] TestWTF exited rc={rc}')
+                return rc
+            if time.monotonic() > deadline:
+                print(f'[driver] timed out after {OVERALL_TIMEOUT_SECONDS}s; killing TestWTF', file=sys.stderr)
+                child.kill()
+                child.wait()
+                return 1
+
+            # The child's subscription becomes live only after g_bus_get +
+            # signal_subscribe finish asynchronously; emits before then are
+            # silently dropped. Re-emit on every tick until the child observes
+            # the bump and exits PASS.
+            emit_timezone_changed(owner_connection, args.timezone)
+            time.sleep(EMIT_INTERVAL_SECONDS)
+    finally:
+        daemon.terminate()
+        try:
+            daemon.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            daemon.kill()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Tools/Scripts/run-wpe-tests
+++ b/Tools/Scripts/run-wpe-tests
@@ -84,4 +84,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     runner = WPETestRunner(options, args)
-    sys.exit(runner.run_tests())
+    api_test_rc = runner.run_tests()
+    e2e_rc = runner.run_glib_companion_e2e_tests()
+    # Both suites report their own results; exit non-zero if either failed.
+    sys.exit(0 if api_test_rc == 0 and e2e_rc == 0 else 1)

--- a/Tools/TestWebKitAPI/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/PlatformGTK.cmake
@@ -15,10 +15,12 @@ add_dependencies(WebKitGLibAPITestsCore TestWebKitAPI-forwarding-headers)
 # TestWTF
 list(APPEND TestWTF_SOURCES
     Tests/WTF/glib/ActivityObserver.cpp
+    Tests/WTF/glib/FilePathWatcher.cpp
     Tests/WTF/glib/GMallocString.cpp
     Tests/WTF/glib/GRefPtr.cpp
     Tests/WTF/glib/GUniquePtr.cpp
     Tests/WTF/glib/GWeakPtr.cpp
+    Tests/WTF/glib/TimeZoneGLib.cpp
     Tests/WTF/glib/WorkQueueGLib.cpp
 
     generic/main.cpp

--- a/Tools/TestWebKitAPI/PlatformJSCOnly.cmake
+++ b/Tools/TestWebKitAPI/PlatformJSCOnly.cmake
@@ -1,3 +1,12 @@
 set(TESTWEBKITAPI_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/TestWebKitAPI")
 
 list(APPEND TestWTF_SOURCES generic/main.cpp)
+
+if (LOWERCASE_EVENT_LOOP_TYPE STREQUAL "glib")
+    list(APPEND TestWTF_SOURCES
+        Tests/WTF/glib/FilePathWatcher.cpp
+    )
+    list(APPEND TestWTF_LIBRARIES
+        GLib::Gio
+    )
+endif ()

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -19,10 +19,12 @@ list(APPEND TestWTF_SOURCES
     ${test_main_SOURCES}
 
     Tests/WTF/glib/ActivityObserver.cpp
+    Tests/WTF/glib/FilePathWatcher.cpp
     Tests/WTF/glib/GMallocString.cpp
     Tests/WTF/glib/GRefPtr.cpp
     Tests/WTF/glib/GUniquePtr.cpp
     Tests/WTF/glib/GWeakPtr.cpp
+    Tests/WTF/glib/TimeZoneGLib.cpp
     Tests/WTF/glib/WorkQueueGLib.cpp
 )
 

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/FilePathWatcher.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/FilePathWatcher.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/glib/FilePathWatcher.h>
+
+#include "GLibMainLoopUtilities.h"
+#include "Helpers/Test.h"
+#include <gio/gio.h>
+#include <glib/gstdio.h>
+#include <unistd.h>
+#include <wtf/FileSystem.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/CString.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+namespace {
+
+class TempDir {
+public:
+    TempDir()
+    {
+        GUniqueOutPtr<GError> error;
+        m_path.reset(g_dir_make_tmp("wtf-fpw-XXXXXX", &error.outPtr()));
+    }
+
+    // Remove any leftover entries before rmdir so the directory is cleaned up
+    // even when a test fails partway through (the tests create no subdirs).
+    ~TempDir()
+    {
+        if (!m_path)
+            return;
+        if (GDir* dir = g_dir_open(m_path.get(), 0, nullptr)) {
+            while (const char* name = g_dir_read_name(dir)) {
+                GUniquePtr<char> child(g_build_filename(m_path.get(), name, nullptr));
+                g_unlink(child.get());
+            }
+            g_dir_close(dir);
+        }
+        g_rmdir(m_path.get());
+    }
+
+    const char* path() const { return m_path.get(); }
+    bool isValid() const { return !!m_path; }
+
+private:
+    GUniquePtr<char> m_path;
+};
+
+String writeAndReturnPath(const char* dir, const char* name, std::span<const uint8_t> contents)
+{
+    GUniquePtr<char> joined(g_build_filename(dir, name, nullptr));
+    String path = String::fromUTF8(joined.get());
+    FileSystem::overwriteEntireFile(path, contents);
+    return path;
+}
+
+} // namespace
+
+TEST(WTF_FilePathWatcher, FiresOnWrite)
+{
+    TempDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    // Seed the file before watching: the watcher suppresses bare DELETED
+    // events that fire mid-rewrite (see FilePathWatcher.cpp), so we want a
+    // CHANGES_DONE_HINT terminator on the next write.
+    String watched = writeAndReturnPath(dir.path(), "watched", std::span<const uint8_t> { });
+
+    bool fired = false;
+    FilePathWatcher watcher(watched, [&] {
+        fired = true;
+    });
+    EXPECT_TRUE(watcher.isActive());
+
+    auto contents = String::fromLatin1("changed").utf8();
+    FileSystem::overwriteEntireFile(watched, byteCast<uint8_t>(contents.span()));
+
+    EXPECT_TRUE(runMainLoopUntil([&] {
+        return fired;
+    }));
+}
+
+// Simulates the /etc/localtime symlink-swap that timedated performs: first
+// remove the existing symlink, then re-create it pointing at a new target.
+// GIO terminates this with CREATED, which the watcher honors.
+TEST(WTF_FilePathWatcher, FiresOnSymlinkSwap)
+{
+    TempDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    String targetA = writeAndReturnPath(dir.path(), "tz-a", std::span<const uint8_t> { });
+    String targetB = writeAndReturnPath(dir.path(), "tz-b", std::span<const uint8_t> { });
+    GUniquePtr<char> linkPath(g_build_filename(dir.path(), "localtime", nullptr));
+
+    if (symlink(targetA.utf8().data(), linkPath.get()) < 0)
+        GTEST_SKIP() << "symlink() unavailable on this filesystem";
+
+    bool fired = false;
+    FilePathWatcher watcher(String::fromUTF8(linkPath.get()), [&] {
+        fired = true;
+    });
+    EXPECT_TRUE(watcher.isActive());
+
+    g_unlink(linkPath.get());
+    ASSERT_EQ(symlink(targetB.utf8().data(), linkPath.get()), 0);
+
+    EXPECT_TRUE(runMainLoopUntil([&] {
+        return fired;
+    }));
+}
+
+TEST(WTF_FilePathWatcher, IgnoresUnrelatedSiblings)
+{
+    TempDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    String watched = writeAndReturnPath(dir.path(), "watched", std::span<const uint8_t> { });
+    String sibling = writeAndReturnPath(dir.path(), "sibling", std::span<const uint8_t> { });
+
+    bool fired = false;
+    FilePathWatcher watcher(watched, [&] {
+        fired = true;
+    });
+    EXPECT_TRUE(watcher.isActive());
+
+    auto contents = String::fromLatin1("noise").utf8();
+    FileSystem::overwriteEntireFile(sibling, byteCast<uint8_t>(contents.span()));
+
+    // 1s of pumping is more than enough for any real notification to land;
+    // we expect timeout (predicate stays false) which is what we want.
+    EXPECT_FALSE(runMainLoopUntil([&] {
+        return fired;
+    }, /* timeoutSeconds */ 1));
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/GLibMainLoopUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/GLibMainLoopUtilities.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <glib.h>
+
+namespace TestWebKitAPI {
+
+// Spin the default GLib main context until either `predicate` returns true or
+// `timeoutSeconds` elapses. Returns whatever `predicate` reports on exit.
+template<typename Predicate>
+bool runMainLoopUntil(Predicate&& predicate, unsigned timeoutSeconds = 5)
+{
+    GMainContext* context = g_main_context_default();
+    GMainLoop* loop = g_main_loop_new(context, false);
+
+    struct Quit {
+        GMainLoop* loop;
+        bool* timedOut;
+    };
+
+    bool timedOut = false;
+    Quit quit { loop, &timedOut };
+
+    guint timeoutId = g_timeout_add_seconds(timeoutSeconds, [](gpointer userData) -> gboolean {
+        auto* q = static_cast<Quit*>(userData);
+        *q->timedOut = true;
+        g_main_loop_quit(q->loop);
+        return G_SOURCE_REMOVE;
+    }, &quit);
+
+    while (!predicate() && !timedOut)
+        g_main_context_iteration(context, true);
+
+    // Only remove the timeout if it hasn't already fired; otherwise GLib logs a
+    // "source ID not found" critical because the callback already returned
+    // G_SOURCE_REMOVE.
+    if (!timedOut)
+        g_source_remove(timeoutId);
+    g_main_loop_unref(loop);
+    return predicate();
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/TimeZoneGLib.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/TimeZoneGLib.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/TimeZone.h>
+
+#include "GLibMainLoopUtilities.h"
+#include "Helpers/Test.h"
+#include <gio/gio.h>
+
+namespace TestWebKitAPI {
+
+namespace {
+
+// Returned variant carries a floating reference, intended to be sunk by
+// `@a{sv}` in a g_variant_new() call.
+GVariant* buildChangedDict(std::initializer_list<std::pair<const char*, const char*>> entries)
+{
+    GVariantBuilder builder;
+    g_variant_builder_init(&builder, G_VARIANT_TYPE("a{sv}"));
+    for (const auto& entry : entries)
+        g_variant_builder_add(&builder, "{sv}", entry.first, g_variant_new_string(entry.second));
+    return g_variant_builder_end(&builder);
+}
+
+// Returned variant carries a floating reference (see buildChangedDict).
+GVariant* buildInvalidatedArray(std::initializer_list<const char*> names)
+{
+    GVariantBuilder builder;
+    g_variant_builder_init(&builder, G_VARIANT_TYPE("as"));
+    for (const auto* name : names)
+        g_variant_builder_add(&builder, "s", name);
+    return g_variant_builder_end(&builder);
+}
+
+void emitPropertiesChanged(GDBusConnection* connection, GVariant* changed, GVariant* invalidated)
+{
+    g_dbus_connection_emit_signal(connection,
+        nullptr,
+        "/org/freedesktop/timedate1",
+        "org.freedesktop.DBus.Properties",
+        "PropertiesChanged",
+        g_variant_new("(s@a{sv}@as)", "org.freedesktop.timedate1", changed, invalidated),
+        nullptr);
+}
+
+// GBusNameAcquiredCallback: sets the bool pointed to by userData to true.
+void nameAcquiredCallback(GDBusConnection*, const char*, gpointer userData)
+{
+    *static_cast<bool*>(userData) = true;
+}
+
+} // namespace
+
+// listenForTimeZoneChangeNotifications() is std::call_once'd, so the whole
+// fixture is bound to a single bus brought up in SetUpTestSuite and shared
+// by every TEST_F below.
+class WTF_TimeZoneGLib : public ::testing::Test {
+public:
+    static void SetUpTestSuite()
+    {
+        // Both the fixture and WTF_TimeZoneGLib_External below trip
+        // listenForTimeZoneChangeNotifications()'s call_once. Letting both
+        // run in one binary invocation would leak whichever bus loses the
+        // race into the other path's tests and produce a 30s mystery hang.
+        if (g_getenv("WEBKIT_TIMEDATE1_TEST_BUS")) {
+            g_error("WEBKIT_TIMEDATE1_TEST_BUS is set, but the WTF_TimeZoneGLib fixture "
+                "would steal listenForTimeZoneChangeNotifications()'s call_once from "
+                "the external test. Re-run via Tools/Scripts/run-timezone-glib-e2e-test.");
+        }
+
+        s_bus = g_test_dbus_new(G_TEST_DBUS_NONE);
+        g_test_dbus_up(s_bus);
+
+        // The production proxy uses the SYSTEM bus; GTestDBus only writes
+        // DBUS_SESSION_BUS_ADDRESS, so we point the system-bus var at the
+        // same daemon to redirect g_bus_get(SYSTEM).
+        const char* address = g_test_dbus_get_bus_address(s_bus);
+        ASSERT_TRUE(address);
+        g_setenv("DBUS_SYSTEM_BUS_ADDRESS", address, TRUE);
+
+        GError* error = nullptr;
+        s_serverConnection = g_dbus_connection_new_for_address_sync(address,
+            static_cast<GDBusConnectionFlags>(G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT | G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION),
+            nullptr, nullptr, &error);
+        ASSERT_TRUE(s_serverConnection) << (error ? error->message : "no error");
+
+        bool nameAcquired = false;
+        s_ownerId = g_bus_own_name_on_connection(s_serverConnection,
+            "org.freedesktop.timedate1",
+            G_BUS_NAME_OWNER_FLAGS_NONE,
+            nameAcquiredCallback,
+            nullptr,
+            &nameAcquired, nullptr);
+        ASSERT_TRUE(runMainLoopUntil([&] {
+            return nameAcquired;
+        }));
+
+        WTF::listenForTimeZoneChangeNotifications();
+
+        // The subscription resolves the well-known name's unique owner via
+        // an async GetNameOwner call. Signals emitted before that lands are
+        // dropped at the filter stage, and there's no hook to observe the
+        // resolution finishing, so probe-with-retry until a single Timezone
+        // bump confirms the wiring is live. Each retry waits for its own
+        // emit to land, so no stale signals leak into the per-test cases.
+        uint64_t baseline = WTF::lastTimeZoneID();
+        bool wired = false;
+        for (unsigned attempt = 0; attempt < 50 && !wired; ++attempt) {
+            emitPropertiesChanged(s_serverConnection,
+                buildChangedDict({ { "Timezone", "Etc/UTC" } }),
+                buildInvalidatedArray({ }));
+            wired = runMainLoopUntil([&] {
+                return WTF::lastTimeZoneID() > baseline;
+            }, 1);
+        }
+        ASSERT_TRUE(wired) << "timedate1 subscription never observed our probe Timezone change";
+    }
+
+    static void TearDownTestSuite()
+    {
+        if (s_ownerId)
+            g_bus_unown_name(s_ownerId);
+        if (s_serverConnection) {
+            g_dbus_connection_close_sync(s_serverConnection, nullptr, nullptr);
+            g_object_unref(s_serverConnection);
+        }
+        if (s_bus) {
+            g_test_dbus_down(s_bus);
+            g_object_unref(s_bus);
+        }
+        s_ownerId = 0;
+        s_serverConnection = nullptr;
+        s_bus = nullptr;
+    }
+
+protected:
+    static GTestDBus* s_bus;
+    static GDBusConnection* s_serverConnection;
+    static guint s_ownerId;
+};
+
+GTestDBus* WTF_TimeZoneGLib::s_bus = nullptr;
+GDBusConnection* WTF_TimeZoneGLib::s_serverConnection = nullptr;
+guint WTF_TimeZoneGLib::s_ownerId = 0;
+
+TEST_F(WTF_TimeZoneGLib, FiresOnTimezonePropertyChange)
+{
+    uint64_t baseline = WTF::lastTimeZoneID();
+    emitPropertiesChanged(s_serverConnection,
+        buildChangedDict({ { "Timezone", "Europe/Madrid" } }),
+        buildInvalidatedArray({ }));
+    EXPECT_TRUE(runMainLoopUntil([&] {
+        return WTF::lastTimeZoneID() > baseline;
+    }));
+}
+
+// The freedesktop Properties spec lets services report a change via the
+// invalidated-array (key only) instead of the changed-dict; missing that path
+// would silently drop notifications from implementations that prefer it.
+TEST_F(WTF_TimeZoneGLib, FiresOnInvalidatedTimezone)
+{
+    uint64_t baseline = WTF::lastTimeZoneID();
+    emitPropertiesChanged(s_serverConnection,
+        buildChangedDict({ }),
+        buildInvalidatedArray({ "Timezone" }));
+    EXPECT_TRUE(runMainLoopUntil([&] {
+        return WTF::lastTimeZoneID() > baseline;
+    }));
+}
+
+// timedate1 emits PropertiesChanged for NTP/LocalRTC too — those must NOT
+// bump the time-zone ID, or every NTP toggle would force JSC's date cache
+// to invalidate.
+TEST_F(WTF_TimeZoneGLib, IgnoresUnrelatedProperties)
+{
+    uint64_t baseline = WTF::lastTimeZoneID();
+    emitPropertiesChanged(s_serverConnection,
+        buildChangedDict({ { "NTP", "true" }, { "LocalRTC", "false" } }),
+        buildInvalidatedArray({ "CanNTP" }));
+    EXPECT_FALSE(runMainLoopUntil([&] {
+        return WTF::lastTimeZoneID() > baseline;
+    }, 1));
+}
+
+// Driven by Tools/Scripts/run-timezone-glib-e2e-test, which owns timedate1
+// from a separate process and emits PropertiesChanged across a real bus.
+TEST(WTF_TimeZoneGLib_External, ReceivesExternalSignal)
+{
+    const char* externalBus = g_getenv("WEBKIT_TIMEDATE1_TEST_BUS");
+    if (!externalBus) {
+        // The WebKit gtest listener prints any non-Passed() result as **FAIL**,
+        // so GTEST_SKIP would surface noise in default runs. Return cleanly
+        // and rely on the driver to invoke us under the env var.
+        SAFE_FPRINTF(stderr, "WTF_TimeZoneGLib_External: WEBKIT_TIMEDATE1_TEST_BUS unset; "
+            "run via Tools/Scripts/run-timezone-glib-e2e-test to exercise.\n");
+        return;
+    }
+
+    g_setenv("DBUS_SYSTEM_BUS_ADDRESS", externalBus, TRUE);
+    WTF::listenForTimeZoneChangeNotifications();
+
+    uint64_t baseline = WTF::lastTimeZoneID();
+    EXPECT_TRUE(runMainLoopUntil([&] {
+        return WTF::lastTimeZoneID() > baseline;
+    }, 30));
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -549,6 +549,23 @@ class TestRunner(object):
 
         return number_of_failed_tests
 
+    def run_glib_companion_e2e_tests(self):
+        # Non-gtest companion tests for the GLib ports. Each script must exit 0
+        # on success; run them after the gtest suite so a failure surfaces in
+        # the same CI step. Returns the first non-zero exit code, or 0.
+        if self._options.list_tests:
+            return 0
+        testwtf = os.path.join(self._test_programs_base_dir(), "TestWTF")
+        scripts = [
+            os.path.join(common.top_level_path(), "Tools", "Scripts", "run-timezone-glib-e2e-test"),
+        ]
+        result = 0
+        for script in scripts:
+            rc = subprocess.call([sys.executable, script, "--testwtf", testwtf])
+            if rc and not result:
+                result = rc
+        return result
+
 
 def check_environment(port):
     if jhbuildutils.should_use_jhbuild():


### PR DESCRIPTION
#### 65d36770c7a64316ceb12e0e9d57930fe9f8a5a7
<pre>
[re-land] Support time zone change notifications on linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=314414">https://bugs.webkit.org/show_bug.cgi?id=314414</a>

Reviewed by Yusuke Suzuki.

We add a timezone change observer for linux that watches both dbus
and /etc/localtime.

We add some testing helpers and some generated tests too. This uncovered
an existing bug with DST time changes.

Re-land: I added a missing header and some additional clean-ups.
Canonical link: <a href="https://commits.webkit.org/316629@main">https://commits.webkit.org/316629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/390725bab4981ed6bc5645bbdf2850ccb017d596

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182330 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130426 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134454 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114923 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36490 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34812 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30927 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3536 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184864 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34132 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143260 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46460 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143132 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38663 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47138 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31350 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112140 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38115 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118898 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205548 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45655 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9462 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54877 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45056 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45288 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->