### PR TITLE
REGRESSION(313528@main): [GCC] MotionMark regression in Skia-GPU

### DIFF
--- a/Source/WTF/wtf/Variant.h
+++ b/Source/WTF/wtf/Variant.h
@@ -1320,10 +1320,17 @@ namespace mpark {
         template <typename Visitor, typename... Vs>
         inline static constexpr base::dispatch_result_t<Visitor, Vs...>
         visit_alt_at(std::size_t index, Visitor &&visitor, Vs &&... vs) {
+#if defined(__GNUC__) && !defined(__clang__)
+          constexpr std::size_t N = lib::decay_t<
+              lib::type_pack_element_t<0, Vs...>>::size();
+          return switch_at<0, N>(index, lib::forward<Visitor>(visitor),
+                                 lib::forward<Vs>(vs)...);
+#else
           return fold_at(std::make_index_sequence<lib::decay_t<
                              lib::type_pack_element_t<0, Vs...>>::size()>{},
                          index, lib::forward<Visitor>(visitor),
                          lib::forward<Vs>(vs)...);
+#endif
         }
 
       private:
@@ -1333,6 +1340,48 @@ namespace mpark {
           return lib::invoke(lib::forward<Visitor>(visitor),
                              access::base::get_alt<I>(as_base(lib::forward<Vs>(vs)))...);
         }
+
+#if defined(__GNUC__) && !defined(__clang__)
+        // GCC does not reliably lower the comma-fold in fold_at() to a jump
+        // table and instead emits an O(N) cmp/branch cascade, which badly hurts
+        // visits over large variants such as DisplayList::Item (60+
+        // alternatives). This is target-dependent: GCC 14 recovers a jump table
+        // on x86_64 but not on aarch64, where even 14.2 emits the cascade, so
+        // gate on the compiler rather than a version. An explicit switch is
+        // lowered to a jump table everywhere. Clang recovers a jump table from
+        // fold_at() on its own, so it keeps the fold (and its compile-time
+        // benefit).
+        template <std::size_t Base, std::size_t N,
+                  typename Visitor, typename... Vs>
+        inline static constexpr base::dispatch_result_t<Visitor, Vs...>
+        switch_at(std::size_t index, Visitor &&visitor, Vs &&... vs) {
+#define MPARK_CASE(I)                                                          \
+          case Base + I:                                                       \
+            if constexpr (Base + I < N)                                        \
+              return step_at<(Base + I < N ? Base + I : 0)>(                   \
+                  lib::forward<Visitor>(visitor), lib::forward<Vs>(vs)...);    \
+            else                                                               \
+              MPARK_BUILTIN_UNREACHABLE;
+          switch (index) {
+            MPARK_CASE(0)  MPARK_CASE(1)  MPARK_CASE(2)  MPARK_CASE(3)
+            MPARK_CASE(4)  MPARK_CASE(5)  MPARK_CASE(6)  MPARK_CASE(7)
+            MPARK_CASE(8)  MPARK_CASE(9)  MPARK_CASE(10) MPARK_CASE(11)
+            MPARK_CASE(12) MPARK_CASE(13) MPARK_CASE(14) MPARK_CASE(15)
+            MPARK_CASE(16) MPARK_CASE(17) MPARK_CASE(18) MPARK_CASE(19)
+            MPARK_CASE(20) MPARK_CASE(21) MPARK_CASE(22) MPARK_CASE(23)
+            MPARK_CASE(24) MPARK_CASE(25) MPARK_CASE(26) MPARK_CASE(27)
+            MPARK_CASE(28) MPARK_CASE(29) MPARK_CASE(30) MPARK_CASE(31)
+            default:
+              if constexpr (Base + 32 < N)
+                return switch_at<Base + 32, N>(
+                    index, lib::forward<Visitor>(visitor),
+                    lib::forward<Vs>(vs)...);
+              else
+                MPARK_BUILTIN_UNREACHABLE;
+          }
+#undef MPARK_CASE
+        }
+#endif
 
         template <std::size_t... Is, typename Visitor, typename... Vs>
         inline static constexpr base::dispatch_result_t<Visitor, Vs...>


### PR DESCRIPTION
#### 2217b2a8f16c571430432c58a99b894849a58230
<pre>
REGRESSION(313528@main): [GCC] MotionMark regression in Skia-GPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=315641">https://bugs.webkit.org/show_bug.cgi?id=315641</a>

Reviewed by Geoffrey Garen.

313528@main simplified WTF::Variant and replaced the switch-based dispatcher in
the single-variant visit path with a C++17 fold expression of the form
((index == Is ? step_at&lt;Is&gt;(...) : void()), ...). GCC does not turn this fold
into a jump table and emits a linear cmp/branch cascade instead.
DisplayList::Item is a Variant with more than 60 alternatives, and it is visited
once per item while a display list is replayed, so each dispatch went from a
single indirect branch to as many as 60 comparisons. This regressed the
MotionMark Design and Multiply subtests on the WPE Skia GPU bot (Raspberry Pi 4,
GCC 13.3).

Upgrading the compiler does not fix it: GCC still emits the cascade on aarch64
through at least GCC 16. Clang lowers the same fold to a jump table, so the
regression only appeared on the GCC-built ports.

Restore an explicit switch in visit_alt_at for GCC, and leave the fold in place
for Clang, which already compiles it to a jump table and keeps the compile-time
improvement from 313528@main. The gate is on the compiler rather than a version,
since no GCC we tested recovers the fold reliably. The switch instantiates the
same step_at&lt;I&gt; bodies as the fold, so it is compile-time neutral on GCC; it is
also the dispatch shape that was in place before 313528@main.

* Source/WTF/wtf/Variant.h:
(mpark::detail::visitation::alt::visit_alt_at):
(mpark::detail::visitation::alt::switch_at):

Canonical link: <a href="https://commits.webkit.org/313961@main">https://commits.webkit.org/313961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d861469d00d7c8e34fc63993be271ef62bc43614

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164697 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121949 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127988 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108533 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27960 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21490 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156848 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176255 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25589 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29079 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136306 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136268 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147541 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101128 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25064 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31541 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24397 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197100 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110492 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51781 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36846 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2462 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37094 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36994 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->