### PR TITLE
[CMake] iOS build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,23 +113,6 @@ if (SWIFT_REQUIRED)
         endif ()
     endif ()
 
-    if (PORT STREQUAL "IOS")
-        execute_process(COMMAND xcrun --show-sdk-platform-path
-            OUTPUT_VARIABLE _ios_platform_path
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET)
-        if (_ios_platform_path)
-            execute_process(COMMAND find "${_ios_platform_path}" -name swiftc -path "*/xctoolchain/*" -type f -print -quit
-                OUTPUT_VARIABLE _ios_swiftc
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-                ERROR_QUIET)
-            if (_ios_swiftc AND NOT _ios_swiftc STREQUAL CMAKE_Swift_COMPILER)
-                set(CMAKE_Swift_COMPILER "${_ios_swiftc}" CACHE FILEPATH "Swift compiler" FORCE)
-                message(STATUS "iOS: using platform-specific Swift compiler: ${_ios_swiftc}")
-            endif ()
-        endif ()
-    endif ()
-
     enable_language(Swift)
 
     # -F causes Swift to find C++23 framework headers in implicit module builds.
@@ -137,17 +120,12 @@ if (SWIFT_REQUIRED)
         set(CMAKE_Swift_FRAMEWORK_SEARCH_FLAG "-Xcc -iquote")
     endif ()
 
-    # Override Swift compiler to a wrapper script to work around the
-    # fact CMake feeds incorrect flags to swiftc.
-    set(_swift_wrapper "${CMAKE_SOURCE_DIR}/Tools/Scripts/swift/swiftc-wrapper.sh")
-    if (CMAKE_Swift_COMPILER STREQUAL _swift_wrapper)
-        if (NOT ORIGINAL_Swift_COMPILER)
-            find_program(ORIGINAL_Swift_COMPILER NAMES swiftc REQUIRED)
-        endif ()
+    if (APPLE)
+        WEBKIT_XCRUN(ORIGINAL_Swift_COMPILER --find swiftc)
     else ()
-        set(ORIGINAL_Swift_COMPILER "${CMAKE_Swift_COMPILER}" CACHE FILEPATH "Original Swift compiler" FORCE)
+        set(ORIGINAL_Swift_COMPILER "${CMAKE_Swift_COMPILER}")
     endif ()
-    set(CMAKE_Swift_COMPILER "${_swift_wrapper}")
+    set(CMAKE_Swift_COMPILER "${CMAKE_SOURCE_DIR}/Tools/Scripts/swift/swiftc-wrapper.sh")
     add_compile_options($<$<COMPILE_LANGUAGE:Swift>:--original-swift-compiler=${ORIGINAL_Swift_COMPILER}>)
     add_link_options($<$<LINK_LANGUAGE:Swift>:--original-swift-compiler=${ORIGINAL_Swift_COMPILER}>)
     # The static archive rule (<CMAKE_Swift_CREATE_STATIC_LIBRARY>) uses neither
@@ -155,7 +133,6 @@ if (SWIFT_REQUIRED)
     string(REPLACE "<CMAKE_Swift_COMPILER>"
         "<CMAKE_Swift_COMPILER> --original-swift-compiler=${ORIGINAL_Swift_COMPILER}"
         CMAKE_Swift_CREATE_STATIC_LIBRARY "${CMAKE_Swift_CREATE_STATIC_LIBRARY}")
-    unset(_swift_wrapper)
 endif ()
 
 # -----------------------------------------------------------------------------

--- a/Source/WebKit/PlatformIOS.cmake
+++ b/Source/WebKit/PlatformIOS.cmake
@@ -315,7 +315,7 @@ add_custom_target(WebKit_MigrateHeaders
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/Source/cmake/MigrateHeaders.cmake "${_migrate_pairs_file}"
     COMMENT "Migrating WebCore/WebKitLegacy headers into WebKit.framework/{Headers,PrivateHeaders}/"
 )
-add_dependencies(WebKit_MigrateHeaders WebCore_CopyPrivateHeaders WebKitLegacy_CopyHeaders)
+add_dependencies(WebKit_MigrateHeaders WebKit_StageFrameworkHeaders WebCore_CopyPrivateHeaders WebKitLegacy_CopyHeaders)
 add_dependencies(WebKit WebKit_MigrateHeaders)
 unset(_migrate_pairs_file)
 unset(_migrate_pairs_content)

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -398,7 +398,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [result setMerchantCategoryCode:toPKMerchantCategoryCode(merchantCategoryCode)];
 #endif
 
-#if HAVE(PASSKIT_DELEGATED_REQUEST)
+#if ENABLE(APPLE_PAY_DELEGATED_REQUEST)
     if (auto isDelegatedRequest = paymentRequest.isDelegatedRequest()) {
         // FIXME: <rdar://165836164> (Remove bincompat staging code from WebKit)
         if ([result respondsToSelector:@selector(setIsDelegatedRequest:)])

--- a/Source/WebKitLegacy/PlatformIOS.cmake
+++ b/Source/WebKitLegacy/PlatformIOS.cmake
@@ -1031,12 +1031,6 @@ foreach (_file ${WebKitLegacy_LEGACY_FORWARDING_HEADERS_FILES})
     else ()
         set(_src_path "${CMAKE_CURRENT_SOURCE_DIR}/${_file}")
     endif ()
-    # WebCore-sourced headers (WAKView.h etc.) are owned by WebCore_Private.Core.*.
-    # Stage a forwarding stub so WebKitLegacy re-exports that submodule.
-    cmake_path(IS_PREFIX WEBCORE_DIR "${_src_path}" NORMALIZE _is_from_webcore)
-    if (_is_from_webcore)
-        set(_migrated "#import <WebCore/${_name}>\n")
-    else ()
     # Stage 1 -- migrate-header-rule:
     #   sed -E -e 's/<WebCore\//<WebKitLegacy\//' -e 's/(^ *)WEBCORE_EXPORT /\1/'
     # Mac-only `<WebCore/...>` imports become `<WebKitLegacy/...>` because Xcode
@@ -1078,7 +1072,6 @@ foreach (_file ${WebKitLegacy_LEGACY_FORWARDING_HEADERS_FILES})
     endif ()
     file(READ "${_unifdef_output}" _migrated)
     file(REMOVE "${_unifdef_input}" "${_unifdef_output}")
-    endif ()
 
     set(_existing "")
     if (EXISTS "${_target_filename}")

--- a/Source/cmake/OptionsIOS.cmake
+++ b/Source/cmake/OptionsIOS.cmake
@@ -120,6 +120,17 @@ if (_sdk_major_minor AND (NOT CMAKE_OSX_DEPLOYMENT_TARGET OR CMAKE_OSX_DEPLOYMEN
     message(WARNING "Deployment target auto-set to SDK version: ${CMAKE_OSX_DEPLOYMENT_TARGET} (SPI header guards require this)")
 endif ()
 
+# Resolve the real clang once and pin it for the lifetime of this build tree.
+# This is a build speed optimization, and also a defense against tearing between
+# resolved toolchain and resolved SDK path / version.
+WEBKIT_XCRUN(_clang -f clang)
+if (EXISTS "${_clang}")
+    set(CMAKE_C_COMPILER "${_clang}")
+    set(CMAKE_CXX_COMPILER "${_clang}++")
+    set(CMAKE_OBJC_COMPILER "${_clang}")
+    set(CMAKE_OBJCXX_COMPILER "${_clang}++")
+endif ()
+
 include(OptionsCocoa)
 
 enable_language(OBJC OBJCXX)

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -153,15 +153,6 @@ if (EXISTS "${_clang}")
     set(CMAKE_OBJCXX_COMPILER "${_clang}++")
 endif ()
 
-# Resolve the real swiftc alongside clang so both are pinned to the same SDK.
-WEBKIT_XCRUN(_swiftc --find swiftc)
-if (_swiftc)
-    set(ORIGINAL_Swift_COMPILER "${_swiftc}" CACHE FILEPATH "Original Swift compiler" FORCE)
-else ()
-    message(FATAL_ERROR "xcrun --sdk ${WEBKIT_SDK} --find swiftc failed")
-endif ()
-unset(_swiftc)
-
 # Deployment target must match SDK version -- PlatformHave.h SPI guards depend on
 # __MAC_OS_X_VERSION_MIN_REQUIRED. Auto-bump if the preset floor is below the SDK.
 string(REGEX MATCH "^[0-9]+\\.[0-9]+" _sdk_major_minor "${_sdk_version}")

--- a/Source/cmake/WebKitCommon.cmake
+++ b/Source/cmake/WebKitCommon.cmake
@@ -9,7 +9,7 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
     # Preset values are not replayed on auto-reconfigure; if CMake's "compiler
     # changed" path wipes the cache, these silently revert. Stamp them outside
     # the cache and refuse to proceed if any go missing.
-    set(WEBKIT_IDENTITY_VARS CMAKE_BUILD_TYPE PORT DEVELOPER_MODE ENABLE_SANITIZERS CMAKE_IOS_SIMULATOR)
+    set(WEBKIT_IDENTITY_VARS CMAKE_BUILD_TYPE PORT DEVELOPER_MODE ENABLE_SANITIZERS CMAKE_IOS_SIMULATOR CMAKE_OSX_SYSROOT)
     set(_config_stamp "${CMAKE_BINARY_DIR}/.webkit-config-stamp")
     if (EXISTS "${_config_stamp}")
         file(STRINGS "${_config_stamp}" _stamp_lines)
@@ -25,6 +25,11 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
                         "variables that require your cache to be deleted\"). Re-run "
                         "'cmake --preset <name>' to restore your configuration, or "
                         "delete the build directory.")
+                elseif (NOT "$CACHE{${_var}}" STREQUAL "${_prev}")
+                    message(FATAL_ERROR
+                        "${_var} changed from '${_prev}' to '$CACHE{${_var}}'. This build "
+                        "directory's identity variables must not change after the first "
+                        "configure. Delete the build directory and reconfigure.")
                 endif ()
             endif ()
         endforeach ()


### PR DESCRIPTION
#### c02833edc5077e35a3f84c658bd7d14584922cc8
<pre>
[CMake] iOS build fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=315683">https://bugs.webkit.org/show_bug.cgi?id=315683</a>
<a href="https://rdar.apple.com/178073543">rdar://178073543</a>

Reviewed by Pascoe.

* CMakeLists.txt: Enable CMP0157 here because Swift needs it early.

Use the shared WEBKIT_XCRUN to make sure that we maintain a consistent
toolchain + SDK.

* Source/WebKit/PlatformIOS.cmake: Depend on WebKit_StageFrameworkHeaders
because we use them.

* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest): Use
ENABLE(APPLE_PAY_DELEGATED_REQUEST) because that&apos;s the corresponding
check in WebCore. (They differ in my current SDK.)

* Source/WebKitLegacy/PlatformIOS.cmake: No need to special case WebCore
headers now that we properly depend on WebKit_StageFrameworkHeaders.

* Source/cmake/OptionsIOS.cmake: Use the shared WEBKIT_XCRUN to make
sure that we maintain a consistent toolchain + SDK.

* Source/cmake/OptionsMac.cmake: Moved to root CMakeLists to share with iOS.

* Source/cmake/WebKitCommon.cmake: Add CMAKE_OSX_SYSROOT to the stamp
because nothing good will happen if you change the sysroot but don&apos;t
update the rest of the build. (And, for some reason, claude decided
to trying doing it anyway.)

Canonical link: <a href="https://commits.webkit.org/313992@main">https://commits.webkit.org/313992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7a896b6154fde8b33e7ab301b34c1f153d67893

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38259 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/31830 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173810 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52f4df90-04a4-48b6-a51a-3324b1dcd84f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38261 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/128056 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d20b23e-fe6d-4555-9d23-8fcdcea137ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167734 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/30359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/148100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108602 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/730dddf2-1464-44c5-9f59-466fdbb9ea1d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21569 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/156926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/25816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176333 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25667 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/27485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/136375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38328 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32152 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136338 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39018 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/147611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101235 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25080 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Reviewed by Pascoe; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31608 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197178 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110571 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/51802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36924 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/2533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37172 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37072 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->