### PR TITLE
Crash in -[WKDateTimePicker removeDatePickerPresentation] via SetForScope destructor writing to self

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -189,7 +189,7 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
     if (_datePickerController) {
         if (!_isDismissingDatePicker) {
             SetForScope isDismissingDatePicker { _isDismissingDatePicker, YES };
-            [_datePickerController dismissViewControllerAnimated:NO completion:nil];
+            [protect(_datePickerController) dismissViewControllerAnimated:NO completion:nil];
         }
 
         _datePickerController = nil;

--- a/Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.mm
@@ -53,7 +53,7 @@
         return;
 
     _editing = YES;
-    [_control controlBeginEditing];
+    [protect(_control) controlBeginEditing];
 }
 
 - (void)updateEditing
@@ -70,7 +70,7 @@
         return;
 
     _editing = NO;
-    [_control controlEndEditing];
+    [protect(_control) controlEndEditing];
 }
 
 - (UIView *)assistantView


### PR DESCRIPTION
#### 7b904b118790e7f76366e63a97abe024e1a57a44
<pre>
Crash in -[WKDateTimePicker removeDatePickerPresentation] via SetForScope destructor writing to self
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=310591">https://bugs.webkit.org/show_bug.cgi?id=310591</a>&gt;
&lt;<a href="https://rdar.apple.com/173194730">rdar://173194730</a>&gt;

Reviewed by Geoffrey Garen.

Protect callers of `-[WKDateTimePicker removeDatePickerPresentation]`
and `-handleDatePickerPresentationDismissal` against deallocation of
the `WKDateTimePicker` object during the call.

When a `DidCommitLoadForFrame` IPC message triggers date picker
dismissal during navigation, `-removeDatePickerPresentation` calls
`-[UIViewController dismissViewControllerAnimated:NO completion:nil]`
on `_datePickerController`.  During this call, the `WKDateTimePicker`
object is freed by an unknown mechanism, and the `SetForScope&lt;bool&gt;`
destructor then writes `_isDismissingDatePicker = NO` to freed
memory.

Also protect the `__weak _delegate` in `WKDatePickerPopoverController`
and the `_datePickerController` member in `WKDateTimePicker` before
calling non-trivial methods through them.

No test since the conditions to reproduce the crash are not known.
Verified locally by reproducing with an arbitrary method swizzled.

* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm:
(-[WKDatePickerPopoverController resetDatePicker]):
- Drive-by fix: protect `__weak _delegate` before calling through it.
(-[WKDatePickerPopoverController _dispatchPopoverControllerDidDismissIfNeeded]):
- Drive-by fix: protect `__weak _delegate` before calling through it.
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimePicker removeDatePickerPresentation]):
- Drive-by fix: protect `_datePickerController` before calling
  `dismissViewControllerAnimated:completion:`.
* Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.mm:
(-[WKFormPeripheralBase beginEditing]):
- Drive-by fix: protect `_control` before calling
  `controlBeginEditing`.
(-[WKFormPeripheralBase endEditing]):
- Crash fix: protect `_control` before calling `controlEndEditing`.

Originally-landed-as: 305413.576@rapid/safari-7624.2.5.110-branch (a3ee68e14af5). <a href="https://rdar.apple.com/176061926">rdar://176061926</a>
Canonical link: <a href="https://commits.webkit.org/314043@main">https://commits.webkit.org/314043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcce9b4aa92f33f25bee018f21a43044438d4213

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122017 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128048 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90157 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108594 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29393 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28018 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21559 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139297 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176323 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29151 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136367 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136330 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36772 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39008 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147600 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101219 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31598 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24456 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37516 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110561 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36914 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2522 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37162 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->