### PR TITLE
Audio from SpeechSynthesis may leak to the next page on cross-origin navigation

### DIFF
--- a/LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-on-navigation-expected.txt
+++ b/LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-on-navigation-expected.txt
@@ -1,0 +1,13 @@
+Tests that speech synthesis is cancelled when the page enters the back-forward cache.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS speechSynthesis.speaking is true
+PASS Page was restored from the page cache
+PASS speechSynthesis.speaking is false
+PASS speechSynthesis.pending is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-on-navigation.html
+++ b/LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-on-navigation.html
@@ -1,0 +1,38 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test-pre.js"></script>
+<script>
+description('Tests that speech synthesis is cancelled when the page enters the back-forward cache.');
+window.jsTestIsAsync = true;
+
+if (window.internals)
+    window.internals.enableMockSpeechSynthesizer();
+
+window.addEventListener("pageshow", function(event) {
+    if (event.persisted) {
+        testPassed("Page was restored from the page cache");
+        shouldBeFalse("speechSynthesis.speaking");
+        shouldBeFalse("speechSynthesis.pending");
+        finishJSTest();
+    }
+});
+
+var u = new SpeechSynthesisUtterance("This is a test utterance that should be cancelled on navigation");
+
+// Start speaking and navigate in a setTimeout after load to ensure the page is
+// fully loaded and has a proper history entry for back-forward cache eligibility.
+window.addEventListener("load", function() {
+    setTimeout(function() {
+        speechSynthesis.speak(u);
+        // The mock synthesizer fires didStartSpeaking synchronously, so speech
+        // is active right after speak() returns.
+        shouldBeTrue("speechSynthesis.speaking");
+        window.location.href = "../history/resources/page-cache-helper.html";
+    }, 0);
+});
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -365,6 +365,18 @@ void SpeechSynthesis::simulateVoicesListChange()
         voicesDidChange();
 }
 
+void SpeechSynthesis::suspend(ReasonForSuspension)
+{
+    if (speaking())
+        cancel();
+}
+
+void SpeechSynthesis::stop()
+{
+    if (speaking())
+        cancel();
+}
+
 bool SpeechSynthesis::virtualHasPendingActivity() const
 {
     return m_voiceList && m_hasEventListener;

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -100,6 +100,8 @@ private:
     void voicesChanged() override;
 
     // ActiveDOMObject
+    void suspend(ReasonForSuspension) final;
+    void stop() final;
     bool NODELETE virtualHasPendingActivity() const final;
 
     void startSpeakingImmediately(SpeechSynthesisUtterance&);

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
@@ -102,6 +102,9 @@ void SpeechSynthesisUtterance::eventOccurred(const AtomString& type, uint32_t ch
         return;
     }
 
+    if (!isAllowedToRunScript())
+        return;
+
     auto init = SpeechSynthesisEvent::Init {
         { false, false, false },
         *this,
@@ -119,6 +122,9 @@ void SpeechSynthesisUtterance::errorEventOccurred(const AtomString& type, Speech
         m_completionHandler(*this);
         return;
     }
+
+    if (!isAllowedToRunScript())
+        return;
 
     auto init = SpeechSynthesisErrorEvent::Init { {
             { false, false, false },


### PR DESCRIPTION
#### 35c8316c38ff4ca167e6e92cb8b1139257a1d191
<pre>
Audio from SpeechSynthesis may leak to the next page on cross-origin navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=310260">https://bugs.webkit.org/show_bug.cgi?id=310260</a>
<a href="https://rdar.apple.com/171777671">rdar://171777671</a>

Reviewed by Brady Eidson.

Audio from SpeechSynthesis may leak to the next page on cross-origin
navigation. Address the issue by calling SpeechSynthesis::cancel()
when the script execution context is going away or getting suspended for
back/forward cache.

* LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-on-navigation-expected.txt: Added.
* LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-on-navigation.html: Added.
* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::suspend):
(WebCore::SpeechSynthesis::stop):
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp:
(WebCore::SpeechSynthesisUtterance::eventOccurred):
(WebCore::SpeechSynthesisUtterance::errorEventOccurred):

Originally-landed-as: 305413.549@rapid/safari-7624.2.5.110-branch (26fa1088eb27). <a href="https://rdar.apple.com/176062259">rdar://176062259</a>
Canonical link: <a href="https://commits.webkit.org/314031@main">https://commits.webkit.org/314031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/265892081a2ca023dddf1ae1c45fa582db3eb702

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122200 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128173 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108699 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29525 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28138 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21741 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176508 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136492 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136438 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36762 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147707 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101462 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31709 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24573 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37702 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110773 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37099 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2647 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->