### PR TITLE
[JSC] ExpressionInfo::Encoder::adjustInstPC should take an index instead of a pointer

### DIFF
--- a/JSTests/stress/generator-expression-info-multiwide-remap.js
+++ b/JSTests/stress/generator-expression-info-multiwide-remap.js
@@ -1,0 +1,21 @@
+let code = `
+function* gen(a) {
+  a.b;
+  a.b;
+  a.b;
+  a.b;
+  a.b;
+  yield 1;
+  ` + " ".repeat(9000000) + `a.b;
+}
+let it = gen({});
+it.next();
+it.next();
+`;
+
+try {
+    eval(code);
+    print("Done");
+} catch(e) {
+    print("Error: " + e);
+}

--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
@@ -384,11 +384,9 @@ auto ExpressionInfo::Encoder::encodeBasic(const Diff& diff) -> EncodedInfo
     return { word };
 }
 
-void ExpressionInfo::Encoder::adjustInstPC(EncodedInfo* info, unsigned instPCDelta)
+void ExpressionInfo::Encoder::adjustInstPC(unsigned infoIndex, unsigned instPCDelta)
 {
-    unsigned infoIndex = info - &m_expressionInfoEncodedInfo[0];
-    auto* firstInfo = info;
-    unsigned firstValue = firstInfo->value;
+    unsigned firstValue = m_expressionInfoEncodedInfo[infoIndex].value;
 
     unsigned headerBits = firstValue >> headerShift;
     bool isMulti = (firstValue >> multiBitShift) & 1;
@@ -402,7 +400,7 @@ void ExpressionInfo::Encoder::adjustInstPC(EncodedInfo* info, unsigned instPCDel
         unsigned instPC = cast<unsigned, specialValueBits>(firstValue);
         unsigned updatedInstPC = instPC + instPCDelta;
         if (fits<unsigned, specialValueBits>(updatedInstPC)) {
-            *firstInfo = encodeAbsInstPC(updatedInstPC);
+            m_expressionInfoEncodedInfo[infoIndex] = encodeAbsInstPC(updatedInstPC);
             return;
         }
         goto emitExtension;
@@ -416,7 +414,7 @@ void ExpressionInfo::Encoder::adjustInstPC(EncodedInfo* info, unsigned instPCDel
             unsigned candidateInstPC = cast<unsigned, singleValueBits>(firstValue);
             unsigned updatedInstPC = candidateInstPC + instPCDelta;
             if (fieldID == FieldID::InstPC && fits<unsigned, singleValueBits>(updatedInstPC)) {
-                *firstInfo = encodeSingle(FieldID::InstPC, updatedInstPC);
+                m_expressionInfoEncodedInfo[infoIndex] = encodeSingle(FieldID::InstPC, updatedInstPC);
                 return;
             }
             goto emitExtension;
@@ -432,7 +430,7 @@ void ExpressionInfo::Encoder::adjustInstPC(EncodedInfo* info, unsigned instPCDel
             if (fieldID == FieldID::InstPC && fits<unsigned, duoValueBits>(updatedInstPC)) {
                 FieldID fieldID2 = static_cast<FieldID>((firstValue >> duoSecondFieldIDShift) & fieldIDMask);
                 unsigned value2 = cast<unsigned, duoValueBits>(firstValue >> duoSecondValueShift);
-                *firstInfo = encodeDuo(FieldID::InstPC, updatedInstPC, fieldID2, value2);
+                m_expressionInfoEncodedInfo[infoIndex] = encodeDuo(FieldID::InstPC, updatedInstPC, fieldID2, value2);
                 return;
             }
             goto emitExtension;
@@ -454,12 +452,13 @@ void ExpressionInfo::Encoder::adjustInstPC(EncodedInfo* info, unsigned instPCDel
 
         m_expressionInfoEncodedInfo.append({ firstValue }); // MultiWide header.
         for (unsigned i = 1; i < numberOfFields; ++i) {
-            m_expressionInfoEncodedInfo.append(firstInfo[i]);
-            firstInfo[i] = encodeSingle(FieldID::InstPC, 0); // Replace with a no-op.
+            auto fieldValue = m_expressionInfoEncodedInfo[infoIndex + i];
+            m_expressionInfoEncodedInfo.append(fieldValue);
+            m_expressionInfoEncodedInfo[infoIndex + i] = encodeSingle(FieldID::InstPC, 0); // Replace with a no-op.
         }
         // Save the last field in firstValue, and let the extension emitter below append it.
-        firstValue = firstInfo[numberOfFields].value;
-        firstInfo[numberOfFields] = encodeSingle(FieldID::InstPC, 0); // Replace with a no-op.
+        firstValue = m_expressionInfoEncodedInfo[infoIndex + numberOfFields].value;
+        m_expressionInfoEncodedInfo[infoIndex + numberOfFields] = encodeSingle(FieldID::InstPC, 0); // Replace with a no-op.
         goto emitExtension;
     }
 
@@ -470,7 +469,7 @@ void ExpressionInfo::Encoder::adjustInstPC(EncodedInfo* info, unsigned instPCDel
         if (updatedInstPC < maxInstPCValue) {
             unsigned replacement = firstValue & ((1u << instPCShift) - 1);
             replacement |= updatedInstPC << instPCShift;
-            *firstInfo = { replacement };
+            m_expressionInfoEncodedInfo[infoIndex] = { replacement };
             return;
         }
     }

--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.h
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.h
@@ -115,7 +115,7 @@ public:
         static EncodedInfo NODELETE encodeMultiHeader(unsigned numWides, Wide*);
         static EncodedInfo NODELETE encodeBasic(const Diff&);
 
-        void adjustInstPC(EncodedInfo*, unsigned instPCDelta);
+        void adjustInstPC(unsigned infoIndex, unsigned instPCDelta);
 
         template<unsigned bitCount> bool NODELETE fits(Wide);
         template<typename T, unsigned bitCount> bool fits(T);

--- a/Source/JavaScriptCore/bytecode/ExpressionInfoInlines.h
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfoInlines.h
@@ -102,7 +102,8 @@ void ExpressionInfo::Encoder::remap(Vector<unsigned>&& adjustmentLabelPoints, Re
                 cummulativeDelta = 0;
             instPCDelta = remapFunc(instPC) - instPC - cummulativeDelta;
             if (instPCDelta || isAbsInstPC) {
-                adjustInstPC(decoder.currentInfo(), instPCDelta);
+                unsigned infoIndex = static_cast<unsigned>(decoder.currentInfo() - m_expressionInfoEncodedInfo.begin());
+                adjustInstPC(infoIndex, instPCDelta);
 
                 // adjustInstPC() may have resized and reallocated m_expressionInfoEncodedInfo.
                 // So, we need to re-compute endInfo. info will be re-computed at the top of the loop.


### PR DESCRIPTION
#### 799e388d2eb5ad657027a45b14091070d06925e8
<pre>
[JSC] ExpressionInfo::Encoder::adjustInstPC should take an index instead of a pointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=309843">https://bugs.webkit.org/show_bug.cgi?id=309843</a>
<a href="https://rdar.apple.com/172411808">rdar://172411808</a>

Reviewed by Mark Lam.

adjustInstPC() previously took a raw EncodedInfo* pointer that aliased
m_expressionInfoEncodedInfo&apos;s backing buffer. This is fragile since the
pointer can become invalid if the vector is resized.

Change adjustInstPC() to take an unsigned index instead. An integer
index remains valid across reallocations since vector element access
always recomputes the address from the current base pointer.

Test: JSTests/stress/generator-expression-info-multiwide-remap.js

Originally-landed-as: 305413.466@rapid/safari-7624.2.5.110-branch (31c074842fc5). <a href="https://rdar.apple.com/176062572">rdar://176062572</a>
Canonical link: <a href="https://commits.webkit.org/313990@main">https://commits.webkit.org/313990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/251c97e7b1c235668b5c1f7c9132091e571addbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121992 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128028 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108574 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28001 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21534 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156891 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176298 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25632 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29122 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136348 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136311 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36712 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147580 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101188 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31582 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24436 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197143 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37491 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110536 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51790 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36889 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2501 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37137 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37037 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->