### PR TITLE
Don't log interaction from temporary gesture on storage access rejection

### DIFF
--- a/LayoutTests/http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https-expected.txt
+++ b/LayoutTests/http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https-expected.txt
@@ -1,0 +1,17 @@
+Tests that a no-gesture requestStorageAccess() rejection in a popup's cross-site iframe does not fabricate user interaction that silently grants storage access under the opener.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS requestStorageAccess() was rejected without a user gesture in the popup iframe.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+Should not receive first-party cookie.
+Did not receive cookie named 'firstPartyCookie'.
+Client-side document.cookie:

--- a/LayoutTests/http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https.html
+++ b/LayoutTests/http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="/resourceLoadStatistics/resources/util.js"></script>
+</head>
+<body onload="run()">
+<script>
+    description("Tests that a no-gesture requestStorageAccess() rejection in a popup's cross-site iframe does not fabricate user interaction that silently grants storage access under the opener.");
+    jsTestIsAsync = true;
+
+    function finishTest() {
+        setEnableFeature(false, finishJSTest);
+    }
+
+    function openIframe(url, onLoadHandler) {
+        const element = document.createElement("iframe");
+        element.src = url;
+        if (onLoadHandler) {
+            element.onload = onLoadHandler;
+        }
+        document.body.appendChild(element);
+    }
+
+    const thirdPartyOrigin = "https://localhost:8443";
+    const resourcePath = "/storageAccess/resources";
+    const thirdPartyBaseUrl = thirdPartyOrigin + resourcePath;
+    const firstPartyCookieName = "firstPartyCookie";
+    const subPathToGetCookies = "/get-cookies.py?name1=" + firstPartyCookieName;
+    var newWin;
+
+    function receiveMessage(event) {
+        if (event.origin === thirdPartyOrigin && event.data && event.data.type === "popup-result") {
+            if (event.data.storageAccessResult === "rejected")
+                testPassed("requestStorageAccess() was rejected without a user gesture in the popup iframe.");
+            else
+                testFailed("requestStorageAccess() was not rejected. Result: " + event.data.storageAccessResult);
+
+            newWin.close();
+
+            openIframe(thirdPartyBaseUrl + subPathToGetCookies + "&message=Should not receive first-party cookie.", finishTest);
+        }
+    }
+
+    function run() {
+        setEnableFeature(true, function() {
+            window.addEventListener("message", receiveMessage, false);
+
+            testRunner.setStatisticsPrevalentResource(thirdPartyOrigin, true, function() {
+                if (!testRunner.isStatisticsPrevalentResource(thirdPartyOrigin))
+                    testFailed("Host did not get set as prevalent resource.");
+                testRunner.setStatisticsHasHadUserInteraction(thirdPartyOrigin, true, function() {
+                    if (!testRunner.isStatisticsHasHadUserInteraction(thirdPartyOrigin))
+                        testFailed("Host did not get logged for user interaction.");
+                    testRunner.dumpChildFramesAsText();
+
+                    testRunner.statisticsUpdateCookieBlocking(function() {
+                        newWin = window.open(thirdPartyOrigin + resourcePath + "/request-storage-access-without-gesture-and-report-back.html#https://127.0.0.1:8443", "testWindow");
+                    });
+                });
+            });
+        });
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/storageAccess/resources/request-storage-access-without-gesture-and-report-back.html
+++ b/LayoutTests/http/tests/storageAccess/resources/request-storage-access-without-gesture-and-report-back.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script>
+        document.cookie = "firstPartyCookie=value; SameSite=None; Secure";
+
+        window.addEventListener("message", function(event) {
+            if (event.data && event.data.type === "storage-access-result") {
+                window.opener.postMessage({
+                    type: "popup-result",
+                    storageAccessResult: event.data.result,
+                    storageAccessError: event.data.error
+                }, "https://127.0.0.1:8443");
+            }
+        });
+    </script>
+</head>
+<body>
+    <iframe id="crossSiteFrame"></iframe>
+    <script>
+        var frameOrigin = document.location.hash.substring(1);
+        document.getElementById("crossSiteFrame").src = frameOrigin + "/storageAccess/resources/request-storage-access-without-gesture-in-iframe.html";
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/storageAccess/resources/request-storage-access-without-gesture-in-iframe.html
+++ b/LayoutTests/http/tests/storageAccess/resources/request-storage-access-without-gesture-in-iframe.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+    <script>
+        function run() {
+            document.requestStorageAccess().then(
+                function() {
+                    window.parent.postMessage({
+                        type: "storage-access-result",
+                        result: "resolved",
+                        error: null
+                    }, "*");
+                },
+                function(e) {
+                    window.parent.postMessage({
+                        type: "storage-access-result",
+                        result: "rejected",
+                        error: e.toString()
+                    }, "*");
+                }
+            );
+        }
+    </script>
+</head>
+<body onload="run()">
+</body>
+</html>

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -388,7 +388,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
 
 void DocumentStorageAccess::enableTemporaryTimeUserGesture()
 {
-    m_temporaryUserGesture = makeUnique<UserGestureIndicator>(IsProcessingUserGesture::Yes, protect(m_document).ptr());
+    m_temporaryUserGesture = makeUnique<UserGestureIndicator>(IsProcessingUserGesture::Yes, protect(m_document).ptr(), UserGestureType::ActivationTriggering, UserGestureIndicator::ProcessInteractionStyle::Never);
 }
 
 void DocumentStorageAccess::consumeTemporaryTimeUserGesture()


### PR DESCRIPTION
#### 5021f999fefdad2d467accbaec86b73268b5942e
<pre>
Don&apos;t log interaction from temporary gesture on storage access rejection
<a href="https://bugs.webkit.org/show_bug.cgi?id=309504">https://bugs.webkit.org/show_bug.cgi?id=309504</a>
<a href="https://rdar.apple.com/171546420">rdar://171546420</a>

Reviewed by Abrar Rahman Protyasha.

The no-gesture requestStorageAccess() rejection path preserves the user gesture so callers can still
perform gesture-gated actions like window.open(). However, the temporary UserGestureIndicator was
created with ProcessInteractionStyle::Immediate, which logged user interaction as a side effect. In
a popup with an opener, this fabricated interaction triggered requestStorageAccessUnderOpener(),
silently granting storage access without a prompt.

Pass ProcessInteractionStyle::Never to prevent interaction logging from the temporary gesture while
still preserving gesture-gated capabilities.

Test: http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https.html
* LayoutTests/http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https-expected.txt: Added.
* LayoutTests/http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https.html: Added.
* LayoutTests/http/tests/storageAccess/resources/request-storage-access-without-gesture-and-report-back.html: Added.
* LayoutTests/http/tests/storageAccess/resources/request-storage-access-without-gesture-in-iframe.html: Added.
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::enableTemporaryTimeUserGesture):

Originally-landed-as: 305413.463@rapid/safari-7624.2.5.110-branch (8360fe257449). <a href="https://rdar.apple.com/176062508">rdar://176062508</a>
Canonical link: <a href="https://commits.webkit.org/314172@main">https://commits.webkit.org/314172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b508665f940fb2ac366e5e195fb450d458fd84b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122068 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38794 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128080 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90187 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108626 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29811 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28436 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21610 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176374 "Built successfully") | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136400 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38369 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32574 "Found 3 new test failures: http/tests/site-isolation/accessibility/focus-in-remote-frame.html imported/w3c/web-platform-tests/css/css-display/display-contents-svg-elements.html imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-font-matching.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136364 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36860 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148005 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101278 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31637 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24872 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37567 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111134 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36965 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2950 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37113 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->