### PR TITLE
navigator.mediaCapabilities wrapper should not become GC-collectable before its navigator object

### DIFF
--- a/LayoutTests/fast/dom/navigator-property-gc-after-frame-detach-expected.txt
+++ b/LayoutTests/fast/dom/navigator-property-gc-after-frame-detach-expected.txt
@@ -3,16 +3,19 @@ Tests that Navigator properties do not get GC'd before their Navigator object.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS frameNavigator.mediaCapabilities.foo is 1
 PASS frameNavigator.geolocation.foo is 1
 PASS frameNavigator.mimeTypes.foo is 1
 PASS frameNavigator.plugins.foo is 1
 PASS frameNavigator.serviceWorker.foo is 1
 
+PASS frameNavigator.mediaCapabilities.foo is 1
 PASS frameNavigator.geolocation.foo is 1
 PASS frameNavigator.mimeTypes.foo is 1
 PASS frameNavigator.plugins.foo is 1
 PASS frameNavigator.serviceWorker.foo is 1
 
+PASS frameNavigator.mediaCapabilities.foo is 1
 PASS frameNavigator.geolocation.foo is 1
 PASS frameNavigator.mimeTypes.foo is 1
 PASS frameNavigator.plugins.foo is 1

--- a/LayoutTests/fast/dom/navigator-property-gc-after-frame-detach.html
+++ b/LayoutTests/fast/dom/navigator-property-gc-after-frame-detach.html
@@ -7,7 +7,7 @@
 description("Tests that Navigator properties do not get GC'd before their Navigator object.");
 jsTestIsAsync = true;
 
-var navigatorProperties = [ "geolocation", "mimeTypes", "plugins" ];
+var navigatorProperties = [ "mediaCapabilities", "geolocation", "mimeTypes", "plugins" ];
 if (navigator.serviceWorker)
     navigatorProperties.push("serviceWorker");
 

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -48,6 +48,16 @@
 
 namespace WebCore {
 
+MediaCapabilities::MediaCapabilities(NavigatorBase& navigator)
+    : m_navigator(navigator)
+{
+}
+
+NavigatorBase* MediaCapabilities::navigator()
+{
+    return m_navigator.get();
+}
+
 static bool isValidMediaMIMEType(const ContentType& contentType)
 {
     // A "bucket" MIME types is one whose container type does not uniquely specify a codec.

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.h
@@ -33,20 +33,24 @@
 namespace WebCore {
 
 class DeferredPromise;
+class NavigatorBase;
 class ScriptExecutionContext;
 struct MediaDecodingConfiguration;
 struct MediaEncodingConfiguration;
 
 class MediaCapabilities : public RefCountedAndCanMakeWeakPtr<MediaCapabilities> {
 public:
-    static Ref<MediaCapabilities> create() { return adoptRef(*new MediaCapabilities); }
+    static Ref<MediaCapabilities> create(NavigatorBase& navigator) { return adoptRef(*new MediaCapabilities(navigator)); }
+
+    NavigatorBase* navigator();
 
     void decodingInfo(ScriptExecutionContext&, MediaDecodingConfiguration&&, Ref<DeferredPromise>&&);
     void encodingInfo(ScriptExecutionContext&, MediaEncodingConfiguration&&, Ref<DeferredPromise>&&);
 
 private:
-    MediaCapabilities() = default;
+    explicit MediaCapabilities(NavigatorBase&);
 
+    WeakPtr<NavigatorBase> m_navigator;
     uint64_t m_nextTaskIdentifier { 0 };
     HashMap<uint64_t, PlatformMediaEngineConfigurationFactory::DecodingConfigurationCallback> m_decodingTasks;
     HashMap<uint64_t, PlatformMediaEngineConfigurationFactory::EncodingConfigurationCallback> m_encodingTasks;

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.idl
@@ -26,7 +26,8 @@
 // https://w3c.github.io/media-capabilities/#media-capabilities-interface
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
-    Exposed=(Window,DedicatedWorker)
+    Exposed=(Window,DedicatedWorker),
+    GenerateIsReachable=ReachableFromNavigator
 ] interface MediaCapabilities {
     [CallWith=CurrentScriptExecutionContext] Promise<MediaCapabilitiesDecodingInfo> decodingInfo(MediaDecodingConfiguration configuration);
     [CallWith=CurrentScriptExecutionContext] Promise<MediaCapabilitiesEncodingInfo> encodingInfo(MediaEncodingConfiguration configuration);

--- a/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
@@ -34,8 +34,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigatorMediaCapabilities);
 
-NavigatorMediaCapabilities::NavigatorMediaCapabilities()
-    : m_mediaCapabilities(MediaCapabilities::create())
+NavigatorMediaCapabilities::NavigatorMediaCapabilities(Navigator& navigator)
+    : m_mediaCapabilities(MediaCapabilities::create(navigator))
 {
 }
 
@@ -45,7 +45,7 @@ NavigatorMediaCapabilities& NavigatorMediaCapabilities::from(Navigator& navigato
 {
     auto* supplement = downcast<NavigatorMediaCapabilities>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
-        auto newSupplement = makeUnique<NavigatorMediaCapabilities>();
+        auto newSupplement = makeUnique<NavigatorMediaCapabilities>(navigator);
         supplement = newSupplement.get();
         provideTo(&navigator, supplementName(), WTF::move(newSupplement));
     }

--- a/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h
@@ -36,7 +36,7 @@ class Navigator;
 class NavigatorMediaCapabilities final : public Supplement<Navigator> {
     WTF_MAKE_TZONE_ALLOCATED(NavigatorMediaCapabilities);
 public:
-    NavigatorMediaCapabilities();
+    explicit NavigatorMediaCapabilities(Navigator&);
     ~NavigatorMediaCapabilities();
 
     static MediaCapabilities& mediaCapabilities(Navigator&);

--- a/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
@@ -34,8 +34,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerNavigatorMediaCapabilities);
 
-WorkerNavigatorMediaCapabilities::WorkerNavigatorMediaCapabilities()
-    : m_mediaCapabilities(MediaCapabilities::create())
+WorkerNavigatorMediaCapabilities::WorkerNavigatorMediaCapabilities(WorkerNavigator& navigator)
+    : m_mediaCapabilities(MediaCapabilities::create(navigator))
 {
 }
 
@@ -45,7 +45,7 @@ WorkerNavigatorMediaCapabilities& WorkerNavigatorMediaCapabilities::from(WorkerN
 {
     auto* supplement = downcast<WorkerNavigatorMediaCapabilities>(Supplement<WorkerNavigator>::from(&navigator, supplementName()));
     if (!supplement) {
-        auto newSupplement = makeUnique<WorkerNavigatorMediaCapabilities>();
+        auto newSupplement = makeUnique<WorkerNavigatorMediaCapabilities>(navigator);
         supplement = newSupplement.get();
         provideTo(&navigator, supplementName(), WTF::move(newSupplement));
     }

--- a/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h
@@ -36,7 +36,7 @@ class WorkerNavigator;
 class WorkerNavigatorMediaCapabilities final : public Supplement<WorkerNavigator> {
     WTF_MAKE_TZONE_ALLOCATED(WorkerNavigatorMediaCapabilities);
 public:
-    WorkerNavigatorMediaCapabilities();
+    explicit WorkerNavigatorMediaCapabilities(WorkerNavigator&);
     ~WorkerNavigatorMediaCapabilities();
 
     static MediaCapabilities& mediaCapabilities(WorkerNavigator&);


### PR DESCRIPTION
#### 083f263204a7f4fa1168ce116eaf30cd8c1868b2
<pre>
navigator.mediaCapabilities wrapper should not become GC-collectable before its navigator object
<a href="https://bugs.webkit.org/show_bug.cgi?id=315684">https://bugs.webkit.org/show_bug.cgi?id=315684</a>

Reviewed by Ryosuke Niwa.

navigator.mediaCapabilities wrapper should not become GC-collectable before its navigator object.
The MediaCapabilities interface is annotated [SameObject] in the spec:
<a href="https://www.w3.org/TR/media-capabilities/#idl-index">https://www.w3.org/TR/media-capabilities/#idl-index</a>
It means that navigator.mediaCapabilities must return the same object on every access.

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1678">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1678</a>

Original author: Andrzej Surdej (<a href="https://github.com/asurdej-comcast)">https://github.com/asurdej-comcast)</a>

Updated existing LayoutTest with mediaCapabilities case.

* LayoutTests/fast/dom/navigator-property-gc-after-frame-detach-expected.txt:
* LayoutTests/fast/dom/navigator-property-gc-after-frame-detach.html:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp:
(WebCore::MediaCapabilities::MediaCapabilities):
(WebCore::MediaCapabilities::navigator):
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.h:
(WebCore::MediaCapabilities::create):
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.idl:
* Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp:
(WebCore::NavigatorMediaCapabilities::NavigatorMediaCapabilities):
(WebCore::NavigatorMediaCapabilities::from):
* Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h:
* Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp:
(WebCore::WorkerNavigatorMediaCapabilities::WorkerNavigatorMediaCapabilities):
(WebCore::WorkerNavigatorMediaCapabilities::from):
* Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h:

Canonical link: <a href="https://commits.webkit.org/315088@main">https://commits.webkit.org/315088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2def00ad108f4247117155b7af25930d23613e9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122033 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128059 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90171 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108680 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29407 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28034 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; 9 api tests failed or timed out; Running re-run-api-tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21575 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176339 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29167 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136380 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136343 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37446 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147615 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101243 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31613 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24472 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37532 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110577 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36930 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2634 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37178 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->