### PR TITLE
[JSC] Let's always return CoW array from ownPropertyKeys in common case

### DIFF
--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -1301,48 +1301,36 @@ JSArray* ownPropertyKeys(JSGlobalObject* globalObject, JSObject* object, Propert
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     size_t numProperties = properties.size();
-    if (numProperties < MIN_SPARSE_ARRAY_INDEX)  [[likely]] {
-        if (!globalObject->isHavingABadTime()) {
-            auto copyPropertiesToBuffer = [&](WriteBarrier<Unknown>* buffer, JSCell* owner) {
-                for (size_t i = 0; i < numProperties; i++) {
-                    const auto& identifier = properties[i];
-                    if (propertyNameMode != PropertyNameMode::Strings && identifier.isSymbol()) {
-                        ASSERT(!identifier.isPrivateName());
-                        buffer[i].set(vm, owner, Symbol::create(vm, static_cast<SymbolImpl&>(*identifier.impl())));
-                    } else
-                        buffer[i].set(vm, owner, jsOwnedString(vm, identifier.string()));
-                }
-            };
-
-            Structure* structure = object->structure();
-            if (structure->canCacheOwnPropertyNames()) {
-                auto* cachedButterfly = structure->cachedPropertyNamesIgnoringSentinel(kind);
-                if (cachedButterfly == StructureRareData::cachedPropertyNamesSentinel()) {
-                    auto* newButterfly = JSCellButterfly::tryCreate(vm, CopyOnWriteArrayWithContiguous, numProperties);
-                    if (!newButterfly) [[unlikely]] {
-                        throwOutOfMemoryError(globalObject, scope);
-                        return { };
-                    }
-                        copyPropertiesToBuffer(newButterfly->toButterfly()->contiguous().data(), newButterfly);
-
-                    structure->setCachedPropertyNames(vm, kind, newButterfly);
-                    Structure* arrayStructure = globalObject->originalArrayStructureForIndexingType(newButterfly->indexingMode());
-                    return JSArray::createWithButterfly(vm, nullptr, arrayStructure, newButterfly->toButterfly());
-                }
-
-                if (cachedButterfly == nullptr)
-                    structure->setCachedPropertyNames(vm, kind, StructureRareData::cachedPropertyNamesSentinel());
+    if (numProperties < MIN_SPARSE_ARRAY_INDEX && !globalObject->isHavingABadTime())  [[likely]] {
+        auto copyPropertiesToBuffer = [&](WriteBarrier<Unknown>* buffer, JSCell* owner) {
+            for (size_t i = 0; i < numProperties; i++) {
+                const auto& identifier = properties[i];
+                if (propertyNameMode != PropertyNameMode::Strings && identifier.isSymbol()) {
+                    ASSERT(!identifier.isPrivateName());
+                    buffer[i].set(vm, owner, Symbol::create(vm, static_cast<SymbolImpl&>(*identifier.impl())));
+                } else
+                    buffer[i].set(vm, owner, jsOwnedString(vm, identifier.string()));
             }
+        };
 
-            JSArray* keys = JSArray::tryCreate(vm, globalObject->originalArrayStructureForIndexingType(ArrayWithContiguous), numProperties);
-            if (!keys) [[unlikely]] {
-                throwOutOfMemoryError(globalObject, scope);
-                return { };
-            }
-            copyPropertiesToBuffer(keys->butterfly()->contiguous().data(), keys);
-
-            return keys;
+        auto* newButterfly = JSCellButterfly::tryCreate(vm, CopyOnWriteArrayWithContiguous, numProperties);
+        if (!newButterfly) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return { };
         }
+        copyPropertiesToBuffer(newButterfly->toButterfly()->contiguous().data(), newButterfly);
+        Structure* arrayStructure = globalObject->originalArrayStructureForIndexingType(newButterfly->indexingMode());
+        auto* result = JSArray::createWithButterfly(vm, nullptr, arrayStructure, newButterfly->toButterfly());
+
+        Structure* structure = object->structure();
+        if (structure->canCacheOwnPropertyNames()) {
+            auto* cachedButterfly = structure->cachedPropertyNamesIgnoringSentinel(kind);
+            if (cachedButterfly == StructureRareData::cachedPropertyNamesSentinel())
+                structure->setCachedPropertyNames(vm, kind, newButterfly);
+            if (cachedButterfly == nullptr)
+                structure->setCachedPropertyNames(vm, kind, StructureRareData::cachedPropertyNamesSentinel());
+        }
+        return result;
     }
 
     JSArray* keys = constructEmptyArray(globalObject, nullptr);


### PR DESCRIPTION
#### a5760beba07ce4c1e6a21cc3de9affbfbceb0e1b
<pre>
[JSC] Let&apos;s always return CoW array from ownPropertyKeys in common case
<a href="https://bugs.webkit.org/show_bug.cgi?id=315644">https://bugs.webkit.org/show_bug.cgi?id=315644</a>
<a href="https://rdar.apple.com/178025453">rdar://178025453</a>

Reviewed by Yijia Huang.

Making array return types random (sometimes CoW and sometimes non-CoW)
easily causes mis-speculation in DFG, leading to frequent OSR exit.
Let&apos;s just return CoW from ownPropertyKeys in common case consistently.

* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::ownPropertyKeys):

Canonical link: <a href="https://commits.webkit.org/313980@main">https://commits.webkit.org/313980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0e31105d209fd66e789ef5f1dbe79343f04f0ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173720 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121937 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e37731dd-2e97-454b-92e1-d270a6b0388e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127976 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90081 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf288f6e-c1c4-4b28-a54b-a2989f0d957a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148017 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108521 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/301587ba-7a46-48f1-bda5-438372d3784d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29323 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27948 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21478 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156836 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176243 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25577 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29067 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136294 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136256 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147528 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101105 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25073 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24384 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197088 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37436 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110480 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51777 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36834 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2448 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37082 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36982 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->