### PR TITLE
[GFC] Complete specified size suggestion handling in GridLayoutUtils

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -66,14 +66,19 @@ static bool NODELETE spansFlexMaxTrackSizingFunction(WTF::Range<size_t> spannedT
 
 // https://www.w3.org/TR/css-grid-2/#specified-size-suggestion
 // If the item's preferred size in the relevant axis is definite, then the specified size suggestion is that size. It is otherwise undefined.
-static std::optional<LayoutUnit> inlineSpecifiedSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, LayoutUnit containingBlockSize)
+static std::optional<LayoutUnit> inlineSpecifiedSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, std::optional<LayoutUnit> containingBlockSize)
 {
     auto& preferredSize = gridItem.inlineAxisSizes().preferredSize;
-    if (preferredSize.isFixed() || preferredSize.isPercent() || preferredSize.isCalculated())
-        return Style::evaluate<LayoutUnit>(preferredSize, containingBlockSize, gridItem.usedZoom()) + borderAndPadding;
-    if (preferredSize.isAuto())
+    if (auto fixed = preferredSize.tryFixed())
+        return Style::evaluate<LayoutUnit>(*fixed, gridItem.usedZoom()) + borderAndPadding;
+    if (preferredSize.isPercentOrCalculated()) {
+        if (!containingBlockSize)
+            return { };
+        return Style::evaluate<LayoutUnit>(preferredSize, *containingBlockSize, gridItem.usedZoom()) + borderAndPadding;
+    }
+    if (preferredSize.isAuto() || preferredSize.isMinContent() || preferredSize.isMaxContent() || preferredSize.isFitContent() || preferredSize.isStretch() || preferredSize.isIntrinsicKeyword() || preferredSize.isMinIntrinsic())
         return { };
-    ASSERT_NOT_IMPLEMENTED_YET();
+    ASSERT_NOT_REACHED();
     return { };
 }
 
@@ -91,14 +96,19 @@ static LayoutUnit inlineContentSizeSuggestion(const PlacedGridItem& gridItem, co
 
 // https://www.w3.org/TR/css-grid-2/#specified-size-suggestion
 // If the item's preferred size in the relevant axis is definite, then the specified size suggestion is that size. It is otherwise undefined.
-static std::optional<LayoutUnit> blockSpecifiedSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, LayoutUnit containingBlockSize)
+static std::optional<LayoutUnit> blockSpecifiedSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, std::optional<LayoutUnit> containingBlockSize)
 {
     auto& preferredSize = gridItem.blockAxisSizes().preferredSize;
-    if (preferredSize.isFixed() || preferredSize.isPercent() || preferredSize.isCalculated())
-        return Style::evaluate<LayoutUnit>(preferredSize, containingBlockSize, gridItem.usedZoom()) + borderAndPadding;
-    if (preferredSize.isAuto())
+    if (auto fixed = preferredSize.tryFixed())
+        return Style::evaluate<LayoutUnit>(*fixed, gridItem.usedZoom()) + borderAndPadding;
+    if (preferredSize.isPercentOrCalculated()) {
+        if (!containingBlockSize)
+            return { };
+        return Style::evaluate<LayoutUnit>(preferredSize, *containingBlockSize, gridItem.usedZoom()) + borderAndPadding;
+    }
+    if (preferredSize.isAuto() || preferredSize.isMinContent() || preferredSize.isMaxContent() || preferredSize.isFitContent() || preferredSize.isStretch() || preferredSize.isIntrinsicKeyword() || preferredSize.isMinIntrinsic())
         return { };
-    ASSERT_NOT_IMPLEMENTED_YET();
+    ASSERT_NOT_REACHED();
     return { };
 }
 


### PR DESCRIPTION
#### bf00feccd25b9bea655bc3f83fb06d85f4330fea
<pre>
[GFC] Complete specified size suggestion handling in GridLayoutUtils
<a href="https://bugs.webkit.org/show_bug.cgi?id=315616">https://bugs.webkit.org/show_bug.cgi?id=315616</a>
<a href="https://rdar.apple.com/177991503">rdar://177991503</a>

Reviewed by NOBODY (OOPS!).

The inline/blockSpecifiedSizeSuggestion helpers previously only handled
fixed, percent, calc, and auto preferred sizes, falling through to
ASSERT_NOT_IMPLEMENTED_YET() for the remaining sizing keywords. The
suggestion is defined only when the preferred size is definite and is
otherwise undefined, so all intrinsic keywords (min-content, max-content,
fit-content, stretch, intrinsic, min-intrinsic) and auto should yield no
value. With every alternative of PreferredSize now covered, the trailing
ASSERT becomes ASSERT_NOT_REACHED().

Also change the containing block size parameter to std::optional&lt;LayoutUnit&gt;.
During the track sizing algorithm there is no available space to resolve
percent or calc against; in that case the suggestion is undefined and the
function returns nullopt. Existing callers pass a definite LayoutUnit,
which converts implicitly to the optional, so behavior is unchanged.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf00feccd25b9bea655bc3f83fb06d85f4330fea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173628 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121845 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127895 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90019 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167552 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108439 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/716458bf-d0a8-4f00-96d0-de7ec0957abb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29239 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27865 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21386 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176151 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28972 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136211 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136175 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147434 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100990 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31449 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24290 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37344 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110388 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36742 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2353 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36990 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36890 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->