### PR TITLE
[Site Isolation] WebPageProxy::scheduleFullEditorStateUpdate() should send to the correct web process

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3758,12 +3758,18 @@ void WebPageProxy::setMaintainsInactiveSelection(bool newValue)
     m_maintainsInactiveSelection = newValue;
 }
 
+// FIXME: (rdar://178266745) It is unclear if this function is needed.
+// EWS testing shows that removing it doesn't break any tests but more
+// thorough manual testing should be done before removing.
 void WebPageProxy::scheduleFullEditorStateUpdate()
 {
     if (!hasRunningProcess())
         return;
 
-    send(Messages::WebPage::ScheduleFullEditorStateUpdate());
+    if (RefPtr frame = focusedFrame())
+        sendToProcessContainingFrame(frame->frameID(), Messages::WebPage::ScheduleFullEditorStateUpdate());
+    else
+        send(Messages::WebPage::ScheduleFullEditorStateUpdate());
 }
 
 void WebPageProxy::selectAll()


### PR DESCRIPTION
#### 2e23f5c960aed492c06f0924e5eba92660911d6a
<pre>
[Site Isolation] WebPageProxy::scheduleFullEditorStateUpdate() should send to the correct web process
<a href="https://bugs.webkit.org/show_bug.cgi?id=315721">https://bugs.webkit.org/show_bug.cgi?id=315721</a>
<a href="https://rdar.apple.com/178098149">rdar://178098149</a>

Reviewed by Aditya Keerthi.

Currently, WebPageProxy::scheduleFullEditorStateUpdate() only ever requests an
editor state update from the main frame&apos;s web process. But with site isolation,
a WebPageProxy is responsible for multiple web processes, so it should request
the editor state update from the process that currently contains the focused
frame, with the main frame&apos;s process as a backup.

There&apos;s no test because its unclear what this fixes. There are four callers of
this function, all in WKContentViewInteraction:

1. insertText
   I manually tested that autocapitalization of words works with or without
   changes to this function.

2. _scrollingNodeScrollingDidEnd
   This was added in <a href="https://bugs.webkit.org/show_bug.cgi?id=290393.">https://bugs.webkit.org/show_bug.cgi?id=290393.</a> I verified
   that the test added there does pass with and without site isolation on (even
   when the test itself is refactored to be in a cross-site iframe).

3. _continueElementDidFocus
   This was added in <a href="https://bugs.webkit.org/show_bug.cgi?id=214272.">https://bugs.webkit.org/show_bug.cgi?id=214272.</a> There was
   no test added there.

4. willFinishIgnoringCalloutBarFadeAfterPerformingAction
   This was added in <a href="https://bugs.webkit.org/show_bug.cgi?id=197532.">https://bugs.webkit.org/show_bug.cgi?id=197532.</a> The test
   fixed there was removed in <a href="https://bugs.webkit.org/show_bug.cgi?id=241903">https://bugs.webkit.org/show_bug.cgi?id=241903</a>
   because the functionality it tested was removed.

We could possibly remove this function. EWS shows that removing it doesn&apos;t break
any tests (see the radar). But more manual testing should be done before removing
it. So for now, we simply make it work with site isolation since it&apos;s possible
that things get fixed with site isolation on.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::scheduleFullEditorStateUpdate):

Canonical link: <a href="https://commits.webkit.org/314227@main">https://commits.webkit.org/314227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64d8034fa607e9c0a589b046a4d421e8eddfe1fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174391 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122604 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae25d093-f321-4b4c-b56f-4b7abeca9799) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128496 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90433 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22ddc4f0-9555-4698-a79e-a33654ca51b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109021 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0cec5f8f-100c-45b5-8a55-4d3ddd82dde5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29854 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28473 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22465 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139749 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176913 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29814 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136817 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136753 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39596 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101940 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25183 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32023 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24909 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197750 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38106 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111180 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/197750 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37503 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2987 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37751 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->