### PR TITLE
PerformanceEventTiming.target returns un-retargeted node for pointer events without a DOM listener

### DIFF
--- a/LayoutTests/performance-api/event-timing-target-retarget-shadow-dom-expected.txt
+++ b/LayoutTests/performance-api/event-timing-target-retarget-shadow-dom-expected.txt
@@ -1,0 +1,11 @@
+Tests that PerformanceEventTiming.target is retargeted out of user-agent shadow DOM even without event listeners.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS 'mouseup' entry has correctly retargeted target: INPUT#test-input
+PASS 'click' entry has correctly retargeted target: INPUT#test-input
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/performance-api/event-timing-target-retarget-shadow-dom.html
+++ b/LayoutTests/performance-api/event-timing-target-retarget-shadow-dom.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../resources/js-test.js"></script>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<input id="test-input" type="text" value="click me" style="display:block; width:200px; height:50px;">
+<script>
+
+description("Tests that PerformanceEventTiming.target is retargeted out of user-agent shadow DOM even without event listeners.");
+window.jsTestIsAsync = true;
+
+function busyWait(ms) {
+    const target = performance.now() + ms;
+    while (performance.now() < target);
+}
+
+async function test()
+{
+    const input = document.getElementById('test-input');
+    const collectedEntries = [];
+
+    // Register a click listener with busy-wait to ensure all entries in the
+    // same interaction (including pointerup which has no listener) exceed the
+    // duration threshold. click fires after pointerup in the same task, so
+    // the busy-wait delays the rendering update for all entries.
+    input.addEventListener('click', () => {
+        busyWait(50);
+    });
+
+    const observerReady = new Promise(resolve => {
+        const observer = new PerformanceObserver(list => {
+            for (const entry of list.getEntries())
+                collectedEntries.push(entry);
+
+            const types = new Set(collectedEntries.map(e => e.name));
+            if (types.has('click'))
+                resolve();
+        });
+        observer.observe({ type: 'event', durationThreshold: 16 });
+    });
+
+    if (window.testRunner)
+        await UIHelper.activateElement(input);
+    await observerReady;
+
+    for (const entry of collectedEntries) {
+        if (!entry.target || !['mouseup', 'click'].includes(entry.name))
+            continue;
+        if (entry.target !== input)
+            testFailed("'" + entry.name + "' entry has wrong target: " + entry.target + " (expected the <input> element)");
+        else if (entry.target.getRootNode() !== document)
+            testFailed("'" + entry.name + "' entry target's root node is not the document (got " + entry.target.getRootNode() + ")");
+        else
+            testPassed("'" + entry.name + "' entry has correctly retargeted target: " + entry.target.tagName + "#" + entry.target.id);
+    }
+
+    finishJSTest();
+}
+
+test();
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2703,7 +2703,14 @@ void LocalDOMWindow::markEndOfProcessingForEventTiming(PerformanceEventTimingCan
     // Maps to "Finalize event timing" in the spec.
     auto processingEnd = performance().nowInReducedResolutionSeconds();
     entry.processingEnd = processingEnd;
-    entry.target = event.target();
+    // Per the Event Timing spec, the target must be retargeted to the document scope.
+    // Without this, when no event listeners are registered for a given event type,
+    // the event target may be an un-retargeted node inside a user-agent shadow tree
+    // (e.g., an internal node of <input>), leaking shadow DOM internals.
+    if (RefPtr targetNode = dynamicDowncast<Node>(event.target()))
+        entry.target = targetNode->document().retargetToScope(*targetNode).get();
+    else
+        entry.target = event.target();
 
     switch (type) {
     case EventType::pointerdown: {


### PR DESCRIPTION
#### 91afa18d36f924a8f1f890957c9ee49ba0328adc
<pre>
PerformanceEventTiming.target returns un-retargeted node for pointer events without a DOM listener
<a href="https://bugs.webkit.org/show_bug.cgi?id=309910">https://bugs.webkit.org/show_bug.cgi?id=309910</a>
<a href="https://rdar.apple.com/172516264">rdar://172516264</a>

Reviewed by Wenson Hsieh.

This PR fixes a bug that PerformanceEventTiming would expose a node in a UA shadow trees.

Test: performance-api/event-timing-target-retarget-shadow-dom.html

* LayoutTests/performance-api/event-timing-target-retarget-shadow-dom-expected.txt: Added.
* LayoutTests/performance-api/event-timing-target-retarget-shadow-dom.html: Added.
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::finalizeEventTimingEntry):

Originally-landed-as: 305413.521@rapid/safari-7624.2.5.110-branch (b6884036db8c). <a href="https://rdar.apple.com/176061999">rdar://176061999</a>
Canonical link: <a href="https://commits.webkit.org/314047@main">https://commits.webkit.org/314047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afa91148fed433eb65f4f896d47f951e7c626d69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128067 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90176 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108613 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28040 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21586 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176350 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29179 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Running scan-build") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27495 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136387 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38345 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136350 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36774 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147621 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101254 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31622 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24478 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37543 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110588 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36941 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2543 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37189 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->