### PR TITLE
Zooming with scroll snap can trigger infinite recursion

### DIFF
--- a/LayoutTests/css3/scroll-snap/scroll-snap-zoom-after-overflow-scroll-expected.txt
+++ b/LayoutTests/css3/scroll-snap/scroll-snap-zoom-after-overflow-scroll-expected.txt
@@ -1,0 +1,10 @@
+Changing page zoom on a horizontal scroll-snap carousel should not crash
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/css3/scroll-snap/scroll-snap-zoom-after-overflow-scroll.html
+++ b/LayoutTests/css3/scroll-snap/scroll-snap-zoom-after-overflow-scroll.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        section {
+            display: flex;
+            margin: 2rem auto;
+            inline-size: 50%;
+            block-size: 10rem;
+            overflow: scroll;
+            scrollbar-width: none;
+            overscroll-behavior: none;
+            scroll-snap-type: x mandatory;
+        }
+
+        section > div {
+            min-inline-size: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 3rem;
+            scroll-snap-align: start;
+            scroll-snap-stop: always;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+        description("Changing page zoom on a horizontal scroll-snap carousel should not crash");
+        jsTestIsAsync = true;
+
+        async function startTest()
+        {
+            const carousel = document.getElementById('carousel');
+            const slide1 = document.getElementById('slide1');
+            const slide3 = document.getElementById('slide3');
+
+            let index = 0;
+            function updateIndex(step) {
+                index += step;
+                slide1.textContent = index - 1;
+                document.getElementById('slide2').textContent = index;
+                slide3.textContent = index + 1;
+            }
+
+            const observer = new IntersectionObserver(([{ isIntersecting, target }]) => {
+                if (isIntersecting) {
+                    updateIndex(target === slide1 ? -1 : 1);
+                    carousel.scrollLeft = carousel.clientWidth;
+                }
+            }, { root: carousel, threshold: 1.0 });
+
+            carousel.scrollLeft = carousel.clientWidth;
+            observer.observe(slide1);
+            observer.observe(slide3);
+
+            await new Promise(requestAnimationFrame);
+            await new Promise(requestAnimationFrame);
+
+            if (window.internals) {
+                internals.setPageZoomFactor(2);
+                await new Promise(requestAnimationFrame);
+                internals.setPageZoomFactor(1);
+                await new Promise(requestAnimationFrame);
+            }
+
+            testPassed("Did not crash.");
+            document.getElementById('carousel').remove();
+            finishJSTest();
+        }
+
+        window.addEventListener('load', startTest, false);
+    </script>
+</head>
+<body>
+    <section id="carousel">
+        <div id="slide1">-1</div>
+        <div id="slide2">0</div>
+        <div id="slide3">1</div>
+    </section>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -242,8 +242,8 @@ void RenderLayerScrollableArea::applyPostLayoutScrollPositionIfNeeded()
     if (!m_postLayoutScrollPosition)
         return;
 
-    scrollToOffset(scrollOffsetFromPosition(m_postLayoutScrollPosition.value()));
-    m_postLayoutScrollPosition = std::nullopt;
+    auto position = std::exchange(m_postLayoutScrollPosition, std::nullopt);
+    scrollToOffset(scrollOffsetFromPosition(*position));
 }
 
 void RenderLayerScrollableArea::scrollToXPosition(int x, const ScrollPositionChangeOptions& options)


### PR DESCRIPTION
#### 1aba36b70ea151d9cd176af96b7ccf439a0a49c8
<pre>
Zooming with scroll snap can trigger infinite recursion
<a href="https://bugs.webkit.org/show_bug.cgi?id=315613">https://bugs.webkit.org/show_bug.cgi?id=315613</a>
<a href="https://rdar.apple.com/177991127">rdar://177991127</a>

Reviewed by Sammy Gill.

Changing the zoom level triggered recursion via:

RenderLayer::updateLayerPositionsAfterLayout(bool, bool)
RenderLayerCompositor::updateCompositingLayers(WebCore::CompositingUpdateType, WebCore::RenderLayer*)
RenderLayerScrollableArea::updateCompositingLayersAfterScroll()
RenderLayerScrollableArea::scrollTo(WebCore::IntPoint const&amp;)
RenderLayerScrollableArea::setScrollOffset(WebCore::IntPoint const&amp;)
ScrollableArea::scrollPositionChanged(WebCore::IntPoint const&amp;)
ScrollableArea::notifyScrollPositionChanged(WebCore::IntPoint const&amp;)
AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll()
AsyncScrollingCoordinator::applyScrollPositionUpdate(WebCore::ScrollUpdate&amp;&amp;, WebCore::ScrollType, WebCore::ViewportRectStability)
AsyncScrollingCoordinator::applyScrollUpdate(WebCore::ScrollUpdate&amp;&amp;, WebCore::ScrollType, WebCore::ViewportRectStability)
AsyncScrollingCoordinator::requestScrollToPosition(WebCore::ScrollableArea&amp;, WebCore::IntPoint const&amp;, WebCore::ScrollPositionChangeOptions const&amp;)
RenderLayerScrollableArea::requestScrollToPosition(WebCore::IntPoint const&amp;, WebCore::ScrollPositionChangeOptions const&amp;)
RenderLayerScrollableArea::scrollToOffset(WebCore::IntPoint const&amp;, WebCore::ScrollPositionChangeOptions const&amp;)
RenderLayerScrollableArea::applyPostLayoutScrollPositionIfNeeded()
RenderLayer::recursiveUpdateLayerPositions&lt;&gt;()
...
RenderLayer::recursiveUpdateLayerPositions&lt;&gt;()
RenderLayer::updateLayerPositionsAfterLayout(bool, bool)
LocalFrameViewLayoutContext::flushUpdateLayerPositions()
LocalFrameViewLayoutContext::didLayout(bool)

Clear `m_postLayoutScrollPosition` in `RenderLayerScrollableArea::applyPostLayoutScrollPositionIfNeeded()`
to prevent the recursion.

Test: css3/scroll-snap/scroll-snap-zoom-after-overflow-scroll.html

* LayoutTests/css3/scroll-snap/scroll-snap-zoom-after-overflow-scroll-expected.txt: Added.
* LayoutTests/css3/scroll-snap/scroll-snap-zoom-after-overflow-scroll.html: Added.
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::applyPostLayoutScrollPositionIfNeeded):

Canonical link: <a href="https://commits.webkit.org/313972@main">https://commits.webkit.org/313972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1276c578d11049c3ccd979e427580c9d10a6a87a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121846 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ed60a87-dc56-4307-95a3-fd793a816681) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127894 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90020 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa556c36-befc-4418-bfe7-2137b291314a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108438 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d663fb84-fb9b-4547-b1a2-e66c28a8fb9c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29240 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27866 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21387 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139143 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176152 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28973 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136212 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136176 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36706 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147451 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100991 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31450 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24307 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37345 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110389 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36743 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2370 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36891 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->