### PR TITLE
Reduce async operations in model as they are not really async

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
@@ -26,7 +26,7 @@
 import Metal
 import USDKit
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit
-@_spi(RealityCoreRendererAPI) import RealityKit
+import RealityKit
 
 class IBLTextures {
     static func loadIBLTextures(

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -29,23 +29,25 @@ import USDKit
 @_spi(Private) import RealityKit
 import simd
 
-class Renderer {
-    let device: any MTLDevice
+final class Renderer {
+    private let device: any MTLDevice
     let commandQueue: any MTLCommandQueue
     var renderContext: (any LowLevelRenderContext)?
     var renderer: LowLevelRenderer?
+    var pendingStandaloneResources: LowLevelRenderContextStandalone.Resources?
+    var pendingRendererResources: LowLevelRenderer.Resources?
     var renderTargetDescriptor: LowLevelRenderTarget.Descriptor {
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         renderer!.renderTargetDescriptor
     }
 
-    var cameraPosition: SIMD3<Float>
-    var cameraRotation: simd_quatf
-    static let cameraDistance: Float = 0.5
-    var effectiveCameraDistance: Float = Renderer.cameraDistance
-    var fovY: Float = 60 * .pi / 180
-    var clearColor: MTLClearColor = .init(red: 1, green: 1, blue: 1, alpha: 1)
+    private var cameraPosition: SIMD3<Float>
+    private var cameraRotation: simd_quatf
+    private static let cameraDistance: Float = 0.5
+    private var effectiveCameraDistance: Float = Renderer.cameraDistance
+    private var fovY: Float = 60 * .pi / 180
+    private var clearColor: MTLClearColor = .init(red: 1, green: 1, blue: 1, alpha: 1)
     let memoryOwner: task_id_token_t
 
     init(device: any MTLDevice, memoryOwner: task_id_token_t) throws {
@@ -61,28 +63,21 @@ class Renderer {
         self.memoryOwner = memoryOwner
     }
 
-    func createMaterialCompiler(colorPixelFormat: MTLPixelFormat, rasterSampleCount: Int, colorSpace: CGColorSpace? = nil) async throws {
+    func createMaterialCompiler(resources: LowLevelRenderContextStandalone.Resources) throws {
         var configuration = LowLevelRenderContextStandalone.Configuration(device: device)
         configuration.memoryOwner = self.memoryOwner
         configuration.residencySetBehavior = LowLevelRenderContextStandalone.Configuration.ResidencySetBehavior.disable
-        let renderContext = try await LowLevelRenderContextStandalone(configuration: configuration)
-
-        let renderer = try await LowLevelRenderer(
-            configuration: .init(
-                output: .init(colorPixelFormat: colorPixelFormat),
-                rasterSampleCount: rasterSampleCount,
-                enableTonemap: false,
-                enableColorMatch: colorSpace != nil,
-                alphaPremultiply: false
-            ),
-            renderContext: renderContext
-        )
-        renderer.meshInstancesArrayCount = 1
+        let renderContext = try LowLevelRenderContextStandalone(configuration: configuration, resources: resources)
         self.renderContext = renderContext
-        self.renderer = renderer
     }
 
-    func newCommandBuffer() -> any MTLCommandBuffer {
+    func createRenderer(resources: LowLevelRenderer.Resources) throws {
+        let renderer = try LowLevelRenderer(resources: resources)
+        self.renderer = renderer
+        renderer.meshInstancesArrayCount = 1
+    }
+
+    private func newCommandBuffer() -> any MTLCommandBuffer {
         guard let renderCommandBuffer = commandQueue.makeCommandBuffer() else {
             fatalError("Failed to make command buffer")
         }

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -479,7 +479,10 @@ NS_SWIFT_SENDABLE
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithDevice:(id<MTLDevice>)device memoryOwner:(task_id_token_t)memoryOwner NS_DESIGNATED_INITIALIZER;
 
-- (void)createMaterialCompiler:(void (^)(void))completionHandler;
+- (void)makeStandaloneResourcesWithCompletionHandler:(void (^)(void))completionHandler;
+- (void)createMaterialCompiler;
+- (void)makeRendererResourcesWithCompletionHandler:(void (^)(void))completionHandler;
+- (void)createRenderer;
 
 @end
 
@@ -487,9 +490,9 @@ NS_SWIFT_SENDABLE
 
 - (nullable id<MTLCommandBuffer>)commandBuffer;
 - (void)renderWithTexture:(id<MTLTexture>)texture commandBuffer:(id<MTLCommandBuffer>)commandBuffer;
-- (void)updateMesh:(NSArray<WKBridgeUpdateMesh *> *)descriptor completionHandler:(void (^)(void))completionHandler;
+- (void)updateMesh:(NSArray<WKBridgeUpdateMesh *> *)descriptor;
 - (void)updateTexture:(NSArray<WKBridgeUpdateTexture *> *)descriptor;
-- (void)updateMaterial:(NSArray<WKBridgeUpdateMaterial *> *)descriptor completionHandler:(void (^)(void))completionHandler;
+- (void)updateMaterial:(NSArray<WKBridgeUpdateMaterial *> *)descriptor;
 - (BOOL)processRemovals:(NSArray<WKBridgeTypedResourceId *> *)meshRemovals materialRemovals:(NSArray<WKBridgeTypedResourceId *> *)materialRemovals  textureRemovals:(NSArray<WKBridgeTypedResourceId *> *)textureRemovals;
 - (void)setTransform:(simd_float4x4)transform;
 - (void)setFOV:(float)fovY;

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -28,7 +28,6 @@ import simd
 
 #if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && canImport(RealityCoreRenderer, _version: 22) && canImport(ShaderGraph, _version: 156) && arch(arm64)
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit
-@_spi(RealityCoreRendererAPI) import RealityKit
 import USDKit
 @_spi(SwiftAPI) import DirectResource
 import RealityKit
@@ -490,10 +489,48 @@ extension WKBridgeUSDConfiguration {
         }
     }
 
-    @objc(createMaterialCompiler:)
-    func createMaterialCompiler() async {
+    func makeStandaloneResources() async {
         do {
-            try await self.appRenderer.createMaterialCompiler(colorPixelFormat: .rgba16Float, rasterSampleCount: 4)
+            appRenderer.pendingStandaloneResources = try await LowLevelRenderContextStandalone.Resources(device: self.device)
+        } catch {
+            fatalError("Exception creating standalone resources \(error)")
+        }
+    }
+
+    func createMaterialCompiler() {
+        do {
+            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+            // swift-format-ignore: NeverForceUnwrap
+            try appRenderer.createMaterialCompiler(resources: appRenderer.pendingStandaloneResources!)
+            appRenderer.pendingStandaloneResources = nil
+        } catch {
+            fatalError("Exception creating material compiler \(error)")
+        }
+    }
+
+    func makeRendererResources() async {
+        do {
+            appRenderer.pendingRendererResources = try await LowLevelRenderer.Resources(
+                configuration: .init(
+                    output: .init(colorPixelFormat: .rgba16Float),
+                    rasterSampleCount: 4,
+                    enableTonemap: false,
+                    enableColorMatch: false,
+                    alphaPremultiply: false
+                ),
+                renderContext: self.renderContext
+            )
+        } catch {
+            fatalError("Exception creating renderer resources \(error)")
+        }
+    }
+
+    func createRenderer() {
+        do {
+            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+            // swift-format-ignore: NeverForceUnwrap
+            try appRenderer.createRenderer(resources: appRenderer.pendingRendererResources!)
+            appRenderer.pendingRendererResources = nil
         } catch {
             fatalError("Exception creating renderer \(error)")
         }
@@ -606,8 +643,11 @@ extension WKBridgeReceiver {
         self.imageBasedLightTextureGenerator = ImageBasedLightTextureGenerator(device: configuration.device)
         self.commandQueue = configuration.commandQueue
         self.deformationSystem = try _Proto_LowLevelDeformationSystem_v1.make(configuration.device, configuration.commandQueue).get()
-        let meshInstances = try configuration.renderContext.makeMeshInstanceArray(renderTargets: [configuration.renderTarget], count: 16)
-        self.meshInstancePool = MeshInstancePool(renderContext: configuration.renderContext, meshInstances: meshInstances)
+        self.meshInstancePool = try MeshInstancePool(
+            renderContext: configuration.renderContext,
+            renderTargets: [configuration.renderTarget],
+            initialCapacity: 16
+        )
         let lightingFunction = configuration.renderContext.lighting.makeImageBasedLightingFunction()
         guard
             let diffuseTexture = makeTextureFromImageAsset(
@@ -737,8 +777,8 @@ extension WKBridgeReceiver {
         }
     }
 
-    @objc(updateMaterial:completionHandler:)
-    func updateMaterial(_ updates: [WKBridgeUpdateMaterial]) async {
+    @objc(updateMaterial:)
+    func updateMaterial(_ updates: [WKBridgeUpdateMaterial]) {
         do {
             for data in updates {
                 logInfo("updateMaterial (pre-dispatch) \(data.identifier)")
@@ -750,7 +790,7 @@ extension WKBridgeReceiver {
                     fatalError("No materialGraph data provided for material \(identifier)")
                 }
 
-                let shaderGraphOutput = try await renderContext.shaderGraph.makeShaderGraphFunctions(
+                let shaderGraphOutput = try renderContext.shaderGraph.makeShaderGraphFunctions(
                     shaderGraph: shaderGraph,
                     constantValues: .init()
                 )
@@ -770,7 +810,7 @@ extension WKBridgeReceiver {
 
                 let geometryModifier = shaderGraphOutput.geometryModifier ?? renderContext.makeDefaultGeometryModifier()
                 let surfaceShader = shaderGraphOutput.surfaceShader
-                let materialResource = try await renderContext.makeMaterialResource(
+                let materialResource = try renderContext.makeMaterialResource(
                     descriptor: .init(
                         geometry: geometryModifier,
                         surface: surfaceShader,
@@ -825,8 +865,8 @@ extension WKBridgeReceiver {
         return true
     }
 
-    @objc(updateMesh:completionHandler:)
-    func updateMesh(_ updates: [WKBridgeUpdateMesh]) async {
+    @objc(updateMesh:)
+    func updateMesh(_ updates: [WKBridgeUpdateMesh]) {
         do {
             var deferredMeshUpdates: [DeferredMeshUpdate] = []
 
@@ -897,7 +937,7 @@ extension WKBridgeReceiver {
                                 fatalError("Failed to get material instance \(materialIdentifier)")
                             }
 
-                            let pipeline = try await renderContext.makeRenderPipelineState(
+                            let pipeline = try renderContext.makeRenderPipelineState(
                                 descriptor: .init(
                                     mesh: meshResource.descriptor,
                                     material: material.resource,
@@ -2365,8 +2405,16 @@ extension WKBridgeUSDConfiguration {
     init(device: any MTLDevice, memoryOwner: task_id_token_t) {
     }
 
-    @objc(createMaterialCompiler:)
-    func createMaterialCompiler() async {
+    func makeStandaloneResources() async {
+    }
+
+    func createMaterialCompiler() {
+    }
+
+    func makeRendererResources() async {
+    }
+
+    func createRenderer() {
     }
 }
 
@@ -2392,12 +2440,12 @@ extension WKBridgeReceiver {
     func updateTexture(_ data: [WKBridgeUpdateTexture]) {
     }
 
-    @objc(updateMaterial:completionHandler:)
-    func updateMaterial(_ data: [WKBridgeUpdateMaterial]) async {
+    @objc(updateMaterial:)
+    func updateMaterial(_ data: [WKBridgeUpdateMaterial]) {
     }
 
-    @objc(updateMesh:completionHandler:)
-    func updateMesh(_ data: [WKBridgeUpdateMesh]) async {
+    @objc(updateMesh:)
+    func updateMesh(_ data: [WKBridgeUpdateMesh]) {
     }
 
     @objc

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -876,11 +876,18 @@ WebMesh::WebMesh(const WebModelCreateMeshDescriptor& descriptor)
     WKBridgeImageAsset *diffuseAsset = WebModel::convert(descriptor.diffuseTexture);
     WKBridgeImageAsset *specularAsset = WebModel::convert(descriptor.specularTexture);
     if (configuration) {
-        BinarySemaphore completion;
-        [configuration createMaterialCompiler:[&completion] mutable {
-            completion.signal();
+        BinarySemaphore standaloneResourcesCompletion;
+        [configuration makeStandaloneResourcesWithCompletionHandler:[&standaloneResourcesCompletion] mutable {
+            standaloneResourcesCompletion.signal();
         }];
-        completion.wait();
+        standaloneResourcesCompletion.wait();
+        [configuration createMaterialCompiler];
+        BinarySemaphore rendererResourcesCompletion;
+        [configuration makeRendererResourcesWithCompletionHandler:[&rendererResourcesCompletion] mutable {
+            rendererResourcesCompletion.signal();
+        }];
+        rendererResourcesCompletion.wait();
+        [configuration createRenderer];
     }
 
     NSError *error;
@@ -945,13 +952,9 @@ void WebMesh::update(Vector<WebModel::UpdateMeshDescriptor>&& inputArray)
         return;
 
     RELEASE_ASSERT(m_receiver);
-    BinarySemaphore completion;
     [m_receiver updateMesh:createNSArray(inputArray, [](const WebModel::UpdateMeshDescriptor& desc) {
         return convert(desc);
-    }) completionHandler:[&] mutable {
-        completion.signal();
-    }];
-    completion.wait();
+    })];
     m_meshDataExists = true;
 #else
     UNUSED_PARAM(inputArray);
@@ -990,13 +993,9 @@ void WebMesh::updateMaterial(Vector<WebModel::UpdateMaterialDescriptor>&& inputA
 {
 #if ENABLE(GPU_PROCESS_MODEL)
     RELEASE_ASSERT(m_receiver);
-    BinarySemaphore completion;
     [m_receiver updateMaterial:createNSArray(inputArray, [](const WebModel::UpdateMaterialDescriptor& desc) {
         return convert(desc);
-    }) completionHandler:[&] mutable {
-        completion.signal();
-    }];
-    completion.wait();
+    })];
 #else
     UNUSED_PARAM(inputArray);
 #endif


### PR DESCRIPTION
#### 4abb5c4584bfe1807fce4af698b71e447493b8a7
<pre>
Reduce async operations in model as they are not really async
<a href="https://bugs.webkit.org/show_bug.cgi?id=315638">https://bugs.webkit.org/show_bug.cgi?id=315638</a>
<a href="https://rdar.apple.com/178013176">rdar://178013176</a>

Reviewed by Etienne Segonzac.

There were many places we were would say:

  semaphore s;
  async_task(f(), [] { s.signal() });
  s.wait();

that is not asynchronous. Remove this via calling synchronous versions
of functions.

* Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
(Renderer.pendingStandaloneResources):
(Renderer.pendingRendererResources):
(Renderer.createMaterialCompiler(_:)):
(Renderer.createRenderer(_:)):
(Renderer.createMaterialCompiler(_:rasterSampleCount:colorSpace:)): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(WKBridgeUSDConfiguration.makeStandaloneResources):
(WKBridgeUSDConfiguration.createMaterialCompiler):
(WKBridgeUSDConfiguration.makeRendererResources):
(WKBridgeUSDConfiguration.createRenderer):
(updateMaterial(_:)):
(updateMesh(_:)):
(WKBridgeReceiver.updateMaterial(_:)):
(WKBridgeReceiver.updateMesh(_:)):
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebKit::WebMesh::WebMesh):
(WebKit::WebMesh::update):
(WebKit::WebMesh::updateMaterial):

Canonical link: <a href="https://commits.webkit.org/314061@main">https://commits.webkit.org/314061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/833f9583d842ae8a88a6e07b2cd95afbdabf0c5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122007 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0ca89d7-0e98-4aff-8221-66a4fd66e3d4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38241 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128040 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90151 "2 flakes 1 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/834c55c8-ab22-41b0-83aa-cf20c5314e5a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108586 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00658049-4786-4e49-bc77-575e4a2b83d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29386 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28012 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21549 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139290 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176313 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25647 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29139 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27461 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136357 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136320 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36786 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147587 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101208 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24443 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37506 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110551 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36904 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2509 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37152 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37052 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->