### PR TITLE
AX: When an area element's associated image is removed from the DOM, it becomes orphaned in the accessibility tree

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/accessibility-crash-in-axcontainer-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/accessibility-crash-in-axcontainer-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS link.description is 'AXLabel: yellow'
-PASS link.parentElement() == null || link.parentElement().isValid is true
+PASS link.parentElement().isValid is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/ios-simulator/accessibility-crash-in-axcontainer.html
+++ b/LayoutTests/accessibility/ios-simulator/accessibility-crash-in-axcontainer.html
@@ -32,8 +32,9 @@ var successfullyParsed = false;
 
         document.getElementById("backImg").parentNode.removeChild(document.getElementById("backImg"));
 
-        // Should not crash here when asking for parentElement (even though it was removed).
-        shouldBeTrue("link.parentElement() == null || link.parentElement().isValid");
+        // Retrieving the parent should not cause a crash (despite the associated image being removed), and should
+        // return a valid fallback parent.
+        shouldBeTrue("link.parentElement().isValid");
     }
 
     successfullyParsed = true;

--- a/LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
@@ -322,7 +322,9 @@ map
       Could not get AX element.
 
 area
-      Could not get AX element.
+      AXRole: AXLink
+      AXSubrole:
+      AXRoleDescription: link
 
 main
       AXRole: AXGroup

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -274,7 +274,11 @@ AccessibilityObject* AccessibilityNodeObject::parentObject() const
 
     if (RefPtr areaElement = dynamicDowncast<HTMLAreaElement>(*node)) {
         RefPtr map = ancestorsOfType<HTMLMapElement>(*areaElement).first();
-        return map ? cache->getOrCreate(map->imageElement().get()) : nullptr;
+        if (RefPtr imageElement = map ? map->imageElement() : nullptr)
+            return cache->getOrCreate(imageElement.get());
+        // The usemap-associated image was removed from the DOM. Fall through and use
+        // the area's DOM parent (the <map>) as the AX parent so the area stays
+        // connected to the AX tree instead of being orphaned.
     }
 
     if (RefPtr ownerParent = ownerParentObject()) [[unlikely]]


### PR DESCRIPTION
#### 6104138c2c147cd98292dc76ad0e4d7da104fc78
<pre>
AX: When an area element&apos;s associated image is removed from the DOM, it becomes orphaned in the accessibility tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=315622">https://bugs.webkit.org/show_bug.cgi?id=315622</a>
<a href="https://rdar.apple.com/177995531">rdar://177995531</a>

Reviewed by Dominic Mazzoni.

When an area element&apos;s associated image is removed from the DOM, fallback to using the area element&apos;s natural DOM
parent, ensuring the area link is still accessible to assistive technologies.

* LayoutTests/accessibility/ios-simulator/accessibility-crash-in-axcontainer-expected.txt:
* LayoutTests/accessibility/ios-simulator/accessibility-crash-in-axcontainer.html:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::parentObject const):

Canonical link: <a href="https://commits.webkit.org/314059@main">https://commits.webkit.org/314059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b11ce282085d6055cadb69b58f8b86ab80f2a083

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122005 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6237495b-ed3f-4255-b98c-9158c0672078) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128038 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19c50ae2-26e1-4267-a4b4-2b71f4660bed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167712 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108584 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/899137bc-bf60-40c9-ba7b-cfd419f0617f) 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29384 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Passed layout tests; 4 new passes 1 flakes 4 failures; Uploaded test results; Running re-run-layout-tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28010 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21547 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176311 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29137 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136356 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136319 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36785 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147591 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101206 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31592 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24468 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37504 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110549 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36902 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2513 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37150 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->