### PR TITLE
calendar.google.com: Safari: Print job fails to start when attempting to print Google Calendar

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1935,6 +1935,11 @@ std::optional<String> Quirks::needsCustomUserAgentOverride(const URL& url, const
     if (host == "outlook.live.com"_s)
         return chromeUserAgent;
 
+    // calendar.google.com rdar://173413224
+    // Gcal's non-Chromium print path serves a PDF whose OpenAction this.print() isn't honored by WebKit's PDF viewer; spoofing Chromium routes Safari to the JS-driven print path.
+    if (host == "calendar.google.com"_s)
+        return chromeUserAgent;
+
 #if PLATFORM(COCOA)
     // FIXME(rdar://148759791): Remove this once TikTok removes the outdated error message.
     if (hostDomain.string() == "tiktok.com"_s) {


### PR DESCRIPTION
#### 859b956d84059ad5c9718ed37a199aeb2b8e8e1b
<pre>
calendar.google.com: Safari: Print job fails to start when attempting to print Google Calendar
<a href="https://bugs.webkit.org/show_bug.cgi?id=315720">https://bugs.webkit.org/show_bug.cgi?id=315720</a>
<a href="https://rdar.apple.com/173413224">rdar://173413224</a>

Reviewed by NOBODY (OOPS!).

The problem: clicking &quot;Print&quot; inside Gcal&apos;s print preview silently does
nothing in Safari. Gcal has 2 different print paths based on browser:
1) Chromium browsers: a load handler on a hidden iframe calls
iframe.contentWindow.print() once the iframe loads
2) non-Chromium browsers (Firefox, Safari): the server returns a PDF with
an embedded OpenAction that runs this.print() in the PDF&apos;s own JavaScript,
which auto-fires the print dialog when the PDF loads

Firefox prints fine because Gecko honors PDF OpenAction execution. WebKit&apos;s
PDF viewer doesn&apos;t, so stock Safari hits the same non-Chromium path Firefox
does but the auto-print never fires.

The fix: have UA override return a Chrome/macOS string for Gcal so Gcal&apos;s
JS routes Safari to the Chromium path (which calls print() from JS, no PDF
OpenAction needed). Matches the existing pattern for outlook.live.com.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsCustomUserAgentOverride):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/859b956d84059ad5c9718ed37a199aeb2b8e8e1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174165 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122380 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128321 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90319 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108846 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29679 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28303 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21920 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176688 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29565 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136640 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136582 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147873 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101680 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24740 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110954 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37279 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2816 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37525 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37423 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->