### PR TITLE
[JSC] __proto__ access on the global object throws TypeError

### DIFF
--- a/JSTests/stress/global-this-proto-getter.js
+++ b/JSTests/stress/global-this-proto-getter.js
@@ -1,0 +1,30 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test() {
+    return __proto__;
+}
+
+noInline(test);
+
+shouldBe(__proto__, globalThis.__proto__);
+
+var result = test();
+shouldBe(result, globalThis.__proto__);
+
+// Make sure __proto__ is consistently the same value, and that it doesn't change after JIT compilation.
+for (var i = 0; i < 2e6; ++i) {
+    result = test();
+    shouldBe(result, globalThis.__proto__);
+}
+
+// We also test with ES modules.
+import('./global-this-proto-getter.mjs')
+    .then(() => {
+        // pass
+    })
+    .catch((error) => {
+        throw error;
+    });

--- a/JSTests/stress/global-this-proto-getter.mjs
+++ b/JSTests/stress/global-this-proto-getter.mjs
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test() {
+    return __proto__;
+}
+
+noInline(test);
+
+shouldBe(this, undefined);
+shouldBe(__proto__, globalThis.__proto__);
+
+var result = test();
+shouldBe(result, globalThis.__proto__);
+
+// Make sure __proto__ is consistently the same value, and that it doesn't change after JIT compilation.
+for (var i = 0; i < 2e6; ++i) {
+    result = test();
+    shouldBe(result, globalThis.__proto__);
+}

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -725,7 +725,13 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncMakeTypeError, (JSGlobalObject* globalObject,
 
 JSC_DEFINE_HOST_FUNCTION(globalFuncProtoGetter, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    JSValue thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
+    JSValue thisValue = callFrame->thisValue();
+
+    if (thisValue.isObject() && asObject(thisValue)->inherits<JSScope>())
+        thisValue = globalObject->globalThis();
+    else
+        thisValue = thisValue.toThis(globalObject, ECMAMode::strict());
+
     return JSValue::encode(thisValue.getPrototype(globalObject));
 }
 


### PR DESCRIPTION
#### ec7d4139c4e11b1fdd098f696a1eece092dd5999
<pre>
[JSC] __proto__ access on the global object throws TypeError
<a href="https://bugs.webkit.org/show_bug.cgi?id=299441">https://bugs.webkit.org/show_bug.cgi?id=299441</a>

Reviewed by NOBODY (OOPS!).

Object.prototype.__proto__ getter may be reached through global identifier
resolution with a JSGlobalObject/JSScope receiver. Host function this
conversion currently maps JSScope to undefined in strict mode, which causes
getPrototype() to throw. This patch normalizes JSScope receivers to the
JSGlobalObject&apos;s globalThis before querying the prototype.

Test: JSTests/stress/global-this-proto-getter.js

* JSTests/stress/global-this-proto-getter.js: Added.
(shouldBe):
(test):
(import.string_appeared_here.then):
(catch):
* JSTests/stress/global-this-proto-getter.mjs: Added.
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec7d4139c4e11b1fdd098f696a1eece092dd5999

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121966 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38200 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128005 "Found 2 new test failures: js/object-literal-shorthand-construction.html js/sloppy-getter-setter-global-object.html (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90110 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167673 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30304 "Found 2 new test failures: js/object-literal-shorthand-construction.html js/sloppy-getter-setter-global-object.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29350 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27976 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21507 "Built successfully") | 
| [❌ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156865 "Found 15 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout, jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout-ftl-no-cjit, jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout-no-ftl, jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout-no-llint, jsc-layout-tests.yaml/js/script-tests/sloppy-getter-setter-global-object.js.layout, jsc-layout-tests.yaml/js/script-tests/sloppy-getter-setter-global-object.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/sloppy-getter-setter-global-object.js.layout-ftl-eager-no-cjit ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139254 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176272 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25606 "Found 15 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout, jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout-ftl-no-cjit, jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout-no-ftl, jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout-no-llint, jsc-layout-tests.yaml/js/script-tests/sloppy-getter-setter-global-object.js.layout, jsc-layout-tests.yaml/js/script-tests/sloppy-getter-setter-global-object.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/sloppy-getter-setter-global-object.js.layout-ftl-eager-no-cjit ... (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29096 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27431 "Found 2 new test failures: js/object-literal-shorthand-construction.html js/sloppy-getter-setter-global-object.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136322 "Found 2 new test failures: js/object-literal-shorthand-construction.html js/sloppy-getter-setter-global-object.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38267 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32100 "Found 2 new test failures: js/object-literal-shorthand-construction.html js/sloppy-getter-setter-global-object.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136284 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147557 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101152 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31555 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24413 "Found 2 new test failures: js/object-literal-shorthand-construction.html js/sloppy-getter-setter-global-object.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197117 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37465 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110510 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51784 "Found 3 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/object-literal-shorthand-construction.js.layout, jsc-layout-tests.yaml/js/script-tests/sloppy-getter-setter-global-object.js.layout, stress/object-prototype-proto-accessors-should-throw-on-undefined-this.js.misc-ftl-no-cjit (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36863 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2478 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->