### PR TITLE
[CMake] Stop compiling every module 6 times (shared list of compiler arugments)

### DIFF
--- a/Source/WebGPU/WebGPU/CMakeLists.txt
+++ b/Source/WebGPU/WebGPU/CMakeLists.txt
@@ -304,10 +304,6 @@ if (SWIFT_REQUIRED)
         "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-library-level spi>"
         "$<$<COMPILE_LANGUAGE:Swift>:-no-verify-emitted-module-interface>"
         "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-access-control>"
-        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -D__WEBGPU__>"
-        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DENABLE_WEBGPU_SWIFT=1>"
-        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DUCHAR_TYPE=char16_t>"
-        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fvisibility=hidden>"
     )
 
     if (CMAKE_SYSTEM_NAME STREQUAL "iOS")

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -862,24 +862,11 @@ set(WebKit_SWIFT_CLANG_INCLUDE_DIRS
 )
 
 if (NOT APPLE AND SWIFT_REQUIRED)
-    # Export macro stubs – on Linux these expand to __attribute__((visibility))
-    # but per-module PCM compiles don't pull in the config headers that define them.
-    # Define as empty so C++ headers compile cleanly in isolation.
+    # Export-macro stubs, NODELETE=, WK_SUPPORTS_SWIFT_OBJCXX_INTEROP and the
+    # full ENABLE/HAVE/USE config-var set now come from
+    # _WEBKIT_COMPUTE_SWIFT_SHARED_CLANG_FLAGS in WebKitMacros.cmake. Only
+    # Linux-specific importer flags remain here.
     set(WebKit_SWIFT_CLANG_FLAG_PAIRS
-        "-Xcc -DJS_EXPORT_PRIVATE="
-        "-Xcc -DPAL_EXPORT="
-        "-Xcc -DWEBCORE_EXPORT="
-        "-Xcc -DWEBCORE_TESTSUPPORT_EXPORT="
-        "-Xcc -DWK_EXPORT="
-        "-Xcc -DWK_SUPPORTS_SWIFT_OBJCXX_INTEROP=1"
-        "-Xcc -DWTF_EXPORT_PRIVATE="
-
-        # NODELETE expands to [[clang::annotate_type(...)]], a type attribute.
-        # Clang 21 (Swift 6.3 embedded clang) rejects it on function declarations;
-        # nullify it for the Swift module importer since the annotation is only
-        # meaningful to Apple's static analyser.
-        "-Xcc -DNODELETE="
-
         # libstdc++ gates coroutine support in <bits/version.h> behind
         # __glibcxx_want_coroutine.  Swift's Clang 21 compiles <bits/version.h>
         # as a PCM before that flag is set, so __cpp_lib_coroutine stays
@@ -889,19 +876,6 @@ if (NOT APPLE AND SWIFT_REQUIRED)
         "-Xcc -D__glibcxx_want_coroutine=1"
         "-Xcc -fmodule-map-file=${WTF_FRAMEWORK_HEADERS_DIR}/wtf/module.modulemap"
     )
-    # Mirror cmake config variables as -Xcc -D so ENABLE()/HAVE() macros in
-    # C++ headers agree with the regular C++ compilation when the Clang importer
-    # compiles them as part of Swift's C++ interop modules.
-    GET_WEBKIT_CONFIG_VARIABLES(_swift_clang_config_vars)
-    list(REMOVE_DUPLICATES _swift_clang_config_vars)
-    foreach (_var IN LISTS _swift_clang_config_vars)
-        if (${${_var}})
-            list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -D${_var}=1")
-        else ()
-            list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -D${_var}=0")
-        endif ()
-    endforeach ()
-    unset(_swift_clang_config_vars)
     foreach (_dir IN LISTS WebKit_SWIFT_CLANG_INCLUDE_DIRS)
         list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -I${_dir}")
     endforeach ()

--- a/Source/WebKit/PlatformIOS.cmake
+++ b/Source/WebKit/PlatformIOS.cmake
@@ -497,31 +497,12 @@ target_compile_options(WebKit PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-no-verify-emitted-module-interface>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-library-level api>"
     "$<$<COMPILE_LANGUAGE:Swift>:-strict-memory-safety>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -std=c++2b>"
+    # -Xcc -D/-f flags shared with PAL/WebGPU come from
+    # _WEBKIT_COMPUTE_SWIFT_SHARED_CLANG_FLAGS in WebKitMacros.cmake (which also
+    # omits WK_SUPPORTS_SWIFT_OBJCXX_INTEROP on iOS — see bug 312083). Only
+    # -I/-isystem/-ivfsoverlay/-fmodule-map-file (not in the module-cache hash)
+    # remain per-target here.
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DHAVE_CONFIG_H=1>"
-    # Intentionally do NOT define WK_SUPPORTS_SWIFT_OBJCXX_INTEROP for the Swift
-    # compile's clang importer. WebKit_Internal headers (WKWebViewIOS.h,
-    # WKWebViewInternal.h, _WKTextExtractionInternal.h, ...) gate their C++
-    # / Obj-C++ surface behind this macro; with it set, headers do textual
-    # `#import "_WKTapHandlingResult.h"` and similar that trip clang's strict
-    # cross-module-import-visibility check during the WebKit_Internal PCM
-    # compile (bug 312083). With the macro undefined, the gated sections are
-    # skipped and only the `WKViewInternalIOS_SwiftNonObjCxxSupport` Swift-
-    # friendly category (declaring `_allowsMagnification` etc.) is exposed —
-    # exactly what the iOS Swift sources need. The non-Swift C++/Obj-C++
-    # TUs still see WK_SUPPORTS_SWIFT_OBJCXX_INTEROP=1 via xcconfig-mirroring
-    # in WebKitMacros.cmake (only the Swift→Clang side is gated here).
-    # Export-macro stubs. CMakeLists.txt:866-901 sets these only for non-Apple;
-    # but Swift's clang importer on iOS hits the same problem — when WebKit_Internal
-    # or wtf submodules compile in isolation, headers using WTF_EXPORT_PRIVATE,
-    # JS_EXPORT_PRIVATE, etc. don't see those macros via the usual prefix-header /
-    # transitive ExportMacros.h chain. Stub them empty for the Swift clang importer
-    # (no effect on the regular ObjC++ compile, which has them defined normally).
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DJS_EXPORT_PRIVATE=>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DPAL_EXPORT=>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DWK_EXPORT=>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DWTF_EXPORT_PRIVATE=>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DNODELETE=>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${CMAKE_BINARY_DIR}>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-cross-import-overlays>"
     # Auto-import the WebKit framework's clang module (matched by -module-name
@@ -560,7 +541,6 @@ target_compile_options(WebKit PRIVATE
 
 target_compile_options(WebKit PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-swift-version 6>"
     "$<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-private-module-interface-path ${CMAKE_BINARY_DIR}/Source/WebKit/WebKit.private.swiftinterface>"
 )

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -117,51 +117,13 @@ set(WebKit_SWIFT_CLANG_INCLUDE_DIRS
     ${WebKit_PRIVATE_INCLUDE_DIRECTORIES}
 )
 
-# Module PCMs compile with a clean preprocessor (no -include), so feed
-# cmakeconfig.h's content and the export-macro stubs as -Xcc -D instead. The
-# Clang importer applies -D to every module build. Each pair is kept as a single
-# list element so target_compile_options can wrap it in SHELL: -- otherwise CMake
-# deduplicates the repeated -Xcc and only the first flag reaches the importer.
-set(WebKit_SWIFT_CLANG_FLAG_PAIRS
-    "-Xcc -DBUILDING_WEBKIT"
-    "-Xcc -DJS_EXPORT_PRIVATE="
-    "-Xcc -DPAL_EXPORT="
-    "-Xcc -DWEBCORE_EXPORT="
-    "-Xcc -DWEBCORE_TESTSUPPORT_EXPORT="
-    "-Xcc -DWK_SUPPORTS_SWIFT_OBJCXX_INTEROP=1"
-    "-Xcc -fmodule-map-file=${WTF_FRAMEWORK_HEADERS_DIR}/wtf/module.modulemap"
-    "-Xcc -fmodule-map-file=${PAL_FRAMEWORK_HEADERS_DIR}/pal/module.modulemap"
-)
-# ASSERT_ENABLED (and therefore the layout of RefCountedBase, IPC::MessageReceiver,
-# and many others) is keyed off NDEBUG. CMake adds -DNDEBUG to CXX flags in Release
-# but not to swiftc, so the Clang importer would otherwise see a Debug layout and
-# inline ref()/adoptRef() against the wrong member offsets.
-string(TOUPPER "${CMAKE_BUILD_TYPE}" _build_type_upper)
-if (CMAKE_CXX_FLAGS_${_build_type_upper} MATCHES "NDEBUG" OR CMAKE_CXX_FLAGS MATCHES "NDEBUG")
-    list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -DNDEBUG" "-Xcc -DRELEASE_WITHOUT_OPTIMIZATIONS")
-endif ()
-unset(_build_type_upper)
-# GET_WEBKIT_CONFIG_VARIABLES filters out falsy entries, so the importer would
-# miss every =0 and fall back to PlatformEnableCocoa.h defaults — which diverges
-# from cmakeconfig.h and shifts member offsets in headers Swift inlines.
-set(_swift_clang_config_vars ${_WEBKIT_CONFIG_FILE_VARIABLES})
-list(REMOVE_DUPLICATES _swift_clang_config_vars)
-foreach (_var IN LISTS _swift_clang_config_vars)
-    if (${${_var}})
-        list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -D${_var}=1")
-    else ()
-        list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -D${_var}=0")
-    endif ()
-endforeach ()
-unset(_swift_clang_config_vars)
+# -Xcc -D/-f flags shared with PAL/WebGPU come from
+# _WEBKIT_COMPUTE_SWIFT_SHARED_CLANG_FLAGS so all three targets land in the
+# same SwiftModuleCache hash dir. Only -I (not hashed) remains per-target.
 foreach (_dir IN LISTS WebKit_SWIFT_CLANG_INCLUDE_DIRS)
-    list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -I${_dir}")
+    target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${_dir}>")
 endforeach ()
-
 target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MATERIAL_HOSTING>")
-foreach (_pair IN LISTS WebKit_SWIFT_CLANG_FLAG_PAIRS)
-    target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:SHELL:${_pair}>")
-endforeach ()
 foreach (_dir IN LISTS WebKit_SWIFT_INCLUDE_DIRECTORIES)
     target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:-I${_dir}>")
 endforeach ()

--- a/Source/cmake/OptionsIOS.cmake
+++ b/Source/cmake/OptionsIOS.cmake
@@ -169,12 +169,6 @@ if (CMAKE_OSX_SYSROOT)
     set(WEBKIT_PRIVATE_FRAMEWORKS_COMPILE_FLAG "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks>")
 endif ()
 
-# Export macros must be predefined for Swift explicit-module builds (no prefix headers).
-add_compile_options(
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DWEBCORE_EXPORT=>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DWEBCORE_TESTSUPPORT_EXPORT=>"
-)
-
 if (CMAKE_OSX_SYSROOT MATCHES "\\.Internal\\.sdk$")
     add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:-DUSE_APPLE_INTERNAL_SDK>")
 endif ()

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -770,6 +770,59 @@ macro(WEBKIT_CREATE_SYMLINK target src dest)
         COMMENT "Create symlink from ${src} to ${dest}")
 endmacro()
 
+function(_WEBKIT_COMPUTE_SWIFT_SHARED_CLANG_FLAGS _outvar)
+    # All Swift C++-interop targets pass the same -Xcc -D set so the clang
+    # importer's module-cache hash matches and bmalloc/wtf/SDK PCMs build once.
+    # -I/-isystem/-fmodule-map-file/-fvisibility are not in the hash and stay
+    # per-target. Per-target target_compile_definitions are intentionally NOT
+    # forwarded here; the wrapper no longer mirrors plain -D to -Xcc.
+    set(_flags
+        -DENABLE_WEBGPU_SWIFT=1
+        -DJS_EXPORT_PRIVATE=
+        -DNODELETE=
+        -DPAL_EXPORT=
+        -DUCHAR_TYPE=char16_t
+        -DWEBCORE_EXPORT=
+        -DWEBCORE_TESTSUPPORT_EXPORT=
+        -DWK_EXPORT=
+        -DWTF_EXPORT_PRIVATE=
+        -D__WEBGPU__
+    )
+    # iOS WebKit_Internal headers gate textual #imports behind this macro that
+    # trip strict cross-module-import-visibility checks (bug 312083).
+    if (NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+        list(APPEND _flags -DWK_SUPPORTS_SWIFT_OBJCXX_INTEROP=1)
+    endif ()
+    if (APPLE)
+        # Normalize the LangOpt that WebGPU's SafeInteropWrappers enables
+        # implicitly so PAL/WebKit hash to the same module-cache dir.
+        list(APPEND _flags -fexperimental-bounds-safety-attributes)
+    endif ()
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" _bt)
+    if (CMAKE_CXX_FLAGS_${_bt} MATCHES "NDEBUG" OR CMAKE_CXX_FLAGS MATCHES "NDEBUG")
+        list(APPEND _flags -DNDEBUG -DRELEASE_WITHOUT_OPTIMIZATIONS)
+    endif ()
+    # Globals from add_definitions() (BUILDING_WEBKIT=1, PAS_BMALLOC=1,
+    # _LIBCPP_HARDENING_MODE=...). Read from a fixed directory so every caller
+    # sees the same set regardless of its own add_definitions().
+    get_directory_property(_dir_defs DIRECTORY "${CMAKE_SOURCE_DIR}/Source" COMPILE_DEFINITIONS)
+    foreach (_d IN LISTS _dir_defs)
+        if (NOT _d MATCHES "^(BUILDING_WITH_CMAKE|HAVE_CONFIG_H)($|=)")
+            list(APPEND _flags "-D${_d}")
+        endif ()
+    endforeach ()
+    set(_vars ${_WEBKIT_CONFIG_FILE_VARIABLES})
+    list(REMOVE_DUPLICATES _vars)
+    foreach (_v IN LISTS _vars)
+        if (${${_v}})
+            list(APPEND _flags "-D${_v}=1")
+        else ()
+            list(APPEND _flags "-D${_v}=0")
+        endif ()
+    endforeach ()
+    set(${_outvar} ${_flags} PARENT_SCOPE)
+endfunction()
+
 function(_webkit_setup_swift_header_deps _target _stamp _header)
     # Discover _CopyHeaders/_CopyPrivateHeaders targets for this target and its
     # direct framework dependencies. Called via cmake_language(DEFER CALL ...)
@@ -905,6 +958,14 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         # which is also Swift-only) can set
         # ${_target}_SWIFT_INTEROP_MODULE_PATH_SWIFT_ONLY to TRUE.
         list(APPEND _swift_options "-cxx-interoperability-mode=default" "-Xcc" "-std=c++2b")
+        _WEBKIT_COMPUTE_SWIFT_SHARED_CLANG_FLAGS(_shared_cc_flags)
+        foreach (_f IN LISTS _shared_cc_flags)
+            list(APPEND _swift_options "-Xcc" "${_f}")
+        endforeach ()
+        # Match Xcode's CommonBase.xcconfig SWIFT_VERSION = 6.0. The importer's
+        # apinotes version is keyed off the effective Swift language mode, so
+        # this also keeps PAL/WebGPU/WebKit on the same module-cache hash.
+        list(APPEND _swift_options "-swift-version" "6")
         if (${_target}_SWIFT_INTEROP_MODULE_PATH_SWIFT_ONLY)
             list(APPEND _swift_options "-I${_interop_module_path}")
         else ()

--- a/Tools/Scripts/swift/swiftc-wrapper.sh
+++ b/Tools/Scripts/swift/swiftc-wrapper.sh
@@ -76,21 +76,10 @@ for arg in "$@"; do
         "--original-swift-compiler="*)
             REAL_SWIFTC="${arg#--original-swift-compiler=}"
             ;;
-        "-D"*)
-            # Propagate -D to both swiftc (Swift conditionals) and -Xcc -D
-            # (Clang importer). EXCEPT for cmake-build-mode defines that signal
-            # to our own headers we're building under cmake — propagating those
-            # to the Clang importer makes SDK framework PCMs (e.g. JSC's
-            # config.h) take their cmake-only branches and look for headers
-            # like cmakeconfig.h that don't exist in the SDK build context.
-            case "$arg" in
-                "-DBUILDING_WITH_CMAKE"*|"-DHAVE_CONFIG_H"*)
-                    args+=("$arg")
-                    ;;
-                *)
-                    args+=("$arg" "-Xcc" "$arg")
-                    ;;
-            esac
+        "-D"*"="*)
+            # Swift conditional-compilation flags are valueless; the importer's
+            # -D set comes from _WEBKIT_COMPUTE_SWIFT_SHARED_CLANG_FLAGS, so
+            # valued target_compile_definitions are dropped here.
             ;;
         *)
             if [[ -n "$skip_next" ]]; then


### PR DESCRIPTION
#### f0eef5f60a16a9b69b1db60186262b476ce7d1ae
<pre>
[CMake] Stop compiling every module 6 times (shared list of compiler arugments)
<a href="https://bugs.webkit.org/show_bug.cgi?id=315636">https://bugs.webkit.org/show_bug.cgi?id=315636</a>
<a href="https://rdar.apple.com/178012097">rdar://178012097</a>

Reviewed by Mike Wyrzykowski.

Swift currently compiles every module 6 times.

You get a new module any time you invoke swiftc with arguments that don&apos;t match
a previous invocation.

Triggers for this pathology:
* PAL enables Swift 6, and other targets don&apos;t
* WebGPU enables SafeInteropWrappers, and other targets don&apos;t
* WebKit hand-rolls a large -Xcc -D set, and other targets don&apos;t

In some ways, these triggers also risk correctness issues, since we&apos;re
ultimately not compiling with cosistent settings.

Also:
* CMake provides all target_compile_definitions to swiftc, even when they&apos;re
not relevant

This patch addresses the issue by establishing a central defintion for the
flags we need when compiling Swift, and using it everywhere.

Conversely, swift-wrapper now strips any stray -D arguments not from the list,
to help ensure uniformity.

Canonical link: <a href="https://commits.webkit.org/314049@main">https://commits.webkit.org/314049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93defe0393d547ee4491715a0c5cee9966ac9120

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174044 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b804a8b2-45ac-46ca-a650-c4129f23f646) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166870 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38494 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/128221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3041458f-7ca7-4c46-b6ad-3dc19a39196a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108747 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa79d521-8018-425d-97a3-14d5ed0f2e9e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21799 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157161 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176567 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25897 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27668 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/136542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38561 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/136487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147760 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101550 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25107 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31760 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197405 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37761 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/52098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37158 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2701 "Passed tests") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37302 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->