### PR TITLE
[JSC] Map / Set iterator next operation should not touch JSMapIterator / JSSetIterator directly

### DIFF
--- a/JSTests/stress/map-set-iterator-next-deferred-commit.js
+++ b/JSTests/stress/map-set-iterator-next-deferred-commit.js
@@ -1,0 +1,205 @@
+// Regression test for https://bugs.webkit.org/show_bug.cgi?id=315650
+//
+// MapIteratorNext is modeled statelessly: it returns the advanced (storage, entry)
+// pair, and the parser commits it back into the iterator via PutInternalField nodes
+// emitted *after* the key/value loads. This gives two properties we verify here:
+//
+//   1. ObjectAllocationSinking can eliminate the JSMapIterator/JSSetIterator in for-of.
+//      Iteration must still produce the correct sequence even when the iterator object
+//      is never allocated.
+//   2. The irreversible advance is published only once everything is done, so an OSR
+//      exit (or escape) part-way through must leave the iterator in a consistent state:
+//      never partially advanced, never double-advanced.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' (expected ' + expected + ')');
+}
+
+// 1. for-of over Map/Set with a sunk iterator, across keys/values/entries.
+(function () {
+    var map = new Map();
+    var set = new Set();
+    var keySum = 0, valSum = 0;
+    for (var i = 0; i < 64; ++i) {
+        map.set(i, i * 2);
+        set.add(i);
+        keySum += i;
+        valSum += i * 2;
+    }
+
+    function sumMapKeys(map) {
+        var r = 0;
+        for (var k of map.keys())
+            r += k;
+        return r;
+    }
+    function sumMapValues(map) {
+        var r = 0;
+        for (var v of map.values())
+            r += v;
+        return r;
+    }
+    function sumMapEntries(map) {
+        var r = 0;
+        for (var [k, v] of map) {
+            if (v !== k * 2)
+                throw new Error('entry mismatch: ' + k + ' -> ' + v);
+            r += k;
+        }
+        return r;
+    }
+    function sumSet(set) {
+        var r = 0;
+        for (var k of set)
+            r += k;
+        return r;
+    }
+    function sumSetEntries(set) {
+        var r = 0;
+        for (var [a, b] of set.entries()) {
+            if (a !== b)
+                throw new Error('set entry mismatch: ' + a + ' vs ' + b);
+            r += a;
+        }
+        return r;
+    }
+    noInline(sumMapKeys);
+    noInline(sumMapValues);
+    noInline(sumMapEntries);
+    noInline(sumSet);
+    noInline(sumSetEntries);
+
+    for (var i = 0; i < testLoopCount; ++i) {
+        shouldBe(sumMapKeys(map), keySum);
+        shouldBe(sumMapValues(map), valSum);
+        shouldBe(sumMapEntries(map), keySum);
+        shouldBe(sumSet(set), keySum);
+        shouldBe(sumSetEntries(set), keySum);
+    }
+})();
+
+// 2. The iterator escapes on a rare path after a partial advance. Because the advance is
+//    committed before the iterator can be observed, the materialized iterator must resume
+//    from exactly the next live entry.
+(function () {
+    var map = new Map([[10, 100], [20, 200], [30, 300], [40, 400]]);
+    var mapIteratorPrototype = map.values().__proto__;
+
+    function test(map, flag) {
+        var iterator = map.values();
+        var first = iterator.next().value;   // advance once: now positioned after entry 0
+        var second = iterator.next().value;  // advance twice: now positioned after entry 1
+        if (flag)
+            return iterator;                 // escape -> force materialization
+        return first + second;
+    }
+    noInline(test);
+
+    for (var i = 0; i < testLoopCount; ++i) {
+        var flag = (i % 1234) === 0;
+        var result = test(map, flag);
+        if (flag) {
+            shouldBe(typeof result, "object");
+            shouldBe(result.__proto__, mapIteratorPrototype);
+            // The escaped iterator was advanced exactly twice, so the next two values
+            // must be the 3rd and 4th, then done.
+            shouldBe(result.next().value, 300);
+            shouldBe(result.next().value, 400);
+            shouldBe(result.next().done, true);
+        } else
+            shouldBe(result, 100 + 200);
+    }
+})();
+
+// 2b. Same escape-after-partial-advance property for Set.
+(function () {
+    var set = new Set([1, 2, 3, 4, 5]);
+    var setIteratorPrototype = set.values().__proto__;
+
+    function test(set, flag) {
+        var iterator = set.values();
+        iterator.next();
+        iterator.next();
+        iterator.next();
+        if (flag)
+            return iterator;
+        return true;
+    }
+    noInline(test);
+
+    for (var i = 0; i < testLoopCount; ++i) {
+        var flag = (i % 1234) === 0;
+        var result = test(set, flag);
+        if (flag) {
+            shouldBe(result.__proto__, setIteratorPrototype);
+            shouldBe(result.next().value, 4);
+            shouldBe(result.next().value, 5);
+            shouldBe(result.next().done, true);
+        } else
+            shouldBe(result, true);
+    }
+})();
+
+// 3. Force an OSR exit immediately after an advance. The iterator must not be left
+//    partially advanced: re-running from the checkpoint after the exit must continue
+//    the iteration cleanly without skipping or repeating an element.
+(function () {
+    var map = new Map([[0, 0], [1, 1], [2, 2]]);
+    var mapIteratorPrototype = map.values().__proto__;
+
+    function test(map, flag) {
+        var iterator = map.values();
+        iterator.next();
+        if (flag) {
+            OSRExit();
+            return iterator;
+        }
+        return iterator.next().value;
+    }
+    noInline(test);
+
+    for (var i = 0; i < testLoopCount; ++i)
+        shouldBe(test(map, false), 1);
+
+    var iterator = test(map, true);
+    shouldBe(iterator.__proto__, mapIteratorPrototype);
+    shouldBe(iterator.next().value, 1);
+    shouldBe(iterator.next().value, 2);
+    shouldBe(iterator.next().done, true);
+})();
+
+// 4. Mutation during iteration drives the stateless slow path (obsolete/rehashed tables).
+//    Entries added during iteration are visited; entries deleted before being visited are
+//    skipped. This must hold once the loop tiers up to DFG/FTL.
+(function () {
+    function run() {
+        var m = new Map();
+        for (var i = 0; i < 8; ++i)
+            m.set(i, i);
+        var sum = 0, c = 0;
+        for (var [k, v] of m) {
+            if (v !== k)
+                throw new Error('value mismatch: ' + k + ' -> ' + v);
+            sum += k;
+            if (c === 2) {
+                for (var j = 100; j < 140; ++j) // force rehash + obsolete-table chain
+                    m.set(j, j);
+            }
+            if (c === 4) {
+                m.delete(5);
+                m.delete(6);
+                m.delete(7);
+            }
+            ++c;
+        }
+        return sum;
+    }
+    noInline(run);
+
+    var expected = (0 + 1 + 2 + 3 + 4); // 5, 6, 7 deleted before being visited
+    for (var j = 100; j < 140; ++j)
+        expected += j;
+    for (var i = 0; i < testLoopCount; ++i)
+        shouldBe(run(), expected);
+})();

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1735,6 +1735,10 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
 
     case MapIteratorNext:
+        m_state.setTypeForTupleNode(node, 0, SpecCellOther);
+        m_state.setNonCellTypeForTupleNode(node, 1, SpecInt32Only);
+        clearForNode(node);
+        break;
     case IsEmptyStorage:
         setTypeForNode(node, SpecBoolean);
         break;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -4411,9 +4411,35 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             insertChecks();
             Node* mapIterator = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
-            UseKind useKind = intrinsic == JSMapIteratorNextIntrinsic ? MapIteratorObjectUse : SetIteratorObjectUse;
-            Node* storage = addToGraph(MapIteratorNext, Edge(mapIterator, useKind));
-            setResult(storage);
+            bool isMapIterator = intrinsic == JSMapIteratorNextIntrinsic;
+            UseKind iteratorUseKind = isMapIterator ? MapIteratorObjectUse : SetIteratorObjectUse;
+            UseKind ownerUseKind = isMapIterator ? MapObjectUse : SetObjectUse;
+            SpeculatedType ownerSpec = isMapIterator ? SpecMapObject : SpecSetObject;
+
+            unsigned storageFieldIndex = isMapIterator ? static_cast<unsigned>(JSMapIterator::Field::Storage) : static_cast<unsigned>(JSSetIterator::Field::Storage);
+            unsigned iteratedObjectFieldIndex = isMapIterator ? static_cast<unsigned>(JSMapIterator::Field::IteratedObject) : static_cast<unsigned>(JSSetIterator::Field::IteratedObject);
+            unsigned entryFieldIndex = isMapIterator ? static_cast<unsigned>(JSMapIterator::Field::Entry) : static_cast<unsigned>(JSSetIterator::Field::Entry);
+
+            addToGraph(Check, Edge(mapIterator, iteratorUseKind));
+
+            Node* storageField = addToGraph(GetInternalField, OpInfo(storageFieldIndex), OpInfo(SpecCellOther | SpecEmpty), mapIterator);
+            Node* iteratedObjectField = addToGraph(GetInternalField, OpInfo(iteratedObjectFieldIndex), OpInfo(ownerSpec), mapIterator);
+            Node* entryField = addToGraph(GetInternalField, OpInfo(entryFieldIndex), OpInfo(SpecInt32Only), mapIterator);
+
+            Node* tuple = addToGraph(MapIteratorNext, Edge(storageField), Edge(iteratedObjectField, ownerUseKind), Edge(entryField));
+
+            Node* newStorage = addToGraph(ExtractFromTuple, OpInfo(0), tuple);
+            newStorage->setResult(NodeResultJS);
+            Node* newEntry = addToGraph(ExtractFromTuple, OpInfo(1), tuple);
+            newEntry->setResult(NodeResultInt32);
+
+            addToGraph(PutInternalField, OpInfo(storageFieldIndex), mapIterator, newStorage);
+            addToGraph(PutInternalField, OpInfo(entryFieldIndex), mapIterator, newEntry);
+
+            FrozenValue* sentinelConst = m_graph.freezeStrong(m_graph.m_vm.orderedHashTableSentinel());
+            Node* done = addToGraph(CompareEqPtr, OpInfo(sentinelConst), newStorage);
+
+            setResult(done);
             return CallOptimizationResult::Inlined;
         }
 
@@ -4423,9 +4449,20 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             insertChecks();
             Node* mapIterator = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
-            UseKind useKind = intrinsic == JSMapIteratorKeyIntrinsic ? MapIteratorObjectUse : SetIteratorObjectUse;
-            Node* storage = addToGraph(MapIteratorKey, OpInfo(0), OpInfo(prediction), Edge(mapIterator, useKind));
-            setResult(storage);
+            bool isMapIterator = intrinsic == JSMapIteratorKeyIntrinsic;
+            UseKind iteratorUseKind = isMapIterator ? MapIteratorObjectUse : SetIteratorObjectUse;
+            BucketOwnerType ownerType = isMapIterator ? BucketOwnerType::Map : BucketOwnerType::Set;
+
+            unsigned storageFieldIndex = isMapIterator ? static_cast<unsigned>(JSMapIterator::Field::Storage) : static_cast<unsigned>(JSSetIterator::Field::Storage);
+            unsigned entryFieldIndex = isMapIterator ? static_cast<unsigned>(JSMapIterator::Field::Entry) : static_cast<unsigned>(JSSetIterator::Field::Entry);
+
+            addToGraph(Check, Edge(mapIterator, iteratorUseKind));
+
+            Node* storageField = addToGraph(GetInternalField, OpInfo(storageFieldIndex), OpInfo(SpecCellOther), mapIterator);
+            Node* entryField = addToGraph(GetInternalField, OpInfo(entryFieldIndex), OpInfo(SpecInt32Only), mapIterator);
+
+            Node* result = addToGraph(MapIteratorKey, OpInfo(ownerType), OpInfo(prediction), Edge(storageField), Edge(entryField));
+            setResult(result);
             return CallOptimizationResult::Inlined;
         }
 
@@ -4434,8 +4471,17 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             insertChecks();
             Node* mapIterator = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
-            Node* storage = addToGraph(MapIteratorValue, OpInfo(0), OpInfo(prediction), Edge(mapIterator, MapIteratorObjectUse));
-            setResult(storage);
+
+            unsigned storageFieldIndex = static_cast<unsigned>(JSMapIterator::Field::Storage);
+            unsigned entryFieldIndex = static_cast<unsigned>(JSMapIterator::Field::Entry);
+
+            addToGraph(Check, Edge(mapIterator, MapIteratorObjectUse));
+
+            Node* storageField = addToGraph(GetInternalField, OpInfo(storageFieldIndex), OpInfo(SpecCellOther), mapIterator);
+            Node* entryField = addToGraph(GetInternalField, OpInfo(entryFieldIndex), OpInfo(SpecInt32Only), mapIterator);
+
+            Node* result = addToGraph(MapIteratorValue, OpInfo(BucketOwnerType::Map), OpInfo(prediction), Edge(storageField), Edge(entryField));
+            setResult(result);
             return CallOptimizationResult::Inlined;
         }
 
@@ -12170,10 +12216,43 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         BasicBlock* isDoneBlock = allocateUntargetableBlock();
         BasicBlock* doLoadBlock = allocateUntargetableBlock();
 
+        unsigned storageFieldIndex = static_cast<unsigned>(JSMapIterator::Field::Storage);
+        unsigned iteratedObjectFieldIndex = static_cast<unsigned>(JSMapIterator::Field::IteratedObject);
+        unsigned entryFieldIndex = static_cast<unsigned>(JSMapIterator::Field::Entry);
+
+        // The iterator is not mutated in this block. We carry the advanced (storage,
+        // entry) pair to the successor blocks via tmps and commit it there, so an OSR
+        // exit at the iterator_next checkpoint can simply re-run next() cleanly.
+        auto nextTmps = allocatePrivateTmps(2);
+        Operand tmpStorage = nextTmps.operandAt(0);
+        Operand tmpEntry = nextTmps.operandAt(1);
+
         {
-            // Now MapIterator status gets mutated. So we must not do OSRExit unless it is throwing an exception.
             Node* iterator = get(bytecode.m_iterator);
-            Node* doneNode = addToGraph(MapIteratorNext, Edge(iterator, MapIteratorObjectUse));
+
+            Node* storageField = addToGraph(GetInternalField, OpInfo(storageFieldIndex), OpInfo(SpecCellOther | SpecEmpty), iterator);
+            Node* iteratedObjectField = addToGraph(GetInternalField, OpInfo(iteratedObjectFieldIndex), OpInfo(SpecMapObject), iterator);
+            Node* entryField = addToGraph(GetInternalField, OpInfo(entryFieldIndex), OpInfo(SpecInt32Only), iterator);
+
+            Node* tuple = addToGraph(MapIteratorNext, Edge(storageField), Edge(iteratedObjectField, MapObjectUse), Edge(entryField));
+
+            Node* newStorage = addToGraph(ExtractFromTuple, OpInfo(0), tuple);
+            newStorage->setResult(NodeResultJS);
+            Node* newEntry = addToGraph(ExtractFromTuple, OpInfo(1), tuple);
+            newEntry->setResult(NodeResultInt32);
+
+            // Flush so the successor reads go through a phi merge rather than
+            // short-circuiting to the producer, which would create cross-block edges
+            // that violate the CPS validator.
+            set(tmpStorage, newStorage, ImmediateNakedSet);
+            flush(tmpStorage);
+            set(tmpEntry, newEntry, ImmediateNakedSet);
+            flush(tmpEntry);
+
+            FrozenValue* sentinelConst = m_graph.freezeStrong(m_graph.m_vm.orderedHashTableSentinel());
+            Node* doneNode = addToGraph(CompareEqPtr, OpInfo(sentinelConst), newStorage);
+
+            emitExitOK();
 
             BranchData* branchData = m_graph.m_branchData.add();
             branchData->taken = BranchTarget(isDoneBlock);
@@ -12186,20 +12265,22 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
             clearCaches();
             keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
+
+            Node* keyStorage = get(tmpStorage);
+            Node* keyEntry = get(tmpEntry);
 
             Node* value = nullptr;
             switch (kind) {
             case IterationKind::Keys:
-                value = addToGraph(MapIteratorKey, OpInfo(0), OpInfo(prediction), Edge(get(bytecode.m_iterator), MapIteratorObjectUse));
+                value = addToGraph(MapIteratorKey, OpInfo(BucketOwnerType::Map), OpInfo(prediction), Edge(keyStorage), Edge(keyEntry));
                 break;
             case IterationKind::Values:
-                value = addToGraph(MapIteratorValue, OpInfo(0), OpInfo(prediction), Edge(get(bytecode.m_iterator), MapIteratorObjectUse));
+                value = addToGraph(MapIteratorValue, OpInfo(BucketOwnerType::Map), OpInfo(prediction), Edge(keyStorage), Edge(keyEntry));
                 break;
             case IterationKind::Entries: {
-                Node* key = addToGraph(MapIteratorKey, OpInfo(0), OpInfo(prediction), Edge(get(bytecode.m_iterator), MapIteratorObjectUse));
-                Node* mapValue = addToGraph(MapIteratorValue, OpInfo(0), OpInfo(prediction), Edge(get(bytecode.m_iterator), MapIteratorObjectUse));
+                Node* key = addToGraph(MapIteratorKey, OpInfo(BucketOwnerType::Map), OpInfo(SpecBytecodeTop), Edge(keyStorage), Edge(keyEntry));
+                Node* mapValue = addToGraph(MapIteratorValue, OpInfo(BucketOwnerType::Map), OpInfo(SpecBytecodeTop), Edge(keyStorage), Edge(keyEntry));
                 addVarArgChild(key);
                 addVarArgChild(mapValue);
                 unsigned vectorHint = 2;
@@ -12208,6 +12289,12 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
             }
             }
             Node* falseNode = jsConstant(jsBoolean(false));
+
+            // Commit the advanced state after the loads, so a key/value OSR exit cannot
+            // leave the iterator partially advanced.
+            Node* iterator = get(bytecode.m_iterator);
+            addToGraph(PutInternalField, OpInfo(storageFieldIndex), iterator, keyStorage);
+            addToGraph(PutInternalField, OpInfo(entryFieldIndex), iterator, keyEntry);
 
             set(bytecode.m_value, value);
             set(bytecode.m_done, falseNode);
@@ -12226,8 +12313,14 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
             m_currentBlock = isDoneBlock;
             clearCaches();
             keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+
+            emitExitOK();
+
             Node* trueNode = jsConstant(jsBoolean(true));
             Node* bottomNode = jsConstant(m_graph.bottomValueMatchingSpeculation(prediction));
+
+            Node* iterator = get(bytecode.m_iterator);
+            addToGraph(PutInternalField, OpInfo(storageFieldIndex), iterator, weakJSConstant(m_graph.m_vm.orderedHashTableSentinel()));
 
             set(bytecode.m_value, bottomNode);
             set(bytecode.m_done, trueNode);
@@ -12277,10 +12370,43 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         BasicBlock* isDoneBlock = allocateUntargetableBlock();
         BasicBlock* doLoadBlock = allocateUntargetableBlock();
 
+        unsigned storageFieldIndex = static_cast<unsigned>(JSSetIterator::Field::Storage);
+        unsigned iteratedObjectFieldIndex = static_cast<unsigned>(JSSetIterator::Field::IteratedObject);
+        unsigned entryFieldIndex = static_cast<unsigned>(JSSetIterator::Field::Entry);
+
+        // The iterator is not mutated in this block. We carry the advanced (storage,
+        // entry) pair to the successor blocks via tmps and commit it there, so an OSR
+        // exit at the iterator_next checkpoint can simply re-run next() cleanly.
+        auto nextTmps = allocatePrivateTmps(2);
+        Operand tmpStorage = nextTmps.operandAt(0);
+        Operand tmpEntry = nextTmps.operandAt(1);
+
         {
-            // Now SetIterator status gets mutated. So we must not do OSRExit unless it is throwing an exception.
             Node* iterator = get(bytecode.m_iterator);
-            Node* doneNode = addToGraph(MapIteratorNext, Edge(iterator, SetIteratorObjectUse));
+
+            Node* storageField = addToGraph(GetInternalField, OpInfo(storageFieldIndex), OpInfo(SpecCellOther | SpecEmpty), iterator);
+            Node* iteratedObjectField = addToGraph(GetInternalField, OpInfo(iteratedObjectFieldIndex), OpInfo(SpecSetObject), iterator);
+            Node* entryField = addToGraph(GetInternalField, OpInfo(entryFieldIndex), OpInfo(SpecInt32Only), iterator);
+
+            Node* tuple = addToGraph(MapIteratorNext, Edge(storageField), Edge(iteratedObjectField, SetObjectUse), Edge(entryField));
+
+            Node* newStorage = addToGraph(ExtractFromTuple, OpInfo(0), tuple);
+            newStorage->setResult(NodeResultJS);
+            Node* newEntry = addToGraph(ExtractFromTuple, OpInfo(1), tuple);
+            newEntry->setResult(NodeResultInt32);
+
+            // Flush so the successor reads go through a phi merge rather than
+            // short-circuiting to the producer, which would create cross-block edges
+            // that violate the CPS validator.
+            set(tmpStorage, newStorage, ImmediateNakedSet);
+            flush(tmpStorage);
+            set(tmpEntry, newEntry, ImmediateNakedSet);
+            flush(tmpEntry);
+
+            FrozenValue* sentinelConst = m_graph.freezeStrong(m_graph.m_vm.orderedHashTableSentinel());
+            Node* doneNode = addToGraph(CompareEqPtr, OpInfo(sentinelConst), newStorage);
+
+            emitExitOK();
 
             BranchData* branchData = m_graph.m_branchData.add();
             branchData->taken = BranchTarget(isDoneBlock);
@@ -12293,18 +12419,27 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
             clearCaches();
             keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
-            Node* key = addToGraph(MapIteratorKey, OpInfo(0), OpInfo(prediction), Edge(get(bytecode.m_iterator), SetIteratorObjectUse));
-            Node* value = key;
+            Node* keyStorage = get(tmpStorage);
+            Node* keyEntry = get(tmpEntry);
+
+            Node* value = nullptr;
             if (kind == IterationKind::Entries) {
+                Node* key = addToGraph(MapIteratorKey, OpInfo(BucketOwnerType::Set), OpInfo(SpecBytecodeTop), Edge(keyStorage), Edge(keyEntry));
                 addVarArgChild(key);
                 addVarArgChild(key);
                 unsigned vectorHint = 2;
                 value = addToGraph(Node::VarArg, NewArray, OpInfo(ArrayWithContiguous), OpInfo(vectorHint));
-            }
+            } else
+                value = addToGraph(MapIteratorKey, OpInfo(BucketOwnerType::Set), OpInfo(prediction), Edge(keyStorage), Edge(keyEntry));
             Node* falseNode = jsConstant(jsBoolean(false));
+
+            // Commit the advanced state after the loads, so a key OSR exit cannot leave
+            // the iterator partially advanced.
+            Node* iterator = get(bytecode.m_iterator);
+            addToGraph(PutInternalField, OpInfo(storageFieldIndex), iterator, keyStorage);
+            addToGraph(PutInternalField, OpInfo(entryFieldIndex), iterator, keyEntry);
 
             set(bytecode.m_value, value);
             set(bytecode.m_done, falseNode);
@@ -12323,8 +12458,14 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
             m_currentBlock = isDoneBlock;
             clearCaches();
             keepUsesOfCurrentInstructionAlive(currentInstruction, m_currentIndex.checkpoint());
+
+            emitExitOK();
+
             Node* trueNode = jsConstant(jsBoolean(true));
             Node* bottomNode = jsConstant(m_graph.bottomValueMatchingSpeculation(prediction));
+
+            Node* iterator = get(bytecode.m_iterator);
+            addToGraph(PutInternalField, OpInfo(storageFieldIndex), iterator, weakJSConstant(m_graph.m_vm.orderedHashTableSentinel()));
 
             set(bytecode.m_value, bottomNode);
             set(bytecode.m_done, trueNode);

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2480,27 +2480,25 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     }
 
     case MapIteratorNext: {
-        Edge& mapIteratorEdge = node->child1();
-        AbstractHeapKind ownerHeap = (mapIteratorEdge.useKind() == MapIteratorObjectUse) ? JSMapFields : JSSetFields;
-        AbstractHeapKind heap = (mapIteratorEdge.useKind() == MapIteratorObjectUse) ? JSMapIteratorFields : JSSetIteratorFields;
+        Edge& iteratedObjectEdge = node->child2();
+        AbstractHeapKind ownerHeap = (iteratedObjectEdge.useKind() == MapObjectUse) ? JSMapFields : JSSetFields;
         read(ownerHeap);
-        read(heap);
-        write(heap);
-        def(HeapLocation(MapIteratorNextLoc, heap, mapIteratorEdge), LazyNode(node));
+        // We do not def here as it is tuple result.
         return;
     }
     case MapIteratorKey: {
-        Edge& mapIteratorEdge = node->child1();
-        AbstractHeapKind heap = (mapIteratorEdge.useKind() == MapIteratorObjectUse) ? JSMapIteratorFields : JSSetIteratorFields;
+        Edge& storageEdge = node->child1();
+        Edge& entryEdge = node->child2();
+        AbstractHeapKind heap = (node->bucketOwnerType() == BucketOwnerType::Map) ? JSMapFields : JSSetFields;
         read(heap);
-        def(HeapLocation(MapIteratorKeyLoc, heap, mapIteratorEdge), LazyNode(node));
+        def(HeapLocation(MapIteratorKeyLoc, heap, storageEdge, entryEdge), LazyNode(node));
         return;
     }
     case MapIteratorValue: {
-        Edge& mapIteratorEdge = node->child1();
-        AbstractHeapKind heap = (mapIteratorEdge.useKind() == MapIteratorObjectUse) ? JSMapIteratorFields : JSSetIteratorFields;
-        read(heap);
-        def(HeapLocation(MapIteratorValueLoc, heap, mapIteratorEdge), LazyNode(node));
+        Edge& storageEdge = node->child1();
+        Edge& entryEdge = node->child2();
+        read(JSMapFields);
+        def(HeapLocation(MapIteratorValueLoc, JSMapFields, storageEdge, entryEdge), LazyNode(node));
         return;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3235,14 +3235,25 @@ private:
             break;
 
         case MapIteratorNext:
-        case MapIteratorKey:
-        case MapIteratorValue:
-            if (node->child1().useKind() == MapIteratorObjectUse)
-                fixEdge<MapIteratorObjectUse>(node->child1());
-            else if (node->child1().useKind() == SetIteratorObjectUse)
-                fixEdge<SetIteratorObjectUse>(node->child1());
+            // child1: storage JSValue (cell or empty); leave as UntypedUse so GetInternalField's
+            // empty-marker value flows through without a speculation check.
+            // child2: iterated map/set object, child3: entry int32.
+            if (node->child2().useKind() == MapObjectUse)
+                fixEdge<MapObjectUse>(node->child2());
+            else if (node->child2().useKind() == SetObjectUse)
+                fixEdge<SetObjectUse>(node->child2());
             else
                 RELEASE_ASSERT_NOT_REACHED();
+            fixEdge<Int32Use>(node->child3());
+            m_graph.m_tupleData.at(node->tupleOffset()).resultFlags = NodeResultJS;
+            m_graph.m_tupleData.at(node->tupleOffset() + 1).resultFlags = NodeResultInt32;
+            break;
+
+        case MapIteratorKey:
+        case MapIteratorValue:
+            // child1: storage cell, child2: entry int32. Map vs Set distinction is in OpInfo (BucketOwnerType).
+            fixEdge<KnownCellUse>(node->child1());
+            fixEdge<Int32Use>(node->child2());
             break;
 
         case MapHash: {

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1803,6 +1803,7 @@ public:
         case EnumeratorNextUpdateIndexAndMode:
         case StringIteratorNext:
         case StringIteratorNextWithUndefined:
+        case MapIteratorNext:
             return true;
         default:
             return false;
@@ -1845,6 +1846,7 @@ public:
         case EnumeratorNextUpdateIndexAndMode:
         case StringIteratorNext:
         case StringIteratorNextWithUndefined:
+        case MapIteratorNext:
             return 2;
         default:
             break;
@@ -3743,7 +3745,7 @@ public:
 
     bool hasBucketOwnerType()
     {
-        return op() == MapIterationNext || op() == MapIterationEntry || op() == MapIterationEntryKey || op() == MapIterationEntryValue || op() == MapStorage || op() == MapStorageOrSentinel;
+        return op() == MapIterationNext || op() == MapIterationEntry || op() == MapIterationEntryKey || op() == MapIterationEntryValue || op() == MapStorage || op() == MapStorageOrSentinel || op() == MapIteratorKey || op() == MapIteratorValue;
     }
 
     unsigned numberOfBoundArguments()

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -611,7 +611,7 @@ namespace JSC { namespace DFG {
     macro(NormalizeMapKey, NodeResultJS) \
     macro(MapGet, NodeResultStorage) \
     macro(LoadMapValue, NodeResultJS) \
-    macro(MapIteratorNext, NodeResultBoolean) \
+    macro(MapIteratorNext, 0) \
     macro(MapIteratorKey, NodeResultJS) \
     macro(MapIteratorValue, NodeResultJS) \
     macro(MapStorage, NodeResultJS) /* Get the map storage if exists. */ \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -5919,20 +5919,54 @@ JSC_DEFINE_JIT_OPERATION(operationStringIteratorNext, UGPRPair, (JSGlobalObject*
     OPERATION_RETURN(scope, makeUGPRPair(std::bit_cast<UCPURegister>(value), static_cast<uint32_t>(nextPosition)));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMapIteratorNext, EncodedJSValue, (VM* vmPointer, JSCell* cell))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMapIteratorNext, UGPRPair, (VM* vmPointer, JSCell* storageCell, JSCell* iteratedObjectCell, int32_t entry))
 {
     VM& vm = *vmPointer;
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return JSValue::encode(uncheckedDowncast<JSMapIterator>(cell)->next(vm));
+
+    JSCell* sentinel = vm.orderedHashTableSentinel();
+    JSCell* storage = storageCell;
+    if (storage == sentinel)
+        return makeUGPRPair(std::bit_cast<UCPURegister>(sentinel), 0);
+
+    if (!storage) {
+        JSMap* map = uncheckedDowncast<JSMap>(iteratedObjectCell);
+        storage = map->storage();
+        if (!storage) [[likely]]
+            return makeUGPRPair(std::bit_cast<UCPURegister>(sentinel), 0);
+    }
+
+    JSMap::Storage& storageRef = *uncheckedDowncast<JSMap::Storage>(storage);
+    auto result = JSMap::Helper::transitAndNext(vm, storageRef, entry);
+    if (!result.storage)
+        return makeUGPRPair(std::bit_cast<UCPURegister>(sentinel), 0);
+    return makeUGPRPair(std::bit_cast<UCPURegister>(result.storage), static_cast<UCPURegister>(result.entry + 1));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationSetIteratorNext, EncodedJSValue, (VM* vmPointer, JSCell* cell))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationSetIteratorNext, UGPRPair, (VM* vmPointer, JSCell* storageCell, JSCell* iteratedObjectCell, int32_t entry))
 {
     VM& vm = *vmPointer;
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return JSValue::encode(uncheckedDowncast<JSSetIterator>(cell)->next(vm));
+
+    JSCell* sentinel = vm.orderedHashTableSentinel();
+    JSCell* storage = storageCell;
+    if (storage == sentinel)
+        return makeUGPRPair(std::bit_cast<UCPURegister>(sentinel), 0);
+
+    if (!storage) {
+        JSSet* set = uncheckedDowncast<JSSet>(iteratedObjectCell);
+        storage = set->storage();
+        if (!storage) [[likely]]
+            return makeUGPRPair(std::bit_cast<UCPURegister>(sentinel), 0);
+    }
+
+    JSSet::Storage& storageRef = *uncheckedDowncast<JSSet::Storage>(storage);
+    auto result = JSSet::Helper::transitAndNext(vm, storageRef, entry);
+    if (!result.storage)
+        return makeUGPRPair(std::bit_cast<UCPURegister>(sentinel), 0);
+    return makeUGPRPair(std::bit_cast<UCPURegister>(result.storage), static_cast<UCPURegister>(result.entry + 1));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationSetAdd, void, (JSGlobalObject* globalObject, JSCell* set, EncodedJSValue key, int32_t hash))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -363,8 +363,8 @@ JSC_DECLARE_JIT_OPERATION(operationSetIterationEntry, EncodedJSValue, (JSGlobalO
 JSC_DECLARE_JIT_OPERATION(operationSetIterationEntryKey, EncodedJSValue, (JSGlobalObject*, JSCell*));
 
 JSC_DECLARE_JIT_OPERATION(operationStringIteratorNext, UGPRPair, (JSGlobalObject*, JSString*, int32_t));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMapIteratorNext, EncodedJSValue, (VM*, JSCell*));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationSetIteratorNext, EncodedJSValue, (VM*, JSCell*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMapIteratorNext, UGPRPair, (VM*, JSCell*, JSCell*, int32_t));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationSetIteratorNext, UGPRPair, (VM*, JSCell*, JSCell*, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationNewMap, JSMap*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewSet, JSSet*, (VM*, Structure*));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1160,7 +1160,10 @@ private:
             setPrediction(SpecInt32Only);
             break;
 
-        case MapIteratorNext:
+        case MapIteratorNext: {
+            setTuplePredictions(SpecCellOther, SpecInt32Only);
+            break;
+        }
         case GetRegExpFlag:
             setPrediction(SpecBoolean);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -14933,80 +14933,59 @@ void SpeculativeJIT::compileMapStorageOrSentinel(Node* node)
 
 void SpeculativeJIT::compileMapIteratorKey(Node* node)
 {
-    SpeculateCellOperand iterator(this, node->child1());
+    bool isMapIterator = node->bucketOwnerType() == BucketOwnerType::Map;
+    SpeculateCellOperand storage(this, node->child1());
+    SpeculateInt32Operand entry(this, node->child2());
     GPRTemporary scratch1(this);
     GPRTemporary scratch2(this);
-    GPRTemporary scratch3(this);
 
-    GPRReg iteratorGPR = iterator.gpr();
+    GPRReg storageGPR = storage.gpr();
+    GPRReg entryGPR = entry.gpr();
     GPRReg scratchGPR1 = scratch1.gpr();
     GPRReg scratchGPR2 = scratch2.gpr();
-    GPRReg scratchGPR3 = scratch3.gpr();
     auto resultRegs = JSValueRegs::withTwoAvailableRegs(scratchGPR1, scratchGPR2);
 
-    switch (node->child1().useKind()) {
-    case MapIteratorObjectUse: {
-        speculateMapIteratorObject(node->child1(), iteratorGPR);
-
-        load32(Address(iteratorGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSMapIterator::Field::Entry))), scratchGPR1);
-        loadPtr(Address(iteratorGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSMapIterator::Field::Storage))), scratchGPR3);
-
+    if (isMapIterator) {
         static_assert(JSMap::Helper::EntrySize == 3);
-        lshift32(scratchGPR1, TrustedImm32(1), scratchGPR2);
-        add32(scratchGPR1, scratchGPR2);
-        load32(Address(scratchGPR3, JSCellButterfly::offsetOfData() + JSMap::Helper::capacityIndex() * sizeof(uint64_t)), scratchGPR1);
+        lshift32(entryGPR, TrustedImm32(1), scratchGPR2);
+        add32(entryGPR, scratchGPR2);
+        load32(Address(storageGPR, JSCellButterfly::offsetOfData() + JSMap::Helper::capacityIndex() * sizeof(uint64_t)), scratchGPR1);
         add32(scratchGPR1, scratchGPR2);
         add32(TrustedImm32(JSMap::Helper::hashTableStartIndex() - JSMap::Helper::EntrySize), scratchGPR2);
-        break;
-    }
-    case SetIteratorObjectUse: {
-        speculateSetIteratorObject(node->child1(), iteratorGPR);
-
-        load32(Address(iteratorGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSSetIterator::Field::Entry))), scratchGPR1);
-        loadPtr(Address(iteratorGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSSetIterator::Field::Storage))), scratchGPR3);
-
+    } else {
         static_assert(JSSet::Helper::EntrySize == 2);
-        add32(scratchGPR1, scratchGPR1, scratchGPR2);
-        load32(Address(scratchGPR3, JSCellButterfly::offsetOfData() + JSSet::Helper::capacityIndex() * sizeof(uint64_t)), scratchGPR1);
+        add32(entryGPR, entryGPR, scratchGPR2);
+        load32(Address(storageGPR, JSCellButterfly::offsetOfData() + JSSet::Helper::capacityIndex() * sizeof(uint64_t)), scratchGPR1);
         add32(scratchGPR1, scratchGPR2);
         add32(TrustedImm32(JSSet::Helper::hashTableStartIndex() - JSSet::Helper::EntrySize), scratchGPR2);
-        break;
-    }
-    default:
-        DFG_CRASH(m_graph, node, "Bad use kind");
     }
 
-    loadValue(BaseIndex(scratchGPR3, scratchGPR2, TimesEight, JSCellButterfly::offsetOfData()), resultRegs);
+    loadValue(BaseIndex(storageGPR, scratchGPR2, TimesEight, JSCellButterfly::offsetOfData()), resultRegs);
     jsValueResult(resultRegs, node);
 }
 
 void SpeculativeJIT::compileMapIteratorValue(Node* node)
 {
-    SpeculateCellOperand iterator(this, node->child1());
+    ASSERT(node->bucketOwnerType() == BucketOwnerType::Map);
+    SpeculateCellOperand storage(this, node->child1());
+    SpeculateInt32Operand entry(this, node->child2());
     GPRTemporary scratch1(this);
     GPRTemporary scratch2(this);
-    GPRTemporary scratch3(this);
 
-    GPRReg iteratorGPR = iterator.gpr();
+    GPRReg storageGPR = storage.gpr();
+    GPRReg entryGPR = entry.gpr();
     GPRReg scratchGPR1 = scratch1.gpr();
     GPRReg scratchGPR2 = scratch2.gpr();
-    GPRReg scratchGPR3 = scratch3.gpr();
     auto resultRegs = JSValueRegs::withTwoAvailableRegs(scratchGPR1, scratchGPR2);
 
-    ASSERT(node->child1().useKind() == MapIteratorObjectUse);
-    speculateMapIteratorObject(node->child1(), iteratorGPR);
-
-    load32(Address(iteratorGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSMapIterator::Field::Entry))), scratchGPR1);
-    loadPtr(Address(iteratorGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSMapIterator::Field::Storage))), scratchGPR3);
-
     static_assert(JSMap::Helper::EntrySize == 3);
-    lshift32(scratchGPR1, TrustedImm32(1), scratchGPR2);
-    add32(scratchGPR1, scratchGPR2);
-    load32(Address(scratchGPR3, JSCellButterfly::offsetOfData() + JSMap::Helper::capacityIndex() * sizeof(uint64_t)), scratchGPR1);
+    lshift32(entryGPR, TrustedImm32(1), scratchGPR2);
+    add32(entryGPR, scratchGPR2);
+    load32(Address(storageGPR, JSCellButterfly::offsetOfData() + JSMap::Helper::capacityIndex() * sizeof(uint64_t)), scratchGPR1);
     add32(scratchGPR1, scratchGPR2);
     add32(TrustedImm32(JSMap::Helper::hashTableStartIndex() - JSMap::Helper::EntrySize + /* value offset */ 1), scratchGPR2);
 
-    loadValue(BaseIndex(scratchGPR3, scratchGPR2, TimesEight, JSCellButterfly::offsetOfData()), resultRegs);
+    loadValue(BaseIndex(storageGPR, scratchGPR2, TimesEight, JSCellButterfly::offsetOfData()), resultRegs);
     jsValueResult(resultRegs, node);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -956,6 +956,22 @@ public:
         }
     }
 
+#if USE(JSVALUE64)
+    void jsValueTupleResultWithoutUsingChildren(GPRReg reg, Node* node, unsigned index, DataFormat format = DataFormatJS)
+    {
+        ASSERT(index < node->tupleSize());
+        unsigned refCount = m_graph.m_tupleData.at(node->tupleOffset() + index).refCount;
+        if (!refCount)
+            return;
+        ASSERT(refCount == 1);
+        ASSERT(format & DataFormatJS);
+        VirtualRegister virtualRegister = m_graph.m_tupleData.at(node->tupleOffset() + index).virtualRegister;
+        GenerationInfo& info = generationInfoFromVirtualRegister(virtualRegister);
+        m_gprs.retain(reg, virtualRegister, SpillOrderJS);
+        info.initJSValue(node, refCount, reg, format);
+    }
+#endif
+
     void cellTupleResultWithoutUsingChildren(GPRReg reg, Node* node, unsigned index)
     {
         ASSERT(index < node->tupleSize());
@@ -968,21 +984,6 @@ public:
         m_gprs.retain(reg, virtualRegister, SpillOrderCell);
         info.initCell(node, refCount, reg);
     }
-
-#if USE(JSVALUE64)
-    void jsValueTupleResultWithoutUsingChildren(GPRReg reg, Node* node, unsigned index)
-    {
-        ASSERT(index < node->tupleSize());
-        unsigned refCount = m_graph.m_tupleData.at(node->tupleOffset() + index).refCount;
-        if (!refCount)
-            return;
-        ASSERT(refCount == 1);
-        VirtualRegister virtualRegister = m_graph.m_tupleData.at(node->tupleOffset() + index).virtualRegister;
-        GenerationInfo& info = generationInfoFromVirtualRegister(virtualRegister);
-        m_gprs.retain(reg, virtualRegister, SpillOrderJS);
-        info.initJSValue(node, refCount, reg, DataFormatJS);
-    }
-#endif
 
     template<typename OperationType>
     void operationExceptionCheck()

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -5595,21 +5595,35 @@ void SpeculativeJIT::speculateInt32(Edge edge, JSValueRegs regs)
 
 void SpeculativeJIT::compileMapIteratorNext(Node* node)
 {
-    SpeculateCellOperand mapIterator(this, node->child1());
-    GPRReg mapIteratorGPR = mapIterator.gpr();
+    bool isMapIterator = node->child2().useKind() == MapObjectUse;
 
-    if (node->child1().useKind() == MapIteratorObjectUse)
-        speculateMapIteratorObject(node->child1(), mapIteratorGPR);
-    else if (node->child1().useKind() == SetIteratorObjectUse)
-        speculateSetIteratorObject(node->child1(), mapIteratorGPR);
+    JSValueOperand storage(this, node->child1());
+    SpeculateCellOperand iteratedObject(this, node->child2());
+    SpeculateInt32Operand currentEntry(this, node->child3());
+
+    JSValueRegs storageRegs = storage.jsValueRegs();
+    GPRReg iteratedObjectGPR = iteratedObject.gpr();
+    GPRReg currentEntryGPR = currentEntry.gpr();
+
+    if (isMapIterator)
+        speculateMapObject(node->child2(), iteratedObjectGPR);
     else
-        RELEASE_ASSERT_NOT_REACHED();
+        speculateSetObject(node->child2(), iteratedObjectGPR);
 
     flushRegisters();
-    JSValueRegsFlushedCallResult result(this);
-    JSValueRegs resultRegs = result.regs();
-    callOperationWithoutExceptionCheck(node->child1().useKind() == MapIteratorObjectUse ? operationMapIteratorNext : operationSetIteratorNext, resultRegs, TrustedImmPtr(&vm()), mapIteratorGPR);
-    jsValueResult(resultRegs, node);
+
+    GPRFlushedCallResult resultStorage(this);
+    GPRFlushedCallResult2 resultEntry(this);
+    GPRReg resultStorageGPR = resultStorage.gpr();
+    GPRReg resultEntryGPR = resultEntry.gpr();
+
+    auto operation = isMapIterator ? operationMapIteratorNext : operationSetIteratorNext;
+    setupArguments<decltype(operationMapIteratorNext)>(TrustedImmPtr(&vm()), storageRegs.payloadGPR(), iteratedObjectGPR, currentEntryGPR);
+    appendCallSetResult(operation, resultStorageGPR, resultEntryGPR);
+
+    useChildren(node);
+    cellTupleResultWithoutUsingChildren(resultStorageGPR, node, 0);
+    strictInt32TupleResultWithoutUsingChildren(resultEntryGPR, node, 1);
 }
 
 void SpeculativeJIT::compileStringIteratorNext(Node* node)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -8816,93 +8816,106 @@ void SpeculativeJIT::compileMapStorage(Node* node)
 
 void SpeculativeJIT::compileMapIteratorNext(Node* node)
 {
-    bool isMapIterator = node->child1().useKind() == MapIteratorObjectUse;
+    bool isMapIterator = node->child2().useKind() == MapObjectUse;
 
-    SpeculateCellOperand iterator(this, node->child1());
+    // Storage may be empty (raw zero) on the very first iteration; load as JSValue
+    // and treat the raw bits as a pointer for null/sentinel testing.
+    JSValueOperand storage(this, node->child1());
+    SpeculateCellOperand iteratedObject(this, node->child2());
+    SpeculateInt32Operand currentEntry(this, node->child3());
+
+    GPRTemporary newStorage(this);
+    GPRTemporary newEntry(this);
     GPRTemporary scratch1(this);
     GPRTemporary scratch2(this);
-    GPRTemporary scratch3(this);
-    GPRTemporary scratch4(this);
 
-    GPRReg iteratorGPR = iterator.gpr();
+    GPRReg storageGPR = storage.gpr();
+    GPRReg iteratedObjectGPR = iteratedObject.gpr();
+    GPRReg currentEntryGPR = currentEntry.gpr();
+    GPRReg newStorageGPR = newStorage.gpr();
+    GPRReg newEntryGPR = newEntry.gpr();
     GPRReg scratchGPR1 = scratch1.gpr();
     GPRReg scratchGPR2 = scratch2.gpr();
-    GPRReg scratchGPR3 = scratch3.gpr();
-    GPRReg scratchGPR4 = scratch4.gpr();
 
     if (isMapIterator)
-        speculateMapIteratorObject(node->child1(), iteratorGPR);
+        speculateMapObject(node->child2(), iteratedObjectGPR);
     else
-        speculateSetIteratorObject(node->child1(), iteratorGPR);
+        speculateSetObject(node->child2(), iteratedObjectGPR);
 
-    unsigned storageFieldIndex;
-    unsigned iteratedObjectFieldIndex;
-    unsigned entryFieldIndex;
-    if (isMapIterator) {
-        storageFieldIndex = static_cast<unsigned>(JSMapIterator::Field::Storage);
-        iteratedObjectFieldIndex = static_cast<unsigned>(JSMapIterator::Field::IteratedObject);
-        entryFieldIndex = static_cast<unsigned>(JSMapIterator::Field::Entry);
-    } else {
-        storageFieldIndex = static_cast<unsigned>(JSSetIterator::Field::Storage);
-        iteratedObjectFieldIndex = static_cast<unsigned>(JSSetIterator::Field::IteratedObject);
-        entryFieldIndex = static_cast<unsigned>(JSSetIterator::Field::Entry);
-    }
     uint8_t entrySize = isMapIterator ? JSMap::Helper::EntrySize : JSSet::Helper::EntrySize;
     uint32_t capacityIndex = isMapIterator ? JSMap::Helper::capacityIndex() : JSSet::Helper::capacityIndex();
     uint32_t hashTableStartIndex = isMapIterator ? JSMap::Helper::hashTableStartIndex() : JSSet::Helper::hashTableStartIndex();
+    uint32_t aliveEntryCountIndex = isMapIterator ? JSMap::Helper::aliveEntryCountIndex() : JSSet::Helper::aliveEntryCountIndex();
+    auto storageOffset = isMapIterator ? JSMap::offsetOfStorage() : JSSet::offsetOfStorage();
 
     JITCompiler::JumpList slowCases;
-    JITCompiler::JumpList doneCases;
     JITCompiler::JumpList markClosed;
+    JITCompiler::JumpList doneCases;
 
-    loadPtr(Address(iteratorGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(storageFieldIndex)), scratchGPR3);
-    auto storageEmpty = branchTestPtr(JITCompiler::Zero, scratchGPR3);
-    // Check if storage is sentinel
-    auto returnTrue = branchLinkableConstant(JITCompiler::Equal, scratchGPR3, LinkableConstant(*this, vm().orderedHashTableSentinel()));
+    auto storageEmpty = branchTestPtr(JITCompiler::Zero, storageGPR);
+    auto returnSentinel = branchLinkableConstant(JITCompiler::Equal, storageGPR, LinkableConstant(*this, vm().orderedHashTableSentinel()));
 
     // Check if storage is obsolete
-    load64(Address(scratchGPR3, JSCellButterfly::offsetOfData() + (isMapIterator ? JSMap::Helper::aliveEntryCountIndex() : JSSet::Helper::aliveEntryCountIndex()) * sizeof(uint64_t)), scratchGPR4);
-    slowCases.append(branchIfNotInt32(JSValueRegs { scratchGPR4 }));
+    load64(Address(storageGPR, JSCellButterfly::offsetOfData() + aliveEntryCountIndex * sizeof(uint64_t)), scratchGPR2);
+    slowCases.append(branchIfNotInt32(JSValueRegs { scratchGPR2 }));
 
-    // Fast path: iterate to find next non-deleted entry
-    load32(Address(iteratorGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(entryFieldIndex)), scratchGPR1);
-    load32(Address(scratchGPR3, JSCellButterfly::offsetOfData() + capacityIndex * sizeof(uint64_t)), scratchGPR2);
-    add32(TrustedImm32(hashTableStartIndex), scratchGPR2);
-    // Compute entryKeyIndex = dataTableStartIndex + entry * entrySize
+    // Fast path: iterate to find next non-deleted entry.
+    move(currentEntryGPR, newEntryGPR);
+    load32(Address(storageGPR, JSCellButterfly::offsetOfData() + capacityIndex * sizeof(uint64_t)), scratchGPR1);
+    add32(TrustedImm32(hashTableStartIndex), scratchGPR1);
     if (entrySize == 3) {
-        lshift32(scratchGPR1, TrustedImm32(1), scratchGPR4);
-        add32(scratchGPR1, scratchGPR4);
+        lshift32(newEntryGPR, TrustedImm32(1), scratchGPR2);
+        add32(newEntryGPR, scratchGPR2);
     } else if (entrySize == 2)
-        add32(scratchGPR1, scratchGPR1, scratchGPR4);
-    add32(scratchGPR4, scratchGPR2);
+        add32(newEntryGPR, newEntryGPR, scratchGPR2);
+    add32(scratchGPR2, scratchGPR1);
 
     auto loopStart = label();
-    load64(BaseIndex(scratchGPR3, scratchGPR2, TimesEight, JSCellButterfly::offsetOfData()), scratchGPR4);
-    markClosed.append(branchTest64(JITCompiler::Zero, scratchGPR4));
+    load64(BaseIndex(storageGPR, scratchGPR1, TimesEight, JSCellButterfly::offsetOfData()), scratchGPR2);
+    markClosed.append(branchTest64(JITCompiler::Zero, scratchGPR2));
 
-    add32(TrustedImm32(1), scratchGPR1);
-    add32(TrustedImm32(entrySize), scratchGPR2);
-    branchLinkableConstant(JITCompiler::Equal, scratchGPR4, LinkableConstant(*this, vm().orderedHashTableDeletedValue())).linkTo(loopStart, this);
+    add32(TrustedImm32(1), newEntryGPR);
+    add32(TrustedImm32(entrySize), scratchGPR1);
+    branchLinkableConstant(JITCompiler::Equal, scratchGPR2, LinkableConstant(*this, vm().orderedHashTableDeletedValue())).linkTo(loopStart, this);
 
-    store32(scratchGPR1, Address(iteratorGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(entryFieldIndex)));
-    move(TrustedImm64(JSValue::encode(jsBoolean(false))), scratchGPR4);
+    // Found a valid entry: storage unchanged, newEntry holds advanced position.
+    move(storageGPR, newStorageGPR);
     doneCases.append(jump());
 
+    // Closed because of empty initial map or end of table.
     storageEmpty.link(this);
-    loadPtr(Address(iteratorGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(iteratedObjectFieldIndex)), scratchGPR4);
-    loadPtr(Address(scratchGPR4, isMapIterator ? JSMap::offsetOfStorage() : JSSet::offsetOfStorage()), scratchGPR3);
-    slowCases.append(branchTest64(JITCompiler::NonZero, scratchGPR3));
+    loadPtr(Address(iteratedObjectGPR, storageOffset), scratchGPR1);
+    slowCases.append(branchTest64(JITCompiler::NonZero, scratchGPR1));
 
     markClosed.link(this);
-    loadLinkableConstant(LinkableConstant(*this, vm().orderedHashTableSentinel()), scratchGPR1);
-    storePtr(scratchGPR1, Address(iteratorGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(storageFieldIndex)));
-    returnTrue.link(this);
-    move(TrustedImm64(JSValue::encode(jsBoolean(true))), scratchGPR4);
+    loadLinkableConstant(LinkableConstant(*this, vm().orderedHashTableSentinel()), newStorageGPR);
+    move(TrustedImm32(0), newEntryGPR);
+    doneCases.append(jump());
 
-    addSlowPathGenerator(slowPathCall(slowCases, this, isMapIterator ? operationMapIteratorNext : operationSetIteratorNext, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, scratchGPR4, TrustedImmPtr(&vm()), iteratorGPR));
+    returnSentinel.link(this);
+    move(storageGPR, newStorageGPR);
+    move(TrustedImm32(0), newEntryGPR);
 
     doneCases.link(this);
-    jsValueResult(scratchGPR4, node);
+    auto doneLabel = label();
+
+    if (!slowCases.empty()) {
+        Vector<SilentRegisterSavePlan> savePlans;
+        silentSpillAllRegistersImpl(false, savePlans, newStorageGPR, newEntryGPR);
+
+        addSlowPathGeneratorLambda([=, this, slowCases = WTF::move(slowCases), savePlans = WTF::move(savePlans)] () mutable {
+            slowCases.link(this);
+            silentSpill(savePlans);
+            setupArguments<decltype(operationMapIteratorNext)>(TrustedImmPtr(&vm()), storageGPR, iteratedObjectGPR, currentEntryGPR);
+            appendCallSetResult(isMapIterator ? operationMapIteratorNext : operationSetIteratorNext, newStorageGPR, newEntryGPR);
+            silentFill(savePlans);
+            jump().linkTo(doneLabel, this);
+        });
+    }
+
+    useChildren(node);
+    cellTupleResultWithoutUsingChildren(newStorageGPR, node, 0);
+    strictInt32TupleResultWithoutUsingChildren(newEntryGPR, node, 1);
 }
 
 void SpeculativeJIT::compileStringIteratorNext(Node* node)

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -16639,16 +16639,15 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileMapIteratorNext()
     {
-        bool isMapIterator = m_node->child1().useKind() == MapIteratorObjectUse;
-        LValue iterator;
-        if (isMapIterator)
-            iterator = lowMapIteratorObject(m_node->child1());
-        else if (m_node->child1().useKind() == SetIteratorObjectUse)
-            iterator = lowSetIteratorObject(m_node->child1());
-        else
-            RELEASE_ASSERT_NOT_REACHED();
+        bool isMapIterator = m_node->child2().useKind() == MapObjectUse;
 
-        LBasicBlock checkCurrentStorage = m_out.newBlock();
+        // Storage may be empty (raw zero) on the very first iteration, so we cannot
+        // speculate it as a cell here; treat the JSValue's raw bits as a pointer.
+        LValue storage = lowJSValue(m_node->child1());
+        LValue iteratedObject = isMapIterator ? lowMapObject(m_node->child2()) : lowSetObject(m_node->child2());
+        LValue currentEntry = lowInt32(m_node->child3());
+
+        LBasicBlock checkOwnerStorage = m_out.newBlock();
         LBasicBlock setEmptySentinel = m_out.newBlock();
         LBasicBlock checkSentinel = m_out.newBlock();
         LBasicBlock checkObsolete = m_out.newBlock();
@@ -16659,50 +16658,38 @@ IGNORE_CLANG_WARNINGS_END
         LBasicBlock slowPath = m_out.newBlock();
         LBasicBlock continuation = m_out.newBlock();
 
-        unsigned storageFieldIndex;
-        unsigned iteratedObjectFieldIndex;
-        unsigned entryFieldIndex;
-        if (isMapIterator) {
-            storageFieldIndex = static_cast<unsigned>(JSMapIterator::Field::Storage);
-            iteratedObjectFieldIndex = static_cast<unsigned>(JSMapIterator::Field::IteratedObject);
-            entryFieldIndex = static_cast<unsigned>(JSMapIterator::Field::Entry);
-        } else {
-            storageFieldIndex = static_cast<unsigned>(JSSetIterator::Field::Storage);
-            iteratedObjectFieldIndex = static_cast<unsigned>(JSSetIterator::Field::IteratedObject);
-            entryFieldIndex = static_cast<unsigned>(JSSetIterator::Field::Entry);
-        }
-        // They are strongly held by VM so do not need to have write-barrier when storing this to the field.
+        // The sentinel is returned as the new storage when the iterator is exhausted; the deleted
+        // value is the marker we skip over while scanning the data table. This node no longer writes
+        // the iterator's fields itself: the commit is done by the PutInternalField nodes the parser
+        // emits after the key/value loads.
         LValue sentinel = m_out.constIntPtr(std::bit_cast<void*>(vm().orderedHashTableSentinel()));
         LValue deletedValue = m_out.constIntPtr(std::bit_cast<void*>(vm().orderedHashTableDeletedValue()));
 
-        LValue storage = m_out.loadPtr(iterator, m_heaps.JSInternalFieldObjectImpl_internalFields[storageFieldIndex]);
-        m_out.branch(m_out.isNull(storage), unsure(checkCurrentStorage), unsure(checkSentinel));
+        m_out.branch(m_out.isNull(storage), unsure(checkOwnerStorage), unsure(checkSentinel));
 
-        LBasicBlock lastNext = m_out.appendTo(checkCurrentStorage, setEmptySentinel);
-        LValue iteratedObject = m_out.loadPtr(iterator, m_heaps.JSInternalFieldObjectImpl_internalFields[iteratedObjectFieldIndex]);
+        LBasicBlock lastNext = m_out.appendTo(checkOwnerStorage, setEmptySentinel);
         LValue ownerStorage = m_out.loadPtr(iteratedObject, isMapIterator ? m_heaps.JSMap_storage : m_heaps.JSSet_storage);
         m_out.branch(m_out.isNull(ownerStorage), usually(setEmptySentinel), rarely(slowPath));
 
         m_out.appendTo(setEmptySentinel, checkSentinel);
-        m_out.storePtr(sentinel, iterator, m_heaps.JSInternalFieldObjectImpl_internalFields[storageFieldIndex]);
-        ValueFromBlock emptyResult = m_out.anchor(m_out.constInt64(JSValue::encode(jsBoolean(true))));
+        ValueFromBlock emptyStorageResult = m_out.anchor(sentinel);
+        ValueFromBlock emptyEntryResult = m_out.anchor(m_out.int32Zero);
         m_out.jump(continuation);
 
         // Check if storage is sentinel (iterator is already closed)
         m_out.appendTo(checkSentinel, checkObsolete);
-        ValueFromBlock sentinelResult = m_out.anchor(m_out.constInt64(JSValue::encode(jsBoolean(true))));
+        ValueFromBlock sentinelStorageResult = m_out.anchor(sentinel);
+        ValueFromBlock sentinelEntryResult = m_out.anchor(m_out.int32Zero);
         m_out.branch(m_out.equal(storage, sentinel), unsure(continuation), unsure(checkObsolete));
 
         // Check if storage is obsolete (first field is a Cell pointer, not an Int32 JSValue)
         m_out.appendTo(checkObsolete, fastPath);
         LValue butterfly = toButterfly(storage);
         LValue aliveEntryCount = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMapIterator ? JSMap::Helper::aliveEntryCountIndex() : JSSet::Helper::aliveEntryCountIndex())));
-        // If it's not an int32, it means it's a nextTable pointer (obsolete table).
         m_out.branch(isNotInt32(aliveEntryCount), rarely(slowPath), usually(fastPath));
 
         // Fast path: iterate through entries to find next non-deleted entry
         m_out.appendTo(fastPath, loop);
-        LValue currentEntry = m_out.load32(iterator, m_heaps.JSInternalFieldObjectImpl_internalFields[entryFieldIndex]);
         LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMapIterator ? JSMap::Helper::capacityIndex() : JSSet::Helper::capacityIndex())));
         LValue dataTableStartIndex = m_out.add(m_out.constInt32(isMapIterator ? JSMap::Helper::hashTableStartIndex() : JSSet::Helper::hashTableStartIndex()), bucketCount);
         LValue entrySize = m_out.constIntPtr(isMapIterator ? JSMap::Helper::EntrySize : JSSet::Helper::EntrySize);
@@ -16734,80 +16721,69 @@ IGNORE_CLANG_WARNINGS_END
         m_out.addIncomingToPhi(entryIndex, m_out.anchor(nextEntryIndex));
         m_out.branch(m_out.equal(key, deletedValue), unsure(loop), unsure(foundEntry));
 
-        // Found a valid entry: update entry field and return false
+        // Found a valid entry: storage is unchanged, entry advances to nextEntry.
         m_out.appendTo(foundEntry, slowPath);
-        m_out.store32(nextEntry, iterator, m_heaps.JSInternalFieldObjectImpl_internalFields[entryFieldIndex]);
-        ValueFromBlock foundResult = m_out.anchor(m_out.constInt64(JSValue::encode(jsBoolean(false))));
+        ValueFromBlock foundStorageResult = m_out.anchor(storage);
+        ValueFromBlock foundEntryResult = m_out.anchor(nextEntry);
         m_out.jump(continuation);
 
-        // Slow path: call the operation (for obsolete tables)
+        // Slow path: call the operation (lazy storage init / obsolete table)
         m_out.appendTo(slowPath, continuation);
         auto operation = isMapIterator ? operationMapIteratorNext : operationSetIteratorNext;
-        ValueFromBlock slowResult = m_out.anchor(vmCall(Int64, operation, m_vmValue, iterator));
+        LValue slowTuple = vmCall(toOperationType(pointerType()), operation, m_vmValue, storage, iteratedObject, currentEntry);
+        ValueFromBlock slowStorageResult = m_out.anchor(m_out.extract(slowTuple, 0));
+        ValueFromBlock slowEntryResult = m_out.anchor(m_out.castToInt32(m_out.extract(slowTuple, 1)));
         m_out.jump(continuation);
 
         m_out.appendTo(continuation, lastNext);
-        setJSValue(m_out.phi(Int64, emptyResult, sentinelResult, foundResult, slowResult));
+        LValue newStorage = m_out.phi(pointerType(), emptyStorageResult, sentinelStorageResult, foundStorageResult, slowStorageResult);
+        LValue newEntry = m_out.phi(Int32, emptyEntryResult, sentinelEntryResult, foundEntryResult, slowEntryResult);
+        setTuple(0, newStorage);
+        setTuple(1, newEntry);
     }
 
     void compileMapIteratorKey()
     {
-        switch (m_node->child1().useKind()) {
-        case MapIteratorObjectUse: {
-            LValue iterator = lowMapIteratorObject(m_node->child1());
-            LValue entry = m_out.load32(iterator, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSMapIterator::Field::Entry)]);
-            LValue storage = m_out.loadPtr(iterator, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSMapIterator::Field::Storage)]);
-            LValue butterfly = toButterfly(storage);
-            LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(JSMap::Helper::capacityIndex())));
+        bool isMapIterator = m_node->bucketOwnerType() == BucketOwnerType::Map;
+        LValue storage = lowCell(m_node->child1());
+        LValue entry = lowInt32(m_node->child2());
 
+        LValue butterfly = toButterfly(storage);
+        LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMapIterator ? JSMap::Helper::capacityIndex() : JSSet::Helper::capacityIndex())));
+
+        LValue multiplied;
+        int32_t entrySize;
+        int32_t hashTableStartIndex;
+        if (isMapIterator) {
             static_assert(JSMap::Helper::EntrySize == 3);
-            LValue multiplied = m_out.add(entry, m_out.shl(entry, m_out.constInt32(1)));
-            LValue entryInButterfly = m_out.add(m_out.constInt32(JSMap::Helper::hashTableStartIndex() - JSMap::Helper::EntrySize), m_out.add(bucketCount, multiplied));
-            LValue key = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.zeroExtPtr(entryInButterfly)));
-            setJSValue(key);
-            break;
-        }
-        case SetIteratorObjectUse: {
-            LValue iterator = lowSetIteratorObject(m_node->child1());
-            LValue entry = m_out.load32(iterator, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSSetIterator::Field::Entry)]);
-            LValue storage = m_out.loadPtr(iterator, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSSetIterator::Field::Storage)]);
-            LValue butterfly = toButterfly(storage);
-            LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(JSSet::Helper::capacityIndex())));
-
+            entrySize = JSMap::Helper::EntrySize;
+            hashTableStartIndex = JSMap::Helper::hashTableStartIndex();
+            multiplied = m_out.add(entry, m_out.shl(entry, m_out.constInt32(1)));
+        } else {
             static_assert(JSSet::Helper::EntrySize == 2);
-            LValue multiplied = m_out.add(entry, entry);
-            LValue entryInButterfly = m_out.add(m_out.constInt32(JSSet::Helper::hashTableStartIndex() - JSSet::Helper::EntrySize), m_out.add(bucketCount, multiplied));
-            LValue key = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.zeroExtPtr(entryInButterfly)));
-            setJSValue(key);
-            break;
+            entrySize = JSSet::Helper::EntrySize;
+            hashTableStartIndex = JSSet::Helper::hashTableStartIndex();
+            multiplied = m_out.add(entry, entry);
         }
-        default:
-            DFG_CRASH(m_graph, m_node, "Bad use kind");
-            break;
-        }
+        LValue entryInButterfly = m_out.add(m_out.constInt32(hashTableStartIndex - entrySize), m_out.add(bucketCount, multiplied));
+        LValue key = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.zeroExtPtr(entryInButterfly)));
+        setJSValue(key);
     }
 
     void compileMapIteratorValue()
     {
-        switch (m_node->child1().useKind()) {
-        case MapIteratorObjectUse: {
-            LValue iterator = lowMapIteratorObject(m_node->child1());
-            LValue entry = m_out.load32(iterator, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSMapIterator::Field::Entry)]);
-            LValue storage = m_out.loadPtr(iterator, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSMapIterator::Field::Storage)]);
-            LValue butterfly = toButterfly(storage);
-            LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(JSMap::Helper::capacityIndex())));
+        ASSERT(m_node->bucketOwnerType() == BucketOwnerType::Map);
+        LValue storage = lowCell(m_node->child1());
+        LValue entry = lowInt32(m_node->child2());
 
-            static_assert(JSMap::Helper::EntrySize == 3);
-            LValue multiplied = m_out.add(entry, m_out.shl(entry, m_out.constInt32(1)));
-            LValue entryInButterfly = m_out.add(m_out.add(m_out.constInt32(JSMap::Helper::hashTableStartIndex() - JSMap::Helper::EntrySize), m_out.add(bucketCount, multiplied)), /* value offset */ m_out.constInt32(1));
-            LValue value = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.zeroExtPtr(entryInButterfly)));
-            setJSValue(value);
-            break;
-        }
-        default:
-            DFG_CRASH(m_graph, m_node, "Bad use kind");
-            break;
-        }
+        LValue butterfly = toButterfly(storage);
+        LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(JSMap::Helper::capacityIndex())));
+
+        static_assert(JSMap::Helper::EntrySize == 3);
+        LValue multiplied = m_out.add(entry, m_out.shl(entry, m_out.constInt32(1)));
+        LValue entryInButterfly = m_out.add(m_out.add(m_out.constInt32(JSMap::Helper::hashTableStartIndex() - JSMap::Helper::EntrySize), m_out.add(bucketCount, multiplied)), /* value offset */ m_out.constInt32(1));
+        LValue value = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.zeroExtPtr(entryInButterfly)));
+        setJSValue(value);
     }
 
     void compileExtractValueFromWeakMapGet()


### PR DESCRIPTION
#### 7937fd75aea7b110e74d088f4fa99dbac5e2f72c
<pre>
[JSC] Map / Set iterator next operation should not touch JSMapIterator / JSSetIterator directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=315650">https://bugs.webkit.org/show_bug.cgi?id=315650</a>
<a href="https://rdar.apple.com/178034413">rdar://178034413</a>

Reviewed by Yijia Huang.

This patch moves MapIteratorNext model from the model modifying
JSMapIterator itself to getting advanced storage and index: so this
makes the model more stateless instead of depending on the state of
JSMapIterator. This offers significant benefit.

1. Since iteration itself does not change iterator&apos;s field implicitly,
   DFG / FTL now can see full modification of iterator
   (PutInternalField), thus they can do ObjectAllocationSinking for
   for-of case for JSMapIterator / JSSetIterator.
2. DFG / FTL can control when publishing the side-effect of iteration
   (advancing the iterator) fully, which removes OSR exit related
   restrictions on for-of iteration code in DFG / FTL. They can now
   publish the irreversible change only after ensuring everything is done!

The new code leverages the newly introduced private tmp to carry the
obtained tuple entries. We do not do what JSStringIterator is doing here
since we cannot return prediction-typed result value when encountering the sentinel.
JSStringIterator can consistently produce String for value not to
pollute types and not to cause OSR exit. But in MapIterator /
SetIterator case, the expected value&apos;s speculation is coming from prediction
type, so sentinel handling is hard since we are not having arbitrary bottom value
for the prediction. It is much simpler for us to have done and load
blocks and generating the results in each block.

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
(JSC::DFG::ByteCodeParser::handleIteratorNext):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::isTuple const):
(JSC::DFG::Node::tupleSize const):
(JSC::DFG::Node::hasBucketOwnerType):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
(JSC::DFG::SpeculativeJIT::jsValueTupleResultWithoutUsingChildren):
(JSC::DFG::SpeculativeJIT::cellTupleResultWithoutUsingChildren):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compileMapIteratorNext):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileMapIteratorNext):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileMapIteratorNext):
(JSC::FTL::DFG::LowerDFGToB3::compileMapIteratorKey):
(JSC::FTL::DFG::LowerDFGToB3::compileMapIteratorValue):
* JSTests/stress/map-set-iterator-next-deferred-commit.js: Added.

Canonical link: <a href="https://commits.webkit.org/315330@main">https://commits.webkit.org/315330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/012ce7b993b78a3ae69696d27679b05aed2b0894

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177888 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126259 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2fb073e1-0f2a-47cc-93d8-25a85544f823) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131210 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92288 "2 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce7b06d4-5fd5-4ce6-af71-9eada5920c11) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111721 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca2a0e2c-5530-407f-b99d-2c3a984a27aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32656 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31359 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26583 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/161177 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142642 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180487 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29805 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139651 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42127 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139509 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42815 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27859 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106477 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25695 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34791 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114575 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201236 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41319 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5942 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54039 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40716 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40967 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40861 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->