### PR TITLE
Use PLATFORM(COCOA) instead of OS(DARWIN) && !PLATFORM(GTK) in crypto key headers

### DIFF
--- a/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
@@ -31,7 +31,7 @@
 #include "JsonWebKey.h"
 #include <wtf/text/Base64.h>
 
-#if OS(DARWIN) && !PLATFORM(GTK)
+#if PLATFORM(COCOA)
 #include <pal/crypto/CryptoTypes.h>
 #include <pal/crypto/PlatformECKey.h>
 #endif

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.h
@@ -29,7 +29,7 @@
 #include <WebCore/CryptoKeyPair.h>
 
 #include <wtf/Platform.h>
-#if OS(DARWIN) && !PLATFORM(GTK)
+#if PLATFORM(COCOA)
 #include <WebCore/CommonCryptoUtilities.h>
 
 #include <pal/crypto/CryptoTypes.h>

--- a/Source/WebCore/crypto/keys/CryptoKeyRSA.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyRSA.h
@@ -28,7 +28,7 @@
 #include "CryptoKey.h"
 #include <wtf/Function.h>
 
-#if OS(DARWIN) && !PLATFORM(GTK)
+#if PLATFORM(COCOA)
 #include "CommonCryptoUtilities.h"
 
 typedef CCRSACryptorRef PlatformRSAKey;


### PR DESCRIPTION
#### 89bcbd82604cb9c3738ac54119c1ecf50904449b
<pre>
Use PLATFORM(COCOA) instead of OS(DARWIN) &amp;&amp; !PLATFORM(GTK) in crypto key headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=315700">https://bugs.webkit.org/show_bug.cgi?id=315700</a>

Reviewed by NOBODY (OOPS!).

Three files in Source/WebCore/crypto/keys/ still use the legacy
`OS(DARWIN) &amp;&amp; !PLATFORM(GTK)` guard around CommonCrypto includes.
These are the only remaining instances of that idiom in all of
Source/WebCore. The rest of crypto/ (e.g. CryptoAlgorithmX25519.cpp,
CryptoAlgorithmEd25519.cpp, CryptoKeyOKP.cpp) uses PLATFORM(COCOA),
which is what CommonCryptoUtilities.h actually requires.

Replace the three sites with PLATFORM(COCOA). No functional change
for any upstream port.

* Source/WebCore/crypto/keys/CryptoKeyEC.cpp:
* Source/WebCore/crypto/keys/CryptoKeyEC.h:
* Source/WebCore/crypto/keys/CryptoKeyRSA.h:
Switch the guards from `OS(DARWIN) &amp;&amp; !PLATFORM(GTK)` to
`PLATFORM(COCOA)`.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89bcbd82604cb9c3738ac54119c1ecf50904449b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122069 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128081 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90188 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167776 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30389 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; Running layout-tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148125 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108627 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21611 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139339 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176375 "Built successfully") | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136401 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38370 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32181 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Running layout-tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136365 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147636 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101279 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31639 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24493 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37568 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110613 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Running scan-build") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36966 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2559 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37214 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->