### PR TITLE
Check for destroyed

### DIFF
--- a/LayoutTests/fast/webgpu/render-pass-destroyed-depth-stencil-no-color-expected.txt
+++ b/LayoutTests/fast/webgpu/render-pass-destroyed-depth-stencil-no-color-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Render pass with destroyed depth-stencil texture and no color attachments should not crash
+

--- a/LayoutTests/fast/webgpu/render-pass-destroyed-depth-stencil-no-color.html
+++ b/LayoutTests/fast/webgpu/render-pass-destroyed-depth-stencil-no-color.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGPU Render Pass with Destroyed Depth-Stencil and No Color Attachments</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async t => {
+    const adapter = await navigator.gpu.requestAdapter();
+    assert_true(adapter !== null, "Failed to get GPU adapter");
+
+    const device = await adapter.requestDevice();
+    assert_true(device !== null, "Failed to get GPU device");
+
+    // Create a depth-stencil texture
+    const depthTexture = device.createTexture({
+        size: { width: 256, height: 256, depthOrArrayLayers: 1 },
+        format: 'depth24plus-stencil8',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const depthTextureView = depthTexture.createView();
+
+    // Destroy the texture - this makes it invalid but the view still exists
+    depthTexture.destroy();
+
+    const commandEncoder = device.createCommandEncoder();
+
+    // Try to begin render pass with no color attachments and destroyed depth-stencil
+    // This should gracefully fail validation rather than crash
+    const renderPassDescriptor = {
+        colorAttachments: [], // No color attachments - triggers zeroColorTargets path
+        depthStencilAttachment: {
+            view: depthTextureView,
+            depthClearValue: 1.0,
+            depthLoadOp: 'clear',
+            depthStoreOp: 'store',
+        }
+    };
+
+    // This should not crash - it should either succeed or fail gracefully
+    try {
+        const renderPass = commandEncoder.beginRenderPass(renderPassDescriptor);
+        renderPass.end();
+
+        // Try to finish the command encoder
+        const commandBuffer = commandEncoder.finish();
+
+        // Submit should handle the invalid state gracefully
+        device.queue.submit([commandBuffer]);
+    } catch (e) {
+        // Graceful failure is acceptable
+        console.log("Render pass creation failed gracefully:", e.message);
+    }
+
+    // The test passes if we get here without crashing
+}, 'Render pass with destroyed depth-stencil texture and no color attachments should not crash');
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/webgpu/render-pass-resolve-texture-store-action-expected.txt
+++ b/LayoutTests/fast/webgpu/render-pass-resolve-texture-store-action-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Render pass with deprecated resolveTexture field should set correct storeAction
+

--- a/LayoutTests/fast/webgpu/render-pass-resolve-texture-store-action.html
+++ b/LayoutTests/fast/webgpu/render-pass-resolve-texture-store-action.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGPU Render Pass with Deprecated resolveTexture Field</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async t => {
+    const adapter = await navigator.gpu.requestAdapter();
+    assert_true(adapter !== null, "Failed to get GPU adapter");
+
+    const device = await adapter.requestDevice();
+    assert_true(device !== null, "Failed to get GPU device");
+
+    // Create a multisampled color texture
+    const msaaTexture = device.createTexture({
+        size: { width: 256, height: 256, depthOrArrayLayers: 1 },
+        sampleCount: 4,
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const msaaView = msaaTexture.createView();
+
+    // Create a resolve texture (non-multisampled)
+    const resolveTexture = device.createTexture({
+        size: { width: 256, height: 256, depthOrArrayLayers: 1 },
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const resolveView = resolveTexture.createView();
+
+    const commandEncoder = device.createCommandEncoder();
+
+    // Use the deprecated resolveTexture field instead of resolveTarget
+    // This should still work correctly and set the proper storeAction
+    const renderPassDescriptor = {
+        colorAttachments: [{
+            view: msaaView,
+            resolveTexture: resolveView, // Using deprecated field
+            clearValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+            loadOp: 'clear',
+            storeOp: 'store',
+        }]
+    };
+
+    // This should not crash with Metal validation error about storeAction
+    const renderPass = commandEncoder.beginRenderPass(renderPassDescriptor);
+    renderPass.end();
+
+    const commandBuffer = commandEncoder.finish();
+    device.queue.submit([commandBuffer]);
+
+    // The test passes if we get here without Metal validation errors
+}, 'Render pass with deprecated resolveTexture field should set correct storeAction');
+</script>
+</body>
+</html>

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -1407,6 +1407,9 @@ extension WebGPU.CommandEncoder {
             }
 
             if zeroColorTargets {
+                if isDestroyed {
+                    return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "no color targets and depth-stencil texture is destroyed")
+                }
                 // FIMXE: (rdar://170907318) This should be changed to `guard let` when possible.
                 guard var metalDepthStencilTexture, metalDepthStencilTexture.sampleCount > 0 else {
                     return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "no color targets and depth-stencil texture is nil")


### PR DESCRIPTION
#### 5b76a524758c9f420a217eace9d0231a49d03383
<pre>
Check for destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=309859">https://bugs.webkit.org/show_bug.cgi?id=309859</a>
<a href="https://rdar.apple.com/172190344">rdar://172190344</a>

Reviewed by Mike Wyrzykowski.

Check for destroyed texture view before using it. Partially fixed by
<a href="https://github.com/WebKit/WebKit/commit/84d8d7e6cf6780b29d994ee64ba37f8e76532f18">https://github.com/WebKit/WebKit/commit/84d8d7e6cf6780b29d994ee64ba37f8e76532f18</a>
on main.

Tests: fast/webgpu/render-pass-destroyed-depth-stencil-no-color.html
       fast/webgpu/render-pass-resolve-texture-store-action.html

* LayoutTests/fast/webgpu/render-pass-destroyed-depth-stencil-no-color-expected.txt: Added.
* LayoutTests/fast/webgpu/render-pass-destroyed-depth-stencil-no-color.html: Added.
* LayoutTests/fast/webgpu/render-pass-resolve-texture-store-action-expected.txt: Added.
* LayoutTests/fast/webgpu/render-pass-resolve-texture-store-action.html: Added.
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.beginRenderPass(_:)):

Originally-landed-as: 305413.469@safari-7624-branch (a786cee9480f). <a href="https://rdar.apple.com/176062039">rdar://176062039</a>
Canonical link: <a href="https://commits.webkit.org/315322@main">https://commits.webkit.org/315322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/647ce2d0eed6735aae895dc12fb67a9ee1ad1e99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168708 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178039 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7000ae93-55ad-44de-abdf-5a86c94d68cd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42227 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f187b2c-8c18-408f-a30e-f713b07ec154) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33799 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111855 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/405a467e-64ad-41c5-a177-28c27a0ce95a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26734 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180640 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139794 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139643 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37595 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42968 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106695 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34921 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41471 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6082 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40868 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41122 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->