### PR TITLE
Cherry-pick(s) db05eacaeb0c. rdar://176058395

### DIFF
--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -179,6 +179,7 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
             //
             // See also: https://github.com/w3c/csswg-drafts/issues/7680
 
+<<<<<<< HEAD
             bool hasSource = false;
             for (Ref face : matchingFaces) {
                 if (face->sourceCount()) {
@@ -192,6 +193,20 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
                 }));
                 return;
             }
+=======
+        bool hasSource = false;
+        for (Ref face : matchingFaces) {
+            if (face->sourceCount()) {
+                hasSource = true;
+                break;
+            }
+        }
+        if (!hasSource) {
+            promise.resolve(matchingFaces.map([scriptExecutionContext = scriptExecutionContext()] (const auto& matchingFace) {
+                return matchingFace->wrapper(scriptExecutionContext);
+            }));
+            return;
+>>>>>>> db05eacaeb0c (Use-after-free in CSSFontFace::setStatus and CSSFontFace::pump)
         }
     }
 
@@ -206,12 +221,20 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
     bool waiting = false;
 
     for (Ref face : matchingFaces) {
+<<<<<<< HEAD
         pendingPromise->faces.append(face->wrapper(protect(scriptExecutionContext()).get()));
+=======
+        pendingPromise->faces.append(face.get().wrapper(protectedScriptExecutionContext().get()));
+>>>>>>> db05eacaeb0c (Use-after-free in CSSFontFace::setStatus and CSSFontFace::pump)
         if (face->status() == CSSFontFace::Status::Success)
             continue;
         waiting = true;
         ASSERT(face->existingWrapper());
+<<<<<<< HEAD
         m_pendingPromises.add(*face->existingWrapper(), Vector<Ref<PendingPromise>>()).iterator->value.append(pendingPromise.copyRef());
+=======
+        m_pendingPromises.add(face->existingWrapper(), Vector<Ref<PendingPromise>>()).iterator->value.append(pendingPromise.copyRef());
+>>>>>>> db05eacaeb0c (Use-after-free in CSSFontFace::setStatus and CSSFontFace::pump)
     }
 
     if (!waiting)


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176058395 to main. The following sources [5f0480f771ba] will still need to be cherry-picked once the conflict is resolved.

```Use-after-free in CSSFontFace::setStatus and CSSFontFace::pump
https://bugs.webkit.org/show_bug.cgi?id=312202
rdar://174525579

Reviewed by Simon Fraser.

Fixed the bug by using Ref instead of std::reference_wrapper in the return value of
CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts and local variables in
FontFaceSet::load to keep CSSFontFace objects alive long enough.

Test: fast/text/fontface-setstatus-crash.html

* LayoutTests/fast/text/fontface-setstatus-crash-expected.txt: Added.
* LayoutTests/fast/text/fontface-setstatus-crash.html: Added.
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts):
* Source/WebCore/css/CSSFontFaceSet.h:
* Source/WebCore/css/FontFaceSet.cpp:
(WebCore::FontFaceSet::load):

Originally-landed-as: 305413.664@safari-7624-branch (db05eacaeb0c). rdar://176058395

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8975a722e8befa0e07925e3c2fd486eb84c15912

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164616 "6 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38100 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/31671 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/173651 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121868 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/166485 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38102 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/173651 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121868 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/167575 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/31671 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/173651 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38102 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/21409 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/31671 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176174 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28995 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31671 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/176174 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38169 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/38102 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176174 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/31671 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101013 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31671 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37367 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110411 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/36765 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/31671 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37013 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/36913 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->