### PR TITLE
[JSC] Add ArrayJoin DFG nodes

### DIFF
--- a/JSTests/stress/array-join-dfg-empty-separator.js
+++ b/JSTests/stress/array-join-dfg-empty-separator.js
@@ -1,0 +1,42 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected ' + expected);
+}
+
+function joinInt32(arr) {
+    return arr.join("");
+}
+noInline(joinInt32);
+
+function joinContiguous(arr) {
+    return arr.join("");
+}
+noInline(joinContiguous);
+
+function joinDouble(arr) {
+    return arr.join("");
+}
+noInline(joinDouble);
+
+var int32Array = [1, 2, 3, 4, 5];
+var contiguousArray = ["a", "b", "c", "d", "e"];
+var doubleArray = [1.5, 2.5, 3.5];
+var mixedArray = [1, "x", 2, "y", 3];
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(joinInt32(int32Array), "12345");
+    shouldBe(joinContiguous(contiguousArray), "abcde");
+    shouldBe(joinDouble(doubleArray), "1.52.53.5");
+    shouldBe(joinContiguous(mixedArray), "1x2y3");
+}
+
+shouldBe(joinInt32([]), "");
+shouldBe(joinInt32([42]), "42");
+shouldBe(joinContiguous(["solo"]), "solo");
+
+var withHole = [1, , 3];
+shouldBe(withHole.join(""), "13");
+
+var sparseInt32 = [1, 2];
+sparseInt32.length = 4;
+shouldBe(sparseInt32.join(""), "12");

--- a/JSTests/stress/array-join-dfg-object-separator-tostring-once.js
+++ b/JSTests/stress/array-join-dfg-object-separator-tostring-once.js
@@ -1,0 +1,88 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected ' + expected);
+}
+
+// When the separator is an object, operationArrayJoinGeneric must not call
+// ToString itself: doing so would let the side effect run, and a subsequent
+// revalidation failure (e.g. mutated array length / indexing type) would
+// trigger an OSR exit, after which the bytecode-level slow path would call
+// ToString again. Verify ToString is invoked exactly once per join() call
+// across all tiers.
+
+function join(arr, sep) {
+    return arr.join(sep);
+}
+noInline(join);
+
+// Plain object separator: counter should equal the number of calls.
+{
+    var arr = [1, 2, 3];
+    var calls = 0;
+    var sep = { toString() { ++calls; return ","; } };
+    for (var i = 0; i < testLoopCount; ++i)
+        shouldBe(join(arr, sep), "1,2,3");
+    shouldBe(calls, testLoopCount);
+}
+
+// Object separator whose ToString shrinks the array. Even when the mutation
+// invalidates the fast path, ToString must run exactly once per join().
+{
+    var calls = 0;
+    function call() {
+        var arr = [1, 2, 3];
+        var sep = { toString() { ++calls; arr.length = 1; return ","; } };
+        return arr.join(sep);
+    }
+    noInline(call);
+    for (var i = 0; i < testLoopCount; ++i)
+        shouldBe(call(), "1,,");
+    shouldBe(calls, testLoopCount);
+}
+
+// Object separator whose ToString transitions the array's indexing type
+// (Int32 -> Contiguous). ToString must still run exactly once per call.
+{
+    var calls = 0;
+    function call() {
+        var arr = [1, 2, 3];
+        var sep = { toString() { ++calls; arr[1] = "X"; return ","; } };
+        return arr.join(sep);
+    }
+    noInline(call);
+    for (var i = 0; i < testLoopCount; ++i)
+        shouldBe(call(), "1,X,3");
+    shouldBe(calls, testLoopCount);
+}
+
+// Object separator with empty-string ToString that punches a hole. The
+// empty-separator fast path would otherwise read the hole; ToString still
+// runs exactly once per call.
+{
+    var calls = 0;
+    function call() {
+        var arr = [1, 2, 3];
+        var sep = { toString() { ++calls; delete arr[1]; return ""; } };
+        return arr.join(sep);
+    }
+    noInline(call);
+    for (var i = 0; i < testLoopCount; ++i)
+        shouldBe(call(), "13");
+    shouldBe(calls, testLoopCount);
+}
+
+// Object separator with empty-string ToString that shrinks the array. The
+// empty-separator fast path would otherwise read past the new length;
+// ToString still runs exactly once per call.
+{
+    var calls = 0;
+    function call() {
+        var arr = [1, 2, 3];
+        var sep = { toString() { ++calls; arr.length = 1; return ""; } };
+        return arr.join(sep);
+    }
+    noInline(call);
+    for (var i = 0; i < testLoopCount; ++i)
+        shouldBe(call(), "1");
+    shouldBe(calls, testLoopCount);
+}

--- a/JSTests/stress/array-join-dfg-string-separator.js
+++ b/JSTests/stress/array-join-dfg-string-separator.js
@@ -1,0 +1,39 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected ' + expected);
+}
+
+function joinComma(arr) {
+    return arr.join(",");
+}
+noInline(joinComma);
+
+function joinDash(arr) {
+    return arr.join("-");
+}
+noInline(joinDash);
+
+function joinMulti(arr) {
+    return arr.join("--");
+}
+noInline(joinMulti);
+
+var int32Array = [1, 2, 3, 4, 5];
+var contiguousArray = ["a", "b", "c"];
+var doubleArray = [1.5, 2.5, 3.5];
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(joinComma(int32Array), "1,2,3,4,5");
+    shouldBe(joinDash(int32Array), "1-2-3-4-5");
+    shouldBe(joinMulti(int32Array), "1--2--3--4--5");
+    shouldBe(joinComma(contiguousArray), "a,b,c");
+    shouldBe(joinDash(contiguousArray), "a-b-c");
+    shouldBe(joinComma(doubleArray), "1.5,2.5,3.5");
+}
+
+// Edge cases
+shouldBe(joinComma([]), "");
+shouldBe(joinComma([42]), "42");
+shouldBe(joinComma([null, undefined, 1]), ",,1");
+shouldBe(joinComma([NaN, Infinity, -0]), "NaN,Infinity,0");
+shouldBe([1, , 3].join(","), "1,,3");

--- a/JSTests/stress/array-join-dfg-tostring-mutation.js
+++ b/JSTests/stress/array-join-dfg-tostring-mutation.js
@@ -1,0 +1,86 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected ' + expected);
+}
+
+// 1. ToString shrinks arr.length. Per spec (Array.prototype.join):
+//    Step 2 captures len BEFORE step 4 ToString(separator). The loop iterates
+//    over the captured len; mutated indices read as undefined and become "".
+function joinShrink() {
+    var arr = [1, 2, 3];
+    var sep = { toString() { arr.length = 1; return ","; } };
+    return arr.join(sep);
+}
+noInline(joinShrink);
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(joinShrink(), "1,,");
+
+// 2. ToString grows arr.length. Captured len is 3, so we ignore appended items.
+function joinGrow() {
+    var arr = [1, 2, 3];
+    var sep = { toString() { arr.push(99, 100); return ","; } };
+    return arr.join(sep);
+}
+noInline(joinGrow);
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(joinGrow(), "1,2,3");
+
+// 3. ToString causes Int32→Contiguous transition (storing a string forces the
+//    indexing type to widen). Post-toString must revalidate the array mode.
+function joinTransition() {
+    var arr = [1, 2, 3];
+    var sep = { toString() { arr[1] = "X"; return ","; } };
+    return arr.join(sep);
+}
+noInline(joinTransition);
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(joinTransition(), "1,X,3");
+
+// 4. ToString punches a hole in the array and reads it via the empty-separator
+//    fast path. The joiner must see the hole and fall back; result is "13".
+function joinHolePunch() {
+    var arr = [1, 2, 3];
+    var sep = { toString() { delete arr[1]; return ""; } };
+    return arr.join(sep);
+}
+noInline(joinHolePunch);
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(joinHolePunch(), "13");
+
+// 5. ToString replaces an Int32 element with a non-string/non-int32 value
+//    (object). The empty-separator JSOnlyStringsAndInt32sJoiner must bail out
+//    of its fast path and the slow path must still produce spec-correct output.
+function joinNonStringElement() {
+    var arr = [1, 2, 3];
+    var obj = { toString() { return "OBJ"; } };
+    var sep = { toString() { arr[1] = obj; return ""; } };
+    return arr.join(sep);
+}
+noInline(joinNonStringElement);
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(joinNonStringElement(), "1OBJ3");
+
+// 6. ToString shrinks the array AND uses the empty-separator fast path. The
+//    fast path reads butterfly[0, capturedLength); after shrink, slots beyond
+//    the new length are conceptually undefined, so reading them via the joiner
+//    is incorrect. The needsRevalidation path must detect length mismatch and
+//    fall through to fastArrayJoin which handles it. Expected: "1".
+function joinShrinkEmpty() {
+    var arr = [1, 2, 3];
+    var sep = { toString() { arr.length = 1; return ""; } };
+    return arr.join(sep);
+}
+noInline(joinShrinkEmpty);
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(joinShrinkEmpty(), "1");
+
+// 7. ToString grows the array with empty separator. Captured length is 3, so
+//    appended elements are ignored. Expected: "123".
+function joinGrowEmpty() {
+    var arr = [1, 2, 3];
+    var sep = { toString() { arr.push(99, 100); return ""; } };
+    return arr.join(sep);
+}
+noInline(joinGrowEmpty);
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(joinGrowEmpty(), "123");

--- a/JSTests/stress/array-join-dfg-undefined-separator.js
+++ b/JSTests/stress/array-join-dfg-undefined-separator.js
@@ -1,0 +1,53 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected ' + expected);
+}
+
+// Parser-level fold: arr.join(undefined) where undefined is a static JSConstant
+function joinUndefinedLiteral(arr) {
+    return arr.join(undefined);
+}
+noInline(joinUndefinedLiteral);
+
+// Parser-level fold: arr.join() with no argument (separator is implicit undefined)
+function joinNoArg(arr) {
+    return arr.join();
+}
+noInline(joinNoArg);
+
+// Strength-reduction case: separator is a variable that resolves to undefined
+// after constant propagation. The bytecode parser sees a non-constant Get,
+// but later phases fold it.
+function joinViaVar(arr) {
+    var sep;
+    return arr.join(sep);
+}
+noInline(joinViaVar);
+
+// Inlined: callee passes through a parameter that the caller leaves undefined.
+function inner(arr, sep) {
+    return arr.join(sep);
+}
+function outer(arr) {
+    return inner(arr);
+}
+noInline(outer);
+
+var int32Array = [1, 2, 3, 4, 5];
+var contiguousArray = ["a", "b", "c"];
+var doubleArray = [1.5, 2.5, 3.5];
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(joinUndefinedLiteral(int32Array), "1,2,3,4,5");
+    shouldBe(joinUndefinedLiteral(contiguousArray), "a,b,c");
+    shouldBe(joinUndefinedLiteral(doubleArray), "1.5,2.5,3.5");
+
+    shouldBe(joinNoArg(int32Array), "1,2,3,4,5");
+    shouldBe(joinNoArg(contiguousArray), "a,b,c");
+
+    shouldBe(joinViaVar(int32Array), "1,2,3,4,5");
+    shouldBe(joinViaVar(contiguousArray), "a,b,c");
+
+    shouldBe(outer(int32Array), "1,2,3,4,5");
+    shouldBe(outer(contiguousArray), "a,b,c");
+}

--- a/JSTests/stress/array-join-dfg-untyped-separator.js
+++ b/JSTests/stress/array-join-dfg-untyped-separator.js
@@ -1,0 +1,80 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected ' + expected);
+}
+
+function shouldThrow(fn, errorType) {
+    var threw = false;
+    try {
+        fn();
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof errorType))
+            throw new Error('Expected ' + errorType.name + ', got ' + e);
+    }
+    if (!threw)
+        throw new Error('Expected throw');
+}
+
+function join(arr, sep) {
+    return arr.join(sep);
+}
+noInline(join);
+
+var array = [1, 2, 3];
+
+// Number separator -> ToString -> "1"
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(join(array, 1), "11213");
+
+// Boolean separator -> "true"
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(join(array, true), "1true2true3");
+
+// Null separator -> "null"
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(join(array, null), "1null2null3");
+
+// Object with custom toString
+var customSep = { toString() { return "<>"; } };
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(join(array, customSep), "1<>2<>3");
+
+// Toggling separator types in the same compiled function (forces UntypedUse)
+function pick(i) {
+    if (i & 1)
+        return ",";
+    return 1;
+}
+function joinPicked(arr, i) {
+    return arr.join(pick(i));
+}
+noInline(joinPicked);
+for (var i = 0; i < testLoopCount; ++i) {
+    if (i & 1)
+        shouldBe(joinPicked(array, i), "1,2,3");
+    else
+        shouldBe(joinPicked(array, i), "11213");
+}
+
+// Symbol separator throws TypeError
+for (var i = 0; i < 1000; ++i) {
+    shouldThrow(() => join(array, Symbol("s")), TypeError);
+}
+
+// toString that throws propagates the error
+function throwingSep() {
+    return { toString() { throw new Error("boom"); } };
+}
+for (var i = 0; i < 1000; ++i) {
+    var threw = false;
+    try {
+        join(array, throwingSep());
+    } catch (e) {
+        threw = true;
+        if (e.message !== "boom")
+            throw new Error('Wrong error: ' + e.message);
+    }
+    if (!threw)
+        throw new Error('Expected throw');
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3360,6 +3360,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         setNonCellTypeForNode(node, SpecInt32Only);
         break;
     }
+
+    case ArrayJoin:
+        clobberWorld();
+        setTypeForNode(node, SpecString);
+        break;
             
     case ArrayPop:
         clobberWorld();

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -414,6 +414,12 @@ private:
             break;
         }
 
+        case ArrayJoin: {
+            m_graph.varArgChild(node, 0)->mergeFlags(NodeBytecodeUsesAsValue);
+            m_graph.varArgChild(node, 1)->mergeFlags(NodeBytecodeUsesAsValue);
+            break;
+        }
+
         case UInt32ToNumber: {
             node->child1()->mergeFlags(flags);
             break;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2995,6 +2995,65 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
         case ArraySortIntrinsic:
             return handleArraySort(callee, resultOperand, variant, registerOffset, argumentCountIncludingThis, osrExitIndex, prediction, insertChecks, setResult);
 
+        case ArrayJoinIntrinsic: {
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadIndexingType)
+                || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantCache)
+                || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadCache)
+                || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType)
+                || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, ExoticObjectMode))
+                return CallOptimizationResult::DidNothing;
+
+            ArrayMode arrayMode = getArrayMode(Array::Read);
+            if (!arrayMode.isJSArray())
+                return CallOptimizationResult::DidNothing;
+
+            if (!arrayMode.isJSArrayWithOriginalStructure())
+                return CallOptimizationResult::DidNothing;
+
+            if (arrayMode.doesConversion())
+                return CallOptimizationResult::DidNothing;
+
+            switch (arrayMode.type()) {
+            case Array::Double:
+            case Array::Int32:
+            case Array::Contiguous: {
+                JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
+                if (globalObject->arrayPrototypeChainIsSaneWatchpointSet().state() != IsWatched)
+                    return CallOptimizationResult::DidNothing;
+
+                Node* separator = nullptr;
+                if (argumentCountIncludingThis >= 2) {
+                    Node* separatorArg = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+                    if (separatorArg->op() == JSConstant && separatorArg->asJSValue().isUndefined())
+                        separator = nullptr;
+                    else
+                        separator = separatorArg;
+                }
+
+                m_graph.watchpoints().addLazily(globalObject->arrayPrototypeChainIsSaneWatchpointSet());
+
+                insertChecks();
+
+                if (!separator)
+                    separator = jsConstant(m_vm->smallStrings.singleCharacterString(','));
+
+                Node* array = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+                addVarArgChild(array);
+                addVarArgChild(separator);
+                addVarArgChild(nullptr); // Filled in by fixup phase as the storage edge.
+
+                Node* join = addToGraph(Node::VarArg, ArrayJoin, OpInfo(arrayMode.asWord()), OpInfo(prediction));
+                setResult(join);
+                return CallOptimizationResult::Inlined;
+            }
+            default:
+                return CallOptimizationResult::DidNothing;
+            }
+
+            RELEASE_ASSERT_NOT_REACHED();
+            return CallOptimizationResult::DidNothing;
+        }
+
         case ArrayPopIntrinsic: {
             ArrayMode arrayMode = getArrayMode(Array::Write);
             if (!arrayMode.isJSArray())

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -175,6 +175,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case ArrayUnshift:
         case ArrayIncludes:
         case ArrayIndexOf:
+        case ArrayJoin:
         case HasIndexedProperty:
         case AtomicsAdd:
         case AtomicsAnd:
@@ -770,6 +771,11 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
             RELEASE_ASSERT_NOT_REACHED();
             return;
         }
+        return;
+    }
+
+    case ArrayJoin: {
+        clobberTop();
         return;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -160,6 +160,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(ArithUnary, Common) \
     CLONE_STATUS(ArrayIncludes, Common) \
     CLONE_STATUS(ArrayIndexOf, Common) \
+    CLONE_STATUS(ArrayJoin, Common) \
     CLONE_STATUS(ArrayPop, Common) \
     CLONE_STATUS(ArrayPush, Common) \
     CLONE_STATUS(ArrayShift, Common) \

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -476,6 +476,7 @@ bool doesGC(Graph& graph, Node* node)
     case ArrayConcatAppendOne:
     case ArrayIncludes:
     case ArrayIndexOf:
+    case ArrayJoin:
     case ParseInt: // We might resolve a rope even though we don't clobber anything.
     case SetAdd:
     case MapSet:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1834,6 +1834,20 @@ private:
             break;
         }
 
+        case ArrayJoin: {
+            Edge& array = m_graph.varArgChild(node, 0);
+            Edge& storage = m_graph.varArgChild(node, 2);
+            blessArrayOperation(array, Edge(), storage);
+            ASSERT_WITH_MESSAGE(storage.node(), "blessArrayOperation for ArrayJoin must set Butterfly for storage edge.");
+            fixEdge<KnownCellUse>(array);
+            Edge& separator = m_graph.varArgChild(node, 1);
+            if (separator->shouldSpeculateString())
+                fixEdge<StringUse>(separator);
+            else
+                fixEdge<UntypedUse>(separator);
+            break;
+        }
+
         case ArrayIncludes:
         case ArrayIndexOf:
             fixupArrayIndexOfOrArrayIncludes(node);

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -2330,6 +2330,7 @@ public:
         case EnumeratorNextUpdateIndexAndMode:
         case ArrayIncludes:
         case ArrayIndexOf:
+        case ArrayJoin:
             return true;
         default:
             break;
@@ -2743,6 +2744,7 @@ public:
         case ArrayUnshift:
         case ArrayIncludes:
         case ArrayIndexOf:
+        case ArrayJoin:
         case HasIndexedProperty:
         case AtomicsAdd:
         case AtomicsAnd:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -351,6 +351,7 @@ namespace JSC { namespace DFG {
     macro(ArrayConcatAppendOne, NodeResultJS | NodeMustGenerate) \
     macro(ArrayIncludes, NodeResultBoolean | NodeHasVarArgs) \
     macro(ArrayIndexOf, NodeResultInt32 | NodeHasVarArgs) \
+    macro(ArrayJoin, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(ArraySplice, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     \
     /* Optimizations for regular expression matching. */\

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1567,6 +1567,54 @@ JSC_DEFINE_JIT_OPERATION(operationArrayConcatAppendOne, JSArray*, (JSGlobalObjec
     OPERATION_RETURN(scope, tryConcatOneArgFast(globalObject, vm, firstArray, JSValue::decode(encodedSecond)));
 }
 
+static ALWAYS_INLINE JSString* arrayJoinWithStringSeparator(JSGlobalObject* globalObject, JSArray* array, JSString* separator, ThrowScope& scope)
+{
+    unsigned length = array->length();
+    if (!separator->length() && (array->indexingType() == ArrayWithContiguous || array->indexingType() == ArrayWithInt32)) {
+        auto* butterfly = array->butterfly();
+        JSOnlyStringsAndInt32sJoiner joiner(StringView { });
+        auto* joined = joiner.tryJoin(globalObject, butterfly->contiguous().data(), length);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (joined)
+            return joined;
+    }
+
+    auto view = separator->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    bool sawHoles = false;
+    bool genericCase = false;
+    return fastArrayJoin(globalObject, array, view, length, sawHoles, genericCase);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationArrayJoin, JSString*, (JSGlobalObject* globalObject, JSArray* array, JSString* separator))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    OPERATION_RETURN(scope, arrayJoinWithStringSeparator(globalObject, array, separator, scope));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationArrayJoinGeneric, JSString*, (JSGlobalObject* globalObject, JSArray* array, EncodedJSValue encodedSeparator))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue separatorValue = JSValue::decode(encodedSeparator);
+    JSString* separator;
+    if (separatorValue.isUndefined())
+        separator = vm.smallStrings.singleCharacterString(',');
+    else if (!separatorValue.isObject()) {
+        separator = separatorValue.toString(globalObject);
+        OPERATION_RETURN_IF_EXCEPTION(scope, nullptr);
+    } else
+        OPERATION_RETURN(scope, nullptr);
+    OPERATION_RETURN(scope, arrayJoinWithStringSeparator(globalObject, array, separator, scope));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationRegExpExecString, EncodedJSValue, (JSGlobalObject* globalObject, RegExpObject* regExpObject, JSString* argument))
 {
     SuperSamplerScope superSamplerScope(false);

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -231,6 +231,8 @@ JSC_DECLARE_JIT_OPERATION(operationArraySplice, EncodedJSValue, (JSGlobalObject*
 JSC_DECLARE_JIT_OPERATION(operationArraySpliceIgnoreResult, EncodedJSValue, (JSGlobalObject*, JSArray*, int32_t start, int32_t deleteCount, EncodedJSValue*, unsigned));
 JSC_DECLARE_JIT_OPERATION(operationArrayConcatArray, JSArray*, (JSGlobalObject*, JSArray*, JSArray*));
 JSC_DECLARE_JIT_OPERATION(operationArrayConcatAppendOne, JSArray*, (JSGlobalObject*, JSArray*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationArrayJoin, JSString*, (JSGlobalObject*, JSArray*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationArrayJoinGeneric, JSString*, (JSGlobalObject*, JSArray*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationRegExpExecString, EncodedJSValue, (JSGlobalObject*, RegExpObject*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationRegExpExec, EncodedJSValue, (JSGlobalObject*, RegExpObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationRegExpExecGeneric, EncodedJSValue, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1239,6 +1239,7 @@ private:
         case StringSubstr:
         case ToUpperCase:
         case ToLowerCase:
+        case ArrayJoin:
             setPrediction(SpecString);
             break;
 

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -367,7 +367,8 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case ArrayConcatArray:
     case ArrayConcatAppendOne:
     case ArrayIncludes:
-    case ArrayIndexOf: {
+    case ArrayIndexOf:
+    case ArrayJoin: {
         // You could plausibly move this code around as long as you proved the
         // incoming array base structure is an original array at the hoisted location.
         // Instead of doing that extra work, we just conservatively return false.

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -10198,6 +10198,37 @@ void SpeculativeJIT::compileArrayConcatAppendOne(Node* node)
     cellResult(resultGPR, node);
 }
 
+void SpeculativeJIT::compileArrayJoin(Node* node)
+{
+    Edge& separatorEdge = m_graph.varArgChild(node, 1);
+    SpeculateCellOperand array(this, m_graph.varArgChild(node, 0));
+    GPRReg arrayGPR = array.gpr();
+
+    if (separatorEdge.useKind() == StringUse) {
+        SpeculateCellOperand separator(this, separatorEdge);
+        GPRReg separatorGPR = separator.gpr();
+        speculateString(separatorEdge, separatorGPR);
+
+        flushRegisters();
+        GPRFlushedCallResult result(this);
+        GPRReg resultGPR = result.gpr();
+        callOperation(operationArrayJoin, resultGPR, LinkableConstant::globalObject(*this, node), arrayGPR, separatorGPR);
+        speculationCheck(ExoticObjectMode, JSValueSource(), nullptr, branchTestPtr(Zero, resultGPR));
+        cellResult(resultGPR, node);
+        return;
+    }
+
+    JSValueOperand separator(this, separatorEdge);
+    JSValueRegs separatorRegs = separator.jsValueRegs();
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationArrayJoinGeneric, resultGPR, LinkableConstant::globalObject(*this, node), arrayGPR, separatorRegs);
+    speculationCheck(ExoticObjectMode, JSValueSource(), nullptr, branchTestPtr(Zero, resultGPR));
+    cellResult(resultGPR, node);
+}
+
 void SpeculativeJIT::compileArraySplice(Node* node)
 {
     unsigned refCount = node->refCount();

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1688,6 +1688,7 @@ public:
     void compileArrayConcatAppendOne(Node*);
     void compileArraySplice(Node*);
     void compileArrayIndexOfOrArrayIncludes(Node*);
+    void compileArrayJoin(Node*);
     void compileArrayPush(Node*);
     void compileArrayUnshift(Node*);
     void compileNotifyWrite(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2973,6 +2973,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ArrayJoin: {
+        compileArrayJoin(node);
+        break;
+    }
+
     case DFG::Jump: {
         jump(node->targetBlock());
         noResult(node);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4279,6 +4279,11 @@ void SpeculativeJIT::compile(Node* node)
         compileArrayIndexOfOrArrayIncludes(node);
         break;
     }
+
+    case ArrayJoin: {
+        compileArrayJoin(node);
+        break;
+    }
         
     case ArrayPop: {
         ASSERT(node->arrayMode().isJSArray());

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1417,6 +1417,17 @@ private:
             break;
         }
 
+        case ArrayJoin: {
+            Edge& separatorEdge = m_graph.varArgChild(m_node, 1);
+            Node* separator = separatorEdge.node();
+            if (separatorEdge.useKind() == UntypedUse && separator->op() == JSConstant && separator->asJSValue().isUndefined()) {
+                Node* commaNode = m_insertionSet.insertConstant(m_nodeIndex, m_node->origin, vm().smallStrings.singleCharacterString(','));
+                separatorEdge = Edge(commaNode, StringUse);
+                m_changed = true;
+            }
+            break;
+        }
+
         case StringIndexOf: {
             Node* stringNode = m_node->child1().node();
             String string = stringNode->tryGetString(m_graph);

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -455,6 +455,7 @@ inline CapabilityLevel canCompile(Node* node)
     case ArraySplice:
     case ArrayIncludes:
     case ArrayIndexOf:
+    case ArrayJoin:
     case ArrayPop:
     case ArrayPush:
     case ArrayShift:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1207,6 +1207,9 @@ private:
         case ArrayIndexOf:
             compileArrayIndexOfOrArrayIncludes();
             break;
+        case ArrayJoin:
+            compileArrayJoin();
+            break;
         case CreateActivation:
             compileCreateActivation();
             break;
@@ -8529,6 +8532,23 @@ IGNORE_CLANG_WARNINGS_END
         LValue firstArray = lowCell(m_node->child1());
         LValue second = lowJSValue(m_node->child2());
         LValue result = vmCall(pointerType(), operationArrayConcatAppendOne, weakPointer(globalObject), firstArray, second);
+        speculate(ExoticObjectMode, noValue(), nullptr, m_out.isNull(result));
+        setJSValue(result);
+    }
+
+    void compileArrayJoin()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        LValue array = lowCell(m_graph.varArgChild(m_node, 0));
+        Edge separatorEdge = m_graph.varArgChild(m_node, 1);
+        LValue result;
+        if (separatorEdge.useKind() == StringUse) {
+            LValue separator = lowString(separatorEdge);
+            result = vmCall(pointerType(), operationArrayJoin, weakPointer(globalObject), array, separator);
+        } else {
+            LValue separator = lowJSValue(separatorEdge);
+            result = vmCall(pointerType(), operationArrayJoinGeneric, weakPointer(globalObject), array, separator);
+        }
         speculate(ExoticObjectMode, noValue(), nullptr, m_out.isNull(result));
         setJSValue(result);
     }

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -107,7 +107,7 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->toLocaleString, arrayProtoFuncToLocaleString, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().concatPublicName(), arrayProtoFuncConcat, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArrayConcatIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->fill, arrayProtoFuncFill, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->join, arrayProtoFuncJoin, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->join, arrayProtoFuncJoin, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArrayJoinIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("pop"_s, arrayProtoFuncPop, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public, ArrayPopIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().pushPublicName(), arrayProtoFuncPush, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArrayPushIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("reverse"_s, arrayProtoFuncReverse, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
@@ -442,8 +442,26 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncJoin, (JSGlobalObject* globalObject, Call
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    JSValue thisValue = callFrame->thisValue();
+    JSValue separatorValue = callFrame->argument(0);
+    {
+        if (isJSArray(thisValue) && separatorValue.isString()) [[likely]] {
+            JSArray* array = asArray(thisValue);
+            JSString* separatorString = asString(separatorValue);
+            if (!separatorString->length() && (array->indexingType() == ArrayWithContiguous || array->indexingType() == ArrayWithInt32)) {
+                auto* butterfly = array->butterfly();
+                unsigned length = butterfly->publicLength();
+                JSOnlyStringsAndInt32sJoiner joiner(StringView { });
+                auto* joined = joiner.tryJoin(globalObject, butterfly->contiguous().data(), length);
+                RETURN_IF_EXCEPTION(scope, { });
+                if (joined)
+                    return JSValue::encode(joined);
+            }
+        }
+    }
+
     // 1. Let O be ? ToObject(this value).
-    JSObject* thisObject = callFrame->thisValue().toThis(globalObject, ECMAMode::strict()).toObject(globalObject);
+    JSObject* thisObject = thisValue.toThis(globalObject, ECMAMode::strict()).toObject(globalObject);
     EXCEPTION_ASSERT(!!scope.exception() == !thisObject);
     if (!thisObject) [[unlikely]]
         return encodedJSValue();
@@ -458,7 +476,6 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncJoin, (JSGlobalObject* globalObject, Call
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     // 3. If separator is undefined, let separator be the single-element String ",".
-    JSValue separatorValue = callFrame->argument(0);
     if (separatorValue.isUndefined()) {
         const Latin1Character comma = ',';
 

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -61,6 +61,7 @@ namespace JSC {
     macro(ArraySpliceIntrinsic) \
     macro(ArrayIncludesIntrinsic) \
     macro(ArrayIndexOfIntrinsic) \
+    macro(ArrayJoinIntrinsic) \
     macro(ArraySortIntrinsic) \
     macro(ArrayValuesIntrinsic) \
     macro(ArrayKeysIntrinsic) \


### PR DESCRIPTION
#### 26b192b1d62481cbc5ef9833d657cf3126cdf458
<pre>
[JSC] Add ArrayJoin DFG nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=315610">https://bugs.webkit.org/show_bug.cgi?id=315610</a>
<a href="https://rdar.apple.com/177988353">rdar://177988353</a>

Reviewed by Sosuke Suzuki and Yijia Huang.

This patch implements ArrayJoin DFG node.

1. We add super fast path for join with empty string as it is very
   frequently happen (this is used when array is used for string
   builder).
2. We add DFG ArrayJoin node which optimize Array#join in general. We
   can use ArrayMode to reduce the kind of arrays we will see.

Tests: JSTests/stress/array-join-dfg-empty-separator.js
       JSTests/stress/array-join-dfg-string-separator.js
       JSTests/stress/array-join-dfg-undefined-separator.js
       JSTests/stress/array-join-dfg-untyped-separator.js

* JSTests/stress/array-join-dfg-empty-separator.js: Added.
(shouldBe):
(joinInt32):
(joinContiguous):
(joinDouble):
* JSTests/stress/array-join-dfg-object-separator-tostring-once.js: Added.
(shouldBe):
(join):
(noInline):
(shouldBe.call):
* JSTests/stress/array-join-dfg-string-separator.js: Added.
(shouldBe):
(joinComma):
(joinDash):
(joinMulti):
* JSTests/stress/array-join-dfg-tostring-mutation.js: Added.
(shouldBe):
(joinShrink):
(joinGrow):
(joinTransition):
(joinHolePunch):
(joinNonStringElement):
(joinShrinkEmpty):
(joinGrowEmpty):
* JSTests/stress/array-join-dfg-undefined-separator.js: Added.
(shouldBe):
(joinUndefinedLiteral):
(joinNoArg):
(joinViaVar):
(inner):
(outer):
* JSTests/stress/array-join-dfg-untyped-separator.js: Added.
(shouldBe):
(shouldThrow):
(join):
(customSep.toString):
(pick):
(joinPicked):
(throwingSep):
(i.catch):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasStorageChild const):
(JSC::DFG::Node::hasArrayMode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::arrayJoinWithStringSeparator):
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileArrayJoin):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::ArrayPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/Intrinsic.h:

Canonical link: <a href="https://commits.webkit.org/313949@main">https://commits.webkit.org/313949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/797743a44c252de8388328a224ce37ba98cd3ac0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173661 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121878 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127923 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108467 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27896 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21419 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156777 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176184 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25518 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29006 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136245 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136202 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147479 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101031 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25059 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31477 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24335 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197029 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37377 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110421 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51754 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36775 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2398 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37023 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36923 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->