### PR TITLE
Potential use after free of m_stream in ReadableStreamBYOBReader::visitAdditionalChildren()

### DIFF
--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
@@ -61,7 +61,11 @@ ReadableStreamBYOBReader::ReadableStreamBYOBReader(Ref<DOMPromise>&& promise, Re
 
 ReadableStreamBYOBReader::~ReadableStreamBYOBReader()
 {
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
     if (stream && stream->byobReader() == this)
         stream->setByobReader(nullptr);
 }
@@ -96,18 +100,22 @@ void ReadableStreamBYOBReader::readForBindings(JSDOMGlobalObject& globalObject, 
             return promise->reject(Exception { ExceptionCode::RangeError, "view's buffer is not large enough"_s });
     }
 
-    if (!m_stream)
-        return promise->reject(Exception { ExceptionCode::TypeError, "reader has no stream"_s });
-
+    {
+        Locker locker { m_streamLock };
+        if (!m_stream)
+            return promise->reject(Exception { ExceptionCode::TypeError, "reader has no stream"_s });
+    }
     read(globalObject, view, options.min, ReadableStreamReadIntoRequest::create(WTF::move(promise)));
 }
 
 // https://streams.spec.whatwg.org/#byob-reader-release-lock
 void ReadableStreamBYOBReader::releaseLock(JSDOMGlobalObject& globalObject)
 {
-    if (!m_stream)
-        return;
-
+    {
+        Locker locker { m_streamLock };
+        if (!m_stream)
+            return;
+    }
     genericRelease(globalObject);
 
     errorReadIntoRequests(Exception { ExceptionCode::TypeError, "releasing stream"_s });
@@ -116,7 +124,12 @@ void ReadableStreamBYOBReader::releaseLock(JSDOMGlobalObject& globalObject)
 // https://streams.spec.whatwg.org/#generic-reader-cancel
 Ref<DOMPromise> ReadableStreamBYOBReader::cancel(JSDOMGlobalObject& globalObject, JSC::JSValue value)
 {
-    if (!m_stream) {
+    bool hasStream;
+    {
+        Locker locker { m_streamLock };
+        hasStream = m_stream;
+    }
+    if (!hasStream) {
         auto [promise, deferred] = createPromiseAndWrapper(globalObject);
         deferred->reject(Exception { ExceptionCode::TypeError, "no stream"_s });
         return promise;
@@ -141,7 +154,10 @@ ExceptionOr<void> ReadableStreamBYOBReader::setupBYOBReader(JSDOMGlobalObject& g
 // https://streams.spec.whatwg.org/#set-up-readable-stream-byob-reader
 void ReadableStreamBYOBReader::initialize(JSDOMGlobalObject& globalObject, ReadableStream& stream)
 {
-    m_stream = &stream;
+    {
+        Locker locker { m_streamLock };
+        m_stream = stream;
+    }
 
     stream.setByobReader(this);
 
@@ -160,8 +176,11 @@ void ReadableStreamBYOBReader::initialize(JSDOMGlobalObject& globalObject, Reada
 // https://streams.spec.whatwg.org/#readable-stream-byob-reader-read
 void ReadableStreamBYOBReader::read(JSDOMGlobalObject& globalObject, JSC::ArrayBufferView& view, uint64_t optionMin, Ref<ReadableStreamReadIntoRequest>&& readRequest)
 {
-    ASSERT(m_stream);
-    Ref stream = *m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
 
     stream->markAsDisturbed();
     if (stream->state() == ReadableStream::State::Errored) {
@@ -176,8 +195,11 @@ void ReadableStreamBYOBReader::read(JSDOMGlobalObject& globalObject, JSC::ArrayB
 // https://streams.spec.whatwg.org/#readable-stream-reader-generic-release
 void ReadableStreamBYOBReader::genericRelease(JSDOMGlobalObject& globalObject)
 {
-    ASSERT(m_stream);
-    Ref stream = *m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
 
     ASSERT(stream->byobReader() == this);
 
@@ -194,7 +216,11 @@ void ReadableStreamBYOBReader::genericRelease(JSDOMGlobalObject& globalObject)
         controller->runReleaseSteps();
 
     stream->setByobReader(nullptr);
-    m_stream = nullptr;
+
+    {
+        Locker locker { m_streamLock };
+        m_stream = nullptr;
+    }
 }
 
 // https://streams.spec.whatwg.org/#abstract-opdef-readablestreambyobreadererrorreadintorequests
@@ -225,7 +251,11 @@ void ReadableStreamBYOBReader::rejectClosedPromise(JSC::JSValue reason)
 // https://streams.spec.whatwg.org/#readable-stream-reader-generic-cancel
 Ref<DOMPromise> ReadableStreamBYOBReader::genericCancel(JSDOMGlobalObject& globalObject, JSC::JSValue value)
 {
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
 
     ASSERT(stream);
     ASSERT(stream->byobReader() == this);
@@ -269,6 +299,7 @@ void ReadableStreamBYOBReader::onClosedPromiseRejection(ClosedCallback&& callbac
 
 bool ReadableStreamBYOBReader::isReachableFromOpaqueRoots() const
 {
+    Locker locker { m_streamLock };
     return readIntoRequestsSize() && m_stream && m_stream->isReachableFromOpaqueRoots();
 }
 
@@ -293,6 +324,7 @@ bool JSReadableStreamBYOBReaderOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC
 template<typename Visitor>
 void ReadableStreamBYOBReader::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
+    Locker locker { m_streamLock };
     if (m_stream)
         SUPPRESS_UNCOUNTED_ARG m_stream->visitAdditionalChildrenInGCThread(visitor);
 }

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
@@ -31,6 +31,7 @@
 #include "ScriptWrappable.h"
 #include "WebCoreOpaqueRoot.h"
 #include <wtf/Deque.h>
+#include <wtf/Lock.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
@@ -90,7 +91,8 @@ private:
 
     Ref<DOMPromise> m_closedPromise;
     Ref<DeferredPromise> m_closedDeferred;
-    RefPtr<ReadableStream> m_stream;
+    mutable Lock m_streamLock;
+    RefPtr<ReadableStream> m_stream WTF_GUARDED_BY_LOCK(m_streamLock);
     Deque<Ref<ReadableStreamReadIntoRequest>> m_readIntoRequests;
 
     ClosedCallback m_closedCallback;


### PR DESCRIPTION
#### 597af50a6484453da5c501a12f8145eb07f3fcf7
<pre>
Potential use after free of m_stream in ReadableStreamBYOBReader::visitAdditionalChildren()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309885">https://bugs.webkit.org/show_bug.cgi?id=309885</a>
<a href="https://rdar.apple.com/172460621">rdar://172460621</a>

Reviewed by Ryosuke Niwa and Youenn Fablet.

ReadableStreamBYOBReader::visitAdditionalChildren() runs on the GC
thread but dereferences m_stream which can get nulled out of the main
thread.

Address the issue via locking since we cannot easily ref the stream on
the GC thread.

* Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp:
(WebCore::ReadableStreamBYOBReader::~ReadableStreamBYOBReader):
(WebCore::ReadableStreamBYOBReader::readForBindings):
(WebCore::ReadableStreamBYOBReader::releaseLock):
(WebCore::ReadableStreamBYOBReader::cancel):
(WebCore::ReadableStreamBYOBReader::initialize):
(WebCore::ReadableStreamBYOBReader::read):
(WebCore::ReadableStreamBYOBReader::genericRelease):
(WebCore::ReadableStreamBYOBReader::genericCancel):
(WebCore::ReadableStreamBYOBReader::isReachableFromOpaqueRoots const):
(WebCore::ReadableStreamBYOBReader::visitAdditionalChildren):
* Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h:

Originally-landed-as: 305413.476@rapid/safari-7624.2.5.110-branch (645b3e428ffb). <a href="https://rdar.apple.com/176061793">rdar://176061793</a>
Canonical link: <a href="https://commits.webkit.org/313947@main">https://commits.webkit.org/313947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/774b32568035ecd7c131cba3325d3803cde61cfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173675 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166509 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127935 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147977 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108479 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21433 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176198 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136253 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38193 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136216 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36687 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147488 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101045 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31490 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24344 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37391 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110435 "Found 1 new failure in Modules/streams/ReadableStreamBYOBReader.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36789 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2407 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->