### PR TITLE
Use -emit-clang-header-min-access only if supported by swiftc

### DIFF
--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -1150,6 +1150,13 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         if (NOT DEFINED ${_target}_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS)
             set(${_target}_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS internal)
         endif ()
+        # -emit-clang-header-min-access was added in Swift 6.3. Please simplify
+        # this once that becomes mandatory.
+        include(CheckCompilerFlag)
+        check_compiler_flag(Swift -emit-clang-header-min-access CAN_USE_EMIT_CLANG_HEADER_MIN_ACCESS)
+        if (CAN_USE_EMIT_CLANG_HEADER_MIN_ACCESS)
+            set(${_target}_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS_FLAGS -Xfrontend -emit-clang-header-min-access -Xfrontend ${${_target}_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS})
+        endif ()
         # Always create the SwiftCxxHeader placeholder so external callers
         # (e.g. Source/WebKit/CMakeLists.txt's deferred add_dependencies) can
         # reference it even when ${_target}_SWIFT_TYPECHECK_SOURCES is empty
@@ -1178,7 +1185,7 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
                     ${_swift_xcc_options}
                     ${_swift_sources}
                     -module-name ${_module_name}
-                    -Xfrontend -emit-clang-header-min-access -Xfrontend ${${_target}_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS}
+                    ${${_target}_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS_FLAGS}
                     -emit-clang-header-path ${_header_tmp_path}
                     -emit-dependencies
                 COMMAND


### PR DESCRIPTION
#### 704788c49ee2ca255f9441bf0faebbd4a32e9124
<pre>
Use -emit-clang-header-min-access only if supported by swiftc
<a href="https://bugs.webkit.org/show_bug.cgi?id=315689">https://bugs.webkit.org/show_bug.cgi?id=315689</a>

Reviewed by Adrian Taylor.

This flag is new in Swift 6.3, so use it only if available.

Canonical link: <a href="https://commits.webkit.org/314034@main">https://commits.webkit.org/314034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92ffa4ab0963c9322d4dd972437a29d0e92fd615

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173869 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128087 "Passed tests") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167793 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30393 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; Running layout-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148130 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108633 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29455 "4 new passes 4 failures") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21628 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156985 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC; Running jscore-test") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139343 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Running run-api-tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176392 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25726 "Built successfully and passed tests") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136407 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38387 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136371 "Found 2 new API test failures: TestWebKit:WebKit.LoadPageAfterCrash, TestWebKit:WebKit.MouseMoveAfterCrash (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36764 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147641 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101296 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31643 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24498 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197237 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37585 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51813 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36983 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2564 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->