### PR TITLE
Correct matching of :heading with qualified names

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/heading-prefixed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/heading-prefixed-expected.txt
@@ -1,0 +1,8 @@
+
+PASS :heading(1) matches <h:h1> in the HTML namespace
+PASS :heading(2) matches <h:h2> in the HTML namespace
+PASS :heading(3) matches <h:h3> in the HTML namespace
+PASS :heading(4) matches <h:h4> in the HTML namespace
+PASS :heading(5) matches <h:h5> in the HTML namespace
+PASS :heading(6) matches <h:h6> in the HTML namespace
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/heading-prefixed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/heading-prefixed.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>:heading(N) matches prefixed HTML headings</title>
+<link rel="help" href="https://drafts.csswg.org/selectors-5/#headings">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="host"></div>
+
+<script>
+const xhtml = "http://www.w3.org/1999/xhtml";
+
+for (let level = 1; level <= 6; level++) {
+  test(t => {
+    const el = document.createElementNS(xhtml, `h:h${level}`);
+    document.getElementById("host").append(el);
+    t.add_cleanup(() => el.remove());
+    assert_true(el.matches(`:heading(${level})`), `:heading(${level}) matches`);
+    assert_true(el.matches(":heading"), ":heading matches");
+  }, `:heading(${level}) matches <h:h${level}> in the HTML namespace`);
+}
+</script>

--- a/Source/WebCore/html/HTMLHeadingElement.cpp
+++ b/Source/WebCore/html/HTMLHeadingElement.cpp
@@ -44,21 +44,18 @@ HTMLHeadingElement::~HTMLHeadingElement() = default;
 
 unsigned HTMLHeadingElement::level() const
 {
-    auto& tag = tagQName();
-    if (tag == HTMLNames::h1Tag)
+    if (hasTagName(HTMLNames::h1Tag))
         return 1;
-    if (tag == HTMLNames::h2Tag)
+    if (hasTagName(HTMLNames::h2Tag))
         return 2;
-    if (tag == HTMLNames::h3Tag)
+    if (hasTagName(HTMLNames::h3Tag))
         return 3;
-    if (tag == HTMLNames::h4Tag)
+    if (hasTagName(HTMLNames::h4Tag))
         return 4;
-    if (tag == HTMLNames::h5Tag)
+    if (hasTagName(HTMLNames::h5Tag))
         return 5;
-    if (tag == HTMLNames::h6Tag)
-        return 6;
-    ASSERT_NOT_REACHED();
-    return 0;
+    ASSERT(hasTagName(HTMLNames::h6Tag));
+    return 6;
 }
 
 }


### PR DESCRIPTION
#### c475e74dd21df266f9754a9f2700ea847205a106
<pre>
Correct matching of :heading with qualified names
<a href="https://bugs.webkit.org/show_bug.cgi?id=315645">https://bugs.webkit.org/show_bug.cgi?id=315645</a>

Reviewed by Tim Nguyen.

We incorrectly compared the qualified name with local names. Also tidy
up the assert. No need to ever return 0.

Test: imported/w3c/web-platform-tests/css/selectors/heading-prefixed.html

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/60201">https://github.com/web-platform-tests/wpt/pull/60201</a>
Canonical link: <a href="https://commits.webkit.org/313963@main">https://commits.webkit.org/313963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6069e9908f37a6663f4a9c7e24d8a7f4019d93cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173722 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121939 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127977 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108522 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27950 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21480 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139230 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176245 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29069 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136296 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136258 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147530 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101107 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25065 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31528 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24386 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37438 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110482 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36836 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2450 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37084 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36984 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->