### PR TITLE
[CMake] Emit Swift C++-interop header while compiling (instead of compiling twice)

### DIFF
--- a/Source/WebCore/PAL/pal/CMakeLists.txt
+++ b/Source/WebCore/PAL/pal/CMakeLists.txt
@@ -99,24 +99,6 @@ if (SWIFT_REQUIRED AND NOT (PORT STREQUAL GTK OR PORT STREQUAL WPE))
         ${PAL_DIR}/pal/crypto/CryptoKitShim.swift
     )
 
-    # Use -Xcc -I for ALL include paths (like Xcode does). Plain -I triggers
-    # Swift's own module discovery which causes C++ stdlib module conflicts.
-    set(PAL_SWIFT_INCLUDE_DIRECTORIES "")
-
-    set(PAL_SWIFT_EXTRA_OPTIONS
-        "-import-underlying-module"
-        "-strict-memory-safety"
-        "-swift-version" "6"
-        "-Xcc" "-I${PAL_FRAMEWORK_HEADERS_DIR}"
-        "-Xcc" "-I${CMAKE_BINARY_DIR}/WTF/Headers"
-        "-Xcc" "-I${CMAKE_BINARY_DIR}/bmalloc/Headers"
-        "-Xcc" "-I${CMAKE_BINARY_DIR}"
-        "-Xcc" "-I${PAL_DERIVED_SOURCES_DIR}"
-    )
-    # Bundled ICU shadows SDK ICU in explicit module builds on iOS.
-    if (NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
-        list(APPEND PAL_SWIFT_EXTRA_OPTIONS "-Xcc" "-I${CMAKE_BINARY_DIR}/ICU/Headers")
-    endif ()
     if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
         # iOS Swift compiles transitively load UIKit→UIKitCore→WebKit_Private,
         # whose PCM build needs our project -Xcc flags. Explicit modules let
@@ -149,10 +131,8 @@ if (SWIFT_REQUIRED AND NOT (PORT STREQUAL GTK OR PORT STREQUAL WPE))
         "${PAL_FRAMEWORK_HEADERS_DIR}/pal"
         "PALSwift-Generated.h")
 
-    # Also pass these options to CMake's native Swift compilation (the macro
-    # only adds them to the custom typecheck command). SHELL: keeps multi-token
-    # groups (-swift-version 6, -Xcc -I<path>) together; without it CMake
-    # deduplicates repeated -Xcc tokens, leaving -I paths unguarded.
+    # SHELL: keeps multi-token groups (-swift-version 6, -Xcc -I<path>) together;
+    # without it CMake deduplicates repeated -Xcc tokens, leaving -I paths unguarded.
     # https://bugs.webkit.org/show_bug.cgi?id=312105
     target_compile_options(PAL PRIVATE
         "$<$<COMPILE_LANGUAGE:Swift>:-import-underlying-module>"

--- a/Source/WebGPU/WebGPU/CMakeLists.txt
+++ b/Source/WebGPU/WebGPU/CMakeLists.txt
@@ -310,43 +310,6 @@ if (SWIFT_REQUIRED)
         "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fvisibility=hidden>"
     )
 
-    set(WebGPU_SWIFT_INCLUDE_DIRECTORIES "")
-
-    # FIXME: Disable access control until CMake replicates Xcode's DEFINES_MODULE.
-    # https://bugs.webkit.org/show_bug.cgi?id=312083
-    set(WebGPU_SWIFT_EXTRA_OPTIONS
-        "-Xcc" "-DENABLE_WEBGPU_SWIFT=1"
-        "-Xcc" "-DUCHAR_TYPE=char16_t"
-        "-Xcc" "-D__WEBGPU__"
-        "-Xcc" "-fvisibility=hidden"
-        "-Xfrontend" "-disable-access-control"
-        "-Xfrontend" "-emit-clang-header-min-access" "-Xfrontend" "public"
-        "-enable-experimental-feature" "LifetimeDependence"
-        "-enable-experimental-feature" "Lifetimes"
-        "-enable-experimental-feature" "SafeInteropWrappers"
-        "-import-underlying-module"
-        "-library-level" "spi"
-        "-no-verify-emitted-module-interface"
-        "-strict-memory-safety"
-        "-swift-version" "6"
-        "-F" "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
-        "-Xcc" "-I${WebGPU_FRAMEWORK_HEADERS_DIR}"
-        "-Xcc" "-I${WebGPU_PRIVATE_FRAMEWORK_HEADERS_DIR}"
-        "-Xcc" "-I${CMAKE_CURRENT_SOURCE_DIR}/Internal"
-        "-Xcc" "-I${CMAKE_CURRENT_SOURCE_DIR}"
-        "-Xcc" "-I${CMAKE_CURRENT_SOURCE_DIR}/.."
-        "-Xcc" "-I${WGSL_DIR}"
-        "-Xcc" "-I${WGSL_DIR}/AST"
-        "-Xcc" "-I${WGSL_DIR}/Metal"
-        "-Xcc" "-I${CMAKE_CURRENT_BINARY_DIR}/../WGSL"
-        "-Xcc" "-I${CMAKE_BINARY_DIR}/WTF/Headers"
-        "-Xcc" "-I${CMAKE_BINARY_DIR}/bmalloc/Headers"
-        "-Xcc" "-I${CMAKE_BINARY_DIR}"
-        "-Xcc" "-I${CMAKE_CURRENT_BINARY_DIR}"
-    )
-    if (NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
-        list(APPEND WebGPU_SWIFT_EXTRA_OPTIONS "-Xcc" "-I${CMAKE_BINARY_DIR}/ICU/Headers")
-    endif ()
     if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
         # iOS Swift compiles transitively load UIKit→UIKitCore→WebKit_Private,
         # whose PCM build needs our project -Xcc flags. Explicit modules let

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -925,8 +925,6 @@ if (NOT APPLE AND SWIFT_REQUIRED)
 
     foreach (_pair IN LISTS WebKit_SWIFT_CLANG_FLAG_PAIRS)
         target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:SHELL:${_pair}>")
-        string(REPLACE " " ";" _split "${_pair}")
-        list(APPEND WebKit_SWIFT_EXTRA_OPTIONS ${_split})
     endforeach ()
 endif ()
 

--- a/Source/WebKit/PlatformIOS.cmake
+++ b/Source/WebKit/PlatformIOS.cmake
@@ -565,10 +565,6 @@ target_compile_options(WebKit PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-private-module-interface-path ${CMAKE_BINARY_DIR}/Source/WebKit/WebKit.private.swiftinterface>"
 )
 
-set(WebKit_SWIFT_EXTRA_OPTIONS
-    -DHAVE_MATERIAL_HOSTING
-)
-
 # FIXME: Re-enable Swift C++ interop header generation once WebKit_Internal
 # umbrella module compiles cleanly on iOS. https://bugs.webkit.org/show_bug.cgi?id=312083
 set(WebKit_SWIFT_TYPECHECK_SOURCES "")

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -158,18 +158,10 @@ foreach (_dir IN LISTS WebKit_SWIFT_CLANG_INCLUDE_DIRS)
     list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -I${_dir}")
 endforeach ()
 
-# HAVE_MATERIAL_HOSTING is a PlatformHave.h preprocessor flag (macOS 16+),
-# not a CMake define. SWIFT_EXTRA_OPTIONS and SWIFT_INCLUDE_DIRECTORIES only
-# affect the typecheck custom command. Mirror everything to target_compile_options
-# so the actual Swift compilation sees the same flags.
-set(WebKit_SWIFT_EXTRA_OPTIONS -DHAVE_MATERIAL_HOSTING)
 target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MATERIAL_HOSTING>")
 foreach (_pair IN LISTS WebKit_SWIFT_CLANG_FLAG_PAIRS)
     target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:SHELL:${_pair}>")
-    string(REPLACE " " ";" _split "${_pair}")
-    list(APPEND WebKit_SWIFT_EXTRA_OPTIONS ${_split})
 endforeach ()
-list(APPEND WebKit_SWIFT_EXTRA_OPTIONS -Xfrontend -emit-clang-header-min-access -Xfrontend internal)
 foreach (_dir IN LISTS WebKit_SWIFT_INCLUDE_DIRECTORIES)
     target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:-I${_dir}>")
 endforeach ()

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -829,14 +829,9 @@ function(_webkit_setup_swift_header_deps _target _stamp _header)
     if (NOT EXISTS "${_trigger_path}")
         file(WRITE "${_trigger_path}" "// Auto-generated; mtime tracks ${_target}'s Swift emit-clang-header stamp.\n")
     endif ()
-    if (DEFINED ${_target}_SWIFT_INTEROP_SOURCES)
-        set(_trigger_deps ${${_target}_SWIFT_INTEROP_HEADERS})
-    else ()
-        set(_trigger_deps "${_stamp}")
-    endif ()
     add_custom_command(
         OUTPUT "${_trigger_path}"
-        DEPENDS ${_trigger_deps}
+        DEPENDS ${${_target}_SWIFT_INTEROP_HEADERS}
         COMMAND ${CMAKE_COMMAND} -E touch "${_trigger_path}"
         COMMENT "Refreshing ${_target} Swift rebuild trigger"
     )
@@ -849,13 +844,28 @@ function(_webkit_setup_swift_header_deps _target _stamp _header)
         add_dependencies(${_target}_SwiftCxxHeader ${_deps})
         add_dependencies(${_target}_SwiftGeneratedDeps ${_deps})
     endif ()
-    if (DEFINED ${_target}_SWIFT_INTEROP_SOURCES)
-        add_dependencies(${_target}_SwiftInterop ${_target}_SwiftCxxHeader)
-    elseif (_deps)
-        add_dependencies(${_target} ${_target}_SwiftCxxHeader)
-    else ()
-        target_sources(${_target} PRIVATE ${_header})
+
+    # Pre-CMP0157 CMake compiles .swift files inside ${_target}'s link rule, which is a
+    # circular dependency. This workaround retains the old "compile twice" behavior,
+    # with the first compilation producing a throw-away .a file for the purpose of
+    # generating the C++ interop header.
+    if (NOT POLICY CMP0157)
+        get_target_property(_swift_srcs ${_target} SOURCES)
+        list(FILTER _swift_srcs INCLUDE REGEX "\\.swift$")
+        if (_swift_srcs)
+            get_target_property(_module_name ${_target} Swift_MODULE_NAME)
+            add_library(${_target}_SwiftCompile STATIC EXCLUDE_FROM_ALL ${_swift_srcs})
+            set_target_properties(${_target}_SwiftCompile PROPERTIES Swift_MODULE_NAME ${_module_name})
+            target_compile_options(${_target}_SwiftCompile PRIVATE $<TARGET_PROPERTY:${_target},COMPILE_OPTIONS>)
+            target_compile_definitions(${_target}_SwiftCompile PRIVATE $<TARGET_PROPERTY:${_target},COMPILE_DEFINITIONS>)
+            target_include_directories(${_target}_SwiftCompile PRIVATE $<TARGET_PROPERTY:${_target},INCLUDE_DIRECTORIES>)
+            add_dependencies(${_target}_SwiftCompile ${_target}_SwiftGeneratedDeps)
+            file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swift-link)
+            set_target_properties(${_target} PROPERTIES Swift_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swift-link)
+        endif ()
     endif ()
+
+    add_dependencies(${_target}_SwiftInterop ${_target}_SwiftCxxHeader)
 endfunction()
 
 macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_name _interop_module_path _output_header)
@@ -884,22 +894,6 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         GET_WEBKIT_CONFIG_VARIABLES(_swift_definitions)
         list(TRANSFORM _swift_definitions PREPEND "-D")
         set(_swift_options ${_swift_definitions})
-        set(_swift_xcc_options "")
-        foreach (item IN LISTS _swift_options)
-            list(APPEND _swift_xcc_options "-Xcc" ${item})
-        endforeach ()
-        get_directory_property(_dir_defs COMPILE_DEFINITIONS)
-        foreach (_def IN LISTS _dir_defs)
-            # Skip cmake-build-mode defines: propagating them to the Clang
-            # importer makes SDK framework PCMs (e.g. JSC's config.h) take
-            # cmake-only branches and look for headers like cmakeconfig.h that
-            # don't exist in SDK PCM build context. Our own C/C++ TUs still
-            # see them via add_definitions; only the Swift→Clang side is gated.
-            if (_def MATCHES "^BUILDING_WITH_CMAKE($|=)" OR _def MATCHES "^HAVE_CONFIG_H($|=)")
-                continue ()
-            endif ()
-            list(APPEND _swift_xcc_options "-Xcc" "-D${_def}")
-        endforeach ()
         # Other options needed by Swift for C++ interop, including the location
         # of the modulemap and hader for WebKit's internal "APIs" which we
         # make available from C++ to Swift.
@@ -1043,16 +1037,6 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
             endif ()
         endforeach ()
 
-        if (DEFINED ${_target}_SWIFT_TYPECHECK_SOURCES)
-            set(_swift_sources ${${_target}_SWIFT_TYPECHECK_SOURCES})
-        else ()
-            set(_swift_sources $<TARGET_PROPERTY:${_target},SOURCES>)
-            set(_swift_sources $<FILTER:${_swift_sources},INCLUDE,\\.swift$>)
-            # Exclude the auto-generated rebuild-trigger source from emit-clang-header;
-            # otherwise emit-clang-header → stamp → trigger → emit-clang-header forms a cycle.
-            # The trigger is fed only into the main swift compile.
-            set(_swift_sources $<FILTER:${_swift_sources},EXCLUDE,_SwiftRebuildTrigger\\.swift$>)
-        endif ()
         # Empty list means: skip Swift C++ interop header generation entirely.
         # Useful for iOS where some Swift files transitively import broken
         # umbrella modules. https://bugs.webkit.org/show_bug.cgi?id=312083
@@ -1063,87 +1047,6 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
 
         cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR include OUTPUT_VARIABLE _header_base_path)
         cmake_path(APPEND _header_base_path ${_output_header} OUTPUT_VARIABLE _header_path)
-        cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR "${_target}.emit-module.d" OUTPUT_VARIABLE _depfile_path)
-
-        # Allow targets to override include directories for Swift (e.g. to exclude
-        # directories containing conflicting module.modulemap files).
-        if (DEFINED ${_target}_SWIFT_INCLUDE_DIRECTORIES AND NOT "${${_target}_SWIFT_INCLUDE_DIRECTORIES}" STREQUAL "")
-            list(TRANSFORM ${_target}_SWIFT_INCLUDE_DIRECTORIES PREPEND "-I" OUTPUT_VARIABLE _swift_include_dirs)
-        elseif (NOT DEFINED ${_target}_SWIFT_INCLUDE_DIRECTORIES)
-            set(_swift_include_dirs $<LIST:TRANSFORM,$<TARGET_PROPERTY:${_target},INCLUDE_DIRECTORIES>,PREPEND,-I>)
-        else ()
-            set(_swift_include_dirs "")
-        endif ()
-
-        set(_swift_sdk_flag "")
-        if (APPLE AND CMAKE_OSX_SYSROOT)
-            set(_swift_sdk_flag -sdk ${CMAKE_OSX_SYSROOT})
-        endif ()
-
-        set(_swift_target_flag "")
-        if (CMAKE_Swift_COMPILER_TARGET)
-            set(_swift_target_flag -target ${CMAKE_Swift_COMPILER_TARGET})
-        endif ()
-
-        set(_swift_private_frameworks_flag "")
-        if (CMAKE_SYSTEM_NAME STREQUAL "iOS" AND CMAKE_OSX_SYSROOT)
-            # Our just-built frameworks (WebKit.framework, WebCore.framework,
-            # JavaScriptCore.framework, etc.) must come BEFORE the SDK's
-            # PrivateFrameworks so `<WebCore/X.h>` etc. resolve to the
-            # cmake-built copies that match the source we're compiling.
-            # Mirrors Xcode's BUILT_PRODUCTS_DIR taking precedence over SDK.
-            set(_swift_private_frameworks_flag
-                -Xcc -F${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-                -F ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-                -Xcc -iframework${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks
-                -F ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks
-            )
-            if (EXISTS "${CMAKE_OSX_SYSROOT}/usr/local/include/unicode_private.modulemap")
-                list(APPEND _swift_private_frameworks_flag
-                    -Xcc -isystem${CMAKE_OSX_SYSROOT}/usr/local/include
-                    -Xcc -fmodule-map-file=${CMAKE_OSX_SYSROOT}/usr/local/include/unicode_private.modulemap
-                )
-            endif ()
-        endif ()
-
-        set(_swift_wka_flag "")
-        if (WEBKIT_ADDITIONS_COMPILE_PATH)
-            set(_swift_wka_flag -Xcc -isystem${WEBKIT_ADDITIONS_COMPILE_PATH})
-        elseif (WEBKIT_ADDITIONS_INCLUDE_PATH)
-            set(_swift_wka_flag -Xcc -isystem${WEBKIT_ADDITIONS_INCLUDE_PATH})
-        endif ()
-
-        # Cmake's WTF/bmalloc/PAL/WebCore/JSC are not real framework bundles —
-        # they're directories of staged headers. Pass them as -Xcc -I so PCM
-        # compiles spawned from this target's Swift compile can resolve
-        # `<wtf/X.h>`, `<JavaScriptCore/X.h>`, etc. when our framework-staged
-        # WebCore_Private/JavaScriptCore_Private modulemaps reach into them.
-        set(_swift_internal_includes "")
-        foreach (_dir IN ITEMS
-            "${WTF_FRAMEWORK_HEADERS_DIR}"
-            "${bmalloc_FRAMEWORK_HEADERS_DIR}"
-            "${PAL_FRAMEWORK_HEADERS_DIR}"
-            "${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}"
-            "${JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS_DIR}")
-            if (_dir)
-                list(APPEND _swift_internal_includes -Xcc "-I${_dir}")
-            endif ()
-        endforeach ()
-        # libwebrtc's SDK-installed forwarding headers (usr/local/include/webrtc/...)
-        # do quoted #include "api/audio/..." lookups that need our local libwebrtc
-        # source tree on the include path. Mirrors WebKit/CMakeLists.txt's
-        # WebKit_SYSTEM_INCLUDE_DIRECTORIES, which the clang importer doesn't see
-        # via INCLUDE_DIRECTORIES alone.
-        if (USE_LIBWEBRTC)
-            foreach (_dir IN ITEMS
-                "${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source"
-                "${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source/webrtc"
-                "${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source/third_party/abseil-cpp")
-                if (EXISTS "${_dir}")
-                    list(APPEND _swift_internal_includes -Xcc "-isystem${_dir}")
-                endif ()
-            endforeach ()
-        endif ()
 
         set(_header_tmp_path "${_header_path}.tmp")
         set(_header_stamp_path "${_header_path}.stamp")
@@ -1153,10 +1056,7 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         # -emit-clang-header-min-access was added in Swift 6.3. Please simplify
         # this once that becomes mandatory.
         include(CheckCompilerFlag)
-        check_compiler_flag(Swift -emit-clang-header-min-access CAN_USE_EMIT_CLANG_HEADER_MIN_ACCESS)
-        if (CAN_USE_EMIT_CLANG_HEADER_MIN_ACCESS)
-            set(${_target}_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS_FLAGS -Xfrontend -emit-clang-header-min-access -Xfrontend ${${_target}_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS})
-        endif ()
+        check_compiler_flag(Swift "-emit-clang-header-min-access internal" CAN_USE_EMIT_CLANG_HEADER_MIN_ACCESS)
         # Always create the SwiftCxxHeader placeholder so external callers
         # (e.g. Source/WebKit/CMakeLists.txt's deferred add_dependencies) can
         # reference it even when ${_target}_SWIFT_TYPECHECK_SOURCES is empty
@@ -1167,37 +1067,20 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
             # call populates it with all generated (binary-dir) headers for this target
             # once ${_target}_HEADERS and ${_target}_DERIVED_SOURCES are fully known.
             add_custom_target(${_target}_SwiftGeneratedDeps)
+            target_compile_options(${_target} PRIVATE
+                "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-clang-header-path ${_header_tmp_path}>")
+            if (CAN_USE_EMIT_CLANG_HEADER_MIN_ACCESS)
+                target_compile_options(${_target} PRIVATE
+                    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -emit-clang-header-min-access -Xfrontend ${${_target}_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS}>")
+            endif ()
             add_custom_command(
                 OUTPUT ${_header_stamp_path}
                 BYPRODUCTS ${_header_path}
-                DEPENDS ${_swift_sources} ${_target}_SwiftGeneratedDeps ${${_target}_SWIFT_INTEROP_HEADERS}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                COMMAND
-                    ${CMAKE_Swift_COMPILER} --original-swift-compiler=${ORIGINAL_Swift_COMPILER} -typecheck
-                    ${_swift_options}
-                    ${${_target}_SWIFT_EXTRA_OPTIONS}
-                    ${_swift_sdk_flag}
-                    ${_swift_target_flag}
-                    ${_swift_private_frameworks_flag}
-                    ${_swift_wka_flag}
-                    ${_swift_internal_includes}
-                    ${_swift_include_dirs}
-                    ${_swift_xcc_options}
-                    ${_swift_sources}
-                    -module-name ${_module_name}
-                    ${${_target}_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS_FLAGS}
-                    -emit-clang-header-path ${_header_tmp_path}
-                    -emit-dependencies
-                COMMAND
-                    ${CMAKE_COMMAND} -E copy_if_different ${_header_tmp_path} ${_header_path}
-                COMMAND
-                    ${CMAKE_COMMAND} -E rm -f ${_header_tmp_path}
-                COMMAND
-                    ${CMAKE_COMMAND} -E touch ${_header_stamp_path}
-                DEPFILE ${_depfile_path}
-                COMMENT
-                    "Generating ${_target} C++ bindings to Swift at '${_header_path}'"
-                COMMAND_EXPAND_LISTS)
+                DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${_module_name}.swiftmodule
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_header_tmp_path} ${_header_path}
+                COMMAND ${CMAKE_COMMAND} -E touch ${_header_stamp_path}
+                COMMENT "Generating ${_target} Swift-C++ header"
+                VERBATIM)
 
             target_include_directories(${_target} PUBLIC ${_header_base_path})
             # Defer dependency wiring until end-of-directory so if(TARGET ...) inside


### PR DESCRIPTION
#### 9deb2aaf5f035dfb8ca8ad58d9b8eaae419a5d00
<pre>
[CMake] Emit Swift C++-interop header while compiling (instead of compiling twice)
<a href="https://bugs.webkit.org/show_bug.cgi?id=315699">https://bugs.webkit.org/show_bug.cgi?id=315699</a>
<a href="https://rdar.apple.com/178081023">rdar://178081023</a>

Reviewed by Mike Wyrzykowski.

Currently we compile Swift modules in -typecheck first, and then in
regular mode. -typecheck mode emits the Swift-C++ interop header.

Adopt -emit-clang-header so we can do both in one go.

Clients that depend on the Swift interop header depend on this build
step via ${target}_SwiftInterop sub-targets.

* Source/WebCore/PAL/pal/CMakeLists.txt:
* Source/WebGPU/WebGPU/CMakeLists.txt:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/PlatformIOS.cmake:
* Source/WebKit/PlatformMac.cmake:

* Source/cmake/WebKitMacros.cmake: In Linux builds with CMake &lt; CMP0157,
compilation and linking happen at the same time, which creates a circular
dependency in the build graph.

Work around this issue by:
* defining a separate Swift sub-target
* describing the target&apos;s output as throwaway .a, so implicit
link-when-compiling is a no-op.

Canonical link: <a href="https://commits.webkit.org/314042@main">https://commits.webkit.org/314042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f01dbcfb368ce3f6ce5c8b6d75575674457ed74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122234 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16e60f0e-854d-418f-922b-f3eba40cd88d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128202 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0f3d384-2059-4bd7-820c-232ec0336719) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148242 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108728 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/421104b5-e014-4a2d-a9e7-5560a19a4cc8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28170 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21775 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157137 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176543 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25873 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29395 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/27648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136522 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136467 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147740 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101517 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25103 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31740 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24605 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197381 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110808 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/51905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37134 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2680 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37380 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37278 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->