### PR TITLE
Use PseudoClassChangeInvalidation for :empty

### DIFF
--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1777,6 +1777,7 @@ bool SelectorChecker::matchHasArgumentSelector(CheckingContext& checkingContext,
             checkingContext.styleRelations.append(relation);
             return;
         case Style::Relation::AffectedByEmpty:
+            checkingContext.styleRelations.append(relation);
             return;
         case Style::Relation::AffectedByPreviousSibling:
         case Style::Relation::AffectsNextSibling:

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -81,10 +81,17 @@ ExceptionOr<String> CharacterData::substringData(unsigned offset, unsigned count
     return m_data.substring(offset, count);
 }
 
-static ContainerNode::ChildChange NODELETE makeChildChange(CharacterData& characterData, ContainerNode::ChildChange::Source source)
+static ContainerNode::ChildChange::Type NODELETE textChildChangeType(unsigned oldLength, bool toEmpty)
+{
+    if (oldLength && !toEmpty)
+        return ContainerNode::ChildChange::Type::TextChanged;
+    return toEmpty ? ContainerNode::ChildChange::Type::TextRemoved : ContainerNode::ChildChange::Type::TextInserted;
+}
+
+static ContainerNode::ChildChange NODELETE makeChildChange(CharacterData& characterData, bool toEmpty, ContainerNode::ChildChange::Source source)
 {
     return {
-        ContainerNode::ChildChange::Type::TextChanged,
+        textChildChangeType(characterData.length(), toEmpty),
         nullptr,
         nullptr,
         ElementTraversal::previousSibling(characterData),
@@ -96,7 +103,7 @@ static ContainerNode::ChildChange NODELETE makeChildChange(CharacterData& charac
 
 void CharacterData::parserAppendData(StringView string, StringBuilder& buffer)
 {
-    auto childChange = makeChildChange(*this, ContainerNode::ChildChange::Source::Parser);
+    auto childChange = makeChildChange(*this, false, ContainerNode::ChildChange::Source::Parser);
     std::optional<Style::ChildChangeInvalidation> styleInvalidation;
     if (RefPtr parent = parentNode())
         styleInvalidation.emplace(*parent, childChange);
@@ -185,14 +192,15 @@ void CharacterData::setDataWithoutUpdate(const String& data)
 
 void CharacterData::setDataAndUpdate(const String& newData, unsigned offsetOfReplacedData, unsigned oldLength, unsigned newLength, UpdateLiveRanges shouldUpdateLiveRanges)
 {
-    auto childChange = makeChildChange(*this, ContainerNode::ChildChange::Source::API);
+    auto childChange = makeChildChange(*this, !newData.length(), ContainerNode::ChildChange::Source::API);
 
-    String oldData = WTF::move(m_data);
+    String oldData;
     {
         std::optional<Style::ChildChangeInvalidation> styleInvalidation;
         if (RefPtr parent = parentNode())
             styleInvalidation.emplace(*parent, childChange);
 
+        oldData = WTF::move(m_data);
         m_data = newData;
     }
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5893,7 +5893,6 @@ void Element::resetComputedStyle()
 
 void Element::resetStyleRelations()
 {
-    clearStyleFlags(NodeStyleFlag::StyleAffectedByEmpty);
     if (!hasRareData())
         return;
     elementRareData()->setChildIndex(0);

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -122,11 +122,6 @@ inline bool RenderStyle::isLink() const
     return m_computedStyle.isLink();
 }
 
-inline bool RenderStyle::emptyState() const
-{
-    return m_computedStyle.emptyState();
-}
-
 inline bool RenderStyle::firstChildState() const
 {
     return m_computedStyle.firstChildState();

--- a/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
@@ -102,11 +102,6 @@ inline void RenderStyle::setIsLink(bool isLink)
     m_computedStyle.setIsLink(isLink);
 }
 
-inline void RenderStyle::setEmptyState(bool emptyState)
-{
-    m_computedStyle.setEmptyState(emptyState);
-}
-
 inline void RenderStyle::setFirstChildState()
 {
     m_computedStyle.setFirstChildState();

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -103,9 +103,6 @@ public:
     inline bool isLink() const;
     inline void setIsLink(bool);
 
-    inline bool emptyState() const;
-    inline void setEmptyState(bool);
-
     inline bool firstChildState() const;
     inline void setFirstChildState();
 

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -39,19 +39,27 @@
 
 namespace WebCore::Style {
 
-static bool rightmostCompoundContainsEmpty(const CSSSelector& selector)
+static bool elementIsEmptyForCSS(const Element& element)
 {
-    for (auto* simple = &selector; simple; simple = simple->followingInCompound()) {
-        if (simple->match() == CSSSelector::Match::PseudoClass && simple->pseudoClass() == CSSSelector::PseudoClass::Empty)
-            return true;
-        if (auto* selectorList = simple->selectorList()) {
-            for (auto& inner : *selectorList) {
-                if (rightmostCompoundContainsEmpty(inner))
-                    return true;
-            }
+    for (auto* node = element.firstChild(); node; node = node->nextSibling()) {
+        if (is<Element>(*node))
+            return false;
+        if (auto* textNode = dynamicDowncast<Text>(*node)) {
+            if (!textNode->data().isEmpty())
+                return false;
         }
     }
-    return false;
+    return true;
+}
+
+bool ChildChangeInvalidation::emptyStateMayChange() const
+{
+    // CharacterData::makeChildChange uses TextChanged only when both the old and new data are non-empty,
+    // so the parent's :empty state can't flip and we can skip the traversal below.
+    if (m_childChange.type == ContainerNode::ChildChange::Type::TextChanged)
+        return false;
+    bool wasEmpty = elementIsEmptyForCSS(*m_parentElement);
+    return m_childChange.isInsertion() == wasEmpty;
 }
 
 static bool isSiblingHasRelation(const MatchElement& matchElement)
@@ -73,7 +81,7 @@ static bool isSiblingHasRelation(const MatchElement& matchElement)
     return false;
 }
 
-void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElement, MatchingHasSelectors& matchingHasSelectors, ChangedElementRelation changedElementRelation, EmptyInvalidation emptyInvalidation)
+void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElement, MatchingHasSelectors& matchingHasSelectors, ChangedElementRelation changedElementRelation)
 {
     auto& ruleSets = parentElement().styleResolver().ruleSets();
 
@@ -120,10 +128,6 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
         checkingContext.matchesAllHasScopes = true;
 
         for (auto& selector : invalidationRuleSet.invalidationSelectors) {
-            // For :empty invalidation only look for :empty selectors to avoid invalidating unnecessarily.
-            if (emptyInvalidation == EmptyInvalidation::Yes && !rightmostCompoundContainsEmpty(selector))
-                continue;
-
             if (hasAlreadyMatchedAndMutationIsIrrelevant(invalidationRuleSet)) {
                 // FIXME: We could cache this state across invalidations instead of just testing a single sibling.
                 RefPtr sibling = m_childChange.previousSiblingElement ? m_childChange.previousSiblingElement : m_childChange.nextSiblingElement;
@@ -209,15 +213,6 @@ void ChildChangeInvalidation::invalidateForHasBeforeMutation()
         invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
     });
 
-    auto emptyStateWillChange = [&] {
-        bool isEmpty = !parentElement().hasChildNodes();
-        return m_childChange.isInsertion() == isEmpty;
-    };
-
-    // :empty is special because insertions and removals can affect the matching state of the parent element.
-    if (emptyStateWillChange())
-        invalidateForChangedElement(parentElement(), matchingHasSelectors, ChangedElementRelation::SelfOrDescendant, EmptyInvalidation::Yes);
-
     invalidateForHasSiblings(matchingHasSelectors, MutationPhase::Before);
 }
 
@@ -230,15 +225,6 @@ void ChildChangeInvalidation::invalidateForHasAfterMutation()
     traverseAddedElements([&](auto& changedElement) {
         invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
     });
-
-    auto emptyStateDidChange = [&] {
-        bool isEmpty = !parentElement().hasChildNodes();
-        return m_childChange.isInsertion() != isEmpty;
-    };
-
-    // :empty is special because insertions and removals can affect the matching state of the parent element.
-    if (emptyStateDidChange())
-        invalidateForChangedElement(parentElement(), matchingHasSelectors, ChangedElementRelation::SelfOrDescendant, EmptyInvalidation::Yes);
 
     invalidateForHasSiblings(matchingHasSelectors, MutationPhase::After);
 }
@@ -300,16 +286,6 @@ void ChildChangeInvalidation::traverseAddedElements(Function&& function)
     }
 }
 
-static void checkForEmptyStyleChange(Element& element)
-{
-    if (!element.styleAffectedByEmpty())
-        return;
-
-    auto* style = element.renderStyle();
-    if (!style || (!style->emptyState() || element.hasChildNodes()))
-        element.invalidateStyleForSubtree();
-}
-
 static void invalidateForForwardPositionalRules(Element& parent, Element* elementAfterChange)
 {
     bool childrenAffected = parent.childrenAffectedByForwardPositionalRules();
@@ -362,8 +338,6 @@ static void invalidateForLastChildState(Element& child, bool state)
 
 void ChildChangeInvalidation::invalidateAfterChange()
 {
-    checkForEmptyStyleChange(parentElement());
-
     if (m_childChange.source == ContainerNode::ChildChange::Source::Parser)
         return;
 
@@ -374,8 +348,6 @@ void ChildChangeInvalidation::invalidateAfterFinishedParsingChildren(Element& pa
 {
     if (!parent.needsStyleInvalidation())
         return;
-
-    checkForEmptyStyleChange(parent);
 
     RefPtr lastChildElement = ElementTraversal::lastChild(parent);
     if (!lastChildElement)

--- a/Source/WebCore/style/ChildChangeInvalidation.h
+++ b/Source/WebCore/style/ChildChangeInvalidation.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Element.h"
+#include "PseudoClassChangeInvalidation.h"
 #include "StyleInvalidator.h"
 #include "StyleScope.h"
 #include <wtf/HashSet.h>
@@ -47,10 +48,11 @@ private:
     void checkForSiblingStyleChanges();
     using MatchingHasSelectors = HashSet<const CSSSelector*>;
     enum class ChangedElementRelation : uint8_t { SelfOrDescendant, Sibling };
-    enum class EmptyInvalidation : bool { No, Yes };
     enum class MutationPhase : bool { Before, After };
-    void invalidateForChangedElement(Element&, MatchingHasSelectors&, ChangedElementRelation, EmptyInvalidation = EmptyInvalidation::No);
+    void invalidateForChangedElement(Element&, MatchingHasSelectors&, ChangedElementRelation);
     void invalidateForHasSiblings(MatchingHasSelectors&, MutationPhase);
+
+    bool emptyStateMayChange() const;
 
     template<typename Function> void traverseRemovedElements(Function&&);
     template<typename Function> void traverseAddedElements(Function&&);
@@ -62,6 +64,8 @@ private:
 
     const bool m_isEnabled;
     const bool m_needsHasInvalidation;
+
+    std::optional<PseudoClassChangeInvalidation> m_emptyInvalidation;
 };
 
 inline ChildChangeInvalidation::ChildChangeInvalidation(ContainerNode& container, const ContainerNode::ChildChange& childChange)
@@ -72,6 +76,9 @@ inline ChildChangeInvalidation::ChildChangeInvalidation(ContainerNode& container
 {
     if (!m_isEnabled)
         return;
+
+    if (m_parentElement->styleAffectedByEmpty() && emptyStateMayChange())
+        m_emptyInvalidation.emplace(*m_parentElement, CSSSelector::PseudoClass::Empty, PseudoClassChangeInvalidation::AnyValue);
 
     if (m_needsHasInvalidation)
         invalidateForHasBeforeMutation();

--- a/Source/WebCore/style/StyleRelations.cpp
+++ b/Source/WebCore/style/StyleRelations.cpp
@@ -53,7 +53,6 @@ std::unique_ptr<Relations> commitRelationsToRenderStyle(RenderStyle& style, cons
         }
         switch (relation.type) {
         case Relation::AffectedByEmpty:
-            style.setEmptyState(relation.value);
             appendStyleRelation(relation);
             break;
         case Relation::FirstChild:
@@ -148,8 +147,6 @@ void commitRelations(std::unique_ptr<Relations> relations, Update& update)
 
 void copyRelations(RenderStyle& to, const RenderStyle& from)
 {
-    if (from.emptyState())
-        to.setEmptyState(true);
     if (from.firstChildState())
         to.setFirstChildState();
     if (from.lastChildState())

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -66,7 +66,6 @@ struct SameSizeAsComputedStyle : CanMakeCheckedPtr<SameSizeAsComputedStyle> {
         bool useTreeCountingFunctions : 1;
         bool hasExplicitlyInheritedProperties : 1;
         bool disallowsFastPathInheritance : 1;
-        bool emptyState : 1;
         bool firstChildState : 1;
         bool lastChildState : 1;
         bool isLink : 1;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
@@ -81,7 +81,6 @@ inline ComputedStyleBase::ComputedStyleBase(CreateDefaultStyleTag)
     m_nonInheritedFlags.useTreeCountingFunctions = false;
     m_nonInheritedFlags.hasExplicitlyInheritedProperties = false;
     m_nonInheritedFlags.disallowsFastPathInheritance = false;
-    m_nonInheritedFlags.emptyState = false;
     m_nonInheritedFlags.firstChildState = false;
     m_nonInheritedFlags.lastChildState = false;
     m_nonInheritedFlags.isLink = false;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -124,11 +124,6 @@ inline bool ComputedStyleBase::isLink() const
     return m_nonInheritedFlags.isLink;
 }
 
-inline bool ComputedStyleBase::emptyState() const
-{
-    return m_nonInheritedFlags.emptyState;
-}
-
 inline bool ComputedStyleBase::firstChildState() const
 {
     return m_nonInheritedFlags.firstChildState;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -83,11 +83,6 @@ inline void ComputedStyleBase::setIsLink(bool isLink)
     m_nonInheritedFlags.isLink = isLink;
 }
 
-inline void ComputedStyleBase::setEmptyState(bool emptyState)
-{
-    m_nonInheritedFlags.emptyState = emptyState;
-}
-
 inline void ComputedStyleBase::setFirstChildState()
 {
     m_nonInheritedFlags.firstChildState = true;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -446,7 +446,6 @@ void ComputedStyleBase::NonInheritedFlags::dumpDifferences(TextStream& ts, const
     LOG_IF_DIFFERENT(hasExplicitlyInheritedProperties);
     LOG_IF_DIFFERENT(disallowsFastPathInheritance);
 
-    LOG_IF_DIFFERENT(emptyState);
     LOG_IF_DIFFERENT(firstChildState);
     LOG_IF_DIFFERENT(lastChildState);
     LOG_IF_DIFFERENT(isLink);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -477,9 +477,6 @@ public:
     inline bool isLink() const;
     inline void setIsLink(bool);
 
-    inline bool emptyState() const;
-    inline void setEmptyState(bool);
-
     inline bool firstChildState() const;
     inline void setFirstChildState();
 
@@ -755,7 +752,6 @@ public:
         PREFERRED_TYPE(bool) unsigned disallowsFastPathInheritance : 1;
 
         // Non-property related state bits.
-        PREFERRED_TYPE(bool) unsigned emptyState : 1;
         PREFERRED_TYPE(bool) unsigned firstChildState : 1;
         PREFERRED_TYPE(bool) unsigned lastChildState : 1;
         PREFERRED_TYPE(bool) unsigned isLink : 1;


### PR DESCRIPTION
#### d7d8d592181885f0e2bf9835a1170474183805e2
<pre>
Use PseudoClassChangeInvalidation for :empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=315655">https://bugs.webkit.org/show_bug.cgi?id=315655</a>
<a href="https://rdar.apple.com/178042916">rdar://178042916</a>

Reviewed by Alan Baradlay.

Route :empty invalidation through the fine-grained PseudoClassChangeInvalidation
machinery instead of the coarse parent.invalidateStyleForSubtree path in
checkForEmptyStyleChange. ChildChangeInvalidation now constructs a
PseudoClassChangeInvalidation for :empty when the parent has the
styleAffectedByEmpty bit set and a fast pre-check decides the upcoming mutation
can flip the parent&apos;s :empty state.

The :has(:empty) case used to need a separate path because the per-element
styleAffectedByEmpty bit wasn&apos;t set on descendants matched only inside :has().
Forwarding Style::Relation::AffectedByEmpty out of the local hasCheckingContext
in matchHasArgumentSelector fixes that, and the bit is no longer cleared in
resetStyleRelations so it stays set across style recalcs. The :has() :empty
special case is gone.

The dead RenderStyle::emptyState bit (only read by the removed
checkForEmptyStyleChange) is removed.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchHasArgumentSelector const):

Forward AffectedByEmpty so the bit gets set on :has(:empty) descendants.

* Source/WebCore/dom/CharacterData.cpp:
(WebCore::makeChildChange):
(WebCore::CharacterData::parserAppendData):
(WebCore::CharacterData::setDataAndUpdate):

Pick a precise ChildChange::Type for text data updates: TextChanged only
when both old and new data are non-empty, TextRemoved when the new data is
empty, TextInserted otherwise. Lets emptyStateMayChange skip the children
traversal for TextChanged.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resetStyleRelations):

Stop clearing NodeStyleFlag::StyleAffectedByEmpty. The bit is a hint to fire
m_emptyInvalidation; over-set is correctness-safe.

* Source/WebCore/style/ChildChangeInvalidation.h:
(WebCore::Style::ChildChangeInvalidation::ChildChangeInvalidation):

* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::elementIsEmptyForCSS):
(WebCore::Style::ChildChangeInvalidation::emptyStateMayChange const):
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):
(WebCore::Style::ChildChangeInvalidation::invalidateForHasBeforeMutation):
(WebCore::Style::ChildChangeInvalidation::invalidateForHasAfterMutation):
(WebCore::Style::ChildChangeInvalidation::invalidateAfterChange):
(WebCore::Style::ChildChangeInvalidation::invalidateAfterFinishedParsingChildren):
(WebCore::Style::rightmostCompoundContainsEmpty): Deleted.
(WebCore::Style::checkForEmptyStyleChange): Deleted.

Add m_emptyInvalidation. Drop checkForEmptyStyleChange, the :has() :empty
special case in invalidateForHas{Before,After}Mutation, the EmptyInvalidation
enum and parameter, and the rightmostCompoundContainsEmpty helper.

* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
(WebCore::RenderStyle::emptyState const): Deleted.

* Source/WebCore/rendering/style/RenderStyle+SettersInlines.h:
(WebCore::RenderStyle::setEmptyState): Deleted.

* Source/WebCore/rendering/style/RenderStyle.h:

* Source/WebCore/style/StyleRelations.cpp:
(WebCore::Style::commitRelationsToRenderStyle):
(WebCore::Style::copyRelations):

* Source/WebCore/style/computed/StyleComputedStyle.cpp:

* Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h:
(WebCore::Style::ComputedStyleBase::ComputedStyleBase):

* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
(WebCore::Style::ComputedStyleBase::emptyState const): Deleted.

* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
(WebCore::Style::ComputedStyleBase::setEmptyState): Deleted.

* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
(WebCore::Style::ComputedStyleBase::NonInheritedFlags::dumpDifferences const):

* Source/WebCore/style/computed/StyleComputedStyleBase.h:

Remove RenderStyle::emptyState/setEmptyState and the underlying
m_nonInheritedFlags.emptyState bit.

Canonical link: <a href="https://commits.webkit.org/314037@main">https://commits.webkit.org/314037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e0f98ba7787c41f6a693abfd5439349be95ef35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173762 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121979 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05820d39-2d23-4c30-bf07-2371f7179559) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128018 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b89fddb-674a-47f1-b505-18bd6a863f60) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108564 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f05daf6a-e617-47b5-8646-112ade44151d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29366 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27987 "Found 10 new API test failures: TestWebKitAPI.ResourceLoadStatistics.DataTaskIdentifierCollision, TestWebKitAPI.PrivateClickMeasurement.Basic, TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToDevToolsBackground, TestWebKitAPI.PrivateClickMeasurement.EphemeralWithAttributedBundleIdentifier, TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground, TestWebKitAPI.PrivateClickMeasurement.DestinationClickFraudPrevention, TestWebKitAPI.WKWebExtension.ContentScriptImport, TestWebKitAPI.ProcessSwap.SessionStorage, TestWebKitAPI.PrivateClickMeasurement.ManualAttributionAndConversion, TestWebKitAPI.WKWebExtensionAPIDevTools.NetworkNavigatedEvent (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21521 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176285 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29109 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136336 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136300 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36766 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147565 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101170 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31570 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24421 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110523 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36876 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2486 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37124 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37024 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->