### PR TITLE
[JSC] Use in-place JSBigInt for small-size calculation (or when only one digit is wasteful)

### DIFF
--- a/JSTests/stress/bigint-in-place-thresholds.js
+++ b/JSTests/stress/bigint-in-place-thresholds.js
@@ -1,0 +1,113 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+// Exercise both sides of maxInPlaceSubSize = 16 (absoluteSub) and
+// maxInPlaceCachedModSize = 8 (cachedMod) so that a future tweak to either
+// constant can't silently bypass the in-place fast path on the hot path.
+
+// absoluteSub: x and y are positive, |x| > |y|, x.length() in {15, 16, 17, 18} digits (64-bit).
+// length L means 2^((L-1)*64) <= |x| < 2^(L*64).
+{
+    const oneDigitBits = 64n;
+    function pow2(n) { return 1n << n; }
+    function topDigitBit(L) { return BigInt(L) * oneDigitBits - 1n; }
+
+    for (const L of [15, 16, 17, 18, 32, 64]) {
+        // Force x to have exactly L digits and y to have L-1 digits.
+        const x = pow2(topDigitBit(L)) | 12345n;
+        const y = pow2(topDigitBit(L - 1)) | 7n;
+        const expected = x - y;
+        let actual = 0n;
+        for (let i = 0; i < 200; i++)
+            actual = x - y;
+        shouldBe(actual, expected);
+        // Negation path (resultSign flipped).
+        let actualNeg = 0n;
+        for (let i = 0; i < 200; i++)
+            actualNeg = y - x;
+        shouldBe(actualNeg, -expected);
+    }
+}
+
+// absoluteSub: result normalizes to zero (|x| - |y| with all leading digits cancelling).
+{
+    for (const L of [4, 8, 16, 17, 32]) {
+        const x = (1n << BigInt(L * 64)) - 1n;
+        const y = (1n << BigInt(L * 64)) - 1n;
+        let actual = -1n;
+        for (let i = 0; i < 200; i++)
+            actual = x - y;
+        shouldBe(actual, 0n);
+    }
+}
+
+// absoluteAdd: in-place path is always taken below maxLength; verify various sizes.
+{
+    for (const L of [1, 2, 8, 16, 17, 32, 100]) {
+        const x = (1n << BigInt(L * 64 - 1)) | 3n;
+        const y = (1n << BigInt(L * 64 - 1)) | 5n;
+        const expected = x + y;
+        let actual = 0n;
+        for (let i = 0; i < 200; i++)
+            actual = x + y;
+        shouldBe(actual, expected);
+        // Carry that grows the length by one.
+        const xMax = (1n << BigInt(L * 64)) - 1n;
+        const yOne = 1n;
+        let actualCarry = 0n;
+        for (let i = 0; i < 200; i++)
+            actualCarry = xMax + yOne;
+        shouldBe(actualCarry, 1n << BigInt(L * 64));
+    }
+}
+
+// cachedMod: install divisor in cache (>= 100 iters with same y), then run past
+// the threshold. ySpan.size() in {7, 8, 9, 10, 16, 32} digits.
+{
+    function divisorWithLength(L) {
+        // Top digit non-zero, low digit non-zero — canonicalised to exactly L digits.
+        return (1n << BigInt(L * 64 - 1)) | 19n;
+    }
+    for (const L of [7, 8, 9, 10, 16, 32]) {
+        const p = divisorWithLength(L);
+        // Dividend roughly 2x divisor size — falls under the xSpan <= 2*ySpan guard.
+        let x = (1n << BigInt(L * 64 + L * 32)) | 0xdeadbeefn;
+        const seed = x;
+        let actual = x;
+        for (let i = 0; i < 250; i++)
+            actual = (actual * 3n + 1n) % p;
+        // Recompute with a fresh divisor object so we exit the cached path; results must match.
+        const pCopy = (p + 0n);  // identity, but JIT/runtime treats as same value
+        let expected = seed;
+        for (let i = 0; i < 250; i++)
+            expected = (expected * 3n + 1n) % pCopy;
+        shouldBe(actual, expected);
+        // Dividend exact multiple: cached-mod yields zero (canonical zero return path).
+        let zero = -1n;
+        for (let i = 0; i < 200; i++)
+            zero = (p * 7n) % p;
+        shouldBe(zero, 0n);
+        // Negative dividend: sign handling with cached mod.
+        let neg = 0n;
+        for (let i = 0; i < 200; i++)
+            neg = (-(seed * 5n + 3n)) % p;
+        shouldBe(neg <= 0n, true);
+        if (neg !== 0n)
+            shouldBe(-neg < p, true);
+    }
+}
+
+// cachedMod: divisor swap mid-loop — cache must invalidate cleanly.
+{
+    const p1 = (1n << 511n) | 19n;     // 8 digits
+    const p2 = (1n << 575n) | 23n;     // 9 digits — crosses the maxInPlaceCachedModSize boundary
+    let x = (1n << 600n) | 1n;
+    for (let i = 0; i < 150; i++)
+        x = (x * x + 1n) % p1;
+    let y = x;
+    for (let i = 0; i < 150; i++)
+        y = (y * y + 1n) % p2;
+    shouldBe(y >= 0n && y < p2, true);
+}

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -1390,6 +1390,9 @@ public:
 
     JSBigInt* decode(Decoder& decoder) const
     {
+        if (!m_length)
+            return decoder.vm().heapBigIntConstantZero.get();
+
         JSBigInt* bigInt = JSBigInt::tryCreateWithLength(decoder.vm(), m_length);
         RELEASE_ASSERT(bigInt);
         bigInt->setSign(m_sign);

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -81,19 +81,18 @@ Structure* JSBigInt::createStructure(VM& vm, JSGlobalObject* globalObject, JSVal
     return Structure::create(vm, globalObject, prototype, TypeInfo(HeapBigIntType, StructureFlags), info());
 }
 
-inline JSBigInt* JSBigInt::createZero(JSGlobalObject* nullOrGlobalObjectForOOM, VM& vm)
+inline JSBigInt* JSBigInt::createZero(VM& vm)
 {
-    return createWithLength(nullOrGlobalObjectForOOM, vm, 0);
-}
-
-JSBigInt* JSBigInt::createZero(JSGlobalObject* globalObject)
-{
-    return createZero(globalObject, globalObject->vm());
+    JSBigInt* cached = vm.heapBigIntConstantZero.get();
+    ASSERT(cached);
+    return cached;
 }
 
 JSBigInt* JSBigInt::tryCreateZero(VM& vm)
 {
-    return createZero(nullptr, vm);
+    JSBigInt* cached = vm.heapBigIntConstantZero.get();
+    ASSERT(cached);
+    return cached;
 }
 
 inline JSBigInt* JSBigInt::createWithLength(JSGlobalObject* nullOrGlobalObjectForOOM, VM& vm, unsigned length)
@@ -134,7 +133,7 @@ JSBigInt* JSBigInt::createWithLength(JSGlobalObject* globalObject, unsigned leng
 inline JSBigInt* JSBigInt::createFrom(JSGlobalObject* nullOrGlobalObjectForOOM, VM& vm, int32_t value)
 {
     if (!value)
-        return createZero(nullOrGlobalObjectForOOM, vm);
+        return createZero(vm);
 
     JSBigInt* bigInt = createWithLength(nullOrGlobalObjectForOOM, vm, 1);
     if (!bigInt) [[unlikely]]
@@ -165,7 +164,7 @@ JSBigInt* JSBigInt::createFrom(JSGlobalObject* globalObject, uint32_t value)
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!value)
-        RELEASE_AND_RETURN(scope, createZero(globalObject));
+        RELEASE_AND_RETURN(scope, createZero(vm));
     
     JSBigInt* bigInt = createWithLength(globalObject, 1);
     RETURN_IF_EXCEPTION(scope, nullptr);
@@ -179,7 +178,7 @@ inline JSBigInt* JSBigInt::tryCreateFromImpl(JSGlobalObject* globalObject, uint6
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!value)
-        RELEASE_AND_RETURN(scope, createZero(globalObject));
+        RELEASE_AND_RETURN(scope, createZero(vm));
 
     if (sizeof(Digit) == 8 || value <= UINT32_MAX) {
         JSBigInt* bigInt = createWithLength(globalObject, 1);
@@ -227,7 +226,7 @@ JSBigInt* JSBigInt::createFrom(JSGlobalObject* globalObject, Int128 value)
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!value)
-        RELEASE_AND_RETURN(scope, createZero(globalObject));
+        RELEASE_AND_RETURN(scope, createZero(vm));
 
     UInt128 unsignedValue;
     bool sign = false;
@@ -283,7 +282,7 @@ JSBigInt* JSBigInt::createFrom(JSGlobalObject* globalObject, bool value)
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!value)
-        RELEASE_AND_RETURN(scope, createZero(globalObject));
+        RELEASE_AND_RETURN(scope, createZero(vm));
 
     JSBigInt* bigInt = createWithLength(globalObject, 1);
     RETURN_IF_EXCEPTION(scope, nullptr);
@@ -298,7 +297,7 @@ JSBigInt* JSBigInt::createFrom(JSGlobalObject* globalObject, double value)
 
     ASSERT(isInteger(value));
     if (!value)
-        RELEASE_AND_RETURN(scope, createZero(globalObject));
+        RELEASE_AND_RETURN(scope, createZero(vm));
 
     bool sign = value < 0; // -0 was already handled above.
     uint64_t doubleBits = std::bit_cast<uint64_t>(value);
@@ -558,13 +557,13 @@ static ALWAYS_INLINE JSValue NODELETE tryConvertToBigInt32(JSBigInt::ImplResult 
     return tryConvertToBigInt32(implResult.payload.asHeapBigInt());
 }
 
-static ALWAYS_INLINE JSBigInt::ImplResult zeroImpl(JSGlobalObject* globalObject)
+static ALWAYS_INLINE JSBigInt::ImplResult zeroImpl(VM& vm)
 {
 #if USE(BIGINT32)
-    UNUSED_PARAM(globalObject);
+    UNUSED_PARAM(vm);
     return jsBigInt32(0);
 #else
-    return JSBigInt::createZero(globalObject);
+    return vm.heapBigIntConstantZero.get();
 #endif
 }
 
@@ -1557,7 +1556,7 @@ JSBigInt::ImplResult JSBigInt::divideImpl(JSGlobalObject* globalObject, BigIntIm
     bool resultSign = x.sign() != y.sign();
     switch (absoluteCompare(x, y)) {
     case ComparisonResult::LessThan: {
-        RELEASE_AND_RETURN(scope, zeroImpl(globalObject));
+        RELEASE_AND_RETURN(scope, zeroImpl(vm));
     }
     case ComparisonResult::Equal: {
         RELEASE_AND_RETURN(scope, createFrom(globalObject, vm, resultSign ? -1 : 1));
@@ -1586,7 +1585,7 @@ JSBigInt::ImplResult JSBigInt::divideImpl(JSGlobalObject* globalObject, BigIntIm
     if (xSpan.size() == ySpan.size()) {
         auto quotientDigit = divideSameSize(xSpan, ySpan);
         if (!quotientDigit)
-            RELEASE_AND_RETURN(scope, zeroImpl(globalObject));
+            RELEASE_AND_RETURN(scope, zeroImpl(vm));
 
         auto* quotient = createWithLength(globalObject, 1);
         RETURN_IF_EXCEPTION(scope, nullptr);
@@ -1638,7 +1637,7 @@ JSBigInt::ImplResult JSBigInt::unaryMinusImpl(JSGlobalObject* globalObject, BigI
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (x.isZero())
-        RELEASE_AND_RETURN(scope, zeroImpl(globalObject));
+        RELEASE_AND_RETURN(scope, zeroImpl(vm));
 
     JSBigInt* result = copy(globalObject, x);
     RETURN_IF_EXCEPTION(scope, nullptr);
@@ -1831,7 +1830,7 @@ JSBigInt::ImplResult JSBigInt::remainderImpl(JSGlobalObject* globalObject, BigIn
         return { x };
     }
     case ComparisonResult::Equal: {
-        RELEASE_AND_RETURN(scope, zeroImpl(globalObject));
+        RELEASE_AND_RETURN(scope, zeroImpl(vm));
     }
     case ComparisonResult::GreaterThan:
     case ComparisonResult::Undefined:
@@ -1843,12 +1842,12 @@ JSBigInt::ImplResult JSBigInt::remainderImpl(JSGlobalObject* globalObject, BigIn
     if (ySpan.size() == 1) {
         Digit divisor = ySpan[0];
         if (divisor == 1)
-            RELEASE_AND_RETURN(scope, zeroImpl(globalObject));
+            RELEASE_AND_RETURN(scope, zeroImpl(vm));
 
         Digit remainderDigit;
         divideSingle({ }, remainderDigit, xSpan, divisor);
         if (!remainderDigit)
-            RELEASE_AND_RETURN(scope, zeroImpl(globalObject));
+            RELEASE_AND_RETURN(scope, zeroImpl(vm));
 
         auto* remainder = createWithLength(globalObject, 1);
         RETURN_IF_EXCEPTION(scope, nullptr);
@@ -1858,12 +1857,27 @@ JSBigInt::ImplResult JSBigInt::remainderImpl(JSGlobalObject* globalObject, BigIn
         return remainder;
     }
 
-    Vector<Digit, 16> r(ySpan.size());
-
     // Cached multiplicative inverse optimization for repeated modulo with the same divisor.
     if constexpr (std::is_same_v<BigIntImpl2, HeapBigIntImpl>) {
         if (vm.m_cachedBigIntDivisor.get() == y.toHeapBigInt(globalObject)) {
             if (xSpan.size() <= 2 * ySpan.size()) {
+                unsigned resultLength = ySpan.size();
+                if (resultLength <= maxInPlaceCachedModSize) {
+                    auto* cell = tryAllocateCell<JSBigInt>(vm, JSBigInt::allocationSize(resultLength));
+                    if (!cell) [[unlikely]] {
+                        throwOutOfMemoryError(globalObject, scope);
+                        return nullptr;
+                    }
+                    JSBigInt* bigInt = new (NotNull, cell) JSBigInt(vm, vm.bigIntStructure.get(), resultLength);
+                    bigInt->finishCreation(vm);
+                    bigInt->setSign(x.sign());
+                    auto rSpan = normalize(cachedMod(vm, bigInt->digits(), xSpan, ySpan));
+                    if (rSpan.empty())
+                        RELEASE_AND_RETURN(scope, zeroImpl(vm));
+                    bigInt->setLength(rSpan.size());
+                    return bigInt;
+                }
+                Vector<Digit, maxCachedModDivisorSize> r(resultLength);
                 auto rSpan = cachedMod(vm, r.mutableSpan(), xSpan, ySpan);
                 RELEASE_AND_RETURN(scope, tryCreateFromImpl(globalObject, vm, x.sign(), rSpan));
             }
@@ -1878,6 +1892,7 @@ JSBigInt::ImplResult JSBigInt::remainderImpl(JSGlobalObject* globalObject, BigIn
         }
     }
 
+    Vector<Digit, 16> r(ySpan.size());
     std::span<const Digit> rSpan;
     if (xSpan.size() == ySpan.size())
         rSpan = remainderSameSize(r.mutableSpan(), xSpan, ySpan);
@@ -2646,9 +2661,29 @@ JSBigInt::ImplResult JSBigInt::absoluteAdd(JSGlobalObject* globalObject, BigIntI
         RELEASE_AND_RETURN(scope, unaryMinusImpl(globalObject, x));
     }
 
-    Vector<Digit, 16> result(x.length() + 1);
-    auto span = addTextbook(x.digits(), y.digits(), result.mutableSpan());
-    RELEASE_AND_RETURN(scope, tryCreateFromImpl(globalObject, vm, resultSign, span));
+    unsigned resultLength = x.length() + 1;
+    if (resultLength > maxLength) [[unlikely]] {
+        Vector<Digit> scratch(resultLength);
+        auto span = addTextbook(x.digits(), y.digits(), scratch.mutableSpan());
+        RELEASE_AND_RETURN(scope, tryCreateFromImpl(globalObject, vm, resultSign, span));
+    }
+
+    auto* cell = tryAllocateCell<JSBigInt>(vm, JSBigInt::allocationSize(resultLength));
+    if (!cell) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
+    }
+
+    JSBigInt* bigInt = new (NotNull, cell) JSBigInt(vm, vm.bigIntStructure.get(), resultLength);
+    bigInt->finishCreation(vm);
+    bigInt->setSign(resultSign);
+
+    auto span = addTextbook(x.digits(), y.digits(), bigInt->digits());
+    ASSERT(!span.empty());
+    if (!span.back())
+        bigInt->setLength(span.size() - 1);
+
+    return bigInt;
 }
 
 std::span<JSBigInt::Digit> JSBigInt::subTextbook(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
@@ -2695,11 +2730,30 @@ JSBigInt::ImplResult JSBigInt::absoluteSub(JSGlobalObject* globalObject, BigIntI
     }
 
     if (comparisonResult == ComparisonResult::Equal)
-        RELEASE_AND_RETURN(scope, zeroImpl(globalObject));
+        RELEASE_AND_RETURN(scope, zeroImpl(vm));
 
-    Vector<Digit, 16> result(x.length());
-    auto span = subTextbook(x.digits(), y.digits(), result.mutableSpan());
-    RELEASE_AND_RETURN(scope, tryCreateFromImpl(globalObject, vm, resultSign, span));
+    unsigned resultLength = x.length();
+    if (resultLength > maxInPlaceSubSize) [[unlikely]] {
+        Vector<Digit> scratch(resultLength);
+        auto span = subTextbook(x.digits(), y.digits(), scratch.mutableSpan());
+        RELEASE_AND_RETURN(scope, tryCreateFromImpl(globalObject, vm, resultSign, span));
+    }
+
+    auto* cell = tryAllocateCell<JSBigInt>(vm, JSBigInt::allocationSize(resultLength));
+    if (!cell) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
+    }
+
+    JSBigInt* bigInt = new (NotNull, cell) JSBigInt(vm, vm.bigIntStructure.get(), resultLength);
+    bigInt->finishCreation(vm);
+    bigInt->setSign(resultSign);
+
+    auto span = normalize(subTextbook(x.digits(), y.digits(), bigInt->digits()));
+    if (span.empty())
+        RELEASE_AND_RETURN(scope, zeroImpl(vm));
+    bigInt->setLength(span.size());
+    return bigInt;
 }
 
 // Returns whether (factor1 * factor2) > (high << digitBits) + low.
@@ -2959,7 +3013,7 @@ JSBigInt::ImplResult JSBigInt::rightShiftByMaximum(JSGlobalObject* globalObject,
     if (sign)
         return createFrom(globalObject, -1);
 
-    return createZero(globalObject);
+    return createZero(globalObject->vm());
 }
 
 // Lookup table for the maximum number of bits required per character of a
@@ -3216,7 +3270,7 @@ JSValue JSBigInt::parseInt(JSGlobalObject* nullOrGlobalObjectForOOM, VM& vm, std
 #if USE(BIGINT32)
         return jsBigInt32(0);
 #else
-        return createZero(nullOrGlobalObjectForOOM, vm);
+        return createZero(vm);
 #endif
     }
 
@@ -3711,7 +3765,7 @@ JSBigInt::ImplResult JSBigInt::asIntNImpl(JSGlobalObject* globalObject, uint64_t
     if (bigInt.isZero())
         return { bigInt };
     if (n == 0)
-        RELEASE_AND_RETURN(scope, zeroImpl(globalObject));
+        RELEASE_AND_RETURN(scope, zeroImpl(vm));
 
     uint64_t neededLength = (n + digitBits - 1) / digitBits;
     uint64_t length = static_cast<uint64_t>(bigInt.length());
@@ -3763,7 +3817,7 @@ JSBigInt::ImplResult JSBigInt::asUintNImpl(JSGlobalObject* globalObject, uint64_
     if (bigInt.isZero())
         return { bigInt };
     if (n == 0)
-        RELEASE_AND_RETURN(scope, zeroImpl(globalObject));
+        RELEASE_AND_RETURN(scope, zeroImpl(vm));
 
     // If bigInt is negative, simulate two's complement representation.
     if (bigInt.sign()) {
@@ -3960,7 +4014,7 @@ JSBigInt* JSBigInt::tryCreateFromImpl(JSGlobalObject* nullOrGlobalObjectForOOM, 
 {
     digits = normalize(digits);
     if (digits.empty())
-        return createZero(nullOrGlobalObjectForOOM, vm);
+        return createZero(vm);
 
     JSBigInt* result = createWithLength(nullOrGlobalObjectForOOM, vm, digits.size());
     if (!result) [[unlikely]]

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -76,7 +76,6 @@ public:
     void initialize(InitializationType);
 
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
-    JS_EXPORT_PRIVATE static JSBigInt* createZero(JSGlobalObject*);
     JS_EXPORT_PRIVATE static JSBigInt* tryCreateZero(VM&);
     JS_EXPORT_PRIVATE static JSBigInt* tryCreateWithLength(VM&, unsigned length);
     JS_EXPORT_PRIVATE static JSBigInt* createWithLength(JSGlobalObject*, unsigned length);
@@ -192,6 +191,7 @@ public:
 
 private:
     static JSBigInt* tryCreateFromImpl(JSGlobalObject*, VM&, bool sign, std::span<const Digit>);
+    static JSBigInt* createZero(VM&);
 
     ALWAYS_INLINE static ComparisonResult flip(ComparisonResult result)
     {
@@ -223,7 +223,6 @@ public:
     };
 private:
     static JSBigInt* createWithLength(JSGlobalObject*, VM&, unsigned length);
-    static JSBigInt* createZero(JSGlobalObject*, VM&);
 
     template <typename BigIntImpl1, typename BigIntImpl2>
     static ImplResult exponentiateImpl(JSGlobalObject*, BigIntImpl1 base, BigIntImpl2 exponent);
@@ -577,6 +576,9 @@ private:
     static Digit NODELETE inplaceSub(std::span<Digit> z, std::span<const Digit> x);
 
     static constexpr unsigned maxCachedModDivisorSize = 32; // 2048-bit divisors on 64-bit
+    static constexpr unsigned maxInPlaceSubSize = 16;
+    static constexpr unsigned maxInPlaceCachedModSize = 8;
+    static_assert(maxInPlaceCachedModSize <= maxCachedModDivisorSize);
     static void cachedModMakeInverse(VM&, std::span<const Digit> b);
     static std::span<const Digit> cachedMod(VM&, std::span<Digit> r, std::span<const Digit>, std::span<const Digit>);
     static bool NODELETE greaterThanOrEqual(std::span<const Digit>, std::span<const Digit>);
@@ -599,6 +601,7 @@ private:
     void inplaceMultiplyAdd(Digit multiplier, Digit part);
     template <typename BigIntImpl1, typename BigIntImpl2>
     static ImplResult absoluteAdd(JSGlobalObject*, BigIntImpl1 x, BigIntImpl2 y, bool resultSign);
+
     template <typename BigIntImpl1, typename BigIntImpl2>
     static ImplResult absoluteSub(JSGlobalObject*, BigIntImpl1 x, BigIntImpl2 y, bool resultSign);
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -400,6 +400,17 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 RELEASE_ASSERT_RESOURCE_AVAILABLE(bigInt, MemoryExhaustion, "Crash intentionally because memory is exhausted.");
         }
     }
+    {
+        auto* bigInt = JSBigInt::tryCreateWithLength(*this, 0);
+        if (bigInt)
+            heapBigIntConstantZero.setWithoutWriteBarrier(bigInt);
+        else {
+            if (success)
+                *success = false;
+            else
+                RELEASE_ASSERT_RESOURCE_AVAILABLE(bigInt, MemoryExhaustion, "Crash intentionally because memory is exhausted.");
+        }
+    }
 
     Thread::currentSingleton().setCurrentAtomStringTable(existingEntryAtomStringTable);
     
@@ -1913,6 +1924,7 @@ void VM::visitAggregateImpl(Visitor& visitor)
     visitor.append(m_slowCanConstructBoundExecutable);
     visitor.append(lastCachedString);
     visitor.append(heapBigIntConstantOne);
+    visitor.append(heapBigIntConstantZero);
     visitor.append(m_cachedBigIntDivisor);
     visitor.append(m_nextCachedBigIntDivisor);
 

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -621,6 +621,7 @@ public:
     WTF::SymbolRegistry& privateSymbolRegistry() { return m_privateSymbolRegistry.get(); }
 
     WriteBarrier<JSBigInt> heapBigIntConstantOne;
+    WriteBarrier<JSBigInt> heapBigIntConstantZero;
 
     // Cached multiplicative inverse for BigInt modulo optimization.
     WriteBarrier<JSBigInt> m_cachedBigIntDivisor;


### PR DESCRIPTION
#### c60baa450f96b48f6db64fd49c53a30611854017
<pre>
[JSC] Use in-place JSBigInt for small-size calculation (or when only one digit is wasteful)
<a href="https://bugs.webkit.org/show_bug.cgi?id=315628">https://bugs.webkit.org/show_bug.cgi?id=315628</a>
<a href="https://rdar.apple.com/178003514">rdar://178003514</a>

Reviewed by Yijia Huang.

Using Vector and copying the result to JSBigInt is costly if size is
enough small. This patch attempts to use allocated JSBigInt&apos;s storage
directly.

1. Add case is at most only one digit space is wasteful, so just using
   JSBigInt always makes sense in terms of tradeoff.
2. We add this optimization to cachedMod / sub only when potential
   result size is small (8 or 16).
3. Also, cache 0n in VM.

* JSTests/stress/bigint-in-place-thresholds.js: Added.
(shouldBe):
(throw.new.Error.pow2):
(throw.new.Error.topDigitBit):
(throw.new.Error):
(divisorWithLength):
(neg.0n.shouldBe):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedBigInt::decode const):
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::createZero):
(JSC::JSBigInt::tryCreateZero):
(JSC::JSBigInt::createFrom):
(JSC::JSBigInt::tryCreateFromImpl):
(JSC::zeroImpl):
(JSC::JSBigInt::divideImpl):
(JSC::JSBigInt::unaryMinusImpl):
(JSC::JSBigInt::remainderImpl):
(JSC::JSBigInt::absoluteAdd):
(JSC::JSBigInt::absoluteSub):
(JSC::JSBigInt::rightShiftByMaximum):
(JSC::JSBigInt::parseInt):
(JSC::JSBigInt::asIntNImpl):
(JSC::JSBigInt::asUintNImpl):
* Source/JavaScriptCore/runtime/JSBigInt.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::visitAggregateImpl):
* Source/JavaScriptCore/runtime/VM.h:

Canonical link: <a href="https://commits.webkit.org/313977@main">https://commits.webkit.org/313977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ab37db689d8dd9c07b2ad750beb6230a8817499

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121898 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127942 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90056 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167605 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108486 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29291 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27914 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21439 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156797 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139195 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176204 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25538 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29028 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136259 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32038 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136222 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147493 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101051 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25071 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31496 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24349 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197049 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110441 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51762 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36795 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2412 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37043 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36943 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->