### PR TITLE
[JSC] Set storage of JSMapIterator / JSSetIterator creation in DFG / FTL

### DIFF
--- a/JSTests/stress/map-set-for-of-fast-iterator-storage.js
+++ b/JSTests/stress/map-set-for-of-fast-iterator-storage.js
@@ -1,0 +1,164 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+noInline(shouldBe);
+
+function forOfMap(map) {
+    let sumKeys = 0;
+    let sumValues = 0;
+    let count = 0;
+    for (const [k, v] of map) {
+        sumKeys += k;
+        sumValues += v;
+        count++;
+    }
+    return [sumKeys, sumValues, count];
+}
+noInline(forOfMap);
+
+function forOfSet(set) {
+    let sum = 0;
+    let count = 0;
+    for (const v of set) {
+        sum += v;
+        count++;
+    }
+    return [sum, count];
+}
+noInline(forOfSet);
+
+function testEmptyMap() {
+    const m = new Map();
+    const [k, v, c] = forOfMap(m);
+    shouldBe(k, 0);
+    shouldBe(v, 0);
+    shouldBe(c, 0);
+}
+
+function testNonEmptyMap() {
+    const m = new Map();
+    let expectedK = 0;
+    let expectedV = 0;
+    for (let i = 0; i < 16; i++) {
+        m.set(i, i * 2);
+        expectedK += i;
+        expectedV += i * 2;
+    }
+    const [k, v, c] = forOfMap(m);
+    shouldBe(k, expectedK);
+    shouldBe(v, expectedV);
+    shouldBe(c, 16);
+}
+
+function testMapWithDeletions() {
+    const m = new Map();
+    for (let i = 0; i < 32; i++)
+        m.set(i, i);
+    for (let i = 0; i < 32; i += 2)
+        m.delete(i);
+    let expected = 0;
+    for (let i = 1; i < 32; i += 2)
+        expected += i;
+    const [k, v, c] = forOfMap(m);
+    shouldBe(k, expected);
+    shouldBe(v, expected);
+    shouldBe(c, 16);
+}
+
+function testEmptySet() {
+    const s = new Set();
+    const [sum, c] = forOfSet(s);
+    shouldBe(sum, 0);
+    shouldBe(c, 0);
+}
+
+function testNonEmptySet() {
+    const s = new Set();
+    let expected = 0;
+    for (let i = 0; i < 16; i++) {
+        s.add(i);
+        expected += i;
+    }
+    const [sum, c] = forOfSet(s);
+    shouldBe(sum, expected);
+    shouldBe(c, 16);
+}
+
+function testSetWithDeletions() {
+    const s = new Set();
+    for (let i = 0; i < 32; i++)
+        s.add(i);
+    for (let i = 0; i < 32; i += 2)
+        s.delete(i);
+    let expected = 0;
+    for (let i = 1; i < 32; i += 2)
+        expected += i;
+    const [sum, c] = forOfSet(s);
+    shouldBe(sum, expected);
+    shouldBe(c, 16);
+}
+
+function testMapMutationDuringIteration() {
+    const m = new Map();
+    m.set(1, 10);
+    m.set(2, 20);
+    let count = 0;
+    for (const [k, v] of m) {
+        count++;
+        if (k === 1)
+            m.set(3, 30);
+        if (count > 10)
+            break;
+    }
+    shouldBe(count, 3);
+}
+noInline(testMapMutationDuringIteration);
+
+function testSetMutationDuringIteration() {
+    const s = new Set();
+    s.add(1);
+    s.add(2);
+    let count = 0;
+    for (const v of s) {
+        count++;
+        if (v === 1)
+            s.add(3);
+        if (count > 10)
+            break;
+    }
+    shouldBe(count, 3);
+}
+noInline(testSetMutationDuringIteration);
+
+function testReusedEmptyMap() {
+    const m = new Map();
+    let total = 0;
+    for (const [k, v] of m)
+        total++;
+    shouldBe(total, 0);
+}
+
+function testReusedEmptySet() {
+    const s = new Set();
+    let total = 0;
+    for (const v of s)
+        total++;
+    shouldBe(total, 0);
+}
+
+for (let i = 0; i < 5000; i++) {
+    testEmptyMap();
+    testNonEmptyMap();
+    testMapWithDeletions();
+    testEmptySet();
+    testNonEmptySet();
+    testSetWithDeletions();
+    testReusedEmptyMap();
+    testReusedEmptySet();
+}
+
+for (let i = 0; i < 1000; i++) {
+    testMapMutationDuringIteration();
+    testSetMutationDuringIteration();
+}

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -11211,8 +11211,11 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
 
         Node* kindNode = jsConstant(jsNumber(static_cast<uint32_t>(IterationKind::Entries)));
         Node* next = jsConstant(JSValue());
+        Node* iterated = get(bytecode.m_iterable);
+        Node* storage = addToGraph(MapStorage, Edge(iterated, MapObjectUse));
         Node* iterator = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->mapIteratorStructure())));
-        addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSMapIterator::Field::IteratedObject)), iterator, get(bytecode.m_iterable));
+        addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSMapIterator::Field::IteratedObject)), iterator, iterated);
+        addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSMapIterator::Field::Storage)), iterator, storage);
         addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSMapIterator::Field::Kind)), iterator, kindNode);
         set(bytecode.m_iterator, iterator);
 
@@ -11269,8 +11272,11 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
 
         Node* kindNode = jsConstant(jsNumber(static_cast<uint32_t>(IterationKind::Values)));
         Node* next = jsConstant(JSValue());
+        Node* iterated = get(bytecode.m_iterable);
+        Node* storage = addToGraph(MapStorage, Edge(iterated, SetObjectUse));
         Node* iterator = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->setIteratorStructure())));
-        addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSSetIterator::Field::IteratedObject)), iterator, get(bytecode.m_iterable));
+        addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSSetIterator::Field::IteratedObject)), iterator, iterated);
+        addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSSetIterator::Field::Storage)), iterator, storage);
         addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSSetIterator::Field::Kind)), iterator, kindNode);
         set(bytecode.m_iterator, iterator);
 


### PR DESCRIPTION
#### 0206365a0d08367d32abb77c39420dac472924b4
<pre>
[JSC] Set storage of JSMapIterator / JSSetIterator creation in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=315648">https://bugs.webkit.org/show_bug.cgi?id=315648</a>
<a href="https://rdar.apple.com/178032814">rdar://178032814</a>

Reviewed by Yijia Huang.

Let&apos;s set storage of JSMapIterator / JSSetIterator for FastMap / FastSet
iteration in DFG / FTL. While nullptr works, setting this avoids calling
an operation at the first call of `next()`, and it is more aligned to
C++ code.

                                         ToT                     Patched

    for-of-map-entries-small        9.8359+-0.0752     ^      9.5363+-0.0646        ^ definitely 1.0314x faster
    set-for-of                      1.0529+-0.0154     ?      1.0660+-0.0151        ? might be 1.0124x slower
    for-of-set-values               2.5517+-0.0118     ?      2.5590+-0.0140        ?
    for-of-map-entries              8.8384+-0.0613     ^      8.7312+-0.0372        ^ definitely 1.0123x faster
    map-for-of                      1.8168+-0.0151     ?      1.8186+-0.0154        ?
    for-of-set-values-small         3.2684+-0.0242     ^      3.0344+-0.0113        ^ definitely 1.0771x faster

    &lt;geometric&gt;                     3.3387+-0.0128     ^      3.2830+-0.0104        ^ definitely 1.0170x faster

Test: JSTests/stress/map-set-for-of-fast-iterator-storage.js

* JSTests/stress/map-set-for-of-fast-iterator-storage.js: Added.
(shouldBe):
(forOfMap):
(testEmptyMap):
(testNonEmptyMap):
(testMapWithDeletions):
(testEmptySet):
(testNonEmptySet):
(testSetWithDeletions):
(testMapMutationDuringIteration):
(testSetMutationDuringIteration):
(testReusedEmptyMap):
(testReusedEmptySet):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIteratorOpen):

Canonical link: <a href="https://commits.webkit.org/313982@main">https://commits.webkit.org/313982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91664770b82d910c65c9ae57a68b0c894d5e490e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121945 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7bb586ca-f685-41f4-9366-e38c1a52cfd3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127984 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90087 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/663f1016-25d6-4b4d-b443-b14ed280c7c2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108529 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29333 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27957 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21486 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156844 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139237 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176251 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25585 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29075 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136302 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136264 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147535 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101120 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25074 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31537 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24391 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197096 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37444 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110488 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51779 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36842 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2455 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37090 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36990 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->