### PR TITLE
Unreviewed, reverting 313978@main (0733f639c1a5)

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -346,12 +346,8 @@ void HTMLModelElement::didMoveToNewDocument(Document& oldDocument, Document& new
 
 // MARK: - Rendering overrides.
 
-RenderPtr<RenderElement> HTMLModelElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& position)
+RenderPtr<RenderElement> HTMLModelElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    if (RefPtr page = document().page()) {
-        if (RefPtr provider = page->modelPlayerProvider(); provider && !provider->isAvailable())
-            return HTMLElement::createElementRenderer(WTF::move(style), position);
-    }
     return createRenderer<RenderModel>(*this, WTF::move(style));
 }
 
@@ -1815,8 +1811,8 @@ ModelPlayerAccessibilityChildren HTMLModelElement::accessibilityChildren()
 
 LayoutSize HTMLModelElement::contentSize() const
 {
-    if (CheckedPtr model = dynamicDowncast<RenderModel>(renderer()))
-        return model->replacedContentRect().size();
+    if (CheckedPtr renderer = this->renderer())
+        return downcast<RenderReplaced>(*renderer).replacedContentRect().size();
 
     return LayoutSize();
 }

--- a/Source/WebCore/Modules/model-element/ModelPlayerProvider.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayerProvider.cpp
@@ -33,9 +33,4 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelPlayerProvider);
 
 ModelPlayerProvider::~ModelPlayerProvider() = default;
 
-bool ModelPlayerProvider::isAvailable() const
-{
-    return true;
-}
-
 }

--- a/Source/WebCore/Modules/model-element/ModelPlayerProvider.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerProvider.h
@@ -39,8 +39,6 @@ class WEBCORE_EXPORT ModelPlayerProvider : public RefCountedAndCanMakeWeakPtr<Mo
 public:
     virtual ~ModelPlayerProvider();
 
-    virtual bool isAvailable() const;
-
     // FIXME: Once all clients have adopted ModelPlayerProvider, this should
     // be changed to return a Ref<ModelPlayer>
     virtual RefPtr<ModelPlayer> createModelPlayer(ModelPlayerClient&) = 0;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
@@ -34,10 +34,6 @@
 #include <WebCore/Settings.h>
 #include <wtf/TZoneMallocInlines.h>
 
-#if PLATFORM(COCOA)
-#include <sys/sysctl.h>
-#include <wtf/spi/darwin/OSVariantSPI.h>
-#endif
 
 #if ENABLE(MODEL_PROCESS)
 #include "ModelProcessModelPlayer.h"
@@ -47,18 +43,6 @@
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebModelPlayerProvider);
-
-#if PLATFORM(COCOA)
-static bool isRunningInRecoveryOS()
-{
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-    static bool isBaseSystem = os_variant_is_basesystem("WebKit");
-    return isBaseSystem;
-#else
-    return false;
-#endif
-}
-#endif
 
 Ref<WebModelPlayerProvider> WebModelPlayerProvider::create(WebPage& webPage)
 {
@@ -74,24 +58,9 @@ WebModelPlayerProvider::~WebModelPlayerProvider() = default;
 
 // MARK: - WebCore::ModelPlayerProvider overrides.
 
-bool WebModelPlayerProvider::isAvailable() const
-{
-#if PLATFORM(COCOA)
-    return !isRunningInRecoveryOS();
-#else
-    return true;
-#endif
-}
-
 RefPtr<WebCore::ModelPlayer> WebModelPlayerProvider::createModelPlayer(WebCore::ModelPlayerClient& client)
 {
     Ref page = m_page.get();
-#if PLATFORM(COCOA)
-    if (!isAvailable()) {
-        UNUSED_PARAM(client);
-        return nullptr;
-    }
-#endif
 #if ENABLE(MODEL_PROCESS)
     if (page->corePage() && page->corePage()->settings().modelProcessEnabled())
         return WebProcess::singleton().modelProcessModelPlayerManager().createModelProcessModelPlayer(page, client);

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h
@@ -44,7 +44,6 @@ private:
     WebModelPlayerProvider(WebPage&);
 
     // WebCore::ModelPlayerProvider overrides.
-    bool isAvailable() const final;
     RefPtr<WebCore::ModelPlayer> createModelPlayer(WebCore::ModelPlayerClient&) final;
     void deleteModelPlayer(WebCore::ModelPlayer&) final;
 


### PR DESCRIPTION
#### 15e163fe11e0a22393b9e85a1baecbeb559cf2d2
<pre>
Unreviewed, reverting 313978@main (0733f639c1a5)
<a href="https://bugs.webkit.org/show_bug.cgi?id=315686">https://bugs.webkit.org/show_bug.cgi?id=315686</a>
<a href="https://rdar.apple.com/178072938">rdar://178072938</a>

Unreviewed Infrastructure Fix.

This reverts because it broke the build on the bots.

Reverted change:

    Navigating to a page with a model tag crashes in recovery mode
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315620">https://bugs.webkit.org/show_bug.cgi?id=315620</a>
    <a href="https://rdar.apple.com/177993583">rdar://177993583</a>
    313978@main (0733f639c1a5)

Canonical link: <a href="https://commits.webkit.org/313993@main">https://commits.webkit.org/313993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c7b968af22f5507d5edc9f89eebaff079d02abb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/164782 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/31837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/173817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/166651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38268 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/173817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/167741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/30360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/148103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/173817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/21576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/25819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/27488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/176340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39025 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/147614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25081 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/31614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/36931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/2536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/37079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->