### PR TITLE
Concurrent HashMap access leads to MTE crashes

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -147,8 +147,9 @@ HTMLModelElement::HTMLModelElement(const QualifiedName& tagName, Document& docum
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        if (auto* screenData = WebCore::screenData(displayID))
-            protectedThis->updateScreenHeadroom(screenData->currentEDRHeadroom, screenData->suppressEDR);
+        auto platformScreen = PlatformScreen::singleton();
+        if (auto* data = platformScreen->screenData(displayID))
+            protectedThis->updateScreenHeadroom(data->currentEDRHeadroom, data->suppressEDR);
     }))
 #endif
 {

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -126,6 +126,7 @@
 #include "RenderVideo.h"
 #include "RenderView.h"
 #include "ResourceLoadInfo.h"
+#include "PlatformScreen.h"
 #include "ScreenProperties.h"
 #include "ScriptController.h"
 #include "ScriptDisallowedScope.h"
@@ -683,7 +684,8 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
     m_shouldVideoPlaybackRequireUserGesture = videoNeedsUserGesturePerPage && !processingUserGestureForMedia();
 
 #if PLATFORM(MAC)
-    if (auto data = screenData(primaryScreenDisplayID()))
+    auto platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(platformScreen->primaryScreenDisplayID()))
         m_screenReserved = data->reserved;
 #endif
 
@@ -10474,7 +10476,8 @@ void HTMLMediaElement::screenPropertiesChanged(PlatformDisplayID displayID)
 {
     setPreferredDynamicRangeMode(preferredDynamicRangeMode(protect(document().view()).get()));
 #if PLATFORM(MAC)
-    if (auto data = screenData(displayID))
+    auto platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID))
         setScreenReserved(data->reserved);
 #else
     UNUSED_PARAM(displayID);

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -93,7 +93,8 @@ private:
     float computeContentsHeadroom();
     void updateContentsHeadroom();
     void updateScreenHeadroom(float, bool suppressEDR);
-    void updateScreenHeadroomFromScreenProperties();
+    void updateScreenHeadroomFromScreenPropertiesIfNeeded();
+    void updateHeadroomFromScreenProperties();
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
     void updateMemoryCost() const;
 
@@ -122,6 +123,8 @@ private:
     RefPtr<ScreenPropertiesChangedObserver> m_screenPropertiesChangedObserver;
     PlatformDynamicRangeLimit m_dynamicRangeLimit { PlatformDynamicRangeLimit::initialValue() };
     float m_currentEDRHeadroom { 1 };
+    float m_screenEDRHeadroom { 0.f };
+    bool m_screenSuppressEDR { false };
     bool m_suppressEDR { false };
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
     bool m_compositingResultsNeedsUpdating { false };

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -188,11 +188,10 @@ GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, Ref<GPUComposit
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        if (auto* screenData = WebCore::screenData(displayID)) {
-            protectedThis->m_screenEDRHeadroom = screenData->currentEDRHeadroom;
-            protectedThis->m_screenSuppressEDR = screenData->suppressEDR;
-            protectedThis->updateHeadroomFromScreenProperties();
-        }
+
+        Ref screen = PlatformScreen::singleton();
+        if (auto* screenData = screen->screenData(displayID))
+            protectedThis->updateScreenHeadroom(screenData->currentEDRHeadroom, screenData->suppressEDR);
     }))
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
 {
@@ -270,17 +269,12 @@ void GPUCanvasContextCocoa::updateScreenHeadroomFromScreenPropertiesIfNeeded()
     if (!m_layerContentsDisplayDelegate->hasExtendedRange())
         return;
 
-    if (m_screenPropertiesChangedObserver && (m_currentEDRHeadroom >= 1.f || m_screenEDRHeadroom >= 1.f)) {
-        if (m_currentEDRHeadroom < 1.f)
-            updateHeadroomFromScreenProperties();
-        return;
-    }
-
     float maxEDRHeadroom = 1.f;
     bool suppressEDR = false;
 
     auto gatherScreenProperties = [&] {
-        for (const auto& screenData : WebCore::getScreenProperties().screenDataMap.values()) {
+        auto screen = PlatformScreen::singleton();
+        for (const auto& screenData : screen->screenProperties().screenDataMap.values()) {
             maxEDRHeadroom = std::max(maxEDRHeadroom, screenData.currentEDRHeadroom);
             suppressEDR |= screenData.suppressEDR;
         }

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -42,6 +42,7 @@
 #include "ScreenProperties.h"
 #include "Settings.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/threads/BinarySemaphore.h>
 
 namespace WebCore {
 
@@ -91,6 +92,14 @@ public:
     void NODELETE setOpaque(bool opaque)
     {
         m_isOpaque = opaque;
+    }
+    bool hasExtendedRange() const
+    {
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+        return m_contentsFormat == ContentsFormat::RGBA16F;
+#else
+        return false;
+#endif
     }
 private:
     GPUDisplayBufferDisplayDelegate(bool isOpaque, float contentsScale)
@@ -179,8 +188,11 @@ GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, Ref<GPUComposit
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        if (auto* screenData = WebCore::screenData(displayID))
-            protectedThis->updateScreenHeadroom(screenData->currentEDRHeadroom, screenData->suppressEDR);
+        if (auto* screenData = WebCore::screenData(displayID)) {
+            protectedThis->m_screenEDRHeadroom = screenData->currentEDRHeadroom;
+            protectedThis->m_screenSuppressEDR = screenData->suppressEDR;
+            protectedThis->updateHeadroomFromScreenProperties();
+        }
     }))
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
 {
@@ -232,7 +244,15 @@ float GPUCanvasContextCocoa::computeContentsHeadroom()
 
 void GPUCanvasContextCocoa::updateContentsHeadroom()
 {
+    if (!m_layerContentsDisplayDelegate->hasExtendedRange())
+        return;
+
     m_compositorIntegration->updateContentsHeadroom(computeContentsHeadroom());
+}
+
+void GPUCanvasContextCocoa::updateHeadroomFromScreenProperties()
+{
+    updateScreenHeadroom(m_screenEDRHeadroom, m_screenSuppressEDR);
 }
 
 void GPUCanvasContextCocoa::updateScreenHeadroom(float currentEDRHeadroom, bool suppressEDR)
@@ -245,15 +265,39 @@ void GPUCanvasContextCocoa::updateScreenHeadroom(float currentEDRHeadroom, bool 
     updateContentsHeadroom();
 }
 
-void GPUCanvasContextCocoa::updateScreenHeadroomFromScreenProperties()
+void GPUCanvasContextCocoa::updateScreenHeadroomFromScreenPropertiesIfNeeded()
 {
-    m_currentEDRHeadroom = 1.f;
-    m_suppressEDR = false;
-    for (const auto& screenData : WebCore::getScreenProperties().screenDataMap.values()) {
-        m_currentEDRHeadroom = std::max(m_currentEDRHeadroom, screenData.currentEDRHeadroom);
-        m_suppressEDR |= screenData.suppressEDR;
+    if (!m_layerContentsDisplayDelegate->hasExtendedRange())
+        return;
+
+    if (m_screenPropertiesChangedObserver && (m_currentEDRHeadroom >= 1.f || m_screenEDRHeadroom >= 1.f)) {
+        if (m_currentEDRHeadroom < 1.f)
+            updateHeadroomFromScreenProperties();
+        return;
     }
-    updateContentsHeadroom();
+
+    float maxEDRHeadroom = 1.f;
+    bool suppressEDR = false;
+
+    auto gatherScreenProperties = [&] {
+        for (const auto& screenData : WebCore::getScreenProperties().screenDataMap.values()) {
+            maxEDRHeadroom = std::max(maxEDRHeadroom, screenData.currentEDRHeadroom);
+            suppressEDR |= screenData.suppressEDR;
+        }
+    };
+
+    if (isMainThread())
+        gatherScreenProperties();
+    else {
+        BinarySemaphore semaphore;
+        callOnMainThread([&gatherScreenProperties, &semaphore] {
+            gatherScreenProperties();
+            semaphore.signal();
+        });
+        semaphore.wait();
+    }
+
+    updateScreenHeadroom(maxEDRHeadroom, suppressEDR);
 }
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
@@ -264,8 +308,7 @@ void GPUCanvasContextCocoa::setDynamicRangeLimit(PlatformDynamicRangeLimit dynam
 
     m_dynamicRangeLimit = dynamicRangeLimit;
 
-    if (!m_screenPropertiesChangedObserver || m_currentEDRHeadroom < 1.f)
-        return updateScreenHeadroomFromScreenProperties();
+    updateScreenHeadroomFromScreenPropertiesIfNeeded();
 
     updateContentsHeadroom();
 }
@@ -333,8 +376,7 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=294654 - OffscreenCanvas may not reflect the display the OffscreenCanvas is displayed on during background / resume
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    if (!m_screenPropertiesChangedObserver)
-        updateScreenHeadroomFromScreenProperties();
+    updateScreenHeadroomFromScreenPropertiesIfNeeded();
 #endif
 
     auto frameCount = m_configuration->frameCount;

--- a/Source/WebCore/platform/PlatformScreen.cpp
+++ b/Source/WebCore/platform/PlatformScreen.cpp
@@ -29,58 +29,96 @@
 #if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
 
 #include "ScreenProperties.h"
+#include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 
-static ScreenProperties& NODELETE screenProperties()
+static Lock& platformScreenLock()
 {
-    ASSERT(isMainThread());
-
-    static NeverDestroyed<ScreenProperties> screenProperties;
-    return screenProperties;
+    static Lock lock;
+    return lock;
 }
 
-const ScreenProperties& getScreenProperties()
+Ref<PlatformScreen>& PlatformScreen::instance() WTF_REQUIRES_LOCK(platformScreenLock())
 {
-    return screenProperties();
+    static NeverDestroyed<Ref<PlatformScreen>> platformScreen = PlatformScreen::create({ });
+    static NeverDestroyed<Ref<PlatformScreen>> ref { platformScreen.get() };
+    return ref.get();
 }
 
-PlatformDisplayID primaryScreenDisplayID()
+PlatformScreen::PlatformScreen(ScreenProperties&& properties)
+    : m_properties(WTF::move(properties))
 {
-    return screenProperties().primaryDisplayID;
 }
 
-void setScreenProperties(const ScreenProperties& properties)
+Ref<PlatformScreen> PlatformScreen::create(ScreenProperties&& properties)
 {
-    screenProperties() = properties;
+    return adoptRef(*new PlatformScreen(WTF::move(properties)));
 }
 
-const ScreenData* screenData(PlatformDisplayID screenDisplayID)
+Ref<const PlatformScreen> PlatformScreen::singleton()
 {
-    if (screenProperties().screenDataMap.isEmpty())
+    Locker locker { platformScreenLock() };
+    return instance().get();
+}
+
+const ScreenData* PlatformScreen::screenData(PlatformDisplayID screenDisplayID) const
+{
+    if (m_properties.screenDataMap.isEmpty())
         return nullptr;
 
     // Return property of the first screen if the screen is not found in the map.
     if (auto displayID = screenDisplayID ? screenDisplayID : primaryScreenDisplayID()) {
-        auto properties = screenProperties().screenDataMap.find(displayID);
-        if (properties != screenProperties().screenDataMap.end())
+        auto properties = m_properties.screenDataMap.find(displayID);
+        if (properties != m_properties.screenDataMap.end())
             return &properties->value;
     }
 
     // Last resort: use the first item in the screen list.
-    return &screenProperties().screenDataMap.begin()->value;
+    return &m_properties.screenDataMap.begin()->value;
+}
+
+PlatformDisplayID PlatformScreen::primaryScreenDisplayID() const
+{
+    return m_properties.primaryDisplayID;
+}
+
+const ScreenProperties& PlatformScreen::screenProperties() const
+{
+    return m_properties;
+}
+
+const ScreenDataMap& PlatformScreen::screenDatas() const
+{
+    return screenProperties().screenDataMap;
 }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-void setScreenContentsFormatsForTesting(OptionSet<ContentsFormat> contentsFormats)
+OptionSet<ContentsFormat> PlatformScreen::screenContentsFormatsForTesting() const
 {
-    screenProperties().screenContentsFormatsForTesting = contentsFormats;
+    return m_properties.screenContentsFormatsForTesting;
+}
+#endif
+
+void PlatformScreen::updateSingletonProperties(ScreenProperties&& properties)
+{
+    Locker locker { platformScreenLock() };
+    Ref<PlatformScreen>& platformScreenRef = PlatformScreen::instance();
+
+    // If we have the only reference, we can update in place
+    if (platformScreenRef->hasOneRef())
+        platformScreenRef->m_properties = WTF::move(properties);
+    else
+        platformScreenRef = PlatformScreen::create(WTF::move(properties));
 }
 
-OptionSet<ContentsFormat> screenContentsFormatsForTesting()
+#if HAVE(SUPPORT_HDR_DISPLAY)
+void PlatformScreen::updateSingletonContentsFormatsForTesting(OptionSet<ContentsFormat> contentsFormats)
 {
-    return screenProperties().screenContentsFormatsForTesting;
+    auto properties = singleton()->screenProperties();
+    properties.screenContentsFormatsForTesting = contentsFormats;
+    updateSingletonProperties(WTF::move(properties));
 }
 #endif
 

--- a/Source/WebCore/platform/PlatformScreen.cpp
+++ b/Source/WebCore/platform/PlatformScreen.cpp
@@ -35,6 +35,8 @@ namespace WebCore {
 
 static ScreenProperties& NODELETE screenProperties()
 {
+    ASSERT(isMainThread());
+
     static NeverDestroyed<ScreenProperties> screenProperties;
     return screenProperties;
 }

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -26,8 +26,10 @@
 #pragma once
 
 #include <WebCore/ContentsFormat.h>
+#include <WebCore/ScreenProperties.h>
 #include <wtf/Forward.h>
 #include <wtf/Platform.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 #if PLATFORM(MAC)
 OBJC_CLASS NSScreen;
@@ -59,10 +61,6 @@ class FloatRect;
 class FloatSize;
 class Widget;
 
-using PlatformDisplayID = uint32_t;
-
-using PlatformGPUID = uint64_t; // On MAC, global IOKit registryID that can identify a GPU across process boundaries.
-
 int screenDepth(Widget*);
 int screenDepthPerComponent(Widget*);
 bool screenIsMonochrome(Widget*);
@@ -81,13 +79,6 @@ FloatRect screenAvailableRect(Widget*);
 WEBCORE_EXPORT OptionSet<ContentsFormat> screenContentsFormats(Widget* = nullptr);
 WEBCORE_EXPORT bool screenSupportsExtendedColor(Widget* = nullptr);
 
-enum class DynamicRangeMode : uint8_t {
-    None,
-    Standard,
-    HLG,
-    HDR10,
-    DolbyVisionPQ,
-};
 #if HAVE(AVPLAYER_VIDEORANGEOVERRIDE)
 WEBCORE_EXPORT DynamicRangeMode preferredDynamicRangeMode(Widget* = nullptr);
 #else
@@ -103,17 +94,34 @@ constexpr bool screenSupportsHighDynamicRange(Widget* = nullptr) { return false;
 
 struct ScreenProperties;
 struct ScreenData;
-    
-WEBCORE_EXPORT ScreenProperties collectScreenProperties();
-WEBCORE_EXPORT void setScreenProperties(const ScreenProperties&);
-WEBCORE_EXPORT const ScreenProperties& NODELETE getScreenProperties();
-WEBCORE_EXPORT const ScreenData* screenData(PlatformDisplayID screendisplayID);
-WEBCORE_EXPORT PlatformDisplayID NODELETE primaryScreenDisplayID();
+
+class PlatformScreen : public ThreadSafeRefCounted<PlatformScreen> {
+public:
+    WEBCORE_EXPORT static Ref<const PlatformScreen> singleton();
+    WEBCORE_EXPORT static void updateSingletonProperties(ScreenProperties&&);
+
+    WEBCORE_EXPORT const ScreenData* screenData(PlatformDisplayID) const LIFETIME_BOUND;
+    WEBCORE_EXPORT PlatformDisplayID primaryScreenDisplayID() const;
+    WEBCORE_EXPORT const ScreenProperties& screenProperties() const LIFETIME_BOUND;
+    WEBCORE_EXPORT const ScreenDataMap& screenDatas() const LIFETIME_BOUND;
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-WEBCORE_EXPORT void NODELETE setScreenContentsFormatsForTesting(OptionSet<ContentsFormat>);
-OptionSet<ContentsFormat> NODELETE screenContentsFormatsForTesting();
+    WEBCORE_EXPORT OptionSet<ContentsFormat> screenContentsFormatsForTesting() const;
+    WEBCORE_EXPORT static void updateSingletonContentsFormatsForTesting(OptionSet<ContentsFormat>);
+#endif
 
+private:
+    static Ref<PlatformScreen> create(ScreenProperties&&);
+    static Ref<PlatformScreen>& instance();
+
+    explicit PlatformScreen(ScreenProperties&&);
+
+    ScreenProperties m_properties;
+};
+
+WEBCORE_EXPORT ScreenProperties collectScreenProperties();
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
 WEBCORE_EXPORT float currentEDRHeadroomForDisplay(PlatformDisplayID);
 WEBCORE_EXPORT float maxEDRHeadroomForDisplay(PlatformDisplayID);
 WEBCORE_EXPORT bool suppressEDRForDisplay(PlatformDisplayID);

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -27,13 +27,26 @@
 
 #include <WebCore/DestinationColorSpace.h>
 #include <WebCore/FloatRect.h>
-#include <WebCore/PlatformScreen.h>
 #include <wtf/HashMap.h>
 #include <wtf/Platform.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+enum class ContentsFormat : uint8_t;
+
+using PlatformGPUID = uint64_t; // On MAC, global IOKit registryID that can identify a GPU across process boundaries.
+
+using PlatformDisplayID = uint32_t;
+
+enum class DynamicRangeMode : uint8_t {
+    None,
+    Standard,
+    HLG,
+    HDR10,
+    DolbyVisionPQ,
+};
 
 struct ScreenData {
     FloatRect screenAvailableRect;

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -291,7 +291,8 @@ static bool isVP9CodecConfigurationRecordSupported(const VPCodecConfigurationRec
         auto screenSize = FloatSize(overrideForTesting->width, overrideForTesting->height).scaled(overrideForTesting->scale);
         has4kScreen = resolutionCategory(screenSize) >= ResolutionCategory::R_4K;
     } else {
-        for (auto& screenData : getScreenProperties().screenDataMap.values()) {
+        Ref screen = PlatformScreen::singleton();
+        for (auto& screenData : screen->screenDatas().values()) {
             if (resolutionCategory(screenData.screenRect.size().scaled(screenData.scaleFactor)) >= ResolutionCategory::R_4K) {
                 has4kScreen = true;
                 break;
@@ -424,7 +425,8 @@ std::optional<PlatformMediaCapabilitiesInfo> computeVPParameters(const PlatformM
         auto screenSize = FloatSize(overrideForTesting->width, overrideForTesting->height).scaled(overrideForTesting->scale);
         has4kScreen = resolutionCategory(screenSize) >= ResolutionCategory::R_4K;
     } else {
-        for (auto& screenData : getScreenProperties().screenDataMap.values()) {
+        Ref screen = PlatformScreen::singleton();
+        for (auto& screenData : screen->screenDatas().values()) {
             if (resolutionCategory(screenData.screenRect.size().scaled(screenData.scaleFactor)) >= ResolutionCategory::R_4K) {
                 has4kScreen = true;
                 break;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1140,7 +1140,8 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfi
         }
 
 #if ENABLE(WPE_PLATFORM)
-        auto* scrData = screenData(primaryScreenDisplayID());
+        Ref platformScreen = PlatformScreen::singleton();
+        auto* scrData = platformScreen->screenData(platformScreen->primaryScreenDisplayID());
         if (!scrData || !scrData->screenSupportsHighDynamicRange) {
             // Check HDR metadata field
             if (videoConfiguration.hdrMetadataType.has_value())

--- a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
@@ -59,13 +59,15 @@ static PlatformDisplayID widgetDisplayID(Widget* widget)
 
 int screenDepth(Widget* widget)
 {
-    auto* data = screenData(widgetDisplayID(widget));
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(widgetDisplayID(widget));
     return data ? data->screenDepth : 24;
 }
 
 int screenDepthPerComponent(Widget* widget)
 {
-    auto* data = screenData(widgetDisplayID(widget));
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(widgetDisplayID(widget));
     return data ? data->screenDepthPerComponent : 8;
 }
 
@@ -90,27 +92,31 @@ double fontDPI()
     if (xftDPI)
         return xftDPI.value() / 1024.0;
 
-    auto* data = screenData(primaryScreenDisplayID());
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(platformScreen->primaryScreenDisplayID());
     return data ? data->dpi : 96.;
 }
 
 double screenDPI(PlatformDisplayID screendisplayID)
 {
-    auto* data = screenData(screendisplayID);
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(screendisplayID);
     return data ? data->dpi : 96.;
 }
 
 
 FloatRect screenRect(Widget* widget)
 {
-    if (auto* data = screenData(widgetDisplayID(widget)))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto* data = platformScreen->screenData(widgetDisplayID(widget)))
         return data->screenRect;
     return { };
 }
 
 FloatRect screenAvailableRect(Widget* widget)
 {
-    if (auto* data = screenData(widgetDisplayID(widget)))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto* data = platformScreen->screenData(widgetDisplayID(widget)))
         return data->screenAvailableRect;
     return { };
 }
@@ -123,7 +129,8 @@ bool screenSupportsExtendedColor(Widget*)
 #if ENABLE(TOUCH_EVENTS)
 bool screenHasTouchDevice()
 {
-    return getScreenProperties().screenHasTouchDevice;
+    Ref platformScreen = PlatformScreen::singleton();
+    return platformScreen->screenProperties().screenHasTouchDevice;
 }
 #endif // ENABLE(TOUCH_EVENTS)
 

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -66,7 +66,8 @@ bool screenIsMonochrome(Widget*)
 
 bool screenHasInvertedColors()
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->screenHasInvertedColors;
 
     return PAL::softLinkUIKitUIAccessibilityIsInvertColorsEnabled();
@@ -92,12 +93,13 @@ OptionSet<ContentsFormat> screenContentsFormats(Widget* widget)
 
 bool screenSupportsExtendedColor(Widget*)
 {
+    Ref screen = PlatformScreen::singleton();
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGB10)
-    if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA10))
+    if (screen->screenContentsFormatsForTesting().contains(ContentsFormat::RGBA10))
         return true;
 #endif
 
-    if (auto data = screenData(primaryScreenDisplayID()))
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->screenSupportsExtendedColor;
 
     return MGGetBoolAnswer(kMGQHasExtendedColorDisplay);
@@ -105,12 +107,13 @@ bool screenSupportsExtendedColor(Widget*)
 
 bool screenSupportsHighDynamicRange(Widget*)
 {
+    Ref screen = PlatformScreen::singleton();
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
-    if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA16F))
+    if (screen->screenContentsFormatsForTesting().contains(ContentsFormat::RGBA16F))
         return true;
 #endif
 
-    if (auto data = screenData(primaryScreenDisplayID()))
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->screenSupportsHighDynamicRange;
 
 #if USE(MEDIATOOLBOX)
@@ -128,7 +131,8 @@ bool screenSupportsHighDynamicRange(PlatformDisplayID)
 #if HAVE(SUPPORT_HDR_DISPLAY)
 float currentEDRHeadroomForDisplay(PlatformDisplayID)
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->currentEDRHeadroom;
 
     return [[PAL::getUIScreenClassSingleton() mainScreen] currentEDRHeadroom];
@@ -136,7 +140,8 @@ float currentEDRHeadroomForDisplay(PlatformDisplayID)
 
 float maxEDRHeadroomForDisplay(PlatformDisplayID)
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->maxEDRHeadroom;
 
     return [[PAL::getUIScreenClassSingleton() mainScreen] potentialEDRHeadroom];
@@ -144,7 +149,8 @@ float maxEDRHeadroomForDisplay(PlatformDisplayID)
 
 bool suppressEDRForDisplay(PlatformDisplayID)
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->suppressEDR;
 
     return false;
@@ -199,7 +205,8 @@ FloatRect screenAvailableRect(Widget* widget)
 
 float screenPPIFactor()
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->scaleFactor;
 
     static float ppiFactor = [] {
@@ -222,7 +229,8 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         return { 320, 480 };
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->screenRect.size();
 
     return FloatSize([[PAL::getUIScreenClassSingleton() mainScreen] _referenceBounds].size);
@@ -236,7 +244,8 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         return { 320, 480 };
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->screenAvailableRect.size();
 
     return FloatSize([PAL::getUIScreenClassSingleton() mainScreen].bounds.size);

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -206,7 +206,8 @@ void setShouldOverrideScreenSupportsHighDynamicRange(bool shouldOverride, bool s
 
 uint32_t primaryOpenGLDisplayMask()
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->displayMask;
 
     return 0;
@@ -214,7 +215,8 @@ uint32_t primaryOpenGLDisplayMask()
 
 uint32_t displayMaskForDisplay(PlatformDisplayID displayID)
 {
-    if (auto data = screenData(displayID))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(displayID))
         return data->displayMask;
 
     ASSERT_NOT_REACHED();
@@ -223,12 +225,13 @@ uint32_t displayMaskForDisplay(PlatformDisplayID displayID)
 
 PlatformGPUID primaryGPUID()
 {
-    return gpuIDForDisplay(primaryScreenDisplayID());
+    return gpuIDForDisplay(PlatformScreen::singleton()->primaryScreenDisplayID());
 }
 
 PlatformGPUID gpuIDForDisplay(PlatformDisplayID displayID)
 {
-    if (auto data = screenData(displayID))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(displayID))
         return data->gpuID;
 
     return 0;
@@ -272,14 +275,10 @@ PlatformGPUID gpuIDForDisplayMask(GLuint displayMask)
     return static_cast<PlatformGPUID>(static_cast<uint32_t>(gpuIDHigh)) << 32 | static_cast<uint32_t>(gpuIDLow);
 }
 
-static const ScreenData* screenProperties(Widget* widget)
-{
-    return screenData(displayID(widget));
-}
-
 bool screenIsMonochrome(Widget* widget)
 {
-    if (auto data = screenProperties(widget))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget)))
         return data->screenIsMonochrome;
 
     // This is a system-wide accessibility setting, same on all screens.
@@ -289,7 +288,8 @@ bool screenIsMonochrome(Widget* widget)
 
 bool screenHasInvertedColors()
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->screenHasInvertedColors;
 
     // This is a system-wide accessibility setting, same on all screens.
@@ -299,7 +299,8 @@ bool screenHasInvertedColors()
 
 int screenDepth(Widget* widget)
 {
-    if (auto data = screenProperties(widget)) {
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget))) {
         ASSERT(data->screenDepth);
         return data->screenDepth;
     }
@@ -310,7 +311,8 @@ int screenDepth(Widget* widget)
 
 int screenDepthPerComponent(Widget* widget)
 {
-    if (auto data = screenProperties(widget)) {
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget))) {
         ASSERT(data->screenDepthPerComponent);
         return data->screenDepthPerComponent;
     }
@@ -321,7 +323,8 @@ int screenDepthPerComponent(Widget* widget)
 
 FloatRect screenRectForDisplay(PlatformDisplayID displayID)
 {
-    if (auto data = screenData(displayID)) {
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID)) {
         ASSERT(!data->screenRect.isEmpty());
         return data->screenRect;
     }
@@ -332,13 +335,14 @@ FloatRect screenRectForDisplay(PlatformDisplayID displayID)
 
 FloatRect screenRectForPrimaryScreen()
 {
-    return screenRectForDisplay(primaryScreenDisplayID());
+    return screenRectForDisplay(PlatformScreen::singleton()->primaryScreenDisplayID());
 }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
 float currentEDRHeadroomForDisplay(PlatformDisplayID displayID)
 {
-    if (auto data = screenData(displayID))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID))
         return data->currentEDRHeadroom;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -347,7 +351,8 @@ float currentEDRHeadroomForDisplay(PlatformDisplayID displayID)
 
 float maxEDRHeadroomForDisplay(PlatformDisplayID displayID)
 {
-    if (auto data = screenData(displayID))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID))
         return data->maxEDRHeadroom;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -356,7 +361,8 @@ float maxEDRHeadroomForDisplay(PlatformDisplayID displayID)
 
 bool suppressEDRForDisplay(PlatformDisplayID displayID)
 {
-    if (auto data = screenData(displayID))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID))
         return data->suppressEDR;
 
     return false;
@@ -365,7 +371,8 @@ bool suppressEDRForDisplay(PlatformDisplayID displayID)
 
 FloatRect screenRect(Widget* widget)
 {
-    if (auto data = screenProperties(widget))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget)))
         return data->screenRect;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -374,7 +381,8 @@ FloatRect screenRect(Widget* widget)
 
 FloatRect screenAvailableRect(Widget* widget)
 {
-    if (auto data = screenProperties(widget))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget)))
         return data->screenAvailableRect;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -399,7 +407,8 @@ NSScreen *screen(PlatformDisplayID displayID)
 
 DestinationColorSpace screenColorSpace(Widget* widget)
 {
-    if (auto data = screenProperties(widget))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget)))
         return data->colorSpace;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -426,12 +435,13 @@ OptionSet<ContentsFormat> screenContentsFormats(Widget* widget)
 
 bool screenSupportsExtendedColor(Widget* widget)
 {
+    Ref platformScreen = PlatformScreen::singleton();
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGB10)
-    if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA10))
+    if (platformScreen->screenContentsFormatsForTesting().contains(ContentsFormat::RGBA10))
         return true;
 #endif
 
-    if (auto data = screenProperties(widget))
+    if (auto data = platformScreen->screenData(displayID(widget)))
         return data->screenSupportsExtendedColor;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -445,12 +455,14 @@ bool screenSupportsHighDynamicRange(Widget* widget)
 
 bool screenSupportsHighDynamicRange(PlatformDisplayID displayID)
 {
+    Ref screen = PlatformScreen::singleton();
+
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
-    if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA16F))
+    if (screen->screenContentsFormatsForTesting().contains(ContentsFormat::RGBA16F))
         return true;
 #endif
 
-    if (auto data = screenData(displayID))
+    if (auto data = screen->screenData(displayID))
         return data->screenSupportsHighDynamicRange;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -464,7 +476,8 @@ bool screenSupportsHighDynamicRange(PlatformDisplayID displayID)
 #if HAVE(AVPLAYER_VIDEORANGEOVERRIDE)
 DynamicRangeMode preferredDynamicRangeMode(Widget* widget)
 {
-    if (auto data = screenProperties(widget))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget)))
         return data->preferredDynamicRangeMode;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -487,14 +500,14 @@ FloatRect toUserSpace(const NSRect& rect, NSWindow *destination)
 FloatRect toUserSpaceForPrimaryScreen(const NSRect& rect)
 {
     FloatRect userRect = rect;
-    userRect.setY(NSMaxY(screenRectForDisplay(primaryScreenDisplayID())) - (userRect.y() + userRect.height())); // flip
+    userRect.setY(NSMaxY(screenRectForDisplay(PlatformScreen::singleton()->primaryScreenDisplayID())) - (userRect.y() + userRect.height())); // flip
     return userRect;
 }
 
 FloatPoint toUserSpaceForPrimaryScreen(const NSPoint& point)
 {
     FloatPoint userPoint = point;
-    userPoint.setY(NSMaxY(screenRectForDisplay(primaryScreenDisplayID())) - userPoint.y()); // flip
+    userPoint.setY(NSMaxY(screenRectForDisplay(PlatformScreen::singleton()->primaryScreenDisplayID())) - userPoint.y()); // flip
     return userPoint;
 }
 

--- a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
@@ -57,7 +57,8 @@ static PlatformDisplayID widgetDisplayID(Widget* widget)
 int screenDepth(Widget* widget)
 {
 #if ENABLE(WPE_PLATFORM)
-    auto* data = screenData(widgetDisplayID(widget));
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(widgetDisplayID(widget));
     return data ? data->screenDepth : 24;
 #else
     UNUSED_PARAM(widget);
@@ -69,7 +70,8 @@ int screenDepth(Widget* widget)
 int screenDepthPerComponent(Widget* widget)
 {
 #if ENABLE(WPE_PLATFORM)
-    auto* data = screenData(widgetDisplayID(widget));
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(widgetDisplayID(widget));
     return data ? data->screenDepthPerComponent : 8;
 #else
     UNUSED_PARAM(widget);
@@ -97,7 +99,8 @@ bool screenHasInvertedColors()
 double screenDPI(PlatformDisplayID screendisplayID)
 {
 #if ENABLE(WPE_PLATFORM)
-    auto* data = screenData(screendisplayID);
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(screendisplayID);
     return data ? data->dpi : 96.;
 #else
     UNUSED_PARAM(screendisplayID);
@@ -110,7 +113,7 @@ double fontDPI()
 {
 #if ENABLE(WPE_PLATFORM)
     // In WPE, there is no notion of font scaling separate from device DPI.
-    return screenDPI(primaryScreenDisplayID());
+    return screenDPI(PlatformScreen::singleton()->primaryScreenDisplayID());
 #else
     notImplemented();
     return 96.;
@@ -120,7 +123,8 @@ double fontDPI()
 FloatRect screenRect(Widget* widget)
 {
 #if ENABLE(WPE_PLATFORM)
-    if (auto* data = screenData(widgetDisplayID(widget)))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto* data = platformScreen->screenData(widgetDisplayID(widget)))
         return data->screenRect;
 #endif
     // WPE can't offer any more useful information about the screen size,
@@ -134,7 +138,8 @@ FloatRect screenRect(Widget* widget)
 FloatRect screenAvailableRect(Widget* widget)
 {
 #if ENABLE(WPE_PLATFORM)
-    if (auto* data = screenData(widgetDisplayID(widget)))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto* data = platformScreen->screenData(widgetDisplayID(widget)))
         return data->screenAvailableRect;
 #endif
     return screenRect(widget);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4285,7 +4285,7 @@ void Internals::setScreenContentsFormatsForTesting(const Vector<Internals::Conte
     }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    WebCore::setScreenContentsFormatsForTesting(contentsFormats);
+    PlatformScreen::singleton()->updateSingletonContentsFormatsForTesting(contentsFormats);
 #else
     UNUSED_PARAM(contentsFormats);
 #endif
@@ -7385,7 +7385,7 @@ void Internals::notifyResourceLoadObserver()
 unsigned Internals::primaryScreenDisplayID()
 {
 #if PLATFORM(COCOA)
-    return WebCore::primaryScreenDisplayID();
+    return PlatformScreen::singleton()->primaryScreenDisplayID();
 #else
     return 0;
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -673,7 +673,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request, RenderPro
     addTableRow(displayObject, "Bits per color component"_s, String::number(screenDepthPerComponent(nullptr)));
     addTableRow(displayObject, "Font Scaling DPI"_s, String::number(WebCore::fontDPI()));
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
-    addTableRow(displayObject, "Screen DPI"_s, String::number(screenDPI(displayID.value_or(primaryScreenDisplayID()))));
+    addTableRow(displayObject, "Screen DPI"_s, String::number(screenDPI(displayID.value_or(PlatformScreen::singleton()->primaryScreenDisplayID()))));
 #endif
 
     if (displayID) {

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1403,7 +1403,8 @@ void WebProcessPool::registerHighDynamicRangeChangeCallback()
 void WebProcessPool::didRefreshDisplay()
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    float headroom = currentEDRHeadroomForDisplay(primaryScreenDisplayID());
+    Ref screen = PlatformScreen::singleton();
+    float headroom = currentEDRHeadroomForDisplay(screen->primaryScreenDisplayID());
     if (m_currentEDRHeadroom != headroom) {
         m_currentEDRHeadroom = headroom;
         screenPropertiesChanged();

--- a/Source/WebKit/UIProcess/glib/ScreenManager.h
+++ b/Source/WebKit/UIProcess/glib/ScreenManager.h
@@ -35,13 +35,17 @@
 
 #if PLATFORM(GTK)
 typedef struct _GdkMonitor GdkMonitor;
-using PlatformScreen = GdkMonitor;
 #elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
 typedef struct _WPEScreen WPEScreen;
-using PlatformScreen = WPEScreen;
 #endif
 
 namespace WebKit {
+
+#if PLATFORM(GTK)
+using PlatformScreen = GdkMonitor;
+#elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+using PlatformScreen = WPEScreen;
+#endif
 
 using PlatformDisplayID = uint32_t;
 

--- a/Source/WebKit/UIProcess/gtk/ScreenManagerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ScreenManagerGtk.cpp
@@ -154,7 +154,7 @@ ScreenProperties ScreenManager::collectScreenProperties() const
     }
 
     // FIXME: don't use PlatformScreen from the UI process, better use ScreenManager directly.
-    WebCore::setScreenProperties(properties);
+    WebCore::PlatformScreen::updateSingletonProperties(ScreenProperties { properties });
 
     return properties;
 }

--- a/Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp
@@ -93,7 +93,7 @@ ScreenProperties ScreenManager::collectScreenProperties() const
     }
 
     // FIXME: don't use PlatformScreen from the UI process, better use ScreenManager directly.
-    WebCore::setScreenProperties(properties);
+    WebCore::PlatformScreen::updateSingletonProperties(ScreenProperties { properties });
 
     return properties;
 }

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -147,8 +147,9 @@ WebModelPlayer::WebModelPlayer(WebCore::Page& page, WebCore::ModelPlayerClient& 
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
-            if (auto* screenData = WebCore::screenData(displayID))
-                protectedThis->updateScreenHeadroom(screenData->currentEDRHeadroom, screenData->suppressEDR);
+            auto platformScreen = WebCore::PlatformScreen::singleton();
+            if (auto* data = platformScreen->screenData(displayID))
+                protectedThis->updateScreenHeadroom(data->currentEDRHeadroom, data->suppressEDR);
         });
 
         document->addScreenPropertiesChangedObserver(*m_screenPropertiesChangedObserver);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1073,7 +1073,8 @@ double UnifiedPDFPlugin::scaleForActualSize() const
     if (!webPage)
         return 1;
 
-    auto* screenData = WebCore::screenData(webPage->corePage()->displayID());
+    Ref screen = PlatformScreen::singleton();
+    auto* screenData = screen->screenData(webPage->corePage()->displayID());
     if (!screenData)
         return 1;
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -731,7 +731,7 @@ private:
 #endif
 
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
-    void setScreenProperties(const WebCore::ScreenProperties&);
+    void setScreenProperties(WebCore::ScreenProperties&&);
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -591,7 +591,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     });
 #endif
 
-    WebCore::setScreenProperties(parameters.screenProperties);
+    WebCore::PlatformScreen::updateSingletonProperties(WTF::move(parameters.screenProperties));
 
 #if PLATFORM(MAC)
     scrollerStylePreferenceChanged(parameters.useOverlayScrollbars);
@@ -1521,7 +1521,7 @@ void WebProcess::switchFromStaticFontRegistryToUserFontRegistry(Vector<WebKit::S
 }
 #endif // !ENABLE(REMOVE_XPC_AND_MACH_SANDBOX_EXTENSIONS_IN_WEBCONTENT)
 
-void WebProcess::setScreenProperties(const WebCore::ScreenProperties& properties)
+void WebProcess::setScreenProperties(WebCore::ScreenProperties&& properties)
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
     auto propertiesWithStyleAffectingOnly = [](auto properties) {
@@ -1532,12 +1532,12 @@ void WebProcess::setScreenProperties(const WebCore::ScreenProperties& properties
         }
         return properties;
     };
-    bool affectsStyle = propertiesWithStyleAffectingOnly(properties) != propertiesWithStyleAffectingOnly(WebCore::getScreenProperties());
+    bool affectsStyle = propertiesWithStyleAffectingOnly(properties) != propertiesWithStyleAffectingOnly(WebCore::PlatformScreen::singleton()->screenProperties());
 #else
     constexpr bool affectsStyle = true;
 #endif
 
-    WebCore::setScreenProperties(properties);
+    WebCore::PlatformScreen::updateSingletonProperties(WTF::move(properties));
     for (auto& page : m_pageMap.values())
         page->screenPropertiesDidChange(affectsStyle);
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -261,14 +261,14 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
         FontRenderOptions::singleton().disableHintingForTesting();
 
 #if PLATFORM(GTK)
-    WebCore::setScreenProperties(parameters.screenProperties);
+    WebCore::PlatformScreen::updateSingletonProperties(WTF::move(parameters.screenProperties));
 
     WebCore::SystemSoundManager::singleton().setSystemSoundDelegate(makeUnique<WebSystemSoundDelegate>());
 #endif
 
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
     if (!m_rendererBufferTransportMode.isEmpty())
-        WebCore::setScreenProperties(parameters.screenProperties);
+        WebCore::PlatformScreen::updateSingletonProperties(WTF::move(parameters.screenProperties));
 #endif
 }
 
@@ -315,10 +315,10 @@ void WebProcess::releaseSystemMallocMemory()
 }
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-void WebProcess::setScreenProperties(const WebCore::ScreenProperties& properties)
+void WebProcess::setScreenProperties(WebCore::ScreenProperties&& properties)
 {
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
-    WebCore::setScreenProperties(properties);
+    WebCore::PlatformScreen::updateSingletonProperties(WTF::move(properties));
 #endif
     for (auto& page : m_pageMap.values())
         page->screenPropertiesDidChange();


### PR DESCRIPTION
#### 08911bd034c30613cc2a3b07c587138a7cf281ac
<pre>
Concurrent HashMap access leads to MTE crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=308476">https://bugs.webkit.org/show_bug.cgi?id=308476</a>
<a href="https://rdar.apple.com/163967950">rdar://163967950</a>

Reviewed by Kimmo Kinnunen.

Remove free-standing getScreenProperties() and screenData() functions
from PlatformScreen which allow accessing either the container or iterators
within a HashMap as it was discovered in #4632
that these functions may be called off the main thread.

Replace with a singleton that has CoW semantics and is resettable, so in the
case a seperate thread is accessing PlatformScreen, we will have two, or potentially K,
PlatformScreen instances alive until the other threads release their ref counts.

* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::updateScreenHeadroomFromScreenProperties):
* Source/WebCore/platform/PlatformScreen.cpp:
(WebCore::platformScreenLock):
(WebCore::platformScreenInstance):
(WebCore::PlatformScreen::PlatformScreen):
(WebCore::PlatformScreen::create):
(WebCore::PlatformScreen::singleton):
(WebCore::PlatformScreen::screenData const):
(WebCore::PlatformScreen::primaryScreenDisplayID const):
(WebCore::PlatformScreen::screenProperties const):
(WebCore::PlatformScreen::screenContentsFormatsForTesting const):
(WebCore::PlatformScreen::updateSingletonProperties):
(WebCore::PlatformScreen::setScreenContentsFormatsForTesting):
(WebCore::screenProperties): Deleted.
(WebCore::getScreenProperties): Deleted.
(WebCore::primaryScreenDisplayID): Deleted.
(WebCore::setScreenProperties): Deleted.
(WebCore::screenData): Deleted.
(WebCore::setScreenContentsFormatsForTesting): Deleted.
(WebCore::screenContentsFormatsForTesting): Deleted.
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::isVP9CodecConfigurationRecordSupported):
(WebCore::computeVPParameters):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::isConfigurationSupported const):
* Source/WebCore/platform/gtk/PlatformScreenGtk.cpp:
(WebCore::screenDepth):
(WebCore::screenDepthPerComponent):
(WebCore::fontDPI):
(WebCore::screenDPI):
(WebCore::screenRect):
(WebCore::screenAvailableRect):
* Source/WebCore/platform/ios/PlatformScreenIOS.mm:
(WebCore::screenHasInvertedColors):
(WebCore::screenSupportsExtendedColor):
(WebCore::screenSupportsHighDynamicRange):
(WebCore::currentEDRHeadroomForDisplay):
(WebCore::maxEDRHeadroomForDisplay):
(WebCore::suppressEDRForDisplay):
(WebCore::screenPPIFactor):
(WebCore::screenSize):
(WebCore::availableScreenSize):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::primaryOpenGLDisplayMask):
(WebCore::displayMaskForDisplay):
(WebCore::primaryGPUID):
(WebCore::gpuIDForDisplay):
(WebCore::screenIsMonochrome):
(WebCore::screenHasInvertedColors):
(WebCore::screenDepth):
(WebCore::screenDepthPerComponent):
(WebCore::screenRectForDisplay):
(WebCore::screenRectForPrimaryScreen):
(WebCore::currentEDRHeadroomForDisplay):
(WebCore::maxEDRHeadroomForDisplay):
(WebCore::suppressEDRForDisplay):
(WebCore::screenRect):
(WebCore::screenAvailableRect):
(WebCore::screenColorSpace):
(WebCore::screenSupportsExtendedColor):
(WebCore::screenSupportsHighDynamicRange):
(WebCore::preferredDynamicRangeMode):
(WebCore::toUserSpaceForPrimaryScreen):
(WebCore::screenProperties): Deleted.
* Source/WebCore/platform/wpe/PlatformScreenWPE.cpp:
(WebCore::screenDepth):
(WebCore::screenDepthPerComponent):
(WebCore::screenDPI):
(WebCore::screenRect):
(WebCore::screenAvailableRect):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setScreenContentsFormatsForTesting):
(WebCore::Internals::primaryScreenDisplayID):
* Source/WebKit/UIProcess/gtk/ScreenManagerGtk.cpp:
(WebKit::ScreenManager::collectScreenProperties const):
* Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp:
(WebKit::ScreenManager::collectScreenProperties const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::scaleForActualSize const):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):
(WebKit::WebProcess::setScreenProperties):

Originally-landed-as: 305413.483@rapid/safari-7624.2.5.110-branch (962438e00d35). <a href="https://rdar.apple.com/176062075">rdar://176062075</a>
Canonical link: <a href="https://commits.webkit.org/314108@main">https://commits.webkit.org/314108@main</a>
</pre>
----------------------------------------------------------------------
#### cf20d123b3b1aef8ba0ecfe83ee2b493e33f28e8
<pre>
Concurrent HashMap access leads to MTE crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=308476">https://bugs.webkit.org/show_bug.cgi?id=308476</a>
<a href="https://rdar.apple.com/163967950">rdar://163967950</a>

Reviewed by Gerald Squelart.

Calling WebCore::getScreenProperties from a worker thread and iterating
over the HashMap is unsafe, since the main thread might be simultaneously
mutating it.

Correct this by only calling WebCore::getScreenProperties on the main thread.

* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::updateHeadroomFromScreenProperties):
(WebCore::GPUCanvasContextCocoa::updateScreenHeadroomFromScreenPropertiesIfNeeded):
(WebCore::GPUCanvasContextCocoa::setDynamicRangeLimit):
(WebCore::GPUCanvasContextCocoa::surfaceBufferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::updateScreenHeadroomFromScreenProperties): Deleted.
* Source/WebCore/platform/PlatformScreen.cpp:
(WebCore::getScreenProperties):

Originally-landed-as: 305413.414@rapid/safari-7624.2.5.110-branch (500da5401d26). <a href="https://rdar.apple.com/176062075">rdar://176062075</a>
Canonical link: <a href="https://commits.webkit.org/314107@main">https://commits.webkit.org/314107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/598109ec015935eac095acb961e0270cb0876d20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165121 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174163 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6759308e-f4a2-4a7e-83c9-dea73334aebc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128322 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a55a80ea-1102-4a28-914c-f1400bf1c566) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108847 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/681a18ba-9e7d-43e3-85fe-ca4a56943854) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21918 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176686 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136639 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136581 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36815 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147871 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101678 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31859 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24738 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37880 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110952 "Found 2 new failures in testing/Internals.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37277 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2814 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37523 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->