### PR TITLE
Cherry-pick(s) 76bd64baa59e. rdar://176062041

### DIFF
--- a/Source/WebCore/dom/ContainerNodeInlines.h
+++ b/Source/WebCore/dom/ContainerNodeInlines.h
@@ -34,7 +34,7 @@ inline ContainerNode& ContainerNode::rootNode() const
 {
     if (isInTreeScope())
         return treeScope().rootNode();
-    return traverseToRootNode();
+    return downcast<ContainerNode>(shadowIncludingRoot());
 }
 
 inline RenderElement* ContainerNode::renderer() const

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3368,6 +3368,12 @@ void Element::setInvokedPopover(RefPtr<Element>&& element)
     invalidateStyleInternal();
 }
 
+inline void ShadowRoot::setHost(Element* host)
+{
+    m_host = host;
+    m_shadowIncludingRoot = host ? &host->shadowIncludingRoot() : this;
+}
+
 void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
 {
     ASSERT(!newShadowRoot->hasChildNodes());
@@ -3382,7 +3388,7 @@ void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
 
         m_shadowRoot = WTF::move(newShadowRoot);
 
-        shadowRoot->setHost(*this);
+        shadowRoot->setHost(this);
         shadowRoot->setParentTreeScope(treeScope());
 
         NodeVector postInsertionNotificationTargets;

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -130,6 +130,7 @@ public:
     uint32_t stateFlags;
     void* parentNode;
     void* treeScope;
+    void* shadowIncludingRoot;
     void* previous;
     void* next;
     void* renderer;
@@ -378,6 +379,7 @@ Node::Node(Document& document, NodeType type, OptionSet<TypeFlag> flags)
     : EventTarget(ConstructNode)
     , m_typeBitFields(constructBitFieldsFromNodeTypeAndFlags(type, flags))
     , m_treeScope((isDocumentNode() || isShadowRoot()) ? nullptr : &document)
+    , m_shadowIncludingRoot(this)
 {
     ASSERT(nodeType() == type);
     ASSERT(isMainThread());
@@ -1176,7 +1178,7 @@ bool Node::isDescendantOf(const Node& other) const
     // Return true if other is an ancestor of this.
     if (other.isTreeScope())
         return &treeScope().rootNode() == &other && !isTreeScope() && isInTreeScope();
-    if (!other.hasChildNodes() || isConnected() != other.isConnected())
+    if (!other.hasChildNodes() || isConnected() != other.isConnected() || &shadowIncludingRoot() != &other.shadowIncludingRoot())
         return false;
     for (auto ancestor = parentNode(); ancestor; ancestor = ancestor->parentNode()) {
         if (ancestor == &other)
@@ -1188,6 +1190,9 @@ bool Node::isDescendantOf(const Node& other) const
 // https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor
 bool Node::isShadowIncludingDescendantOf(const Node& other) const
 {
+    if (&shadowIncludingRoot() != &other.shadowIncludingRoot())
+        return false;
+
     if (isDescendantOf(other))
         return true;
 
@@ -1201,6 +1206,11 @@ bool Node::isShadowIncludingDescendantOf(const Node& other) const
 
 bool Node::isComposedTreeDescendantOf(const Node& node) const
 {
+<<<<<<< HEAD
+=======
+    if (&shadowIncludingRoot() != &node.shadowIncludingRoot())
+        return false;
+>>>>>>> 76bd64baa59e (Race condition in Node::traverseToOpaqueRoot)
     for (auto* currentAncestor = parentElementInComposedTree(); currentAncestor; currentAncestor = currentAncestor->parentElementInComposedTree()) {
         if (currentAncestor == &node)
             return true;
@@ -1473,6 +1483,7 @@ Node& Node::traverseToRootNode() const
     return traverseToRootNodeInternal(*this);
 }
 
+<<<<<<< HEAD
 // https://dom.spec.whatwg.org/#concept-shadow-including-root
 Node& Node::shadowIncludingRoot() const
 {
@@ -1494,6 +1505,8 @@ SUPPRESS_NODELETE WebCoreOpaqueRoot Node::opaqueRoot() const
     return traverseToOpaqueRoot();
 }
 
+=======
+>>>>>>> 76bd64baa59e (Race condition in Node::traverseToOpaqueRoot)
 Node& Node::getRootNode(const GetRootNodeOptions& options) const
 {
     return options.composed ? shadowIncludingRoot() : rootNode();
@@ -1506,13 +1519,42 @@ void Node::queueTaskToDispatchEvent(TaskSource source, Ref<Event>&& event)
     });
 }
 
+<<<<<<< HEAD
 Node::NeedsPostConnectionSteps Node::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+=======
+#if ASSERT_ENABLED
+static Node* traverseToShadowIncludingRoot(Node* current)
+{
+    while (auto* parent = current->parentOrShadowHostNode())
+        current = parent;
+    return current;
+}
+#endif
+
+ALWAYS_INLINE void Node::updateShadowIncludingRoot()
+{
+    if (auto* parent = parentNode())
+        m_shadowIncludingRoot = parent->m_shadowIncludingRoot;
+    else if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(this)) [[unlikely]] {
+        auto* host = shadowRoot->host();
+        auto* root = host ? host->m_shadowIncludingRoot : shadowRoot;
+        shadowRoot->setShadowIncludingRoot(root);
+        m_shadowIncludingRoot = root;
+    } else
+        m_shadowIncludingRoot = this;
+    ASSERT(traverseToShadowIncludingRoot(this) == m_shadowIncludingRoot);
+}
+
+Node::InsertedIntoAncestorResult Node::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+>>>>>>> 76bd64baa59e (Race condition in Node::traverseToOpaqueRoot)
 {
     ASSERT(!containsSelectionEndPoint());
     if (insertionType.connectedToDocument)
         setEventTargetFlag(EventTargetFlag::IsConnected);
     if (parentOfInsertedTree.isInShadowTree())
         setEventTargetFlag(EventTargetFlag::IsInShadowTree);
+
+    updateShadowIncludingRoot();
 
     invalidateStyle(Style::Validity::SubtreeInvalid, Style::InvalidationMode::InsertedIntoAncestor);
 
@@ -1526,6 +1568,9 @@ void Node::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemo
         clearEventTargetFlag(EventTargetFlag::IsConnected);
     if (isInShadowTree() && !treeScope().rootNode().isShadowRoot())
         clearEventTargetFlag(EventTargetFlag::IsInShadowTree);
+
+    updateShadowIncludingRoot();
+
     if (removalType.disconnectedFromDocument) {
         if (CheckedPtr cache = oldParentOfRemovedTree.document().existingAXObjectCache())
             cache->remove(*this);
@@ -2982,19 +3027,6 @@ void Node::setUsesEffectiveTextDirection(bool value)
 bool Node::inRenderedDocument() const
 {
     return isConnected() && document().hasLivingRenderTree();
-}
-
-WebCoreOpaqueRoot Node::traverseToOpaqueRoot() const
-{
-    ASSERT_WITH_MESSAGE(!isConnected(), "Call opaqueRoot() or document() when the node is connected");
-    const Node* node = this;
-    for (;;) {
-        const Node* nextNode = node->parentOrShadowHostNode();
-        if (!nextNode)
-            break;
-        node = nextNode;
-    }
-    return WebCoreOpaqueRoot { const_cast<Node*>(node) };
 }
 
 void Node::notifyInspectorOfRendererChange()

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -300,14 +300,26 @@ public:
     WEBCORE_EXPORT Element* NODELETE parentElementInComposedTree() const;
     Element* NODELETE parentOrShadowHostElement() const;
     inline void setParentNode(ContainerNode*);
+<<<<<<< HEAD
     inline Node& NODELETE rootNode() const;
     WEBCORE_EXPORT Node& NODELETE traverseToRootNode() const;
     Node& NODELETE shadowIncludingRoot() const;
+=======
+    inline Node& rootNode() const;
+    WEBCORE_EXPORT Node& traverseToRootNode() const;
+    Node& shadowIncludingRoot() const { return *m_shadowIncludingRoot; }
+>>>>>>> 76bd64baa59e (Race condition in Node::traverseToOpaqueRoot)
 
     struct GetRootNodeOptions {
         bool composed;
     };
+<<<<<<< HEAD
     Node& NODELETE getRootNode(const GetRootNodeOptions&) const;
+=======
+    Node& getRootNode(const GetRootNodeOptions&) const;
+    
+    inline WebCoreOpaqueRoot opaqueRoot() const;
+>>>>>>> 76bd64baa59e (Race condition in Node::traverseToOpaqueRoot)
 
     WebCoreOpaqueRoot opaqueRoot() const final;
 
@@ -778,6 +790,7 @@ private:
     void refEventTarget() final;
     void derefEventTarget() final;
 
+<<<<<<< HEAD
 #if ASSERT_ENABLED
     bool checkIsInUserAgentShadowTree(bool) const;
 #else
@@ -785,6 +798,12 @@ private:
 #endif
 
     void NODELETE trackForDebugging();
+=======
+    void trackForDebugging();
+
+    void updateShadowIncludingRoot();
+
+>>>>>>> 76bd64baa59e (Race condition in Node::traverseToOpaqueRoot)
     void materializeRareData();
 
     Vector<Ref<MutationObserverRegistration>>* NODELETE mutationObserverRegistry();
@@ -815,6 +834,7 @@ private:
 
     CheckedPtr<ContainerNode> m_parentNode;
     TreeScope* m_treeScope { nullptr };
+    Node* m_shadowIncludingRoot { nullptr };
     Node* m_previousSibling { nullptr };
     CheckedPtr<Node> m_next;
     RenderObject* m_renderer { nullptr };

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -54,8 +54,27 @@ inline ContainerNode* Node::parentOrShadowHostNode() const
 
 inline Document* Node::ownerDocument() const
 {
+<<<<<<< HEAD
     auto* document = &this->document();
     return document == this ? nullptr : document;
+=======
+    return parentOrShadowHostNode();
+}
+
+inline RefPtr<ScriptExecutionContext> Node::protectedScriptExecutionContext() const
+{
+    return scriptExecutionContext();
+}
+
+inline WebCoreOpaqueRoot Node::opaqueRoot() const
+{
+    return WebCoreOpaqueRoot { m_shadowIncludingRoot };
+}
+
+inline Ref<TreeScope> Node::protectedTreeScope() const
+{
+    return treeScope();
+>>>>>>> 76bd64baa59e (Race condition in Node::traverseToOpaqueRoot)
 }
 
 inline RenderBox* Node::renderBox() const
@@ -167,7 +186,7 @@ inline Node& Node::rootNode() const
 {
     if (isInTreeScope())
         return treeScope().rootNode();
-    return traverseToRootNode();
+    return *m_shadowIncludingRoot;
 }
 
 inline void Node::setParentNode(ContainerNode* parent)

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -62,6 +62,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ShadowRoot);
 struct SameSizeAsShadowRoot : public DocumentFragment, public TreeScope {
     uint8_t flagsAndModes[3];
     WeakPtr<Element, WeakPtrImplWithEventTargetData> host;
+    void* shadowIncludingRoot;
     void* styleSheetList;
     void* styleScope;
     void* slotAssignment;
@@ -84,6 +85,7 @@ ShadowRoot::ShadowRoot(Document& document, ShadowRootMode mode, SlotAssignmentMo
     , m_hasScopedCustomElementRegistry(scopedRegistry == ShadowRootScopedCustomElementRegistry::Yes)
     , m_mode(mode)
     , m_slotAssignmentMode(assignmentMode)
+    , m_shadowIncludingRoot(this)
     , m_styleScope(makeUnique<Style::Scope>(*this))
     , m_referenceTarget(referenceTarget)
 {

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -95,8 +95,17 @@ public:
     bool isDeclarativeShadowRoot() const { return m_isDeclarativeShadowRoot; }
     void setIsDeclarativeShadowRoot(bool flag) { m_isDeclarativeShadowRoot = flag; }
 
+<<<<<<< HEAD
     Element* host() const { return m_host; }
+=======
+    Element* host() const { return m_host.get(); }
+    inline void setHost(Element*); // Defined and only used in Element.cpp
+    RefPtr<Element> protectedHost() const { return m_host.get(); }
+>>>>>>> 76bd64baa59e (Race condition in Node::traverseToOpaqueRoot)
     void setHost(WeakPtr<Element, WeakPtrImplWithEventTargetData>&& host) { m_host = WTF::move(host); }
+
+    Node* shadowIncludingRoot() const { return m_shadowIncludingRoot; }
+    inline void setShadowIncludingRoot(Node* root) { m_shadowIncludingRoot = root; }
 
     bool hasScopedCustomElementRegistry() const { return m_hasScopedCustomElementRegistry; }
     CustomElementRegistry* registryForBindings() const;
@@ -177,6 +186,7 @@ private:
     SlotAssignmentMode m_slotAssignmentMode { SlotAssignmentMode::Named };
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_host;
+    Node* m_shadowIncludingRoot { nullptr };
     RefPtr<StyleSheetList> m_styleSheetList;
 
     std::unique_ptr<Style::Scope> m_styleScope;


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176062041 to main. [76bd64baa59e] caused a merge conflict. 

```Race condition in Node::traverseToOpaqueRoot
https://bugs.webkit.org/show_bug.cgi?id=310029
<rdar://172327427>

Reviewed by Anne van Kesteren.

Store the opaque root in Node instead of computing it during a marking phase of GC
to avoid the race condition. Also optimize a few DOM functions.

No new tests since there should be no observable behavior differences other than
the fix to the race condition and the race condition is hard to test reliably.

* Source/WebCore/dom/ContainerNodeInlines.h:
(WebCore::ContainerNode::rootNode const):
* Source/WebCore/dom/Element.cpp:
(WebCore::ShadowRoot::setHost):
(WebCore::Element::addShadowRoot):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::Node):
(WebCore::Node::isDescendantOf const): Added an optimization to avoid tree
traversal if the root node of two trees differ.
(WebCore::Node::isShadowIncludingDescendantOf const): Ditto.
(WebCore::Node::isComposedTreeDescendantOf const): Ditto.
(WebCore::traverseToShadowIncludingRoot):
(WebCore::Node::updateShadowIncludingRoot):
(WebCore::Node::insertedIntoAncestor):
(WebCore::Node::removedFromAncestor):
(WebCore::Node::shadowIncludingRoot const): Deleted.
(WebCore::Node::traverseToOpaqueRoot const): Deleted.
* Source/WebCore/dom/Node.h:
(WebCore::Node::shadowIncludingRoot const):
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::opaqueRoot const):
(WebCore::Node::rootNode const):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::ShadowRoot):
* Source/WebCore/dom/ShadowRoot.h:

Originally-landed-as: 305413.522@rapid/safari-7624.2.5.110-branch (76bd64baa59e). rdar://176062041

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65b3ff50ec74e8f7ae956b3088eb15040286dc09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164809 "9 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38293 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/31864 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/173844 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122061 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/166678 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38627 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/173844 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122061 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/167768 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38627 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/31864 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/173844 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38627 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/21603 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38627 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/31864 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176367 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31864 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/176367 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38362 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/38295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176367 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/39052 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/31864 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101271 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/39052 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31864 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37560 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110605 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/36958 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/31864 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37206 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/37106 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->