### PR TITLE
[ANGLE] Metal backend: Fix crash on OOB vertex attribute offset in syncDirtyAttrib

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
@@ -15,6 +15,7 @@
 
 #include <TargetConditionals.h>
 
+#include "common/mathutil.h"
 #include "libANGLE/ErrorStrings.h"
 #include "libANGLE/renderer/metal/BufferMtl.h"
 #include "libANGLE/renderer/metal/ContextMtl.h"
@@ -105,20 +106,21 @@ size_t GetVertexCount(BufferMtl *srcBuffer,
                       const gl::VertexBinding &binding,
                       uint32_t srcFormatSize)
 {
-    // Bytes usable for vertex data.
-    GLint64 bytes = srcBuffer->size() - binding.getOffset();
-    if (bytes < srcFormatSize)
+    GLintptr bindingOffset = binding.getOffset();
+    if (bindingOffset < 0)
         return 0;
 
+    // Bytes usable for vertex data.
+    angle::CheckedNumeric<size_t> bytes = srcBuffer->size();
+    bytes -= static_cast<size_t>(bindingOffset);
     // Count the last vertex.  It may occupy less than a full stride.
-    size_t numVertices = 1;
     bytes -= srcFormatSize;
+    if (!bytes.IsValid())
+        return 0;
 
     // Count how many strides fit remaining space.
-    if (bytes > 0)
-        numVertices += static_cast<size_t>(bytes) / binding.getStride();
-
-    return numVertices;
+    size_t effectiveStride = binding.getStride() > 0 ? binding.getStride() : srcFormatSize;
+    return 1 + static_cast<size_t>(bytes.ValueOrDie()) / effectiveStride;
 }
 
 size_t GetVertexCountWithConversion(BufferMtl *srcBuffer,
@@ -126,21 +128,24 @@ size_t GetVertexCountWithConversion(BufferMtl *srcBuffer,
                                     const gl::VertexBinding &binding,
                                     uint32_t srcFormatSize)
 {
+    // Use the smaller of the conversion buffer offset and the binding offset.
+    GLintptr bindingOffset = binding.getOffset();
+    if (bindingOffset < 0)
+        return 0;
+    size_t effectiveOffset =
+        std::min(conversionBuffer->offset, static_cast<size_t>(bindingOffset));
+
     // Bytes usable for vertex data.
-    GLint64 bytes = srcBuffer->size() -
-                    MIN(static_cast<GLintptr>(conversionBuffer->offset), binding.getOffset());
-    if (bytes < srcFormatSize)
+    angle::CheckedNumeric<size_t> bytes = srcBuffer->size();
+    bytes -= effectiveOffset;
+    // Count the last vertex.  It may occupy less than a full stride.
+    bytes -= srcFormatSize;
+    if (!bytes.IsValid())
         return 0;
 
-    // Count the last vertex.  It may occupy less than a full stride.
-    size_t numVertices = 1;
-    bytes -= srcFormatSize;
-
     // Count how many strides fit remaining space.
-    if (bytes > 0)
-        numVertices += static_cast<size_t>(bytes) / binding.getStride();
-
-    return numVertices;
+    size_t effectiveStride = binding.getStride() > 0 ? binding.getStride() : srcFormatSize;
+    return 1 + static_cast<size_t>(bytes.ValueOrDie()) / effectiveStride;
 }
 
 inline void SetDefaultVertexBufferLayout(mtl::VertexBufferLayoutDesc *layout)
@@ -630,17 +635,27 @@ angle::Result VertexArrayMtl::syncDirtyAttrib(const gl::Context *glContext,
                 (binding.getStride() < format.actualAngleFormat().pixelBytes) ||
                 (binding.getStride() % mtl::kVertexAttribBufferStrideAlignment) != 0;
 
-            if (needConversion)
+            unsigned srcFormatSize = format.actualAngleFormat().pixelBytes;
+            size_t numVertices = GetVertexCount(bufferMtl, binding, srcFormatSize);
+            if (numVertices == 0)
+            {
+                // Out of bound buffer access, can return any values.
+                // See KHR_robust_buffer_access_behavior.
+                mCurrentArrayBuffers[attribIndex]       = bufferMtl;
+                mCurrentArrayBufferFormats[attribIndex] = &format;
+                mCurrentArrayBufferOffsets[attribIndex] = 0;
+                mCurrentArrayBufferStrides[attribIndex] = 16;
+            }
+            else if (needConversion)
             {
                 ANGLE_TRY(convertVertexBuffer(glContext, bufferMtl, binding, attribIndex, format));
             }
             else
             {
                 mCurrentArrayBuffers[attribIndex]       = bufferMtl;
+                mCurrentArrayBufferFormats[attribIndex] = &format;
                 mCurrentArrayBufferOffsets[attribIndex] = binding.getOffset();
                 mCurrentArrayBufferStrides[attribIndex] = binding.getStride();
-
-                mCurrentArrayBufferFormats[attribIndex] = &format;
             }
         }
         else
@@ -989,18 +1004,6 @@ angle::Result VertexArrayMtl::convertVertexBuffer(const gl::Context *glContext,
 {
     unsigned srcFormatSize = srcVertexFormat.intendedAngleFormat().pixelBytes;
 
-    size_t numVertices = GetVertexCount(srcBuffer, binding, srcFormatSize);
-    if (numVertices == 0)
-    {
-        // Out of bound buffer access, can return any values.
-        // See KHR_robust_buffer_access_behavior
-        mCurrentArrayBuffers[attribIndex]       = srcBuffer;
-        mCurrentArrayBufferFormats[attribIndex] = &srcVertexFormat;
-        mCurrentArrayBufferOffsets[attribIndex] = 0;
-        mCurrentArrayBufferStrides[attribIndex] = 16;
-        return angle::Result::Continue;
-    }
-
     ContextMtl *contextMtl = mtl::GetImpl(glContext);
 
     // Convert to tightly packed format
@@ -1027,7 +1030,7 @@ angle::Result VertexArrayMtl::convertVertexBuffer(const gl::Context *glContext,
         mCurrentArrayBufferStrides[attribIndex] = stride;
         return angle::Result::Continue;
     }
-    numVertices = GetVertexCountWithConversion(
+    size_t numVertices = GetVertexCountWithConversion(
         srcBuffer, static_cast<VertexConversionBufferMtl *>(conversion), binding, srcFormatSize);
 
     const angle::Format &convertedAngleFormat = convertedFormat.actualAngleFormat();

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/VertexAttributeTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/VertexAttributeTest.cpp
@@ -5945,6 +5945,59 @@ void main()
     EXPECT_PIXEL_COLOR_NEAR(0, 0, GLColor::white, 1);
 }
 
+// After a draw with an out-of-bounds vertex attribute offset (undefined behavior in ES),
+// verify that subsequent valid draws still render correctly and the backend state is not
+// corrupted.
+TEST_P(VertexAttributeTest, OutOfBoundsOffsetNoFormatConversion)
+{
+    constexpr char kVS[] =
+        R"(attribute vec4 a_position;
+void main()
+{
+    gl_Position = a_position;
+    gl_PointSize = 1.0;
+})";
+
+    ANGLE_GL_PROGRAM(program, kVS, essl1_shaders::fs::Red());
+    glUseProgram(program);
+
+    GLint posLoc = glGetAttribLocation(program, "a_position");
+    ASSERT_NE(-1, posLoc);
+
+    const GLfloat vertices[] = {
+        -1.0f, -1.0f,
+         1.0f, -1.0f,
+         1.0f,  1.0f,
+        -1.0f,  1.0f,
+    };
+    GLBuffer buffer;
+    glBindBuffer(GL_ARRAY_BUFFER, buffer);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+
+    glEnableVertexAttribArray(posLoc);
+
+    // Valid draw: prove setup is correct.
+    glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, 0, 0);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+    ASSERT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(32, 32, GLColor::red);
+
+    // OOB draw: offset far exceeds buffer. Result is UB in ES — no assertion.
+    glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, 0,
+                          reinterpret_cast<const void *>(1024));
+    glDrawArrays(GL_POINTS, 0, 1);
+
+    // Valid draw again: prove the backend recovered and state is not corrupted.
+    glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, 0, 0);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+    ASSERT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(32, 32, GLColor::red);
+}
+
 // VAO emulation fails on Mac but is not used on Mac in the wild. http://anglebug.com/40096758
 #if !defined(__APPLE__)
 #    define EMULATED_VAO_CONFIGS                                          \


### PR DESCRIPTION
#### 0fe9ff8c6712d184e1ea0ecf178381dceb30fd30
<pre>
[ANGLE] Metal backend: Fix crash on OOB vertex attribute offset in syncDirtyAttrib
<a href="https://bugs.webkit.org/show_bug.cgi?id=309989">https://bugs.webkit.org/show_bug.cgi?id=309989</a>
<a href="https://rdar.apple.com/172179424">rdar://172179424</a>

Reviewed by Kimmo Kinnunen.

VertexArrayMtl::syncDirtyAttrib&apos;s non-conversion path stores
binding.getOffset() unchecked and crashes in VertexArrayMtl::setupDraw
when the offset exceeds the buffer size.

Fix by hoisting GetVertexCount check before the needConversion branch so
both paths are guarded, clamping to safe defaults when no vertices fit.
Also rewrite GetVertexCount/GetVertexCountWithConversion using
CheckedNumeric to handle negative offsets and zero strides.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm:
(rx::VertexArrayMtl::syncDirtyAttrib):
(rx::VertexArrayMtl::convertVertexBuffer):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/VertexAttributeTest.cpp:

Originally-landed-as: 305413.586@rapid/safari-7624.2.5.110-branch (845230f29cf4). <a href="https://rdar.apple.com/176062010">rdar://176062010</a>
Canonical link: <a href="https://commits.webkit.org/314003@main">https://commits.webkit.org/314003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c8e4a86f6b15dee54b93bf22b2216b2d97a0694

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121997 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128031 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29379 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28004 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21539 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176303 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136350 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136313 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36718 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147583 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101201 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31584 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24439 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37496 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36894 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2505 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->