### PR TITLE
Adopt :heading in html.css

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -170,51 +170,44 @@ audio:not([controls]) {
 
 /* heading elements */
 
-h1 {
+:heading {
     display: block;
+    font-weight: bold;
+}
+
+:heading(1) {
     font-size: 2em;
     margin-block: 0.67__qem 0.67em;
     margin-inline: 0;
-    font-weight: bold;
 }
 
-h2 {
-    display: block;
+:heading(2) {
     font-size: 1.5em;
     margin-block: 0.83__qem 0.83em;
     margin-inline: 0;
-    font-weight: bold;
 }
 
-h3 {
-    display: block;
+:heading(3) {
     font-size: 1.17em;
     margin-block: 1__qem 1em;
     margin-inline: 0;
-    font-weight: bold;
 }
 
-h4 {
-    display: block;
+:heading(4) {
     margin-block: 1.33__qem 1.33em;
     margin-inline: 0;
-    font-weight: bold;
 }
 
-h5 {
-    display: block;
+:heading(5) {
     font-size: .83em;
     margin-block: 1.67__qem 1.67em;
     margin-inline: 0;
-    font-weight: bold;
 }
 
-h6 {
-    display: block;
+:heading(6, 7, 8, 9) {
     font-size: .67em;
     margin-block: 2.33__qem 2.33em;
     margin-inline: 0;
-    font-weight: bold;
 }
 
 /* tables */


### PR DESCRIPTION
#### 7fd188fd94ad083e66b663b41222e74b96deb121
<pre>
Adopt :heading in html.css
<a href="https://bugs.webkit.org/show_bug.cgi?id=315659">https://bugs.webkit.org/show_bug.cgi?id=315659</a>

Reviewed by Tim Nguyen.

This is a requirement for bug 295092, but best landed separately for
blame purposes.

Coupled with 314339@main and 314340@main this tested as neutral on
Speedometer.

Canonical link: <a href="https://commits.webkit.org/314357@main">https://commits.webkit.org/314357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2729f864506e8bb64108f96311391575d1fad4e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174933 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123145 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/736471e5-362f-44b8-8440-eb566e460027) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128929 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21f8da00-d3f6-4868-8151-b7f694dfca82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109456 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1331da4d-4575-4df2-8037-c24a3d5fdba5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28955 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23077 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177467 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30372 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137269 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137196 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148538 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102701 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25252 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32480 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25405 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38648 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111721 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38044 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3487 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38290 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38188 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->