### PR TITLE
Tighten USE(SKIA) guard around settings().hardwareAccelerationEnabled() in Page.cpp

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4896,7 +4896,7 @@ OptionSet<FilterRenderingMode> Page::preferredFilterRenderingModes(const Graphic
         modes.add(FilterRenderingMode::Accelerated);
 #endif
 
-#if USE(SKIA) && !PLATFORM(WIN) && (!PLATFORM(WPE) || ENABLE(WPE_PLATFORM))
+#if USE(SKIA) && (PLATFORM(GTK) || ENABLE(WPE_PLATFORM))
     if (settings().hardwareAccelerationEnabled())
         modes.add(FilterRenderingMode::Accelerated);
 #endif


### PR DESCRIPTION
#### a4cfe86bc450d43e4235df1df07536f6a230bbe5
<pre>
Tighten USE(SKIA) guard around settings().hardwareAccelerationEnabled() in Page.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=315690">https://bugs.webkit.org/show_bug.cgi?id=315690</a>

Reviewed by NOBODY (OOPS!).

The HardwareAccelerationEnabled preference is gated on
`PLATFORM(GTK) || ENABLE(WPE_PLATFORM)` in UnifiedWebPreferences.yaml,
but Page::preferredFilterRenderingModes guarded its use with
`USE(SKIA) &amp;&amp; !PLATFORM(WIN) &amp;&amp; (!PLATFORM(WPE) || ENABLE(WPE_PLATFORM))`,
which can match Skia-based ports that are neither GTK nor WPE_PLATFORM.

Align the guard with the preference&apos;s own condition. This also subsumes
the Windows-specific exclusion added in <a href="https://commits.webkit.org/310855@main">310855@main</a> (bug 311829), since
PLATFORM(WIN) cannot satisfy PLATFORM(GTK) || ENABLE(WPE_PLATFORM).

* Source/WebCore/page/Page.cpp:
(WebCore::Page::preferredFilterRenderingModes): Replace
`!PLATFORM(WIN) &amp;&amp; (!PLATFORM(WPE) || ENABLE(WPE_PLATFORM))` with
`(PLATFORM(GTK) || ENABLE(WPE_PLATFORM))` so the call to
settings().hardwareAccelerationEnabled() only compiles on ports where
that preference exists.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4cfe86bc450d43e4235df1df07536f6a230bbe5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173834 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122051 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128072 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90178 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108618 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28047 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21593 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139326 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176357 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29186 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Running scan-build") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136394 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136363 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147628 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101261 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31629 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24485 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37550 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110595 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36948 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2551 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->