### PR TITLE
FileSystemHandle: replace RemoveGlobalIdentifierReference with RemoveGlobalIdentifierReferences

### DIFF
--- a/Source/WebCore/Modules/filesystem/FileSystemHandle.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemHandle.cpp
@@ -60,7 +60,7 @@ void FileSystemHandle::close()
     m_isClosed = true;
     if (m_isUnresolved) {
         if (RefPtr connection = m_connection)
-            connection->removeGlobalIdentifierReference(ClientOrigin { m_origin }, m_globalIdentifier);
+            connection->removeGlobalIdentifierReferences(ClientOrigin { m_origin }, { m_globalIdentifier });
         m_isUnresolved = false;
         resolveEnsureIdentifierCallbacks(false);
         return;
@@ -90,7 +90,7 @@ void FileSystemHandle::ensureIdentifier(CompletionHandler<void(bool)>&& callback
     RefPtr context = scriptExecutionContext();
     if (!context) {
         if (RefPtr connection = m_connection)
-            connection->removeGlobalIdentifierReference(ClientOrigin { m_origin }, m_globalIdentifier);
+            connection->removeGlobalIdentifierReferences(ClientOrigin { m_origin }, { m_globalIdentifier });
         m_isUnresolved = false;
         resolveEnsureIdentifierCallbacks(false);
         return;
@@ -108,7 +108,7 @@ void FileSystemHandle::ensureIdentifier(CompletionHandler<void(bool)>&& callback
         if (result.hasException()) {
             m_isClosed = true;
             if (RefPtr connection = m_connection)
-                connection->removeGlobalIdentifierReference(ClientOrigin { m_origin }, m_globalIdentifier);
+                connection->removeGlobalIdentifierReferences(ClientOrigin { m_origin }, { m_globalIdentifier });
             m_isUnresolved = false;
             resolveEnsureIdentifierCallbacks(false);
             return;
@@ -116,7 +116,7 @@ void FileSystemHandle::ensureIdentifier(CompletionHandler<void(bool)>&& callback
 
         m_identifier = result.returnValue();
         m_isUnresolved = false;
-        protect(m_connection)->removeGlobalIdentifierReference(ClientOrigin { m_origin }, m_globalIdentifier);
+        protect(m_connection)->removeGlobalIdentifierReferences(ClientOrigin { m_origin }, { m_globalIdentifier });
         resolveEnsureIdentifierCallbacks(true);
     });
 }

--- a/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.cpp
@@ -67,14 +67,14 @@ FileSystemHandleKeepAlive::FileSystemHandleKeepAlive(ClientOrigin&& origin, File
 FileSystemHandleKeepAlive::~FileSystemHandleKeepAlive()
 {
     if (RefPtr connection = m_connection; connection && m_globalIdentifier)
-        connection->removeGlobalIdentifierReference(ClientOrigin { m_origin }, *m_globalIdentifier);
+        connection->removeGlobalIdentifierReferences(ClientOrigin { m_origin }, { *m_globalIdentifier });
 }
 
 FileSystemHandleKeepAlive& FileSystemHandleKeepAlive::operator=(FileSystemHandleKeepAlive&& other)
 {
     if (this != &other) {
         if (RefPtr connection = m_connection; connection && m_globalIdentifier)
-            connection->removeGlobalIdentifierReference(ClientOrigin { m_origin }, *m_globalIdentifier);
+            connection->removeGlobalIdentifierReferences(ClientOrigin { m_origin }, { *m_globalIdentifier });
         m_globalIdentifier = std::exchange(other.m_globalIdentifier, Markable<FileSystemHandleGlobalIdentifier> { });
         m_origin = WTF::move(other.m_origin);
         m_connection = WTF::move(other.m_connection);

--- a/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.h
@@ -93,7 +93,7 @@ public:
     virtual void getHandleNames(FileSystemHandleIdentifier, GetHandleNamesCallback&&) = 0;
     virtual void getHandle(FileSystemHandleIdentifier, const String& name, GetHandleCallback&&) = 0;
     virtual void addGlobalIdentifierReference(ClientOrigin&&, FileSystemHandleGlobalIdentifier) = 0;
-    virtual void removeGlobalIdentifierReference(ClientOrigin&&, FileSystemHandleGlobalIdentifier) = 0;
+    virtual void removeGlobalIdentifierReferences(ClientOrigin&&, Vector<FileSystemHandleGlobalIdentifier>&&) = 0;
     virtual void resolveGlobalIdentifier(ClientOrigin&&, FileSystemHandleGlobalIdentifier, ResolveGlobalIdentifierCallback&&) = 0;
 
     WEBCORE_EXPORT bool errorFileSystemWritable(FileSystemWritableFileStreamIdentifier);

--- a/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.cpp
@@ -509,10 +509,10 @@ void WorkerFileSystemStorageConnection::addGlobalIdentifierReference(ClientOrigi
     });
 }
 
-void WorkerFileSystemStorageConnection::removeGlobalIdentifierReference(ClientOrigin&& origin, FileSystemHandleGlobalIdentifier globalIdentifier)
+void WorkerFileSystemStorageConnection::removeGlobalIdentifierReferences(ClientOrigin&& origin, Vector<FileSystemHandleGlobalIdentifier>&& globalIdentifiers)
 {
-    callOnMainThread([mainThreadConnection = m_mainThreadConnection, origin = crossThreadCopy(WTF::move(origin)), globalIdentifier] mutable {
-        mainThreadConnection->removeGlobalIdentifierReference(WTF::move(origin), globalIdentifier);
+    callOnMainThread([mainThreadConnection = m_mainThreadConnection, origin = crossThreadCopy(WTF::move(origin)), globalIdentifiers = WTF::move(globalIdentifiers)] mutable {
+        mainThreadConnection->removeGlobalIdentifierReferences(WTF::move(origin), WTF::move(globalIdentifiers));
     });
 }
 

--- a/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.h
@@ -74,7 +74,7 @@ private:
     void getHandleNames(FileSystemHandleIdentifier, GetHandleNamesCallback&&) final;
     void getHandle(FileSystemHandleIdentifier, const String& name, GetHandleCallback&&) final;
     void addGlobalIdentifierReference(ClientOrigin&&, FileSystemHandleGlobalIdentifier) final;
-    void removeGlobalIdentifierReference(ClientOrigin&&, FileSystemHandleGlobalIdentifier) final;
+    void removeGlobalIdentifierReferences(ClientOrigin&&, Vector<FileSystemHandleGlobalIdentifier>&&) final;
     void resolveGlobalIdentifier(ClientOrigin&&, FileSystemHandleGlobalIdentifier, ResolveGlobalIdentifierCallback&&) final;
     void getFile(FileSystemHandleIdentifier, StringCallback&&) final;
     void createSyncAccessHandle(FileSystemHandleIdentifier, FileSystemStorageConnection::GetAccessHandleCallback&&) final;

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
@@ -280,6 +280,14 @@ void FileSystemStorageManager::removeGlobalIdentifierReference(WebCore::FileSyst
         m_globalIdentifierRegistry.remove(it);
 }
 
+void FileSystemStorageManager::removeGlobalIdentifierReferences(std::span<const WebCore::FileSystemHandleGlobalIdentifier> identifiers)
+{
+    ASSERT(!RunLoop::isMain());
+
+    for (auto& identifier : identifiers)
+        removeGlobalIdentifierReference(identifier);
+}
+
 Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> FileSystemStorageManager::resolveGlobalIdentifier(IPC::Connection::UniqueID connection, WebCore::FileSystemHandleGlobalIdentifier globalIdentifier)
 {
     ASSERT(!RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
@@ -63,7 +63,7 @@ public:
     };
 
     void addGlobalIdentifierReference(WebCore::FileSystemHandleGlobalIdentifier);
-    void removeGlobalIdentifierReference(WebCore::FileSystemHandleGlobalIdentifier);
+    void removeGlobalIdentifierReferences(std::span<const WebCore::FileSystemHandleGlobalIdentifier>);
     Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> resolveGlobalIdentifier(IPC::Connection::UniqueID, WebCore::FileSystemHandleGlobalIdentifier);
 
     enum class LockType : bool { Exclusive, Shared };
@@ -76,6 +76,7 @@ private:
     FileSystemStorageManager(String&& path, FileSystemStorageHandleRegistry&, QuotaCheckFunction&&);
 
     void close();
+    void removeGlobalIdentifierReference(WebCore::FileSystemHandleGlobalIdentifier);
 
     using Lock = FileSystemStorageManagerLock;
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1267,13 +1267,13 @@ void NetworkStorageManager::addGlobalIdentifierReference(IPC::Connection& connec
     fileSystemStorageManager->addGlobalIdentifierReference(globalIdentifier);
 }
 
-void NetworkStorageManager::removeGlobalIdentifierReference(IPC::Connection& connection, WebCore::ClientOrigin&& origin, WebCore::FileSystemHandleGlobalIdentifier globalIdentifier)
+void NetworkStorageManager::removeGlobalIdentifierReferences(IPC::Connection& connection, WebCore::ClientOrigin&& origin, Vector<WebCore::FileSystemHandleGlobalIdentifier>&& globalIdentifiers)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection);
 
     Ref fileSystemStorageManager = originStorageManager(origin)->fileSystemStorageManager(*protect(m_fileSystemStorageHandleRegistry));
-    fileSystemStorageManager->removeGlobalIdentifierReference(globalIdentifier);
+    fileSystemStorageManager->removeGlobalIdentifierReferences(globalIdentifiers.span());
 }
 
 void NetworkStorageManager::resolveGlobalIdentifier(IPC::Connection& connection, WebCore::ClientOrigin&& origin, WebCore::FileSystemHandleGlobalIdentifier globalIdentifier, CompletionHandler<void(Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError>)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -217,7 +217,7 @@ private:
     void getHandleNames(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&&);
     void getHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, CompletionHandler<void(Expected<std::optional<WebCore::FileSystemHandleInfo>, FileSystemStorageError>)>&&);
     void addGlobalIdentifierReference(IPC::Connection&, WebCore::ClientOrigin&&, WebCore::FileSystemHandleGlobalIdentifier);
-    void removeGlobalIdentifierReference(IPC::Connection&, WebCore::ClientOrigin&&, WebCore::FileSystemHandleGlobalIdentifier);
+    void removeGlobalIdentifierReferences(IPC::Connection&, WebCore::ClientOrigin&&, Vector<WebCore::FileSystemHandleGlobalIdentifier>&&);
     void resolveGlobalIdentifier(IPC::Connection&, WebCore::ClientOrigin&&, WebCore::FileSystemHandleGlobalIdentifier, CompletionHandler<void(Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError>)>&&);
 
     // Message handlers for WebStorage.

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -51,7 +51,7 @@
     [EnabledBy=FileSystemEnabled] GetHandleNames(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<Vector<String>, WebKit::FileSystemStorageError> result)
     [EnabledBy=FileSystemEnabled] GetHandle(WebCore::FileSystemHandleIdentifier identifier, String name) -> (Expected<std::optional<WebCore::FileSystemHandleInfo>, WebKit::FileSystemStorageError> result)
     [EnabledBy=FileSystemHandleSerializationEnabled && FileSystemEnabled] AddGlobalIdentifierReference(struct WebCore::ClientOrigin origin, WebCore::FileSystemHandleGlobalIdentifier globalIdentifier)
-    [EnabledBy=FileSystemHandleSerializationEnabled && FileSystemEnabled] RemoveGlobalIdentifierReference(struct WebCore::ClientOrigin origin, WebCore::FileSystemHandleGlobalIdentifier globalIdentifier)
+    [EnabledBy=FileSystemHandleSerializationEnabled && FileSystemEnabled] RemoveGlobalIdentifierReferences(struct WebCore::ClientOrigin origin, Vector<WebCore::FileSystemHandleGlobalIdentifier> globalIdentifiers)
     [EnabledBy=FileSystemHandleSerializationEnabled && FileSystemEnabled] ResolveGlobalIdentifier(struct WebCore::ClientOrigin origin, WebCore::FileSystemHandleGlobalIdentifier globalIdentifier) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result)
 
     [EnabledBy=LocalStorageEnabled || SessionStorageEnabled] ConnectToStorageArea(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (std::optional<WebKit::StorageAreaIdentifier> identifier, HashMap<String, String> items, uint64_t messageIdentifier)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
@@ -221,10 +221,10 @@ void WebFileSystemStorageConnection::addGlobalIdentifierReference(WebCore::Clien
         connection->send(Messages::NetworkStorageManager::AddGlobalIdentifierReference(origin, globalIdentifier), 0);
 }
 
-void WebFileSystemStorageConnection::removeGlobalIdentifierReference(WebCore::ClientOrigin&& origin, WebCore::FileSystemHandleGlobalIdentifier globalIdentifier)
+void WebFileSystemStorageConnection::removeGlobalIdentifierReferences(WebCore::ClientOrigin&& origin, Vector<WebCore::FileSystemHandleGlobalIdentifier>&& globalIdentifiers)
 {
     if (RefPtr connection = m_connection)
-        connection->send(Messages::NetworkStorageManager::RemoveGlobalIdentifierReference(origin, globalIdentifier), 0);
+        connection->send(Messages::NetworkStorageManager::RemoveGlobalIdentifierReferences(WTF::move(origin), WTF::move(globalIdentifiers)), 0);
 }
 
 void WebFileSystemStorageConnection::resolveGlobalIdentifier(WebCore::ClientOrigin&& origin, WebCore::FileSystemHandleGlobalIdentifier globalIdentifier, ResolveGlobalIdentifierCallback&& completionHandler)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
@@ -69,7 +69,7 @@ private:
     void getHandleNames(WebCore::FileSystemHandleIdentifier, FileSystemStorageConnection::GetHandleNamesCallback&&) final;
     void getHandle(WebCore::FileSystemHandleIdentifier, const String& name, FileSystemStorageConnection::GetHandleCallback&&) final;
     void addGlobalIdentifierReference(WebCore::ClientOrigin&&, WebCore::FileSystemHandleGlobalIdentifier) final;
-    void removeGlobalIdentifierReference(WebCore::ClientOrigin&&, WebCore::FileSystemHandleGlobalIdentifier) final;
+    void removeGlobalIdentifierReferences(WebCore::ClientOrigin&&, Vector<WebCore::FileSystemHandleGlobalIdentifier>&&) final;
     void resolveGlobalIdentifier(WebCore::ClientOrigin&&, WebCore::FileSystemHandleGlobalIdentifier, ResolveGlobalIdentifierCallback&&) final;
     void getFile(WebCore::FileSystemHandleIdentifier, StringCallback&&) final;
 


### PR DESCRIPTION
#### 0d21a3218836e2085347dad75d2fb0e7aa0dea60
<pre>
FileSystemHandle: replace RemoveGlobalIdentifierReference with RemoveGlobalIdentifierReferences
<a href="https://bugs.webkit.org/show_bug.cgi?id=315658">https://bugs.webkit.org/show_bug.cgi?id=315658</a>

Reviewed by Sihui Liu.

In preparation for bug 313320 where we want to remove multiple at once.

Canonical link: <a href="https://commits.webkit.org/313979@main">https://commits.webkit.org/313979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/233e02890fe8d879d45db484287c3dbfdda82691

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173748 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121965 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/714a43ed-4420-4b80-be22-5780eda4b644) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128004 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18e60ccb-ca5f-430d-8635-64bf0dd9957a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108549 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00269a52-81c0-4bc0-9906-21e8ad2cd277) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27977 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21506 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139260 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176271 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29095 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136323 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136285 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147548 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101151 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25072 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31556 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24404 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37464 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110509 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36862 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2469 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37110 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37010 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->