### PR TITLE
Autofocus does not focus a host element with a delegatesFocus shadow root

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/supported-elements-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/supported-elements-expected.txt
@@ -2,7 +2,7 @@
 PASS Contenteditable element should support autofocus
 PASS Element with tabindex should support autofocus
 PASS Non-HTMLElement should not support autofocus
-FAIL Host element with delegatesFocus should support autofocus assert_equals: expected Element node <div autofocus=""></div> but got Element node <body><div autofocus=""></div></body>
+PASS Host element with delegatesFocus should support autofocus
 PASS Host element with delegatesFocus including no focusable descendants should be skipped
 PASS Area element should support autofocus
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6361,8 +6361,12 @@ void Document::flushAutofocusCandidates()
             continue;
 
         // FIXME: Need to ignore if the inclusive ancestor documents has a target element.
-        // FIXME: Use the result of getting the focusable area for element if element is not focusable.
-        if (element->isFocusable()) {
+        bool isFocusableArea = element->isFocusable();
+        if (!isFocusableArea) {
+            if (RefPtr root = element->shadowRoot(); root && root->delegatesFocus())
+                isFocusableArea = !!Element::findFocusDelegateForTarget(*root, FocusTrigger::Other);
+        }
+        if (isFocusableArea) {
             clearAutofocusCandidates();
             page->setAutofocusProcessed();
             element->runFocusingStepsForAutofocus();


### PR DESCRIPTION
#### 743a05e255e03131244e433daf3de1afafa8132b
<pre>
Autofocus does not focus a host element with a delegatesFocus shadow root
<a href="https://bugs.webkit.org/show_bug.cgi?id=315722">https://bugs.webkit.org/show_bug.cgi?id=315722</a>
<a href="https://rdar.apple.com/178098507">rdar://178098507</a>

Reviewed by Ryosuke Niwa.

Per spec [1], &quot;If target is not a focusable area, then set target to the
result of getting the focusable area for target.&quot;

Document::flushAutofocusCandidates only runs the focusing steps when the
candidate is itself focusable, so a &lt;div autofocus&gt; whose shadow root has
delegatesFocus is dropped even when the shadow tree has a focus delegate.

Treat the host as a focusable area when findFocusDelegateForTarget on its
delegatesFocus shadow root returns a delegate; Element::focus() then
retargets to the delegate as it already does for direct focus() calls.

[1] <a href="https://html.spec.whatwg.org/multipage/interaction.html#flush-autofocus-candidates">https://html.spec.whatwg.org/multipage/interaction.html#flush-autofocus-candidates</a>

* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/supported-elements-expected.txt: Progression
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::flushAutofocusCandidates):

Canonical link: <a href="https://commits.webkit.org/314112@main">https://commits.webkit.org/314112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a272f281d5f6156b0f533452c2eb199427726b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174097 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122312 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a3fe65e-c5ae-44bd-8141-6cd4c6681007) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38547 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128271 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98290e19-6cf9-49fa-8e00-74d6b7d5b6a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108797 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d37e536-2410-4f88-859a-267542a39fbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29626 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28244 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21852 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176620 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29506 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136588 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136532 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36819 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147814 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101604 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31804 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24681 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37814 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110886 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37211 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2756 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37457 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37355 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->