### PR TITLE
[JSC] Fix AirFixObviousSpills modeling of early defs

### DIFF
--- a/JSTests/stress/fixobviousspills-earlydefs.js
+++ b/JSTests/stress/fixobviousspills-earlydefs.js
@@ -1,0 +1,43 @@
+const L = 100;
+const M = 200;
+const S = 0;
+const E = 256;
+const T = (E - S) - 5;
+
+for (let i = 0; i < 2; i++) {
+  let g = (a) => a.size;
+  let d = [];
+
+  for (let c = 0; c < 16; c++) {
+    g(d);
+
+    try {
+        const g = (a) => a.byteLength;
+        const b = new ArrayBuffer(M, { maxByteLength: M });
+        const d = new DataView(b, 0, L);
+
+        for (let c = S; c < E + 11; c++) {
+          g(1);
+
+          if (c != E) {
+            for (let c = S; c < E; c++) {
+              try { if (c == E - T) { g(1); } else { g(d); } } catch(e) { }
+            }
+
+            if (c != E) {
+              for (let c = S; c < E; c++) {
+                try { if (c == E - T) { g(1); } else { g(d); } } catch(e) { }
+              }
+              if (c != E) {
+                for (let c = S; c < E; c++) {
+                  try { if (c == E - T) { g(1); } else { g(d); } } catch(e) { }
+                }
+              }
+            }
+          }
+
+          if (c == E) { b.resize(L - 5); } else { g(d); }
+      }
+    } catch (e) { }
+  }
+}

--- a/Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp
+++ b/Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp
@@ -55,9 +55,7 @@ public:
 
     void run()
     {
-        if (AirFixObviousSpillsInternal::verbose)
-            dataLog("Code before fixObviousSpills:\n", m_code);
-        
+        dataLogLnIf(AirFixObviousSpillsInternal::verbose, "Code before fixObviousSpills:\n", m_code);
         computeAliases();
         fixCode();
     }
@@ -79,11 +77,13 @@ private:
                 m_block = block;
                 m_state = m_atHead[block];
 
-                if (AirFixObviousSpillsInternal::verbose)
-                    dataLog("Executing block ", *m_block, ": ", m_state, "\n");
-                
-                for (m_instIndex = 0; m_instIndex < block->size(); ++m_instIndex)
-                    executeInst();
+                dataLogLnIf(AirFixObviousSpillsInternal::verbose, "Executing block ", *m_block, ": ", m_state);
+                for (m_instIndex = 0; m_instIndex < block->size(); ++m_instIndex) {
+                    dataLogLnIf(AirFixObviousSpillsInternal::verbose, "    Executing ", m_block->at(m_instIndex), ": ", m_state);
+                    clobberEarlyDefs();
+                    clobberLateDefs();
+                    addInstAliases();
+                }
 
                 // Before we call merge we must make sure that the two states are sorted.
                 m_state.sort();
@@ -116,8 +116,10 @@ private:
             RELEASE_ASSERT(m_notBottom.quickGet(block->index()));
 
             for (m_instIndex = 0; m_instIndex < block->size(); ++m_instIndex) {
+                clobberEarlyDefs();
                 fixInst();
-                executeInst();
+                clobberLateDefs();
+                addInstAliases();
             }
         }
     }
@@ -181,27 +183,33 @@ private:
         }
     }
 
-    void executeInst()
+    void clobberDefs(Inst* prevInst, Inst* nextInst)
     {
-        Inst& inst = m_block->at(m_instIndex);
-
-        if (AirFixObviousSpillsInternal::verbose)
-            dataLog("    Executing ", inst, ": ", m_state, "\n");
-
-        Inst::forEachDefWithExtraClobberedRegs<Reg>(&inst, &inst,
+        Inst::forEachDefWithExtraClobberedRegs<Reg>(prevInst, nextInst,
             [&] (const Reg& reg, Arg::Role, Bank, Width, PreservedWidth) {
-                if (AirFixObviousSpillsInternal::verbose)
-                    dataLog("        Clobbering ", reg, "\n");
+                dataLogLnIf(AirFixObviousSpillsInternal::verbose, "        Clobbering ", reg);
                 m_state.clobber(reg);
             });
 
-        Inst::forEachDef<StackSlot*>(&inst, &inst,
+        Inst::forEachDef<StackSlot*>(prevInst, nextInst,
             [&] (StackSlot* slot, Arg::Role, Bank, Width) {
-                if (AirFixObviousSpillsInternal::verbose)
-                    dataLog("        Clobbering ", *slot, "\n");
+                dataLogLnIf(AirFixObviousSpillsInternal::verbose, "        Clobbering ", *slot);
                 m_state.clobber(slot);
             });
+    }
 
+    void clobberEarlyDefs()
+    {
+        clobberDefs(nullptr, &m_block->at(m_instIndex));
+    }
+
+    void clobberLateDefs()
+    {
+        clobberDefs(&m_block->at(m_instIndex), nullptr);
+    }
+
+    void addInstAliases()
+    {
         forAllAliases(
             [&] (const auto& alias) {
                 m_state.addAlias(alias);
@@ -211,9 +219,7 @@ private:
     void fixInst()
     {
         Inst& inst = m_block->at(m_instIndex);
-
-        if (AirFixObviousSpillsInternal::verbose)
-            dataLog("Fixing inst ", inst, ": ", m_state, "\n");
+        dataLogLnIf(AirFixObviousSpillsInternal::verbose, "Fixing inst ", inst, ": ", m_state);
         
         // Check if alias analysis says that this is unnecessary.
         bool shouldLive = true;
@@ -289,14 +295,12 @@ private:
                 case Width64:
                     if (alias->mode != RegSlot::AllBits)
                         return;
-                    if (AirFixObviousSpillsInternal::verbose)
-                        dataLog("    Replacing ", arg, " with ", alias->reg, "\n");
+                    dataLogLnIf(AirFixObviousSpillsInternal::verbose, "    Replacing ", arg, " with ", alias->reg);
                     arg = Tmp(alias->reg);
                     didThings = true;
                     return;
                 case Width32:
-                    if (AirFixObviousSpillsInternal::verbose)
-                        dataLog("    Replacing ", arg, " with ", alias->reg, " (subwidth case)\n");
+                    dataLogLnIf(AirFixObviousSpillsInternal::verbose, "    Replacing ", arg, " with ", alias->reg, " (subwidth case)");
                     arg = Tmp(alias->reg);
                     didThings = true;
                     return;
@@ -307,8 +311,7 @@ private:
 
             // Revert to immediate if that didn't work.
             if (const SlotConst* alias = m_state.getSlotConst(arg.stackSlot())) {
-                if (AirFixObviousSpillsInternal::verbose)
-                    dataLog("    Replacing ", arg, " with constant ", alias->constant, "\n");
+                dataLogLnIf(AirFixObviousSpillsInternal::verbose, "    Replacing ", arg, " with constant ", alias->constant);
                 if (Arg::isValidImmForm(alias->constant))
                     arg = Arg::imm(alias->constant);
                 else


### PR DESCRIPTION
#### fa0214fe9a50ec15bd24aa5c8200c9f2e298639a
<pre>
[JSC] Fix AirFixObviousSpills modeling of early defs
<a href="https://bugs.webkit.org/show_bug.cgi?id=310303">https://bugs.webkit.org/show_bug.cgi?id=310303</a>
<a href="https://rdar.apple.com/171874387">rdar://171874387</a>

Reviewed by Yusuke Suzuki and Keith Miller.

fixObviousSpills treats early defs the same as late defs, which is
fine for the analysis phase since aliasing is effectively computed
at the boundary after the instruction. However, during the rewrite
phase, it should not use an alias that has been invalidated by
any early defs (e.g. scratch registers). Otherwise, the early def
may clobber the aliased thing before it&apos;s used.

Fix this by breaking apart the steps so that rewriting can be
done in the correct sequence.

Test: JSTests/stress/fixobviousspills-earlydefs.js

* JSTests/stress/fixobviousspills-earlydefs.js: Added.
* Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp:

Originally-landed-as: 305413.539@rapid/safari-7624.2.5.110-branch (383834666ab9). <a href="https://rdar.apple.com/176062230">rdar://176062230</a>
Canonical link: <a href="https://commits.webkit.org/313964@main">https://commits.webkit.org/313964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c95dd1f175906bad87c96f9188d9408dc2e27fb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121920 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127963 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108508 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29310 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27935 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21461 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156819 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176226 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25560 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29050 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27388 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136281 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136243 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36700 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147514 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101081 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31515 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24370 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197071 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37419 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110463 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51772 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36817 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2433 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37065 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->