### PR TITLE
[JSC] Add a root-locale fast path to `toLocaleLowerCase` and `toLocaleUpperCase`

### DIFF
--- a/JSTests/microbenchmarks/intl-string-tolocalelowercase.js
+++ b/JSTests/microbenchmarks/intl-string-tolocalelowercase.js
@@ -1,0 +1,14 @@
+function test() {
+    let count = 0;
+    for (let i = 0; i < 1e5; ++i) {
+        if ("Hello World".toLocaleLowerCase() === "hello world")
+            ++count;
+        if ("HELLO WORLD".toLocaleLowerCase("en") === "hello world")
+            ++count;
+    }
+    return count;
+}
+
+const result = test();
+if (result !== 2e5)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/intl-string-tolocaleuppercase.js
+++ b/JSTests/microbenchmarks/intl-string-tolocaleuppercase.js
@@ -1,0 +1,14 @@
+function test() {
+    let count = 0;
+    for (let i = 0; i < 1e5; ++i) {
+        if ("Hello World".toLocaleUpperCase() === "HELLO WORLD")
+            ++count;
+        if ("hello world".toLocaleUpperCase("en") === "HELLO WORLD")
+            ++count;
+    }
+    return count;
+}
+
+const result = test();
+if (result !== 2e5)
+    throw new Error("Bad result: " + result);

--- a/JSTests/stress/to-locale-case-root-fast-path.js
+++ b/JSTests/stress/to-locale-case-root-fast-path.js
@@ -1,0 +1,64 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+const inputs = [
+    "",
+    "Hello World",
+    "HELLO WORLD",
+    "hello world",
+    "ÀÉÎ",
+    "àéî",
+    "ß",
+    "ΟΔΟΣ",
+    "Größe",
+    "\u{10400}",   // Deseret capital (non-BMP)
+    "\u{10428}",   // Deseret small (non-BMP)
+    "ABCdef123",
+    "Ì",
+];
+
+// Core invariant of the optimization: for any non-tailoring locale, toLocaleLowerCase /
+// toLocaleUpperCase must produce exactly the locale-independent result.
+for (const s of inputs) {
+    const rootLower = s.toLowerCase();
+    const rootUpper = s.toUpperCase();
+    for (const locale of [undefined, "en", "de", "ja", "fr", "en-US", "zh-Hans", "ru", "es-419"]) {
+        shouldBe(s.toLocaleLowerCase(locale), rootLower);
+        shouldBe(s.toLocaleUpperCase(locale), rootUpper);
+    }
+}
+
+// Identity preservation: an already-lowercased/uppercased string round-trips unchanged.
+shouldBe("hello world".toLocaleLowerCase(), "hello world");
+shouldBe("HELLO WORLD".toLocaleUpperCase(), "HELLO WORLD");
+shouldBe("".toLocaleLowerCase("en"), "");
+shouldBe("".toLocaleUpperCase("en"), "");
+
+// German sharp-s uppercases to "SS" in the root locale.
+shouldBe("ß".toLocaleUpperCase(), "SS");
+
+// Tailoring locales must keep going through ICU and differ from the root mapping.
+
+// Turkish / Azeri: dotted/dotless i.
+shouldBe("I".toLocaleLowerCase("tr"), "ı");
+shouldBe("i".toLocaleUpperCase("tr"), "İ");
+shouldBe("I".toLocaleLowerCase("az"), "ı");
+shouldBe("i".toLocaleUpperCase("az"), "İ");
+
+// Unicode extension subtags must not defeat tailoring detection.
+shouldBe("I".toLocaleLowerCase("tr-u-co-phonebk"), "ı");
+
+// Greek: uppercasing strips the tonos accent, differing from the root mapping.
+if ("Άυτη".toLocaleUpperCase("el") === "Άυτη".toUpperCase())
+    throw new Error("Greek uppercasing should differ from root");
+
+// Lithuanian: combining dot above is retained on lowercase of accented I, so it
+// differs from the root locale-independent lowercasing.
+if ("Ì".toLocaleLowerCase("lt") === "Ì".toLowerCase())
+    throw new Error("Lithuanian lowercasing should differ from root");
+
+// Empty string with an explicit tailoring locale.
+shouldBe("".toLocaleLowerCase("tr"), "");
+shouldBe("".toLocaleUpperCase("el"), "");

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1643,8 +1643,13 @@ static EncodedJSValue toLocaleCase(JSGlobalObject* globalObject, CallFrame* call
     });
 
     // 12. If locale is undefined, let locale be "und".
-    if (locale.isNull())
-        locale = "und"_s;
+    if (locale.isNull()) {
+        // Case mapping is locale-independent here, so skip ICU and use the root conversion.
+        String converted = mode == CaseConversionMode::Lower ? s->convertToLowercaseWithoutLocale() : s->convertToUppercaseWithoutLocale();
+        if (converted.impl() == s->impl())
+            return JSValue::encode(sVal);
+        RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, WTF::move(converted))));
+    }
 
     // Delegate the following steps to icu u_strToLower or u_strToUpper.
     // 13. Let cpList be a List containing in order the code points of S as defined in ES2015, 6.1.4, starting at the first element of S.


### PR DESCRIPTION
#### e14189a28e4cb71c4449d328d41cca2851f289e4
<pre>
[JSC] Add a root-locale fast path to `toLocaleLowerCase` and `toLocaleUpperCase`
<a href="https://bugs.webkit.org/show_bug.cgi?id=315630">https://bugs.webkit.org/show_bug.cgi?id=315630</a>

Reviewed by Yusuke Suzuki.

toLocaleLowerCase / toLocaleUpperCase always went through ICU
(u_strToLower / u_strToUpper) and always upconverted the string to UTF-16,
even when the resolved locale does not affect case mapping.

Unicode case mapping is locale-independent except for the tailoring locales
az, el, lt, and tr. For every other locale (including the &quot;und&quot; root locale
that results when the locale argument is undefined), the result is identical
to the locale-independent (&quot;root&quot;) case conversion, which already has
ASCII/Latin-1 fast paths.

                                       TipOfTree                  Patched

intl-string-tolocalelowercase      146.4819+-2.1938     ^     24.6959+-0.5805        ^ definitely 5.9314x faster
intl-string-tolocaleuppercase      147.4327+-2.7373     ^     24.9070+-0.9821        ^ definitely 5.9193x faster

Tests: JSTests/microbenchmarks/intl-string-tolocalelowercase.js
       JSTests/microbenchmarks/intl-string-tolocaleuppercase.js
       JSTests/stress/to-locale-case-root-fast-path.js

* JSTests/microbenchmarks/intl-string-tolocalelowercase.js: Added.
(test):
* JSTests/microbenchmarks/intl-string-tolocaleuppercase.js: Added.
(test):
* JSTests/stress/to-locale-case-root-fast-path.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::toLocaleCase):

Canonical link: <a href="https://commits.webkit.org/313951@main">https://commits.webkit.org/313951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f96e509f453279ad708ab22d33079d6e3e0bba8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121877 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127921 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108465 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27894 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21418 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156776 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25677 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176183 "Hash 1f96e509 for PR 65743 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25517 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29005 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27346 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/176183 "Hash 1f96e509 for PR 65743 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32018 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/176183 "Hash 1f96e509 for PR 65743 does not build (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36689 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147472 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101029 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31474 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24328 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197028 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37376 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110420 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51753 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36774 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2391 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37022 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->