### PR TITLE
rdar://172395438

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.h
@@ -120,6 +120,9 @@ struct HTTPResponse {
     HTTPResponse(HashMap<String, String>&& headerFields, const String& body)
         : headerFields(WTF::move(headerFields))
         , body(bodyFromString(body)) { }
+    HTTPResponse(HashMap<String, String>&& headerFields, NSData *data)
+        : headerFields(WTF::move(headerFields))
+        , body(makeVector(data)) { }
     HTTPResponse(unsigned statusCode, HashMap<String, String>&& headerFields = { }, const String& body = { })
         : statusCode(statusCode)
         , headerFields(WTF::move(headerFields))

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Badging.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Badging.mm
@@ -105,7 +105,16 @@ return "DONE";
     id innerBadge = badge;
     if (!innerBadge)
         innerBadge = [NSNull null];
-    EXPECT_TRUE([_expectedAppBadgeSequence[_appBadgeIndex++] isEqual:innerBadge]);
+
+    if (_expectedAppBadgeSequence)
+        EXPECT_TRUE([_expectedAppBadgeSequence[_appBadgeIndex++] isEqual:innerBadge]);
+    else {
+        // This badging delegate expects no badge updates, so getting any is bad news.
+        // But we'll still bump the _appBadgeIndex variable to register that we received
+        // a badge update for other parts of the test.
+        ++_appBadgeIndex;
+        FAIL();
+    }
 
     if (_serverURL) {
         if (!_shouldAllowOriginViolations)
@@ -577,11 +586,10 @@ static void runAppBadgeSpoofTest(const String& attackerHTML)
 {
     NSURL *coreIPCURL = [NSBundle.test_resourcesBundle URLForResource:@"coreipc" withExtension:@"js"];
     NSData *coreIPCData = [NSData dataWithContentsOfURL:coreIPCURL];
-    RetainPtr coreIPCString = adoptNS([[NSString alloc] initWithData:coreIPCData encoding:NSUTF8StringEncoding]);
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { attackerHTML } },
-        { "/coreipc.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, coreIPCString.get() } },
+        { "/coreipc.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, coreIPCData } },
     });
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### fd1fbad88d034165fe243986a5a90a2967e1659d
<pre>
<a href="https://rdar.apple.com/172395438">rdar://172395438</a>

Reviewed by Chris Dumez.

A compromised web process can send an arbitrary message to the UI process to change
the app badge from any worker domain.

This adds checks to validate that the requested origin is allowed to come from
the web process in consideration.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm

* Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.h:
(TestWebKitAPI::HTTPResponse::HTTPResponse):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Badging.mm:
(-[BadgeDelegate updatedAppBadge:fromOrigin:]):

Originally-landed-as: 305413.558@rapid/safari-7624.2.5.110-branch (7b096816fb37). <a href="https://rdar.apple.com/176061819">rdar://176061819</a>
Canonical link: <a href="https://commits.webkit.org/314500@main">https://commits.webkit.org/314500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/567a2c399a531ee1c7fbb75b8fab0226c55b68db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175355 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129268 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0030fc1-0640-4d9e-be46-2344ac59fc01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169266 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109793 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/999042b8-d4e5-4cfd-bb5e-353bf66d8d5d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23495 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177887 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137620 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39867 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37050 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148914 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103199 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32838 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39065 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38462 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3866 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38605 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->