### PR TITLE
Make legacy DOM setPrefix() APIs no-op and remove Attr::setPrefix()

### DIFF
--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -38,7 +38,6 @@
 #include "TextNodeTraversal.h"
 #include "TreeScopeInlines.h"
 #include "TrustedType.h"
-#include "XMLNSNames.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>
 
@@ -79,24 +78,6 @@ Attr::~Attr()
 
     // Unable to protect the document here as it may have started destruction.
     willBeDeletedFrom(document());
-}
-
-ExceptionOr<void> Attr::setPrefix(const AtomString& prefix)
-{
-    auto result = checkSetPrefix(prefix);
-    if (result.hasException())
-        return result.releaseException();
-
-    if ((prefix == xmlnsAtom() && namespaceURI() != XMLNSNames::xmlnsNamespaceURI) || qualifiedName() == xmlnsAtom())
-        return Exception { ExceptionCode::NamespaceError };
-
-    const AtomString& newPrefix = prefix.isEmpty() ? nullAtom() : prefix;
-    if (RefPtr element = m_element.get())
-        element->ensureUniqueElementData().findAttributeByName(qualifiedName())->setPrefix(newPrefix);
-
-    m_name.setPrefix(newPrefix);
-
-    return { };
 }
 
 ExceptionOr<void> Attr::setValue(const AtomString& value)

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -68,8 +68,6 @@ private:
     String nodeValue() const final { return value(); }
     ExceptionOr<void> setNodeValue(const String&) final;
 
-    ExceptionOr<void> setPrefix(const AtomString&) final;
-
     Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) const final;
     SerializedNode serializeNode(CloningOperation) const final;
 

--- a/Source/WebCore/dom/Attribute.h
+++ b/Source/WebCore/dom/Attribute.h
@@ -65,7 +65,6 @@ public:
     bool matches(const AtomString& prefix, const AtomString& localName, const AtomString& namespaceURI) const;
 
     void setValue(const AtomString& value) { m_value = value; }
-    void setPrefix(const AtomString& prefix) { m_name.setPrefix(prefix); }
 
     // Note: This API is only for HTMLTreeBuilder.  It is not safe to change the
     // name of an attribute once parseAttribute has been called as DOM

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -396,7 +396,7 @@ public:
     ElementName elementName() const { return m_tagName.nodeName(); }
     Namespace nodeNamespace() const { return m_tagName.nodeNamespace(); }
 
-    ExceptionOr<void> setPrefix(const AtomString&) final;
+    ExceptionOr<void> setPrefix(const AtomString&);
 
     String nodeName() const override;
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -818,14 +818,6 @@ const AtomString& Node::prefix() const
     return nullAtom();
 }
 
-ExceptionOr<void> Node::setPrefix(const AtomString&)
-{
-    // The spec says that for nodes other than elements and attributes, prefix is always null.
-    // It does not say what to do when the user tries to set the prefix on another type of
-    // node, however Mozilla throws a NamespaceError exception.
-    return Exception { ExceptionCode::NamespaceError };
-}
-
 const AtomString& Node::localName() const
 {
     return nullAtom();
@@ -1151,8 +1143,7 @@ void Node::clearNodeLists()
 
 ExceptionOr<void> Node::checkSetPrefix(const AtomString& prefix)
 {
-    // Perform error checking as required by spec for setting Node.prefix. Used by
-    // Element::setPrefix() and Attr::setPrefix()
+    // Perform error checking as required by spec for setting Node.prefix. Used by Element::setPrefix().
 
     if (!prefix.isEmpty() && !NameValidation::isValidNamespacePrefix(prefix))
         return Exception { ExceptionCode::InvalidCharacterError };
@@ -1164,8 +1155,6 @@ ExceptionOr<void> Node::checkSetPrefix(const AtomString& prefix)
         return Exception { ExceptionCode::NamespaceError };
     if (prefix == xmlAtom() && namespaceURI != XMLNames::xmlNamespaceURI)
         return Exception { ExceptionCode::NamespaceError };
-
-    // Attribute-specific checks are in Attr::setPrefix().
 
     return { };
 }

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -185,7 +185,6 @@ public:
     virtual const AtomString& NODELETE localName() const;
     virtual const AtomString& NODELETE namespaceURI() const;
     virtual const AtomString& NODELETE prefix() const;
-    virtual ExceptionOr<void> setPrefix(const AtomString&);
     WEBCORE_EXPORT ExceptionOr<void> normalize();
 
     bool isSameNode(Node* other) const { return this == other; }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDeprecated.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDeprecated.cpp
@@ -235,14 +235,6 @@ void webkit_dom_node_set_prefix(WebKitDOMNode* self, const gchar* value, GError*
     g_return_if_fail(!error || !*error);
 
     g_warning("%s: prefix is now a readonly property according to the DOM spec.", __func__);
-
-    WebCore::JSMainThreadNullState state;
-    WebCore::Node* item = WebKit::core(self);
-    auto result = item->setPrefix(WTF::AtomString::fromUTF8(value));
-    if (result.hasException()) {
-        auto description = WebCore::DOMException::description(result.releaseException().code());
-        g_set_error_literal(error, g_quark_from_string("WEBKIT_DOM"), description.legacyCode, description.name);
-    }
 }
 
 gchar* webkit_dom_node_get_local_name(WebKitDOMNode* self)

--- a/Source/WebKitLegacy/mac/DOM/DOMNode.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNode.mm
@@ -161,8 +161,7 @@ DOMNode *kit(WebCore::Node* value)
 
 - (void)setPrefix:(NSString *)newPrefix
 {
-    WebCore::JSMainThreadNullState state;
-    raiseOnDOMError(unwrap(*self).setPrefix(newPrefix));
+    UNUSED_PARAM(newPrefix);
 }
 
 - (NSString *)localName


### PR DESCRIPTION
#### 655a4f788db723e17f941f4f58ba8b2c12074c13
<pre>
Make legacy DOM setPrefix() APIs no-op and remove Attr::setPrefix()
<a href="https://bugs.webkit.org/show_bug.cgi?id=315669">https://bugs.webkit.org/show_bug.cgi?id=315669</a>

Reviewed by Ryosuke Niwa.

We should not allow legacy APIs to invalidate invariants.
Element::setPrefix() should also be removed, but as its own change as
it&apos;s slightly more involved.

Canonical link: <a href="https://commits.webkit.org/314014@main">https://commits.webkit.org/314014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92ef7723b24d9ecc6568079f865e19b4c2d9d986

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173769 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121986 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/202d6c44-8717-417f-8a99-5d8b4f0398d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128025 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c06610ba-7873-4420-b21a-930ef9b66b6a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108571 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a34e8a6-056f-49e5-9cda-9164181f1cf9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29373 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27997 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21528 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176292 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29116 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136344 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136307 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147577 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101178 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25095 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31577 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24433 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37485 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110530 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 32460 issues") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36883 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2498 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37131 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37031 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->