### PR TITLE
[JSC] Fix vector caching in TypedArray.prototype.forEach

### DIFF
--- a/JSTests/stress/typedarray-forEach-transition.js
+++ b/JSTests/stress/typedarray-forEach-transition.js
@@ -1,0 +1,16 @@
+let ta = new Int32Array(100);
+for (let i = 0; i < 100; i++) ta[i] = i;
+
+ta.forEach((v, i) => {
+    if (i === 0) {
+        ta.buffer;
+
+        for (let j = 1; j < 100; j++) {
+            ta[j] = 0xDEAD;
+        }
+    } else {
+        if (v !== 0xDEAD) {
+            throw new Error("read stale value at index ", i);
+        }
+    }
+});

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -207,22 +207,7 @@ static ALWAYS_INLINE void typedArrayViewForEachImpl(JSGlobalObject* globalObject
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (!thisObject->isResizableNonShared()) [[likely]] {
-        // Including GrowableShared. The key invariant here is that we can access element via array[index] if we check isDetached.
-        auto* array = thisObject->typedVector();
-
-        auto loopBody = [&](size_t index) ALWAYS_INLINE_LAMBDA -> IterationStatus {
-            JSValue element = jsUndefined();
-            auto nativeValue = ViewClass::Adaptor::toNativeFromUndefined();
-            if (!thisObject->isDetached()) [[likely]] {
-                nativeValue = array[index];
-                element = ViewClass::Adaptor::toJSValue(globalObject, nativeValue);
-                RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, { });
-            }
-
-            return functor(element, index, nativeValue);
-        };
-
+    auto forEachLoop = [&](auto&& loopBody) ALWAYS_INLINE_LAMBDA {
         if constexpr (direction == ForEachDirection::Forward) {
             for (size_t index = 0; index < length; ++index) {
                 auto status = loopBody(index);
@@ -239,10 +224,35 @@ static ALWAYS_INLINE void typedArrayViewForEachImpl(JSGlobalObject* globalObject
                     return;
             }
         }
+    };
+
+    if (!thisObject->isResizableNonShared()) [[likely]] {
+        // Fixed-length TypedArrays backed by non-shared ArrayBuffers cannot shrink and go out of
+        // bounds, and only need to check for detachment.
+        //
+        // But they may have their vectors move:
+        // - Non-wasteful TypedArrays that don't have a backing ArrayBuffer yet can transition to
+        //   being wasteful, and having an ArrayBuffer and change backing stores.
+        // - BoundsChecking Wasm memories can reallocate.
+        const bool hasStableVector = thisObject->hasArrayBuffer() && !thisObject->possiblySharedBuffer()->isWasmMemory();
+        auto* array = hasStableVector ? thisObject->typedVector() : nullptr;
+
+        forEachLoop([&](size_t index) ALWAYS_INLINE_LAMBDA -> IterationStatus {
+            JSValue element = jsUndefined();
+            auto nativeValue = ViewClass::Adaptor::toNativeFromUndefined();
+            if (!thisObject->isDetached()) [[likely]] {
+                nativeValue = (hasStableVector ? array : thisObject->typedVector())[index];
+                element = ViewClass::Adaptor::toJSValue(globalObject, nativeValue);
+                RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, { });
+            }
+
+            return functor(element, index, nativeValue);
+        });
+
         return;
     }
 
-    auto loopBody = [&](size_t index) ALWAYS_INLINE_LAMBDA -> IterationStatus {
+    forEachLoop([&](size_t index) ALWAYS_INLINE_LAMBDA -> IterationStatus {
         JSValue element = jsUndefined();
         auto nativeValue = ViewClass::Adaptor::toNativeFromUndefined();
         if (!thisObject->isDetached() && thisObject->inBounds(index)) [[likely]] {
@@ -252,24 +262,7 @@ static ALWAYS_INLINE void typedArrayViewForEachImpl(JSGlobalObject* globalObject
         }
 
         return functor(element, index, nativeValue);
-    };
-
-    if constexpr (direction == ForEachDirection::Forward) {
-        for (size_t index = 0; index < length; ++index) {
-            auto status = loopBody(index);
-            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, void());
-            if (IterationStatus::Done == status)
-                return;
-        }
-    } else {
-        size_t index = length;
-        while (index--) {
-            auto status = loopBody(index);
-            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, void());
-            if (IterationStatus::Done == status)
-                return;
-        }
-    }
+    });
 }
 
 template<typename ViewClass>


### PR DESCRIPTION
#### a271abef225ed90f7f5f917fae417077eb0855aa
<pre>
[JSC] Fix vector caching in TypedArray.prototype.forEach
<a href="https://bugs.webkit.org/show_bug.cgi?id=309918">https://bugs.webkit.org/show_bug.cgi?id=309918</a>
<a href="https://rdar.apple.com/172446537">rdar://172446537</a>

Reviewed by Yijia Huang.

A TypedArray&apos;s vector can move even when it&apos;s fixed-length and non-shared due
to materializing its ArrayBuffer and due to BoundsChecking Wasm memories doing
reallocation. In those cases, the current code incorrectly caches the data
pointer to the vector. This PR fixes those cases by reloading the vector.

Test: JSTests/stress/typedarray-forEach-transition.js
* JSTests/stress/typedarray-forEach-transition.js: Added.
(ta.forEach):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::typedArrayViewForEachImpl):

Originally-landed-as: 305413.485@rapid/safari-7624.2.5.110-branch (32d01d0d2755). <a href="https://rdar.apple.com/176061980">rdar://176061980</a>
Canonical link: <a href="https://commits.webkit.org/313960@main">https://commits.webkit.org/313960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64d6604e8bbc8e98662620096c2e5bab6e4c4d0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121905 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127949 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108493 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29295 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27921 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21446 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156804 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176211 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25545 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29035 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136266 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136229 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36697 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147501 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101062 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31499 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24357 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197056 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110448 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51767 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36802 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2420 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37050 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->