### PR TITLE
[JSC][Temporal] Implement Intl.DateTimeFormat Temporal support and toLocaleString

### DIFF
--- a/JSTests/stress/intl-datetimeformat-temporal-formatter-cache.js
+++ b/JSTests/stress/intl-datetimeformat-temporal-formatter-cache.js
@@ -1,0 +1,121 @@
+//@ requireOptions("--useTemporal=1")
+// Stress test for createTemporalFormatter caching:
+// The formatter for each TemporalFieldKind is computed once and cached.
+// Verify that repeated calls and mixed-kind calls produce correct, consistent output.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+// Fixed epoch for deterministic output regardless of timezone.
+const t = new Date(Date.UTC(2024, 0, 15, 10, 30, 45)); // 2024-01-15T10:30:45Z
+
+const plainDate = new Temporal.PlainDate(2024, 1, 15);
+const plainTime = new Temporal.PlainTime(10, 30, 45);
+const plainDateTime = new Temporal.PlainDateTime(2024, 1, 15, 10, 30, 45);
+const plainYM = new Temporal.PlainYearMonth(2024, 1);
+const plainMD = new Temporal.PlainMonthDay(1, 15);
+const instant = new Temporal.Instant(BigInt(t.getTime()) * 1_000_000n);
+
+const fmt = new Intl.DateTimeFormat("en-US", {
+    year: "numeric", month: "short", day: "numeric",
+    hour: "numeric", minute: "2-digit", second: "2-digit",
+    timeZone: "UTC",
+    calendar: "iso8601"
+});
+
+// 1. Repeated calls on same kind must produce identical output.
+{
+    const N = 100;
+    const first = fmt.format(plainDate);
+    for (let i = 0; i < N; i++)
+        shouldBe(fmt.format(plainDate), first, `plainDate iteration ${i}`);
+
+    const firstTime = fmt.format(plainTime);
+    for (let i = 0; i < N; i++)
+        shouldBe(fmt.format(plainTime), firstTime, `plainTime iteration ${i}`);
+
+    const firstDT = fmt.format(plainDateTime);
+    for (let i = 0; i < N; i++)
+        shouldBe(fmt.format(plainDateTime), firstDT, `plainDateTime iteration ${i}`);
+}
+
+// 2. Different kinds on same formatter don't interfere — interleave them.
+{
+    const r1 = fmt.format(plainDate);
+    const r2 = fmt.format(plainTime);
+    const r3 = fmt.format(plainDateTime);
+    const r4 = fmt.format(plainYM);
+    const r5 = fmt.format(plainMD);
+
+    for (let i = 0; i < 50; i++) {
+        shouldBe(fmt.format(plainDate), r1, `interleaved plainDate ${i}`);
+        shouldBe(fmt.format(plainTime), r2, `interleaved plainTime ${i}`);
+        shouldBe(fmt.format(plainDateTime), r3, `interleaved plainDateTime ${i}`);
+        shouldBe(fmt.format(plainYM), r4, `interleaved plainYearMonth ${i}`);
+        shouldBe(fmt.format(plainMD), r5, `interleaved plainMonthDay ${i}`);
+    }
+}
+
+// 3. Plain types must use GMT (not the formatter's timezone), so the date
+//    fields come from the Temporal value itself, not from epoch conversion.
+{
+    // A formatter with a non-UTC timezone — plain types must still show the
+    // Temporal value's fields unchanged (they don't do timezone conversion).
+    const fmtLA = new Intl.DateTimeFormat("en-US", {
+        year: "numeric", month: "numeric", day: "numeric",
+        hour: "numeric", minute: "2-digit",
+        timeZone: "America/Los_Angeles"
+    });
+    // PlainDate 2024-01-15 must format as Jan 15, regardless of LA offset.
+    const pdResult = fmtLA.format(plainDate);
+    shouldBe(pdResult.includes("1/15/2024") || pdResult.includes("15"), true,
+        "PlainDate should show Jan 15 regardless of LA timezone");
+
+    // Instant uses the formatter's timezone (LA), so it could shift the day.
+    const instResult = fmtLA.format(instant); // 10:30 UTC = 02:30 LA → Jan 15 still
+    // Just verify it formats without throwing and is consistent.
+    shouldBe(fmtLA.format(instant), instResult, "Instant result stable");
+
+    // Repeated calls still match.
+    for (let i = 0; i < 20; i++) {
+        shouldBe(fmtLA.format(plainDate), pdResult, `LA plainDate ${i}`);
+        shouldBe(fmtLA.format(instant), instResult, `LA instant ${i}`);
+    }
+}
+
+// 4. formatToParts and format share the same cache — verify consistency.
+{
+    const partsDate = fmt.formatToParts(plainDate);
+    const fmtDate = fmt.format(plainDate);
+    const reconstructed = partsDate.map(p => p.value).join("");
+    shouldBe(reconstructed, fmtDate, "formatToParts reconstructs same string as format");
+
+    for (let i = 0; i < 30; i++) {
+        shouldBe(fmt.format(plainDate), fmtDate, `format after formatToParts ${i}`);
+        shouldBe(fmt.formatToParts(plainDate).map(p => p.value).join(""), fmtDate,
+            `formatToParts after format ${i}`);
+    }
+}
+
+// 5. dateStyle/timeStyle formatters cache correctly.
+{
+    const fmtDS = new Intl.DateTimeFormat("en-US", { dateStyle: "short", timeZone: "UTC" });
+    const fmtTS = new Intl.DateTimeFormat("en-US", { timeStyle: "short", timeZone: "UTC" });
+
+    const dsDate = fmtDS.format(plainDate);
+    const tsTime = fmtTS.format(plainTime);
+    const tsDT = fmtTS.format(plainDateTime);
+
+    for (let i = 0; i < 50; i++) {
+        shouldBe(fmtDS.format(plainDate), dsDate, `dateStyle plainDate ${i}`);
+        shouldBe(fmtTS.format(plainTime), tsTime, `timeStyle plainTime ${i}`);
+        shouldBe(fmtTS.format(plainDateTime), tsDT, `timeStyle plainDateTime ${i}`);
+    }
+
+    // dateStyle + PlainTime must throw (no overlap).
+    let threw = false;
+    try { fmtDS.format(plainTime); } catch (e) { threw = true; }
+    shouldBe(threw, true, "dateStyle + PlainTime must throw TypeError");
+}

--- a/JSTests/stress/temporal-plaindate.js
+++ b/JSTests/stress/temporal-plaindate.js
@@ -1,6 +1,4 @@
 //@ requireOptions("--useTemporal=1")
-// FIXME: toLocaleString requires IntlDateTimeFormat Temporal support, implemented in the next patch.
-//@ skip
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/stress/temporal-plaindatetime.js
+++ b/JSTests/stress/temporal-plaindatetime.js
@@ -1,6 +1,4 @@
 //@ requireOptions("--useTemporal=1")
-// FIXME: toLocaleString requires IntlDateTimeFormat Temporal support, implemented in the next patch.
-//@ skip
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/stress/temporal-plainmonthday.js
+++ b/JSTests/stress/temporal-plainmonthday.js
@@ -1,6 +1,4 @@
 //@ requireOptions("--useTemporal=1")
-// FIXME: toLocaleString requires IntlDateTimeFormat Temporal support, implemented in the next patch.
-//@ skip
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/stress/temporal-plaintime.js
+++ b/JSTests/stress/temporal-plaintime.js
@@ -1,6 +1,4 @@
 //@ requireOptions("--useTemporal=1")
-// FIXME: toLocaleString requires IntlDateTimeFormat Temporal support, implemented in the next patch.
-//@ skip
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/stress/temporal-plainyearmonth.js
+++ b/JSTests/stress/temporal-plainyearmonth.js
@@ -1,6 +1,4 @@
 //@ requireOptions("--useTemporal=1")
-// FIXME: toLocaleString requires IntlDateTimeFormat Temporal support, implemented in the next patch.
-//@ skip
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -130,24 +130,12 @@ test/built-ins/Temporal/Duration/prototype/total/throws-if-target-nanoseconds-ou
 test/built-ins/Temporal/Duration/prototype/total/zero-duration.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, 'UTC')')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, 'UTC')')"
-test/built-ins/Temporal/Instant/prototype/toLocaleString/return-string.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
 test/built-ins/Temporal/PlainDate/from/order-of-operations.js:
   default: 'Test262Error: Actual [get options.overflow, get options.overflow.toString, call options.overflow.toString, get fields.calendar, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.year, get fields.year.valueOf, call fields.year.valueOf] and expected [get fields.calendar, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.year, get fields.year.valueOf, call fields.year.valueOf, get options.overflow, get options.overflow.toString, call options.overflow.toString] should have the same contents. order of operations'
   strict mode: 'Test262Error: Actual [get options.overflow, get options.overflow.toString, call options.overflow.toString, get fields.calendar, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.year, get fields.year.valueOf, call fields.year.valueOf] and expected [get fields.calendar, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.year, get fields.year.valueOf, call fields.year.valueOf, get options.overflow, get options.overflow.toString, call options.overflow.toString] should have the same contents. order of operations'
-test/built-ins/Temporal/PlainDate/prototype/toLocaleString/return-string.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
 test/built-ins/Temporal/PlainDateTime/from/order-of-operations.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, \"UTC\")')"
-test/built-ins/Temporal/PlainDateTime/prototype/toLocaleString/return-string.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/built-ins/Temporal/PlainMonthDay/prototype/toLocaleString/return-string.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
 test/built-ins/Temporal/PlainTime/from/observable-get-overflow-argument-string-invalid.js:
   default: 'Test262Error: Actual [get overflow, get overflow.toString, call overflow.toString] and expected [] should have the same contents. options read after ISO string parsing'
   strict mode: 'Test262Error: Actual [get overflow, get overflow.toString, call overflow.toString] and expected [] should have the same contents. options read after ISO string parsing'
@@ -157,12 +145,6 @@ test/built-ins/Temporal/PlainTime/from/options-wrong-type.js:
 test/built-ins/Temporal/PlainTime/from/order-of-operations.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, \"UTC\")')"
-test/built-ins/Temporal/PlainTime/prototype/toLocaleString/return-string.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/built-ins/Temporal/PlainYearMonth/prototype/toLocaleString/return-string.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
 test/built-ins/Temporal/getOwnPropertyNames.js:
   default: 'Test262Error: ZonedDateTime'
   strict mode: 'Test262Error: ZonedDateTime'
@@ -181,90 +163,12 @@ test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage-empty.js:
 test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage.js:
   default: 'SyntaxError: Uint8Array.prototype.setFromBase64 requires a valid base64 string'
   strict mode: 'SyntaxError: Uint8Array.prototype.setFromBase64 requires a valid base64 string'
-test/intl402/DateTimeFormat/prototype/format/temporal-objects-format-weekday-long.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-objects-format-with-era.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-objects-ignore-timezone.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-objects-no-time-clip-non-latin-numerals.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-objects-no-time-clip-weekday.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-objects-no-time-clip.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-objects-not-overlapping-options.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-plaindate-formatting-datetime-style.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-plaindate-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-plaindatetime-formatting-datetime-style.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-plaindatetime-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-plainmonthday-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainMonthDay.prototype.valueOf must not be called. To compare PlainMonthDay values, use Temporal.PlainDate.compare on the corresponding PlainDate objects.'
-  strict mode: 'TypeError: Temporal.PlainMonthDay.prototype.valueOf must not be called. To compare PlainMonthDay values, use Temporal.PlainDate.compare on the corresponding PlainDate objects.'
-test/intl402/DateTimeFormat/prototype/format/temporal-plaintime-formatting-datetime-style.js:
-  default: 'TypeError: Temporal.PlainTime.prototype.valueOf must not be called. To compare PlainTime values, use Temporal.PlainTime.compare'
-  strict mode: 'TypeError: Temporal.PlainTime.prototype.valueOf must not be called. To compare PlainTime values, use Temporal.PlainTime.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-plaintime-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainTime.prototype.valueOf must not be called. To compare PlainTime values, use Temporal.PlainTime.compare'
-  strict mode: 'TypeError: Temporal.PlainTime.prototype.valueOf must not be called. To compare PlainTime values, use Temporal.PlainTime.compare'
-test/intl402/DateTimeFormat/prototype/format/temporal-plainyearmonth-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainYearMonth.prototype.valueOf must not be called. To compare PlainYearMonth values, use Temporal.PlainYearMonth.compare'
-  strict mode: 'TypeError: Temporal.PlainYearMonth.prototype.valueOf must not be called. To compare PlainYearMonth values, use Temporal.PlainYearMonth.compare'
 test/intl402/DateTimeFormat/prototype/format/temporal-zoneddatetime-not-supported.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
 test/intl402/DateTimeFormat/prototype/formatRange/fails-on-distinct-temporal-types.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, 'America/Kentucky/Louisville')')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, 'America/Kentucky/Louisville')')"
-test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-format-with-era.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-ignore-timezone.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-no-time-clip-weekday.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-no-time-clip.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-not-overlapping-options.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-throws-with-different-calendars.js:
-  default: 'Test262Error: Expected a RangeError but got a TypeError'
-  strict mode: 'Test262Error: Expected a RangeError but got a TypeError'
-test/intl402/DateTimeFormat/prototype/formatRange/temporal-plaindate-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/formatRange/temporal-plaindatetime-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/formatRange/temporal-plainmonthday-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainMonthDay.prototype.valueOf must not be called. To compare PlainMonthDay values, use Temporal.PlainDate.compare on the corresponding PlainDate objects.'
-  strict mode: 'TypeError: Temporal.PlainMonthDay.prototype.valueOf must not be called. To compare PlainMonthDay values, use Temporal.PlainDate.compare on the corresponding PlainDate objects.'
-test/intl402/DateTimeFormat/prototype/formatRange/temporal-plaintime-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainTime.prototype.valueOf must not be called. To compare PlainTime values, use Temporal.PlainTime.compare'
-  strict mode: 'TypeError: Temporal.PlainTime.prototype.valueOf must not be called. To compare PlainTime values, use Temporal.PlainTime.compare'
-test/intl402/DateTimeFormat/prototype/formatRange/temporal-plainyearmonth-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainYearMonth.prototype.valueOf must not be called. To compare PlainYearMonth values, use Temporal.PlainYearMonth.compare'
-  strict mode: 'TypeError: Temporal.PlainYearMonth.prototype.valueOf must not be called. To compare PlainYearMonth values, use Temporal.PlainYearMonth.compare'
 test/intl402/DateTimeFormat/prototype/formatRange/temporal-zoneddatetime-not-supported.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
@@ -274,75 +178,12 @@ test/intl402/DateTimeFormat/prototype/formatRange/to-datetime-formattable-with-d
 test/intl402/DateTimeFormat/prototype/formatRangeToParts/fails-on-distinct-temporal-types.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, 'America/Kentucky/Louisville')')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, 'America/Kentucky/Louisville')')"
-test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-format-with-era.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-ignore-timezone.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-no-time-clip-weekday.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-no-time-clip.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-not-overlapping-options.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-throws-with-different-calendars.js:
-  default: 'Test262Error: Expected a RangeError but got a TypeError'
-  strict mode: 'Test262Error: Expected a RangeError but got a TypeError'
-test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-plaindate-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-plaindatetime-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-plainmonthday-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainMonthDay.prototype.valueOf must not be called. To compare PlainMonthDay values, use Temporal.PlainDate.compare on the corresponding PlainDate objects.'
-  strict mode: 'TypeError: Temporal.PlainMonthDay.prototype.valueOf must not be called. To compare PlainMonthDay values, use Temporal.PlainDate.compare on the corresponding PlainDate objects.'
-test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-plaintime-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainTime.prototype.valueOf must not be called. To compare PlainTime values, use Temporal.PlainTime.compare'
-  strict mode: 'TypeError: Temporal.PlainTime.prototype.valueOf must not be called. To compare PlainTime values, use Temporal.PlainTime.compare'
-test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-plainyearmonth-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainYearMonth.prototype.valueOf must not be called. To compare PlainYearMonth values, use Temporal.PlainYearMonth.compare'
-  strict mode: 'TypeError: Temporal.PlainYearMonth.prototype.valueOf must not be called. To compare PlainYearMonth values, use Temporal.PlainYearMonth.compare'
 test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-zoneddatetime-not-supported.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
 test/intl402/DateTimeFormat/prototype/formatRangeToParts/to-datetime-formattable-with-different-arg-kinds.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, \"UTC\")')"
-test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-format-with-era.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-ignore-timezone.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-no-time-clip-weekday.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-no-time-clip.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-not-overlapping-options.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/formatToParts/temporal-plaindate-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-  strict mode: 'TypeError: Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare'
-test/intl402/DateTimeFormat/prototype/formatToParts/temporal-plaindatetime-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-  strict mode: 'TypeError: Temporal.PlainDateTime.prototype.valueOf must not be called. To compare PlainDateTime values, use Temporal.PlainDateTime.compare'
-test/intl402/DateTimeFormat/prototype/formatToParts/temporal-plainmonthday-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainMonthDay.prototype.valueOf must not be called. To compare PlainMonthDay values, use Temporal.PlainDate.compare on the corresponding PlainDate objects.'
-  strict mode: 'TypeError: Temporal.PlainMonthDay.prototype.valueOf must not be called. To compare PlainMonthDay values, use Temporal.PlainDate.compare on the corresponding PlainDate objects.'
-test/intl402/DateTimeFormat/prototype/formatToParts/temporal-plaintime-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainTime.prototype.valueOf must not be called. To compare PlainTime values, use Temporal.PlainTime.compare'
-  strict mode: 'TypeError: Temporal.PlainTime.prototype.valueOf must not be called. To compare PlainTime values, use Temporal.PlainTime.compare'
-test/intl402/DateTimeFormat/prototype/formatToParts/temporal-plainyearmonth-formatting-timezonename.js:
-  default: 'TypeError: Temporal.PlainYearMonth.prototype.valueOf must not be called. To compare PlainYearMonth values, use Temporal.PlainYearMonth.compare'
-  strict mode: 'TypeError: Temporal.PlainYearMonth.prototype.valueOf must not be called. To compare PlainYearMonth values, use Temporal.PlainYearMonth.compare'
 test/intl402/DateTimeFormat/prototype/formatToParts/temporal-zoneddatetime-not-supported.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
@@ -400,48 +241,6 @@ test/intl402/Temporal/Duration/prototype/total/relativeto-dst-back-transition.js
 test/intl402/Temporal/Duration/prototype/total/relativeto-sub-minute-offset.js:
   default: 'RangeError: relativeTo as ZonedDateTime string is not yet implemented'
   strict mode: 'RangeError: relativeTo as ZonedDateTime string is not yet implemented'
-test/intl402/Temporal/Instant/prototype/toLocaleString/basic.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/dateStyle-timeStyle-undefined.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/dateStyle.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/datestyle-and-timestyle.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/datestyle-not-adjusted-when-no-conflicting-options.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/default-includes-time-not-time-zone-name.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/era.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/hourcycle.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/locales-undefined.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/lone-options-accepted.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/option-timezonename-short.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/options-conflict.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/options-undefined.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-test/intl402/Temporal/Instant/prototype/toLocaleString/respect-timezone-after-formatting-plaindatetime.js:
-  default: 'TypeError: toLocaleString not yet implemented with full Temporal support'
-  strict mode: 'TypeError: toLocaleString not yet implemented with full Temporal support'
 test/language/destructuring/binding/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js:
   default: 'Test262Error: Actual [binding::source, binding::sourceKey, sourceKey, get source, binding::defaultValue, binding::varTarget] and expected [binding::source, binding::sourceKey, sourceKey, binding::varTarget, get source, binding::defaultValue] should have the same contents. '
 test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js:

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -35,7 +35,15 @@
 #include "JSCInlines.h"
 #include "JSDateMath.h"
 #include "ObjectConstructor.h"
+#include "TemporalInstant.h"
+#include "TemporalPlainDate.h"
+#include "TemporalPlainDateTime.h"
+#include "TemporalPlainMonthDay.h"
+#include "TemporalPlainTime.h"
+#include "TemporalPlainYearMonth.h"
+// FIXME #include "TemporalZonedDateTime.h"
 #include <unicode/ucal.h>
+#include <unicode/udatpg.h>
 #include <unicode/uenum.h>
 #include <wtf/Range.h>
 #include <wtf/text/MakeString.h>
@@ -62,9 +70,16 @@ void UDateIntervalFormatDeleter::operator()(UDateIntervalFormat* formatter)
         udtitvfmt_close(formatter);
 }
 
+void UFormattedDateIntervalDeleter::operator()(UFormattedDateInterval* result)
+{
+    if (result)
+        udtitvfmt_closeResult(result);
+}
+
 const ClassInfo IntlDateTimeFormat::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(IntlDateTimeFormat) };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IntlDateTimeFormatImpl);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IntlDateTimeFormatTemporalFormatterCache);
 
 // Approximate sizes of ICU objects for GC memory pressure reporting, measured empirically with udat_open + udat_format.
 static constexpr size_t estimatedUDateFormatSize = 30000;
@@ -122,6 +137,12 @@ void IntlDateTimeFormat::visitChildrenImpl(JSCell* cell, Visitor& visitor)
         visitor.reportExtraMemoryVisited(estimatedUDateFormatSize);
     if (thisObject->m_dateIntervalFormat)
         visitor.reportExtraMemoryVisited(estimatedUDateIntervalFormatSize);
+    if (auto* cache = thisObject->m_impl ? thisObject->m_impl->m_temporalFormatterCache.get() : nullptr) {
+        for (auto& formatter : cache->m_formatters) {
+            if (formatter)
+                visitor.reportExtraMemoryVisited(estimatedUDateFormatSize);
+        }
+    }
 }
 
 DEFINE_VISIT_CHILDREN(IntlDateTimeFormat);
@@ -129,6 +150,41 @@ DEFINE_VISIT_CHILDREN(IntlDateTimeFormat);
 void IntlDateTimeFormat::setBoundFormat(VM& vm, JSBoundFunction* format)
 {
     m_boundFormat.set(vm, this, format);
+}
+
+IntlDateTimeFormat::DateTimeStyle IntlDateTimeFormat::dateStyle() const { return m_impl->m_dateStyle; }
+IntlDateTimeFormat::DateTimeStyle IntlDateTimeFormat::timeStyle() const { return m_impl->m_timeStyle; }
+IntlDateTimeFormat::TimeZoneName IntlDateTimeFormat::timeZoneName() const { return m_impl->m_timeZoneName; }
+
+const String& IntlDateTimeFormat::ensureCalendar() const
+{
+    if (m_impl->m_calendar.isNull())
+        m_impl->m_calendar = defaultCalendarForLocale(m_impl->m_dataLocale);
+    return m_impl->m_calendar;
+}
+
+const String& IntlDateTimeFormat::ensureNumberingSystem() const
+{
+    if (m_impl->m_numberingSystem.isNull())
+        m_impl->m_numberingSystem = defaultNumberingSystemForLocale(m_impl->m_dataLocale);
+    return m_impl->m_numberingSystem;
+}
+
+bool IntlDateTimeFormat::calendarMatchesICU(StringView temporalId, const String& icuCalId)
+{
+    if (temporalId == icuCalId)
+        return true;
+    // Normalize both IDs to their BCP47 canonical form and compare.
+    // mapICUCalendarKeywordToBCP47 maps ICU -> BCP47: "gregorian"->"gregory", "ethiopic-amete-alem"->"ethioaa".
+    // "islamicc" is a legacy alias for "islamic-civil" not covered by the mapping tables.
+    auto normalize = [](const String& id) -> String {
+        if (auto bcp47 = mapICUCalendarKeywordToBCP47(id))
+            return *bcp47;
+        if (id == "islamicc"_s)
+            return "islamic-civil"_s;
+        return id;
+    };
+    return normalize(temporalId.toString()) == normalize(icuCalId);
 }
 
 Vector<String> IntlDateTimeFormat::localeData(const String& locale, RelevantExtensionKey key)
@@ -423,25 +479,37 @@ inline void IntlDateTimeFormat::replaceHourCycleInSkeleton(Vector<char16_t, 32>&
     }
 }
 
+// Returns the ICU pattern character for the given hour cycle, or 'j' (locale default) for None.
+static char16_t hourCharForCycle(IntlDateTimeFormat::HourCycle hourCycle)
+{
+    switch (hourCycle) {
+    case IntlDateTimeFormat::HourCycle::H11:
+        return 'K';
+    case IntlDateTimeFormat::HourCycle::H12:
+        return 'h';
+    case IntlDateTimeFormat::HourCycle::H23:
+        return 'H';
+    case IntlDateTimeFormat::HourCycle::H24:
+        return 'k';
+    default:
+        return 'j';
+    }
+}
+
+// UTS#35 hour skeleton characters (h=h12, H=h23, k=h24, K=h11).
+// Used to detect and replace hour display characters when applying the user's hourCycle.
+static constexpr bool isHourChar(char16_t ch)
+{
+    return ch == 'h' || ch == 'H' || ch == 'k' || ch == 'K';
+}
+
 inline void IntlDateTimeFormat::replaceHourCycleInPattern(Vector<char16_t, 32>& pattern, HourCycle hourCycle)
 {
-    char16_t hourFromHourCycle = 'H';
-    switch (hourCycle) {
-    case HourCycle::H11:
-        hourFromHourCycle = 'K';
-        break;
-    case HourCycle::H12:
-        hourFromHourCycle = 'h';
-        break;
-    case HourCycle::H23:
-        hourFromHourCycle = 'H';
-        break;
-    case HourCycle::H24:
-        hourFromHourCycle = 'k';
-        break;
-    case HourCycle::None:
+    if (hourCycle == HourCycle::None)
         return;
-    }
+    char16_t hourFromHourCycle = hourCharForCycle(hourCycle);
+
+    bool isTarget24Hour = (hourCycle == HourCycle::H23 || hourCycle == HourCycle::H24);
 
     for (unsigned i = 0, length = pattern.size(); i < length; ++i) {
         auto& character = pattern[i];
@@ -455,9 +523,23 @@ inline void IntlDateTimeFormat::replaceHourCycleInPattern(Vector<char16_t, 32>& 
         case 'K':
         case 'h':
         case 'H':
-        case 'k':
+        case 'k': {
+            char16_t originalChar = character;
             character = hourFromHourCycle;
+            // Pad single->double (e.g. H->HH) only when switching from a 12-hour char
+            // (h/K) to a 24-hour cycle, and only if this is a lone single-char symbol.
+            // getTemporalFormatter uses 'j' in the skeleton so ICU returns the locale's
+            // default h12 pattern; switching h->H without padding gives "0:00:00" at midnight.
+            bool isOrigin12Hour = (originalChar == 'h' || originalChar == 'K');
+            bool prevIsHour = i > 0 && isHourChar(pattern[i - 1]);
+            bool nextIsHour = i + 1 < length && isHourChar(pattern[i + 1]);
+            if (isTarget24Hour && isOrigin12Hour && !prevIsHour && !nextIsHour) {
+                pattern.insert(i + 1, hourFromHourCycle);
+                length++;
+                i++;
+            }
             break;
+        }
         }
     }
 }
@@ -650,7 +732,7 @@ String IntlDateTimeFormat::buildSkeleton(Weekday weekday, Era era, Year year, Mo
     return skeletonBuilder.toString();
 }
 
-// https://tc39.github.io/ecma402/#sec-initializedatetimeformat
+// https://tc39.es/proposal-temporal/#sec-initializedatetimeformat
 void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, JSValue locales, JSValue originalOptions, RequiredComponent required, Defaults defaults)
 {
     VM& vm = globalObject->vm();
@@ -672,7 +754,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     String calendar = intlStringOption(globalObject, options, vm.propertyNames->calendar, { }, { }, { });
     RETURN_IF_EXCEPTION(scope, void());
     if (!calendar.isNull()) {
-        if (!isUnicodeLocaleIdentifierType(calendar)) {
+        if (!isUnicodeLocaleIdentifierType(calendar)) [[unlikely]] {
             throwRangeError(globalObject, scope, "calendar is not a well-formed calendar value"_s);
             return;
         }
@@ -682,7 +764,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     String numberingSystem = intlStringOption(globalObject, options, vm.propertyNames->numberingSystem, { }, { }, { });
     RETURN_IF_EXCEPTION(scope, void());
     if (!numberingSystem.isNull()) {
-        if (!isUnicodeLocaleIdentifierType(numberingSystem)) {
+        if (!isUnicodeLocaleIdentifierType(numberingSystem)) [[unlikely]] {
             throwRangeError(globalObject, scope, "numberingSystem is not a well-formed numbering system value"_s);
             return;
         }
@@ -707,7 +789,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     auto resolved = resolveLocale(globalObject, availableLocales, requestedLocales, localeMatcher, localeOptions, { RelevantExtensionKey::Ca, RelevantExtensionKey::Hc, RelevantExtensionKey::Nu }, localeData);
 
     impl->m_locale = resolved.locale;
-    if (impl->m_locale.isEmpty()) {
+    if (impl->m_locale.isEmpty()) [[unlikely]] {
         throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat due to invalid locale"_s);
         return;
     }
@@ -806,6 +888,8 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     intlStringOption(globalObject, options, vm.propertyNames->formatMatcher, { "basic"_s, "best fit"_s }, "formatMatcher must be either \"basic\" or \"best fit\""_s, "best fit"_s);
     RETURN_IF_EXCEPTION(scope, void());
 
+    impl->m_anyPresent = (weekday != Weekday::None || year != Year::None || month != Month::None || day != Day::None || dayPeriod != DayPeriod::None || hour != Hour::None || minute != Minute::None || second != Second::None || fractionalSecondDigits);
+
     impl->m_dateStyle = intlOption<DateTimeStyle>(globalObject, options, vm.propertyNames->dateStyle, { { "full"_s, DateTimeStyle::Full }, { "long"_s, DateTimeStyle::Long }, { "medium"_s, DateTimeStyle::Medium }, { "short"_s, DateTimeStyle::Short } }, "dateStyle must be \"full\", \"long\", \"medium\", or \"short\""_s, DateTimeStyle::None);
     RETURN_IF_EXCEPTION(scope, void());
 
@@ -819,7 +903,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         //     ii. Let p be opt.[[<prop>]].
         //     iii. If p is not undefined, then
         //         1. Throw a TypeError exception.
-        if (weekday != Weekday::None || era != Era::None || year != Year::None || month != Month::None || day != Day::None || dayPeriod != DayPeriod::None || hour != Hour::None || minute != Minute::None || second != Second::None || fractionalSecondDigits != 0 || timeZoneName != TimeZoneName::None) {
+        if (weekday != Weekday::None || era != Era::None || year != Year::None || month != Month::None || day != Day::None || dayPeriod != DayPeriod::None || hour != Hour::None || minute != Minute::None || second != Second::None || fractionalSecondDigits || timeZoneName != TimeZoneName::None) [[unlikely]] {
             throwTypeError(globalObject, scope, "dateStyle and timeStyle may not be used with other DateTimeFormat options"_s);
             return;
         }
@@ -857,13 +941,13 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         String timeZoneForICU = impl->m_timeZone.toICUString();
         StringView timeZoneView(timeZoneForICU);
         auto dateFormatFromStyle = std::unique_ptr<UDateFormat, UDateFormatDeleter>(udat_open(parseUDateFormatStyle(impl->m_timeStyle), parseUDateFormatStyle(impl->m_dateStyle), dataLocaleWithExtensions.data(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), nullptr, -1, &status));
-        if (U_FAILURE(status)) {
+        if (U_FAILURE(status)) [[unlikely]] {
             throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
             return;
         }
         constexpr bool localized = false; // Aligned with how ICU SimpleDateTimeFormat::format works. We do not need to translate this to localized pattern.
         status = callBufferProducingFunction(udat_toPattern, dateFormatFromStyle.get(), localized, patternBuffer);
-        if (U_FAILURE(status)) {
+        if (U_FAILURE(status)) [[unlikely]] {
             throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
             return;
         }
@@ -892,7 +976,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
             if (extractedHourCycle != HourCycle::None && isHour12(extractedHourCycle) != specifiedHour12) {
                 Vector<char16_t, 32> skeleton;
                 auto status = callBufferProducingFunction(udatpg_getSkeleton, nullptr, patternBuffer.span().data(), patternBuffer.size(), skeleton);
-                if (U_FAILURE(status)) {
+                if (U_FAILURE(status)) [[unlikely]] {
                     throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
                     return;
                 }
@@ -900,7 +984,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
                 dataLogLnIf(IntlDateTimeFormatInternal::verbose, "replaced:(", StringView { skeleton.span() }, ")");
 
                 patternBuffer = vm.intlCache().getBestDateTimePattern(dataLocaleWithExtensions, skeleton.span(), status);
-                if (U_FAILURE(status)) {
+                if (U_FAILURE(status)) [[unlikely]] {
                     throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
                     return;
                 }
@@ -939,7 +1023,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         String skeleton = buildSkeleton(weekday, era, year, month, day, hour12, hourCycle, hour, dayPeriod, minute, second, fractionalSecondDigits, timeZoneName);
         UErrorCode status = U_ZERO_ERROR;
         patternBuffer = vm.intlCache().getBestDateTimePattern(dataLocaleWithExtensions, StringView(skeleton).upconvertedCharacters(), status);
-        if (U_FAILURE(status)) {
+        if (U_FAILURE(status)) [[unlikely]] {
             throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
             return;
         }
@@ -957,7 +1041,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     UErrorCode status = U_ZERO_ERROR;
     String timeZoneForICU = impl->m_timeZone.toICUString();
     impl->m_dateFormat = openDateFormat(dataLocaleWithExtensions, timeZoneForICU, patternBuffer.span(), status);
-    if (U_FAILURE(status)) {
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
         return;
     }
@@ -1259,7 +1343,7 @@ static void NODELETE replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(Contain
     }
 }
 
-// https://tc39.es/ecma402/#sec-formatdatetime
+// https://tc39.es/proposal-temporal/#sec-formatdatetime
 JSValue IntlDateTimeFormat::format(JSGlobalObject* globalObject, double value) const
 {
     ASSERT(m_impl->m_dateFormat);
@@ -1342,30 +1426,27 @@ static ASCIILiteral partTypeString(UDateFormatField field)
     return "unknown"_s;
 }
 
-// https://tc39.es/ecma402/#sec-formatdatetimetoparts
-JSValue IntlDateTimeFormat::formatToParts(JSGlobalObject* globalObject, double value, JSString* sourceType) const
+static JSValue buildFormattedDateTimeParts(JSGlobalObject* globalObject, UDateFormat* format, double value, JSString* sourceType)
 {
-    ASSERT(m_impl->m_dateFormat);
-
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (!std::isfinite(value))
+    if (!std::isfinite(value)) [[unlikely]]
         return throwRangeError(globalObject, scope, "date value is not finite in DateTimeFormat formatToParts()"_s);
 
     UErrorCode status = U_ZERO_ERROR;
     auto fields = std::unique_ptr<UFieldPositionIterator, UFieldPositionIteratorDeleter>(ufieldpositer_open(&status));
-    if (U_FAILURE(status))
+    if (U_FAILURE(status)) [[unlikely]]
         return throwTypeError(globalObject, scope, "failed to open field position iterator"_s);
 
     Vector<char16_t, 32> result;
-    status = callBufferProducingFunction(udat_formatForFields, m_impl->m_dateFormat.get(), value, result, fields.get());
-    if (U_FAILURE(status))
+    status = callBufferProducingFunction(udat_formatForFields, format, value, result, fields.get());
+    if (U_FAILURE(status)) [[unlikely]]
         return throwTypeError(globalObject, scope, "failed to format date value"_s);
     replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(result);
 
     JSArray* parts = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 0);
-    if (!parts)
+    if (!parts) [[unlikely]]
         return throwOutOfMemoryError(globalObject, scope);
 
     StringView resultStringView(result.span());
@@ -1417,7 +1498,7 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
     Vector<char16_t, 32> pattern;
     {
         auto status = callBufferProducingFunction(udat_toPattern, m_impl->m_dateFormat.get(), false, pattern);
-        if (U_FAILURE(status)) {
+        if (U_FAILURE(status)) [[unlikely]] {
             throwTypeError(globalObject, scope, "failed to initialize DateIntervalFormat"_s);
             return nullptr;
         }
@@ -1426,7 +1507,7 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
     Vector<char16_t, 32> skeleton;
     {
         auto status = callBufferProducingFunction(udatpg_getSkeleton, nullptr, pattern.span().data(), pattern.size(), skeleton);
-        if (U_FAILURE(status)) {
+        if (U_FAILURE(status)) [[unlikely]] {
             throwTypeError(globalObject, scope, "failed to initialize DateIntervalFormat"_s);
             return nullptr;
         }
@@ -1453,7 +1534,7 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
     String timeZoneForICU = m_impl->m_timeZone.toICUString();
     StringView timeZoneView(timeZoneForICU);
     m_dateIntervalFormat = std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter>(udtitvfmt_open(dataLocaleWithExtensions.data(), skeleton.span().data(), skeleton.size(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), &status));
-    if (U_FAILURE(status)) {
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "failed to initialize DateIntervalFormat"_s);
         return nullptr;
     }
@@ -1463,9 +1544,9 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
     return m_dateIntervalFormat.get();
 }
 
-static std::unique_ptr<UFormattedDateInterval, ICUDeleter<udtitvfmt_closeResult>> formattedValueFromDateRange(UDateIntervalFormat& dateIntervalFormat, const UDateFormat& dateFormat, double startDate, double endDate, UErrorCode& status)
+static std::unique_ptr<UFormattedDateInterval, UFormattedDateIntervalDeleter> formattedValueFromDateRange(UDateIntervalFormat& dateIntervalFormat, const UDateFormat& dateFormat, double startDate, double endDate, UErrorCode& status)
 {
-    auto result = std::unique_ptr<UFormattedDateInterval, ICUDeleter<udtitvfmt_closeResult>>(udtitvfmt_openResult(&status));
+    auto result = std::unique_ptr<UFormattedDateInterval, UFormattedDateIntervalDeleter>(udtitvfmt_openResult(&status));
     if (U_FAILURE(status))
         return nullptr;
 
@@ -1541,36 +1622,35 @@ static bool dateFieldsPracticallyEqual(const UFormattedValue* formattedValue, UE
     return !hasSpan;
 }
 
-JSValue IntlDateTimeFormat::formatRange(JSGlobalObject* globalObject, double startDate, double endDate)
+auto IntlDateTimeFormat::prepareDateRange(JSGlobalObject* globalObject, double& startDate, double& endDate) -> std::optional<DateRangePreamble>
 {
     ASSERT(m_impl->m_dateFormat);
-
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // http://tc39.es/proposal-intl-DateTimeFormat-formatRange/#sec-partitiondatetimerangepattern
     startDate = timeClip(startDate);
     endDate = timeClip(endDate);
-    if (std::isnan(startDate) || std::isnan(endDate)) {
+    if (std::isnan(startDate) || std::isnan(endDate)) [[unlikely]] {
         throwRangeError(globalObject, scope, "Passed date is out of range"_s);
-        return { };
+        return std::nullopt;
     }
 
     auto* dateIntervalFormat = createDateIntervalFormatIfNecessary(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
 
     UErrorCode status = U_ZERO_ERROR;
     auto result = formattedValueFromDateRange(*dateIntervalFormat, *m_impl->m_dateFormat, startDate, endDate, status);
-    if (U_FAILURE(status)) {
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "Failed to format date interval"_s);
-        return { };
+        return std::nullopt;
     }
 
     // UFormattedValue is owned by UFormattedDateInterval. We do not need to close it.
-    auto formattedValue = udtitvfmt_resultAsValue(result.get(), &status);
-    if (U_FAILURE(status)) {
+    auto* formattedValue = udtitvfmt_resultAsValue(result.get(), &status);
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "Failed to format date interval"_s);
-        return { };
+        return std::nullopt;
     }
 
     // If the formatted parts of startDate and endDate are the same, it is possible that the resulted string does not look like range.
@@ -1578,72 +1658,119 @@ JSValue IntlDateTimeFormat::formatRange(JSGlobalObject* globalObject, double sta
     // In that case, startDate and endDate are *practically-equal* (spec term), and we generate parts as we call `formatToParts(startDate)` with
     // `source: "shared"` additional fields.
     bool equal = dateFieldsPracticallyEqual(formattedValue, status);
-    if (U_FAILURE(status)) {
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "Failed to format date interval"_s);
-        return { };
+        return std::nullopt;
     }
 
-    if (equal)
-        RELEASE_AND_RETURN(scope, format(globalObject, startDate));
-
-    int32_t formattedStringLength = 0;
-    const char16_t* formattedStringPointer = ufmtval_getString(formattedValue, &formattedStringLength, &status);
-    if (U_FAILURE(status)) {
-        throwTypeError(globalObject, scope, "Failed to format date interval"_s);
-        return { };
-    }
-    Vector<char16_t, 32> buffer(std::span<const char16_t> { formattedStringPointer, static_cast<size_t>(formattedStringLength) });
-    replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(buffer);
-
-    return jsString(vm, String(WTF::move(buffer)));
+    return DateRangePreamble { std::unique_ptr<UFormattedDateInterval, UFormattedDateIntervalDeleter>(result.release()), formattedValue, equal };
 }
 
-JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, double startDate, double endDate)
+// https://tc39.es/proposal-temporal/#sec-partitiondatetimerangepattern
+//
+// NOTE: Diverges from the spec in two ways for efficiency:
+// 1. Returns a TemporalDateRangePreamble (raw ICU UFormattedDateInterval) instead of the spec's
+//    List of {[[Type]],[[Value]],[[Source]]} records, avoiding an intermediate parts vector.
+// 2. Defers the practically-equal case (spec step: FormatDateTimePattern + tag "shared") to the
+//    callers — formatRange needs a string, formatRangeToParts needs parts; no single output fits both.
+auto IntlDateTimeFormat::partitionDateTimeRangePattern(JSGlobalObject* globalObject, JSValue xValue, JSValue yValue) -> std::optional<TemporalDateRangePreamble>
 {
     ASSERT(m_impl->m_dateFormat);
-
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // http://tc39.es/proposal-intl-DateTimeFormat-formatRange/#sec-partitiondatetimerangepattern
-    startDate = timeClip(startDate);
-    endDate = timeClip(endDate);
-    if (std::isnan(startDate) || std::isnan(endDate)) {
-        throwRangeError(globalObject, scope, "Passed date is out of range"_s);
-        return { };
+    // Step 1: If IsTemporalObject(x) or IsTemporalObject(y), SameTemporalType(x,y) must be true.
+    if (isTemporalObject(xValue) || isTemporalObject(yValue)) [[unlikely]] {
+        if (!sameTemporalType(xValue, yValue)) [[unlikely]] {
+            throwTypeError(globalObject, scope, "formatRange requires both arguments to be the same Temporal type"_s);
+            return std::nullopt;
+        }
     }
 
-    auto* dateIntervalFormat = createDateIntervalFormatIfNecessary(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
+    // Steps 2-3: HandleDateTimeValue for x and y — converts Temporal objects / Numbers to
+    // epoch milliseconds and validates calendar compatibility and format availability.
+    auto startRecord = handleDateTimeValue(globalObject, this, xValue);
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    auto endRecord = handleDateTimeValue(globalObject, this, yValue);
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
 
+    // Steps 4-5: xEpochNanoseconds / yEpochNanoseconds (we use milliseconds for ICU).
+    double startMs = startRecord.value;
+    double endMs = endRecord.value;
+    auto kind = startRecord.kind;
+
+    // Steps 9-10: Assert format and [[IsPlain]] match — guaranteed because SameTemporalType
+    // ensures both records have the same kind, which uniquely determines the format slot.
+    ASSERT(startRecord.kind == endRecord.kind);
+
+    // Non-Temporal path (kind == None): steps 6-21 are handled by the legacy prepareDateRange
+    // path in the caller; return a bare preamble with no ICU interval formatter.
+    if (kind == TemporalFieldKind::None)
+        return TemporalDateRangePreamble { nullptr, nullptr, nullptr, false, startMs, endMs, kind };
+
+    // Step 8: Obtain [[Format]] = the temporal UDateFormat for this kind.
+    // (null means the DTF has no fields applicable to this Temporal type — already checked in
+    // handleDateTimeValue, but guarded here too for the range path.)
+    auto tempFormat = getTemporalFormatter(vm, kind);
+    if (!tempFormat) [[unlikely]] {
+        throwTypeError(globalObject, scope, "DateTimeFormat has no fields applicable to this Temporal type"_s);
+        return std::nullopt;
+    }
+
+    // Steps 6-7, 11-18: ToLocalTime for both endpoints + field-by-field comparison to select
+    // the appropriate range pattern are all handled internally by ICU's UDateIntervalFormat.
+    // createTemporalIntervalFormat builds the interval formatter from the temporal skeleton;
+    // formattedValueFromDateRange calls udtitvfmt_formatToResult (or formatCalendarToResult
+    // for pre-1582 dates) which executes the ToLocalTime + field-comparison loop.
     UErrorCode status = U_ZERO_ERROR;
-    auto result = formattedValueFromDateRange(*dateIntervalFormat, *m_impl->m_dateFormat, startDate, endDate, status);
-    if (U_FAILURE(status)) {
+    auto intervalFormat = createTemporalIntervalFormat(tempFormat, kind, status);
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "Failed to format date interval"_s);
-        return { };
+        return std::nullopt;
+    }
+
+    auto result = formattedValueFromDateRange(*intervalFormat, *tempFormat, startMs, endMs, status);
+    if (U_FAILURE(status)) [[unlikely]] {
+        throwTypeError(globalObject, scope, "Failed to format date interval"_s);
+        return std::nullopt;
     }
 
     // UFormattedValue is owned by UFormattedDateInterval. We do not need to close it.
-    auto formattedValue = udtitvfmt_resultAsValue(result.get(), &status);
-    if (U_FAILURE(status)) {
+    auto* formattedValue = udtitvfmt_resultAsValue(result.get(), &status);
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "Failed to format date interval"_s);
-        return { };
+        return std::nullopt;
     }
 
-    auto sharedString = jsNontrivialString(vm, "shared"_s);
+    // Step 19: relevantFieldsEqual — ICU marks fields as "shared" when both endpoints are equal.
 
     // If the formatted parts of startDate and endDate are the same, it is possible that the resulted string does not look like range.
     // For example, if the requested format only includes "year" and startDate and endDate are the same year, the result just contains one year.
     // In that case, startDate and endDate are *practically-equal* (spec term), and we generate parts as we call `formatToParts(startDate)` with
     // `source: "shared"` additional fields.
     bool equal = dateFieldsPracticallyEqual(formattedValue, status);
-    if (U_FAILURE(status)) {
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "Failed to format date interval"_s);
-        return { };
+        return std::nullopt;
     }
 
-    if (equal)
-        RELEASE_AND_RETURN(scope, formatToParts(globalObject, startDate, sharedString));
+    // Steps 19-21 (completion): building the parts List with [[Source]] = "shared" / "startRange"
+    // / "endRange" is done by the callers (formatRange / formatRangeToParts) using this preamble.
+    return TemporalDateRangePreamble {
+        tempFormat,
+        std::unique_ptr<UFormattedDateInterval, UFormattedDateIntervalDeleter>(result.release()),
+        formattedValue,
+        equal,
+        startMs,
+        endMs,
+        kind
+    };
+}
+
+static JSValue buildFormattedDateIntervalParts(JSGlobalObject* globalObject, const UFormattedValue* formattedValue)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     // ICU produces ranges for the formatted string, and we construct parts array from that.
     // For example, startDate = Jan 3, 2019, endDate = Jan 5, 2019 with en-US locale is,
@@ -1690,9 +1817,10 @@ JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, dou
         return { };
     }
 
+    UErrorCode status = U_ZERO_ERROR;
     int32_t formattedStringLength = 0;
     const char16_t* formattedStringPointer = ufmtval_getString(formattedValue, &formattedStringLength, &status);
-    if (U_FAILURE(status)) {
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "Failed to format date interval"_s);
         return { };
     }
@@ -1704,13 +1832,14 @@ JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, dou
     // We care multiple categories (UFIELD_CATEGORY_DATE and UFIELD_CATEGORY_DATE_INTERVAL_SPAN).
     // So we do not constraint iterator.
     auto iterator = std::unique_ptr<UConstrainedFieldPosition, ICUDeleter<ucfpos_close>>(ucfpos_open(&status));
-    if (U_FAILURE(status)) {
+    if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "Failed to format date interval"_s);
         return { };
     }
 
     auto startRangeString = jsNontrivialString(vm, "startRange"_s);
     auto endRangeString = jsNontrivialString(vm, "endRange"_s);
+    auto sharedString = jsNontrivialString(vm, "shared"_s);
     auto literalString = jsNontrivialString(vm, "literal"_s);
 
     WTF::Range<int32_t> startRange { -1, -1 };
@@ -1733,7 +1862,7 @@ JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, dou
     int32_t previousEndIndex = 0;
     while (true) {
         bool next = ufmtval_nextPosition(formattedValue, iterator.get(), &status);
-        if (U_FAILURE(status)) {
+        if (U_FAILURE(status)) [[unlikely]] {
             throwTypeError(globalObject, scope, "Failed to format date interval"_s);
             return { };
         }
@@ -1741,13 +1870,13 @@ JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, dou
             break;
 
         int32_t category = ucfpos_getCategory(iterator.get(), &status);
-        if (U_FAILURE(status)) {
+        if (U_FAILURE(status)) [[unlikely]] {
             throwTypeError(globalObject, scope, "Failed to format date interval"_s);
             return { };
         }
 
         int32_t fieldType = ucfpos_getField(iterator.get(), &status);
-        if (U_FAILURE(status)) {
+        if (U_FAILURE(status)) [[unlikely]] {
             throwTypeError(globalObject, scope, "Failed to format date interval"_s);
             return { };
         }
@@ -1755,7 +1884,7 @@ JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, dou
         int32_t beginIndex = 0;
         int32_t endIndex = 0;
         ucfpos_getIndexes(iterator.get(), &beginIndex, &endIndex, &status);
-        if (U_FAILURE(status)) {
+        if (U_FAILURE(status)) [[unlikely]] {
             throwTypeError(globalObject, scope, "Failed to format date interval"_s);
             return { };
         }
@@ -1806,6 +1935,498 @@ JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, dou
     return parts;
 }
 
+// https://tc39.es/proposal-temporal/#sec-formatdatetimerangetoparts
+JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, JSValue xValue, JSValue yValue)
+{
+    ASSERT(m_impl->m_dateFormat);
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto preamble = partitionDateTimeRangePattern(globalObject, xValue, yValue);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!preamble)
+        return { };
+
+    if (preamble->kind == TemporalFieldKind::None) {
+        auto nonTemporalPreamble = prepareDateRange(globalObject, preamble->startMs, preamble->endMs);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (!nonTemporalPreamble)
+            return { };
+
+        if (nonTemporalPreamble->equal)
+            RELEASE_AND_RETURN(scope, buildFormattedDateTimeParts(globalObject, m_impl->m_dateFormat.get(), preamble->startMs, jsNontrivialString(vm, "shared"_s)));
+        RELEASE_AND_RETURN(scope, buildFormattedDateIntervalParts(globalObject, nonTemporalPreamble->formattedValue));
+    }
+
+    if (preamble->equal)
+        RELEASE_AND_RETURN(scope, buildFormattedDateTimeParts(globalObject, preamble->tempFormat, preamble->startMs, jsNontrivialString(vm, "shared"_s)));
+    RELEASE_AND_RETURN(scope, buildFormattedDateIntervalParts(globalObject, preamble->formattedValue));
+}
+
+// BitSet<128> of ASCII pattern letters for each Temporal field kind.
+// constexpr: fully evaluated at compile time, zero runtime cost.
+using TemporalFieldSet = WTF::BitSet<128>;
+
+static constexpr TemporalFieldSet makeTemporalFieldSet(std::string_view chars)
+{
+    TemporalFieldSet s;
+    for (unsigned char c : chars)
+        s.set(c);
+    return s;
+}
+
+// Plain Temporal types have no timezone; they use GMT for epoch math and exclude timezone
+// skeleton chars. Only Instant uses the formatter's configured timezone.
+static constexpr bool isPlain(IntlDateTimeFormat::TemporalFieldKind kind)
+{
+    // HandleDateTimeOthers (Kind::None) returns [[IsPlain]]: false.
+    // Instant and ZonedDateTime are timezone-aware, also [[IsPlain]]: false.
+    // All plain Temporal types return [[IsPlain]]: true.
+    return kind != IntlDateTimeFormat::TemporalFieldKind::None
+        && kind != IntlDateTimeFormat::TemporalFieldKind::Instant
+        && kind != IntlDateTimeFormat::TemporalFieldKind::ZonedDateTime;
+}
+
+// UTS#35 timezone display skeleton characters (z=short name, O=GMT offset, v=generic location).
+// Plain Temporal types (PlainDate, PlainTime, etc.) have no timezone — these chars must be
+// excluded when filtering patterns for them. Instant keeps them.
+static constexpr bool isTimeZoneChar(char16_t ch)
+{
+    return ch == 'z' || ch == 'O' || ch == 'v';
+}
+
+// UTS#35 skeleton chars (https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table)
+// mapped to ECMA-402 DateTimeFormat properties (https://tc39.es/ecma402/#table-datetimeformat-components):
+//   E/c -> weekday
+//   G -> era
+//   y -> year
+//   M/L -> month
+//   d -> day
+//   h/H/k/K/j -> hour
+//   m -> minute
+//   s -> second
+//   S -> fractionalSecondDigits
+//   B/b/a -> dayPeriod
+static constexpr TemporalFieldSet dateFields = makeTemporalFieldSet("EcGyMLd"); // weekday, era, year, month, day
+static constexpr TemporalFieldSet timeFields = makeTemporalFieldSet("hHkKjmsBbaS"); // hour, minute, second, fractionalSecondDigits, dayPeriod
+static constexpr TemporalFieldSet yearMonthFields = makeTemporalFieldSet("GyML"); // era, year, month
+static constexpr TemporalFieldSet monthDayFields = makeTemporalFieldSet("MLd"); // month, day
+static constexpr TemporalFieldSet dateTimeFields = [] {
+    auto s = dateFields;
+    s |= timeFields;
+    return s;
+}();
+
+static const TemporalFieldSet& allowedFieldsForKind(IntlDateTimeFormat::TemporalFieldKind kind)
+{
+    static constexpr TemporalFieldSet emptyFields;
+    switch (kind) {
+    case IntlDateTimeFormat::TemporalFieldKind::PlainDate:
+        return dateFields;
+    case IntlDateTimeFormat::TemporalFieldKind::PlainDateTime:
+        return dateTimeFields;
+    case IntlDateTimeFormat::TemporalFieldKind::PlainTime:
+        return timeFields;
+    case IntlDateTimeFormat::TemporalFieldKind::PlainYearMonth:
+        return yearMonthFields;
+    case IntlDateTimeFormat::TemporalFieldKind::PlainMonthDay:
+        return monthDayFields;
+    default:
+        return emptyFields;
+    }
+}
+
+// Lazily computes and caches the [[TemporalXxxFormat]] slot for the given Temporal type.
+// Returns a non-owning pointer — no clone needed since JS is single-threaded (no re-entrance).
+// The spec computes these eagerly in CreateDateTimeFormat; we do it on demand and cache.
+UDateFormat* IntlDateTimeFormat::getTemporalFormatter(VM& vm, TemporalFieldKind kind) const
+{
+    ASSERT(kind != TemporalFieldKind::None && kind != TemporalFieldKind::ZonedDateTime);
+    // Instant with dateStyle/timeStyle: computeAdjustDateTimeStyleFormat step 3 returns baseFormat
+    // as-is (no pattern change, no timezone change). Reuse m_dateFormat directly — no clone needed.
+    if (kind == TemporalFieldKind::Instant
+        && (m_impl->m_dateStyle != DateTimeStyle::None || m_impl->m_timeStyle != DateTimeStyle::None))
+        return m_impl->m_dateFormat.get();
+    if (!m_impl->m_temporalFormatterCache) {
+        auto cache = makeUnique<IntlDateTimeFormatTemporalFormatterCache>();
+        WTF::storeStoreFence(); // Publish cache contents before the pointer.
+        m_impl->m_temporalFormatterCache = WTF::move(cache);
+    }
+    auto& cached = m_impl->m_temporalFormatterCache->m_formatters[static_cast<size_t>(kind)];
+    if (!cached) {
+        cached = computeTemporalFormatter(kind);
+        if (cached)
+            vm.heap.reportExtraMemoryAllocated(this, estimatedUDateFormatSize);
+    }
+    return cached.get();
+}
+
+
+// https://tc39.es/proposal-temporal/#sec-createdatetimeformat (dispatch)
+// CreateDateTimeFormat calls AdjustDateTimeStyleFormat/GetDateTimeFormat eagerly at construction.
+// We implement them lazily here on first use, dispatching based on the same conditions.
+std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTimeFormat::computeTemporalFormatter(TemporalFieldKind kind) const
+{
+    ASSERT(kind != TemporalFieldKind::ZonedDateTime);
+    Vector<char16_t, 32> patternBuf;
+    UErrorCode status = U_ZERO_ERROR;
+    status = callBufferProducingFunction(udat_toPattern, m_impl->m_dateFormat.get(), false, patternBuf);
+    if (U_FAILURE(status))
+        return nullptr;
+    Vector<char16_t, 32> skeleton;
+    status = callBufferProducingFunction(udatpg_getSkeleton, nullptr, patternBuf.span().data(), patternBuf.size(), skeleton);
+    if (U_FAILURE(status))
+        return nullptr;
+
+    if (m_impl->m_dateStyle != DateTimeStyle::None || m_impl->m_timeStyle != DateTimeStyle::None) {
+        // CreateDateTimeFormat step k: Instant -> bestFormat directly (no field filtering).
+        // Steps f/g: PlainDate/YearMonth/MonthDay -> null if dateStyle is undefined (step g).
+        // Steps h/i: PlainTime -> null if timeStyle is undefined (step i).
+        // Step j: PlainDateTime -> AdjustDateTimeStyleFormat always.
+        if (isPlain(kind) && kind != TemporalFieldKind::PlainDateTime) {
+            bool isDateType = (kind == TemporalFieldKind::PlainDate || kind == TemporalFieldKind::PlainYearMonth || kind == TemporalFieldKind::PlainMonthDay);
+            if (isDateType && m_impl->m_dateStyle == DateTimeStyle::None)
+                return nullptr; // Step g: dateStyle undefined -> null.
+            if (kind == TemporalFieldKind::PlainTime && m_impl->m_timeStyle == DateTimeStyle::None)
+                return nullptr; // Step i: timeStyle undefined -> null.
+        }
+        return computeAdjustDateTimeStyleFormat(kind, skeleton);
+    }
+    // CreateDateTimeFormat -> GetDateTimeFormat.
+    return computeGetDateTimeFormat(kind, skeleton);
+}
+
+
+// https://tc39.es/proposal-temporal/#sec-adjustdatetimestyleformat
+std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTimeFormat::computeAdjustDateTimeStyleFormat(TemporalFieldKind kind, const Vector<char16_t, 32>& skeleton) const
+{
+    ASSERT(kind != TemporalFieldKind::ZonedDateTime);
+
+    UErrorCode status = U_ZERO_ERROR;
+    auto allowed = allowedFieldsForKind(kind);
+    bool plain = isPlain(kind);
+
+    // Steps 1-2: for plain types, scan for conflicting fields (not in allowedOptions).
+    // Timezone chars excluded — plain types have no timezone concept.
+    // For Instant, all fields are allowed -> skip, anyConflictingFields stays false.
+    Vector<char16_t, 32> filteredSkeleton;
+    bool anyConflictingFields = false;
+    if (plain) {
+        for (auto ch : skeleton) {
+            if (ch >= 128 || isTimeZoneChar(ch))
+                continue;
+            if (allowed.get(ch))
+                filteredSkeleton.append(ch);
+            else
+                anyConflictingFields = true;
+        }
+    }
+
+    // Step 3: no conflicting fields — return baseFormat directly.
+    // For Instant: baseFormat already carries the correct timezone from construction.
+    // For plain types: baseFormat with GMT substituted for timezone-unaware epoch math.
+    if (!anyConflictingFields) {
+        auto tempFormat = std::unique_ptr<UDateFormat, UDateFormatDeleter>(udat_clone(m_impl->m_dateFormat.get(), &status));
+        if (U_FAILURE(status))
+            return nullptr;
+        if (plain) {
+            auto* tempCal = const_cast<UCalendar*>(udat_getCalendar(tempFormat.get()));
+            ucal_setTimeZone(tempCal, u"GMT", 3, &status);
+            if (U_FAILURE(status))
+                return nullptr;
+        }
+        return tempFormat;
+    }
+
+    // Step 4 (NOTE): steps 1-3 avoid an altered format when baseFormat is already sufficient,
+    // because ECMA-402 does not guarantee DateTimeStyleFormat output can round-trip through
+    // BestFitFormatMatcher.
+
+    // Steps 5-6: formatOptions = allowedOptions fields present in baseFormat (filteredSkeleton).
+    if (filteredSkeleton.isEmpty())
+        return nullptr;
+
+    // Steps 7-8: BestFitFormatMatcher(formatOptions, formats) -> udatpg_getBestPatternWithOptions.
+    String generatorLocale = m_impl->m_dataLocale;
+    if (!generatorLocale.contains("calendar"_s) && !m_impl->m_calendar.isEmpty())
+        generatorLocale = makeString(generatorLocale, generatorLocale.contains('@') ? ";calendar="_s : "@calendar="_s, m_impl->m_calendar);
+    auto generator = std::unique_ptr<UDateTimePatternGenerator, ICUDeleter<udatpg_close>>(udatpg_open(generatorLocale.utf8().data(), &status));
+    if (U_FAILURE(status))
+        return nullptr;
+    Vector<char16_t, 32> bestPattern;
+    status = callBufferProducingFunction(udatpg_getBestPatternWithOptions, generator.get(),
+        filteredSkeleton.span().data(), filteredSkeleton.size(),
+        UDATPG_MATCH_HOUR_FIELD_LENGTH, bestPattern);
+    if (U_FAILURE(status) || bestPattern.isEmpty())
+        return nullptr;
+    if (m_impl->m_hourCycle != HourCycle::None)
+        replaceHourCycleInPattern(bestPattern, m_impl->m_hourCycle);
+
+    // Step 9: return bestFormat; plain types use GMT for timezone-unaware epoch math.
+    auto tempFormat = std::unique_ptr<UDateFormat, UDateFormatDeleter>(udat_clone(m_impl->m_dateFormat.get(), &status));
+    if (U_FAILURE(status))
+        return nullptr;
+    udat_applyPattern(tempFormat.get(), false, bestPattern.span().data(), bestPattern.size());
+    if (plain) {
+        auto* tempCal = const_cast<UCalendar*>(udat_getCalendar(tempFormat.get()));
+        ucal_setTimeZone(tempCal, u"GMT", 3, &status);
+        if (U_FAILURE(status))
+            return nullptr;
+    }
+    return tempFormat;
+}
+
+// https://tc39.es/proposal-temporal/#sec-getdatetimeformat
+std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTimeFormat::computeGetDateTimeFormat(TemporalFieldKind kind, const Vector<char16_t, 32>& skeleton) const
+{
+    ASSERT(kind != TemporalFieldKind::ZonedDateTime);
+    UErrorCode status = U_ZERO_ERROR;
+
+    // Steps 1-10: requiredOptions/defaultOptions are encoded in `kind`; allowedFieldsForKind = requiredOptions, switch below = defaultOptions.
+    auto allowed = allowedFieldsForKind(kind);
+
+    // Steps 11-12: inherit=~all~ only for Instant;
+    //              all plain types use inherit=~relevant~.
+    bool inheritAll = kind == TemporalFieldKind::Instant;
+
+    if (m_impl->m_anyPresent && inheritAll) {
+        // Step 11: formatOptions = copy of options. Step 14: anyPresent=true.
+        // Step 16: needDefaults=false. Steps 18-19: BestFitFormatMatcher = main formatter.
+        auto tempFormat = std::unique_ptr<UDateFormat, UDateFormatDeleter>(udat_clone(m_impl->m_dateFormat.get(), &status));
+        if (U_FAILURE(status))
+            return nullptr;
+        return tempFormat;
+    }
+
+    // Steps 13-16: build filteredSkeleton (our formatOptions), check needDefaults.
+    Vector<char16_t, 32> filteredSkeleton;
+    for (auto ch : skeleton) {
+        if (ch < 128 && allowed.get(ch) && !isTimeZoneChar(ch))
+            filteredSkeleton.append(ch);
+    }
+
+    if (m_impl->m_anyPresent) {
+        // Step 17a: inherit=~relevant~, anyPresent=true — return null if no required fields.
+        if (filteredSkeleton.isEmpty())
+            return nullptr;
+        // Required fields present: fall through to BestFitFormatMatcher (needDefaults=false).
+    }
+    bool needDefaults = filteredSkeleton.isEmpty();
+
+    if (needDefaults) {
+        // Step 17b: inject defaultOptions for this Temporal type.
+        char16_t hourChar = hourCharForCycle(m_impl->m_hourCycle);
+        switch (kind) {
+        case TemporalFieldKind::Instant: {
+            // defaultOptions = {year,month,day,hour,minute,second} (step 10).
+            filteredSkeleton = skeleton;
+            bool hasTzField = false;
+            for (auto ch : filteredSkeleton) {
+                if (isTimeZoneChar(ch))
+                    hasTzField = true;
+            }
+            TemporalFieldSet existingChars;
+            for (auto ch : filteredSkeleton) {
+                if (ch < 128)
+                    existingChars.set(ch);
+            }
+            for (auto c : { u'y', u'M', u'd', u'j', u'm', u's' }) {
+                if (!existingChars.get(c))
+                    filteredSkeleton.append(c);
+            }
+            // Step 17c: defaults=~zoned-date-time~ -> inject timeZoneName="short" if absent.
+            if (!hasTzField)
+                filteredSkeleton.append('z');
+            break;
+        }
+        case TemporalFieldKind::PlainTime:
+            filteredSkeleton.appendList({ hourChar, u'm', u's' });
+            break;
+        case TemporalFieldKind::PlainDate:
+            filteredSkeleton.appendList({ u'y', u'M', u'd' });
+            break;
+        case TemporalFieldKind::PlainDateTime:
+            filteredSkeleton.appendList({ u'y', u'M', u'd', hourChar, u'm', u's' });
+            break;
+        case TemporalFieldKind::PlainYearMonth:
+            filteredSkeleton.appendList({ u'y', u'M' });
+            break;
+        case TemporalFieldKind::PlainMonthDay:
+            filteredSkeleton.appendList({ u'M', u'd' });
+            break;
+        default:
+            return nullptr;
+        }
+    }
+
+    // Steps 18-19: BestFitFormatMatcher(formatOptions, formats).
+    String generatorLocale = m_impl->m_dataLocale;
+    if (!generatorLocale.contains("calendar"_s) && !m_impl->m_calendar.isEmpty())
+        generatorLocale = makeString(generatorLocale, generatorLocale.contains('@') ? ";calendar="_s : "@calendar="_s, m_impl->m_calendar);
+    auto generator = std::unique_ptr<UDateTimePatternGenerator, ICUDeleter<udatpg_close>>(udatpg_open(generatorLocale.utf8().data(), &status));
+    if (U_FAILURE(status))
+        return nullptr;
+    Vector<char16_t, 32> bestPattern;
+    status = callBufferProducingFunction(udatpg_getBestPatternWithOptions, generator.get(),
+        filteredSkeleton.span().data(), filteredSkeleton.size(),
+        UDATPG_MATCH_HOUR_FIELD_LENGTH, bestPattern);
+    if (U_FAILURE(status) || bestPattern.isEmpty())
+        return nullptr;
+    if (m_impl->m_hourCycle != HourCycle::None)
+        replaceHourCycleInPattern(bestPattern, m_impl->m_hourCycle);
+
+    // Step 20: return bestFormat. Plain types use GMT (epoch at noon UTC, no timezone offset).
+    auto tempFormat = std::unique_ptr<UDateFormat, UDateFormatDeleter>(udat_clone(m_impl->m_dateFormat.get(), &status));
+    if (U_FAILURE(status))
+        return nullptr;
+    udat_applyPattern(tempFormat.get(), false, bestPattern.span().data(), bestPattern.size());
+    if (isPlain(kind)) {
+        auto* tempCal = const_cast<UCalendar*>(udat_getCalendar(tempFormat.get()));
+        ucal_setTimeZone(tempCal, u"GMT", 3, &status);
+        if (U_FAILURE(status))
+            return nullptr;
+    }
+    return tempFormat;
+}
+
+// https://tc39.es/proposal-temporal/#sec-formatdatetime
+// FormatDateTime(dateTimeFormat, x) — dispatches through HandleDateTimeValue for Temporal objects.
+JSValue IntlDateTimeFormat::format(JSGlobalObject* globalObject, JSValue x) const
+{
+    ASSERT(m_impl->m_dateFormat);
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto record = handleDateTimeValue(globalObject, this, x);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (record.kind == TemporalFieldKind::None)
+        RELEASE_AND_RETURN(scope, format(globalObject, record.value));
+
+    ASSERT(record.kind != TemporalFieldKind::ZonedDateTime);
+
+    if (!std::isfinite(record.value))
+        return throwRangeError(globalObject, scope, "date value is not finite in DateTimeFormat format()"_s);
+
+    auto tempFormat = getTemporalFormatter(vm, record.kind);
+    if (!tempFormat) [[unlikely]]
+        return throwTypeError(globalObject, scope, "DateTimeFormat has no fields applicable to this Temporal type"_s);
+
+    Vector<char16_t, 32> result;
+    auto fmtStatus = callBufferProducingFunction(udat_format, tempFormat, record.value, result, nullptr);
+    if (U_FAILURE(fmtStatus))
+        return throwTypeError(globalObject, scope, "failed to format date value"_s);
+    replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(result);
+    return jsString(vm, String(WTF::move(result)));
+}
+
+// https://tc39.es/proposal-temporal/#sec-formatdatetimetoparts
+JSValue IntlDateTimeFormat::formatToParts(JSGlobalObject* globalObject, JSValue x) const
+{
+    ASSERT(m_impl->m_dateFormat);
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto record = handleDateTimeValue(globalObject, this, x);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    ASSERT(record.kind != TemporalFieldKind::ZonedDateTime);
+
+    UDateFormat* fmt;
+    if (record.kind == TemporalFieldKind::None)
+        fmt = m_impl->m_dateFormat.get();
+    else {
+        fmt = getTemporalFormatter(vm, record.kind);
+        if (!fmt) [[unlikely]]
+            return throwTypeError(globalObject, scope, "DateTimeFormat has no fields applicable to this Temporal type"_s);
+    }
+
+    RELEASE_AND_RETURN(scope, buildFormattedDateTimeParts(globalObject, fmt, record.value, nullptr));
+}
+
+std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter>
+IntlDateTimeFormat::createTemporalIntervalFormat(UDateFormat* tempFormat, TemporalFieldKind kind, UErrorCode& status) const
+{
+    ASSERT(kind != TemporalFieldKind::ZonedDateTime);
+    Vector<char16_t, 32> tempPattern;
+    status = callBufferProducingFunction(udat_toPattern, tempFormat, false, tempPattern);
+    if (U_FAILURE(status))
+        return nullptr;
+    Vector<char16_t, 32> tempSkeleton;
+    status = callBufferProducingFunction(udatpg_getSkeleton, nullptr, tempPattern.span().data(), tempPattern.size(), tempSkeleton);
+    if (U_FAILURE(status))
+        return nullptr;
+
+    bool plain = isPlain(kind);
+    String tzForInterval = plain ? "GMT"_s : m_impl->m_timeZone.toICUString();
+    StringView tzView(tzForInterval);
+
+    StringBuilder localeBuilder;
+    localeBuilder.append(m_impl->m_dataLocale, "-u-ca-"_s, ensureCalendar(), "-nu-"_s, ensureNumberingSystem());
+    if (m_impl->m_hourCycle != HourCycle::None)
+        localeBuilder.append("-hc-"_s, hourCycleString(m_impl->m_hourCycle));
+    CString localeWithExt = localeBuilder.toString().utf8();
+
+    return std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter>(
+        udtitvfmt_open(localeWithExt.data(), tempSkeleton.span().data(), tempSkeleton.size(),
+        tzView.upconvertedCharacters(), tzView.length(), &status));
+}
+
+
+// https://tc39.es/proposal-temporal/#sec-formatdatetimerange
+JSValue IntlDateTimeFormat::formatRange(JSGlobalObject* globalObject, JSValue xValue, JSValue yValue)
+{
+    ASSERT(m_impl->m_dateFormat);
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto preamble = partitionDateTimeRangePattern(globalObject, xValue, yValue);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!preamble)
+        return { };
+
+    if (preamble->kind == TemporalFieldKind::None) {
+        auto nonTemporalPreamble = prepareDateRange(globalObject, preamble->startMs, preamble->endMs);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (!nonTemporalPreamble)
+            return { };
+
+        if (nonTemporalPreamble->equal)
+            RELEASE_AND_RETURN(scope, format(globalObject, preamble->startMs));
+
+        UErrorCode status = U_ZERO_ERROR;
+        int32_t formattedStringLength = 0;
+        const char16_t* formattedStringPointer = ufmtval_getString(nonTemporalPreamble->formattedValue, &formattedStringLength, &status);
+        if (U_FAILURE(status)) [[unlikely]] {
+            throwTypeError(globalObject, scope, "Failed to format date interval"_s);
+            return { };
+        }
+        Vector<char16_t, 32> buffer(std::span<const char16_t> { formattedStringPointer, static_cast<size_t>(formattedStringLength) });
+        replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(buffer);
+        return jsString(vm, String(WTF::move(buffer)));
+    }
+
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t length;
+    const char16_t* chars = ufmtval_getString(preamble->formattedValue, &length, &status);
+    if (U_FAILURE(status)) [[unlikely]] {
+        throwTypeError(globalObject, scope, "Failed to format date interval"_s);
+        return { };
+    }
+
+    if (preamble->equal) {
+        Vector<char16_t, 32> singleResult;
+        auto singleStatus = callBufferProducingFunction(udat_format, preamble->tempFormat, preamble->startMs, singleResult, nullptr);
+        if (U_FAILURE(singleStatus)) [[unlikely]]
+            return throwTypeError(globalObject, scope, "failed to format date value"_s);
+        replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(singleResult);
+        return jsString(vm, String(WTF::move(singleResult)));
+    }
+
+    Vector<char16_t, 32> resultChars(std::span(chars, length));
+    replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(resultChars);
+    return jsString(vm, String(WTF::move(resultChars)));
+}
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
@@ -29,9 +29,11 @@
 #include "ISO8601.h"
 #include "JSObject.h"
 #include <unicode/udat.h>
+#include <unicode/uformattedvalue.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
 struct UDateIntervalFormat;
+struct UFormattedDateInterval;
 
 namespace JSC {
 
@@ -41,6 +43,10 @@ class JSBoundFunction;
 
 struct UDateIntervalFormatDeleter {
     JS_EXPORT_PRIVATE void operator()(UDateIntervalFormat*);
+};
+
+struct UFormattedDateIntervalDeleter {
+    JS_EXPORT_PRIVATE void operator()(UFormattedDateInterval*);
 };
 
 using UDateFormatDeleter = ICUDeleter<udat_close>;
@@ -76,11 +82,48 @@ public:
     enum class HourCycle : uint8_t { None, H11, H12, H23, H24 };
 
     void initializeDateTimeFormat(JSGlobalObject*, JSValue locales, JSValue options, RequiredComponent, Defaults);
+    // https://tc39.es/proposal-temporal/#sec-temporal-handledatetimevalue dispatches to:
+    //   None          -> HandleDateTimeOthers          -> [[DateTimeFormat]]
+    //   Instant       -> HandleDateTimeTemporalInstant -> [[TemporalInstantFormat]]
+    //   PlainDate     -> HandleDateTimeTemporalDate    -> [[TemporalPlainDateFormat]]
+    //   PlainDateTime -> HandleDateTimeTemporalDateTime-> [[TemporalPlainDateTimeFormat]]
+    //   PlainTime     -> HandleDateTimeTemporalTime    -> [[TemporalPlainTimeFormat]]
+    //   PlainYearMonth-> HandleDateTimeTemporalYearMonth->[[TemporalPlainYearMonthFormat]]
+    //   PlainMonthDay -> HandleDateTimeTemporalMonthDay-> [[TemporalPlainMonthDayFormat]]
+    //   ZonedDateTime -> spec throws TypeError; we handle it as a special case
+    enum class TemporalFieldKind : uint8_t {
+        None = 0, // Non-Temporal (legacy Date)
+        Instant, // Temporal.Instant — all fields, formatter's timezone
+        // FIXME: ZonedDateTime support not yet
+        ZonedDateTime, // Temporal.ZonedDateTime — all fields + timezone name
+        PlainDate, // Date fields only, GMT
+        PlainDateTime, // Date + time fields, GMT
+        PlainTime, // Time fields only, GMT
+        PlainYearMonth, // Year + month fields, GMT
+        PlainMonthDay, // Month + day fields, GMT
+        Count // sentinel — must remain last
+    };
+
+    struct DateTimeValueRecord {
+        double value;
+        TemporalFieldKind kind;
+        // [[IsPlain]] from the spec Value Format Record is not stored here: our ICU-based
+        // implementation derives plain/non-plain from `kind` directly — getTemporalFormatter
+        // uses GMT for plain types and createTemporalIntervalFormat recomputes it as
+        // (kind != Instant), so no separate field is needed.
+    };
+    static DateTimeValueRecord handleDateTimeValue(JSGlobalObject*, const IntlDateTimeFormat*, JSValue);
+
     JSValue format(JSGlobalObject*, double value) const;
-    JSValue formatToParts(JSGlobalObject*, double value, JSString* sourceType = nullptr) const;
-    JSValue formatRange(JSGlobalObject*, double startDate, double endDate);
-    JSValue formatRangeToParts(JSGlobalObject*, double startDate, double endDate);
+    // https://tc39.es/proposal-temporal/#sec-formatdatetime
+    JSValue format(JSGlobalObject*, JSValue) const;
+    JSValue formatToParts(JSGlobalObject*, JSValue) const;
+    JSValue formatRange(JSGlobalObject*, JSValue startDate, JSValue endDate);
+    JSValue formatRangeToParts(JSGlobalObject*, JSValue startDate, JSValue endDate);
     JSObject* resolvedOptions(JSGlobalObject*) const;
+
+    static bool isTemporalObject(JSValue);
+    static bool sameTemporalType(JSValue, JSValue);
 
     JSBoundFunction* boundFormat() const LIFETIME_BOUND { return m_boundFormat.get(); }
     void setBoundFormat(VM&, JSBoundFunction*);
@@ -91,6 +134,43 @@ public:
 
     const IntlDateTimeFormatImpl& impl() const LIFETIME_BOUND { return *m_impl; }
     void setImpl(Ref<const IntlDateTimeFormatImpl>&& impl) { m_impl = WTF::move(impl); }
+
+    enum class TimeZoneName : uint8_t { None, Short, Long, ShortOffset, LongOffset, ShortGeneric, LongGeneric };
+    enum class DateTimeStyle : uint8_t { None, Full, Long, Medium, Short };
+
+    DateTimeStyle dateStyle() const;
+    DateTimeStyle timeStyle() const;
+    TimeZoneName timeZoneName() const;
+    const String& ensureCalendar() const;
+    const String& ensureNumberingSystem() const;
+
+    static bool calendarMatchesICU(StringView temporalId, const String& icuCalId);
+
+    using UDateFormatDeleter = ICUDeleter<udat_close>;
+    UDateFormat* getTemporalFormatter(VM&, TemporalFieldKind) const; // Non-owning; no clone needed (single-threaded JS).
+    std::unique_ptr<UDateFormat, UDateFormatDeleter> computeTemporalFormatter(TemporalFieldKind) const;
+    std::unique_ptr<UDateFormat, UDateFormatDeleter> computeAdjustDateTimeStyleFormat(TemporalFieldKind, const Vector<char16_t, 32>& skeleton) const;
+    std::unique_ptr<UDateFormat, UDateFormatDeleter> computeGetDateTimeFormat(TemporalFieldKind, const Vector<char16_t, 32>& skeleton) const;
+    std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter> createTemporalIntervalFormat(UDateFormat*, TemporalFieldKind, UErrorCode&) const;
+
+    struct DateRangePreamble {
+        std::unique_ptr<UFormattedDateInterval, UFormattedDateIntervalDeleter> result;
+        const UFormattedValue* formattedValue { nullptr };
+        bool equal { false };
+    };
+    std::optional<DateRangePreamble> prepareDateRange(JSGlobalObject*, double& startDate, double& endDate);
+
+    // https://tc39.es/proposal-temporal/#sec-partitiondatetimerangepattern
+    struct TemporalDateRangePreamble {
+        UDateFormat* tempFormat { nullptr }; // Non-owning; lifetime guaranteed by IntlDateTimeFormatImpl.
+        std::unique_ptr<UFormattedDateInterval, UFormattedDateIntervalDeleter> result;
+        const UFormattedValue* formattedValue { nullptr };
+        bool equal { false };
+        double startMs { 0 };
+        double endMs { 0 };
+        TemporalFieldKind kind { TemporalFieldKind::None };
+    };
+    std::optional<TemporalDateRangePreamble> partitionDateTimeRangePattern(JSGlobalObject*, JSValue x, JSValue y);
 
 private:
     friend class IntlDateTimeFormatImpl;
@@ -111,8 +191,6 @@ private:
     enum class Hour : uint8_t { None, TwoDigit, Numeric };
     enum class Minute : uint8_t { None, TwoDigit, Numeric };
     enum class Second : uint8_t { None, TwoDigit, Numeric };
-    enum class TimeZoneName : uint8_t { None, Short, Long, ShortOffset, LongOffset, ShortGeneric, LongGeneric };
-    enum class DateTimeStyle : uint8_t { None, Full, Long, Medium, Short };
 
     static void NODELETE setFormatsFromPattern(IntlDateTimeFormatImpl&, StringView);
     static ASCIILiteral hourCycleString(HourCycle);
@@ -131,12 +209,20 @@ private:
     static HourCycle NODELETE hourCycleFromSymbol(char16_t);
     static HourCycle parseHourCycle(const String&);
     static void NODELETE replaceHourCycleInSkeleton(Vector<char16_t, 32>&, bool hour12);
-    static void NODELETE replaceHourCycleInPattern(Vector<char16_t, 32>&, HourCycle);
+    static void replaceHourCycleInPattern(Vector<char16_t, 32>&, HourCycle);
     static String buildSkeleton(Weekday, Era, Year, Month, Day, TriState, HourCycle, Hour, DayPeriod, Minute, Second, unsigned, TimeZoneName);
 
     WriteBarrier<JSBoundFunction> m_boundFormat;
     std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter> m_dateIntervalFormat;
     RefPtr<const IntlDateTimeFormatImpl> m_impl;
+};
+
+class IntlDateTimeFormatTemporalFormatterCache {
+    WTF_MAKE_TZONE_ALLOCATED(IntlDateTimeFormatTemporalFormatterCache);
+    WTF_MAKE_NONCOPYABLE(IntlDateTimeFormatTemporalFormatterCache);
+public:
+    IntlDateTimeFormatTemporalFormatterCache() = default;
+    std::array<std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter>, static_cast<size_t>(IntlDateTimeFormat::TemporalFieldKind::Count)> m_formatters { };
 };
 
 class IntlDateTimeFormatImpl : public RefCounted<IntlDateTimeFormatImpl> {
@@ -170,7 +256,9 @@ public:
     IntlDateTimeFormat::TimeZoneName m_timeZoneName { IntlDateTimeFormat::TimeZoneName::None };
     IntlDateTimeFormat::DateTimeStyle m_dateStyle { IntlDateTimeFormat::DateTimeStyle::None };
     IntlDateTimeFormat::DateTimeStyle m_timeStyle { IntlDateTimeFormat::DateTimeStyle::None };
+    bool m_anyPresent { false };
     std::unique_ptr<UDateFormat, UDateFormatDeleter> m_dateFormat;
+    mutable std::unique_ptr<IntlDateTimeFormatTemporalFormatterCache> m_temporalFormatterCache;
 
 private:
     IntlDateTimeFormatImpl() = default;

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
@@ -33,6 +33,11 @@
 #include "JSBoundFunction.h"
 #include "JSCInlines.h"
 #include "TemporalInstant.h"
+#include "TemporalPlainDate.h"
+#include "TemporalPlainDateTime.h"
+#include "TemporalPlainMonthDay.h"
+#include "TemporalPlainTime.h"
+#include "TemporalPlainYearMonth.h"
 #include <wtf/DateMath.h>
 
 namespace JSC {
@@ -87,51 +92,174 @@ void IntlDateTimeFormatPrototype::finishCreation(VM& vm, JSGlobalObject* globalO
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 
+using DateTimeValueRecord = IntlDateTimeFormat::DateTimeValueRecord;
+
+
+bool IntlDateTimeFormat::isTemporalObject(JSValue x)
+{
+    // FIXME: || dynamicDowncast<TemporalZonedDateTime>(x)
+    return dynamicDowncast<TemporalInstant>(x)
+        || dynamicDowncast<TemporalPlainDate>(x)
+        || dynamicDowncast<TemporalPlainDateTime>(x)
+        || dynamicDowncast<TemporalPlainTime>(x)
+        || dynamicDowncast<TemporalPlainYearMonth>(x)
+        || dynamicDowncast<TemporalPlainMonthDay>(x);
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal-sametemporaltype
+bool IntlDateTimeFormat::sameTemporalType(JSValue x, JSValue y)
+{
+    if (!isTemporalObject(x) || !isTemporalObject(y))
+        return false;
+#define CHECK(T)                                                    \
+    if ((bool)dynamicDowncast<T>(x) != (bool)dynamicDowncast<T>(y)) \
+        return false;
+    CHECK(TemporalInstant)
+    CHECK(TemporalPlainDate)
+    CHECK(TemporalPlainDateTime)
+    CHECK(TemporalPlainTime)
+    CHECK(TemporalPlainYearMonth)
+    CHECK(TemporalPlainMonthDay)
+    // FIXME: CHECK(TemporalZonedDateTime)
+#undef CHECK
+    return true;
+}
+
 // HandleDateTimeValue ( dateTimeFormat, x )
 // https://tc39.es/proposal-temporal/#sec-temporal-handledatetimevalue
-static double handleDateTimeValue(JSGlobalObject* globalObject, JSValue x)
+IntlDateTimeFormat::DateTimeValueRecord IntlDateTimeFormat::handleDateTimeValue(JSGlobalObject* globalObject, const IntlDateTimeFormat* dtf, JSValue x)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (x.isUndefined())
-        RELEASE_AND_RETURN(scope, dateNowImpl().toNumber(globalObject));
+    using Kind = IntlDateTimeFormat::TemporalFieldKind;
 
-    // FIXME:
-    //  - Add all of the other Temporal types
-    //  - Work in epoch nanoseconds
-    //  - Return UDateFormat and UDateIntervalFormat depending on the type
-    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(x);
-    if (instant)
-        return instant->exactTime().epochMilliseconds();
+    // If date is undefined, let x be !Call(%Date.now%, undefined).
+    // (#sec-datetime-format-functions step 3, #sec-Intl.DateTimeFormat.prototype.formatToParts step 3)
+    if (x.isUndefined()) {
+        double now = dateNowImpl().toNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        return { now, Kind::None };
+    }
 
-    RELEASE_AND_RETURN(scope, WTF::timeClip(x.toNumber(globalObject)));
+    // iso8601Exempt: per spec, PlainDate and PlainDateTime allow iso8601 calendar to match any DTF
+    // calendar (HandleDateTimeTemporalDate/DateTime step 1: "not either dtf.[[Calendar]] or 'iso8601'").
+    // PlainYearMonth and PlainMonthDay require exact calendar match — iso8601 is NOT exempt
+    // (HandleDateTimeTemporalYearMonth/MonthDay step 1: "not equal to dtf.[[Calendar]]").
+    auto validateCalendar = [&](CalendarID calendarId, Kind kind) -> bool {
+        bool iso8601Exempt = (kind == Kind::PlainDate || kind == Kind::PlainDateTime);
+        if (!dtf || (calendarId == iso8601CalendarID() && iso8601Exempt))
+            return false;
+        if (!IntlDateTimeFormat::calendarMatchesICU(TemporalCore::calendarIDToString(calendarId), dtf->ensureCalendar())) [[unlikely]] {
+            throwRangeError(globalObject, scope, "Temporal object's calendar does not match DateTimeFormat calendar"_s);
+            return true;
+        }
+        return false;
+    };
+
+    auto makeDateRecord = [&](CalendarID calId, Kind kind, int32_t y, uint8_t m, uint8_t d) -> DateTimeValueRecord {
+        // Step 1: calendar mismatch → RangeError.
+        if (validateCalendar(calId, kind))
+            return { };
+        // Steps 2-3: CombineISODateAndTimeRecord(isoDate, NoonTimeRecord()) + GetUTCEpochNanoseconds.
+        auto et = ISO8601::ExactTime::fromISOPartsAndOffset(y, m, d, 12, 0, 0, 0, 0, 0, 0);
+        // Steps 4-5: [[TemporalXxxFormat]] null → TypeError. getTemporalFormatter covers all
+        // cases (explicit time-only fields, timeStyle-only, etc.), not just a dateStyle heuristic.
+        if (dtf && !dtf->getTemporalFormatter(vm, kind)) [[unlikely]] {
+            throwTypeError(globalObject, scope, "DateTimeFormat has no fields applicable to this Temporal type"_s);
+            return { };
+        }
+        return { static_cast<double>(et.epochMilliseconds()), kind }; // Step 6.
+    };
+
+    // Step 2: [[InitializedTemporalDate]] -> HandleDateTimeTemporalDate.
+    // https://tc39.es/proposal-temporal/#sec-temporal-handledatetimetemporaldate
+    if (auto* plainDate = dynamicDowncast<TemporalPlainDate>(x))
+        return makeDateRecord(plainDate->calendarID(), Kind::PlainDate, plainDate->year(), plainDate->month(), plainDate->day());
+
+    // Step 3: [[InitializedTemporalYearMonth]] -> HandleDateTimeTemporalYearMonth.
+    // https://tc39.es/proposal-temporal/#sec-temporal-handledatetimetemporalyearmonth
+    if (auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(x)) {
+        auto iso = yearMonth->plainYearMonth().isoPlainDate();
+        return makeDateRecord(yearMonth->calendarID(), Kind::PlainYearMonth, iso.year(), iso.month(), iso.day());
+    }
+
+    // Step 4: [[InitializedTemporalMonthDay]] -> HandleDateTimeTemporalMonthDay.
+    // https://tc39.es/proposal-temporal/#sec-temporal-handledatetimetemporalmonthday
+    if (auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(x)) {
+        auto md = monthDay->plainMonthDay();
+        return makeDateRecord(monthDay->calendarID(), Kind::PlainMonthDay, md.isoPlainDate().year(), md.isoPlainDate().month(), md.isoPlainDate().day());
+    }
+
+    // Step 5: [[InitializedTemporalTime]] -> HandleDateTimeTemporalTime.
+    // https://tc39.es/proposal-temporal/#sec-temporal-handledatetimetemporaltime
+    if (auto* plainTime = dynamicDowncast<TemporalPlainTime>(x)) {
+        // Step 5: [[TemporalPlainTimeFormat]] null → TypeError.
+        if (dtf && !dtf->getTemporalFormatter(vm, Kind::PlainTime)) [[unlikely]] {
+            throwTypeError(globalObject, scope, "DateTimeFormat has no fields applicable to this Temporal type"_s);
+            return { };
+        }
+        // Steps 2-3: CombineISODateAndTimeRecord({1970,1,1}, temporalTime) + GetUTCEpochNanoseconds.
+        auto t = plainTime->plainTime();
+        auto et = ISO8601::ExactTime::fromISOPartsAndOffset(
+            1970, 1, 1, t.hour(), t.minute(), t.second(),
+            t.millisecond(), t.microsecond(), t.nanosecond(), 0);
+        return { static_cast<double>(et.epochMilliseconds()), Kind::PlainTime }; // Step 6.
+    }
+
+    // Step 6: [[InitializedTemporalDateTime]] -> HandleDateTimeTemporalDateTime.
+    // https://tc39.es/proposal-temporal/#sec-temporal-handledatetimetemporaldatetime
+    if (auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(x)) {
+        if (validateCalendar(plainDateTime->calendarID(), Kind::PlainDateTime))
+            return { };
+        auto d = plainDateTime->plainDate();
+        auto t = plainDateTime->plainTime();
+        auto et = ISO8601::ExactTime::fromISOPartsAndOffset(
+            d.year(), d.month(), d.day(), t.hour(), t.minute(), t.second(),
+            t.millisecond(), t.microsecond(), t.nanosecond(), 0);
+        return { static_cast<double>(et.epochMilliseconds()), Kind::PlainDateTime };
+    }
+
+    // Step 7: [[InitializedTemporalInstant]] -> HandleDateTimeTemporalInstant.
+    // https://tc39.es/proposal-temporal/#sec-temporal-handledatetimetemporalinstant
+    if (auto* instant = dynamicDowncast<TemporalInstant>(x))
+        return { static_cast<double>(instant->exactTime().epochMilliseconds()), Kind::Instant };
+
+    // FIXME
+    // Step 8: Assert ZonedDateTime -> throw TypeError.
+    // if (dynamicDowncast<TemporalZonedDateTime>(x)) [[unlikely]] {
+    //     throwTypeError(globalObject, scope, "Temporal.ZonedDateTime is not supported in Intl.DateTimeFormat; use toLocaleString() or convert to PlainDateTime first"_s);
+    //     return { };
+    // }
+
+    // Step 1 (HandleDateTimeOthers): x is a Number — TimeClip.
+    // https://tc39.es/proposal-temporal/#sec-temporal-handledatetimeothers
+    double clipped = WTF::timeClip(x.toNumber(globalObject));
+    RETURN_IF_EXCEPTION(scope, { });
+    return { clipped, IntlDateTimeFormat::TemporalFieldKind::None };
 }
 
+// https://tc39.es/proposal-temporal/#sec-datetime-format-functions
 JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatFuncFormatDateTime, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    // 12.1.7 DateTime Format Functions (ECMA-402)
-    // https://tc39.github.io/ecma402/#sec-formatdatetime
 
+    // Step 1: Let dtf be F.[[DateTimeFormat]].
     IntlDateTimeFormat* format = dynamicDowncast<IntlDateTimeFormat>(callFrame->thisValue());
     if (!format) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.format called on value that's not a DateTimeFormat"_s));
 
-    JSValue date = callFrame->argument(0);
-    double value = handleDateTimeValue(globalObject, date);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(format->format(globalObject, value)));
+    // Steps 3-5: undefined->Date.now() / ToDateTimeFormattable / FormatDateTime (#sec-formatdatetime).
+    RELEASE_AND_RETURN(scope, JSValue::encode(format->format(globalObject, callFrame->argument(0))));
 }
 
+// https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.format
 JSC_DEFINE_CUSTOM_GETTER(intlDateTimeFormatPrototypeGetterFormat, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // 12.3.3 Intl.DateTimeFormat.prototype.format (ECMA-402 2.0)
     // 1. Let dtf be this DateTimeFormat object.
     auto* dtf = IntlDateTimeFormat::unwrapForOldFunctions(globalObject, JSValue::decode(thisValue));
     RETURN_IF_EXCEPTION(scope, { });
@@ -144,7 +272,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlDateTimeFormatPrototypeGetterFormat, (JSGlobalObjec
     if (!boundFormat) {
         JSGlobalObject* globalObject = dtf->realm();
         // a. Let F be a new built-in function object as defined in 12.3.4.
-        // b. The value of F’s length property is 1. (Note: F’s length property was 0 in ECMA-402 1.0)
+        // b. The value of F's length property is 1. (Note: F's length property was 0 in ECMA-402 1.0)
         JSFunction* targetObject = JSFunction::create(vm, globalObject, 1, "format"_s, intlDateTimeFormatFuncFormatDateTime, ImplementationVisibility::Public);
         // c. Let bf be BoundFunctionCreate(F, «this value»).
         boundFormat = JSBoundFunction::create(vm, globalObject, targetObject, dtf, { }, 1, jsEmptyString(vm), makeSource("format"_s, SourceOrigin(), SourceTaintedOrigin::Untainted));
@@ -159,82 +287,88 @@ JSC_DEFINE_CUSTOM_GETTER(intlDateTimeFormatPrototypeGetterFormat, (JSGlobalObjec
     return JSValue::encode(boundFormat);
 }
 
+// https://tc39.es/proposal-temporal/#sec-Intl.DateTimeFormat.prototype.formatToParts
 JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatToParts, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // 15.4 Intl.DateTimeFormat.prototype.formatToParts (ECMA-402 4.0)
-    // https://tc39.github.io/ecma402/#sec-Intl.DateTimeFormat.prototype.formatToParts
-
-    // Do not use unwrapForOldFunctions.
+    // Step 1: Let dtf be this value. Step 2: RequireInternalSlot.
     auto* dateTimeFormat = dynamicDowncast<IntlDateTimeFormat>(callFrame->thisValue());
     if (!dateTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.formatToParts called on value that's not a DateTimeFormat"_s));
 
-    JSValue date = callFrame->argument(0);
-    double value = handleDateTimeValue(globalObject, date);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(dateTimeFormat->formatToParts(globalObject, value)));
+    // Steps 3-5: undefined->Date.now() / ToDateTimeFormattable / FormatDateTimeToParts (#sec-formatdatetimetoparts).
+    RELEASE_AND_RETURN(scope, JSValue::encode(dateTimeFormat->formatToParts(globalObject, callFrame->argument(0))));
 }
 
-// http://tc39.es/proposal-intl-DateTimeFormat-formatRange/#sec-intl.datetimeformat.prototype.formatRange
+// https://tc39.es/proposal-temporal/#sec-intl.datetimeformat.prototype.formatRange
 JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatRange, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Do not use unwrapForOldFunctions.
+    // Step 1: Let dtf be this value. Step 2: RequireInternalSlot.
     auto* dateTimeFormat = dynamicDowncast<IntlDateTimeFormat>(callFrame->thisValue());
     if (!dateTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.formatRange called on value that's not a DateTimeFormat"_s));
 
-    JSValue startDateValue = callFrame->argument(0);
-    JSValue endDateValue = callFrame->argument(1);
-
-    if (startDateValue.isUndefined() || endDateValue.isUndefined())
+    // Step 3: If startDate or endDate is undefined, throw TypeError.
+    JSValue startDate = callFrame->argument(0);
+    JSValue endDate = callFrame->argument(1);
+    if (startDate.isUndefined() || endDate.isUndefined()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "startDate or endDate is undefined"_s);
 
-    double startDate = handleDateTimeValue(globalObject, startDateValue);
-    RETURN_IF_EXCEPTION(scope, { });
-    double endDate = handleDateTimeValue(globalObject, endDateValue);
-    RETURN_IF_EXCEPTION(scope, { });
+    // Steps 4-5: ToDateTimeFormattable — non-Temporal values convert to Number.
+    if (!IntlDateTimeFormat::isTemporalObject(startDate)) {
+        startDate = jsNumber(startDate.toNumber(globalObject));
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+    if (!IntlDateTimeFormat::isTemporalObject(endDate)) {
+        endDate = jsNumber(endDate.toNumber(globalObject));
+        RETURN_IF_EXCEPTION(scope, { });
+    }
 
+    // Step 6: Return ?FormatDateTimeRange(dtf, x, y) — PartitionDateTimeRangePattern inside.
     RELEASE_AND_RETURN(scope, JSValue::encode(dateTimeFormat->formatRange(globalObject, startDate, endDate)));
 }
 
-// http://tc39.es/proposal-intl-DateTimeFormat-formatRange/#sec-intl.datetimeformat.prototype.formatRangeToParts
+// https://tc39.es/proposal-temporal/#sec-Intl.DateTimeFormat.prototype.formatRangeToParts
 JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatRangeToParts, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Do not use unwrapForOldFunctions.
+    // Step 1: Let dtf be this value. Step 2: RequireInternalSlot.
     auto* dateTimeFormat = dynamicDowncast<IntlDateTimeFormat>(callFrame->thisValue());
     if (!dateTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.formatRangeToParts called on value that's not a DateTimeFormat"_s));
 
-    JSValue startDateValue = callFrame->argument(0);
-    JSValue endDateValue = callFrame->argument(1);
-
-    if (startDateValue.isUndefined() || endDateValue.isUndefined())
+    // Step 3: If startDate or endDate is undefined, throw TypeError.
+    JSValue startDate = callFrame->argument(0);
+    JSValue endDate = callFrame->argument(1);
+    if (startDate.isUndefined() || endDate.isUndefined()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "startDate or endDate is undefined"_s);
 
-    double startDate = handleDateTimeValue(globalObject, startDateValue);
-    RETURN_IF_EXCEPTION(scope, { });
-    double endDate = handleDateTimeValue(globalObject, endDateValue);
-    RETURN_IF_EXCEPTION(scope, { });
+    // Steps 4-5: ToDateTimeFormattable — non-Temporal values convert to Number.
+    if (!IntlDateTimeFormat::isTemporalObject(startDate)) {
+        startDate = jsNumber(startDate.toNumber(globalObject));
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+    if (!IntlDateTimeFormat::isTemporalObject(endDate)) {
+        endDate = jsNumber(endDate.toNumber(globalObject));
+        RETURN_IF_EXCEPTION(scope, { });
+    }
 
+    // Step 6: Return ?FormatDateTimeRangeToParts(dtf, x, y) — PartitionDateTimeRangePattern inside.
     RELEASE_AND_RETURN(scope, JSValue::encode(dateTimeFormat->formatRangeToParts(globalObject, startDate, endDate)));
 }
 
+// https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.resolvedoptions
 JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncResolvedOptions, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // 12.3.5 Intl.DateTimeFormat.prototype.resolvedOptions() (ECMA-402 2.0)
 
     auto* dateTimeFormat = IntlDateTimeFormat::unwrapForOldFunctions(globalObject, callFrame->thisValue());
     RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
@@ -294,8 +294,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncToLocaleString, (JSGlobalOb
     formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Any, IntlDateTimeFormat::Defaults::All);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // FIXME: Implement using IntlDateTimeFormat Temporal support.
-    return throwVMTypeError(globalObject, scope, "toLocaleString not yet implemented with full Temporal support"_s);
+    RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.valueof

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -410,8 +410,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToLocaleString, (JSGlobal
     formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Date, IntlDateTimeFormat::Defaults::Date);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // FIXME: Implement using IntlDateTimeFormat Temporal support.
-    return throwVMTypeError(globalObject, scope, "toLocaleString not yet implemented with full Temporal support"_s);
+    RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.valueof

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -530,8 +530,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncToLocaleString, (JSGl
     formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Any, IntlDateTimeFormat::Defaults::All);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // FIXME: Implement using IntlDateTimeFormat Temporal support.
-    return throwVMTypeError(globalObject, scope, "toLocaleString not yet implemented with full Temporal support"_s);
+    RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -136,8 +136,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToLocaleString, (JSGl
     formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Date, IntlDateTimeFormat::Defaults::Date);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // FIXME: Implement using IntlDateTimeFormat Temporal support.
-    return throwVMTypeError(globalObject, scope, "toLocaleString not yet implemented with full Temporal support"_s);
+    RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.with

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
@@ -280,9 +280,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToLocaleString, (JSGlobal
     formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Time, IntlDateTimeFormat::Defaults::Time);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // FormatDateTime via HandleDateTimeTemporalTime: use 1970-01-01 as the reference ISO date.
-    // FIXME: Implement using IntlDateTimeFormat Temporal support.
-    return throwVMTypeError(globalObject, scope, "toLocaleString not yet implemented with full Temporal support"_s);
+    RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.valueof

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
@@ -344,9 +344,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToLocaleString, (JSG
     formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Date, IntlDateTimeFormat::Defaults::Date);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // PlainYearMonth: calendar must always match locale (ISO NOT exempt).
-    // FIXME: Implement using IntlDateTimeFormat Temporal support.
-    return throwVMTypeError(globalObject, scope, "toLocaleString not yet implemented with full Temporal support"_s);
+    RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.valueof


### PR DESCRIPTION
#### 5745eb4c8ff15d24b72273f76364a1d3468608db
<pre>
[JSC][Temporal] Implement Intl.DateTimeFormat Temporal support and toLocaleString
<a href="https://bugs.webkit.org/show_bug.cgi?id=315637">https://bugs.webkit.org/show_bug.cgi?id=315637</a>
<a href="https://rdar.apple.com/178012405">rdar://178012405</a>

Reviewed by Yusuke Suzuki.

Implement the Temporal proposal&apos;s Intl.DateTimeFormat integration: HandleDateTimeValue,
SameTemporalType, AdjustDateTimeStyleFormat, GetDateTimeFormat, FormatDateTime,
FormatDateTimeToParts, FormatDateTimeRange, and FormatDateTimeRangeToParts.

Introduce TemporalFieldKind to drive per-type ICU skeleton filtering, lazy formatter
caching, and timezone selection (GMT for plain types, DTF timezone for Instant).
Calendar validation throws RangeError before TypeError; iso8601 is exempt only for
PlainDate and PlainDateTime.

Wire up toLocaleString on all six Temporal prototype objects. Remove the
//@ skip directives that were blocking toLocaleString tests. Remove 201
now-passing test262 expectations.

Test: JSTests/stress/intl-datetimeformat-temporal-formatter-cache.js
Canonical link: <a href="https://commits.webkit.org/314183@main">https://commits.webkit.org/314183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07ae82cf1f62259f1a9bccfe040e1fa142a1fab1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122610 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3adaf744-c105-4d0e-9fb9-98bf9f4c5335) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128499 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f7942e52-812d-4152-991e-4b2e0cecf5ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109024 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67b6e2b0-1fd2-4d5b-bfc7-62ae52756990) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28480 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22478 "Hash 07ae82cf for PR 65752 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157512 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139752 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176919 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26248 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136823 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136759 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/36866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148048 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101946 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25159 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24915 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38112 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111186 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37509 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2993 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37756 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37653 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->