### PR TITLE
Crash in -[WebScrollbarPartAnimationMac setCurrentProgress:]

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -32,6 +32,7 @@
 #include <WebCore/UserInterfaceLayoutDirection.h>
 #include <wtf/RecursiveLockAdapter.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
 OBJC_CLASS CALayer;
@@ -48,12 +49,11 @@ class ScrollerPairMac;
 
 struct ScrollbarColor;
 
-class ScrollerMac final : public CanMakeThreadSafeCheckedPtr<ScrollerMac> {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ScrollerMac);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollerMac);
+class ScrollerMac final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ScrollerMac, WTF::DestructionThread::Main> {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollerMac);
     friend class ScrollerPairMac;
 public:
-    ScrollerMac(ScrollerPairMac&, ScrollbarOrientation);
+    static Ref<ScrollerMac> create(ScrollerPairMac&, ScrollbarOrientation);
 
     ~ScrollerMac();
 
@@ -99,6 +99,8 @@ public:
     RecursiveLock& scrollerImpLock() const LIFETIME_BOUND { return m_scrollerImpLock; }
 
 private:
+    ScrollerMac(ScrollerPairMac&, ScrollbarOrientation);
+
     int m_minimumKnobLength { 0 };
 
     bool m_isEnabled { false };

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -40,6 +40,7 @@
 #import <QuartzCore/QuartzCore.h>
 #import <pal/spi/mac/NSScrollerImpSPI.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/TZoneMallocInlines.h>
 
 enum class FeatureToAnimate {
     KnobAlpha,
@@ -49,7 +50,7 @@ enum class FeatureToAnimate {
 };
 
 @interface WebScrollbarPartAnimationMac : NSAnimation {
-    CheckedPtr<WebCore::ScrollerMac> _scroller;
+    ThreadSafeWeakPtr<WebCore::ScrollerMac> _scroller;
     FeatureToAnimate _featureToAnimate;
     CGFloat _startValue;
     CGFloat _endValue;
@@ -77,7 +78,7 @@ enum class FeatureToAnimate {
 
 - (void)startAnimation
 {
-    ASSERT(_scroller);
+    ASSERT(_scroller.get());
 
     [super startAnimation];
 }
@@ -96,13 +97,17 @@ enum class FeatureToAnimate {
 {
     [super setCurrentProgress:progress];
 
+    RefPtr scroller = _scroller.get();
+    if (!scroller)
+        return;
+
     CGFloat currentValue;
     if (_startValue > _endValue)
         currentValue = 1 - progress;
     else
         currentValue = progress;
 
-    CheckedPtr { _scroller }->updateProgress(_featureToAnimate, currentValue);
+    scroller->updateProgress(_featureToAnimate, currentValue);
 }
 
 - (void)invalidate
@@ -116,7 +121,7 @@ enum class FeatureToAnimate {
 @end
 
 @interface WebScrollerImpDelegateMac : NSObject<NSAnimationDelegate, NSScrollerImpDelegate> {
-    CheckedPtr<WebCore::ScrollerMac> _scroller;
+    ThreadSafeWeakPtr<WebCore::ScrollerMac> _scroller;
 
     RetainPtr<WebScrollbarPartAnimationMac> _knobAlphaAnimation;
     RetainPtr<WebScrollbarPartAnimationMac> _trackAlphaAnimation;
@@ -166,12 +171,13 @@ enum class FeatureToAnimate {
 
 - (NSPoint)mouseLocationInScrollerForScrollerImp:(NSScrollerImp *)scrollerImp
 {
-    if (!_scroller)
+    RefPtr scroller = _scroller.get();
+    if (!scroller)
         return NSZeroPoint;
 
-    ASSERT(_scroller->isScrollerFor(scrollerImp));
+    ASSERT(scroller->isScrollerFor(scrollerImp));
 
-    return CheckedPtr { _scroller }->lastKnownMousePositionInScrollbar();
+    return scroller->lastKnownMousePositionInScrollbar();
 }
 
 - (NSRect)convertRectToLayer:(NSRect)rect
@@ -190,11 +196,15 @@ enum class FeatureToAnimate {
 {
     UNUSED_PARAM(scrollerImp);
 
-    if (!_scroller)
+    RefPtr scroller = _scroller.get();
+    if (!scroller)
+        return [NSAppearance currentDrawingAppearance];
+    RefPtr pair = scroller->pair();
+    if (!pair)
         return [NSAppearance currentDrawingAppearance];
     // The base system does not support dark Aqua, so we might get a null result.
     // FIXME: This is a static analysis false positive.
-    SUPPRESS_UNRETAINED_ARG if (auto *appearance = [NSAppearance appearanceNamed:_scroller->pair()->useDarkAppearance() ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua])
+    SUPPRESS_UNRETAINED_ARG if (auto *appearance = [NSAppearance appearanceNamed:pair->useDarkAppearance() ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua])
         return appearance;
     return [NSAppearance currentDrawingAppearance];
 }
@@ -207,7 +217,9 @@ enum class FeatureToAnimate {
         scrollbarPartAnimation = nil;
     }
 
-    CheckedPtr scroller = _scroller;
+    RefPtr scroller = _scroller.get();
+    if (!scroller)
+        return;
     CGFloat currentAlpha = featureToAnimate == FeatureToAnimate::KnobAlpha ? scroller->knobAlpha() : scroller->trackAlpha();
 
     scrollbarPartAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:scroller.get()
@@ -220,35 +232,38 @@ enum class FeatureToAnimate {
 
 - (void)scrollerImp:(NSScrollerImp *)scrollerImp animateKnobAlphaTo:(CGFloat)newKnobAlpha duration:(NSTimeInterval)duration
 {
-    if (!_scroller)
+    RefPtr scroller = _scroller.get();
+    if (!scroller)
         return;
 
-    ASSERT(_scroller->isScrollerFor(scrollerImp));
-    CheckedPtr { _scroller }->visibilityChanged(newKnobAlpha > 0);
+    ASSERT(scroller->isScrollerFor(scrollerImp));
+    scroller->visibilityChanged(newKnobAlpha > 0);
     [self setUpAlphaAnimation:_knobAlphaAnimation featureToAnimate:FeatureToAnimate::KnobAlpha animateAlphaTo:newKnobAlpha duration:duration];
 }
 
 - (void)scrollerImp:(NSScrollerImp *)scrollerImp animateTrackAlphaTo:(CGFloat)newTrackAlpha duration:(NSTimeInterval)duration
 {
-    if (!_scroller)
+    RefPtr scroller = _scroller.get();
+    if (!scroller)
         return;
 
-    ASSERT(_scroller->isScrollerFor(scrollerImp));
+    ASSERT(scroller->isScrollerFor(scrollerImp));
     [self setUpAlphaAnimation:_trackAlphaAnimation featureToAnimate:FeatureToAnimate::TrackAlpha animateAlphaTo:newTrackAlpha duration:duration];
 }
 
 - (void)scrollerImp:(NSScrollerImp *)scrollerImp animateUIStateTransitionWithDuration:(NSTimeInterval)duration
 {
-    if (!_scroller)
+    RefPtr scroller = _scroller.get();
+    if (!scroller)
         return;
 
-    ASSERT(_scroller->isScrollerFor(scrollerImp));
+    ASSERT(scroller->isScrollerFor(scrollerImp));
 
     // UIStateTransition always animates to 1. In case an animation is in progress this avoids a hard transition.
     [scrollerImp setUiStateTransitionProgress:1 - [scrollerImp uiStateTransitionProgress]];
 
     if (!_uiStateTransitionAnimation) {
-        _uiStateTransitionAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:_scroller.get()
+        _uiStateTransitionAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:scroller.get()
             featureToAnimate:FeatureToAnimate::UIStateTransition
             animateFrom:[scrollerImp uiStateTransitionProgress]
             animateTo:1.0
@@ -264,16 +279,17 @@ enum class FeatureToAnimate {
 
 - (void)scrollerImp:(NSScrollerImp *)scrollerImp animateExpansionTransitionWithDuration:(NSTimeInterval)duration
 {
-    if (!_scroller)
+    RefPtr scroller = _scroller.get();
+    if (!scroller)
         return;
 
-    ASSERT(_scroller->isScrollerFor(scrollerImp));
+    ASSERT(scroller->isScrollerFor(scrollerImp));
 
     // ExpansionTransition always animates to 1. In case an animation is in progress this avoids a hard transition.
     [scrollerImp setExpansionTransitionProgress:1 - [scrollerImp expansionTransitionProgress]];
 
     if (!_expansionTransitionAnimation) {
-        _expansionTransitionAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:_scroller.get()
+        _expansionTransitionAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:scroller.get()
             featureToAnimate:FeatureToAnimate::ExpansionTransition
             animateFrom:[scrollerImp expansionTransitionProgress]
             animateTo:1.0
@@ -295,7 +311,7 @@ enum class FeatureToAnimate {
 
 - (void)invalidate
 {
-    _scroller = nil;
+    _scroller = nullptr;
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     [_knobAlphaAnimation invalidate];
     [_trackAlphaAnimation invalidate];
@@ -308,6 +324,13 @@ enum class FeatureToAnimate {
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollerMac);
+
+Ref<ScrollerMac> ScrollerMac::create(ScrollerPairMac& pair, ScrollbarOrientation orientation)
+{
+    return adoptRef(*new ScrollerMac(pair, orientation));
+}
+
 ScrollerMac::ScrollerMac(ScrollerPairMac& pair, ScrollbarOrientation orientation)
     : m_pair(pair)
     , m_orientation(orientation)
@@ -316,6 +339,7 @@ ScrollerMac::ScrollerMac(ScrollerPairMac& pair, ScrollbarOrientation orientation
 
 ScrollerMac::~ScrollerMac()
 {
+    ASSERT(isMainThread());
     [m_scrollerImpDelegate invalidate];
 }
 
@@ -464,7 +488,7 @@ IntPoint ScrollerMac::lastKnownMousePositionInScrollbar() const
     // When we dont have an update from the Web Process, return
     // a point outside of the scrollbars
     RefPtr pair = m_pair.get();
-    if (!pair->mouseInContentArea())
+    if (!pair || !pair->mouseInContentArea())
         return { -1, -1 };
     return m_lastKnownMousePositionInScrollbar;
 }
@@ -476,6 +500,8 @@ void ScrollerMac::visibilityChanged(bool isVisible)
     m_isVisible = isVisible;
 
     RefPtr pair = m_pair.get();
+    if (!pair)
+        return;
     if (RefPtr node = pair->node())
         node->scrollbarVisibilityDidChange(m_orientation, isVisible);
 }
@@ -487,6 +513,8 @@ void ScrollerMac::updateMinimumKnobLength(int minimumKnobLength)
     m_minimumKnobLength = minimumKnobLength;
 
     RefPtr pair = m_pair.get();
+    if (!pair)
+        return;
     if (RefPtr node = pair->node())
         node->scrollbarMinimumThumbLengthDidChange(m_orientation, m_minimumKnobLength);
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -130,8 +130,8 @@ private:
 
     ScrollbarHoverState m_scrollbarHoverState;
 
-    const UniqueRef<ScrollerMac> m_verticalScroller;
-    const UniqueRef<ScrollerMac> m_horizontalScroller;
+    const Ref<ScrollerMac> m_verticalScroller;
+    const Ref<ScrollerMac> m_horizontalScroller;
 
     std::optional<FloatPoint> m_lastScrollOffset;
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -106,11 +106,7 @@
     if (!scrollerPair || !scrollerImp)
         return NSZeroPoint;
 
-    CheckedPtr<WebCore::ScrollerMac> scroller;
-    if ([scrollerImp isHorizontal])
-        scroller = &scrollerPair->horizontalScroller();
-    else
-        scroller = &scrollerPair->verticalScroller();
+    Ref<WebCore::ScrollerMac> scroller = [scrollerImp isHorizontal] ? scrollerPair->horizontalScroller() : scrollerPair->verticalScroller();
 
     ASSERT(scroller->isScrollerFor(scrollerImp));
 
@@ -140,8 +136,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollerPairMac);
 
 ScrollerPairMac::ScrollerPairMac(ScrollingTreeScrollingNode& node)
     : m_scrollingNode(node)
-    , m_verticalScroller(makeUniqueRef<ScrollerMac>(*this, ScrollbarOrientation::Vertical))
-    , m_horizontalScroller(makeUniqueRef<ScrollerMac>(*this, ScrollbarOrientation::Horizontal))
+    , m_verticalScroller(ScrollerMac::create(*this, ScrollbarOrientation::Vertical))
+    , m_horizontalScroller(ScrollerMac::create(*this, ScrollbarOrientation::Horizontal))
 {
 }
 
@@ -167,8 +163,7 @@ ScrollerPairMac::~ScrollerPairMac()
     m_verticalScroller->detach();
     m_horizontalScroller->detach();
 
-    ensureOnMainThread([scrollerImpPair = std::exchange(m_scrollerImpPair, nil), verticalScrollerImp = m_verticalScroller->takeScrollerImp(), horizontalScrollerImp = m_horizontalScroller->takeScrollerImp()] {
-    });
+    ensureOnMainThread([scrollerImpPair = std::exchange(m_scrollerImpPair, nil)] { });
 }
 
 void ScrollerPairMac::handleWheelEventPhase(PlatformWheelEventPhase phase)

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -63,8 +63,8 @@ void ScrollingTreeScrollingNodeDelegateMac::nodeWillBeDestroyed()
 
 void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingStateScrollingNode& scrollingStateNode)
 {
-    CheckedRef horizontalScroller = m_scrollerPair->horizontalScroller();
-    CheckedRef verticalScroller = m_scrollerPair->verticalScroller();
+    Ref horizontalScroller = m_scrollerPair->horizontalScroller();
+    Ref verticalScroller = m_scrollerPair->verticalScroller();
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::PainterForScrollbar)) {
         auto horizontalScrollbar = scrollingStateNode.horizontalScrollerImp();


### PR DESCRIPTION
#### a926a679cffa70eddd05e6eedaed7347c3066665
<pre>
Crash in -[WebScrollbarPartAnimationMac setCurrentProgress:]
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=310238">https://bugs.webkit.org/show_bug.cgi?id=310238</a>&gt;
&lt;<a href="https://rdar.apple.com/162407650">rdar://162407650</a>&gt;

Reviewed by Chris Dumez.

A cross-thread crash occurs in
`-[WebScrollbarPartAnimationMac setCurrentProgress:]` on the
&quot;WebCore: Scrolling&quot; thread when an in-flight `NSAnimation`
display-link callback accesses a `ScrollerMac` object that has
already been destroyed on the main thread by the
`ScrollerPairMac` destructor.

Make `ScrollerMac` thread-safe ref-counted to fix the crash.  This allows
`WebScrollbarPartAnimationMac` and `WebScrollerImpDelegateMac` to
hold `ThreadSafeWeakPtr&lt;ScrollerMac&gt;` instead of `CheckedPtr&lt;ScrollerMac&gt;`.
Use `WTF::DestructionThread::Main` to ensure `ScrollerMac` is always
destroyed on the main thread, and remove the now-unnecessary
`takeScrollerImp()` captures from `~ScrollerPairMac()`&apos;s
`ensureOnMainThread` block.

Add null guards for `m_pair` in `lastKnownMousePositionInScrollbar()`,
`visibilityChanged()`, and `updateMinimumKnobLength()` since a
`RefPtr` from an in-flight callback can briefly keep `ScrollerMac`
alive after `ScrollerPairMac` drops its `Ref`.

Covered by existing scrollbar tests.

* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
(WebCore::ScrollerMac): Use `WTF::DestructionThread::Main`.
(WebCore::ScrollerMac::create): Add.
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::~ScrollerMac):
- Add `ASSERT(isMainThread())`.
(-[WebScrollbarPartAnimationMac startAnimation]):
(-[WebScrollbarPartAnimationMac setCurrentProgress:]):
(-[WebScrollerImpDelegateMac mouseLocationInScrollerForScrollerImp:]):
(-[WebScrollerImpDelegateMac effectiveAppearanceForScrollerImp:]):
(-[WebScrollerImpDelegateMac setUpAlphaAnimation:featureToAnimate:animateAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateKnobAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateTrackAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateUIStateTransitionWithDuration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateExpansionTransitionWithDuration:]):
(-[WebScrollerImpDelegateMac invalidate]):
(WebCore::ScrollerMac::create): Add.
(WebCore::ScrollerMac::lastKnownMousePositionInScrollbar const):
(WebCore::ScrollerMac::visibilityChanged):
(WebCore::ScrollerMac::updateMinimumKnobLength):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(-[WebScrollerImpPairDelegateMac scrollerImpPair:convertContentPoint:toScrollerImp:]):
- Hold `ScrollerMac` as `Ref&lt;ScrollerMac&gt;` per SaferCPP guidelines.
(WebCore::ScrollerPairMac::~ScrollerPairMac):
- Simplify `ensureOnMainThread` block to only capture `m_scrollerImpPair`.
(WebCore::ScrollerPairMac::ScrollerPairMac):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode):

Originally-landed-as: 305413.553@rapid/safari-7624.2.5.110-branch (6ef1f5a9c30e). <a href="https://rdar.apple.com/176061766">rdar://176061766</a>
Canonical link: <a href="https://commits.webkit.org/314087@main">https://commits.webkit.org/314087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f950ce0e27b9cb6ec568d7a6a1984f62328b5334

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128228 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108754 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29588 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28201 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21809 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176577 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29431 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136552 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136493 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36801 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147773 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101560 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31771 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24638 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37771 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110842 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37168 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2715 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37312 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->