### PR TITLE
<svg:image> 'auto' sizing should follow the CSS default sizing algorithm

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/svg-image-intrinsic-size-with-cssstyle-auto-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/svg-image-intrinsic-size-with-cssstyle-auto-expected.txt
@@ -16,11 +16,11 @@ PASS <svg:image> 'auto' sizing with default sized svg image, without attributes 
 PASS <svg:image> 'auto' sizing with default sized svg image viewBox='0 0 400 100', attributes width='60' height='60' and no css width/height specified
 PASS <svg:image> 'auto' sizing with default sized svg image viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'width:auto'
 PASS <svg:image> 'auto' sizing with default sized svg image viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'height:auto'
-FAIL <svg:image> 'auto' sizing with default sized svg image viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'width:auto; height:auto' assert_equals: width expected 300 but got 400
+PASS <svg:image> 'auto' sizing with default sized svg image viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'width:auto; height:auto'
 PASS <svg:image> 'auto' sizing with svg image width='200' viewBox='0 0 400 100', attributes width='60' height='60' and no css width/height specified
 PASS <svg:image> 'auto' sizing with svg image width='200' viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'width:auto'
 PASS <svg:image> 'auto' sizing with svg image width='200' viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'height:auto'
-FAIL <svg:image> 'auto' sizing with svg image width='200' viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'width:auto; height:auto' assert_equals: width expected 200 but got 400
+PASS <svg:image> 'auto' sizing with svg image width='200' viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'width:auto; height:auto'
 PASS <svg:image> 'auto' sizing with svg image height='100' viewBox='0 0 400 100', attributes width='60' height='60' and no css width/height specified
 PASS <svg:image> 'auto' sizing with svg image height='100' viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'width:auto'
 PASS <svg:image> 'auto' sizing with svg image height='100' viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'height:auto'
@@ -29,6 +29,6 @@ PASS <svg:image> 'auto' sizing with 200x100 svg image viewBox='0 0 400 100', att
 PASS <svg:image> 'auto' sizing with 200x100 svg image viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'width:auto'
 PASS <svg:image> 'auto' sizing with 200x100 svg image viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'height:auto'
 PASS <svg:image> 'auto' sizing with 200x100 svg image viewBox='0 0 400 100', attributes width='60' height='60' and CSS 'width:auto; height:auto'
-FAIL <svg:image> 'auto' sizing with default sized svg image, attributes width='60' height='60' and CSS 'height:auto' assert_equals: height expected 150 but got 30
-FAIL <svg:image> 'auto' sizing with default sized svg image, attributes width='60' height='60' and CSS 'width:auto' assert_equals: width expected 300 but got 120
+PASS <svg:image> 'auto' sizing with default sized svg image, attributes width='60' height='60' and CSS 'height:auto'
+PASS <svg:image> 'auto' sizing with default sized svg image, attributes width='60' height='60' and CSS 'width:auto'
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3138,6 +3138,7 @@ rendering/svg/RenderSVGTransformableContainer.cpp
 rendering/svg/RenderSVGViewportContainer.cpp @header:RenderStyleGetters
 rendering/svg/SVGBoundingBoxComputation.cpp @header:RenderStyleGetters
 rendering/svg/SVGContainerLayout.cpp @header:RenderStyleGetters
+rendering/svg/SVGImageIntrinsicSizing.cpp @header:RenderStyleGetters
 rendering/svg/SVGInlineFlowBox.cpp
 rendering/svg/SVGInlineTextBox.cpp @header:RenderStyleGetters
 rendering/svg/SVGPathFromElement.cpp @header:RenderStyleGetters

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1309,6 +1309,7 @@
 		32EAFB8D274C5EA600650557 /* FontCascadeCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 32EAFB8B274C5EA500650557 /* FontCascadeCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3320B8F03AA379B81B48F469 /* UnifiedSource24-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 675EA032FFAF2A4098F106D8 /* UnifiedSource24-header-RenderStyleGetters.cpp */; };
 		334408C433F8CA4C10044234 /* SVGLayerTransformUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 3344077412D9BC4A00044234 /* SVGLayerTransformUpdater.h */; };
+		334408C433F8CA4C10044777 /* SVGImageIntrinsicSizing.h in Headers */ = {isa = PBXBuildFile; fileRef = 3344077412D9BC4A00044777 /* SVGImageIntrinsicSizing.h */; };
 		334408C433F8CA4C10044551 /* SVGTransformComputation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3344077412D9BC4A00044551 /* SVGTransformComputation.h */; };
 		334408C433F8CA4C10A328F4 /* SVGVisitedRendererTracking.h in Headers */ = {isa = PBXBuildFile; fileRef = 3344077412D9BC4A00A328F4 /* SVGVisitedRendererTracking.h */; };
 		334B59922E86ACA40067471D /* FocusControllerTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 334B59912E86AC970067471D /* FocusControllerTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -10808,6 +10809,8 @@
 		333F704E0FB49CA2008E12A6 /* Notification.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Notification.idl; sourceTree = "<group>"; };
 		333F704F0FB49CA2008E12A6 /* Notification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Notification.h; sourceTree = "<group>"; };
 		3344077412D9BC4A00044234 /* SVGLayerTransformUpdater.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGLayerTransformUpdater.h; sourceTree = "<group>"; };
+		3344077412D9BC4A00044777 /* SVGImageIntrinsicSizing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGImageIntrinsicSizing.h; sourceTree = "<group>"; };
+		3344077412D9BC4A00044778 /* SVGImageIntrinsicSizing.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SVGImageIntrinsicSizing.cpp; sourceTree = "<group>"; };
 		3344077412D9BC4A00044551 /* SVGTransformComputation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGTransformComputation.h; sourceTree = "<group>"; };
 		3344077412D9BC4A00A328F4 /* SVGVisitedRendererTracking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGVisitedRendererTracking.h; sourceTree = "<group>"; };
 		334A78952B5B3F2B00F7A761 /* EventNames.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = EventNames.json; sourceTree = "<group>"; };
@@ -24879,6 +24882,8 @@
 				0844B01D1255E4E600B9CDD0 /* SVGBoundingBoxComputation.h */,
 				0834B00C1244E5A610B8AFD1 /* SVGContainerLayout.cpp */,
 				0844B01D1255E5A610B8AFD1 /* SVGContainerLayout.h */,
+				3344077412D9BC4A00044778 /* SVGImageIntrinsicSizing.cpp */,
+				3344077412D9BC4A00044777 /* SVGImageIntrinsicSizing.h */,
 				0854B00C1255E4E600B9CDD0 /* SVGInlineFlowBox.cpp */,
 				0854B00D1255E4E600B9CDD0 /* SVGInlineFlowBox.h */,
 				0854B00E1255E4E600B9CDD0 /* SVGInlineTextBox.cpp */,
@@ -49435,6 +49440,7 @@
 				08F859D51463F9CD0067D933 /* SVGImageCache.h in Headers */,
 				B2227A2D0D00BF220071B782 /* SVGImageElement.h in Headers */,
 				08F859D51463F9CD0067D934 /* SVGImageForContainer.h in Headers */,
+				334408C433F8CA4C10044777 /* SVGImageIntrinsicSizing.h in Headers */,
 				B28C6A2A0D00C44800334AA4 /* SVGImageLoader.h in Headers */,
 				0854B01F1255E4E600B9CDD0 /* SVGInlineFlowBox.h in Headers */,
 				0854B0211255E4E600B9CDD0 /* SVGInlineTextBox.h in Headers */,

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -43,6 +43,7 @@
 #include "RenderSVGModelObjectInlines.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGImageElement.h"
+#include "SVGImageIntrinsicSizing.h"
 #include "SVGVisitedRendererTracking.h"
 #include "Settings.h"
 #include <wtf/StackStats.h>
@@ -75,35 +76,7 @@ SVGImageElement& RenderSVGImage::imageElement() const
 
 FloatRect RenderSVGImage::calculateObjectBoundingBox() const
 {
-    LayoutSize intrinsicSize;
-    if (RefPtr cachedImage = imageResource().cachedImage())
-        intrinsicSize = cachedImage->imageSizeForRenderer(nullptr, style().usedZoom());
-
-    Ref imageElement = this->imageElement();
-    SVGLengthContext lengthContext(imageElement.ptr());
-
-    CheckedRef style = this->style();
-    auto& width = style->width();
-    auto& height = style->height();
-    auto usedZoom = style->usedZoomForLength();
-
-    float concreteWidth;
-    if (!width.isAuto())
-        concreteWidth = lengthContext.valueForLength(width, usedZoom, SVGLengthMode::Width);
-    else if (!height.isAuto() && !intrinsicSize.isEmpty())
-        concreteWidth = lengthContext.valueForLength(height, usedZoom, SVGLengthMode::Height) * intrinsicSize.width() / intrinsicSize.height();
-    else
-        concreteWidth = intrinsicSize.width();
-
-    float concreteHeight;
-    if (!height.isAuto())
-        concreteHeight = lengthContext.valueForLength(height, usedZoom, SVGLengthMode::Height);
-    else if (!width.isAuto() && !intrinsicSize.isEmpty())
-        concreteHeight = lengthContext.valueForLength(width, usedZoom, SVGLengthMode::Width) * intrinsicSize.height() / intrinsicSize.width();
-    else
-        concreteHeight = intrinsicSize.height();
-
-    return { imageElement->x().value(lengthContext), imageElement->y().value(lengthContext), concreteWidth, concreteHeight };
+    return calculateSVGImageObjectBoundingBox(imageElement(), style(), imageResource().cachedImage());
 }
 
 void RenderSVGImage::layout()

--- a/Source/WebCore/rendering/svg/SVGImageIntrinsicSizing.cpp
+++ b/Source/WebCore/rendering/svg/SVGImageIntrinsicSizing.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "SVGImageIntrinsicSizing.h"
+
+#include "CachedImage.h"
+#include "Image.h"
+#include "SVGImageElement.h"
+#include "SVGLengthContext.h"
+#include "StyleComputedStyle+GettersInlines.h"
+
+namespace WebCore {
+
+SVGImageIntrinsicSizing resolveSVGImageIntrinsicSizing(CachedImage& cachedImage, float usedZoom)
+{
+    using HasRatio = SVGImageIntrinsicSizing::HasRatio;
+
+    RefPtr image = cachedImage.image();
+
+    // Raster (non-SVG) sources: the intrinsic size *is* the ratio.
+    if (!image || !image->isSVGImage()) {
+        FloatSize size = cachedImage.imageSizeForRenderer(nullptr, usedZoom);
+        return { size, size, size.isEmpty() ? HasRatio::No : HasRatio::Yes };
+    }
+
+    float intrinsicWidth = 0;
+    float intrinsicHeight = 0;
+    FloatSize ratio;
+    cachedImage.computeIntrinsicDimensions(intrinsicWidth, intrinsicHeight, ratio);
+
+    // Both intrinsic dimensions known: the ratio is their ratio, per spec (overriding any
+    // viewBox-derived ratio).
+    if (intrinsicWidth > 0 && intrinsicHeight > 0)
+        return { { intrinsicWidth, intrinsicHeight }, { intrinsicWidth, intrinsicHeight }, HasRatio::Yes };
+
+    auto hasRatio = ratio.isEmpty() ? HasRatio::No : HasRatio::Yes;
+    auto heightFromWidth = [&](float width) {
+        return width * ratio.height() / ratio.width();
+    };
+    auto widthFromHeight = [&](float height) {
+        return height * ratio.width() / ratio.height();
+    };
+    constexpr auto fallback = defaultObjectSizeForSVGImage;
+
+    // Only width known: derive height from the ratio, or fall back.
+    if (intrinsicWidth > 0) {
+        float computedHeight = hasRatio == HasRatio::Yes ? heightFromWidth(intrinsicWidth) : fallback.height();
+        return { { intrinsicWidth, computedHeight }, ratio, hasRatio };
+    }
+
+    // Only height known: derive width from the ratio, or fall back.
+    if (intrinsicHeight > 0) {
+        float computedWidth = hasRatio == HasRatio::Yes ? widthFromHeight(intrinsicHeight) : fallback.width();
+        return { { computedWidth, intrinsicHeight }, ratio, hasRatio };
+    }
+
+    // Only the ratio is known: 'contain' it within the default object size.
+    if (hasRatio == HasRatio::Yes) {
+        float widthAtFallbackHeight = widthFromHeight(fallback.height());
+        if (widthAtFallbackHeight <= fallback.width())
+            return { { widthAtFallbackHeight, fallback.height() }, ratio, HasRatio::Yes };
+        return { { fallback.width(), heightFromWidth(fallback.width()) }, ratio, HasRatio::Yes };
+    }
+
+    // Nothing known: pure fallback.
+    return { fallback, ratio, HasRatio::No };
+}
+
+FloatRect calculateSVGImageObjectBoundingBox(const SVGImageElement& imageElement, const Style::ComputedStyle& style, CachedImage* cachedImage)
+{
+    SVGImageIntrinsicSizing sizing;
+    if (RefPtr protectedCachedImage = cachedImage)
+        sizing = resolveSVGImageIntrinsicSizing(*protectedCachedImage, style.usedZoom());
+
+    SVGLengthContext lengthContext(&imageElement);
+
+    auto& width = style.width();
+    auto& height = style.height();
+    auto usedZoom = style.usedZoomForLength();
+    bool hasRatio = sizing.hasRatio == SVGImageIntrinsicSizing::HasRatio::Yes;
+
+    float concreteWidth;
+    if (!width.isAuto())
+        concreteWidth = lengthContext.valueForLength(width, usedZoom, SVGLengthMode::Width);
+    else if (!height.isAuto() && hasRatio)
+        concreteWidth = lengthContext.valueForLength(height, usedZoom, SVGLengthMode::Height) * sizing.ratio.width() / sizing.ratio.height();
+    else
+        concreteWidth = sizing.size.width();
+
+    float concreteHeight;
+    if (!height.isAuto())
+        concreteHeight = lengthContext.valueForLength(height, usedZoom, SVGLengthMode::Height);
+    else if (!width.isAuto() && hasRatio)
+        concreteHeight = lengthContext.valueForLength(width, usedZoom, SVGLengthMode::Width) * sizing.ratio.height() / sizing.ratio.width();
+    else
+        concreteHeight = sizing.size.height();
+
+    return { imageElement.x().value(lengthContext), imageElement.y().value(lengthContext), concreteWidth, concreteHeight };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGImageIntrinsicSizing.h
+++ b/Source/WebCore/rendering/svg/SVGImageIntrinsicSizing.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "FloatRect.h"
+
+namespace WebCore {
+
+class CachedImage;
+class SVGImageElement;
+
+namespace Style {
+class ComputedStyle;
+}
+
+// SVG 2 §12.2 Placement of the embedded content mandates a 300x150 default object size when the
+// referenced resource has no intrinsic size.
+// https://w3c.github.io/svgwg/svg2-draft/embedded.html#Placement
+constexpr FloatSize defaultObjectSizeForSVGImage { 300, 150 };
+
+struct SVGImageIntrinsicSizing {
+    enum class HasRatio : bool { No, Yes };
+
+    FloatSize size;
+    FloatSize ratio;
+    HasRatio hasRatio { HasRatio::No };
+};
+
+// CSS Images Level 3 default sizing algorithm for <svg:image> sources.
+// https://www.w3.org/TR/css-images-3/#default-sizing-algorithm
+//
+// HasRatio distinguishes a real intrinsic aspect ratio from the 300x150 fallback: callers must not
+// resolve 'auto' dimensions against a fallback ratio, or they get the wrong size.
+SVGImageIntrinsicSizing resolveSVGImageIntrinsicSizing(CachedImage&, float usedZoom);
+
+// Resolves the <svg:image> object bounding box from the CSS 'width' / 'height' computed values and
+// the source's intrinsic sizing, per SVG 2 §12.2. Shared by the LBSE and legacy SVG renderers.
+FloatRect calculateSVGImageObjectBoundingBox(const SVGImageElement&, const Style::ComputedStyle&, CachedImage*);
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -39,6 +39,7 @@
 #include "RenderLayer.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGImageElement.h"
+#include "SVGImageIntrinsicSizing.h"
 #include "SVGRenderingContext.h"
 #include "SVGResources.h"
 #include "SVGResourcesCache.h"
@@ -84,35 +85,7 @@ SVGImageElement& LegacyRenderSVGImage::imageElement() const
 
 FloatRect LegacyRenderSVGImage::calculateObjectBoundingBox() const
 {
-    LayoutSize intrinsicSize;
-    if (RefPtr cachedImage = imageResource().cachedImage())
-        intrinsicSize = cachedImage->imageSizeForRenderer(nullptr, style().usedZoom());
-
-    Ref imageElement = this->imageElement();
-    SVGLengthContext lengthContext(imageElement.ptr());
-
-    CheckedRef style = this->style();
-    auto& width = style->width();
-    auto& height = style->height();
-    auto usedZoom = style->usedZoomForLength();
-
-    float concreteWidth;
-    if (!width.isAuto())
-        concreteWidth = lengthContext.valueForLength(width, usedZoom, SVGLengthMode::Width);
-    else if (!height.isAuto() && !intrinsicSize.isEmpty())
-        concreteWidth = lengthContext.valueForLength(height, usedZoom, SVGLengthMode::Height) * intrinsicSize.width() / intrinsicSize.height();
-    else
-        concreteWidth = intrinsicSize.width();
-
-    float concreteHeight;
-    if (!height.isAuto())
-        concreteHeight = lengthContext.valueForLength(height, usedZoom, SVGLengthMode::Height);
-    else if (!width.isAuto() && !intrinsicSize.isEmpty())
-        concreteHeight = lengthContext.valueForLength(width, usedZoom, SVGLengthMode::Width) * intrinsicSize.height() / intrinsicSize.width();
-    else
-        concreteHeight = intrinsicSize.height();
-
-    return { imageElement->x().value(lengthContext), imageElement->y().value(lengthContext), concreteWidth, concreteHeight };
+    return calculateSVGImageObjectBoundingBox(imageElement(), style(), imageResource().cachedImage());
 }
 
 bool LegacyRenderSVGImage::updateImageViewport()


### PR DESCRIPTION
#### 2025cb32576ca2b653e30d66744c3861cab4bc19
<pre>
&lt;svg:image&gt; &apos;auto&apos; sizing should follow the CSS default sizing algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=194815">https://bugs.webkit.org/show_bug.cgi?id=194815</a>
<a href="https://rdar.apple.com/122586485">rdar://122586485</a>

Reviewed by Nikolas Zimmermann.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per SVG 2 §12.2 &quot;Placement of the embedded content&quot;
(<a href="https://w3c.github.io/svgwg/svg2-draft/embedded.html#Placement)">https://w3c.github.io/svgwg/svg2-draft/embedded.html#Placement)</a>:

    &quot;The &apos;auto&apos; value for width or height is used to size the
     corresponding element automatically based on the intrinsic
     dimensions or intrinsic aspect ratio of the referenced
     resource. Computation of automatically-sized values follows
     the Default Sizing Algorithm defined for replaced elements in
     CSS layout [css-images-3]. In particular, when the referenced
     resource does not have an intrinsic size (such as image types
     with no defined dimensions), it is assumed to have a width of
     300px and a height of 150px.&quot;

The default sizing algorithm itself is defined in CSS Images Level 3 §4.3.1
(<a href="https://www.w3.org/TR/css-images-3/#default-sizing-algorithm).">https://www.w3.org/TR/css-images-3/#default-sizing-algorithm).</a>

calculateObjectBoundingBox() previously used the value returned by
CachedImage::imageSizeForRenderer() as both the intrinsic size and
the intrinsic ratio. For SVG sources this conflated three distinct
cases:

    * An SVG with only a viewBox (no intrinsic width/height) reported
      the viewBox size as if it were intrinsic, so &apos;width:auto;
      height:auto&apos; returned the viewBox dimensions instead of fitting
      the intrinsic ratio into the 300x150 default object size.
    * An SVG with one intrinsic dimension plus a viewBox returned the
      viewBox size, ignoring the intrinsic dimension that should have
      been preserved while the missing dimension is derived from the
      ratio.
    * An empty SVG (no intrinsic dimensions and no viewBox) fell back
      to 300x150 inside imageSizeForRenderer, but the surrounding
      logic then treated that fallback as a real 2:1 intrinsic ratio
      when one CSS axis was &apos;auto&apos;.

Add SVGImageIntrinsicSizing.h, a helper shared by the LBSE and legacy
SVG image renderers, which both previously carried identical copies of
this computation. resolveSVGImageIntrinsicSizing() queries
CachedImage::computeIntrinsicDimensions() for SVG sources and applies
the CSS Images Level 3 §4.3.1 default sizing algorithm with a 300x150
default object size, returning an SVGImageIntrinsicSizing struct: a
concrete intrinsic size, the intrinsic ratio, and a HasRatio enum.
HasRatio distinguishes a real aspect ratio from the 300x150 fallback,
which callers need because resolving &apos;auto&apos; against a fallback ratio
yields the wrong size. When both intrinsic dimensions exist, the
intrinsic ratio is taken from those dimensions (per spec), so the
viewBox-derived ratio cannot override the intrinsic w/h ratio for SVGs
that declare width, height, and viewBox.

calculateSVGImageObjectBoundingBox() resolves the concrete width and
height from the CSS &apos;width&apos; / &apos;height&apos; computed values against that
sizing, keying its ratio branches off HasRatio rather than an emptiness
check, so the 300x150 default-object-size fallback no longer poses as an
aspect ratio. Both RenderSVGImage::calculateObjectBoundingBox() and
LegacyRenderSVGImage::calculateObjectBoundingBox() now just delegate to
it.

Non-SVG (raster) sources are unaffected: the helper returns
imageSizeForRenderer() for them, matching the previous behavior.

* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/svg-image-intrinsic-size-with-cssstyle-auto-expected.txt: Progressions
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::calculateObjectBoundingBox const):
* Source/WebCore/rendering/svg/SVGImageIntrinsicSizing.cpp: Added.
(WebCore::resolveSVGImageIntrinsicSizing):
(WebCore::calculateSVGImageObjectBoundingBox):
* Source/WebCore/rendering/svg/SVGImageIntrinsicSizing.h: Added.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::calculateObjectBoundingBox const):

Canonical link: <a href="https://commits.webkit.org/318548@main">https://commits.webkit.org/318548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/583b303c957aa0126063b2e39e084868d6685fed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140976 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fdab1963-5d8b-4e0e-8888-1efdec645ede) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138527 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96339 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d46662ba-ce3e-4ce9-8f3e-914811e3fa19) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118991 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f1894f1-9035-45b2-860a-059d77c9e037) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40713 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39075 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39506 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35800 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189766 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51334 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147644 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39849 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52016 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/36129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147430 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42143 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124231 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118663 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50524 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13744 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49920 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50160 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49982 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->