### PR TITLE
Fix mismatched namespace brace in LazyLoadVideoObserver.h when ENABLE(VIDEO) is off

### DIFF
--- a/Source/WebCore/html/LazyLoadVideoObserver.h
+++ b/Source/WebCore/html/LazyLoadVideoObserver.h
@@ -53,6 +53,6 @@ private:
     RefPtr<IntersectionObserver> m_observer;
 };
 
-#endif
-
 } // namespace
+
+#endif


### PR DESCRIPTION
#### 4ece6e9aff32d5841ef8527512fc45ec7f95a512
<pre>
Fix mismatched namespace brace in LazyLoadVideoObserver.h when ENABLE(VIDEO) is off
<a href="https://bugs.webkit.org/show_bug.cgi?id=315698">https://bugs.webkit.org/show_bug.cgi?id=315698</a>

Reviewed by NOBODY (OOPS!).

The opening `namespace WebCore {` is inside `#if ENABLE(VIDEO)`, but the
matching closing brace was placed after the `#endif`. On ports built
with VIDEO disabled this leaves a stray `}` at file scope.

Move the namespace closer inside the guard so the brace balance is
preserved in both configurations.

* Source/WebCore/html/LazyLoadVideoObserver.h: Swap `#endif` and
`} // namespace` so the namespace close sits within the
`#if ENABLE(VIDEO)` block alongside its opening.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ece6e9aff32d5841ef8527512fc45ec7f95a512

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122058 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128077 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90184 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108623 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21600 "Built successfully") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139331 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 7 api tests failed or timed out; Running re-run-api-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176364 "Built successfully") | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27505 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136396 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38359 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32173 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 14 flakes 2 failures; Uploaded test results; Running re-run-layout-tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136359 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147631 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101268 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31632 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24488 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37557 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110602 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 32454 issues") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36955 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2554 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->