### PR TITLE
[Cocoa] imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-a-bitrate.html and other tests are flaky failures

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2167,8 +2167,6 @@ webkit.org/b/306294 http/wpt/offscreen-canvas/transferToImageBitmap-webgl.html [
 
 webkit.org/b/306570 [ Tahoe arm64 ] http/tests/webcodecs/video-decoder-callbacks-do-not-leak.html [ Pass Failure ]
 
-webkit.org/b/306629 [ Release arm64 ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-video-bitrate.html [ Pass Failure ]
-
 webkit.org/b/310569 imported/w3c/web-platform-tests/webrtc/transfer-datachannel.html [ Pass Failure ]
 
 webkit.org/b/306301 [ x86_64 ] http/tests/webgpu/webgpu/api/validation/state/device_lost/destroy.html [ Failure ]
@@ -2182,8 +2180,6 @@ webkit.org/b/310823 [ Release arm64 ] imported/w3c/web-platform-tests/html/seman
 webkit.org/b/306808 http/tests/webgpu/webgpu/shader/validation/parse/blankspace.html [ Pass Failure ]
 
 webkit.org/b/306821 [ Tahoe ] fast/css-grid-layout/grid-item-display.html [ Pass Failure ]
-
-webkit.org/b/306380 [ Release arm64 ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-audio-bitrate.html [ Pass Failure ]
 
 webkit.org/b/309600 [ arm64 ] http/tests/xmlhttprequest/chunked-progress-event-expectedLength.html [ Pass Failure ]
 
@@ -2278,8 +2274,6 @@ webkit.org/b/308326 [ Debug ] imported/w3c/web-platform-tests/fetch/api/basic/er
 
 webkit.org/b/308586 imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html [ Pass Failure ]
 
-webkit.org/b/308594 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-framerate.html [ Pass Failure ]
-
 tiled-drawing/mac/margin-tiles-with-banner-view-overlay.html [ Skip ]
 tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-x.html [ Skip ]
 tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y.html [ Skip ]
@@ -2304,8 +2298,6 @@ webkit.org/b/311677 [ Tahoe+ Release ] imported/w3c/web-platform-tests/svg/anima
 webkit.org/b/313278 [ Tahoe+ ] imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-003.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/313346 [ Sequoia+ Debug ] imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-audio-jitterBufferTarget-stats.https.html [ Pass Failure ]
-
-webkit.org/b/313362 [ Sequoia+ ] imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html [ Pass Failure ]
 
 webkit.org/b/313554 [ Debug ] http/tests/security/javascriptURL/xss-ALLOWED-from-javascript-url-to-javscript-url.html [ Skip ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -898,8 +898,6 @@ webkit.org/b/140217 http/tests/navigation/forward-and-cancel.html [ Pass Failure
 
 webkit.org/b/153871 imported/w3c/web-platform-tests/html/semantics/document-metadata/styling/LinkStyle.html [ Pass Failure ]
 
-webkit.org/b/207146 media/media-source/media-source-seek-redundant-append.html [ Pass Timeout ]
-
 # These tests are already run with run-jsc-stress-tests
 webkit.org/b/153879 js/basic-set.html [ Skip ]
 
@@ -1193,10 +1191,6 @@ webkit.org/b/181494 accessibility/mac/aria-multiple-liveregions-notification.htm
 webkit.org/b/180260 http/wpt/resource-timing/rt-resources-per-worker.html [ Pass Failure ]
 
 webkit.org/b/181830 [ Debug ] media/video-main-content-allow-then-deny.html [ Pass Failure ]
-
-webkit.org/b/181565 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-a-bitrate.html [ Pass Failure ]
-webkit.org/b/181565 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-bitrate.html [ Pass Failure ]
-webkit.org/b/181565 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-framesize.html [ Pass Failure ]
 
 webkit.org/b/181969 fast/events/message-port.html [ Skip ]
 
@@ -1985,10 +1979,6 @@ editing/mac/dictionary-lookup/dictionary-lookup.html [ Pass Failure ]
 editing/selection/context-menu-text-selection-lookup.html [ Pass Failure ]
 
 # webkit.org/b/263226 (REGRESSION(268692@main?): [ macOS ] 7 tests under imported/w3c/web-platform-tests/media-source/mediasource-* are flaky failures.)
-imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-av-audio-bitrate.html [ Pass Failure ]
-imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-av-video-bitrate.html [ Pass Failure ]
-imported/w3c/web-platform-tests/media-source/mediasource-play-then-seek-back.html [ Pass Failure ]
-imported/w3c/web-platform-tests/media-source/mediasource-play.html [ Pass Failure ]
 imported/w3c/web-platform-tests/media-source/mediasource-remove-preserves-currentTime.html [ Pass Failure ]
 
 # Failing word-break: auto-phrase tests.

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2183,6 +2183,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/CaretAnimator.h
     platform/ColorChooser.h
     platform/ColorChooserClient.h
+    platform/CombinedMediaSample.h
     platform/CommonAtomStrings.h
     platform/ContentFilterUnblockHandler.h
     platform/ContentType.h

--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -137,10 +137,8 @@ void SampleMap::replaceSample(const MediaSample& original, Ref<MediaSample>&& re
     // key still sorts just ahead of the erased position; this holds for the
     // small shifts that `createCopyWithAdjustedStartTime` produces. A wrong
     // hint is merely a performance regression, not a correctness issue.
-    // The replacement carries the same payload as the original, so the total
-    // size is unchanged.
-    ASSERT(original.sizeInBytes() == replacement->sizeInBytes());
     ASSERT(original.trackID() == replacement->trackID());
+    m_totalSize += replacement->sizeInBytes() - original.sizeInBytes();
 
     MediaTime originalPts = original.presentationTime();
     auto originalDecodeKey = DecodeOrderSampleMap::KeyType(original.decodeTime(), originalPts);

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -716,6 +716,7 @@
 		1AFE119A0CBFFCC4003017FA /* JSSQLResultSetRowList.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AFE11980CBFFCC4003017FA /* JSSQLResultSetRowList.h */; };
 		1B124D8D1D380B7000ECDFB0 /* MediaSampleAVFObjC.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B124D8C1D380B7000ECDFB0 /* MediaSampleAVFObjC.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1BF9DB3C1D3973AD0026AEB7 /* MediaSample.h in Headers */ = {isa = PBXBuildFile; fileRef = CD641EC7181ED60100EE4C41 /* MediaSample.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		039EFFC7DE6A4CCE8F1E3F82 /* CombinedMediaSample.h in Headers */ = {isa = PBXBuildFile; fileRef = DC47AF7A18D643FAAEA191B3 /* CombinedMediaSample.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C010701192594DF008A4201 /* InlineTextBoxStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0106FF192594DF008A4201 /* InlineTextBoxStyle.h */; };
 		1C022F0022CFED68006DF01B /* libcompression.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C8D26D022C09CDE00D125F3 /* libcompression.tbd */; };
 		1C0939EB1A13E12900B788E5 /* CachedSVGFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0939E91A13E12900B788E5 /* CachedSVGFont.h */; };
@@ -21174,6 +21175,7 @@
 		CD641EB11818F5ED00EE4C41 /* MediaSourcePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaSourcePrivate.h; sourceTree = "<group>"; };
 		CD641EB21818F5ED00EE4C41 /* SourceBufferPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SourceBufferPrivate.h; sourceTree = "<group>"; };
 		CD641EC7181ED60100EE4C41 /* MediaSample.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSample.h; sourceTree = "<group>"; };
+		DC47AF7A18D643FAAEA191B3 /* CombinedMediaSample.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CombinedMediaSample.h; sourceTree = "<group>"; };
 		CD671C932F5BA34F00B387A2 /* PaintInfoInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PaintInfoInlines.h; sourceTree = "<group>"; };
 		CD671C952F5BA78100B387A2 /* LegacyRenderSVGModelObjectInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LegacyRenderSVGModelObjectInlines.h; sourceTree = "<group>"; };
 		CD671C972F5BA9EF00B387A2 /* LegacyRenderSVGResourceContainerInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LegacyRenderSVGResourceContainerInlines.h; sourceTree = "<group>"; };
@@ -39384,6 +39386,7 @@
 				C330A22113EC196B0000B45B /* ColorChooser.h */,
 				C37CDEBC149EF2030042090D /* ColorChooserClient.h */,
 				BCC8CFCA0986CD2400140BF2 /* ColorData.gperf */,
+				DC47AF7A18D643FAAEA191B3 /* CombinedMediaSample.h */,
 				839C69CD2810D11C00E69BAD /* CommonAtomStrings.cpp */,
 				839C69CE2810D11C00E69BAD /* CommonAtomStrings.h */,
 				A14090FC1AA51E480091191A /* ContentFilterUnblockHandler.h */,
@@ -44405,6 +44408,7 @@
 				0FEAF66B23BFC39E004030DA /* ColorUtilities.h in Headers */,
 				721B3ECF29680811004F5FF6 /* ColorWellPart.h in Headers */,
 				43EDD67F1B485DBF00640E75 /* CombinedFiltersAlphabet.h in Headers */,
+				039EFFC7DE6A4CCE8F1E3F82 /* CombinedMediaSample.h in Headers */,
 				26E944D91AC4B2DD007B85B5 /* CombinedURLFilters.h in Headers */,
 				A584FE351864D5AF00843B10 /* CommandLineAPIHost.h in Headers */,
 				A584FE2C1863870F00843B10 /* CommandLineAPIModule.h in Headers */,

--- a/Source/WebCore/platform/CombinedMediaSample.h
+++ b/Source/WebCore/platform/CombinedMediaSample.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MediaSample.h"
+#include <wtf/Assertions.h>
+#include <wtf/Ref.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+// Bundles N non-displaying decode prerequisites with a displaying sample,
+// presenting itself with the displaying sample's timing.
+//
+// SourceBufferPrivate's coded-frame processing uses this to keep out-of-order
+// decode prerequisites alive when an incoming sample's PTS shadows their
+// original presentation slots. Without it, those prerequisites would be
+// cascade-evicted, leaving a gap in the buffered range until the next random
+// access point.
+//
+// Lives only in the trackBuffer's sample storage; the trackBuffer's enqueue
+// path unpacks it into its constituent samples at the decode-queue boundary,
+// so platform-specific renderer code never sees a CombinedMediaSample.
+class CombinedMediaSample final : public MediaSample {
+public:
+    // `prerequisites` are inner samples that decode but do not display.
+    // Each must already be non-displaying and have a (DTS, PTS) key distinct
+    // from `displaying` and from every other prerequisite. Their DTS may be
+    // less than or greater than `displaying`'s — the trackBuffer's enqueue
+    // path inserts each sample into the decode queue using its own key, so
+    // ordering is recovered there. `displaying` is the sample whose timing
+    // the combined sample reports.
+    //
+    // Nesting is normalized away: any `prerequisites` entry that is itself a
+    // CombinedMediaSample contributes its own prerequisites + its displaying
+    // sample as flat individual prerequisites of the resulting object. If
+    // `displaying` is already a CombinedMediaSample, the new prerequisites
+    // are prepended to its existing ones and its inner displaying sample is
+    // adopted as the new displaying — so no caller ever has to look through
+    // a CombinedMediaSample wrapping another CombinedMediaSample.
+    static Ref<CombinedMediaSample> create(Vector<Ref<MediaSample>>&& prerequisites, Ref<MediaSample>&& displaying)
+    {
+        auto flattened = flattenPrerequisites(WTF::move(prerequisites));
+        if (RefPtr combined = dynamicDowncast<CombinedMediaSample>(displaying)) {
+            flattened.appendVector(combined->m_prerequisiteSamples);
+            return adoptRef(*new CombinedMediaSample(WTF::move(flattened), combined->m_displayingSample.copyRef()));
+        }
+
+        return adoptRef(*new CombinedMediaSample(WTF::move(flattened), WTF::move(displaying)));
+    }
+
+    const Vector<Ref<MediaSample>>& prerequisiteSamples() const { return m_prerequisiteSamples; }
+    MediaSample& displayingSample() const { return m_displayingSample.get(); }
+
+    // MediaSample overrides — timing forwarded to the displaying sample so the
+    // trackBuffer's (DTS, PTS) keys stay unique.
+    MediaTime presentationTime() const final { return m_displayingSample->presentationTime(); }
+    MediaTime decodeTime()       const final { return m_displayingSample->decodeTime(); }
+    MediaTime duration()         const final { return m_displayingSample->duration(); }
+    TrackID trackID()            const final { return m_displayingSample->trackID(); }
+    FloatSize presentationSize() const final { return m_displayingSample->presentationSize(); }
+    SampleFlags flags()          const final { return m_displayingSample->flags(); }
+    Type type()                  const final { return Type::Combined; }
+
+    size_t sizeInBytes() const final
+    {
+        size_t total = m_displayingSample->sizeInBytes();
+        for (auto& sample : m_prerequisiteSamples)
+            total += sample->sizeInBytes();
+        return total;
+    }
+
+    // CombinedMediaSample is never enqueued to the renderer directly.
+    PlatformSample platformSample() const final
+    {
+        ASSERT_NOT_REACHED();
+        return m_displayingSample->platformSample();
+    }
+
+    // Inner-sample timing is set at construction. The trackBuffer should not
+    // reassign timing of a sample after it has been added.
+    void offsetTimestampsBy(const MediaTime&) final { ASSERT_NOT_REACHED(); }
+    void setTimestamps(const MediaTime&, const MediaTime&) final { ASSERT_NOT_REACHED(); }
+
+    // Used by the trackBuffer's preroll path: build a new combined sample
+    // whose displaying sample has itself been replaced with its non-displaying
+    // copy. The prerequisites were already non-displaying.
+    Ref<MediaSample> createNonDisplayingCopy() const final
+    {
+        return adoptRef(*new CombinedMediaSample(copyToVectorOf<Ref<MediaSample>>(m_prerequisiteSamples), m_displayingSample->createNonDisplayingCopy()));
+    }
+
+private:
+    CombinedMediaSample(Vector<Ref<MediaSample>>&& prerequisites, Ref<MediaSample>&& displaying)
+        : m_prerequisiteSamples(WTF::move(prerequisites))
+        , m_displayingSample(WTF::move(displaying))
+    {
+    }
+
+    static Vector<Ref<MediaSample>> flattenPrerequisites(Vector<Ref<MediaSample>>&& prerequisites)
+    {
+        if (!std::any_of(prerequisites.begin(), prerequisites.end(), [](auto& sample) {
+            return is<CombinedMediaSample>(sample);
+        }))
+            return prerequisites;
+
+        Vector<Ref<MediaSample>> flattened;
+        flattened.reserveInitialCapacity(prerequisites.size());
+        for (auto& prereq : prerequisites) {
+            if (RefPtr combined = dynamicDowncast<CombinedMediaSample>(prereq.get())) {
+                flattened.appendVector(combined->m_prerequisiteSamples);
+                flattened.append(combined->m_displayingSample->createNonDisplayingCopy());
+            } else
+                flattened.append(prereq);
+        }
+
+        return flattened;
+    }
+
+    const Vector<Ref<MediaSample>> m_prerequisiteSamples;
+    const Ref<MediaSample> m_displayingSample;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::CombinedMediaSample)
+    static bool isType(const WebCore::MediaSample& sample) { return sample.type() == WebCore::MediaSample::Type::Combined; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/MediaSample.h
+++ b/Source/WebCore/platform/MediaSample.h
@@ -129,6 +129,7 @@ public:
         MockSampleBox,
         CMSampleBuffer,
         GStreamerSample,
+        Combined,
     };
     virtual Type type() const = 0;
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(MEDIA_SOURCE)
 
 #include "AudioTrackPrivate.h"
+#include "CombinedMediaSample.h"
 #include "Logging.h"
 #include "MediaDescription.h"
 #include "MediaSample.h"
@@ -1479,18 +1480,69 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
             } while (false);
         }
 
-        // 1.15 Remove decoding dependencies of the coded frames removed in the previous step:
+        // 1.15 Remove all possible decoding dependencies on the coded frames removed in the
+        // previous two steps by removing all coded frames from track buffer between those
+        // frames removed in the previous two steps and the next random access point after
+        // those removed frames.
         DecodeOrderSampleMap::MapType dependentSamples;
+        Vector<std::pair<Ref<MediaSample>, Ref<CombinedMediaSample>>> replacedSamples;
         if (!erasedSamples.empty()) {
-            // If detailed information about decoding dependencies is available:
-            // FIXME: Add support for detailed dependency information
-
-            // Otherwise: Remove all coded frames between the coded frames removed in the previous step
-            // and the next random access point after those removed frames.
             auto firstDecodeIter = trackBuffer.samples().decodeOrder().findSampleWithDecodeKey(erasedSamples.decodeOrder().begin()->first);
             auto lastDecodeIter = trackBuffer.samples().decodeOrder().findSampleWithDecodeKey(erasedSamples.decodeOrder().rbegin()->first);
             auto nextSyncIter = trackBuffer.samples().decodeOrder().findSyncSampleAfterDecodeIterator(lastDecodeIter);
-            dependentSamples.insert(firstDecodeIter, nextSyncIter);
+
+            // For out-of-order samples, avoid removing samples whose presentation times are
+            // earlier than the replacement frame, but depend upon samples with presentation
+            // times later than the replacement frame by marking the dependency frames as
+            // non-displaying and combining these samples with the remaining displaying sample.
+            // Instead of removing those samples, mark them as non-displaying and combine them
+            // with the subsequent, earlier display time samples.
+
+            DecodeOrderSampleMap::KeyType decodeKey(sample->decodeTime(), sample->presentationTime());
+
+            // Only consider keeping samples whose PTS and DTS are both earlier than sample.
+            // First, segment the range of dependant samples into those whose DTS is greater
+            // than sample. If all such samples have DTS after sample, simplay add the entire
+            // range and continue.
+            if (firstDecodeIter->first >= decodeKey)
+                dependentSamples.insert(firstDecodeIter, nextSyncIter);
+            else {
+                // Otherwise, find the first sample in the dependant samples whose DTS is greater
+                // than sample, and add that sample and all subsequent samples to the erase list:
+                auto nextSampleInDecodeOrder = trackBuffer.samples().decodeOrder().findSampleAfterDecodeKey(decodeKey);
+                dependentSamples.insert(nextSampleInDecodeOrder, nextSyncIter);
+
+                // Then, iterate over the range of erased samples whose DTS is less than sample.
+                for (auto it = firstDecodeIter; it != nextSampleInDecodeOrder; ++it) {
+                    Ref existing = it->second;
+
+                    // If the sample's PTS < sample, continue without erasing the sample.
+                    if (existing->presentationTime() < sample->presentationTime())
+                        continue;
+
+                    // However, if the sample's PTS >= sample, search forward for a sample
+                    // whose PTS < sample.
+                    auto nextSample = std::find_if(it, nextSampleInDecodeOrder, [&] (auto& next) {
+                        return next.second->presentationTime() < sample->presentationTime();
+                    });
+
+                    // If no such sample exists, remove the remaining samples and break:
+                    if (nextSample == nextSampleInDecodeOrder) {
+                        dependentSamples.insert(it, nextSample);
+                        break;
+                    }
+
+                    // Mark the dependent samples as erased:
+                    dependentSamples.insert(it, nextSample);
+
+                    // Then collapse those same samples into new CombinedMediaSamples:
+                    Vector<Ref<MediaSample>> prereqs;
+                    for (auto& value : std::ranges::subrange(it, nextSample))
+                        prereqs.append(value.second->createNonDisplayingCopy());
+                    replacedSamples.append(std::make_pair(nextSample->second.copyRef(), CombinedMediaSample::create(WTF::move(prereqs), nextSample->second.copyRef())));
+                    it = nextSample;
+                }
+            }
 
             // Proposed amendment to "Coded Frame Processing" tracked at
             // w3c/media-source#374 (SAP Type 2 decode-shadowed orphan cleanup).
@@ -1515,6 +1567,9 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
             }
 
             PlatformTimeRanges erasedRanges = removeSamplesFromTrackBuffer(dependentSamples, trackBuffer, "didReceiveSample"_s);
+
+            for (auto [original, replacement] : replacedSamples)
+                trackBuffer.replaceSample(original, WTF::move(replacement));
 
             // Only force the TrackBuffer to re-enqueue if the removed ranges overlap with enqueued and possibly
             // not yet displayed samples.

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(MEDIA_SOURCE)
 
+#include "CombinedMediaSample.h"
 #include "Logging.h"
 #include <ranges>
 #include <wtf/CryptographicallyRandomNumber.h>
@@ -101,7 +102,6 @@ void TrackBuffer::adjustSampleStartTime(MediaSample& original, const MediaTime& 
 
     MediaTime replacementStart = replacement->presentationTime();
     MediaTime replacementEnd = replacement->presentationEndTime();
-    DecodeOrderSampleMap::KeyType replacementDecodeKey(replacement->decodeTime(), replacementStart);
 
     PlatformTimeRanges invertedRange(originalStart, originalEnd);
     invertedRange.invert();
@@ -116,8 +116,19 @@ void TrackBuffer::adjustSampleStartTime(MediaSample& original, const MediaTime& 
     // erase() is a valid insertion-point hint for the adjusted entry.
     auto queueIt = m_decodeQueue.find(originalDecodeKey);
     if (queueIt != m_decodeQueue.end()) {
-        auto hint = m_decodeQueue.erase(queueIt);
-        m_decodeQueue.insert(hint, { replacementDecodeKey, WTF::move(replacement) });
+        m_decodeQueue.erase(queueIt);
+        insertIntoDecodeQueue(WTF::move(replacement));
+    }
+}
+
+void TrackBuffer::replaceSample(const MediaSample& original, Ref<MediaSample>&& replacement)
+{
+    m_samples.replaceSample(original, replacement.copyRef());
+
+    auto queueIt = m_decodeQueue.find({ original.decodeTime(), original.presentationTime() });
+    if (queueIt != m_decodeQueue.end()) {
+        m_decodeQueue.erase(queueIt);
+        insertIntoDecodeQueue(WTF::move(replacement));
     }
 }
 
@@ -145,7 +156,7 @@ void TrackBuffer::addSample(MediaSample& sample)
     // with earlier timestamps are enqueued. The decode queue is not FIFO, but rather an ordered map.
     DecodeOrderSampleMap::KeyType decodeKey(sample.decodeTime(), sample.presentationTime());
     if (lastEnqueuedDecodeKey().first.isInvalid() || decodeKey > lastEnqueuedDecodeKey()) {
-        auto result = decodeQueue().insert(DecodeOrderSampleMap::MapType::value_type(decodeKey, sample));
+        auto result = insertIntoDecodeQueue(Ref { sample });
         auto it = result.first;
         if (it == decodeQueue().begin())
             m_minimumEnqueuedPresentationTime = sample.presentationTime();
@@ -262,6 +273,22 @@ void TrackBuffer::updateMinimumUpcomingPresentationTime()
         m_minimumEnqueuedPresentationTime = MediaTime::invalidTime();
 }
 
+std::pair<DecodeOrderSampleMap::iterator, bool> TrackBuffer::insertIntoDecodeQueue(Ref<MediaSample>&& sample)
+{
+    if (RefPtr combined = dynamicDowncast<CombinedMediaSample>(sample.get())) {
+        for (auto& prerequisite : combined->prerequisiteSamples()) {
+            DecodeOrderSampleMap::KeyType key(prerequisite->decodeTime(), prerequisite->presentationTime());
+            m_decodeQueue.insert({ key, prerequisite.copyRef() });
+        }
+        Ref displaying = combined->displayingSample();
+        DecodeOrderSampleMap::KeyType key(displaying->decodeTime(), displaying->presentationTime());
+        return m_decodeQueue.insert({ key, WTF::move(displaying) });
+    }
+
+    DecodeOrderSampleMap::KeyType key(sample->decodeTime(), sample->presentationTime());
+    return m_decodeQueue.insert({ key, WTF::move(sample) });
+}
+
 bool TrackBuffer::reenqueueMediaForTime(const MediaTime& time, const MediaTime& timeFudgeFactor, bool isEnded)
 {
     clearDecodeQueue();
@@ -304,28 +331,23 @@ bool TrackBuffer::reenqueueMediaForTime(const MediaTime& time, const MediaTime& 
         return false;
 
     // Fill the decode queue with the non-displaying samples.
-    for (auto iter = reverseLastSyncSampleIter; iter != reverseCurrentSampleIter; --iter) {
-        Ref copy = Ref { iter->second }->createNonDisplayingCopy();
-        DecodeOrderSampleMap::KeyType decodeKey(copy->decodeTime(), copy->presentationTime());
-        m_decodeQueue.insert(DecodeOrderSampleMap::MapType::value_type(decodeKey, WTF::move(copy)));
-    }
+    for (auto iter = reverseLastSyncSampleIter; iter != reverseCurrentSampleIter; --iter)
+        insertIntoDecodeQueue(Ref { iter->second }->createNonDisplayingCopy());
 
     MediaTime previousSampleTime;
 
     // Fill the decode queue with the remaining samples.
     if (currentSampleDTSIterator != m_samples.decodeOrder().end()) {
-        m_decodeQueue.insert(*currentSampleDTSIterator);
+        insertIntoDecodeQueue(currentSampleDTSIterator->second.copyRef());
         m_minimumEnqueuedPresentationTime = Ref { currentSampleDTSIterator->second }->presentationTime();
         previousSampleTime = m_minimumEnqueuedPresentationTime;
     }
     for (auto iter = ++currentSampleDTSIterator; iter != m_samples.decodeOrder().end(); ++iter) {
         Ref sample = iter->second;
         if (sample->presentationTime() < time) {
-            Ref copy = sample->createNonDisplayingCopy();
-            DecodeOrderSampleMap::KeyType decodeKey(copy->decodeTime(), copy->presentationTime());
-            m_decodeQueue.insert(DecodeOrderSampleMap::MapType::value_type(decodeKey, WTF::move(copy)));
+            insertIntoDecodeQueue(sample->createNonDisplayingCopy());
         } else {
-            m_decodeQueue.insert(*iter);
+            insertIntoDecodeQueue(sample.copyRef());
             if (sample->presentationTime() < m_minimumEnqueuedPresentationTime)
                 m_minimumEnqueuedPresentationTime = sample->presentationTime();
             if (std::exchange(previousSampleTime, sample->presentationTime()) > sample->presentationTime())

--- a/Source/WebCore/platform/graphics/TrackBuffer.h
+++ b/Source/WebCore/platform/graphics/TrackBuffer.h
@@ -58,6 +58,8 @@ public:
     // SampleMap and m_decodeQueue, and adjusts m_buffered to match.
     void adjustSampleStartTime(MediaSample& original, const MediaTime& offset);
 
+    void replaceSample(const MediaSample& original, Ref<MediaSample>&& replacement);
+
     bool reenqueueMediaForTime(const MediaTime&, const MediaTime& timeFudgeFactor, bool isEnded = false);
     MediaTime findSeekTimeForTargetTime(const MediaTime& targetTime, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold);
     int64_t removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime);
@@ -132,6 +134,8 @@ private:
     DecodeOrderSampleMap::MapType& decodeQueue() LIFETIME_BOUND { return m_decodeQueue; }
     void updateMinimumUpcomingPresentationTime();
     void clearDecodeQueue();
+
+    std::pair<DecodeOrderSampleMap::iterator, bool> insertIntoDecodeQueue(Ref<MediaSample>&&);
 
     // Result of attempting to split the sample whose presentation range contains a given time.
     struct DivideResult {


### PR DESCRIPTION
#### 945c23c4b010e35f62451b93e3319cfe1ac1c971
<pre>
[Cocoa] imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-a-bitrate.html and other tests are flaky failures
<a href="https://rdar.apple.com/176682211">rdar://176682211</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315707">https://bugs.webkit.org/show_bug.cgi?id=315707</a>

Reviewed by NOBODY (OOPS!).

When MSE &quot;Coded Frame Processing&quot; step 1.14 erases an existing coded
frame that overlaps an incoming one in presentation order, step 1.15
removes &quot;all possible decoding dependencies&quot; by clearing every sample in
decode order between the first erased frame and the next random access
point. For reordered streams (B-frames, or any media where presentation
order differs from decode order) this cascade routinely sweeps away
samples whose presentation slots end strictly before the incoming
sample&apos;s PTS — samples that would still be displayable except that
they share a decode chain with frames in the shadowed range.

The visible symptom is a gap in SourceBuffer.buffered between the kept
tail of the outgoing segment and the start of the incoming one. When
that gap exceeds the renderer&apos;s tolerance (timeFudgeFactor, ~83ms),
the ready state drops mid-playback and the stream stalls. The
mediasource-config-change-mp4-v-framerate WPT test reproduces this with
two H.264 segments at different framerates appended at offsets 0 and
0.5s; before this change it failed ~97% of the time on macOS, leaving
a 108ms gap.

Replace the unconditional sweep with a categorize-and-fold pass against
the incoming frame&apos;s (DTS, PTS):

  - Forward-dependent (existing.DTS &gt;= incoming.DTS): cascade-remove.
    The decode chain through the erased samples is broken; these can&apos;t
    decode after the incoming frame replaces their references.
  - Pre-incoming (existing.DTS &lt; incoming.DTS, existing.PTS &lt;
    incoming.PTS, not in erasedSamples): keep as a regular displaying
    sample. Its presentation slot is before the incoming frame&apos;s, and
    its decode chain is preserved via the prereq fold below.
  - Shadowed (existing.DTS &lt; incoming.DTS, existing.PTS &gt;= incoming.PTS,
    or directly in erasedSamples): non-displayable because the incoming
    frame covers its presentation slot, but still required as a decode
    prerequisite for the kept samples above. Replace its trackBuffer
    entry with a non-displaying copy bundled into a CombinedMediaSample
    whose displaying field is the first surviving displaying sample.

CombinedMediaSample is a new MediaSample subclass that bundles N
non-displaying prerequisites with one displaying sample. It forwards
all timing and metadata methods to the displaying sample, so the
trackBuffer&apos;s SampleMap (keyed by (DTS, PTS)) and m_buffered (indexed
entry with a non-displaying copy bundled into a CombinedMediaSample
whose displaying field is the first surviving displaying sample.

* Source/WebCore/platform/CombinedMediaSample.h: Added.
* Source/WebCore/platform/MediaSample.h: Add Type::Combined to
  Type enum so dynamicDowncast&lt;CombinedMediaSample&gt; works.
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
  (WebCore::SourceBufferPrivate::processMediaSample): Categorize step
  1.15&apos;s scan range by (DTS, PTS) and fold shadowed samples into a
  CombinedMediaSample at the first surviving displaying sample.
* Source/WebCore/platform/graphics/TrackBuffer.h:
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
  (WebCore::TrackBuffer::replaceSample): Added — used by the cascade
  fold to swap a displaying sample with its CombinedMediaSample
  wrapper in both m_samples and m_decodeQueue.
  (WebCore::TrackBuffer::insertIntoDecodeQueue): Added — single
  insertion point for m_decodeQueue that unpacks CombinedMediaSamples
  into their constituent flat samples.
  (WebCore::TrackBuffer::addSample):
  (WebCore::TrackBuffer::adjustSampleStartTime):
  (WebCore::TrackBuffer::reenqueueMediaForTime): Route m_decodeQueue
  insertions through insertIntoDecodeQueue.
* Source/WebCore/Modules/mediasource/SampleMap.cpp:
  (WebCore::SampleMap::replaceSample): Drop the equal-sizeInBytes
  assertion. A CombinedMediaSample replacement carries the prereqs&apos;
  bytes in addition to the displaying sample&apos;s, so the byte sizes
  legitimately differ.
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj: Add
  CombinedMediaSample.h.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/945c23c4b010e35f62451b93e3319cfe1ac1c971

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122349 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128301 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90307 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168051 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108826 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29656 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28276 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21889 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176657 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29520 "Found 1 new failure in platform/graphics/SourceBufferPrivate.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27755 "Exiting early after 10 failures. 114 tests run. 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136615 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38651 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32412 "Exiting early after 10 failures. 87 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136558 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39341 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147846 "Exiting early after 10 failures. 114 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101649 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31836 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24713 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37851 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110923 "Found 1 new failure in platform/graphics/SourceBufferPrivate.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37248 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2789 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37494 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37392 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->