### PR TITLE
[Build perf] Add CMake support to measure-build-time

### DIFF
--- a/Tools/Scripts/caffeinate-ninja
+++ b/Tools/Scripts/caffeinate-ninja
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /usr/bin/caffeinate -i ninja "$@"
+exec /usr/bin/caffeinate -i xcrun ninja "$@"

--- a/Tools/Scripts/measure-build-time
+++ b/Tools/Scripts/measure-build-time
@@ -33,7 +33,7 @@ class Task:
 
     result: TestResult | None
 
-    def __init__(self, args):
+    def __init__(self, args: Arguments):
         self.build_command = args.build_command
         self.stdout_filter = args.stdout_filter
         self.source_dir = args.source_dir
@@ -56,6 +56,11 @@ class CleanBuild(Task):
     name = 'clean'
     description = 'Delete the build directory and run a full build from scratch.'
 
+    def __init__(self, args: Arguments):
+        super().__init__(args)
+        if args.configure_command:
+            self.build_command = f'{args.configure_command} && {self.build_command}'
+
     def __enter__(self):
         if self.build_dir.exists():
             if sys.stdin.isatty():
@@ -71,7 +76,7 @@ class PatchIncrementalBuild(Task):
 
     patch: str
 
-    def __init__(self, args):
+    def __init__(self, args: Arguments):
         super().__init__(args)
         self.unapply_patch = args.unapply_patch
 
@@ -365,15 +370,34 @@ def run_test(name: str, command: str, stdout_filter: str | None = None) -> TestR
 
 # --- Test runner ------------------------------------------------------------
 
-DEFAULT_MAKE_COMMAND = ('make -C {workspace_dir} {configuration} '
-                        'ARGS=-showBuildTimingSummary')
+DEFAULT_MAKE_COMMAND = (
+    'make -C {workspace_dir} {configuration} ARGS=-showBuildTimingSummary'
+)
+DEFAULT_CMAKE_BUILD_COMMAND = (
+    'xcrun ninja -C {build_dir}'
+)
+DEFAULT_CMAKE_CONFIGURE_COMMAND = (
+    'xcrun cmake -S {source_dir} -B {build_dir} --preset {preset}'
+)
 
-def main() -> None:
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s %(levelname)s %(message)s',
-    )
+class Arguments(argparse.Namespace):
+    build_command: str
+    configure_command: str | None
+    make: bool
+    cmake: bool
+    configuration: str
 
+    build_dir: Path
+    source_dir: Path
+
+    tests: list[str]
+    unapply_patch: bool
+    keep_going: bool
+
+    stdout_filter: str | None
+    output: str
+
+def get_args() -> Arguments:
     test_list = '\n'.join(f'  {T.name:<24}{T.description}' for T in AVAILABLE_TESTS)
     parser = argparse.ArgumentParser(
         description='Measure build time and emit perf metrics JSON.',
@@ -381,11 +405,15 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
-    cmd_parser = parser.add_mutually_exclusive_group(required=True)
-    cmd_parser.add_argument('--build-command',
-                            help='Shell command to run the build')
-    cmd_parser.add_argument('--make', action='store_true',
-                            help='Use a default Make invocation to build WebKit.')
+    parser.add_argument('--build-command',
+                        help='Shell command to run the build')
+    parser.add_argument('--configure-command',
+                        help='Shell command to configure the build')
+    parser.add_argument('--make', action='store_true',
+                        help='Use a default Make invocation to build WebKit with Xcode.')
+    parser.add_argument('--cmake', action='store_true',
+                        help='Use a default CMake invocation to build WebKit with Ninja.')
+
     parser.add_argument('--build-dir', type=Path,
                         help='Path to top-level build directory (deleted by `clean` test)')
     parser.add_argument('--source-dir', type=Path,
@@ -397,7 +425,7 @@ def main() -> None:
                         help='Which tests to run (default: all). Will skip test dependencies which are not listed.')
     parser.add_argument('--unapply-patch', action=argparse.BooleanOptionalAction, default=False,
                         help='Whether to undo changes made to the source directory between tests')
-    parser.add_argument('--keep-going', action=argparse.BooleanOptionalAction, default=False,
+    parser.add_argument('--keep-going', action=argparse.BooleanOptionalAction, default=True,
                         help='Continue benchmarking after a build command has failed')
     parser.add_argument('--metric-key',
                         help='Top-level test key in the results. '
@@ -407,7 +435,7 @@ def main() -> None:
     parser.add_argument('--output', '-o', default='build-time-results.json',
                         help='Output JSON file path (default: build-time-results.json)')
 
-    args = parser.parse_args()
+    args = parser.parse_args(namespace=Arguments())
 
     if not args.build_dir:
         args.build_dir = Path(subprocess.check_output(
@@ -416,15 +444,51 @@ def main() -> None:
         ).rstrip())
     if not args.source_dir:
         args.source_dir = SCRIPTS.parent.parent
+
+    if sum((
+        1 if args.make else 0,
+        1 if args.cmake else 0,
+        1 if args.build_command or args.configure_command else 0,
+    )) > 1:
+        parser.error('cannot mix --cmake or --make with a custom build or '
+                     'configure command')
+    if not any((args.make, args.cmake, args.build_command)):
+        parser.error('one of --make, --cmake, or --build-command is required')
+    if args.configure_command and not args.build_command:
+        parser.error('--build-command must be provided when using a custom '
+                     '--configure-command')
+
     if args.make:
         internal_dir = args.source_dir / '../Internal/WebKit'
         args.build_command = DEFAULT_MAKE_COMMAND.format(
             configuration=args.configuration.lower(),
             workspace_dir=str(internal_dir if internal_dir.exists() else args.source_dir)
         )
+    elif args.cmake:
+        args.build_command = DEFAULT_CMAKE_BUILD_COMMAND.format(
+            build_dir=str(args.build_dir),
+        )
+        cmake_preset = {
+            'debug': 'mac-dev-debug',
+            'release': 'mac-dev-release',
+        }.get(args.configuration.lower(), args.configuration)
+        args.configure_command = DEFAULT_CMAKE_CONFIGURE_COMMAND.format(
+            build_dir=str(args.build_dir),
+            source_dir=str(args.source_dir),
+            preset=cmake_preset,
+        )
     if not args.metric_key:
         # e.g. "BuildTime-Debug"
         args.metric_key = f'BuildTime-{args.configuration.capitalize()}'
+    return args
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s %(message)s',
+    )
+
+    args = get_args()
 
     # Read each test's `depends` lists to compute a topological order to run
     # all the tests. Does NOT perform cycle detection.


### PR DESCRIPTION
#### ccbee78d622ce7b0a4b14db2a811e89feb340424
<pre>
[Build perf] Add CMake support to measure-build-time
<a href="https://bugs.webkit.org/show_bug.cgi?id=315640">https://bugs.webkit.org/show_bug.cgi?id=315640</a>
<a href="https://rdar.apple.com/178018333">rdar://178018333</a>

Reviewed by Geoffrey Garen and Richard Robinson.

The tool accepts a --cmake flag that performas a CMake+Ninja build.
Alternatively, custom commmands can be provided via --build-command and
(newly added) --configure-command arguments.

The configure step is run during the `clean` test, and its wall time is
attributed to the overall build time.

* Tools/Scripts/caffeinate-ninja: Search the active Xcode toolchain for
  ninja (which falls back to a normal search of the $PATH).
* Tools/Scripts/measure-build-time:
(Task):
(CleanBuild):
(CleanBuild.__init__):
(PatchIncrementalBuild):
(run_test):
(Arguments): Added to provide type hints for parsed arguments.
(get_args): Added.
(main): Split out argument parsing to get_args.

Canonical link: <a href="https://commits.webkit.org/314010@main">https://commits.webkit.org/314010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d13be2d028a377de1e75bb2e3158d72433ad59e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 ios-apple 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5d7c0c6-4996-4f2f-a5ed-6cf674b83c12) 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78e2568e-6fea-414e-afb8-1184899c3672) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->