### PR TITLE
Compromised web content process unauthorized access to pending MessagePort messages

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1733,6 +1733,9 @@ MessageBatchIdentifier NetworkConnectionToWebProcess::nextMessageBatchIdentifier
 
 void NetworkConnectionToWebProcess::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, std::optional<MessageBatchIdentifier>)>&& callback)
 {
+    // A WebContent process may only receive messages for ports entangled to it.
+    MESSAGE_CHECK_COMPLETION(m_processEntangledPorts.contains(port), callback({ }, std::nullopt));
+
     protect(m_networkProcess->messagePortChannelRegistry())->takeAllMessagesForPort(port, [this, protectedThis = Ref { *this }, callback = WTF::move(callback)](Vector<MessageWithMessagePorts>&& messages, CompletionHandler<void()>&& deliveryCallback) mutable {
         callback(WTF::move(messages), nextMessageBatchIdentifier(WTF::move(deliveryCallback)));
     });

--- a/Tools/TestWebKitAPI/Resources/cocoa/MessagePortSecurity.mm
+++ b/Tools/TestWebKitAPI/Resources/cocoa/MessagePortSecurity.mm
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "HTTPServer.h"
+#import "PlatformUtilities.h"
+#import "TestNavigationDelegate.h"
+#import "TestUIDelegate.h"
+#import "TestWKWebView.h"
+#import "Utilities.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/_WKFeature.h>
+#import <WebKit/_WKWebsiteDataStoreConfiguration.h>
+#import <wtf/RetainPtr.h>
+
+#if ENABLE(IPC_TESTING_API)
+
+static void enableIPCTestingAPI(WKWebViewConfiguration *configuration)
+{
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+}
+
+static constexpr auto sharedWorkerBytes = R"PORTRESOURCE(
+var heldPort = null;
+self.addEventListener('connect', function(e) {
+    var port = e.ports[0];
+    port.addEventListener('message', function(event) {
+        if (event.data === 'store-port' && event.ports && event.ports.length > 0) {
+            heldPort = event.ports[0];
+            port.postMessage('port-stored');
+        } else if (event.data === 'get-port' && heldPort) {
+            port.postMessage('here-is-port', [heldPort]);
+            heldPort = null;
+        }
+    });
+    port.start();
+});
+)PORTRESOURCE"_s;
+
+static constexpr auto senderBytes = R"PORTRESOURCE(
+<script>
+var port2ProcessId, port2PortId;
+IPC.addOutgoingMessageListener('Networking', function(msg) {
+    if (msg.description.indexOf('CreateNewMessagePortChannel') !== -1 && !port2ProcessId) {
+        var buf1 = msg.arguments[1];
+        if (buf1 instanceof ArrayBuffer) {
+            var dv = new DataView(buf1);
+            port2ProcessId = dv.getBigUint64(0, true);
+            port2PortId = dv.getBigUint64(8, true);
+        }
+    }
+});
+var channel = new MessageChannel();
+var worker = new SharedWorker('/worker.js');
+worker.port.addEventListener('message', function(event) {
+    if (event.data === 'port-stored')
+        alert('port-stored');
+});
+worker.port.start();
+worker.port.postMessage('store-port', [channel.port2]);
+</script>
+)PORTRESOURCE"_s;
+
+static constexpr auto receiverBytes = R"PORTRESOURCE(
+<script>
+var worker = new SharedWorker('/worker.js');
+worker.port.addEventListener('message', function(event) {
+    if (event.data === 'here-is-port' && event.ports && event.ports.length > 0) {
+        window.storedPort = event.ports[0];
+        alert('port-received');
+    }
+});
+worker.port.start();
+worker.port.postMessage('get-port');
+</script>
+)PORTRESOURCE"_s;
+
+TEST(MessagePortSecurity, CrossProcessMessageTheftViaTakeAllMessagesForPort)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer server({
+        { "/sender"_s, { senderBytes } },
+        { "/receiver"_s, { receiverBytes } },
+        { "/worker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, sharedWorkerBytes } },
+        { "/attacker"_s, { "<html><body>attacker</body></html>"_s } },
+    });
+
+    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableIPCTestingAPI(config.get());
+    [config setWebsiteDataStore:dataStore.get()];
+
+    // `webViewA` connects to a SharedWorker and sends a message port to it.
+    auto navDelegateA = adoptNS([TestNavigationDelegate new]);
+    auto uiDelegateA = adoptNS([TestUIDelegate new]);
+    auto webViewA = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewA setNavigationDelegate:navDelegateA.get()];
+    [webViewA setUIDelegate:uiDelegateA.get()];
+
+    [webViewA loadRequest:server.request("/sender"_s)];
+    [navDelegateA waitForDidFinishNavigation];
+
+    // The sender page connects to the shared worker and sends it a port from a message channel.
+    // Wait for all of that to finish.
+    EXPECT_WK_STREQ([uiDelegateA waitForAlert], "port-stored");
+
+    // `webViewB` will get the port from the shared worker, formally moving it to a new web content process,
+    // forcing the networking process to be an intermediary.
+    auto navDelegateB = adoptNS([TestNavigationDelegate new]);
+    auto uiDelegateB = adoptNS([TestUIDelegate new]);
+    auto webViewB = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewB setNavigationDelegate:navDelegateB.get()];
+    [webViewB setUIDelegate:uiDelegateB.get()];
+
+    [webViewB loadRequest:server.request("/receiver"_s)];
+
+    // Wait for `webViewB` to get the port from the shared worker, and verify that
+    // it's out of process from the first web view.
+    // At that point, we know that messages to the port are going through the networking
+    // process as an intermediate.
+    EXPECT_WK_STREQ([uiDelegateB waitForAlert], "port-received");
+    EXPECT_NE([webViewA _webProcessIdentifier], [webViewB _webProcessIdentifier]);
+
+    // Post some messages from `webViewA`
+    // Since `webViewB` acquired the port but did not activate it, these messages
+    // will queue up in the Networking process.
+    [webViewA evaluateJavaScript:
+        @"channel.port1.postMessage('secret-message-1');"
+        "channel.port1.postMessage('secret-message-2');"
+        "channel.port1.postMessage('secret-message-3');"
+        "alert('messages-posted');"
+        completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegateA waitForAlert], "messages-posted");
+
+    // Earlier we used CoreIPC JS to grab the process identifier and port ID for the now-remote-MessagePort.
+    // Grab them here for the attacker to use.
+    NSString *port2ProcessString = [webViewA stringByEvaluatingJavaScript:@"port2ProcessId ? port2ProcessId.toString() : 'undefined'"];
+    NSString *port2PortString = [webViewA stringByEvaluatingJavaScript:@"port2PortId ? port2PortId.toString() : 'undefined'"];
+    EXPECT_FALSE([port2ProcessString isEqualToString:@"undefined"]);
+    EXPECT_FALSE([port2PortString isEqualToString:@"undefined"]);
+
+    // `webViewC` is the attacker.
+    auto navDelegateC = adoptNS([TestNavigationDelegate new]);
+    auto uiDelegateC = adoptNS([TestUIDelegate new]);
+    auto webViewC = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewC setNavigationDelegate:navDelegateC.get()];
+    [webViewC setUIDelegate:uiDelegateC.get()];
+
+    [webViewC loadRequest:server.request("/attacker"_s)];
+    [navDelegateC waitForDidFinishNavigation];
+
+    EXPECT_NE([webViewA _webProcessIdentifier], [webViewC _webProcessIdentifier]);
+    EXPECT_NE([webViewB _webProcessIdentifier], [webViewC _webProcessIdentifier]);
+
+    // It uses CoreIPC JS to craft a message to acquire the messages sent to the port
+    // we identified above. Ideally it should *not* be able to get those messages.
+    NSString *attackScript = [NSString stringWithFormat:
+        @"var net = IPC.connectionForProcessTarget('Networking');"
+        "var portId = [{type: 'uint64_t', value: BigInt('%@')}, {type: 'uint64_t', value: BigInt('%@')}];"
+        "net.sendWithAsyncReply(0,"
+        "    IPC.messages.NetworkConnectionToWebProcess_TakeAllMessagesForPort.name,"
+        "    [portId],"
+        "    function(reply) {"
+        "        try {"
+        "            var buf = reply.arguments[0];"
+        "            if (buf instanceof ArrayBuffer) {"
+        "                var dv = new DataView(buf);"
+        "                var count = Number(dv.getBigUint64(0, true));"
+        "                alert('stolen:' + count);"
+        "            } else {"
+        "                alert('stolen:unexpected-type');"
+        "            }"
+        "        } catch(e) {"
+        "            alert('error:' + e.message);"
+        "        }"
+        "    }"
+        ");", port2ProcessString, port2PortString];
+    [webViewC evaluateJavaScript:attackScript completionHandler:nil];
+
+    // If the bug exists, the attacker will manage to get all 3 pending messages, resulting in "stolen:3"
+    // The MESSAGE_CHECK being added responds with an empty set, resulting in "stolen:0"
+    EXPECT_WK_STREQ([uiDelegateC waitForAlert], "stolen:0");
+}
+
+#endif // ENABLE(IPC_TESTING_API)

--- a/Tools/TestWebKitAPI/Scripts/generate-unified-sources.sh
+++ b/Tools/TestWebKitAPI/Scripts/generate-unified-sources.sh
@@ -17,7 +17,7 @@ fi
 UnifiedSourceCppFileCount=5
 UnifiedSourceCFileCount=0
 UnifiedSourceMmFileCount=0
-UnifiedSourceNonARCMmFileCount=51
+UnifiedSourceNonARCMmFileCount=52
 
 if [ $# -eq 0 ]; then
     echo "Using unified source list files: Sources.txt, SourcesCocoa.txt"

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -62,6 +62,8 @@ Helpers/cocoa/SiteIsolationUtilities.mm @nonARC
 Helpers/ios/IOSMouseEventTestHarness.mm @nonARC
 Helpers/mac/WKWebViewForTestingImmediateActions.mm @nonARC
 
+Resources/cocoa/MessagePortSecurity.mm @nonARC
+
 Tests/WTF/cocoa/URLExtras.mm @nonARC
 
 Tests/WebCore/cocoa/WebAVPlayerControllerLeakTests.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		3A5DDB2C28D5525E004DA950 /* libWTF.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C83E0291D0A5CDF00FEBCF3 /* libWTF.a */; };
 		3A5DDB2D28D55265004DA950 /* libwgsl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A5DDB2028D54269004DA950 /* libwgsl.a */; };
 		4135FB852011FABF00332139 /* libWebCoreTestSupport.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4135FB862011FABF00332139 /* libWebCoreTestSupport.dylib */; };
+		51A97F1B2FD0B5A400FBDD0C /* UnifiedSource52-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51A97F062FD0B59400FBDD0C /* UnifiedSource52-nonARC.mm */; };
 		5C9D922C22D7DE12008E9266 /* UnifiedSource1-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C9D922922D7DE01008E9266 /* UnifiedSource1-nonARC.mm */; };
 		5C9D922D22D7DE19008E9266 /* UnifiedSource2-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C9D922B22D7DE01008E9266 /* UnifiedSource2-nonARC.mm */; };
 		5C9D922E22D7DE1C008E9266 /* UnifiedSource1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C9D922A22D7DE01008E9266 /* UnifiedSource1.cpp */; };
@@ -405,6 +406,7 @@
 		466CBA072DADC50A00B32457 /* libWTF.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libWTF.a; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS19.0.Internal.sdk/usr/local/lib/libWTF.a; sourceTree = DEVELOPER_DIR; };
 		49AEEF682407276F00C87E4C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		516281282325C45400BB7E42 /* PDFKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PDFKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/PDFKit.framework; sourceTree = DEVELOPER_DIR; };
+		51A97F062FD0B59400FBDD0C /* UnifiedSource52-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UnifiedSource52-nonARC.mm"; sourceTree = "<group>"; };
 		574F55D0204D471C002948C6 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		578CBD66204FB2C70083B9F2 /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = System/Library/Frameworks/LocalAuthentication.framework; sourceTree = SDKROOT; };
 		5C9D921D22D7DBF7008E9266 /* Sources.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Sources.txt; sourceTree = "<group>"; };
@@ -1798,6 +1800,7 @@
 				5CABDB942735C9BA00B88BCB /* UnifiedSource49-nonARC.mm */,
 				5CABDB932735C9BA00B88BCB /* UnifiedSource50-nonARC.mm */,
 				5CABDB952735C9BB00B88BC0 /* UnifiedSource51-nonARC.mm */,
+				51A97F062FD0B59400FBDD0C /* UnifiedSource52-nonARC.mm */,
 			);
 			path = "unified-sources";
 			sourceTree = "<group>";
@@ -2393,6 +2396,7 @@
 				5CABDBC12735C9BD00B88BCB /* UnifiedSource49-nonARC.mm in Sources */,
 				5CABDBC02735C9BD00B88BCB /* UnifiedSource50-nonARC.mm in Sources */,
 				5CABDBC22735C9BE00B88BC0 /* UnifiedSource51-nonARC.mm in Sources */,
+				51A97F1B2FD0B5A400FBDD0C /* UnifiedSource52-nonARC.mm in Sources */,
 				07792FA62F9D9AE9009EF126 /* WebProcessPlugInWithInternals.mm in Sources */,
 			);
 		};

--- a/Tools/TestWebKitAPI/UnifiedSources-output.xcfilelist
+++ b/Tools/TestWebKitAPI/UnifiedSources-output.xcfilelist
@@ -51,6 +51,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource5.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource50-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource51-nonARC.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource52-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource6-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource7-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource8-nonARC.mm


### PR DESCRIPTION
#### da44cdb89cd768f800e38ca1f675b723b70bb575
<pre>
Compromised web content process unauthorized access to pending MessagePort messages
<a href="https://rdar.apple.com/172706670">rdar://172706670</a>

Reviewed by Chris Dumez.

Specially crafted IPC from a web content process can ask for pending MessagePort messages
that don&apos;t belong to it by either guessing or otherwise establishing the internal
identifier for the given MessagePort.

This patch adds a MESSAGE_CHECK that always returns empty results on such an attempt.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/MessagePortSecurity.mm

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::takeAllMessagesForPort):

* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MessagePortSecurity.mm: Added.
(enableIPCTestingAPI):
(addEventListener):
(function):
((MessagePortSecurity, CrossProcessMessageTheftViaTakeAllMessagesForPort)):

Originally-landed-as: 305413.547@rapid/safari-7624.2.5.110-branch (a9b7107ffbd9). <a href="https://rdar.apple.com/176062008">rdar://176062008</a>
Canonical link: <a href="https://commits.webkit.org/314495@main">https://commits.webkit.org/314495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fb2ca3ab6591d15c093e5bda1ec8119b2205153

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166287 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175335 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5fbcff00-de7b-4031-8d9f-d435ea5990d9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129252 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8104adc2-fa13-4116-9505-739c413087a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109777 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0eec066-2367-40cd-9174-06ffea90c7b0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23475 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177867 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137605 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39847 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33451 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137527 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37049 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148900 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103174 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32823 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39045 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112119 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38442 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3853 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38687 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38585 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->