### PR TITLE
[Site Isolation] [intersection-observer] In Site Isolation mode, scroll margin can get applied to cross-origin frame

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -273,7 +273,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-iframe-002.sub.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-toggle-source.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html [ Failure ]
-imported/w3c/web-platform-tests/intersection-observer/scroll-margin-propagation.html [ Failure ]
 imported/w3c/web-platform-tests/loading/preloader-template.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/defer/tentative/defer-back.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/defer/tentative/restore-after-bfcache.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -259,9 +259,6 @@ http/tests/security/frameNavigation/not-opener.html [ Failure ]
 # stored and run separately at http/tests/site-isolation/inspector/unit-tests/target-manager.html.
 inspector/unit-tests/target-manager.html [ Skip ]
 
-# Intersection Observer x Site Isolation is not fully implemented.
-imported/w3c/web-platform-tests/intersection-observer/scroll-margin-propagation.html [ Failure ]
-
 # Inspector protocol commands (e.g. CSS.getMatchedStylesForNode) return
 # "Not yet implemented for frame targets" under site isolation.
 inspector/css/getMatchedStylesForNodeAdoptedStyleSheet.html [ Skip ]

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -372,25 +372,6 @@ static void expandRootBoundsWithRootMargin(FloatRect& rootBounds, const Intersec
 // originates the very first rect)
 static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const LayoutRect& rect, const SecurityOrigin& targetSecurityOrigin, Variant<const RenderElement*, const Frame*> rendererOrFrame, std::optional<IntersectionObserverMarginBox> scrollMargin)
 {
-    RefPtr rendererOrFrameSecurityOrigin = WTF::visit(WTF::makeVisitor(
-        [&] (const RenderElement* renderer) { return Ref<const Frame>(renderer->frame())->frameDocumentSecurityOrigin(); },
-        [&] (const Frame* frame) { return frame->frameDocumentSecurityOrigin(); }
-    ), rendererOrFrame);
-
-    // targetSecurityOrigin is the security origin of the target (the element that originates the very first rect)
-    // Scroll margin should not propagate past the first cross-origin frame in the chain leading to the main frame.
-    // e.g given the chain: main frame <- cross-origin frame <- same-origin frame 2 <- same-origin frame 1 <- target
-    // then scroll margin is applied to same-origin frame 1/2 but not to cross-origin and main frames.
-    // Hence, clear out the scroll margin when we see a cross-origin frame.
-    bool isSameOriginDomain = [&] () {
-        if (rendererOrFrameSecurityOrigin)
-            return rendererOrFrameSecurityOrigin->isSameOriginDomain(targetSecurityOrigin);
-
-        return false;
-    }();
-    if (!isSameOriginDomain)
-        scrollMargin.reset();
-
     RefPtr<const Frame> enclosingFrame = WTF::visit(WTF::makeVisitor(
         [&] (const RenderElement* renderer) { return static_cast<const Frame*>(&renderer->frame()); },
         [&] (const Frame* frame) { return static_cast<const Frame*>(frame->tree().parent()); }
@@ -403,6 +384,19 @@ static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const Lay
     ASSERT(enclosingFrameView);
     if (!enclosingFrameView)
         return std::nullopt;
+
+    // Scroll margin should not propagate past the first cross-origin frame in the chain leading to the main frame.
+    // e.g given the chain: main <- cross-origin <- same-origin 2 <- same-origin 1 <- target
+    // then scroll margin is applied to same-origin frame 1/2 but not to cross-origin and main frames.
+    // Hence, clear out the scroll margin when we see a cross-origin frame.
+    bool isSameOriginDomain = [&] () {
+        if (RefPtr enclosingFrameSecurityOrigin = enclosingFrame->frameDocumentSecurityOrigin())
+            return enclosingFrameSecurityOrigin->isSameOriginDomain(targetSecurityOrigin);
+
+        return false;
+    }();
+    if (!isSameOriginDomain)
+        scrollMargin.reset();
 
     auto absoluteClippedRect = WTF::visit(WTF::makeVisitor(
         [&] (const RenderElement* renderer) {


### PR DESCRIPTION
#### 9e93965484305236b05b2a0000b9bbee624017c3
<pre>
[Site Isolation] [intersection-observer] In Site Isolation mode, scroll margin can get applied to cross-origin frame
<a href="https://rdar.apple.com/177992045">rdar://177992045</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315617">https://bugs.webkit.org/show_bug.cgi?id=315617</a>

Reviewed by Simon Fraser.

computeClippedRectInRootContentsSpace (in IntersectionObserver.cpp) works by
computing the visible rect of an element in its frame, then recurses if the
frame is another frame, up until it reaches the main frame. When crossing
frame boundaries, it checks whether the current frame is same-origin to the
target element, for applying scroll margin:

    RefPtr rendererOrFrameSecurityOrigin = WTF::visit(WTF::makeVisitor(
        [&amp;] (const RenderElement* renderer) { return Ref&lt;const Frame&gt;(renderer-&gt;frame())-&gt;frameDocumentSecurityOrigin(); },
        [&amp;] (const Frame* frame) { return frame-&gt;frameDocumentSecurityOrigin(); }
    ), rendererOrFrame);

    bool isSameOriginDomain = [&amp;] () {
        if (rendererOrFrameSecurityOrigin)
            return rendererOrFrameSecurityOrigin-&gt;isSameOriginDomain(targetSecurityOrigin);

         return false;
     }();
     if (!isSameOriginDomain)
         scrollMargin.reset();

If the parent frame&apos;s owner renderer is available, then
computeClippedRectInRootContentsSpace is called with that owner renderer.
Then renderer-&gt;frame() is the parent frame, and rendererOrFrameSecurityOrigin
is the parent frame&apos;s security origin.

If the parent frame&apos;s owner renderer is not available (when Site Isolation
is enabled and the parent frame is in another process), then
computeClippedRectInRootContentsSpace is called with the Frame object of
the current frame instead. The intention is to use this as the proxy to
the frame&apos;s owner renderer. But in this case, rendererOrFrameSecurityOrigin
would be the frame&apos;s security origin, instead of the parent frame&apos;s.

As an example, in an page with nested iframes that look like this: (cross
and same-origin are relative to main frame):

(1) main &lt;- (2) cross-origin &lt;- (3) same-origin &lt;- (4) target element

First computeClippedRectInRootContentsSpace is called on (4), then it&apos;s
called on the (3)&apos;s Frame object (because (3)&apos;s owner renderer is in (2),
which is cross-origin and out of process). We cross a cross-origin frame
boundary, so we should not apply and propagate scroll margin. But because
the object being passed to computeClippedRectInRootContentsSpace is (3)&apos;s
Frame object, rendererOrFrameSecurityOrigin is the security origin of (3),
which is also the security origin of (4), as (4) is in (3)

Fix this by getting the security origin from enclosingFrame instead, which is
guaranteed to be the parent frame (aka the frame enclosing rendererOrFrame)

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::computeClippedRectInRootContentsSpace):

Canonical link: <a href="https://commits.webkit.org/316774@main">https://commits.webkit.org/316774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1496fd4ddc309dd16c1ca3d756b89fe4513723f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182802 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130785 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1a905c2-7794-4441-b58e-c290cbd4ed42) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134695 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155321 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115166 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c047560-36a1-4eae-9718-e33e2002874b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36754 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35098 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; 4 api tests failed or timed out; Compiled WebKit (warnings); run-api-tests-without-change; Passed API tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31287 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185224 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39299 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143539 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46829 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143410 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38744 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47508 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112594 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38373 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119257 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46014 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9765 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45416 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45647 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45473 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->