### PR TITLE
Reduce use of `.get()` for smart pointers in WebXR

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRHitTestSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRHitTestSource.cpp
@@ -58,7 +58,7 @@ ExceptionOr<void> WebXRHitTestSource::cancel()
 {
     if (!m_source)
         return Exception { ExceptionCode::InvalidStateError };
-    RefPtr session = m_session.get();
+    RefPtr session { m_session };
     if (!session)
         return Exception { ExceptionCode::InvalidStateError };
 

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
@@ -67,7 +67,7 @@ WebXRSession* WebXRInputSource::session()
 
 void WebXRInputSource::update(double timestamp, const PlatformXR::FrameData::InputSource& source)
 {
-    RefPtr session = m_session.get();
+    RefPtr session { m_session };
     if (!session)
         return;
 
@@ -125,7 +125,7 @@ void WebXRInputSource::disconnect()
 
 void WebXRInputSource::pollEvents(Vector<Ref<XRInputSourceEvent>>& events)
 {
-    RefPtr session = m_session.get();
+    RefPtr session { m_session };
     if (!session)
         return;
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -99,7 +99,7 @@ WebXRSession::WebXRSession(Document& document, XRSessionMode mode, PlatformXR::D
 
 WebXRSession::~WebXRSession()
 {
-    RefPtr device = m_device.get();
+    RefPtr device { m_device };
     if (!m_ended && device)
         device->shutDownTrackingAndRendering();
 }
@@ -241,7 +241,7 @@ bool WebXRSession::referenceSpaceIsSupported(XRReferenceSpaceType type) const
             return true;
 
         // 4. If type is local or local-floor, and the XR device supports reporting orientation data, return true.
-        RefPtr device = m_device.get();
+        RefPtr device { m_device };
         if (device && device->supportsOrientationTracking())
             return true;
     }
@@ -285,7 +285,7 @@ void WebXRSession::requestReferenceSpace(XRReferenceSpaceType type, RequestRefer
             return;
         }
         // 2.2. Set up any platform resources required to track reference spaces of type type.
-        if (RefPtr device = m_device.get())
+        if (RefPtr device = m_device)
             device->initializeReferenceSpace(type);
 
         // 2.3. Queue a task to run the following steps:
@@ -366,7 +366,7 @@ IntSize WebXRSession::nativeWebGLFramebufferResolution() const
 // https://immersive-web.github.io/webxr/#recommended-webgl-framebuffer-resolution
 IntSize WebXRSession::recommendedWebGLFramebufferResolution() const
 {
-    RefPtr device = m_device.get();
+    RefPtr device { m_device };
     ASSERT(device);
     return device ? device->recommendedResolution(m_mode) : IntSize { };
 }
@@ -374,7 +374,7 @@ IntSize WebXRSession::recommendedWebGLFramebufferResolution() const
 // https://immersive-web.github.io/webxr/#view-viewport-modifiable
 bool WebXRSession::supportsViewportScaling() const
 {
-    RefPtr device = m_device.get();
+    RefPtr device { m_device };
     ASSERT(device);
     // Only immersive sessions support viewport scaling.
     return isImmersive(m_mode) && device && device->supportsViewportScaling();
@@ -407,14 +407,14 @@ void WebXRSession::shutdown(InitiatedBySystem initiatedBySystem)
     // 3. If the active immersive session is equal to session, set the active immersive session to null.
     // 4. Remove session from the list of inline sessions.
     for (WeakPtr listener : m_sessionListeners) {
-        if (RefPtr protectedListener = listener.get())
+        if (RefPtr protectedListener = listener)
             protectedListener->onSessionEnded(*this);
     }
     m_sessionListeners.clear();
 
     m_inputSources->clear();
 
-    RefPtr device = m_device.get();
+    RefPtr device { m_device };
     if (initiatedBySystem == InitiatedBySystem::Yes) {
         // If we get here, the session termination was triggered by the system rather than
         // via XRSession.end(). Since the system has completed the session shutdown, we can
@@ -445,7 +445,7 @@ void WebXRSession::didCompleteShutdown()
     if (isImmersive(m_mode) && m_activeRenderState && m_activeRenderState->baseLayer())
         m_activeRenderState->baseLayer()->sessionEnded();
 
-    if (RefPtr device = m_device.get())
+    if (RefPtr device = m_device)
         device->setTrackingAndRenderingClient(nullptr);
 
     // Resolve end promise from XRSession::end()
@@ -644,7 +644,7 @@ void WebXRSession::requestFrameIfNeeded()
     if (m_callbacks.isEmpty() || m_isDeviceFrameRequestPending)
         return;
 
-    RefPtr device = m_device.get();
+    RefPtr device { m_device };
     if (!device)
         return;
     m_isDeviceFrameRequestPending = true;
@@ -783,7 +783,7 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
             }
 #endif
 
-            if (RefPtr device = session.m_device.get())
+            if (RefPtr device = session.m_device)
                 device->submitFrame(WTF::move(frameLayers));
         }
 
@@ -958,7 +958,7 @@ void WebXRSession::addSessionListener(const WebXRSessionListener& listener)
 #if ENABLE(WEBXR_LAYERS)
 unsigned WebXRSession::maxRenderLayers() const
 {
-    RefPtr device = m_device.get();
+    RefPtr device { m_device };
     return device ? device->maxRenderLayers() : 0;
 }
 #endif

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -113,7 +113,7 @@ void WebXRSystem::ensureImmersiveXRDeviceIsSelected(CompletionHandler<void()>&& 
         });
 
         // https://immersive-web.github.io/webxr/#select-an-immersive-xr-device
-        RefPtr oldDevice = m_activeImmersiveDevice.get();
+        RefPtr oldDevice { m_activeImmersiveDevice };
         if (immersiveXRDevices.isEmpty()) {
             m_activeImmersiveDevice = nullptr;
             return;
@@ -179,7 +179,7 @@ void WebXRSystem::isSessionSupported(XRSessionMode mode, IsSessionSupportedPromi
     // 4.1 Ensure an immersive XR device is selected.
     ensureImmersiveXRDeviceIsSelected([this, promise = WTF::move(promise), mode]() mutable {
         // 4.2 If the immersive XR device is null, resolve promise with false and abort these steps.
-        RefPtr activeImmersiveDevice = m_activeImmersiveDevice.get();
+        RefPtr activeImmersiveDevice { m_activeImmersiveDevice };
         if (!activeImmersiveDevice) {
             promise.resolve(false);
             return;
@@ -554,7 +554,7 @@ void WebXRSystem::requestSession(Document& document, XRSessionMode mode, const X
         //  - Reject promise with a "NotSupportedError" DOMException.
         //  - If immersive is true, set pending immersive session to false.
         //  - Abort these steps.
-        RefPtr device = weakDevice.get();
+        RefPtr device { weakDevice };
         if (!device || !device->supports(mode))
             return;
 

--- a/Source/WebCore/Modules/webxr/WebXRTransientInputHitTestSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRTransientInputHitTestSource.cpp
@@ -52,7 +52,7 @@ ExceptionOr<void> WebXRTransientInputHitTestSource::cancel()
 {
     if (!m_source)
         return Exception { ExceptionCode::InvalidStateError };
-    RefPtr session = m_session.get();
+    RefPtr session { m_session };
     if (!session)
         return Exception { ExceptionCode::InvalidStateError };
     session->cancelTransientInputHitTestSource(*m_source);


### PR DESCRIPTION
#### 46084296a9c53dcb0fbf6e2ea6f36f611c3f0df3
<pre>
Reduce use of `.get()` for smart pointers in WebXR
<a href="https://bugs.webkit.org/show_bug.cgi?id=315623">https://bugs.webkit.org/show_bug.cgi?id=315623</a>
<a href="https://rdar.apple.com/177997024">rdar://177997024</a>

Reviewed by Mike Wyrzykowski.

Follow-up to the WebGPU `.get()` cleanup. `RefPtr&lt;T&gt;` has constructors
that take `WeakPtr&lt;T&gt;` and `ThreadSafeWeakPtr&lt;T&gt;` directly (RefPtr.h:104,
L106), each calling `.get()` internally. Removing redundant `.get()`
calls at eighteen sites across six files in `Source/WebCore/Modules/webxr/`
simplifies the code without changing behavior — the constructor invokes
`.get()` itself.

For the fourteen statement-form `RefPtr` initializations from `WeakPtr`
or `ThreadSafeWeakPtr`, also switched from copy-init (`=`) to brace-init
(`{}`) per current WebKit style.

No new tests needed (no behavioral change).

* Source/WebCore/Modules/webxr/WebXRHitTestSource.cpp:
(WebCore::WebXRHitTestSource::cancel):
* Source/WebCore/Modules/webxr/WebXRInputSource.cpp:
(WebCore::WebXRInputSource::update):
(WebCore::WebXRInputSource::pollEvents):
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::~WebXRSession):
(WebCore::WebXRSession::referenceSpaceIsSupported):
(WebCore::WebXRSession::requestReferenceSpace):
(WebCore::WebXRSession::recommendedWebGLFramebufferResolution):
(WebCore::WebXRSession::supportsViewportScaling):
(WebCore::WebXRSession::shutdown):
(WebCore::WebXRSession::didCompleteShutdown):
(WebCore::WebXRSession::requestFrameIfNeeded):
(WebCore::WebXRSession::onFrame):
(WebCore::WebXRSession::maxRenderLayers):
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::ensureImmersiveXRDeviceIsSelected):
(WebCore::WebXRSystem::isSessionSupported):
(WebCore::WebXRSystem::requestSession):
* Source/WebCore/Modules/webxr/WebXRTransientInputHitTestSource.cpp:
(WebCore::WebXRTransientInputHitTestSource::cancel):

Canonical link: <a href="https://commits.webkit.org/314095@main">https://commits.webkit.org/314095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae4a36a6c50104048f3c9996eae12e29a8981094

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121866 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b743d46a-9312-4ac7-8c81-efd111bdb3d2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127913 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90034 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1aa9c765-19a7-44d5-8c9b-175c0a30231d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108457 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ebc07a31-39ec-4707-8a77-dee3a6628b82) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29260 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27885 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21407 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139164 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176172 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28993 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136230 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136194 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36808 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101011 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31465 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24317 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37365 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110409 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36763 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2380 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37011 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36911 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->