### PR TITLE
Potential use after free of m_responseDocument in XMLHttpRequest::visitAdditionalChildren()

### DIFF
--- a/Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp
@@ -45,11 +45,7 @@ using namespace JSC;
 template<typename Visitor>
 void JSXMLHttpRequest::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    if (auto* upload = wrapped().optionalUpload())
-        addWebCoreOpaqueRoot(visitor, *upload);
-
-    if (SUPPRESS_UNCHECKED_LOCAL auto* responseDocument = wrapped().optionalResponseXML())
-        addWebCoreOpaqueRoot(visitor, *responseDocument);
+    wrapped().visitAdditionalChildrenInGCThread(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSXMLHttpRequest);

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -60,6 +60,7 @@
 #include "XMLHttpRequestProgressEvent.h"
 #include "XMLHttpRequestProgressEventThrottle.h"
 #include "XMLHttpRequestUpload.h"
+#include "WebCoreOpaqueRootInlines.h"
 #include "markup.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/ArrayBufferView.h>
@@ -178,6 +179,7 @@ ExceptionOr<Document*> XMLHttpRequest::responseXML()
         // If it is text/html, then the responseType of "document" must have been supplied explicitly.
         if ((m_response.isInHTTPFamily() && !isXML && !isHTML)
             || (isHTML && responseType() == ResponseType::EmptyString)) {
+            Locker locker { m_gcLock };
             m_responseDocument = nullptr;
         } else {
             RefPtr<Document> responseDocument;
@@ -193,6 +195,7 @@ ExceptionOr<Document*> XMLHttpRequest::responseXML()
             if (m_decoder)
                 responseDocument->setDecoder(m_decoder.copyRef());
 
+            Locker locker { m_gcLock };
             if (!isHTML && !responseDocument->wellFormed())
                 m_responseDocument = nullptr;
             else
@@ -201,6 +204,7 @@ ExceptionOr<Document*> XMLHttpRequest::responseXML()
         m_createdDocument = true;
     }
 
+    Locker locker { m_gcLock };
     return m_responseDocument.get();
 }
 
@@ -272,6 +276,7 @@ String XMLHttpRequest::responseURL() const
 
 XMLHttpRequestUpload& XMLHttpRequest::upload()
 {
+    Locker locker { m_gcLock };
     if (!m_upload)
         lazyInitialize(m_upload, makeUniqueWithoutRefCountedCheck<XMLHttpRequestUpload>(*this));
     return *m_upload;
@@ -480,6 +485,7 @@ ExceptionOr<void> XMLHttpRequest::send(Ref<Document>&& document)
         auto converted = replaceUnpairedSurrogatesWithReplacementCharacter(WTF::move(serialized));
         auto encoded = PAL::TextCodecUTF8::encodeUTF8(WTF::move(converted));
         m_requestEntityBody = FormData::create(WTF::move(encoded));
+        Locker locker { m_gcLock };
         if (m_upload)
             m_requestEntityBody->setAlwaysStream(true);
     }
@@ -502,6 +508,7 @@ ExceptionOr<void> XMLHttpRequest::send(String&& body)
         }
 
         m_requestEntityBody = FormData::create(PAL::TextCodecUTF8::encodeUTF8(body));
+        Locker locker { m_gcLock };
         if (m_upload)
             m_requestEntityBody->setAlwaysStream(true);
     }
@@ -578,6 +585,7 @@ ExceptionOr<void> XMLHttpRequest::sendBytesData(std::span<const uint8_t> data)
 
     if (m_method != "GET"_s && m_method != "HEAD"_s) {
         m_requestEntityBody = FormData::create(data);
+        Locker locker { m_gcLock };
         if (m_upload)
             m_requestEntityBody->setAlwaysStream(true);
     }
@@ -593,9 +601,11 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
         return Exception { ExceptionCode::NetworkError };
     }
 
-    if (m_async && m_upload && m_upload->hasEventListeners())
-        m_uploadListenerFlag = true;
-
+    {
+        Locker locker { m_gcLock };
+        if (m_async && m_upload && m_upload->hasEventListeners())
+            m_uploadListenerFlag = true;
+    }
     ResourceRequest request(URL { m_url });
     request.setRequester(ResourceRequestRequester::XHR);
     Ref context = *scriptExecutionContext();
@@ -641,9 +651,13 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
 
     if (m_async) {
         m_progressEventThrottle->dispatchProgressEvent(eventNames().loadstartEvent);
-        if (!m_uploadComplete && m_uploadListenerFlag)
-            m_upload->dispatchProgressEvent(eventNames().loadstartEvent, 0, protect(request.httpBody())->lengthInBytes());
-
+        if (!m_uploadComplete && m_uploadListenerFlag) {
+            RefPtr upload = [&] {
+                Locker locker { m_gcLock };
+                return m_upload.get();
+            }();
+            upload->dispatchProgressEvent(eventNames().loadstartEvent, 0, protect(request.httpBody())->lengthInBytes());
+        }
         if (readyState() != OPENED || !m_sendFlag || m_loadingActivity)
             return { };
 
@@ -735,7 +749,10 @@ void XMLHttpRequest::clearResponseBuffers()
     m_responseBuilder.clear();
     m_responseEncoding = String();
     m_createdDocument = false;
-    m_responseDocument = nullptr;
+    {
+        Locker locker { m_gcLock };
+        m_responseDocument = nullptr;
+    }
     m_binaryResponseBuilder.reset();
     m_responseCacheIsValid = false;
 }
@@ -961,18 +978,22 @@ void XMLHttpRequest::didFinishLoading(ScriptExecutionContextIdentifier, std::opt
 
 void XMLHttpRequest::didSendData(unsigned long long bytesSent, unsigned long long totalBytesToBeSent)
 {
-    if (!m_upload)
+    RefPtr upload = [&] {
+        Locker locker { m_gcLock };
+        return m_upload.get();
+    }();
+    if (!upload)
         return;
 
     if (m_uploadListenerFlag)
-        m_upload->dispatchProgressEvent(eventNames().progressEvent, bytesSent, totalBytesToBeSent);
+        upload->dispatchProgressEvent(eventNames().progressEvent, bytesSent, totalBytesToBeSent);
 
     if (bytesSent == totalBytesToBeSent && !m_uploadComplete) {
         m_wasDidSendDataCalledForTotalBytes = true;
         m_uploadComplete = true;
         if (m_uploadListenerFlag) {
-            m_upload->dispatchProgressEvent(eventNames().loadEvent, bytesSent, totalBytesToBeSent);
-            m_upload->dispatchProgressEvent(eventNames().loadendEvent, bytesSent, totalBytesToBeSent);
+            upload->dispatchProgressEvent(eventNames().loadEvent, bytesSent, totalBytesToBeSent);
+            upload->dispatchProgressEvent(eventNames().loadendEvent, bytesSent, totalBytesToBeSent);
         }
     }
 }
@@ -1113,9 +1134,13 @@ void XMLHttpRequest::dispatchErrorEvents(const AtomString& type)
 {
     if (!m_uploadComplete) {
         m_uploadComplete = true;
-        if (m_upload && m_uploadListenerFlag) {
-            m_upload->dispatchProgressEvent(type, 0, 0);
-            m_upload->dispatchProgressEvent(eventNames().loadendEvent, 0, 0);
+        RefPtr upload = [&] {
+            Locker locker { m_gcLock };
+            return m_upload.get();
+        }();
+        if (upload && m_uploadListenerFlag) {
+            upload->dispatchProgressEvent(type, 0, 0);
+            upload->dispatchProgressEvent(eventNames().loadendEvent, 0, 0);
         }
     }
     m_progressEventThrottle->dispatchErrorProgressEvent(type);
@@ -1183,6 +1208,10 @@ void XMLHttpRequest::contextDestroyed()
 
 void XMLHttpRequest::updateHasRelevantEventListener()
 {
+    bool uploadHasRelevantEventListener = [&] {
+        Locker locker { m_gcLock };
+        return m_upload && m_upload->hasRelevantEventListener();
+    }();
     m_hasRelevantEventListener = hasEventListeners(eventNames().abortEvent)
         || hasEventListeners(eventNames().errorEvent)
         || hasEventListeners(eventNames().loadEvent)
@@ -1190,7 +1219,7 @@ void XMLHttpRequest::updateHasRelevantEventListener()
         || hasEventListeners(eventNames().progressEvent)
         || hasEventListeners(eventNames().readystatechangeEvent)
         || hasEventListeners(eventNames().timeoutEvent)
-        || (m_upload && m_upload->hasRelevantEventListener());
+        || uploadHasRelevantEventListener;
 }
 
 void XMLHttpRequest::eventListenersDidChange()
@@ -1222,5 +1251,18 @@ void XMLHttpRequest::dispatchThrottledProgressEventIfNeeded()
 {
     m_progressEventThrottle->dispatchThrottledProgressEventIfNeeded();
 }
+
+template<typename Visitor>
+void XMLHttpRequest::visitAdditionalChildrenInGCThread(Visitor& visitor)
+{
+    Locker locker { m_gcLock };
+    if (m_upload)
+        addWebCoreOpaqueRoot(visitor, *m_upload);
+
+    SUPPRESS_UNCHECKED_LOCAL if (auto* document = m_responseDocument.get())
+        addWebCoreOpaqueRoot(visitor, *document);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(XMLHttpRequest);
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -104,7 +104,6 @@ public:
     enum class FinalMIMEType : bool { No, Yes };
     String responseMIMEType(FinalMIMEType = FinalMIMEType::No) const;
 
-    Document* optionalResponseXML() const { return m_responseDocument.get(); }
     ExceptionOr<Document*> responseXML();
 
     Ref<Blob> createResponseBlob();
@@ -131,7 +130,6 @@ public:
     String responseURL() const;
 
     XMLHttpRequestUpload& upload();
-    XMLHttpRequestUpload* optionalUpload() const { return m_upload.get(); }
 
     const ResourceResponse& resourceResponse() const LIFETIME_BOUND { return m_response; }
 
@@ -141,6 +139,8 @@ public:
     void dispatchEvent(Event&) override;
 
     void dispatchThrottledProgressEventIfNeeded();
+
+    template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
 
 private:
     friend class XMLHttpRequestUpload;
@@ -221,7 +221,8 @@ private:
 
     unsigned m_timeoutMilliseconds { 0 };
 
-    const std::unique_ptr<XMLHttpRequestUpload> m_upload;
+    Lock m_gcLock;
+    const std::unique_ptr<XMLHttpRequestUpload> m_upload WTF_GUARDED_BY_LOCK(m_gcLock);
 
     URLKeepingBlobAlive m_url;
     String m_method;
@@ -241,7 +242,7 @@ private:
 
     RefPtr<TextResourceDecoder> m_decoder;
 
-    RefPtr<Document> m_responseDocument;
+    RefPtr<Document> m_responseDocument WTF_GUARDED_BY_LOCK(m_gcLock);
 
     SharedBufferBuilder m_binaryResponseBuilder;
 


### PR DESCRIPTION
#### a814080321a1e3031e47b654288281324fd923f9
<pre>
Potential use after free of m_responseDocument in XMLHttpRequest::visitAdditionalChildren()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309947">https://bugs.webkit.org/show_bug.cgi?id=309947</a>
<a href="https://rdar.apple.com/172537101">rdar://172537101</a>

Reviewed by Ryosuke Niwa.

Potential use after free of m_responseDocument in XMLHttpRequest::visitAdditionalChildren()
due to multi-threading. visitAdditionalChildren() dereferences m_responseDocument
on the GC thread while the main thread is running and may null out the RefPtr.

Address the issue via locking.

* Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp:
(WebCore::JSXMLHttpRequest::visitAdditionalChildren):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::upload):
(WebCore::XMLHttpRequest::send):
(WebCore::XMLHttpRequest::sendBytesData):
(WebCore::XMLHttpRequest::createRequest):
(WebCore::XMLHttpRequest::clearResponseBuffers):
(WebCore::XMLHttpRequest::didSendData):
(WebCore::XMLHttpRequest::dispatchErrorEvents):
(WebCore::XMLHttpRequest::updateHasRelevantEventListener):
(WebCore::XMLHttpRequest::visitAdditionalChildren):
* Source/WebCore/xml/XMLHttpRequest.h:

Originally-landed-as: 305413.477@rapid/safari-7624.2.5.110-branch (0de76a6ef7c5). <a href="https://rdar.apple.com/176062384">rdar://176062384</a>
Canonical link: <a href="https://commits.webkit.org/314040@main">https://commits.webkit.org/314040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52bdd53e767b4864a28568dd4e81f81a04d4c9f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128186 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108712 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29541 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28155 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21755 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176522 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29374 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136506 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136452 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36768 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147722 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101485 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31724 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24588 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37716 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110787 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37113 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2663 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37359 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37257 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->