### PR TITLE
[JSC] Cache per-unit number formatters in `Intl.DurationFormat`

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -55,6 +55,8 @@ static constexpr bool verbose = false;
 
 static constexpr unsigned fractionalDigitsUndefinedValue = std::numeric_limits<unsigned>::max();
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IntlDurationFormat::FormatterCache);
+
 const ClassInfo IntlDurationFormat::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(IntlDurationFormat) };
 
 IntlDurationFormat* IntlDurationFormat::create(VM& vm, Structure* structure)
@@ -73,6 +75,24 @@ IntlDurationFormat::IntlDurationFormat(VM& vm, Structure* structure)
     : Base(vm, structure)
 {
 }
+
+template<typename Visitor>
+void IntlDurationFormat::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = uncheckedDowncast<IntlDurationFormat>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+
+    Base::visitChildren(thisObject, visitor);
+
+    if (auto* cache = thisObject->m_formatterCache.get()) {
+        for (auto& formatter : cache->m_formatters) {
+            if (formatter)
+                visitor.reportExtraMemoryVisited(estimatedUNumberFormatterSize);
+        }
+    }
+}
+
+DEFINE_VISIT_CHILDREN(IntlDurationFormat);
 
 enum class StyleListKind : uint8_t { LongShortNarrow, LongShortNarrowNumeric, LongShortNarrowNumericTwoDigit  };
 static IntlDurationFormat::UnitData intlDurationUnitOptions(JSGlobalObject* globalObject, JSObject* options, TemporalUnit unit, PropertyName propertyName, PropertyName displayName, IntlDurationFormat::Style baseStyle, StyleListKind styleList, IntlDurationFormat::UnitStyle digitalBase, std::optional<IntlDurationFormat::UnitStyle> prevStyle)
@@ -494,9 +514,9 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
                 return String(WTF::move(buffer));
             };
 
-            // https://github.com/unicode-org/icu/blob/main/docs/userguide/format_parse/numbers/skeletons.md#sign-display
-            if (needsSignDisplay)
-                skeletonBuilder.append(" +_"_s);
+            // Only the first displayed unit shows the sign. Rather than building a sign-never (" +_") skeleton
+            // variant per unit, format the absolute value for later units so one formatter per unit suffices.
+            bool suppressSign = needsSignDisplay;
 
             auto adjustSignDisplay = [&]() -> void {
                 if (!needsSignDisplay && !value) {
@@ -513,22 +533,17 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
                 auto scope = DECLARE_THROW_SCOPE(vm);
 
                 dataLogLnIf(IntlDurationFormatInternal::verbose, skeleton);
-                StringView skeletonView(skeleton);
-                auto upconverted = skeletonView.upconvertedCharacters();
+
+                auto* numberFormatter = durationFormat->createNumberFormatterIfNecessary(globalObject, unit, skeleton);
+                RETURN_IF_EXCEPTION(scope, { });
 
                 UErrorCode status = U_ZERO_ERROR;
-                auto numberFormatter = std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter>(unumf_openForSkeletonAndLocale(upconverted.get(), skeletonView.length(), durationFormat->dataLocaleWithExtensions().data(), &status));
-                if (U_FAILURE(status)) {
-                    throwTypeError(globalObject, scope, "Failed to initialize NumberFormat"_s);
-                    return { };
-                }
-
                 auto formattedNumber = std::unique_ptr<UFormattedNumber, ICUDeleter<unumf_closeResult>>(unumf_openResult(&status));
                 if (U_FAILURE(status)) {
                     throwTypeError(globalObject, scope, "Failed to format a number."_s);
                     return { };
                 }
-                unumf_formatDouble(numberFormatter.get(), value, formattedNumber.get(), &status);
+                unumf_formatDouble(numberFormatter, suppressSign ? std::abs(value) : value, formattedNumber.get(), &status);
                 if (U_FAILURE(status)) {
                     throwTypeError(globalObject, scope, "Failed to format a number."_s);
                     return { };
@@ -544,26 +559,24 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
                 auto scope = DECLARE_THROW_SCOPE(vm);
 
                 dataLogLnIf(IntlDurationFormatInternal::verbose, skeleton);
-                StringView skeletonView(skeleton);
-                auto upconverted = skeletonView.upconvertedCharacters();
+
+                auto* numberFormatter = durationFormat->createNumberFormatterIfNecessary(globalObject, unit, skeleton);
+                RETURN_IF_EXCEPTION(scope, { });
 
                 UErrorCode status = U_ZERO_ERROR;
-                auto numberFormatter = std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter>(unumf_openForSkeletonAndLocale(upconverted.get(), skeletonView.length(), durationFormat->dataLocaleWithExtensions().data(), &status));
-                if (U_FAILURE(status)) {
-                    throwTypeError(globalObject, scope, "Failed to initialize NumberFormat"_s);
-                    return { };
-                }
-
                 auto formattedNumber = std::unique_ptr<UFormattedNumber, ICUDeleter<unumf_closeResult>>(unumf_openResult(&status));
                 if (U_FAILURE(status)) {
                     throwTypeError(globalObject, scope, "Failed to format a number."_s);
                     return { };
                 }
 
+                Int128 decimalValue = totalNanosecondsValue.value();
+                if (suppressSign && decimalValue < 0)
+                    decimalValue = -decimalValue;
                 // We need to keep string alive while strSpan is in use.
-                auto string = buildDecimalFormat(unit, totalNanosecondsValue.value());
+                auto string = buildDecimalFormat(unit, decimalValue);
                 auto strSpan = string.impl()->span8();
-                unumf_formatDecimal(numberFormatter.get(), reinterpret_cast<const char*>(strSpan.data()), strSpan.size(), formattedNumber.get(), &status);
+                unumf_formatDecimal(numberFormatter, reinterpret_cast<const char*>(strSpan.data()), strSpan.size(), formattedNumber.get(), &status);
                 if (U_FAILURE(status)) {
                     throwTypeError(globalObject, scope, "Failed to format a number."_s);
                     return { };
@@ -643,6 +656,34 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
     }
 
     return elements;
+}
+
+UNumberFormatter* IntlDurationFormat::createNumberFormatterIfNecessary(JSGlobalObject* globalObject, TemporalUnit unit, const String& skeleton) const
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!m_formatterCache) {
+        auto cache = makeUnique<FormatterCache>();
+        WTF::storeStoreFence(); // Expose valid struct for concurrent threads including the concurrent GC marker.
+        m_formatterCache = WTF::move(cache);
+    }
+
+    auto& formatter = m_formatterCache->m_formatters[static_cast<unsigned>(unit)];
+    if (formatter)
+        return formatter.get();
+
+    StringView skeletonView(skeleton);
+    auto upconverted = skeletonView.upconvertedCharacters();
+    UErrorCode status = U_ZERO_ERROR;
+    formatter = std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter>(unumf_openForSkeletonAndLocale(upconverted.get(), skeletonView.length(), m_dataLocaleWithExtensions.data(), &status));
+    if (U_FAILURE(status)) [[unlikely]] {
+        formatter = nullptr;
+        throwTypeError(globalObject, scope, "Failed to initialize NumberFormat"_s);
+        return nullptr;
+    }
+    vm.heap.reportExtraMemoryAllocated(this, estimatedUNumberFormatterSize);
+    return formatter.get();
 }
 
 // https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.prototype.format

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.h
@@ -57,6 +57,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     void initializeDurationFormat(JSGlobalObject*, JSValue localesValue, JSValue optionsValue);
 
     JSValue format(JSGlobalObject*, ISO8601::Duration) const;
@@ -93,6 +95,8 @@ public:
     const String& numberingSystem() const LIFETIME_BOUND;
     const CString& dataLocaleWithExtensions() const LIFETIME_BOUND { return m_dataLocaleWithExtensions; }
 
+    UNumberFormatter* createNumberFormatterIfNecessary(JSGlobalObject*, TemporalUnit, const String& skeleton) const;
+
 private:
     IntlDurationFormat(VM&, Structure*);
     DECLARE_DEFAULT_FINISH_CREATION;
@@ -101,7 +105,14 @@ private:
     static ASCIILiteral unitStyleString(UnitStyle);
     static ASCIILiteral displayString(Display);
 
+    struct FormatterCache {
+        WTF_MAKE_TZONE_ALLOCATED(FormatterCache);
+    public:
+        std::array<std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter>, numberOfTemporalUnits> m_formatters { };
+    };
+
     std::unique_ptr<UListFormatter, UListFormatterDeleter> m_listFormat;
+    mutable std::unique_ptr<FormatterCache> m_formatterCache;
     String m_locale;
     String m_dataLocale;
     mutable String m_numberingSystem;


### PR DESCRIPTION
#### 7e34b01578285a43c611c02e73395f885befdb39
<pre>
[JSC] Cache per-unit number formatters in `Intl.DurationFormat`
<a href="https://bugs.webkit.org/show_bug.cgi?id=315625">https://bugs.webkit.org/show_bug.cgi?id=315625</a>

Reviewed by Yusuke Suzuki.

Intl.DurationFormat.prototype.format and formatToParts open a UNumberFormatter
(unumf_openForSkeletonAndLocale) for every displayed unit on every call, even
though, for a given DurationFormat, a unit&apos;s number skeleton is fixed by the
resolved options. This makes formatting a duration with several units
needlessly expensive.

Cache one formatter per unit on the instance, created lazily on first use and
held in a FixedVector. The formatters are sized by the resolved options, so they
can be reused across calls. The number of cached formatters does not depend on
the sign of the input: instead of building a separate sign-never skeleton
variant for trailing units, the trailing units are formatted with the absolute
value, which is observably equivalent and lets a single formatter per unit serve
both the leading (signed) and trailing (unsigned) positions. The estimated
native memory of each cached formatter is reported to the GC.

                                             TipOfTree                  Patched

intl-constructor-durationformat            8.4315+-0.5931            8.1893+-0.5599          might be 1.0296x faster
intl-durationformat-format              1124.6364+-24.4749    ^     42.4191+-0.6271        ^ definitely 26.5125x faster

* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::IntlDurationFormat::visitChildrenImpl):
(JSC::collectElements):
(JSC::IntlDurationFormat::createNumberFormatterIfNecessary const):
* Source/JavaScriptCore/runtime/IntlDurationFormat.h:

Canonical link: <a href="https://commits.webkit.org/314102@main">https://commits.webkit.org/314102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb46775cc077320647a8566282f52503d774a5ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173988 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122203 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128175 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90221 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108701 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29528 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28143 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21744 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157106 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176511 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25842 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136496 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136442 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36812 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39195 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147712 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101465 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31710 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24578 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197350 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37705 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110776 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51858 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37102 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2652 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->