### PR TITLE
Cross origin iframes should not be able to set the app badge.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https-expected.txt
@@ -1,6 +1,6 @@
 
 
 PASS Test that navigator.setAppBadge is available
-FAIL Test that calling setAppBadge in a cross-origin iframe throws a SecurityError assert_equals: setAppBadge should have rejected with an error expected "error" but got "success"
+PASS Test that calling setAppBadge in a cross-origin iframe throws a SecurityError
 PASS Test that calling setAppBadge in a same-origin iframe succeeds
 

--- a/Source/WebCore/Modules/badge/NavigatorBadge.idl
+++ b/Source/WebCore/Modules/badge/NavigatorBadge.idl
@@ -26,6 +26,6 @@
 [
     EnabledBySetting=AppBadgeEnabled
 ] interface mixin NavigatorBadge {
-    [SecureContext] Promise<undefined> setAppBadge(optional [EnforceRange] unsigned long long contents);
-    [SecureContext] Promise<undefined> clearAppBadge();
+    [SecureContext, CallWith=CurrentScriptExecutionContext] Promise<undefined> setAppBadge(optional [EnforceRange] unsigned long long contents);
+    [SecureContext, CallWith=CurrentScriptExecutionContext] Promise<undefined> clearAppBadge();
 };

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -412,7 +412,7 @@ Document* Navigator::document()
     return frame ? frame->document() : nullptr;
 }
 
-void Navigator::setAppBadge(std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)
+void Navigator::setAppBadge(ScriptExecutionContext& callingContext, std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)
 {
     RefPtr frame = this->frame();
     if (!frame) {
@@ -432,13 +432,25 @@ void Navigator::setAppBadge(std::optional<unsigned long long> badge, Ref<Deferre
         return;
     }
 
-    page->badgeClient().setAppBadge(frame.get(), SecurityOriginData::fromLocalFrame(frame.get()), badge);
+    RefPtr callingOrigin = callingContext.securityOrigin();
+    if (!callingOrigin) {
+        promise->reject(ExceptionCode::InvalidStateError);
+        return;
+    }
+
+    Ref topOrigin = callingContext.topOrigin();
+    if (!callingOrigin->isSameOriginAs(topOrigin.get())) {
+        promise->reject(ExceptionCode::SecurityError);
+        return;
+    }
+
+    page->badgeClient().setAppBadge(frame.get(), SecurityOriginData::fromFrame(*frame), badge);
     promise->resolve();
 }
 
-void Navigator::clearAppBadge(Ref<DeferredPromise>&& promise)
+void Navigator::clearAppBadge(ScriptExecutionContext& callingContext, Ref<DeferredPromise>&& promise)
 {
-    setAppBadge(0, WTF::move(promise));
+    setAppBadge(callingContext, 0, WTF::move(promise));
 }
 
 int Navigator::maxTouchPoints() const

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -76,8 +76,8 @@ public:
     const Document* NODELETE document() const;
     Document* document();
 
-    void setAppBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
-    void clearAppBadge(Ref<DeferredPromise>&&);
+    void setAppBadge(ScriptExecutionContext&, std::optional<unsigned long long>, Ref<DeferredPromise>&&);
+    void clearAppBadge(ScriptExecutionContext&, Ref<DeferredPromise>&&);
 
 private:
     void showShareData(ExceptionOr<ShareDataWithParsedURL&>, Ref<DeferredPromise>&&);

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -86,7 +86,7 @@ GPU* WorkerNavigator::gpu()
 #endif
 }
 
-void WorkerNavigator::setAppBadge(std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)
+void WorkerNavigator::setAppBadge(ScriptExecutionContext&, std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)
 {
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     if (auto* context = dynamicDowncast<ServiceWorkerGlobalScope>(scriptExecutionContext())) {
@@ -108,9 +108,9 @@ void WorkerNavigator::setAppBadge(std::optional<unsigned long long> badge, Ref<D
     promise->resolve();
 }
 
-void WorkerNavigator::clearAppBadge(Ref<DeferredPromise>&& promise)
+void WorkerNavigator::clearAppBadge(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
 {
-    setAppBadge(0, WTF::move(promise));
+    setAppBadge(context, 0, WTF::move(promise));
 }
 
 NavigatorUAData& WorkerNavigator::userAgentData() const

--- a/Source/WebCore/page/WorkerNavigator.h
+++ b/Source/WebCore/page/WorkerNavigator.h
@@ -47,8 +47,8 @@ public:
     bool NODELETE onLine() const final;
     void setIsOnline(bool isOnline) { m_isOnline = isOnline; }
 
-    void setAppBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
-    void clearAppBadge(Ref<DeferredPromise>&&);
+    void setAppBadge(ScriptExecutionContext&, std::optional<unsigned long long>, Ref<DeferredPromise>&&);
+    void clearAppBadge(ScriptExecutionContext&, Ref<DeferredPromise>&&);
     NavigatorUAData& userAgentData() const;
 
     GPU* gpu();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Badging.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Badging.mm
@@ -449,29 +449,34 @@ TEST(Badging, ServiceWorker)
 }
 
 static constexpr auto originMainFrameBytes = R"SWRESOURCE(
-<iframe src="origintest2://main.com/"></iframe>
-)SWRESOURCE"_s;
-
-static constexpr auto originIFrameBytes = R"SWRESOURCE(
+<iframe src="origintest2://main.com/iframe.html"></iframe>
 <script>
-window.navigator.setAppBadge(10);
+window.onmessage = (event) => {
+    window.webkit.messageHandlers.testHandler.postMessage(event.data);
+}
 </script>
 )SWRESOURCE"_s;
 
-// This test verifies that a setAppBadge call from a cross origin iframe passes the correct
-// origin to the delegate.
-// When actually that call should've been rejected down at the DOM level because cross-origin
-// iframes cannot call setAppBadge.
-// Fixing that is for a different day, so for this branch we'll just disable this test.
-TEST(Badging, DISABLED_Origin)
+static constexpr auto originIFrameBytes = R"SWRESOURCE(
+<script type="module">
+try {
+    await window.navigator.setAppBadge(10);
+    window.parent.postMessage("BadgeSucceeded", "*");
+} catch (e) {
+    window.parent.postMessage("BadgeFailed: " + e, "*");
+}
+</script>
+)SWRESOURCE"_s;
+
+static void runOriginTest(NSString *mainURL, NSString *expectedMessage)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
     handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id<WKURLSchemeTask> task) {
-        if ([task.request.URL.scheme isEqualToString:@"origintest1"])
+        if ([task.request.URL.path hasSuffix:@"index.html"])
             return respond(task, originMainFrameBytes);
-        if ([task.request.URL.scheme isEqualToString:@"origintest2"])
+        if ([task.request.URL.path hasSuffix:@"iframe.html"])
             return respond(task, originIFrameBytes);
 
         ASSERT_NOT_REACHED();
@@ -480,19 +485,42 @@ TEST(Badging, DISABLED_Origin)
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"origintest2"];
     configuration.get().preferences._appBadgeEnabled = YES;
 
+    RetainPtr testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
+
+    static bool gotMessage = false;
+    static RetainPtr<NSString> storedMessage;
+    testMessageHandler.get().didReceiveScriptMessage = ^(NSString *message) {
+        storedMessage = message;
+        gotMessage = true;
+    };
+
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
     RetainPtr badgeDelegate = adoptNS([BadgeDelegate new]);
 
-    NSURL *url = [NSURL URLWithString:@"origintest1://webkit.org/index.html"];
+    NSURL *url = [NSURL URLWithString:mainURL];
     badgeDelegate.get().serverURL = url;
     badgeDelegate.get().shouldAllowOriginViolations = YES;
     badgeDelegate.get().expectedAppBadgeSequence = @[@10];
     webView.get().UIDelegate = badgeDelegate.get();
 
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:url]];
+    TestWebKitAPI::Util::run(&gotMessage);
 
-    // Having synchronously loaded, we should already have received the badging update
-    EXPECT_EQ(badgeDelegate.get().originViolationCount, 1);
+    // For the purposes of this test suite, no origin violations should ever
+    // escape the web content process and reach the UI process delegate.
+    EXPECT_EQ(badgeDelegate.get().originViolationCount, 0);
+    EXPECT_TRUE([storedMessage.get() isEqualToString:expectedMessage]);
+}
+
+TEST(Badging, CrossOrigin)
+{
+    runOriginTest(@"origintest1://webkit.org/index.html", @"BadgeFailed: SecurityError: The operation is insecure.");
+}
+
+TEST(Badging, SameOrigin)
+{
+    runOriginTest(@"origintest2://main.com/index.html", @"BadgeSucceeded");
 }
 
 TEST(Badging, ServiceWorkerOverride)


### PR DESCRIPTION
#### 3fa40e65c4ec036c91e8a8c62f59e803530602cd
<pre>
Cross origin iframes should not be able to set the app badge.
<a href="https://rdar.apple.com/173245853">rdar://173245853</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310638">https://bugs.webkit.org/show_bug.cgi?id=310638</a>

Reviewed by Sihui Liu.

The steps for &quot;set the application badge&quot;:
<a href="https://www.w3.org/TR/badging/#dfn-set-the-application-badge">https://www.w3.org/TR/badging/#dfn-set-the-application-badge</a>

...clearly point out that only script from an origin matching the top origin can set the badge.
Otherwise a security error should result.

So let&apos;s implement that.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm
      LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https

* LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https-expected.txt:
* Source/WebCore/Modules/badge/NavigatorBadge.idl:
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::setAppBadge):
(WebCore::Navigator::clearAppBadge):
* Source/WebCore/page/Navigator.h:
* Source/WebCore/page/WorkerNavigator.cpp:
(WebCore::WorkerNavigator::setAppBadge):
(WebCore::WorkerNavigator::clearAppBadge):
* Source/WebCore/page/WorkerNavigator.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm:
((Badging, CrossOrigin)):
((Badging, SameOrigin)):
((Badging, DISABLED_Origin)): Deleted.

Originally-landed-as: 305413.581@rapid/safari-7624.2.5.110-branch (f0c6cc402623). <a href="https://rdar.apple.com/176061670">rdar://176061670</a>
Canonical link: <a href="https://commits.webkit.org/314758@main">https://commits.webkit.org/314758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac615c28ae85f97cc730c0bc91dad397d1265aa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167121 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176169 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129983 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110500 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31361 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24908 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178710 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31610 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138358 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138257 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37219 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41378 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104336 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33518 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112961 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39279 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4621 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39529 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39423 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->