### PR TITLE
Crash in HistoryController::updateForCommit() when calling navigation.reload() during pageswap event handler

### DIFF
--- a/LayoutTests/fast/loader/reload-on-pageswap-crash-expected.txt
+++ b/LayoutTests/fast/loader/reload-on-pageswap-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/loader/reload-on-pageswap-crash.html
+++ b/LayoutTests/fast/loader/reload-on-pageswap-crash.html
@@ -1,0 +1,29 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+(async () => {
+  if (sessionStorage.testCompleted) {
+    delete sessionStorage.testCompleted;
+    testRunner?.notifyDone();
+  } else {
+    sessionStorage.testCompleted = true;
+    await navigation.reload();
+  }
+
+  let audio = document.createElement('audio');
+  audio.src = '/resources/foo.mp4';
+  await navigator.locks.query();
+  onpageswap = async (e) => {
+    let { committed, finished } = navigation.reload();
+    let committedRejected = await committed.then(() => false, () => true);
+    let finishedRejected = await finished.then(() => false, () => true);
+    if (!committedRejected)
+      document.write("FAIL: committed promise should have been rejected.");
+    if (!finishedRejected)
+      document.write("FAIL: finished promise should have been rejected.");
+  };
+  await cookieStore.get("bar");
+})();
+</script>
+PASS if no crash.

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -401,7 +401,7 @@ Navigation::Result Navigation::reload(JSC::JSGlobalObject& globalObject, ReloadO
         state = currentEntry()->associatedHistoryItem().navigationAPIStateObject();
 
     RefPtr window = this->window();
-    if (!protect(window->document())->isFullyActive() || window->document()->unloadCounter())
+    if (RefPtr document = window->document(); !document->isFullyActive() || frame()->loader().isDispatchingPageSwapEvent() || document->unloadCounter())
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::InvalidStateError, "Invalid state"_s);
 
     RefPtr apiMethodTracker = maybeSetUpcomingNonTraversalTracker(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(options.info), WTF::move(state));


### PR DESCRIPTION
#### 8e3ad95fd18ea29689428ad6e79ee2904e07b00d
<pre>
Crash in HistoryController::updateForCommit() when calling navigation.reload() during pageswap event handler
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=309782">https://bugs.webkit.org/show_bug.cgi?id=309782</a>&gt;
&lt;<a href="https://rdar.apple.com/167842846">rdar://167842846</a>&gt;

Reviewed by Chris Dumez.

A reload transitioning to committed dispatches a pageswap event, and a
`navigation.reload()` call inside the pageswap handler does a sync
policy check that clears the provisional `DocumentLoader`.  After the
event returns, `HistoryController::updateForCommit()` dereferences the
now-null `FrameLoader::provisionalDocumentLoader()`.

Extend the fix from Bug 303364 (which cancelled `navigation.navigate()`
during pageswap dispatch) to also cancel `navigation.reload()`.  Do
this by adding the existing `isDispatchingPageSwapEvent()` guard to
`Navigation::reload()` to match the guard already present in
`Navigation::navigate()`.

Test: fast/loader/reload-on-pageswap-crash.html

* LayoutTests/fast/loader/reload-on-pageswap-crash-expected.txt: Add.
* LayoutTests/fast/loader/reload-on-pageswap-crash.html: Add.
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::reload):

Originally-landed-as: 305413.511@rapid/safari-7624.2.5.110-branch (6381422ae099). <a href="https://rdar.apple.com/176061576">rdar://176061576</a>
Canonical link: <a href="https://commits.webkit.org/314088@main">https://commits.webkit.org/314088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e5acdd77f4c25c24e4bdc7c50294b96cc6f8cd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174052 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122266 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128227 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108753 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29587 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28200 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21807 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176575 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29429 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136547 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136492 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36802 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147771 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101558 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31770 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24636 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37769 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110840 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37166 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2713 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->