### PR TITLE
Integer underflow leads to crash in ComputeH264InfoFromAVC

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/h264_bad_avc-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/h264_bad_avc-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Decoding bad AVC should gracefully fail
+

--- a/LayoutTests/http/wpt/webcodecs/h264_bad_avc.html
+++ b/LayoutTests/http/wpt/webcodecs/h264_bad_avc.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+promise_test(async (t) => {
+    for (let i = 0; i < 2; ++i) {
+        const badAvcC = new Uint8Array([
+            0x01, 0x64, 0x00, 0x1f, 0xff,
+            0xe1, 0x00, 0x00, 0x67
+        ]);
+        const decoder = new VideoDecoder({
+            output() { },
+            error: (e) => { }
+        });
+
+        decoder.configure({
+            codec: "avc1.64001f",
+            codedWidth: 16,
+            codedHeight: 16,
+            description: badAvcC,
+            hardwareAcceleration: "prefer-hardware"
+        });
+
+        await new Promise(resolve => setTimeout(() => {
+            resolve();
+            decoder.close()
+        }, 200));
+    }
+}, 'Decoding bad AVC should gracefully fail');
+</script>
+</body>
+</html>

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/nalu_rewriter.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/nalu_rewriter.cc
@@ -748,7 +748,7 @@ std::optional<H264Information> ComputeH264InfoFromAVC(const uint8_t* avcData, si
     offset += 2;
 
     reader.ConsumeBits(8 * (size + H264::kNaluTypeSize));
-    if (!reader.Ok()) {
+    if (!reader.Ok() || size <= H264::kNaluTypeSize) {
       return { };
     }
 


### PR DESCRIPTION
#### 86f9503e099379e82b8bd472f134ae2b199aa387
<pre>
Integer underflow leads to crash in ComputeH264InfoFromAVC
<a href="https://rdar.apple.com/171989035">rdar://171989035</a>

Reviewed by Andy Estes.

We add a check to validate that the size of an encoded sequence parameter set NALU is greater than the NALU prefix.

Test: http/wpt/webcodecs/h264_bad_avc.html

* LayoutTests/http/wpt/webcodecs/h264_bad_avc-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/h264_bad_avc.html: Added.
* Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/objc/components/video_codec/nalu_rewriter.cc:

Originally-landed-as: 305413.562@rapid/safari-7624.2.5.110-branch (5f19c89ea2f0). <a href="https://rdar.apple.com/176062469">rdar://176062469</a>
Canonical link: <a href="https://commits.webkit.org/314045@main">https://commits.webkit.org/314045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1d654912579734426437fe4814315ba85cc46aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173814 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122031 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128058 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90168 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108604 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28032 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; Running re-run-api-tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21573 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176337 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136377 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136340 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36773 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39022 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147609 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101240 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31612 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24465 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37530 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36928 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2531 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37176 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37076 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->