### PR TITLE
Cherry-pick 305413.554@safari-7624-branch (50c79b41fc8e). https://bugs.webkit.org/show_bug.cgi?id=310333

### DIFF
--- a/LayoutTests/webgl/readpixels-pbo-offset-validation-expected.txt
+++ b/LayoutTests/webgl/readpixels-pbo-offset-validation-expected.txt
@@ -1,0 +1,54 @@
+Test that readPixels with invalid PBO offsets are properly validated and don't cause crashes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 45 PASS, 0 FAIL
+
+PASS getError was expected value: NO_ERROR : offset==0
+PASS pixels is expected
+PASS getError was expected value: NO_ERROR : 32x32, offset=256
+PASS pixels is expected
+PASS pixels is [0, 0, 0, 0]
+PASS getError was expected value: INVALID_VALUE : offset=-1
+PASS getError was expected value: INVALID_OPERATION : offset==4
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize - 1
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFF
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFD
+PASS getError was expected value: NO_ERROR : offset==0
+PASS pixels is expected
+PASS getError was expected value: NO_ERROR : 32x32, offset=256
+PASS pixels is expected
+PASS pixels is [0, 0, 0, 0]
+PASS getError was expected value: INVALID_VALUE : offset=-1
+PASS getError was expected value: INVALID_OPERATION : offset==4
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize - 1
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFF
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFD
+PASS getError was expected value: NO_ERROR : offset==0
+PASS pixels is expectedNoAlpha
+PASS getError was expected value: NO_ERROR : 32x32, offset=256
+PASS pixels is expectedNoAlpha
+PASS pixels is [0, 0, 0, 0]
+PASS getError was expected value: INVALID_VALUE : offset=-1
+PASS getError was expected value: INVALID_OPERATION : offset==4
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize - 1
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFF
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFD
+PASS getError was expected value: NO_ERROR : offset==0
+PASS pixels is expectedNoAlpha
+PASS getError was expected value: NO_ERROR : 32x32, offset=256
+PASS pixels is expectedNoAlpha
+PASS pixels is [0, 0, 0, 0]
+PASS getError was expected value: INVALID_VALUE : offset=-1
+PASS getError was expected value: INVALID_OPERATION : offset==4
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize - 1
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFF
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFD
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/readpixels-pbo-offset-validation.html
+++ b/LayoutTests/webgl/readpixels-pbo-offset-validation.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+
+description("Test that readPixels with invalid PBO offsets are properly validated and don't cause crashes.");
+
+var wtu = WebGLTestUtils;
+var gl;
+var expected = [51, 102, 204, 204];
+var expectedNoAlpha = [51, 102, 204, 255];
+var pixels;
+
+function runTest(contextOptions) {
+    var canvas = document.createElement("canvas");
+    var gl = wtu.create3DContext(canvas, contextOptions, 2);
+
+    gl.clearColor(0.2, 0.4, 0.8, 0.8);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    var pbo = gl.createBuffer();
+    gl.bindBuffer(gl.PIXEL_PACK_BUFFER, pbo);
+    var bufferSize = 64 * 64 * 4;
+    gl.bufferData(gl.PIXEL_PACK_BUFFER, bufferSize, gl.DYNAMIC_READ);
+    gl.bindBuffer(gl.COPY_READ_BUFFER, pbo); // For verification getBufferSubData() calls below.
+
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null);
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "offset==0");
+    pixels = new Uint8Array(4);
+    gl.getBufferSubData(gl.COPY_READ_BUFFER, 0, pixels);
+    if (contextOptions.alpha)
+        shouldBe("pixels", "expected");
+    else
+        shouldBe("pixels", "expectedNoAlpha");
+
+
+    gl.bufferData(gl.COPY_READ_BUFFER, bufferSize, gl.DYNAMIC_READ);
+    gl.readPixels(0, 0, 32, 32, gl.RGBA, gl.UNSIGNED_BYTE, 256);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "32x32, offset=256");
+    pixels = new Uint8Array(4);
+    gl.getBufferSubData(gl.COPY_READ_BUFFER, 256, pixels);
+    if (contextOptions.alpha)
+        shouldBe("pixels", "expected");
+    else
+        shouldBe("pixels", "expectedNoAlpha");
+    pixels = new Uint8Array(4);
+    gl.getBufferSubData(gl.COPY_READ_BUFFER, 0, pixels);
+    shouldBe("pixels", "[0, 0, 0, 0]");
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, -1);
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "offset=-1");
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, 4);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "offset==4");
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, bufferSize);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "offset==bufferSize");
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, bufferSize - 1);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "offset==bufferSize - 1");
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, 0x7FFFFFFF);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "offset==0x7FFFFFFF");
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, 0x7FFFFFFD);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "offset==0x7FFFFFFD");
+}
+
+for (let alpha of [true, false]) {
+    for (let antialias of [true, false])
+        runTest({alpha, antialias});
+}
+finishTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -41,6 +41,7 @@
 #include "NotImplemented.h"
 #include <algorithm>
 #include <cstring>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/Seconds.h>
@@ -49,7 +50,6 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/CStringView.h>
 #include <wtf/text/StringBuilder.h>
-
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
 #include "GraphicsContextGLCVCocoa.h"
 #endif
@@ -723,9 +723,32 @@ void GraphicsContextGLANGLE::readPixelsBufferObject(IntRect rect, GCGLenum forma
 {
     if (!makeContextCurrent())
         return;
+    if (!m_isForWebGL2) {
+        addError(GCGLErrorCode::InvalidOperation);
+        return;
+    }
+    GCGLuint pixelPackBuffer = 0;
+    GL_GetIntegerv(GL_PIXEL_PACK_BUFFER_BINDING, reinterpret_cast<GCGLint*>(&pixelPackBuffer));
+    if (!pixelPackBuffer) {
+        addError(GCGLErrorCode::InvalidOperation);
+        return;
+    }
+
+    auto attrs = contextAttributes();
+    if (attrs.antialias && m_state.boundReadFBO == m_multisampleFBO) {
+        resolveMultisamplingIfNecessary(rect);
+        GL_BindFramebuffer(GraphicsContextGL::READ_FRAMEBUFFER, m_fbo);
+    }
+
     setPackParameters(alignment, rowLength, false);
-    std::span<uint8_t> data(reinterpret_cast<uint8_t*>(offset), 0);
-    readPixelsImpl(rect, format, type, data);
+
+    // ANGLE validates the read size against the PBO size.
+    GLsizei bufferSize = std::numeric_limits<GLsizei>::max();
+
+    GL_ReadnPixelsRobustANGLE(rect.x(), rect.y(), rect.width(), rect.height(), format, type, bufferSize, nullptr, nullptr, nullptr, reinterpret_cast<void*>(offset));
+
+    if (attrs.antialias && m_state.boundReadFBO == m_multisampleFBO)
+        GL_BindFramebuffer(GraphicsContextGL::READ_FRAMEBUFFER, m_multisampleFBO);
 }
 
 std::optional<IntSize> GraphicsContextGLANGLE::readPixelsImpl(IntRect rect, GCGLenum format, GCGLenum type, std::span<uint8_t> data)


### PR DESCRIPTION
#### c1a8e5d2571c2805f004e87263b0a670e37e6c55
<pre>
Cherry-pick 305413.554@safari-7624-branch (50c79b41fc8e). <a href="https://bugs.webkit.org/show_bug.cgi?id=310333">https://bugs.webkit.org/show_bug.cgi?id=310333</a>

    WebGL: Crash when reading pixels to PBO with an offset
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310333">https://bugs.webkit.org/show_bug.cgi?id=310333</a>
    <a href="https://rdar.apple.com/171685583">rdar://171685583</a>

    Reviewed by Dan Glastonbury.

    Avoid using the client buffer path when reading pixels to PBO.
    The legacy wipeAlphaChannelFromPixels would be run if PBO was
    read to with an offset.

    Test: webgl/readpixels-pbo-offset-validation.html

    * LayoutTests/webgl/readpixels-pbo-offset-validation-expected.txt: Added.
    * LayoutTests/webgl/readpixels-pbo-offset-validation.html: Added.
    * Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
    (WebCore::GraphicsContextGLANGLE::readPixelsBufferObject):

    Identifier: 305413.554@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.685@webkitglib/2.52">https://commits.webkit.org/305877.685@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddb788ed31044cc3f791c2d129af172879eb9324

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164574 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38058 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/31629 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173613 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121826 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166443 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38392 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38060 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127882 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121826 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167533 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38392 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/31629 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108427 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38392 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38060 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21367 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38392 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/31629 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176131 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25466 "Build is in progress. Recent messages:") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28953 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31629 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136200 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38127 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/38060 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136164 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38817 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/31629 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100971 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25057 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38817 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31629 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37325 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110369 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/36723 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/31629 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/36971 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/36871 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->