### PR TITLE
Potential use after free of m_stream in ReadableStreamDefaultReader::visitAdditionalChildren()

### DIFF
--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -782,7 +782,7 @@ Ref<DOMPromise> ReadableStream::Iterator::next(JSDOMGlobalObject& globalObject)
     return promise;
 }
 
-bool ReadableStream::Iterator::isFinished() const
+SUPPRESS_NODELETE bool ReadableStream::Iterator::isFinished() const
 {
     return !m_reader->stream();
 }

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
@@ -77,7 +77,11 @@ ReadableStreamDefaultReader::ReadableStreamDefaultReader(Ref<ReadableStream>&& s
 
 ReadableStreamDefaultReader::~ReadableStreamDefaultReader()
 {
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
     if (stream && stream->defaultReader() == this)
         stream->setDefaultReader(nullptr);
 }
@@ -130,7 +134,11 @@ void ReadableStreamDefaultReader::read(JSDOMGlobalObject& globalObject, Ref<Read
         return;
     }
 
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
     if (!stream) {
         readRequest->runErrorSteps(Exception { ExceptionCode::TypeError, "stream is undefined"_s });
         return;
@@ -156,17 +164,19 @@ void ReadableStreamDefaultReader::read(JSDOMGlobalObject& globalObject, Ref<Read
 // https://streams.spec.whatwg.org/#default-reader-release-lock
 ExceptionOr<void> ReadableStreamDefaultReader::releaseLock(JSDOMGlobalObject& globalObject)
 {
-    if (!m_stream)
-        return { };
+    {
+        Locker locker { m_streamLock };
+        if (!m_stream)
+            return { };
 
-    if (RefPtr internalReader = this->internalDefaultReader()) {
-        auto result = internalReader->releaseLock();
-        if (!result.hasException()) {
-            RefPtr stream = std::exchange(m_stream, { });
-            stream->setDefaultReader(nullptr);
-            stream = nullptr;
+        if (RefPtr internalReader = this->internalDefaultReader()) {
+            auto result = internalReader->releaseLock();
+            if (!result.hasException()) {
+                RefPtr stream = std::exchange(m_stream, nullptr);
+                stream->setDefaultReader(nullptr);
+            }
+            return result;
         }
-        return result;
     }
 
     genericRelease(globalObject);
@@ -177,7 +187,11 @@ ExceptionOr<void> ReadableStreamDefaultReader::releaseLock(JSDOMGlobalObject& gl
 // https://streams.spec.whatwg.org/#set-up-readable-stream-default-reader
 ExceptionOr<void> ReadableStreamDefaultReader::setup(JSDOMGlobalObject& globalObject)
 {
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
 
     if (!stream)
         return Exception { ExceptionCode::TypeError, "stream is undefined"_s };
@@ -204,7 +218,11 @@ ExceptionOr<void> ReadableStreamDefaultReader::setup(JSDOMGlobalObject& globalOb
 // https://streams.spec.whatwg.org/#readable-stream-reader-generic-release
 void ReadableStreamDefaultReader::genericRelease(JSDOMGlobalObject& globalObject)
 {
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
 
     ASSERT(stream);
     ASSERT(stream->defaultReader() == this);
@@ -224,6 +242,8 @@ void ReadableStreamDefaultReader::genericRelease(JSDOMGlobalObject& globalObject
         controller->runReleaseSteps();
 
     stream->setDefaultReader(nullptr);
+
+    Locker locker { m_streamLock };
     m_stream = nullptr;
 }
 
@@ -238,7 +258,12 @@ void ReadableStreamDefaultReader::errorReadRequests(const Exception& exception)
 // https://streams.spec.whatwg.org/#generic-reader-cancel
 Ref<DOMPromise> ReadableStreamDefaultReader::cancel(JSDOMGlobalObject& globalObject, JSC::JSValue value)
 {
-    if (!m_stream) {
+    bool hasStream;
+    {
+        Locker locker { m_streamLock };
+        hasStream = m_stream;
+    }
+    if (!hasStream) {
         auto [promise, deferred] = createPromiseAndWrapper(globalObject);
         deferred->reject(Exception { ExceptionCode::TypeError, "no stream"_s });
         return promise;
@@ -250,7 +275,11 @@ Ref<DOMPromise> ReadableStreamDefaultReader::cancel(JSDOMGlobalObject& globalObj
 // https://streams.spec.whatwg.org/#readable-stream-reader-generic-cancel
 Ref<DOMPromise> ReadableStreamDefaultReader::genericCancel(JSDOMGlobalObject& globalObject, JSC::JSValue value)
 {
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
 
     ASSERT(stream);
     ASSERT(stream->defaultReader() == this);
@@ -352,8 +381,15 @@ void ReadableStreamDefaultReader::onClosedPromiseResolution(Function<void()>&& c
     });
 }
 
-bool ReadableStreamDefaultReader::isReachableFromOpaqueRoots() const
+ReadableStream* ReadableStreamDefaultReader::stream()
 {
+    Locker locker { m_streamLock };
+    return m_stream.get();
+}
+
+SUPPRESS_NODELETE bool ReadableStreamDefaultReader::isReachableFromOpaqueRoots() const
+{
+    Locker locker { m_streamLock };
     return getNumReadRequests() && m_stream && m_stream->isReachableFromOpaqueRoots();
 }
 
@@ -399,6 +435,7 @@ bool JSReadableStreamDefaultReaderOwner::isReachableFromOpaqueRoots(JSC::Handle<
 template<typename Visitor>
 void ReadableStreamDefaultReader::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
+    Locker locker { m_streamLock };
     if (m_stream)
         SUPPRESS_UNCOUNTED_ARG m_stream->visitAdditionalChildrenInGCThread(visitor);
 }

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
@@ -30,6 +30,7 @@
 #include "ScriptWrappable.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/Strong.h>
+#include <wtf/Lock.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -75,7 +76,7 @@ public:
     bool NODELETE isReachableFromOpaqueRoots() const;
     template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
 
-    ReadableStream* stream() { return m_stream.get(); }
+    ReadableStream* stream();
 
 private:
     ReadableStreamDefaultReader(Ref<ReadableStream>&&, RefPtr<InternalReadableStreamDefaultReader>&&, Ref<DOMPromise>&&, Ref<DeferredPromise>&&);
@@ -86,7 +87,8 @@ private:
 
     Ref<DOMPromise> m_closedPromise;
     Ref<DeferredPromise> m_closedDeferred;
-    RefPtr<ReadableStream> m_stream;
+    mutable Lock m_streamLock;
+    RefPtr<ReadableStream> m_stream WTF_GUARDED_BY_LOCK(m_streamLock);
     Deque<Ref<ReadableStreamReadRequest>> m_readRequests;
 
     const RefPtr<InternalReadableStreamDefaultReader> m_internalDefaultReader;


### PR DESCRIPTION
#### ad57b514bb0d020862e28ac3a5f5fb876b635c4d
<pre>
Potential use after free of m_stream in ReadableStreamDefaultReader::visitAdditionalChildren()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309882">https://bugs.webkit.org/show_bug.cgi?id=309882</a>
<a href="https://rdar.apple.com/172458992">rdar://172458992</a>

Reviewed by Ryosuke Niwa.

ReadableStreamDefaultReader::visitAdditionalChildren() runs on the GC
thread but dereferences m_stream which can get nulled out of the main
thread.

Address the issue via locking since we cannot easily ref the stream on
the GC thread.

* Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp:
(WebCore::ReadableStreamDefaultReader::~ReadableStreamDefaultReader):
(WebCore::ReadableStreamDefaultReader::read):
(WebCore::ReadableStreamDefaultReader::releaseLock):
(WebCore::ReadableStreamDefaultReader::setup):
(WebCore::ReadableStreamDefaultReader::genericRelease):
(WebCore::ReadableStreamDefaultReader::cancel):
(WebCore::ReadableStreamDefaultReader::genericCancel):
(WebCore::ReadableStreamDefaultReader::stream):
(WebCore::ReadableStreamDefaultReader::isReachableFromOpaqueRoots const):
(WebCore::ReadableStreamDefaultReader::visitAdditionalChildren):
* Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h:
(WebCore::ReadableStreamDefaultReader::stream): Deleted.

Originally-landed-as: 305413.472@rapid/safari-7624.2.5.110-branch (1a64bedb202e). <a href="https://rdar.apple.com/176061976">rdar://176061976</a>
Canonical link: <a href="https://commits.webkit.org/314030@main">https://commits.webkit.org/314030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54bccdd4bbfb4ae57abe4881cf087912854f5052

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173984 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122199 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128170 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108696 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29523 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28142 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21740 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176507 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136494 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136440 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36761 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147709 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101461 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31712 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24575 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37701 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110772 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37098 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2649 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37344 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->