### PR TITLE
Navigating to a page with a model tag crashes in recovery mode

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -346,8 +346,12 @@ void HTMLModelElement::didMoveToNewDocument(Document& oldDocument, Document& new
 
 // MARK: - Rendering overrides.
 
-RenderPtr<RenderElement> HTMLModelElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
+RenderPtr<RenderElement> HTMLModelElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& position)
 {
+    if (RefPtr page = document().page()) {
+        if (RefPtr provider = page->modelPlayerProvider(); provider && !provider->isAvailable())
+            return HTMLElement::createElementRenderer(WTF::move(style), position);
+    }
     return createRenderer<RenderModel>(*this, WTF::move(style));
 }
 
@@ -1811,8 +1815,8 @@ ModelPlayerAccessibilityChildren HTMLModelElement::accessibilityChildren()
 
 LayoutSize HTMLModelElement::contentSize() const
 {
-    if (CheckedPtr renderer = this->renderer())
-        return downcast<RenderReplaced>(*renderer).replacedContentRect().size();
+    if (CheckedPtr model = dynamicDowncast<RenderModel>(renderer()))
+        return model->replacedContentRect().size();
 
     return LayoutSize();
 }

--- a/Source/WebCore/Modules/model-element/ModelPlayerProvider.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayerProvider.cpp
@@ -33,4 +33,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelPlayerProvider);
 
 ModelPlayerProvider::~ModelPlayerProvider() = default;
 
+bool ModelPlayerProvider::isAvailable() const
+{
+    return true;
+}
+
 }

--- a/Source/WebCore/Modules/model-element/ModelPlayerProvider.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerProvider.h
@@ -39,6 +39,8 @@ class WEBCORE_EXPORT ModelPlayerProvider : public RefCountedAndCanMakeWeakPtr<Mo
 public:
     virtual ~ModelPlayerProvider();
 
+    virtual bool isAvailable() const;
+
     // FIXME: Once all clients have adopted ModelPlayerProvider, this should
     // be changed to return a Ref<ModelPlayer>
     virtual RefPtr<ModelPlayer> createModelPlayer(ModelPlayerClient&) = 0;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
@@ -34,6 +34,10 @@
 #include <WebCore/Settings.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#if PLATFORM(COCOA)
+#include <sys/sysctl.h>
+#include <wtf/spi/darwin/OSVariantSPI.h>
+#endif
 
 #if ENABLE(MODEL_PROCESS)
 #include "ModelProcessModelPlayer.h"
@@ -43,6 +47,18 @@
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebModelPlayerProvider);
+
+#if PLATFORM(COCOA)
+static bool isRunningInRecoveryOS()
+{
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+    static bool isBaseSystem = os_variant_is_basesystem("WebKit");
+    return isBaseSystem;
+#else
+    return false;
+#endif
+}
+#endif
 
 Ref<WebModelPlayerProvider> WebModelPlayerProvider::create(WebPage& webPage)
 {
@@ -58,9 +74,24 @@ WebModelPlayerProvider::~WebModelPlayerProvider() = default;
 
 // MARK: - WebCore::ModelPlayerProvider overrides.
 
+bool WebModelPlayerProvider::isAvailable() const
+{
+#if PLATFORM(COCOA)
+    return !isRunningInRecoveryOS();
+#else
+    return true;
+#endif
+}
+
 RefPtr<WebCore::ModelPlayer> WebModelPlayerProvider::createModelPlayer(WebCore::ModelPlayerClient& client)
 {
     Ref page = m_page.get();
+#if PLATFORM(COCOA)
+    if (!isAvailable()) {
+        UNUSED_PARAM(client);
+        return nullptr;
+    }
+#endif
 #if ENABLE(MODEL_PROCESS)
     if (page->corePage() && page->corePage()->settings().modelProcessEnabled())
         return WebProcess::singleton().modelProcessModelPlayerManager().createModelProcessModelPlayer(page, client);

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h
@@ -44,6 +44,7 @@ private:
     WebModelPlayerProvider(WebPage&);
 
     // WebCore::ModelPlayerProvider overrides.
+    bool isAvailable() const final;
     RefPtr<WebCore::ModelPlayer> createModelPlayer(WebCore::ModelPlayerClient&) final;
     void deleteModelPlayer(WebCore::ModelPlayer&) final;
 


### PR DESCRIPTION
#### 0733f639c1a5fb7d5274b49600904e09c49e535d
<pre>
Navigating to a page with a model tag crashes in recovery mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=315620">https://bugs.webkit.org/show_bug.cgi?id=315620</a>
<a href="https://rdar.apple.com/177993583">rdar://177993583</a>

Reviewed by Etienne Segonzac.

We don&apos;t support model in recovery mode since the frameworks are not
present, report it as unsupported.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::createElementRenderer):
(WebCore::HTMLModelElement::contentSize const):
* Source/WebCore/Modules/model-element/ModelPlayerProvider.h:
* Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp:
(WebKit::isRunningInVirtualMachine):
(WebKit::isRunningInRecoveryOS):
(WebKit::WebModelPlayerProvider::isAvailable const):
(WebKit::WebModelPlayerProvider::createModelPlayer):
* Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h:

Canonical link: <a href="https://commits.webkit.org/313978@main">https://commits.webkit.org/313978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/949645e7ec4cbe9448d2acc70f8faa5af8f79201

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121985 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0fb8ef9-6521-4c5f-a2bc-2a5b7fee5905) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128022 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68ee6cd6-c21e-4c10-94e7-a720164a7e9e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108568 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ff4ee39-3b27-4893-b490-b1b2846f5880) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27993 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21527 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176291 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29115 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136339 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136303 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36707 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147569 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101176 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31571 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24425 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37484 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110529 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36882 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2490 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37130 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37030 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->