### PR TITLE
Type Confusion in RTCEncodedStreamProducer.cpp Results in OOB Read

### DIFF
--- a/LayoutTests/http/wpt/webrtc/audio-video-transform.js
+++ b/LayoutTests/http/wpt/webrtc/audio-video-transform.js
@@ -1,3 +1,7 @@
+var audioSenderTransformer, videoSenderTransformer;
+var audioReceiverTransformer, videoReceiverTransformer;
+var audioChunk, videoChunk;
+
 class AudioVideoRTCRtpTransformer {
     constructor(transformer) {
         this.askKeyFrame = false;
@@ -17,7 +21,24 @@ class AudioVideoRTCRtpTransformer {
                 this.tryAccessingDataTwice = true;
             else if (event.data === "tryAccessingMetadata")
                 this.tryAccessingMetadata = true;
+            else if (event.data === "tryWritingAudio")
+                this.tryWritingAudio = true;
+            else if (event.data === "tryWritingVideo")
+                this.tryWritingVideo = true;
         };
+
+        if (this.context.options.side === "sender") {
+            if (this.context.options.mediaType === "audio")
+                audioSenderTransformer = this;
+            else if (this.context.options.mediaType === "video")
+                videoSenderTransformer = this;
+        } else {
+            if (this.context.options.mediaType === "audio")
+                audioReceiverTransformer = this;
+            else if (this.context.options.mediaType === "video")
+                videoReceiverTransformer = this;
+        }
+
         this.start();
     }
     start()
@@ -29,9 +50,97 @@ class AudioVideoRTCRtpTransformer {
 
     process()
     {
-        this.reader.read().then(chunk => {
+        this.reader.read().then(async chunk => {
             if (chunk.done)
                 return;
+
+            if (audioSenderTransformer && audioSenderTransformer.tryWritingVideo) {
+                if (audioSenderTransformer === this) {
+                    this.writer.write(chunk.value);
+                    if (videoChunk !== undefined) {
+                       this.writer.write(videoChunk.value);
+                       audioSenderTransformer.tryWritingVideo = false;
+                       this.context.options.port.postMessage("PASS");
+                    }
+                    this.process();
+                    return;
+                }
+                if(videoSenderTransformer === this) {
+                    videoChunk = chunk;
+                    while (audioSenderTransformer.tryWritingVideo)
+                        await new Promise(resolve => setTimeout(resolve, 50));
+                    videoSenderTransformer.writer.write(videoChunk);
+                    videoChunk = undefined;
+                    this.process();
+                    return;
+                }
+            }
+
+            if (videoSenderTransformer && videoSenderTransformer.tryWritingAudio) {
+                if (videoSenderTransformer === this) {
+                    this.writer.write(chunk.value);
+                    if (audioChunk !== undefined) {
+                       this.writer.write(audioChunk.value);
+                       videoSenderTransformer.tryWritingAudio = false;
+                       this.context.options.port.postMessage("PASS");
+                    }
+                    this.process();
+                    return;
+                }
+                if(audioSenderTransformer === this) {
+                    audioChunk = chunk;
+                    while (videoSenderTransformer.tryWritingAudio)
+                        await new Promise(resolve => setTimeout(resolve, 50));
+                    audioSenderTransformer.writer.write(audioChunk);
+                    audioChunk = undefined;
+                    this.process();
+                    return;
+                }
+            }
+
+            if (audioSenderTransformer && audioSenderTransformer.tryWritingAudio) {
+                if (audioSenderTransformer === this) {
+                    this.writer.write(chunk.value);
+                    if (audioChunk !== undefined) {
+                       this.writer.write(audioChunk.value);
+                       audioSenderTransformer.tryWritingAudio = false;
+                       this.context.options.port.postMessage("PASS");
+                    }
+                    this.process();
+                    return;
+                }
+                if(audioReceiverTransformer === this) {
+                    audioChunk = chunk;
+                    while (audioSenderTransformer.tryWritingAudio)
+                        await new Promise(resolve => setTimeout(resolve, 50));
+                    audioReceiverTransformer.writer.write(audioChunk);
+                    audioChunk = undefined;
+                    this.process();
+                    return;
+                }
+            }
+
+            if (videoSenderTransformer && videoSenderTransformer.tryWritingVideo) {
+                if (videoSenderTransformer === this) {
+                    this.writer.write(chunk.value);
+                    if (videoChunk !== undefined) {
+                       this.writer.write(videoChunk.value);
+                       videoSenderTransformer.tryWritingVideo = false;
+                       this.context.options.port.postMessage("PASS");
+                    }
+                    this.process();
+                    return;
+                }
+                if (videoReceiverTransformer === this) {
+                    videoChunk = chunk;
+                    while (videoSenderTransformer.tryWritingVideo)
+                        await new Promise(resolve => setTimeout(resolve, 50));
+                    videoReceiverTransformer.writer.write(videoChunk);
+                    videoChunk = undefined;
+                    this.process();
+                    return;
+                }
+            }
 
             if (this.tryAccessingDataTwice) {
                 this.tryAccessingDataTwice = false;

--- a/LayoutTests/http/wpt/webrtc/audiovideo-script-transform-expected.txt
+++ b/LayoutTests/http/wpt/webrtc/audiovideo-script-transform-expected.txt
@@ -10,4 +10,8 @@ PASS Check data after write
 PASS Check modified data after write
 PASS Check data getter
 PASS Check metadata getter
+PASS Try writing receiver audio data on audio sender
+PASS Try writing receiver video data on video sender
+PASS Try writing video data on audio sender
+PASS Try writing audio data on video sender
 

--- a/LayoutTests/http/wpt/webrtc/audiovideo-script-transform.html
+++ b/LayoutTests/http/wpt/webrtc/audiovideo-script-transform.html
@@ -160,9 +160,33 @@ promise_test(async (test) => {
     videoSenderTransform.port.postMessage("tryAccessingMetadata");
     metadata =await waitForMessage(videoSenderTransform.port);
     assert_array_equals(Object.keys(metadata), ["contributingSources", "dependencies", "frameId", "height", "mimeType", "payloadType", "rtpTimestamp", "spatialIndex", "synchronizationSource", "temporalIndex", "width"]);
+}, "Check metadata getter");
+
+promise_test(async (test) => {
+    audioSenderTransform.port.postMessage("tryWritingAudio");
+    let result = await waitForMessage(audioSenderTransform.port);
+    assert_equals(result, "PASS");
+}, "Try writing receiver audio data on audio sender");
+
+promise_test(async (test) => {
+    videoSenderTransform.port.postMessage("tryWritingVideo");
+    let result = await waitForMessage(videoSenderTransform.port);
+    assert_equals(result, "PASS");
+}, "Try writing receiver video data on video sender");
+
+promise_test(async (test) => {
+    audioSenderTransform.port.postMessage("tryWritingVideo");
+    let result = await waitForMessage(audioSenderTransform.port);
+    assert_equals(result, "PASS");
+}, "Try writing video data on audio sender");
+
+promise_test(async (test) => {
+    videoSenderTransform.port.postMessage("tryWritingAudio");
+    result = await waitForMessage(videoSenderTransform.port);
+    assert_equals(result, "PASS");
 
     test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
-}, "Check metadata getter");
+}, "Try writing audio data on video sender");
         </script>
     </body>
 </html>

--- a/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp
@@ -38,6 +38,7 @@
 #include "JSRTCEncodedAudioFrame.h"
 #include "JSRTCEncodedVideoFrame.h"
 #include "Logging.h"
+#include "RTCRtpScriptTransformer.h"
 #include "ReadableStreamSource.h"
 #include "ScriptExecutionContextInlines.h"
 #include "Settings.h"
@@ -94,7 +95,7 @@ std::optional<Exception> RTCEncodedStreamProducer::initialize(JSDOMGlobalObject&
     return { };
 }
 
-void RTCEncodedStreamProducer::start(Ref<RTCRtpTransformBackend>&& transformBackend, bool isVideo)
+void RTCEncodedStreamProducer::start(Ref<RTCRtpTransformBackend>&& transformBackend, bool isVideo, RTCRtpScriptTransformer* transformer)
 {
     transformBackend->setTransformableFrameCallback([weakThis = WeakPtr { *this }, contextIdentifer = m_contextIdentifier](Ref<RTCRtpTransformableFrame>&& frame) mutable {
         ScriptExecutionContext::postTaskTo(contextIdentifer, [weakThis, frame = WTF::move(frame)](auto&) mutable {
@@ -104,6 +105,8 @@ void RTCEncodedStreamProducer::start(Ref<RTCRtpTransformBackend>&& transformBack
     });
     m_transformBackend = WTF::move(transformBackend);
     m_isVideo = isVideo;
+    m_hasTransformer = !!transformer;
+    m_transformer = transformer;
 }
 
 void RTCEncodedStreamProducer::enqueueFrame(Ref<RTCRtpTransformableFrame>&& frame)
@@ -136,6 +139,7 @@ void RTCEncodedStreamProducer::enqueueFrame(Ref<RTCRtpTransformableFrame>&& fram
     }
 #endif
 
+    frame->setTransformer(m_transformer);
     auto value = m_isVideo ? toJS(globalObject, globalObject, RTCEncodedVideoFrame::create(WTF::move(frame))) : toJS(globalObject, globalObject, RTCEncodedAudioFrame::create(WTF::move(frame)));
 
     m_readableSource->enqueue(value);
@@ -158,15 +162,20 @@ ExceptionOr<void> RTCEncodedStreamProducer::writeFrame(ScriptExecutionContext& c
     if (frameConversionResult.hasException(scope)) [[unlikely]]
         return Exception { ExceptionCode::ExistingExceptionError };
 
+    bool isVideo = false;
     auto frame = frameConversionResult.releaseReturnValue();
     auto rtcFrame = WTF::switchOn(frame,
         [&](Ref<RTCEncodedAudioFrame>& value) {
             return value->rtcFrame(vm);
         },
         [&](Ref<RTCEncodedVideoFrame>& value) {
+            isVideo = true;
             return value->rtcFrame(vm);
         }
     );
+
+    if (m_isVideo != isVideo || (m_hasTransformer && !rtcFrame->isFromTransformer(m_transformer.get())))
+        return { };
 
     // If no data, skip the frame since there is nothing to packetize or decode.
     if (rtcFrame->data().data())

--- a/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.h
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.h
@@ -53,7 +53,7 @@ public:
     static ExceptionOr<Ref<RTCEncodedStreamProducer>> create(ScriptExecutionContext&);
     ~RTCEncodedStreamProducer();
 
-    void start(Ref<RTCRtpTransformBackend>&&, bool isVideo);
+    void start(Ref<RTCRtpTransformBackend>&&, bool isVideo, RTCRtpScriptTransformer* = nullptr);
     void clear(bool shouldClearCallback);
 
     void generateKeyFrame(ScriptExecutionContext&, const String&, Ref<DeferredPromise>&&);
@@ -82,6 +82,8 @@ private:
     RefPtr<RTCRtpTransformBackend> m_transformBackend;
     Vector<Ref<DeferredPromise>> m_pendingKeyFramePromises;
     bool m_isVideo { false };
+    bool m_hasTransformer { false };
+    WeakPtr<RTCRtpScriptTransformer> m_transformer;
 
 #if !RELEASE_LOG_DISABLED
     bool m_enableAdditionalLogging { false };

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -83,7 +83,7 @@ WritableStream& RTCRtpScriptTransformer::writable()
 void RTCRtpScriptTransformer::start(Ref<RTCRtpTransformBackend>&& backend)
 {
     m_isSender = backend->side() == RTCRtpTransformBackend::Side::Sender;
-    m_streamProducer->start(WTF::move(backend), backend->mediaType() == RTCRtpTransformBackend::MediaType::Video);
+    m_streamProducer->start(WTF::move(backend), backend->mediaType() == RTCRtpTransformBackend::MediaType::Video, this);
 }
 
 void RTCRtpScriptTransformer::clear(ClearCallback clearCallback)

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransformableFrame.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransformableFrame.h
@@ -76,8 +76,8 @@ public:
     virtual void setOptions(const RTCEncodedAudioFrameMetadata&) = 0;
     virtual void setOptions(const RTCEncodedVideoFrameMetadata&) = 0;
 
-    void setTransformer(RTCRtpScriptTransformer&);
-    bool isFromTransformer(RTCRtpScriptTransformer& transformer) const { return &transformer == m_transformer.get(); }
+    void setTransformer(WeakPtr<RTCRtpScriptTransformer>);
+    bool isFromTransformer(RTCRtpScriptTransformer* transformer) const { return transformer == m_transformer.get(); }
 
     virtual bool isLibWebRTCRtpTransformableFrame() const { return false; }
 
@@ -85,10 +85,10 @@ private:
     WeakPtr<RTCRtpScriptTransformer> m_transformer;
 };
 
-inline void RTCRtpTransformableFrame::setTransformer(RTCRtpScriptTransformer& transformer)
+inline void RTCRtpTransformableFrame::setTransformer(WeakPtr<RTCRtpScriptTransformer> transformer)
 {
     ASSERT(!m_transformer);
-    m_transformer = transformer;
+    m_transformer = WTF::move(transformer);
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 8384c8455e7b5bc40b42c8cc7e9336b519d6cd80
<pre>
Type Confusion in RTCEncodedStreamProducer.cpp Results in OOB Read
<a href="https://bugs.webkit.org/show_bug.cgi?id=311131">https://bugs.webkit.org/show_bug.cgi?id=311131</a>
<a href="https://rdar.apple.com/173718825">rdar://173718825</a>

Reviewed by Eric Carlson.

We add a check in RTCEncodedStreamProducer::writeFrame that we can only enqueue a video frame on a video sender/receiver,
and audio frame on an audio sender/receiver.
We should also allow write frames in a WritableStream that are generated from the corresponding ReadableStream.
We add the check in RTCEncodedStreamProducer::writeFrame for RTCRtpScriptTransformer and

Covered by updated test.

* LayoutTests/http/wpt/webrtc/audio-video-transform.js:
(AudioVideoRTCRtpTransformer):
(AudioVideoRTCRtpTransformer.prototype.process):
(onrtctransform): Deleted.
* LayoutTests/http/wpt/webrtc/audiovideo-script-transform-expected.txt:
* LayoutTests/http/wpt/webrtc/audiovideo-script-transform.html:
* Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp:
(WebCore::RTCEncodedStreamProducer::start):
(WebCore::RTCEncodedStreamProducer::enqueueFrame):
(WebCore::RTCEncodedStreamProducer::writeFrame):
* Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp:
(WebCore::RTCRtpScriptTransformer::start):
* Source/WebCore/Modules/mediastream/RTCRtpTransformableFrame.h:
(WebCore::RTCRtpTransformableFrame::isFromTransformer const):
(WebCore::RTCRtpTransformableFrame::setTransformer):

Originally-landed-as: 305413.606@rapid/safari-7624.2.5.110-branch (8d45e135c17e). <a href="https://rdar.apple.com/176061902">rdar://176061902</a>
Canonical link: <a href="https://commits.webkit.org/315256@main">https://commits.webkit.org/315256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9b1125dd6af3e1e7a548a28743380547c63cb0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177760 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126133 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131091 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92185 "6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151364 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111602 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32539 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31242 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26456 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142525 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180360 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33084 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139526 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139390 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37553 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106319 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34678 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27739 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41193 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114449 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40590 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5823 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40841 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40735 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->