### PR TITLE
Cherry-pick(s) 845230f29cf4. rdar://176062010

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
@@ -146,6 +146,14 @@ size_t GetVertexCountWithConversion(BufferMtl *srcBuffer,
     // Count how many strides fit remaining space.
     size_t effectiveStride = binding.getStride() > 0 ? binding.getStride() : srcFormatSize;
     return 1 + static_cast<size_t>(bytes.ValueOrDie()) / effectiveStride;
+<<<<<<< HEAD
+=======
+}
+inline size_t GetIndexCount(BufferMtl *srcBuffer, size_t offset, gl::DrawElementsType indexType)
+{
+    size_t elementSize = gl::GetDrawElementsTypeSize(indexType);
+    return (srcBuffer->size() - offset) / elementSize;
+>>>>>>> 845230f29cf4 ([ANGLE] Metal backend: Fix crash on OOB vertex attribute offset in syncDirtyAttrib)
 }
 
 inline void SetDefaultVertexBufferLayout(mtl::VertexBufferLayoutDesc *layout)


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176062010 to main. The following sources [0fe9ff8c6712] will still need to be cherry-picked once the conflict is resolved.

```[ANGLE] Metal backend: Fix crash on OOB vertex attribute offset in syncDirtyAttrib
https://bugs.webkit.org/show_bug.cgi?id=309989
rdar://172179424

Reviewed by Kimmo Kinnunen.

VertexArrayMtl::syncDirtyAttrib's non-conversion path stores
binding.getOffset() unchecked and crashes in VertexArrayMtl::setupDraw
when the offset exceeds the buffer size.

Fix by hoisting GetVertexCount check before the needConversion branch so
both paths are guarded, clamping to safe defaults when no vertices fit.
Also rewrite GetVertexCount/GetVertexCountWithConversion using
CheckedNumeric to handle negative offsets and zero strides.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm:
(rx::VertexArrayMtl::syncDirtyAttrib):
(rx::VertexArrayMtl::convertVertexBuffer):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/VertexAttributeTest.cpp:

Originally-landed-as: 305413.586@rapid/safari-7624.2.5.110-branch (845230f29cf4). rdar://176062010

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c90945bb98081bc8371d0b5b2f96e6381b77e18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164846 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38330 "Hash 8c90945b for PR 65845 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31901 "Hash 8c90945b for PR 65845 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173881 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38664 "Hash 8c90945b for PR 65845 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38332 "Hash 8c90945b for PR 65845 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128092 "Passed tests") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167805 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/38664 "Hash 8c90945b for PR 65845 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/31901 "Hash 8c90945b for PR 65845 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108638 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/38664 "Hash 8c90945b for PR 65845 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/38332 "Hash 8c90945b for PR 65845 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21640 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/38664 "Hash 8c90945b for PR 65845 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/31901 "Hash 8c90945b for PR 65845 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176404 "Built successfully") | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/31901 "Hash 8c90945b for PR 65845 does not build (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136412 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38399 "Hash 8c90945b for PR 65845 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/38332 "Hash 8c90945b for PR 65845 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136376 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39089 "Hash 8c90945b for PR 65845 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/31901 "Hash 8c90945b for PR 65845 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101308 "Built successfully") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/39089 "Hash 8c90945b for PR 65845 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/31901 "Hash 8c90945b for PR 65845 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37597 "Hash 8c90945b for PR 65845 does not build (failure)") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36995 "Hash 8c90945b for PR 65845 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/31901 "Hash 8c90945b for PR 65845 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37243 "Hash 8c90945b for PR 65845 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37143 "Hash 8c90945b for PR 65845 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->