### PR TITLE
Fix CSP 'self' source matching for opaque-origin documents

### DIFF
--- a/LayoutTests/http/wpt/content-security-policy/base-uri/base-uri-self-sandboxed-srcdoc-expected.txt
+++ b/LayoutTests/http/wpt/content-security-policy/base-uri/base-uri-self-sandboxed-srcdoc-expected.txt
@@ -1,0 +1,5 @@
+
+PASS base-uri 'self' blocks cross-origin HTTPS base URL in sandboxed srcdoc iframe with empty meta CSP.
+PASS base-uri 'self' blocks cross-origin HTTPS base URL in sandboxed srcdoc iframe with base-uri 'self' meta CSP.
+PASS base-uri 'self' blocks cross-origin HTTPS base URL in sandboxed srcdoc iframe with allow-same-origin.
+

--- a/LayoutTests/http/wpt/content-security-policy/base-uri/base-uri-self-sandboxed-srcdoc.html
+++ b/LayoutTests/http/wpt/content-security-policy/base-uri/base-uri-self-sandboxed-srcdoc.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="base-uri 'self'">
+    <title>base-uri 'self' is enforced in sandboxed srcdoc iframes</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <div id="log"></div>
+    <script>
+        async_test(function(t) {
+            var i = document.createElement('iframe');
+            i.sandbox = 'allow-scripts';
+            i.srcdoc = "<meta http-equiv='Content-Security-Policy' content='' />"
+                + "<base href='https://evil.com/'/>"
+                + "<sc" + "ript>parent.postMessage(document.baseURI, '*');</sc" + "ript>";
+
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.source === i.contentWindow) {
+                    assert_false(e.data.indexOf('evil.com') !== -1,
+                        'baseURI should not contain evil.com, got: ' + e.data);
+                    t.done();
+                }
+            }));
+
+            document.body.appendChild(i);
+        }, "base-uri 'self' blocks cross-origin HTTPS base URL in sandboxed srcdoc iframe with empty meta CSP.");
+
+        async_test(function(t) {
+            var i = document.createElement('iframe');
+            i.sandbox = 'allow-scripts';
+            i.srcdoc = '<meta http-equiv="Content-Security-Policy" content="base-uri \'self\'" />'
+                + "<base href='https://evil.com/'/>"
+                + "<sc" + "ript>parent.postMessage(document.baseURI, '*');</sc" + "ript>";
+
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.source === i.contentWindow) {
+                    assert_false(e.data.indexOf('evil.com') !== -1,
+                        'baseURI should not contain evil.com, got: ' + e.data);
+                    t.done();
+                }
+            }));
+
+            document.body.appendChild(i);
+        }, "base-uri 'self' blocks cross-origin HTTPS base URL in sandboxed srcdoc iframe with base-uri 'self' meta CSP.");
+
+        async_test(function(t) {
+            var i = document.createElement('iframe');
+            i.sandbox = 'allow-scripts allow-same-origin';
+            i.srcdoc = '<meta http-equiv="Content-Security-Policy" content="base-uri \'self\'" />'
+                + "<base href='https://evil.com/'/>"
+                + "<sc" + "ript>parent.postMessage(document.baseURI, '*');</sc" + "ript>";
+
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.source === i.contentWindow) {
+                    assert_false(e.data.indexOf('evil.com') !== -1,
+                        'baseURI should not contain evil.com, got: ' + e.data);
+                    t.done();
+                }
+            }));
+
+            document.body.appendChild(i);
+        }, "base-uri 'self' blocks cross-origin HTTPS base URL in sandboxed srcdoc iframe with allow-same-origin.");
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/meta/sandbox-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/meta/sandbox-iframe-expected.txt
@@ -1,5 +1,5 @@
 self is derived correctly inside inside a sandboxed iframe.
 
 
-FAIL img-src 'self' works when specified in a meta tag. assert_equals: expected "PASS" but got "FAIL"
+PASS img-src 'self' works when specified in a meta tag.
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -298,7 +298,13 @@ void ContentSecurityPolicy::applyPolicyToScriptExecutionContext()
     // security origin of its owner document.
     RefPtr securityOrigin = scriptExecutionContext->securityOrigin();
     ASSERT(securityOrigin);
-    updateSourceSelf(*securityOrigin);
+
+    // Skip for opaque origins (e.g. sandboxed iframes) to preserve the self-source
+    // established after CSP inheritance. Per the CSP spec §2.2 note, the self-origin
+    // concept exists to facilitate 'self' checks for opaque-origin documents that
+    // inherited their policy.
+    if (!securityOrigin->isOpaque())
+        updateSourceSelf(*securityOrigin);
 
     bool requiresTrustedTypesForScript = false;
     bool requiresTrustedTypesForScriptEnforced = false;

--- a/Source/WebCore/page/csp/ContentSecurityPolicySource.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySource.cpp
@@ -88,7 +88,7 @@ SchemeMatchResult ContentSecurityPolicySource::schemeMatches(const URL& url) con
         return SchemeMatchResult::Match;
 
     // self-sources can always upgrade to secure protocols and side-grade insecure protocols. (§6.7.2.8 step 4 NOTE)
-    if (m_isSelfSource) {
+    if (m_isSelfSource && !scheme.isEmpty()) {
         if (urlScheme == "https"_s || urlScheme == "wss"_s) {
             if (scheme == "http"_s || scheme == "ws"_s)
                 return SchemeMatchResult::InsecureUpgradeMatch;


### PR DESCRIPTION
#### 3ac584d8fd7978a2c2751862e80687e982b5f9f7
<pre>
Fix CSP &apos;self&apos; source matching for opaque-origin documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=308756">https://bugs.webkit.org/show_bug.cgi?id=308756</a>
<a href="https://rdar.apple.com/171275989">rdar://171275989</a>

Reviewed by Ryan Reno.

WebKit fails to enforce base-uri &apos;self&apos; inside sandboxed srcdoc iframes
because the origin that &apos;self&apos; resolves to (inherited from the parent)
gets reset to the opaque origin when a &lt;meta&gt; CSP tag is processed, and
schemeMatches() incorrectly allows HTTPS URLs to match when that origin
has an empty scheme (opaque origins lack scheme/host/port tuple fields).

Preserve the inherited self-origin for opaque-origin documents by
skipping updateSourceSelf() when the security origin is opaque. Guard
the &apos;self&apos; scheme upgrade in schemeMatches() to require a non-empty
scheme, preventing any URL from matching an opaque &apos;self&apos;.

Test: http/wpt/content-security-policy/base-uri/base-uri-self-sandboxed-srcdoc.html

* LayoutTests/http/wpt/content-security-policy/base-uri/base-uri-self-sandboxed-srcdoc-expected.txt: Added.
* LayoutTests/http/wpt/content-security-policy/base-uri/base-uri-self-sandboxed-srcdoc.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/meta/sandbox-iframe-expected.txt:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::applyPolicyToScriptExecutionContext):
* Source/WebCore/page/csp/ContentSecurityPolicySource.cpp:
(WebCore::ContentSecurityPolicySource::schemeMatches const):

Originally-landed-as: 305413.582@rapid/safari-7624.2.5.110-branch (8ed9a1e4e1e0). <a href="https://rdar.apple.com/176062356">rdar://176062356</a>
Canonical link: <a href="https://commits.webkit.org/314912@main">https://commits.webkit.org/314912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f12beae9f7de747e0935f668d42b2014de461147

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176623 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130372 "Passed tests") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110889 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25355 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179162 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32056 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138766 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138652 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37337 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41823 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150041 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104977 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33907 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26920 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40327 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113409 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39724 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5021 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39975 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->