### PR TITLE
Introduce FlexBaseSizeUpdateScrollInfoDisabler to scope scroll-info deferral to the flex base-size measurement

### DIFF
--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -888,6 +888,35 @@ bool LocalFrameViewLayoutContext::isPercentHeightResolveDisabledFor(const Render
     return m_percentHeightIgnoreList.contains(flexItem);
 }
 
+void LocalFrameViewLayoutContext::beginDisableUpdateScrollInfoForFlexBaseSize(const RenderBox& flexItem)
+{
+    m_flexItemsSuspendingUpdateScrollInfo.append(flexItem);
+}
+
+void LocalFrameViewLayoutContext::endDisableUpdateScrollInfoForFlexBaseSize(const RenderBox& flexItem)
+{
+    ASSERT(!m_flexItemsSuspendingUpdateScrollInfo.isEmpty());
+    ASSERT(m_flexItemsSuspendingUpdateScrollInfo.last().get() == &flexItem);
+    UNUSED_PARAM(flexItem);
+    m_flexItemsSuspendingUpdateScrollInfo.removeLast();
+}
+
+void LocalFrameViewLayoutContext::recordSuspendedUpdateScrollInfoForFlexBaseSize(RenderBlock& block)
+{
+    ASSERT(!m_flexItemsSuspendingUpdateScrollInfo.isEmpty());
+    CheckedPtr flexItem = m_flexItemsSuspendingUpdateScrollInfo.last().get();
+    if (!flexItem)
+        return;
+    m_suspendedUpdateScrollInfoBlocksForFlexBaseSize.ensure(*flexItem, [] {
+        return SingleThreadWeakHashSet<RenderBlock> { };
+    }).iterator->value.add(block);
+}
+
+SingleThreadWeakHashSet<RenderBlock> LocalFrameViewLayoutContext::takeSuspendedUpdateScrollInfoBlocksForFlexBaseSize(const RenderBox& flexItem)
+{
+    return m_suspendedUpdateScrollInfoBlocksForFlexBaseSize.take(flexItem);
+}
+
 #ifndef NDEBUG
 void LocalFrameViewLayoutContext::checkLayoutState()
 {

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -112,6 +112,10 @@ public:
 
     bool NODELETE isPercentHeightResolveDisabledFor(const RenderBox& flexItem);
 
+    bool isUpdateScrollInfoDisabledForFlexBaseSize() const { return !m_flexItemsSuspendingUpdateScrollInfo.isEmpty(); }
+    void recordSuspendedUpdateScrollInfoForFlexBaseSize(RenderBlock&);
+    SingleThreadWeakHashSet<RenderBlock> takeSuspendedUpdateScrollInfoBlocksForFlexBaseSize(const RenderBox& flexItem);
+
     struct TextBoxTrim {
         bool trimFirstFormattedLine { false };
         SingleThreadWeakPtr<const RenderBlockFlow> lastFormattedLineRoot;
@@ -197,6 +201,7 @@ private:
     friend class LayoutStateDisabler;
     friend class SubtreeLayoutStateMaintainer;
     friend class FlexPercentResolveDisabler;
+    friend class FlexBaseSizeUpdateScrollInfoDisabler;
     friend class ContentVisibilityOverrideScope;
     friend class RepaintBlocker;
 
@@ -246,6 +251,9 @@ private:
     void disablePercentHeightResolveFor(const RenderBox& flexItem);
     void enablePercentHeightResolveFor(const RenderBox& flexItem);
 
+    void beginDisableUpdateScrollInfoForFlexBaseSize(const RenderBox& flexItem);
+    void endDisableUpdateScrollInfoForFlexBaseSize(const RenderBox& flexItem);
+
     void allowRepaints() { m_repaintsBlocked = false; }
     void blockRepaints() { m_repaintsBlocked = true; }
 
@@ -280,6 +288,8 @@ private:
     std::unique_ptr<UpdateScrollInfoAfterLayoutTransaction> m_updateScrollInfoAfterLayoutTransaction;
     SingleThreadWeakHashMap<RenderBlock, Vector<SingleThreadWeakPtr<RenderBox>>> m_containersWithDescendantsNeedingTransformUpdate;
     SingleThreadWeakHashSet<RenderBox> m_percentHeightIgnoreList;
+    Vector<SingleThreadWeakPtr<const RenderBox>> m_flexItemsSuspendingUpdateScrollInfo;
+    SingleThreadWeakHashMap<const RenderBox, SingleThreadWeakHashSet<RenderBlock>> m_suspendedUpdateScrollInfoBlocksForFlexBaseSize;
     Vector<AnchorScrollAdjuster> m_anchorScrollAdjusters;
     std::optional<TextBoxTrim> m_textBoxTrim;
     std::optional<SubtreeScrollbarChangesState> m_subtreeScrollbarChangesState;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -506,6 +506,15 @@ std::optional<ScrollbarUpdateScope> RenderBlock::updateScrollInfoAfterLayout()
 {
     auto hasNonVisibleOverflow = this->hasNonVisibleOverflow();
 
+    auto& layoutContext = view().frameView().layoutContext();
+    if (layoutContext.isUpdateScrollInfoDisabledForFlexBaseSize()) {
+        auto shouldUpdate = hasNonVisibleOverflow || hasControlClip();
+        if (shouldUpdate) {
+            layoutContext.recordSuspendedUpdateScrollInfoForFlexBaseSize(*this);
+            return { };
+        }
+    }
+
     if (isDelayingUpdateScrollInfoAfterLayout(*this)) {
         auto shouldUpdate = hasNonVisibleOverflow || hasControlClip();
         if (shouldUpdate) {

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -39,7 +39,9 @@
 #include "LayoutIntegrationCoverage.h"
 #include "LayoutIntegrationFlexLayout.h"
 #include "LayoutRepainter.h"
+#include "LayoutScope.h"
 #include "LayoutUnit.h"
+#include "RelayoutScopeForScrollbarChange.h"
 #include "RenderBlockInlines.h"
 #include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
@@ -510,8 +512,6 @@ void RenderFlexibleBox::layoutBlock(RelayoutChildren relayoutChildren, LayoutUni
         m_numberOfFlexItemsOnLastLine = { };
         m_justifyContentStartOverflow = 0;
 
-        beginUpdateScrollInfoAfterLayoutTransaction();
-
         prepareOrderIteratorAndMargins();
 
         // Fieldsets need to find their legend and position it inside the border of the object.
@@ -523,11 +523,6 @@ void RenderFlexibleBox::layoutBlock(RelayoutChildren relayoutChildren, LayoutUni
         appendFlexItemFrameRects(oldFlexItemRects);
 
         performFlexLayout(relayoutChildren);
-
-        {
-            auto scrollbarLayout = SetForScope(m_inPostFlexUpdateScrollbarLayout, true);
-            endAndCommitUpdateScrollInfoAfterLayoutTransaction();
-        }
 
         repaintFlexItemsDuringLayoutIfMoved(oldFlexItemRects);
         // FIXME: css3/flexbox/repaint-rtl-column.html seems to repaint more overflow than it needs to.
@@ -2119,6 +2114,7 @@ void RenderFlexibleBox::ensureBlockAxisContentSizeForFlexItemIfNeeded(RenderBox&
     // where we want percentages to be treated as auto. For flex-basis itself, this is not a problem because
     // by definition we have an indefinite flex basis here and thus percentages should not resolve.
     auto percentResolveDisableScope = FlexPercentResolveDisabler { view().frameView().layoutContext(), flexItem };
+    auto scrollInfoDisableScope = FlexBaseSizeUpdateScrollInfoDisabler { view().frameView().layoutContext(), flexItem };
     flexItem.setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
     flexItem.layoutIfNeeded();
 
@@ -2807,9 +2803,22 @@ void RenderFlexibleBox::layoutFlexItemAfterMainSizing(FlexLayoutItem& flexLayout
     if (flexItem.needsLayout())
         m_flexItemsWithCompletedLayout.add(flexItem);
 
+    bool willRelayoutFlexItem = flexItem.needsLayout();
     {
         auto flexLayoutScope = SetForScope(m_afterMainAxisItemSizing, true);
         flexItem.layoutIfNeeded();
+    }
+
+    auto suspendedBlocks = view().frameView().layoutContext().takeSuspendedUpdateScrollInfoBlocksForFlexBaseSize(flexItem);
+    if (!willRelayoutFlexItem) {
+        // The flex base-size measurement layout was the final layout for this flex item.
+        // Flush the scroll-info updates that the disabler suspended during that measurement.
+        for (CheckedRef<RenderBlock> block : suspendedBlocks) {
+            if (block->hasControlClip() && block->hasRenderOverflow())
+                block->clearLayoutOverflow();
+            if (block->hasNonVisibleOverflow())
+                RelayoutScopeForScrollbarChange relayoutScope { block.get(), InOverflowRelayout::No };
+        }
     }
 
     if (!flexLayoutItem.everHadLayout && flexItem.checkForRepaintDuringLayout()) {

--- a/Source/WebCore/rendering/RenderLayoutState.cpp
+++ b/Source/WebCore/rendering/RenderLayoutState.cpp
@@ -352,6 +352,18 @@ FlexPercentResolveDisabler::~FlexPercentResolveDisabler()
     m_layoutContext->enablePercentHeightResolveFor(m_flexItem);
 }
 
+FlexBaseSizeUpdateScrollInfoDisabler::FlexBaseSizeUpdateScrollInfoDisabler(LocalFrameViewLayoutContext& layoutContext, const RenderBox& flexItem)
+    : m_layoutContext(layoutContext)
+    , m_flexItem(flexItem)
+{
+    m_layoutContext->beginDisableUpdateScrollInfoForFlexBaseSize(flexItem);
+}
+
+FlexBaseSizeUpdateScrollInfoDisabler::~FlexBaseSizeUpdateScrollInfoDisabler()
+{
+    m_layoutContext->endDisableUpdateScrollInfoForFlexBaseSize(m_flexItem);
+}
+
 ContentVisibilityOverrideScope::ContentVisibilityOverrideScope(LocalFrameViewLayoutContext& layoutContext, OptionSet<OverrideType> overrideTypes)
     : m_layoutContext(layoutContext)
 {

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -204,6 +204,16 @@ private:
     const CheckedRef<const RenderBox> m_flexItem;
 };
 
+class FlexBaseSizeUpdateScrollInfoDisabler {
+public:
+    FlexBaseSizeUpdateScrollInfoDisabler(LocalFrameViewLayoutContext&, const RenderBox& flexItem);
+    ~FlexBaseSizeUpdateScrollInfoDisabler();
+
+private:
+    const CheckedRef<LocalFrameViewLayoutContext> m_layoutContext;
+    const CheckedRef<const RenderBox> m_flexItem;
+};
+
 class ContentVisibilityOverrideScope {
 public:
     enum class OverrideType {


### PR DESCRIPTION
#### a9d2948a5f9e6ec7708cddf35c01e237e7eebb77
<pre>
Introduce FlexBaseSizeUpdateScrollInfoDisabler to scope scroll-info deferral to the flex base-size measurement

Replaces the role the broad UpdateScrollInfoAfterLayoutTransaction
played in RenderFlexibleBox::performFlexLayout with a targeted RAII
scope around the actual measurement layout in
RenderFlexibleBox::blockAxisSizeForFlexItem.

While the disabler is active, RenderBlock::updateScrollInfoAfterLayout()
defers updates onto a per-flex-item set held in LocalFrameViewLayoutContext.
In RenderFlexibleBox::layoutAndPlaceFlexItems, after the per-item
layoutIfNeeded() call:

- If the flex item was re-laid out (needsLayout() was true going in), the
  descendants re-issue updateScrollInfoAfterLayout naturally during that
  layout (outside the disabler scope) and the captured set is discarded.
- If the flex item was not re-laid out, the base-size measurement was the
  final layout. The captured set is flushed using the same clearLayoutOverflow
  + RelayoutScopeForScrollbarChange dance that
  endAndCommitUpdateScrollInfoAfterLayoutTransaction performs in RenderBlock.

A stack handles nested flex containers; innermost owns deferral.

The new disabler check in RenderBlock::updateScrollInfoAfterLayout runs
before the existing transaction check so it wins when both contexts are
active (e.g. flex container inside a grid item).

Mirrors the architecture of FlexPercentResolveDisabler in
RenderLayoutState.{h,cpp}.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4dd1f114fdbcf27671e9a97f02f7992fcddf0f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173619 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121837 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5791d0e1-f4ba-4083-9a66-522bc4347b20) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38071 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127891 "Found 4 new test failures: css3/flexbox/overflow-keep-scrollpos.html fast/flexbox/percent-height-flex-content-with-space-taking-scrollbar.html imported/w3c/web-platform-tests/css/css-sizing/stretch/cache-miss-002.html imported/w3c/web-platform-tests/scroll-animations/css/animation-range-visual-test.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90017 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f0378e7-d373-4e34-bff3-09d8cf438e68) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167544 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30188 "Found 1 new test failure: css3/flexbox/overflow-keep-scrollpos.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108435 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eeae0001-8e16-4a97-a945-e561fa57c77f) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29235 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/dynamic-baseline-change-nested.html imported/w3c/web-platform-tests/css/css-flexbox/dynamic-baseline-change.html imported/w3c/web-platform-tests/css/css-flexbox/scrollbars-auto-min-content-sizing.html imported/w3c/web-platform-tests/css/css-sizing/stretch/cache-miss-002.html imported/w3c/web-platform-tests/scroll-animations/css/animation-range-visual-test.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27862 "Found 15 new API test failures: TestWebKitAPI.WKInspectorDelegate.InspectorConfiguration, TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToDevToolsBackground, TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground, TestWebKitAPI.WKInspectorExtensionHost.RegisterExtension, TestWebKitAPI.WKWebExtensionAPIDevTools.Basics, TestWebKitAPI.WKWebExtensionAPIDevTools.InspectedWindowReload, TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToBackground, TestWebKitAPI.WKInspectorExtensionHost.UnregisterExtension, TestWebKitAPI.WKInspectorExtension.EvaluateScriptInExtensionTabCanReturnPromises, TestWebKitAPI.WKInspectorExtension.CanEvaluateScriptInExtensionTab ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21378 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176143 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28964 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27317 "Found 4 new test failures: css3/flexbox/overflow-keep-scrollpos.html fast/flexbox/percent-height-flex-content-with-space-taking-scrollbar.html imported/w3c/web-platform-tests/css/css-sizing/stretch/cache-miss-002.html imported/w3c/web-platform-tests/scroll-animations/css/animation-range-visual-test.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136207 "Found 4 new test failures: css3/flexbox/overflow-keep-scrollpos.html fast/flexbox/percent-height-flex-content-with-space-taking-scrollbar.html imported/w3c/web-platform-tests/css/css-sizing/stretch/cache-miss-002.html imported/w3c/web-platform-tests/scroll-animations/css/animation-range-visual-test.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38138 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31985 "Found 5 new test failures: css3/flexbox/overflow-keep-scrollpos.html fast/flexbox/fixed-position-in-flex-scrollbar-relayout.html fast/flexbox/percent-height-flex-content-with-space-taking-scrollbar.html imported/w3c/web-platform-tests/css/css-sizing/stretch/cache-miss-002.html imported/w3c/web-platform-tests/scroll-animations/css/animation-range-visual-test.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136171 "Found 2 new API test failures: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147443 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100982 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31447 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24299 "Found 4 new test failures: css3/flexbox/overflow-keep-scrollpos.html fast/flexbox/percent-height-flex-content-with-space-taking-scrollbar.html imported/w3c/web-platform-tests/css/css-sizing/stretch/cache-miss-002.html imported/w3c/web-platform-tests/scroll-animations/css/animation-range-visual-test.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37336 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110380 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36734 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2362 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36982 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36882 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->