### PR TITLE
[JSC] Make RegExp tolerant against excessive stress

### DIFF
--- a/JSTests/stress/regexp-alternative-heavy.js
+++ b/JSTests/stress/regexp-alternative-heavy.js
@@ -1,0 +1,41 @@
+//@ runDefault
+
+function tryCompileAndRun(label, buildPattern, testInput) {
+    // print(`\n[*] ${label}`);
+    let pattern;
+    try {
+        pattern = buildPattern();
+        // print(`    Pattern length: ${pattern.length} chars`);
+    } catch(e) {
+        print(`    BUILD ERROR: ${e.message}`);
+        return;
+    }
+
+    let re;
+    try {
+        re = new RegExp(pattern, 'g');
+        // print(`    RegExp constructed OK`);
+    } catch(e) {
+        print(`    REGEXP CONSTRUCTION ERROR (likely limit hit): ${e.message}`);
+        return;
+    }
+
+    // Warm the JIT — JSC typically tiered-compiles after ~6 invocations
+    try {
+        for (let i = 0; i < 8; i++) {
+            re.lastIndex = 0;
+            re.exec(testInput);
+        }
+        // print(`    exec() completed without crash — check for SP corruption artifacts`);
+    } catch(e) {
+        print(`    RUNTIME ERROR: ${e.message}`);
+    }
+}
+
+for (const n of [1000]) {
+    tryCompileAndRun(
+        `Approach C: ${n} alternation groups (a|b)*`,
+        () => '(a|b)*'.repeat(n),
+        'ab'.repeat(50)
+    );
+}

--- a/JSTests/stress/regexp-bol-optimize-out-of-stack.js
+++ b/JSTests/stress/regexp-bol-optimize-out-of-stack.js
@@ -4,7 +4,7 @@
 
 arrayLength = typeof(arrayLength) === 'undefined' ? 50000 : arrayLength;
 
-let expectedException = "SyntaxError: Invalid regular expression: regular expression too large";
+let expectedException = "SyntaxError: Invalid regular expression: too many captures";
 
 function test()
 {

--- a/JSTests/stress/regexp-combined-large.js
+++ b/JSTests/stress/regexp-combined-large.js
@@ -1,0 +1,48 @@
+//@ runDefault
+
+function tryCompileAndRun(label, buildPattern, testInput) {
+    // print(`\n[*] ${label}`);
+    let pattern;
+    try {
+        pattern = buildPattern();
+        // print(`    Pattern length: ${pattern.length} chars`);
+    } catch(e) {
+        print(`    BUILD ERROR: ${e.message}`);
+        return;
+    }
+
+    let re;
+    try {
+        re = new RegExp(pattern, 'g');
+        // print(`    RegExp constructed OK`);
+    } catch(e) {
+        print(`    REGEXP CONSTRUCTION ERROR (likely limit hit): ${e.message}`);
+        return;
+    }
+
+    // Warm the JIT — JSC typically tiered-compiles after ~6 invocations
+    try {
+        for (let i = 0; i < 8; i++) {
+            re.lastIndex = 0;
+            re.exec(testInput);
+        }
+        // print(`    exec() completed without crash — check for SP corruption artifacts`);
+    } catch(e) {
+        print(`    RUNTIME ERROR: ${e.message}`);
+    }
+}
+
+const LARGE_N = 12_500_000;
+tryCompileAndRun(
+    `Approach F: ${LARGE_N} flat groups (maximum feasible)`,
+    () => {
+        // Build in chunks to avoid single large string concat
+        let parts = [];
+        const chunk = '(a)*'.repeat(10000); // 40KB per chunk
+        for (let i = 0; i < LARGE_N / 10000; i++) {
+            parts.push(chunk);
+        }
+        return parts.join('');
+    },
+    'a'
+);

--- a/JSTests/stress/regexp-deep-nested.js
+++ b/JSTests/stress/regexp-deep-nested.js
@@ -1,0 +1,41 @@
+//@ runDefault
+
+function tryCompileAndRun(label, buildPattern, testInput) {
+    // print(`\n[*] ${label}`);
+    let pattern;
+    try {
+        pattern = buildPattern();
+        // print(`    Pattern length: ${pattern.length} chars`);
+    } catch(e) {
+        print(`    BUILD ERROR: ${e.message}`);
+        return;
+    }
+
+    let re;
+    try {
+        re = new RegExp(pattern, 'g');
+        // print(`    RegExp constructed OK`);
+    } catch(e) {
+        print(`    REGEXP CONSTRUCTION ERROR (likely limit hit): ${e.message}`);
+        return;
+    }
+
+    // Warm the JIT — JSC typically tiered-compiles after ~6 invocations
+    try {
+        for (let i = 0; i < 8; i++) {
+            re.lastIndex = 0;
+            re.exec(testInput);
+        }
+        // print(`    exec() completed without crash — check for SP corruption artifacts`);
+    } catch(e) {
+        print(`    RUNTIME ERROR: ${e.message}`);
+    }
+}
+
+for (const depth of [100, 500, 1000, 5000, 10000, 50000]) {
+    tryCompileAndRun(
+        `Approach B: nested depth ${depth} — ((((a)*)*...)*)*`,
+        () => '('.repeat(depth) + 'a' + ')*'.repeat(depth),
+        'a'.repeat(20)
+    );
+}

--- a/JSTests/stress/regexp-heavy-mixed.js
+++ b/JSTests/stress/regexp-heavy-mixed.js
@@ -1,0 +1,46 @@
+//@ runDefault
+
+function tryCompileAndRun(label, buildPattern, testInput) {
+    // print(`\n[*] ${label}`);
+    let pattern;
+    try {
+        pattern = buildPattern();
+        // print(`    Pattern length: ${pattern.length} chars`);
+    } catch(e) {
+        print(`    BUILD ERROR: ${e.message}`);
+        return;
+    }
+
+    let re;
+    try {
+        re = new RegExp(pattern, 'g');
+        // print(`    RegExp constructed OK`);
+    } catch(e) {
+        print(`    REGEXP CONSTRUCTION ERROR (likely limit hit): ${e.message}`);
+        return;
+    }
+
+    // Warm the JIT — JSC typically tiered-compiles after ~6 invocations
+    try {
+        for (let i = 0; i < 8; i++) {
+            re.lastIndex = 0;
+            re.exec(testInput);
+        }
+        // print(`    exec() completed without crash — check for SP corruption artifacts`);
+    } catch(e) {
+        print(`    RUNTIME ERROR: ${e.message}`);
+    }
+}
+
+tryCompileAndRun(
+    `Approach E: mixed named/quantified/lookahead (10k groups)`,
+    () => {
+        // Each unit: (?<x>a)* — named capture with quantifier
+        // Duplicate named captures in alternation arms force numDuplicateNamedCaptures > 0
+        const unit = '(?<g>a(?<h>b)*)';
+        const repeated = unit.repeat(5000);
+        // Wrap in alternation to trigger duplicate-named-capture counting
+        return `(?:${repeated}|${unit.repeat(100)})+`;
+    },
+    'ab'.repeat(30)
+);

--- a/JSTests/stress/regexp-lookahead-heavy.js
+++ b/JSTests/stress/regexp-lookahead-heavy.js
@@ -1,0 +1,41 @@
+//@ runDefault
+
+function tryCompileAndRun(label, buildPattern, testInput) {
+    // print(`\n[*] ${label}`);
+    let pattern;
+    try {
+        pattern = buildPattern();
+        // print(`    Pattern length: ${pattern.length} chars`);
+    } catch(e) {
+        print(`    BUILD ERROR: ${e.message}`);
+        return;
+    }
+
+    let re;
+    try {
+        re = new RegExp(pattern, 'g');
+        // print(`    RegExp constructed OK`);
+    } catch(e) {
+        print(`    REGEXP CONSTRUCTION ERROR (likely limit hit): ${e.message}`);
+        return;
+    }
+
+    // Warm the JIT — JSC typically tiered-compiles after ~6 invocations
+    try {
+        for (let i = 0; i < 8; i++) {
+            re.lastIndex = 0;
+            re.exec(testInput);
+        }
+        // print(`    exec() completed without crash — check for SP corruption artifacts`);
+    } catch(e) {
+        print(`    RUNTIME ERROR: ${e.message}`);
+    }
+}
+
+for (const n of [500, 5000, 20000]) {
+    tryCompileAndRun(
+        `Approach D: ${n} lookaheads (?=(a))*`,
+        () => '(?=(a))'.repeat(n) + 'a*',
+        'a'.repeat(50)
+    );
+}

--- a/JSTests/stress/stack-overflow-regexp.js
+++ b/JSTests/stress/stack-overflow-regexp.js
@@ -7,9 +7,9 @@ function testDeepNesting() {
     try {
         new RegExp(Array(520000).join("(") + "a" + Array(520000).join(")"));
     } catch (e) {
-        if (e instanceof RangeError)
+        if (e instanceof SyntaxError || e instanceof RangeError)
             return;
-        throw new Error("Expected RangeError, got " + e);
+        throw new Error("Expected SyntaxError or RangeError, got " + e);
     }
     // With certain stack configurations the pattern may fit; that's OK.
 }

--- a/LayoutTests/js/script-tests/stack-overflow-regexp.js
+++ b/LayoutTests/js/script-tests/stack-overflow-regexp.js
@@ -1,0 +1,31 @@
+//@ skip if $memoryLimited
+//  &&&&
+description('Test that we do not overflow the stack while handling regular expressions');
+
+// Base case.
+shouldThrow('new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")"))', '"SyntaxError: Invalid regular expression: too many captures"');
+
+{ // Verify that a deep JS stack does not help avoiding the error.
+    function recursiveCall(depth) {
+        if (!(depth % 10)) {
+            debug("Creating RegExp at depth " + depth);
+            shouldThrow('new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")"))', '"SyntaxError: Invalid regular expression: too many captures"');
+        }
+        if (depth < 100) {
+            recursiveCall(depth + 1);
+        }
+    }
+    recursiveCall(0);
+}
+
+{ // Have the deepest nested subpattern surrounded by other expressions.
+    var expression = "";
+    for (let i = 0; i < 500000; ++i) {
+        expression += "((a)(";
+    }
+    expression += "b";
+    for (let i = 0; i < 500000; ++i) {
+        expression += ")(c))";
+    }
+    shouldThrow('new RegExp(expression)', '"SyntaxError: Invalid regular expression: regular expression too large"');
+}

--- a/LayoutTests/js/stack-overflow-regexp-expected.txt
+++ b/LayoutTests/js/stack-overflow-regexp-expected.txt
@@ -1,0 +1,33 @@
+Test that we do not overflow the stack while handling regular expressions
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")")) threw exception SyntaxError: Invalid regular expression: too many captures.
+Creating RegExp at depth 0
+PASS new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")")) threw exception SyntaxError: Invalid regular expression: too many captures.
+Creating RegExp at depth 10
+PASS new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")")) threw exception SyntaxError: Invalid regular expression: too many captures.
+Creating RegExp at depth 20
+PASS new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")")) threw exception SyntaxError: Invalid regular expression: too many captures.
+Creating RegExp at depth 30
+PASS new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")")) threw exception SyntaxError: Invalid regular expression: too many captures.
+Creating RegExp at depth 40
+PASS new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")")) threw exception SyntaxError: Invalid regular expression: too many captures.
+Creating RegExp at depth 50
+PASS new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")")) threw exception SyntaxError: Invalid regular expression: too many captures.
+Creating RegExp at depth 60
+PASS new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")")) threw exception SyntaxError: Invalid regular expression: too many captures.
+Creating RegExp at depth 70
+PASS new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")")) threw exception SyntaxError: Invalid regular expression: too many captures.
+Creating RegExp at depth 80
+PASS new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")")) threw exception SyntaxError: Invalid regular expression: too many captures.
+Creating RegExp at depth 90
+PASS new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")")) threw exception SyntaxError: Invalid regular expression: too many captures.
+Creating RegExp at depth 100
+PASS new RegExp(Array(500000).join("(") + "a" + Array(500000).join(")")) threw exception SyntaxError: Invalid regular expression: too many captures.
+PASS new RegExp(expression) threw exception SyntaxError: Invalid regular expression: regular expression too large.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.h
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.h
@@ -211,7 +211,8 @@ namespace JSC {
 
         void grow(unsigned extraCapacity = 0)
         {
-            m_capacity = m_capacity + m_capacity / 2 + extraCapacity;
+            auto capacity = Checked<unsigned>(m_capacity) + m_capacity / 2 + extraCapacity;
+            m_capacity = capacity.value();
             if (isInlineBuffer()) {
                 m_buffer = static_cast<char*>(AssemblerDataMalloc::malloc(m_capacity));
                 memcpy(m_buffer, m_inlineBuffer, InlineCapacity);
@@ -325,7 +326,6 @@ namespace JSC {
     public:
         AssemblerBuffer()
             : m_storage()
-            , m_index(0)
 #if ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
             , m_hash()
             , m_hashes()
@@ -345,7 +345,7 @@ namespace JSC {
 
         bool isAvailable(unsigned space)
         {
-            return m_index + space <= m_storage.capacity();
+            return static_cast<uint64_t>(m_index) + space <= m_storage.capacity();
         }
 
         void ensureSpace(unsigned space)
@@ -444,7 +444,7 @@ namespace JSC {
             void putIntegralUnchecked(IntegralType value)
             {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-                ASSERT(m_index + sizeof(IntegralType) <= m_buffer.m_storage.capacity());
+                ASSERT(static_cast<uint64_t>(m_index) + sizeof(IntegralType) <= m_buffer.m_storage.capacity());
                 WTF::unalignedStore<IntegralType>(m_storageBuffer + m_index, value);
                 m_index += sizeof(IntegralType);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
@@ -471,8 +471,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         template<typename IntegralType>
         void putIntegral(IntegralType value)
         {
-            unsigned nextIndex = m_index + sizeof(IntegralType);
-            if (nextIndex > m_storage.capacity()) [[unlikely]]
+            auto nextIndex = Checked<unsigned>(m_index) + sizeof(IntegralType);
+            if (nextIndex.value() > m_storage.capacity()) [[unlikely]]
                 outOfLineGrow();
             putIntegralUnchecked<IntegralType>(value);
         }
@@ -517,7 +517,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         friend LinkBuffer;
 
         AssemblerData m_storage;
-        unsigned m_index;
+        unsigned m_index { 0 };
 #if ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
         ARM64EHash<ShouldSign::Yes> m_hash;
         AssemblerHashes m_hashes;

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
@@ -73,6 +73,8 @@ ASCIILiteral errorMessage(ErrorCode error)
         REGEXP_ERROR_PREFIX "negated class set may contain strings"_s,                // NegatedClassSetMayContainStrings
         REGEXP_ERROR_PREFIX "invalid class set character"_s,                          // InvalidClassSetCharacter
         REGEXP_ERROR_PREFIX "invalid regular expression modifier"_s,                  // InvalidRegularExpressionModifier
+        REGEXP_ERROR_PREFIX "too many captures"_s,                                    // TooManyCaptures
+        REGEXP_ERROR_PREFIX "too many frame slots for state"_s,                       // FrameTooLarge
 
         // The following are NOT hard errors.
         REGEXP_ERROR_PREFIX "too many nested disjunctions"_s,                         // TooManyDisjunctions
@@ -118,6 +120,8 @@ JSObject* errorToThrow(JSGlobalObject* globalObject, ErrorCode error)
     case ErrorCode::NegatedClassSetMayContainStrings:
     case ErrorCode::InvalidClassSetCharacter:
     case ErrorCode::InvalidRegularExpressionModifier:
+    case ErrorCode::TooManyCaptures:
+    case ErrorCode::FrameTooLarge:
         return createSyntaxError(globalObject, errorMessage(error));
     case ErrorCode::TooManyDisjunctions:
         return createOutOfMemoryError(globalObject, errorMessage(error));

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.h
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.h
@@ -77,6 +77,8 @@ enum class ErrorCode : uint8_t {
     NegatedClassSetMayContainStrings,
     InvalidClassSetCharacter,
     InvalidRegularExpressionModifier,
+    TooManyCaptures,
+    FrameTooLarge,
 
     // The following are NOT hard errors.
     TooManyDisjunctions, // we ran out stack compiling.

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -65,7 +65,6 @@ template <class T> concept YarrSyntaxCheckable = requires (T& checker, Vector<Ve
     { checker.atomCharacterClassPushNested(bool { }) } -> std::same_as<void>;
     { checker.atomCharacterClassPopNested(bool { }) } -> std::same_as<void>;
     { checker.atomCharacterClassEnd() } -> std::same_as<void>;
-    { checker.atomParenthesesSubpatternBegin() } -> std::same_as<void>;
     { checker.atomParenthesesSubpatternBegin(bool { }) } -> std::same_as<void>;
     { checker.atomParenthesesSubpatternBegin(bool { }, std::optional<String> { }) } -> std::same_as<void>;
     { checker.atomParentheticalAssertionBegin(bool { }, MatchDirection { }) } -> std::same_as<void>;
@@ -102,7 +101,7 @@ public:
      */
     ErrorCode parse()
     {
-        if (m_size > MAX_PATTERN_SIZE)
+        if (m_size > maxPatternSize)
             return ErrorCode::PatternTooLarge;
 
         parseTokens();
@@ -1557,9 +1556,10 @@ private:
                     }
 
                     auto setAddResult = m_namedCaptureGroups.add(groupName.value());
-                    if (setAddResult.isNewEntry)
+                    if (setAddResult.isNewEntry) {
                         m_delegate.atomParenthesesSubpatternBegin(true, groupName);
-                    else
+                        countCaptures();
+                    } else
                         m_errorCode = ErrorCode::DuplicateGroupName;
                 } else {
                     if (tryConsume('=')) {
@@ -1644,8 +1644,10 @@ private:
             default:
                 m_errorCode = ErrorCode::ParenthesesTypeInvalid;
             }
-        } else
-            m_delegate.atomParenthesesSubpatternBegin();
+        } else {
+            m_delegate.atomParenthesesSubpatternBegin(true);
+            countCaptures();
+        }
 
         if (type == ParenthesesType::Subpattern && !isNonCapturingGroup)
             ++m_numSubpatterns;
@@ -2188,6 +2190,12 @@ private:
         return std::nullopt;
     }
 
+    void countCaptures()
+    {
+        if (++m_numCaptures > maxCapturesCount)
+            m_errorCode = ErrorCode::TooManyCaptures;
+    }
+
     bool isLegacyCompilation() const { return m_compileMode == CompileMode::Legacy; }
     bool isUnicodeCompilation() const { return m_compileMode == CompileMode::Unicode; }
     bool isUnicodeSetsCompilation() const { return m_compileMode == CompileMode::UnicodeSets; }
@@ -2204,14 +2212,15 @@ private:
     unsigned m_backReferenceLimit;
     unsigned m_numSubpatterns { 0 };
     unsigned m_maxSeenBackReference { 0 };
+    unsigned m_numCaptures { 0 };
     bool m_isNamedForwardReferenceAllowed;
     bool m_kIdentityEscapeSeen { false };
     Vector<ParenthesesType, 16> m_parenthesesStack;
     NamedCaptureGroups m_namedCaptureGroups;
     UncheckedKeyHashSet<String> m_forwardReferenceNames;
 
-    // Derived by empirical testing of compile time in PCRE and WREC.
-    static constexpr unsigned MAX_PATTERN_SIZE = 1024 * 1024;
+    static constexpr unsigned maxPatternSize = 1024 * 1024; // Derived by empirical testing of compile time in PCRE and WREC.
+    static constexpr unsigned maxCapturesCount = (1 << 16) / 2; // Derived from V8's configuration.
 };
 
 /*

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1439,7 +1439,7 @@ public:
         m_pattern.m_userCharacterClasses.append(WTF::move(newCharacterClass));
     }
 
-    void atomParenthesesSubpatternBegin(bool capture = true, std::optional<String> optGroupName = std::nullopt)
+    void atomParenthesesSubpatternBegin(bool capture, std::optional<String> optGroupName = std::nullopt)
     {
         unsigned subpatternId = m_pattern.m_numSubpatterns + 1;
         if (capture) {
@@ -1774,7 +1774,7 @@ public:
         return m_error;
     }
 
-    [[nodiscard]] ErrorCode setupAlternativeOffsets(PatternAlternative* alternative, unsigned currentCallFrameSize, unsigned initialInputPosition, unsigned& newCallFrameSize)
+    [[nodiscard]] ErrorCode setupAlternativeOffsets(PatternAlternative* alternative, CheckedUint32 currentCallFrameSize, unsigned initialInputPosition, CheckedUint32& newCallFrameSize)
     {
         if (!isSafeToRecurse()) [[unlikely]]
             return ErrorCode::TooManyDisjunctions;
@@ -1798,6 +1798,8 @@ public:
                 term.inputPosition = currentInputPosition;
                 term.frameLocation = currentCallFrameSize;
                 currentCallFrameSize += YarrStackSpaceForBackTrackInfoBackReference;
+                if (currentCallFrameSize.hasOverflowed())
+                    return ErrorCode::FrameTooLarge;
                 alternative->m_hasFixedSize = false;
                 break;
 
@@ -1810,6 +1812,8 @@ public:
                 if (term.quantityType != QuantifierType::FixedCount) {
                     term.frameLocation = currentCallFrameSize;
                     currentCallFrameSize += YarrStackSpaceForBackTrackInfoPatternCharacter;
+                    if (currentCallFrameSize.hasOverflowed())
+                        return ErrorCode::FrameTooLarge;
                     alternative->m_hasFixedSize = false;
                 } else if (m_pattern.eitherUnicode()) {
                     CheckedUint32 tempCount = term.quantityMaxCount;
@@ -1826,10 +1830,14 @@ public:
                 if (term.quantityType != QuantifierType::FixedCount) {
                     term.frameLocation = currentCallFrameSize;
                     currentCallFrameSize += YarrStackSpaceForBackTrackInfoCharacterClass;
+                    if (currentCallFrameSize.hasOverflowed())
+                        return ErrorCode::FrameTooLarge;
                     alternative->m_hasFixedSize = false;
                 } else if (m_pattern.eitherUnicode()) {
                     term.frameLocation = currentCallFrameSize;
                     currentCallFrameSize += YarrStackSpaceForBackTrackInfoCharacterClass;
+                    if (currentCallFrameSize.hasOverflowed())
+                        return ErrorCode::FrameTooLarge;
                     if (term.characterClass->hasOneCharacterSize() && !term.invert()) {
                         CheckedUint32 tempCount = term.quantityMaxCount;
                         tempCount *= term.characterClass->hasNonBMPCharacters() ? 2 : 1;
@@ -1849,6 +1857,8 @@ public:
                 term.frameLocation = currentCallFrameSize;
                 if (term.quantityMaxCount == 1 && !term.parentheses.isCopy) {
                     currentCallFrameSize += YarrStackSpaceForBackTrackInfoParenthesesOnce;
+                    if (currentCallFrameSize.hasOverflowed())
+                        return ErrorCode::FrameTooLarge;
                     error = setupDisjunctionOffsets(term.parentheses.disjunction, currentCallFrameSize, currentInputPosition, currentCallFrameSize);
                     if (hasError(error))
                         return error;
@@ -1858,6 +1868,8 @@ public:
                     term.inputPosition = currentInputPosition;
                 } else if (term.parentheses.isTerminal) {
                     currentCallFrameSize += YarrStackSpaceForBackTrackInfoParenthesesTerminal;
+                    if (currentCallFrameSize.hasOverflowed())
+                        return ErrorCode::FrameTooLarge;
                     error = setupDisjunctionOffsets(term.parentheses.disjunction, currentCallFrameSize, currentInputPosition, currentCallFrameSize);
                     if (hasError(error))
                         return error;
@@ -1865,6 +1877,8 @@ public:
                 } else {
                     term.inputPosition = currentInputPosition;
                     currentCallFrameSize += YarrStackSpaceForBackTrackInfoParentheses;
+                    if (currentCallFrameSize.hasOverflowed())
+                        return ErrorCode::FrameTooLarge;
                     error = setupDisjunctionOffsets(term.parentheses.disjunction, currentCallFrameSize, currentInputPosition, currentCallFrameSize);
                     if (hasError(error))
                         return error;
@@ -1877,7 +1891,10 @@ public:
                 unsigned disjunctionInitialInputPosition = (term.matchDirection() == Forward) ? currentInputPosition.value() : 0;
                 term.inputPosition = currentInputPosition;
                 term.frameLocation = currentCallFrameSize;
-                error = setupDisjunctionOffsets(term.parentheses.disjunction, currentCallFrameSize + YarrStackSpaceForBackTrackInfoParentheticalAssertion, disjunctionInitialInputPosition, currentCallFrameSize);
+                currentCallFrameSize += YarrStackSpaceForBackTrackInfoParentheticalAssertion;
+                if (currentCallFrameSize.hasOverflowed())
+                    return ErrorCode::FrameTooLarge;
+                error = setupDisjunctionOffsets(term.parentheses.disjunction, currentCallFrameSize, disjunctionInitialInputPosition, currentCallFrameSize);
                 if (hasError(error))
                     return error;
                 break;
@@ -1889,6 +1906,8 @@ public:
                 term.inputPosition = initialInputPosition;
                 m_pattern.m_initialStartValueFrameLocation = currentCallFrameSize;
                 currentCallFrameSize += YarrStackSpaceForDotStarEnclosure;
+                if (currentCallFrameSize.hasOverflowed())
+                    return ErrorCode::FrameTooLarge;
                 m_pattern.m_saveInitialStartValue = true;
                 break;
             }
@@ -1897,17 +1916,20 @@ public:
         }
 
         alternative->m_minimumSize = currentInputPosition - initialInputPosition;
-        newCallFrameSize = currentCallFrameSize;
+        newCallFrameSize = currentCallFrameSize.value();
         return error;
     }
 
-    ErrorCode setupDisjunctionOffsets(PatternDisjunction* disjunction, unsigned initialCallFrameSize, unsigned initialInputPosition, unsigned& callFrameSize)
+    ErrorCode setupDisjunctionOffsets(PatternDisjunction* disjunction, CheckedUint32 initialCallFrameSize, unsigned initialInputPosition, CheckedUint32& callFrameSize)
     {
         if (!isSafeToRecurse()) [[unlikely]]
             return ErrorCode::TooManyDisjunctions;
 
-        if ((disjunction != m_pattern.m_body) && (disjunction->m_alternatives.size() > 1))
+        if ((disjunction != m_pattern.m_body) && (disjunction->m_alternatives.size() > 1)) {
             initialCallFrameSize += YarrStackSpaceForBackTrackInfoAlternative;
+            if (initialCallFrameSize.hasOverflowed())
+                return ErrorCode::FrameTooLarge;
+        }
 
         bool shareOffsets = (disjunction == m_pattern.m_body);
 
@@ -1916,15 +1938,15 @@ public:
         bool hasFixedSize = true;
         ErrorCode error = ErrorCode::NoError;
 
-        unsigned perAlternativeInitial = initialCallFrameSize;
+        CheckedUint32 perAlternativeInitial = initialCallFrameSize;
         for (unsigned alt = 0; alt < disjunction->m_alternatives.size(); ++alt) {
             PatternAlternative* alternative = disjunction->m_alternatives[alt].get();
-            unsigned currentAlternativeCallFrameSize;
+            CheckedUint32 currentAlternativeCallFrameSize;
             error = setupAlternativeOffsets(alternative, perAlternativeInitial, initialInputPosition, currentAlternativeCallFrameSize);
             if (hasError(error))
                 return error;
             minimumInputSize = std::min(minimumInputSize, alternative->m_minimumSize);
-            maximumCallFrameSize = std::max(maximumCallFrameSize, currentAlternativeCallFrameSize);
+            maximumCallFrameSize = std::max(maximumCallFrameSize, currentAlternativeCallFrameSize.value());
             hasFixedSize &= alternative->m_hasFixedSize;
             if (alternative->m_minimumSize > INT_MAX)
                 m_pattern.m_containsUnsignedLengthPattern = true;
@@ -1944,7 +1966,7 @@ public:
     ErrorCode setupOffsets()
     {
         // FIXME: Yarr should not use the stack to handle subpatterns (rdar://problem/26436314).
-        unsigned ignoredCallFrameSize;
+        CheckedUint32 ignoredCallFrameSize;
         return setupDisjunctionOffsets(m_pattern.m_body, 0, 0, ignoredCallFrameSize);
     }
 

--- a/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
+++ b/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
@@ -48,7 +48,7 @@ public:
     void NODELETE atomCharacterClassPushNested(bool) { }
     void NODELETE atomCharacterClassPopNested(bool) { }
     void NODELETE atomCharacterClassEnd() { }
-    void NODELETE atomParenthesesSubpatternBegin(bool = true, std::optional<String> = std::nullopt) { }
+    void NODELETE atomParenthesesSubpatternBegin(bool, std::optional<String> = std::nullopt) { }
     void NODELETE atomParentheticalAssertionBegin(bool, MatchDirection) { }
     void NODELETE atomParentheticalModifierBegin(OptionSet<Flags>, OptionSet<Flags>) { }
     void NODELETE atomParenthesesEnd() { }


### PR DESCRIPTION
#### 7663d811d06c32554470828470d3c1764144c397
<pre>
[JSC] Make RegExp tolerant against excessive stress
<a href="https://bugs.webkit.org/show_bug.cgi?id=309601">https://bugs.webkit.org/show_bug.cgi?id=309601</a>
<a href="https://rdar.apple.com/171448096">rdar://171448096</a>

Reviewed by Yijia Huang.

We fixed three issues. But only one is actually critical security issue.
Remaining two are making RegExp tolerant against excessive patterns.

1. We have no guard against too large JIT code generation (4GB~). We fix
   AssemblerBuffer to detect and crash safely.
2. We add RegExp capture limit which is aligned to V8&apos;s number.
3. We add RegExp frame size limit, which makes RegExp parsing failed
   when frame size exceeds `unsigned` entries.

Tests: JSTests/stress/regexp-alternative-heavy.js
       JSTests/stress/regexp-combined-large.js
       JSTests/stress/regexp-deep-nested.js
       JSTests/stress/regexp-heavy-mixed.js
       JSTests/stress/regexp-lookahead-heavy.js

* JSTests/stress/regexp-alternative-heavy.js: Added.
(tryCompileAndRun):
* JSTests/stress/regexp-bol-optimize-out-of-stack.js:
* JSTests/stress/regexp-combined-large.js: Added.
(tryCompileAndRun):
* JSTests/stress/regexp-deep-nested.js: Added.
(tryCompileAndRun):
* JSTests/stress/regexp-heavy-mixed.js: Added.
(tryCompileAndRun):
* JSTests/stress/regexp-lookahead-heavy.js: Added.
(tryCompileAndRun):
* LayoutTests/js/script-tests/stack-overflow-regexp.js:
(shouldThrow.recursiveCall):
(shouldThrow):
(recursiveCall):
* LayoutTests/js/stack-overflow-regexp-expected.txt:
* Source/JavaScriptCore/assembler/AssemblerBuffer.h:
(JSC::AssemblerDataImpl::grow):
(JSC::AssemblerBuffer::AssemblerBuffer):
(JSC::AssemblerBuffer::isAvailable):
(JSC::AssemblerBuffer::LocalWriter::putIntegralUnchecked):
(JSC::AssemblerBuffer::putIntegral):
* Source/JavaScriptCore/yarr/YarrErrorCode.cpp:
(JSC::Yarr::errorMessage):
(JSC::Yarr::errorToThrow):
* Source/JavaScriptCore/yarr/YarrErrorCode.h:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::requires):
(JSC::Yarr::Parser::parse):
(JSC::Yarr::Parser::parseParenthesesBegin):
(JSC::Yarr::Parser::countCaptures):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::atomParenthesesSubpatternBegin):
(JSC::Yarr::YarrPatternConstructor::setupAlternativeOffsets):
(JSC::Yarr::YarrPatternConstructor::setupDisjunctionOffsets):
(JSC::Yarr::YarrPatternConstructor::setupOffsets):
* Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp:
(JSC::Yarr::SyntaxChecker::atomParenthesesSubpatternBegin):

Originally-landed-as: 305413.479@rapid/safari-7624.2.5.110-branch (a0acd4b94ec1). <a href="https://rdar.apple.com/176061626">rdar://176061626</a>
Canonical link: <a href="https://commits.webkit.org/314241@main">https://commits.webkit.org/314241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c42abc29eff57aea28f034819f73d2110a182e64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165556 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174598 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122811 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128662 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168515 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/30983 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109186 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28655 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22676 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157713 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139913 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177122 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26449 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30032 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136988 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136922 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148232 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102266 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25189 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32196 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25099 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111387 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37710 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3180 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->