### PR TITLE
[EME] getSupportedCapabilitiesForAudioVideoType can accidentally include unsupported capabilities

### DIFF
--- a/LayoutTests/media/encrypted-media/mock-getSupportedCapabilitiesForAudioVideoType-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-getSupportedCapabilitiesForAudioVideoType-expected.txt
@@ -1,0 +1,24 @@
+RUN(internals.initializeMockMediaSource())
+RUN(mock = internals.registerMockCDM())
+RUN(mock.supportedDataTypes = ["mock"])
+RUN(mock.unsupportedVideoCodecs = ["bad"])
+
+SET capabilities = '[ { "initDataTypes": [ "mock" ], "videoCapabilities": [ { "contentType": "video/mock; codecs=\"mock\"" }, { "contentType": "video/mock; codecs=\"bad\"" } ] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
+Promise resolved OK
+EXPECTED (access.getConfiguration().videoCapabilities.length == '1') OK
+EXPECTED (access.getConfiguration().videoCapabilities[0].contentType == 'video/mock; codecs="mock"') OK
+
+SET capabilities = '[ { "initDataTypes": [ "mock" ], "videoCapabilities": [ { "contentType": "video/mock; codecs=\"bad\"" } ] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
+Promise rejected correctly OK
+EXPECTED (exceptionCode.name == 'NotSupportedError') OK
+
+RUN(mock.unsupportedVideoCodecs = ["bad", "worse"])
+SET capabilities = '[ { "initDataTypes": [ "mock" ], "videoCapabilities": [ { "contentType": "video/mock; codecs=\"bad\"" }, { "contentType": "video/mock; codecs=\"mock\"" }, { "contentType": "video/mock; codecs=\"worse\"" } ] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
+Promise resolved OK
+EXPECTED (access.getConfiguration().videoCapabilities.length == '1') OK
+EXPECTED (access.getConfiguration().videoCapabilities[0].contentType == 'video/mock; codecs="mock"') OK
+END OF TEST
+

--- a/LayoutTests/media/encrypted-media/mock-getSupportedCapabilitiesForAudioVideoType.html
+++ b/LayoutTests/media/encrypted-media/mock-getSupportedCapabilitiesForAudioVideoType.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src=../video-test.js></script>
+    <script type="text/javascript">
+    var mock;
+    var promise;
+    var capabilities = {};
+
+    function doTest()
+    {
+        if (!window.internals) {
+            failTest("Internals is required for this test.")
+            return;
+        }
+
+        run('internals.initializeMockMediaSource()');
+        run('mock = internals.registerMockCDM()');
+        run('mock.supportedDataTypes = ["mock"]');
+        run('mock.unsupportedVideoCodecs = ["bad"]');
+
+        next();
+    }
+
+    function next() {
+        if (!tests.length) {
+            mock.unregister();
+            endTest()
+            return;
+        }
+
+        var nextTest = tests.shift();
+        consoleWrite('');
+        nextTest();
+    }
+
+    function passingTestWithCapabilities(capabilities, success) {
+        shouldResolve(testWithCapabilities(capabilities)).then(success).then(next, next);
+    }
+
+    function failingTestWithCapabilities(capabilities, failure) {
+        shouldReject(testWithCapabilities(capabilities)).then(failure).then(next, next);
+    }
+
+    function testWithCapabilities(capabilities) {
+        window.capabilities = capabilities;
+        consoleWrite(`SET capabilities = '${ JSON.stringify(capabilities, null, 1) }'`);
+        run('promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities)');
+        return promise;
+    }
+
+    tests = [
+        // A "bad" codec that MediaPlayer accepts as a mock mime but the CDM rejects
+        // under supportsConfigurationWithRestrictions must be filtered out, while a
+        // supported sibling capability is retained.
+        function() {
+            passingTestWithCapabilities([{
+                    initDataTypes: ['mock'],
+                    videoCapabilities: [
+                        { contentType: 'video/mock; codecs="mock"' },
+                        { contentType: 'video/mock; codecs="bad"' },
+                    ],
+                }],
+                mediaKeySystemAccess => {
+                    window.access = mediaKeySystemAccess;
+                    testExpected('access.getConfiguration().videoCapabilities.length', '1');
+                    testExpected('access.getConfiguration().videoCapabilities[0].contentType', 'video/mock; codecs="mock"');
+                });
+        },
+
+        // A single "bad" capability must cause the whole request to fail with
+        // NotSupportedError: this is the HBO Max / HEVC-on-unsupported-system case.
+        function() {
+            failingTestWithCapabilities([{
+                    initDataTypes: ['mock'],
+                    videoCapabilities: [{ contentType: 'video/mock; codecs="bad"' }],
+                }],
+                exceptionCode => {
+                    window.exceptionCode = exceptionCode;
+                    testExpected('exceptionCode.name', 'NotSupportedError');
+                });
+        },
+
+        // Multiple "bad" codecs configured: filter all of them, keep the supported one.
+        function() {
+            run('mock.unsupportedVideoCodecs = ["bad", "worse"]');
+            passingTestWithCapabilities([{
+                    initDataTypes: ['mock'],
+                    videoCapabilities: [
+                        { contentType: 'video/mock; codecs="bad"' },
+                        { contentType: 'video/mock; codecs="mock"' },
+                        { contentType: 'video/mock; codecs="worse"' },
+                    ],
+                }],
+                mediaKeySystemAccess => {
+                    window.access = mediaKeySystemAccess;
+                    testExpected('access.getConfiguration().videoCapabilities.length', '1');
+                    testExpected('access.getConfiguration().videoCapabilities[0].contentType', 'video/mock; codecs="mock"');
+                });
+        },
+    ];
+    </script>
+</head>
+<body onload="doTest()">
+</body>
+</html>

--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
@@ -430,7 +430,13 @@ std::optional<Vector<CDMMediaCapability>> CDMPrivate::getSupportedCapabilitiesFo
                 continue;
         }
 
-        if (!supportsConfigurationWithRestrictions(accumulatedConfiguration, restrictions))
+        // NOTE: step 3.13 evaluates the combination including the requested capability.
+        CDMKeySystemConfiguration probeConfiguration = accumulatedConfiguration;
+        if (type == AudioVideoType::Video)
+            probeConfiguration.videoCapabilities.append(requestedCapability);
+        else
+            probeConfiguration.audioCapabilities.append(requestedCapability);
+        if (!supportsConfigurationWithRestrictions(probeConfiguration, restrictions))
             continue;
 
         // 3.13.1. Add requested media capability to supported media capabilities.

--- a/Source/WebCore/platform/network/ParsedContentType.h
+++ b/Source/WebCore/platform/network/ParsedContentType.h
@@ -49,7 +49,7 @@ public:
     void setCharset(String&&);
 
     // Note that in the case of multiple values for the same name, the last value is returned.
-    String parameterValueForName(const String&) const;
+    WEBCORE_EXPORT String parameterValueForName(const String&) const;
     size_t NODELETE parameterCount() const;
 
     WEBCORE_EXPORT String serialize() const;

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(ENCRYPTED_MEDIA)
 
 #include "InitDataRegistry.h"
+#include "ParsedContentType.h"
 #include "SharedBuffer.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <algorithm>
@@ -176,9 +177,24 @@ bool MockCDM::supportsConfiguration(const MediaKeySystemConfiguration& configura
 
 }
 
-bool MockCDM::supportsConfigurationWithRestrictions(const MediaKeySystemConfiguration&, const MediaKeysRestrictions&) const
+bool MockCDM::supportsConfigurationWithRestrictions(const MediaKeySystemConfiguration& configuration, const MediaKeysRestrictions&) const
 {
-    // NOTE: Implement;
+    if (!m_factory)
+        return true;
+
+    const auto& unsupportedVideoCodecs = m_factory->unsupportedVideoCodecs();
+    if (unsupportedVideoCodecs.isEmpty())
+        return true;
+
+    for (const auto& capability : configuration.videoCapabilities) {
+        auto contentType = ParsedContentType::create(capability.contentType);
+        if (!contentType)
+            continue;
+        auto codecs = contentType->parameterValueForName("codecs"_s);
+        if (!codecs.isEmpty() && unsupportedVideoCodecs.contains(codecs))
+            return false;
+    }
+
     return true;
 }
 

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -78,6 +78,9 @@ public:
     const Vector<MediaKeyEncryptionScheme>& supportedEncryptionSchemes() const LIFETIME_BOUND { return m_supportedEncryptionSchemes; }
     void setSupportedEncryptionSchemes(Vector<MediaKeyEncryptionScheme>&& schemes) { m_supportedEncryptionSchemes = WTF::move(schemes); }
 
+    const Vector<String>& unsupportedVideoCodecs() const LIFETIME_BOUND { return m_unsupportedVideoCodecs; }
+    void setUnsupportedVideoCodecs(Vector<String>&& codecs) { m_unsupportedVideoCodecs = WTF::move(codecs); }
+
     void unregister();
 
     bool hasSessionWithID(const String& id);
@@ -97,6 +100,7 @@ private:
     Vector<MediaKeySessionType> m_supportedSessionTypes;
     Vector<String> m_supportedRobustness;
     Vector<MediaKeyEncryptionScheme> m_supportedEncryptionSchemes;
+    Vector<String> m_unsupportedVideoCodecs;
     bool m_registered { true };
     bool m_canCreateInstances { true };
     bool m_supportsServerCertificates { true };

--- a/Source/WebCore/testing/MockCDMFactory.idl
+++ b/Source/WebCore/testing/MockCDMFactory.idl
@@ -37,6 +37,7 @@
     attribute boolean supportsServerCertificates;
     attribute boolean supportsSessions;
     attribute sequence<MediaKeyEncryptionScheme> supportedEncryptionSchemes;
+    attribute sequence<DOMString> unsupportedVideoCodecs;
 
     undefined unregister();
 };


### PR DESCRIPTION
#### 932c6b3792a18c2d61a0094b8fbe5f56ef98856e
<pre>
[EME] getSupportedCapabilitiesForAudioVideoType can accidentally include unsupported capabilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=315667">https://bugs.webkit.org/show_bug.cgi?id=315667</a>

Reviewed by Philippe Normand.

A local copy of accumulatedConfiguration is created where we append the
requestedCapability, then supportsConfigurationWithRestrictions is
queried. This means that requestedCapabilities cannot be accidentally
added when they aren&apos;t supported.

Tested on HBO Max, which was incorrectly serving HEVC content on a system
that didn&apos;t support it, and added a new test verifying this behaviour
after extending the MockCDMFactory to support this.

* LayoutTests/media/encrypted-media/mock-getSupportedCapabilitiesForAudioVideoType-expected.txt: Added.
* LayoutTests/media/encrypted-media/mock-getSupportedCapabilitiesForAudioVideoType.html: Added.
* Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp:
(WebCore::CDMPrivate::getSupportedCapabilitiesForAudioVideoType):
* Source/WebCore/platform/network/ParsedContentType.h:
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDM::supportsConfigurationWithRestrictions const):
* Source/WebCore/testing/MockCDMFactory.h:
(WebCore::MockCDMFactory::setUnsupportedVideoCodecs):
* Source/WebCore/testing/MockCDMFactory.idl:

Canonical link: <a href="https://commits.webkit.org/314032@main">https://commits.webkit.org/314032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7c14bb33eed0e475f87642afbf815002bba06fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173973 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122189 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128162 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108688 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29516 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28129 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21730 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176496 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29347 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136483 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136429 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36763 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147696 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101442 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31697 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24562 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37690 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110761 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37087 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2636 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37333 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->