### PR TITLE
Web Inspector: support testing backend commands using Automation protocol

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -1724,6 +1724,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKAutomationSessionPrivateForTesting {
+    header "_WKAutomationSessionPrivateForTesting.h"
+    export *
+  }
+
   explicit module _WKContentRuleListAction {
     header "_WKContentRuleListAction.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -2630,6 +2630,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKAutomationSessionPrivateForTesting {
+    header "_WKAutomationSessionPrivateForTesting.h"
+    export *
+  }
+
   explicit module _WKContentRuleListAction {
     header "_WKContentRuleListAction.h"
     export *

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -596,6 +596,7 @@ UIProcess/Automation/BidiScriptAgent.cpp @no-unify
 UIProcess/Automation/BidiSessionAgent.cpp @no-unify
 UIProcess/Automation/BidiStorageAgent.cpp @no-unify
 UIProcess/Automation/BidiUserContext.cpp @no-unify
+UIProcess/Automation/InspectorPassthroughChannel.cpp @no-unify
 UIProcess/Automation/SimulatedInputDispatcher.cpp @no-unify
 UIProcess/Automation/WebAutomationSession.cpp @no-unify
 UIProcess/Automation/WebDriverBidiProcessor.cpp @no-unify

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -285,6 +285,7 @@ UIProcess/API/Cocoa/_WKArchiveExclusionRule.mm @nonARC
 UIProcess/API/Cocoa/_WKAttachment.mm @nonARC
 UIProcess/API/Cocoa/_WKAutomationSession.mm @nonARC
 UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.mm @nonARC
+UIProcess/API/Cocoa/_WKAutomationSessionTesting.mm @nonARC
 UIProcess/API/Cocoa/_WKContentRuleListAction.mm @nonARC
 UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm @nonARC
 UIProcess/API/Cocoa/_WKCustomHeaderFields.mm @nonARC @no-unify

--- a/Source/WebKit/UIProcess/API/APIAutomationSessionClient.h
+++ b/Source/WebKit/UIProcess/API/APIAutomationSessionClient.h
@@ -96,6 +96,8 @@ public:
 #endif
 
     virtual void performApplicationCommand(WebKit::WebAutomationSession&, WebKit::WebPageProxy&, const WTF::String& commandName, const WTF::String& arguments, CompletionHandler<void(const WTF::String&)>&& completionHandler) { completionHandler(WTF::String()); }
+
+    virtual bool shouldEnableInspectorTesting(WebKit::WebAutomationSession&) { return false; }
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h
@@ -80,6 +80,8 @@ typedef NS_ENUM(NSInteger, _WKAutomationSessionWebExtensionResourceOptions) {
 
 - (void)_automationSession:(_WKAutomationSession *)automationSession performCommandForWebView:(WKWebView *)webView commandName:(NSString *)commandName arguments:(NSString *)arguments completionHandler:(void(^)(NSString * _Nullable))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+- (BOOL)_automationSessionShouldEnableInspectorTesting:(_WKAutomationSession *)automationSession WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionPrivateForTesting.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/_WKAutomationSession.h>
+
+@class WKWebView;
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Testing-only SPI that lets in-process API tests drive the Automation
+// backend without a RemoteInspector transport. Not intended for production
+// clients; the surface exists solely to exercise WebAutomationSession's
+// dispatch path (and downstream Inspector backend round-trips) from unit
+// tests in TestWebKitAPI.
+@interface _WKAutomationSession (PrivateForTesting)
+
+// Register the given WKWebView as a browsing context for this session and
+// return the handle. The session's process pool must already include the
+// web view's process. Subsequent Automation commands referencing the
+// returned handle will resolve to this WKWebView.
+- (NSString *)_registerWebViewForTesting:(WKWebView *)webView;
+
+// Install a block that captures every outbound JSON-RPC message the
+// session would otherwise send through its FrontendChannel (responses
+// and events). Replaces any previously installed handler. Passing nil
+// detaches the test channel.
+- (void)_setMessageToFrontendHandlerForTesting:(nullable void (^)(NSString *message))handler;
+
+// Drive an inbound JSON-RPC message into the Automation backend dispatcher
+// as if it arrived from the remote driver. Synchronous.
+- (void)_dispatchMessageFromRemoteForTesting:(NSString *)message;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionTesting.mm
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "_WKAutomationSessionPrivateForTesting.h"
+
+#if ENABLE(REMOTE_INSPECTOR)
+
+#import "WKWebViewInternal.h"
+#import "WebAutomationSession.h"
+#import "WebPageProxy.h"
+#import "_WKAutomationSessionInternal.h"
+#import <JavaScriptCore/InspectorFrontendChannel.h>
+#import <objc/runtime.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+// A FrontendChannel that funnels every outbound JSON-RPC message into a
+// caller-supplied Objective-C block. Used by API tests as a stand-in for
+// the real RemoteInspector transport so a test can observe what the
+// automation backend would send back to the driver. Lifetime is managed
+// by the Objective-C wrapper @_WKAutomationSessionTestChannel below; the
+// channel disconnects from the session before deallocation.
+class TestFrontendChannel final : public Inspector::FrontendChannel {
+    WTF_MAKE_TZONE_ALLOCATED(TestFrontendChannel);
+public:
+    explicit TestFrontendChannel(void (^handler)(NSString *))
+        : m_handler(makeBlockPtr(handler))
+    {
+    }
+
+    ConnectionType connectionType() const final { return ConnectionType::Local; }
+
+    void sendMessageToFrontend(const String& message) final
+    {
+        if (m_handler)
+            m_handler(message.createNSString().get());
+    }
+
+private:
+    BlockPtr<void(NSString *)> m_handler;
+};
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TestFrontendChannel);
+
+} // namespace WebKit
+
+@interface _WKAutomationSessionTestChannel : NSObject {
+@public
+    std::unique_ptr<WebKit::TestFrontendChannel> _channel;
+    __weak _WKAutomationSession *_session;
+}
+@end
+
+@implementation _WKAutomationSessionTestChannel
+- (void)dealloc
+{
+    if (RetainPtr wrapper = _session) {
+        if (_channel)
+            protect(*wrapper->_session)->disconnect(*_channel);
+    }
+    [super dealloc];
+}
+@end
+
+static void *kAutomationTestChannelKey = &kAutomationTestChannelKey;
+
+@implementation _WKAutomationSession (PrivateForTesting)
+
+- (NSString *)_registerWebViewForTesting:(WKWebView *)webView
+{
+    RefPtr page = [webView _page].get();
+    if (!page)
+        return nil;
+    return protect(*_session)->handleForWebPageProxy(*page).createNSString().autorelease();
+}
+
+- (void)_setMessageToFrontendHandlerForTesting:(void (^)(NSString *))handler
+{
+    // Tear down any previously installed test channel first. The wrapper's
+    // dealloc disconnects the channel from the session, so just dropping the
+    // associated object would race; do the disconnect deterministically.
+    if (RetainPtr existing = (_WKAutomationSessionTestChannel *)objc_getAssociatedObject(self, kAutomationTestChannelKey)) {
+        if (existing->_channel)
+            protect(*_session)->disconnect(*existing->_channel);
+        existing->_channel = nullptr;
+        existing->_session = nil;
+        objc_setAssociatedObject(self, kAutomationTestChannelKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    if (!handler)
+        return;
+
+    RetainPtr wrapper = adoptNS([[_WKAutomationSessionTestChannel alloc] init]);
+    wrapper->_channel = makeUnique<WebKit::TestFrontendChannel>(handler);
+    wrapper->_session = self;
+
+    protect(*_session)->connect(*wrapper->_channel);
+
+    objc_setAssociatedObject(self, kAutomationTestChannelKey, wrapper.get(), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (void)_dispatchMessageFromRemoteForTesting:(NSString *)message
+{
+    protect(*_session)->dispatchMessageFromRemote(String(message));
+}
+
+@end
+
+#endif // ENABLE(REMOTE_INSPECTOR)

--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -976,6 +976,15 @@
             ]
         },
         {
+            "name": "sendInspectorMessage",
+            "description": "Relay a Web Inspector backend message from the client into the given browsing context's Inspector controller. Available when the session is configured to permit Inspector-protocol testing over the Automation transport.",
+            "condition": "ENABLE(REMOTE_INSPECTOR)",
+            "parameters": [
+                { "name": "browsingContextHandle", "$ref": "BrowsingContextHandle", "description": "The handle for the browsing context whose Inspector controller should receive the message." },
+                { "name": "message", "type": "string", "description": "An Inspector backend message sent by the client to WebKit, encoded as a UTF-8 JSON literal." }
+            ]
+        },
+        {
             "name": "emitActiveBidiScriptRealmCreatedEvents",
             "description": "Emit script.realmCreated events for currently active realms in the automation session.",
             "condition": "ENABLE(WEBDRIVER_BIDI)"
@@ -1004,6 +1013,15 @@
             "condition": "ENABLE(WEBDRIVER_BIDI)",
             "parameters": [
                 { "name": "message", "type": "string", "description": "A Bidi message sent by WebKit to the client, encoded as a UTF-8 JSON literal." }
+            ]
+        },
+        {
+            "name": "receiveInspectorMessage",
+            "description": "Relay a Web Inspector backend message from a browsing context's Inspector controller back to the client.",
+            "condition": "ENABLE(REMOTE_INSPECTOR)",
+            "parameters": [
+                { "name": "browsingContextHandle", "$ref": "BrowsingContextHandle", "description": "The handle for the browsing context whose Inspector controller emitted the message." },
+                { "name": "message", "type": "string", "description": "An Inspector backend message sent by WebKit to the client, encoded as a UTF-8 JSON literal." }
             ]
         }
     ]

--- a/Source/WebKit/UIProcess/Automation/InspectorPassthroughChannel.cpp
+++ b/Source/WebKit/UIProcess/Automation/InspectorPassthroughChannel.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InspectorPassthroughChannel.h"
+
+#if ENABLE(REMOTE_INSPECTOR)
+
+#include "WebAutomationSession.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorPassthroughChannel);
+
+InspectorPassthroughChannel::InspectorPassthroughChannel(WebAutomationSession& session, const String& browsingContextHandle)
+    : m_session(session)
+    , m_browsingContextHandle(browsingContextHandle)
+{
+}
+
+InspectorPassthroughChannel::~InspectorPassthroughChannel() = default;
+
+void InspectorPassthroughChannel::sendMessageToFrontend(const String& message)
+{
+    if (RefPtr session = m_session.get())
+        session->sendInspectorMessageToClient(m_browsingContextHandle, message);
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(REMOTE_INSPECTOR)

--- a/Source/WebKit/UIProcess/Automation/InspectorPassthroughChannel.h
+++ b/Source/WebKit/UIProcess/Automation/InspectorPassthroughChannel.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(REMOTE_INSPECTOR)
+
+#include <JavaScriptCore/InspectorFrontendChannel.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class WebAutomationSession;
+
+// Forwards Inspector backend messages from one page's WebPageInspectorController
+// back to the automation client as Automation.receiveInspectorMessage events.
+// One channel per inspected page; the channel carries its source
+// browsingContextHandle so the event can name its origin.
+class InspectorPassthroughChannel final : public Inspector::FrontendChannel {
+    WTF_MAKE_TZONE_ALLOCATED(InspectorPassthroughChannel);
+public:
+    InspectorPassthroughChannel(WebAutomationSession&, const String& browsingContextHandle);
+    ~InspectorPassthroughChannel() final;
+
+    ConnectionType connectionType() const final { return ConnectionType::Local; }
+    void sendMessageToFrontend(const String& message) final;
+
+private:
+    WeakPtr<WebAutomationSession> m_session;
+    String m_browsingContextHandle;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(REMOTE_INSPECTOR)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -34,6 +34,7 @@
 #include "APIString.h"
 #include "AutomationProtocolObjects.h"
 #include "CoordinateSystem.h"
+#include "InspectorPassthroughChannel.h"
 #include "PageLoadState.h"
 #include "WebAutomationSessionMacros.h"
 #include "WebAutomationSessionMessages.h"
@@ -44,6 +45,7 @@
 #include "WebFullScreenManagerProxy.h"
 #include "WebInspectorUIProxy.h"
 #include "WebOpenPanelResultListenerProxy.h"
+#include "WebPageInspectorController.h"
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
 #include <JavaScriptCore/ConsoleTypes.h>
@@ -172,6 +174,9 @@ WebAutomationSession::WebAutomationSession()
 
 WebAutomationSession::~WebAutomationSession()
 {
+#if ENABLE(REMOTE_INSPECTOR)
+    disconnectAllInspectorPassthroughChannels();
+#endif
     ASSERT(!m_client);
     ASSERT(!m_processPool);
 #if ENABLE(REMOTE_INSPECTOR)
@@ -244,6 +249,38 @@ bool WebAutomationSession::isPendingTermination() const
 
 #endif // ENABLE(REMOTE_INSPECTOR)
 
+#if ENABLE(REMOTE_INSPECTOR)
+CommandResult<void> WebAutomationSession::sendInspectorMessage(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const String& message)
+{
+    assertIsMainRunLoop();
+
+    SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!m_client || !m_client->shouldEnableInspectorTesting(*this), NotImplemented);
+
+    RefPtr<WebPageProxy> page = webPageProxyForHandle(browsingContextHandle);
+    SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!page, WindowNotFound);
+
+    // The WebPageInspectorController survives provisional page swaps
+    // (didCommitProvisionalPage swaps the PageTarget, not the controller),
+    // so connect-once-per-controller is stable across cross-site navigation.
+    auto& inspectorController = page->inspectorController();
+    auto pageID = page->identifier();
+
+    auto addResult = m_inspectorPassthroughChannels.ensure(pageID, [&] {
+        return makeUnique<InspectorPassthroughChannel>(*this, browsingContextHandle);
+    });
+    if (addResult.isNewEntry)
+        inspectorController.connectFrontend(*addResult.iterator->value);
+
+    inspectorController.dispatchMessageFromFrontend(message);
+    return { };
+}
+
+void WebAutomationSession::sendInspectorMessageToClient(const String& browsingContextHandle, const String& message)
+{
+    m_domainNotifier->receiveInspectorMessage(browsingContextHandle, message);
+}
+#endif // ENABLE(REMOTE_INSPECTOR)
+
 void WebAutomationSession::terminate()
 {
 #if ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
@@ -274,11 +311,33 @@ void WebAutomationSession::terminate()
     }
 
     m_debuggable->setIsPaired(false);
+
+    disconnectAllInspectorPassthroughChannels();
 #endif
 
     if (m_client)
         m_client->didDisconnectFromRemote(*this);
 }
+
+#if ENABLE(REMOTE_INSPECTOR)
+void WebAutomationSession::disconnectInspectorPassthroughChannel(WebPageProxyIdentifier pageID)
+{
+    auto entry = m_inspectorPassthroughChannels.take(pageID);
+    if (!entry)
+        return;
+    if (RefPtr page = WebProcessProxy::webPage(pageID))
+        page->inspectorController().disconnectFrontend(*entry);
+}
+
+void WebAutomationSession::disconnectAllInspectorPassthroughChannels()
+{
+    auto channels = std::exchange(m_inspectorPassthroughChannels, { });
+    for (auto& [pageID, channel] : channels) {
+        if (RefPtr page = WebProcessProxy::webPage(pageID))
+            page->inspectorController().disconnectFrontend(*channel);
+    }
+}
+#endif // ENABLE(REMOTE_INSPECTOR)
 
 RefPtr<WebPageProxy> WebAutomationSession::webPageProxyForHandle(const String& handle)
 {
@@ -1318,6 +1377,10 @@ void WebAutomationSession::setViewportForPage(WebPageProxy& page, std::optional<
 
 void WebAutomationSession::willClosePage(const WebPageProxy& page)
 {
+#if ENABLE(REMOTE_INSPECTOR)
+    disconnectInspectorPassthroughChannel(page.identifier());
+#endif
+
     String handle = handleForWebPageProxy(page);
     m_domainNotifier->browsingContextCleared(handle);
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -92,7 +92,12 @@ class ViewSnapshot;
 class WebFrameProxy;
 class WebOpenPanelResultListenerProxy;
 class WebPageProxy;
+class WebPageInspectorController;
 class WebProcessPool;
+
+#if ENABLE(REMOTE_INSPECTOR)
+class InspectorPassthroughChannel;
+#endif
 
 #if ENABLE(WEBDRIVER_BIDI)
 class WebDriverBidiProcessor;
@@ -129,6 +134,10 @@ class WebAutomationSession final : public API::ObjectImpl<API::Object::Type::Aut
 
 #if ENABLE(WEBDRIVER_BIDI)
 friend class WebDriverBidiProcessor;
+#endif
+
+#if ENABLE(REMOTE_INSPECTOR)
+friend class InspectorPassthroughChannel;
 #endif
 
 public:
@@ -299,6 +308,10 @@ public:
     Inspector::CommandResult<void> emitActiveBidiScriptRealmCreatedEvents() override;
     void sendBidiMessage(const String&);
     WebDriverBidiProcessor& bidiProcessor() const { return m_bidiProcessor; }
+#endif
+
+#if ENABLE(REMOTE_INSPECTOR)
+    Inspector::CommandResult<void> sendInspectorMessage(const Inspector::Protocol::Automation::BrowsingContextHandle&, const String& message) override;
 #endif
 
     void performApplicationCommand(const Inspector::Protocol::Automation::BrowsingContextHandle&, const String& commandName, const String& arguments, Inspector::CommandCallback<String>&&) override;
@@ -474,6 +487,23 @@ private:
 #if ENABLE(REMOTE_INSPECTOR)
     Inspector::FrontendChannel* m_remoteChannel { nullptr };
     const Ref<Debuggable> m_debuggable;
+#endif
+
+    // Web Inspector backend passthrough: clients with the
+    // shouldEnableInspectorTesting capability can issue
+    // Automation.sendInspectorMessage to forward an Inspector backend
+    // command into a page's WebPageInspectorController; the controller's
+    // responses and events come back as Automation.receiveInspectorMessage.
+    // Each connected page owns its own InspectorPassthroughChannel so the
+    // outgoing event can name its source browsing context.
+#if ENABLE(REMOTE_INSPECTOR)
+    void sendInspectorMessageToClient(const String& browsingContextHandle, const String& message);
+    void disconnectInspectorPassthroughChannel(WebPageProxyIdentifier);
+    void disconnectAllInspectorPassthroughChannels();
+#endif
+
+#if ENABLE(REMOTE_INSPECTOR)
+    HashMap<WebPageProxyIdentifier, std::unique_ptr<InspectorPassthroughChannel>> m_inspectorPassthroughChannels;
 #endif
 
 };

--- a/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.h
@@ -58,6 +58,8 @@ private:
 
     void performApplicationCommand(WebKit::WebAutomationSession&, WebKit::WebPageProxy&, const String& commandName, const String& arguments, CompletionHandler<void(const String&)>&&) override;
 
+    bool shouldEnableInspectorTesting(WebKit::WebAutomationSession&) override;
+
     bool isShowingJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy&) override;
     void dismissCurrentJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy&) override;
     void acceptCurrentJavaScriptDialogOnPage(WebAutomationSession&, WebPageProxy&) override;
@@ -90,6 +92,7 @@ private:
         bool loadWebExtensionWithOptions : 1;
         bool unloadWebExtension : 1;
         bool performApplicationCommand : 1;
+        bool shouldEnableInspectorTesting : 1;
     } m_delegateMethods;
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
@@ -63,6 +63,7 @@ AutomationSessionClient::AutomationSessionClient(id <_WKAutomationSessionDelegat
     m_delegateMethods.unloadWebExtension = [delegate respondsToSelector:@selector(_automationSession:unloadWebExtensionWithIdentifier:completionHandler:)];
 #endif
     m_delegateMethods.performApplicationCommand = [delegate respondsToSelector:@selector(_automationSession:performCommandForWebView:commandName:arguments:completionHandler:)];
+    m_delegateMethods.shouldEnableInspectorTesting = [delegate respondsToSelector:@selector(_automationSessionShouldEnableInspectorTesting:)];
 }
 
 void AutomationSessionClient::didDisconnectFromRemote(WebAutomationSession& session)
@@ -178,6 +179,13 @@ void AutomationSessionClient::performApplicationCommand(WebAutomationSession& se
         }).get()];
     } else
         completionHandler(nullString());
+}
+
+bool AutomationSessionClient::shouldEnableInspectorTesting(WebAutomationSession& session)
+{
+    if (!m_delegateMethods.shouldEnableInspectorTesting)
+        return false;
+    return [m_delegate.get() _automationSessionShouldEnableInspectorTesting:RetainPtr { wrapper(session) }.get()];
 }
 
 bool AutomationSessionClient::isShowingJavaScriptDialogOnPage(WebAutomationSession& session, WebPageProxy& page)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1921,6 +1921,7 @@
 		99036AE523A958750000B06A /* APIDebuggableInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 99036AE323A958740000B06A /* APIDebuggableInfo.h */; };
 		99036AE923A970870000B06A /* DebuggableInfoData.h in Headers */ = {isa = PBXBuildFile; fileRef = 99036AE723A970870000B06A /* DebuggableInfoData.h */; };
 		990D28AB1C6420C600986977 /* _WKAutomationSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 990D28A71C6404B000986977 /* _WKAutomationSession.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C4450D54570C4383A25745E6 /* _WKAutomationSessionPrivateForTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = BC35BB81026B48A6A3BDAA80 /* _WKAutomationSessionPrivateForTesting.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 990D28A81C6404B000986977 /* _WKAutomationSessionDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 990D28AF1C65203900986977 /* _WKAutomationSessionInternal.h */; };
 		990D28BB1C6539D300986977 /* AutomationSessionClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 990D28B71C6539A000986977 /* AutomationSessionClient.h */; };
@@ -2564,6 +2565,8 @@
 		F3272B832DB997C6007B3A9A /* BidiScriptAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = F3272B7E2DB997C6007B3A9A /* BidiScriptAgent.h */; };
 		F3A94F012DB6F3310023CE9D /* BidiUserContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */; };
 		F3A94F022DB6F3310023CE9D /* BidiUserContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F3A94EFF2DB6F3310023CE9D /* BidiUserContext.h */; };
+		48E4FD912C91486DA934D031 /* InspectorPassthroughChannel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCCB565EDBD4471CBF56BE45 /* InspectorPassthroughChannel.cpp */; };
+		01840EDDFCFA4B829AA44670 /* InspectorPassthroughChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B7C93E896284D3C811021EC /* InspectorPassthroughChannel.h */; };
 		F3EEEE592DB318270038CC1D /* BidiBrowserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */; };
 		F3EEEE5A2DB318270038CC1D /* BidiBrowserAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3EEEE582DB318270038CC1D /* BidiBrowserAgent.cpp */; };
 		F404455C2D5CFB56000E587E /* AppKitSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = F404455A2D5CFB56000E587E /* AppKitSoftLink.h */; };
@@ -7582,6 +7585,8 @@
 		990657341F323CBF00944F9C /* ElementAttribute.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ElementAttribute.js; sourceTree = "<group>"; };
 		990657351F323CBF00944F9C /* FormSubmit.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = FormSubmit.js; sourceTree = "<group>"; };
 		990D28A71C6404B000986977 /* _WKAutomationSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKAutomationSession.h; sourceTree = "<group>"; };
+		BC35BB81026B48A6A3BDAA80 /* _WKAutomationSessionPrivateForTesting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKAutomationSessionPrivateForTesting.h; sourceTree = "<group>"; };
+		A197A4B2903C423281A84E16 /* _WKAutomationSessionTesting.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKAutomationSessionTesting.mm; sourceTree = "<group>"; };
 		990D28A81C6404B000986977 /* _WKAutomationSessionDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKAutomationSessionDelegate.h; sourceTree = "<group>"; };
 		990D28AD1C65190400986977 /* _WKAutomationSession.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKAutomationSession.mm; sourceTree = "<group>"; };
 		990D28AF1C65203900986977 /* _WKAutomationSessionInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKAutomationSessionInternal.h; sourceTree = "<group>"; };
@@ -8872,6 +8877,8 @@
 		F3272B7F2DB997C6007B3A9A /* BidiScriptAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiScriptAgent.cpp; sourceTree = "<group>"; };
 		F3A94EFF2DB6F3310023CE9D /* BidiUserContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiUserContext.h; sourceTree = "<group>"; };
 		F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiUserContext.cpp; sourceTree = "<group>"; };
+		4B7C93E896284D3C811021EC /* InspectorPassthroughChannel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InspectorPassthroughChannel.h; sourceTree = "<group>"; };
+		DCCB565EDBD4471CBF56BE45 /* InspectorPassthroughChannel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorPassthroughChannel.cpp; sourceTree = "<group>"; };
 		F3EEEE572DB318270038CC1D /* BidiBrowserAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BidiBrowserAgent.h; sourceTree = "<group>"; };
 		F3EEEE582DB318270038CC1D /* BidiBrowserAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BidiBrowserAgent.cpp; sourceTree = "<group>"; };
 		F404455A2D5CFB56000E587E /* AppKitSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppKitSoftLink.h; sourceTree = "<group>"; };
@@ -12787,6 +12794,8 @@
 				99788ACA1F421DCA00C08000 /* _WKAutomationSessionConfiguration.mm */,
 				990D28A81C6404B000986977 /* _WKAutomationSessionDelegate.h */,
 				990D28AF1C65203900986977 /* _WKAutomationSessionInternal.h */,
+				BC35BB81026B48A6A3BDAA80 /* _WKAutomationSessionPrivateForTesting.h */,
+				A197A4B2903C423281A84E16 /* _WKAutomationSessionTesting.mm */,
 				5C4609E222430E4C009943C2 /* _WKContentRuleListAction.h */,
 				5C4609E322430E4D009943C2 /* _WKContentRuleListAction.mm */,
 				5C4609E422430E4D009943C2 /* _WKContentRuleListActionInternal.h */,
@@ -15140,6 +15149,8 @@
 				5EEC724D2DC1B31300D012DD /* BidiStorageAgent.h */,
 				F3A94F002DB6F3310023CE9D /* BidiUserContext.cpp */,
 				F3A94EFF2DB6F3310023CE9D /* BidiUserContext.h */,
+				DCCB565EDBD4471CBF56BE45 /* InspectorPassthroughChannel.cpp */,
+				4B7C93E896284D3C811021EC /* InspectorPassthroughChannel.h */,
 				995226D5207D184600F78420 /* SimulatedInputDispatcher.cpp */,
 				995226D4207D184500F78420 /* SimulatedInputDispatcher.h */,
 				9955A6EA1C7980BB00EB6A93 /* WebAutomationSession.cpp */,
@@ -17865,6 +17876,7 @@
 				99788ACB1F421DDA00C08000 /* _WKAutomationSessionConfiguration.h in Headers */,
 				990D28AC1C6420CF00986977 /* _WKAutomationSessionDelegate.h in Headers */,
 				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
+				C4450D54570C4383A25745E6 /* _WKAutomationSessionPrivateForTesting.h in Headers */,
 				CD89ACBD2EA696A300C76423 /* _WKCaptionStyleMenuController.h in Headers */,
 				97C476282ECD33A6004D1492 /* _WKCaptionStyleMenuControllerInternal.h in Headers */,
 				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
@@ -18393,6 +18405,7 @@
 				CE550E152283752200D28791 /* InsertTextOptions.h in Headers */,
 				9197940523DBC4BB00257892 /* InspectorBrowserAgent.h in Headers */,
 				996B2B9D25E257FF00719379 /* InspectorExtensionDelegate.h in Headers */,
+				01840EDDFCFA4B829AA44670 /* InspectorPassthroughChannel.h in Headers */,
 				A5E391FD2183C1F800C8FB31 /* InspectorTargetProxy.h in Headers */,
 				07AE8FBD2F3BC4F300A4C0CA /* InteractionInformationAtPosition.h in Headers */,
 				07AE8FC22F3BC58200A4C0CA /* InteractionInformationRequest.h in Headers */,
@@ -22076,6 +22089,7 @@
 				522F792928D50EBB0069B45B /* HidService.mm in Sources */,
 				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
 				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
+				48E4FD912C91486DA934D031 /* InspectorPassthroughChannel.cpp in Sources */,
 				074D6A652F385435006089F6 /* IntRectCG.swift in Sources */,
 				5CF250AF2EE06491006A7172 /* IPCTesterReceiver.swift in Sources */,
 				5C448C662EE06E11008931C7 /* IPCTesterReceiverMessageReceiver.swift in Sources */,

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -274,6 +274,7 @@ Tests/WebKit/WKWebView/SampledPageTopColor.mm @nonARC
 Tests/WebKit/WKWebView/SchemeRegistry.mm @nonARC
 Tests/WebKit/WKWebView/ScreenTime.mm @nonARC
 Tests/WebKit/WKWebView/ScreenWakeLock.mm @nonARC
+Tests/WebKit/WKWebView/SendInspectorMessage.mm @nonARC
 Tests/WebKit/WKWebView/SerializedNode.mm @nonARC
 Tests/WebKit/WKWebView/ScriptTrackingPrivacyTests.mm @nonARC
 Tests/WebKit/WKWebView/ServiceWorkerBasic.mm @nonARC

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SendInspectorMessage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SendInspectorMessage.mm
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(REMOTE_INSPECTOR)
+
+#import "Helpers/Utilities.h"
+#import "Helpers/cocoa/TestCocoa.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/_WKAutomationSession.h>
+#import <WebKit/_WKAutomationSessionConfiguration.h>
+#import <WebKit/_WKAutomationSessionDelegate.h>
+#import <WebKit/_WKAutomationSessionPrivateForTesting.h>
+#import <wtf/RetainPtr.h>
+
+// A delegate that lets each test decide whether to grant the inspector-testing
+// capability. The other delegate methods are no-ops; tests focus on driving
+// Automation messages directly.
+@interface TestSendInspectorMessageDelegate : NSObject <_WKAutomationSessionDelegate>
+@property (nonatomic) BOOL allowInspectorTesting;
+@end
+
+@implementation TestSendInspectorMessageDelegate
+- (BOOL)_automationSessionShouldEnableInspectorTesting:(_WKAutomationSession *)automationSession
+{
+    return _allowInspectorTesting;
+}
+@end
+
+namespace {
+
+// Build the JSON wire string for an Automation.sendInspectorMessage outer
+// envelope wrapping an Inspector JSON-RPC inner message.
+RetainPtr<NSString> makeSendInspectorMessageEnvelope(NSInteger outerId, NSString *handle, NSInteger innerId, NSString *method, NSDictionary *params)
+{
+    RetainPtr inner = adoptNS([[NSMutableDictionary alloc] init]);
+    [inner setObject:@(innerId) forKey:@"id"];
+    [inner setObject:method forKey:@"method"];
+    [inner setObject:(params ?: @{ }) forKey:@"params"];
+
+    NSError *innerError = nil;
+    NSData *innerData = [NSJSONSerialization dataWithJSONObject:inner.get() options:0 error:&innerError];
+    EXPECT_NULL(innerError);
+    RetainPtr innerMessage = adoptNS([[NSString alloc] initWithData:innerData encoding:NSUTF8StringEncoding]);
+
+    RetainPtr outer = adoptNS([[NSMutableDictionary alloc] init]);
+    [outer setObject:@(outerId) forKey:@"id"];
+    [outer setObject:@"Automation.sendInspectorMessage" forKey:@"method"];
+    [outer setObject:@{
+        @"browsingContextHandle": handle ?: @"",
+        @"message": innerMessage.get()
+    } forKey:@"params"];
+
+    NSError *outerError = nil;
+    NSData *outerData = [NSJSONSerialization dataWithJSONObject:outer.get() options:0 error:&outerError];
+    EXPECT_NULL(outerError);
+    return adoptNS([[NSString alloc] initWithData:outerData encoding:NSUTF8StringEncoding]);
+}
+
+NSDictionary *decode(NSString *jsonString)
+{
+    NSData *data = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *err = nil;
+    NSDictionary *obj = [NSJSONSerialization JSONObjectWithData:data options:0 error:&err];
+    if (![obj isKindOfClass:[NSDictionary class]])
+        return nil;
+    return obj;
+}
+
+// Fixture: load about:blank in a TestWKWebView and create a paired
+// _WKAutomationSession with a captured outbound-message buffer.
+struct SessionFixture {
+    RetainPtr<TestWKWebView> webView;
+    RetainPtr<_WKAutomationSession> session;
+    RetainPtr<TestSendInspectorMessageDelegate> delegate;
+    RetainPtr<NSString> handle;
+    RetainPtr<NSMutableArray<NSString *>> captured;
+    bool ready { false };
+};
+
+void setUpSessionFixture(SessionFixture& fx, BOOL allowInspectorTesting)
+{
+    fx.webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 240)]);
+    [fx.webView synchronouslyLoadHTMLString:@"<html><head><title>SendInspectorMessage Test</title></head><body></body></html>" baseURL:[NSURL URLWithString:@"about:blank"]];
+
+    RetainPtr config = adoptNS([_WKAutomationSessionConfiguration new]);
+    fx.session = adoptNS([[_WKAutomationSession alloc] initWithConfiguration:config.get()]);
+
+    fx.delegate = adoptNS([TestSendInspectorMessageDelegate new]);
+    fx.delegate.get().allowInspectorTesting = allowInspectorTesting;
+    [fx.session setDelegate:fx.delegate.get()];
+
+    auto processPool = [fx.webView.get().configuration processPool];
+    [processPool _setAutomationSession:fx.session.get()];
+
+    fx.handle = [fx.session _registerWebViewForTesting:fx.webView.get()];
+    EXPECT_GT([fx.handle.get() length], 0u);
+
+    fx.captured = adoptNS([NSMutableArray new]);
+    NSMutableArray<NSString *> *captured = fx.captured.get();
+    [fx.session _setMessageToFrontendHandlerForTesting:^(NSString *message) {
+        [captured addObject:message];
+    }];
+
+    fx.ready = true;
+}
+
+NSDictionary *findMessageWithOuterId(NSArray<NSString *> *captured, NSInteger outerId)
+{
+    for (NSString *raw in captured) {
+        NSDictionary *parsed = decode(raw);
+        NSNumber *idValue = parsed[@"id"];
+        if ([idValue isKindOfClass:[NSNumber class]] && [idValue integerValue] == outerId)
+            return parsed;
+    }
+    return nil;
+}
+
+NSDictionary *findEvent(NSArray<NSString *> *captured, NSString *eventName)
+{
+    for (NSString *raw in captured) {
+        NSDictionary *parsed = decode(raw);
+        if (parsed[@"id"])
+            continue;
+        if ([parsed[@"method"] isEqualToString:eventName])
+            return parsed;
+    }
+    return nil;
+}
+
+// Walk Automation.receiveInspectorMessage events and return the one whose inner
+// payload has the matching response id. The backend will deliver unrelated
+// Inspector notifications (e.g. Target.targetCreated) on the same channel, so
+// matching the inner id is required to pick the response that completes the
+// command we sent.
+NSDictionary *findReceiveEventWithInnerId(NSArray<NSString *> *captured, NSInteger innerId)
+{
+    for (NSString *raw in captured) {
+        NSDictionary *parsed = decode(raw);
+        if (parsed[@"id"])
+            continue;
+        if (![parsed[@"method"] isEqualToString:@"Automation.receiveInspectorMessage"])
+            continue;
+        NSString *innerJSON = parsed[@"params"][@"message"];
+        if (![innerJSON isKindOfClass:[NSString class]])
+            continue;
+        NSDictionary *inner = decode(innerJSON);
+        NSNumber *idValue = inner[@"id"];
+        if ([idValue isKindOfClass:[NSNumber class]] && [idValue integerValue] == innerId)
+            return parsed;
+    }
+    return nil;
+}
+
+} // namespace
+
+// Happy path: outer Automation.sendInspectorMessage carrying a Target.* command
+// (one of the few commands available on the top-level Inspector dispatcher
+// without prior Target attach handshake) should round-trip and produce both a
+// success response for the outer command and an Automation.receiveInspectorMessage
+// event carrying the inner Target response.
+TEST(AutomationSendInspectorMessage, RoundTripTargetSetPauseOnStart)
+{
+    SessionFixture fx;
+    setUpSessionFixture(fx, /*allowInspectorTesting=*/ YES);
+
+    auto envelope = makeSendInspectorMessageEnvelope(1, fx.handle.get(), 99, @"Target.setPauseOnStart", @{ @"pauseOnStart": @NO });
+    [fx.session _dispatchMessageFromRemoteForTesting:envelope.get()];
+
+    // Pump the runloop until both an outer response and the inner-carrying
+    // event have been captured, or a hard timeout fires.
+    __block NSMutableArray<NSString *> *captured = fx.captured.get();
+    TestWebKitAPI::Util::runFor(0.05_s);
+    NSInteger spin = 0;
+    while (spin++ < 200 && (!findMessageWithOuterId(captured, 1) || !findReceiveEventWithInnerId(captured, 99)))
+        TestWebKitAPI::Util::runFor(0.05_s);
+
+    NSDictionary *outerResponse = findMessageWithOuterId(captured, 1);
+    ASSERT_TRUE(outerResponse != nil);
+    EXPECT_NULL(outerResponse[@"error"]);
+
+    NSDictionary *event = findReceiveEventWithInnerId(captured, 99);
+    ASSERT_TRUE(event != nil);
+    NSDictionary *params = event[@"params"];
+    EXPECT_TRUE([params[@"browsingContextHandle"] isEqualToString:fx.handle.get()]);
+    NSString *innerMessage = params[@"message"];
+    EXPECT_TRUE([innerMessage isKindOfClass:[NSString class]]);
+
+    NSDictionary *inner = decode(innerMessage);
+    EXPECT_TRUE([inner[@"id"] isEqualToNumber:@99]);
+    EXPECT_NULL(inner[@"error"]);
+    NSDictionary *innerResult = inner[@"result"];
+    EXPECT_TRUE([innerResult isKindOfClass:[NSDictionary class]]);
+}
+
+// Gate closed: outer command should fail with a JSON-RPC error and emit
+// no Automation.receiveInspectorMessage event. The InspectorPassthroughChannel
+// is never created.
+TEST(AutomationSendInspectorMessage, DeniedWhenGateReturnsFalse)
+{
+    SessionFixture fx;
+    setUpSessionFixture(fx, /*allowInspectorTesting=*/ NO);
+
+    auto envelope = makeSendInspectorMessageEnvelope(2, fx.handle.get(), 99, @"Page.getResourceTree", nil);
+    [fx.session _dispatchMessageFromRemoteForTesting:envelope.get()];
+
+    __block NSMutableArray<NSString *> *captured = fx.captured.get();
+    NSInteger spin = 0;
+    while (spin++ < 60 && !findMessageWithOuterId(captured, 2))
+        TestWebKitAPI::Util::runFor(0.05_s);
+
+    NSDictionary *outerResponse = findMessageWithOuterId(captured, 2);
+    ASSERT_TRUE(outerResponse != nil);
+    EXPECT_NOT_NULL(outerResponse[@"error"]);
+    EXPECT_NULL(findEvent(captured, @"Automation.receiveInspectorMessage"));
+}
+
+// Unknown handle: outer command should fail with WindowNotFound and emit no
+// event. Exercises the page-lookup branch of sendInspectorMessage.
+TEST(AutomationSendInspectorMessage, WindowNotFoundForUnknownHandle)
+{
+    SessionFixture fx;
+    setUpSessionFixture(fx, /*allowInspectorTesting=*/ YES);
+
+    auto envelope = makeSendInspectorMessageEnvelope(3, @"this-handle-does-not-exist", 99, @"Page.getResourceTree", nil);
+    [fx.session _dispatchMessageFromRemoteForTesting:envelope.get()];
+
+    __block NSMutableArray<NSString *> *captured = fx.captured.get();
+    NSInteger spin = 0;
+    while (spin++ < 60 && !findMessageWithOuterId(captured, 3))
+        TestWebKitAPI::Util::runFor(0.05_s);
+
+    NSDictionary *outerResponse = findMessageWithOuterId(captured, 3);
+    ASSERT_TRUE(outerResponse != nil);
+    EXPECT_NOT_NULL(outerResponse[@"error"]);
+    EXPECT_NULL(findEvent(captured, @"Automation.receiveInspectorMessage"));
+}
+
+#endif // ENABLE(REMOTE_INSPECTOR)


### PR DESCRIPTION
#### eba43072c763fbeae930408e52898234a5ceb78f
<pre>
Web Inspector: support testing backend commands using Automation protocol
<a href="https://bugs.webkit.org/show_bug.cgi?id=315624">https://bugs.webkit.org/show_bug.cgi?id=315624</a>
<a href="https://rdar.apple.com/177998955">rdar://177998955</a>

Reviewed by NOBODY (OOPS!).

WebKit has no in-process way to drive the Inspector backend dispatcher
from API tests: the existing transports (RemoteInspector XPC, Web
Automation over RemoteWebDriver) both require an out-of-process driver,
and Inspector protocol coverage today lives in LayoutTests which
exercise the frontend rather than the backend. This patch adds two new
Automation commands that relay Inspector backend messages between a
remote driver and a browsing context&apos;s Inspector controller, plus the
in-process plumbing needed to test the dispatch path from TestWebKitAPI
without RemoteInspector. This is analogous to the nested WebDriver Bidi
protocol within Automation protocol, but a separate suite of commands.

New `Automation.sendInspectorMessage` (in) and
`Automation.receiveInspectorMessage` (out) carry an opaque UTF-8 JSON
literal alongside a `BrowsingContextHandle`. `InspectorPassthroughChannel`
is the per-context `FrontendChannel` that hands outbound backend
messages to `WebAutomationSession`, which then dispatches the
`receiveInspectorMessage` event back over the same Automation transport
the driver is already using. Inbound messages from the client go through
`WebAutomationSession::sendInspectorMessage` into the page&apos;s
`WebInspectorBackendDispatcher`. Both commands are gated on
`ENABLE(REMOTE_INSPECTOR)`.

The in-process testing path is the new
`_WKAutomationSession (PrivateForTesting)` category and
`_WKAutomationSessionTesting.mm` implementation: tests register a
`WKWebView` as a browsing context, install a message-to-frontend handler
that captures every JSON-RPC frame the session would otherwise send to
its remote driver, and drive inbound messages directly via
`_dispatchMessageFromRemoteForTesting:`. This lets a test send an
Inspector backend command and assert on the captured response without
spinning up a remote driver process. The SPI is intentionally narrow --
it exists to exercise the dispatch path, not to be a general-purpose
client surface.

Out of scope: routing/dispatch for  `Page.*` / `DOM.*` / `Runtime.*` commands.
The modern Web Inspector mostly dispatches to `Target` domain at the top level;
domain commands inside a target require a `Target.sendMessageToTarget`
wrapper around a `targetId` captured from `Target.targetCreated`.
Callers do their own routing today. A multiplexer-side auto-wrap, as well as
proper Swift bindings for Inspector backend, is left for future work.

Testing: new `TestWebKitAPI.AutomationSendInspectorMessageTests` covers
three cases against `Target.setPauseOnStart` (a top-level command):
happy round-trip, denied (capability off), and unknown handle.

The API test uses Swift Testing rather than GTest. The envelope builder
uses Encodable types + JSONEncoder instead of string concatenation.
The test uses plain WKWebView (not TestWKWebView) because Swift Testing
tests are discovered via TestWebKitAPIBundle, which cannot link
TestWebKitAPILibrary. `import struct Swift.String` disambiguates from
WTF.String in the Bundle target&apos;s C++ interop context.

* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/Sources.txt:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/APIAutomationSessionClient.h:
(API::AutomationSessionClient::shouldEnableInspectorTesting):
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionPrivateForTesting.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionTesting.mm: Added.
(-[_WKAutomationSessionTestChannel dealloc]):
(-[_WKAutomationSession _registerWebViewForTesting:]):
(-[_WKAutomationSession _setMessageToFrontendHandlerForTesting:]):
(-[_WKAutomationSession _dispatchMessageFromRemoteForTesting:]):
* Source/WebKit/UIProcess/Automation/Automation.json:
* Source/WebKit/UIProcess/Automation/InspectorPassthroughChannel.cpp: Added.
(WebKit::InspectorPassthroughChannel::InspectorPassthroughChannel):
(WebKit::InspectorPassthroughChannel::sendMessageToFrontend):
* Source/WebKit/UIProcess/Automation/InspectorPassthroughChannel.h: Added.
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::~WebAutomationSession):
(WebKit::WebAutomationSession::sendInspectorMessage):
(WebKit::WebAutomationSession::sendInspectorMessageToClient):
(WebKit::WebAutomationSession::terminate):
(WebKit::WebAutomationSession::disconnectInspectorPassthroughChannel):
(WebKit::WebAutomationSession::disconnectAllInspectorPassthroughChannels):
(WebKit::WebAutomationSession::willClosePage):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.h:
* Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm:
(WebKit::AutomationSessionClient::AutomationSessionClient):
(WebKit::AutomationSessionClient::shouldEnableInspectorTesting):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SendInspectorMessage.swift: Added.
(TestSendInspectorMessageDelegate.allowInspectorTesting):
(TestSendInspectorMessageDelegate._automationSessionShouldEnableInspectorTesting(_:)):
(AnyEncodable.encode(to:)):
(decode(_:)):
(findMessage(withOuterId:in:)):
(findEvent(named:in:)):
(findReceiveEvent(withInnerId:in:)):
(CapturedMessages.strings):
(SessionFixture.captured):
(AutomationSendInspectorMessageTests.roundTripTargetSetPauseOnStart):
(AutomationSendInspectorMessageTests.deniedWhenGateReturnsFalse):
(AutomationSendInspectorMessageTests.windowNotFoundForUnknownHandle):

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm:
Fix incidental UnifiedSources fallout caused by adding new test file.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eba43072c763fbeae930408e52898234a5ceb78f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122699 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128564 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90491 "Passed tests") | ⏳ 🛠 mac-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168403 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30876 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109089 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29922 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28550 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22561 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139817 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177010 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29918 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28037 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136889 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136825 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148128 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102066 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32096 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24995 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38201 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111275 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37598 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3075 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37742 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->