### PR TITLE
Additional DeviceConfiguration entitlements should only be allowed via sandbox extension

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -240,6 +240,10 @@ NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSess
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     SandboxExtension::consumePermanently(parameters.webContentRestrictionsConfigurationExtensionHandle);
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS) && PLATFORM(MAC) && HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+    if (parameters.webContentRestrictionsMachExtensionHandle)
+        SandboxExtension::consumePermanently(*parameters.webContentRestrictionsMachExtensionHandle);
+#endif
 }
 
 NetworkSession::~NetworkSession()

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -154,6 +154,9 @@ struct NetworkSessionCreationParameters {
     String webContentRestrictionsConfigurationFile;
     SandboxExtension::Handle webContentRestrictionsConfigurationExtensionHandle;
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS) && PLATFORM(MAC) && HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+    std::optional<SandboxExtension::Handle> webContentRestrictionsMachExtensionHandle;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -122,6 +122,9 @@ enum class WebKit::AllowsCellularAccess : bool;
     String webContentRestrictionsConfigurationFile;
     WebKit::SandboxExtensionHandle webContentRestrictionsConfigurationExtensionHandle;
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS) && PLATFORM(MAC) && HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+    std::optional<WebKit::SandboxExtensionHandle> webContentRestrictionsMachExtensionHandle;
+#endif
 };
 
 #if USE(SOUP)

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -884,6 +884,12 @@
 #if HAVE(WEBCONTENTRESTRICTIONS) && PLATFORM(MAC)
 (allow mach-lookup
     (global-name "com.apple.familycontrols"))
+#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+(allow mach-lookup
+    (require-all
+        (extension "com.apple.webkit.extension.mach")
+        (global-name "com.apple.DeviceConfigurationAgent.consumer")))
+#endif
 #endif
 
 #if HAVE(ENHANCED_SECURITY_LINKS) && __has_include(<WebKitAdditions/EnhancedSecurityLinks-macos.sb>)

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -118,6 +118,9 @@ function mac_process_network_entitlements()
         plistbuddy Add :com.apple.private.assets.accessible-asset-types array
         plistbuddy Add :com.apple.private.assets.accessible-asset-types:0 string com.apple.MobileAsset.WebContentRestrictions
 
+        plistbuddy Add :com.apple.private.device-configuration.effective-configuration-ids.read array
+        plistbuddy Add :com.apple.private.device-configuration.effective-configuration-ids.read:0 string com.apple.WebContentRestrictions
+
         plistbuddy Add :com.apple.private.ciphermld.allow bool YES
 
         plistbuddy Add :com.apple.private.launchservices.allowedtochangethesekeysinotherapplications array

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -107,6 +107,10 @@
 #include "VirtualAuthenticatorManager.h"
 #endif // ENABLE(WEB_AUTHN)
 
+#if HAVE(WEBCONTENTRESTRICTIONS) && PLATFORM(MAC) && HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+#include "WebPreferencesDefaultValues.h"
+#endif
+
 namespace WebKit {
 
 static bool allowsWebsiteDataRecordsForAllOrigins;
@@ -2272,6 +2276,11 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     networkSessionParameters.webContentRestrictionsConfigurationFile = WTF::move(webContentRestrictionsConfigurationFile);
     networkSessionParameters.webContentRestrictionsConfigurationExtensionHandle = WTF::move(webContentRestrictionsConfigurationExtensionHandle);
+#endif
+
+#if HAVE(WEBCONTENTRESTRICTIONS) && PLATFORM(MAC) && HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+    if (defaultWebContentRestrictionsAskToEnabled())
+        networkSessionParameters.webContentRestrictionsMachExtensionHandle = SandboxExtension::createHandleForMachLookup("com.apple.DeviceConfigurationAgent.consumer"_s, std::nullopt);
 #endif
 
     parameters.networkSessionParameters = WTF::move(networkSessionParameters);


### PR DESCRIPTION
#### e3a5b06caa97a2c0b961f560d26d706990d82973
<pre>
Additional DeviceConfiguration entitlements should only be allowed via sandbox extension
<a href="https://bugs.webkit.org/show_bug.cgi?id=315609">https://bugs.webkit.org/show_bug.cgi?id=315609</a>
<a href="https://rdar.apple.com/177971714">rdar://177971714</a>

Reviewed by NOBODY (OOPS!).

This is follow-up from <a href="https://bugs.webkit.org/show_bug.cgi?id=315576">https://bugs.webkit.org/show_bug.cgi?id=315576</a>
Currently, we always allow look-up access to these 3 services:
  - com.apple.DeviceConfigurationAgent.consumer
  - com.apple.DeviceConfigurationAgent.consumer.async
  - com.apple.DeviceConfigurationAgent.publisher
 but this should be done via sandbox extension instead.

No new tests needed.

* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::m_dataStoreIdentifier):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3a5b06caa97a2c0b961f560d26d706990d82973

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164912 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38398 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31974 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173949 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122167 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34bfe3a3-755d-46b8-b826-8de91d618d83) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38732 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38400 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/173949 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90197 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167870 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/38732 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/31974 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/173949 "") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75dbfd60-5b74-4e56-931d-dc63278f69f7) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/164232 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/38732 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/38400 "") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21708 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/38732 "") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/31974 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176473 "") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29324 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/31974 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/176473 "") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38466 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/38400 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/176473 "") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39156 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/31974 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101412 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/39156 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/31974 "") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37666 "") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110735 "") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37062 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/31974 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37309 "") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37209 "") | | | | 
<!--EWS-Status-Bubble-End-->