### PR TITLE
KeyedEncoderGeneric uses size_t with PersistentEncoder

### DIFF
--- a/Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp
+++ b/Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp
@@ -51,7 +51,7 @@ private:
 
 static std::optional<String> readString(WTF::Persistence::Decoder& decoder)
 {
-    std::optional<size_t> size;
+    std::optional<uint64_t> size;
     decoder >> size;
     if (!size)
         return std::nullopt;
@@ -110,7 +110,7 @@ KeyedDecoderGeneric::KeyedDecoderGeneric(std::span<const uint8_t> data)
                 ok = false;
             if (!ok)
                 break;
-            std::optional<size_t> size;
+            std::optional<uint64_t> size;
             decoder >> size;
             if (!size)
                 ok = false;

--- a/Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp
+++ b/Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<KeyedEncoder> KeyedEncoder::encoder()
 void KeyedEncoderGeneric::encodeString(const String& key)
 {
     auto result = key.tryGetUTF8([&](std::span<const char8_t> span) -> bool {
-        m_encoder << span.size();
+        m_encoder << static_cast<uint64_t>(span.size());
         m_encoder.encodeFixedLengthData(byteCast<uint8_t>(span));
         return true;
     });
@@ -51,7 +51,7 @@ void KeyedEncoderGeneric::encodeBytes(const String& key, std::span<const uint8_t
 {
     m_encoder << Type::Bytes;
     encodeString(key);
-    m_encoder << bytes.size();
+    m_encoder << static_cast<uint64_t>(bytes.size());
     m_encoder.encodeFixedLengthData(bytes);
 }
 


### PR DESCRIPTION
#### 115e5b4c502e5d6a9c6c65ecb62734fe968a0a4d
<pre>
KeyedEncoderGeneric uses size_t with PersistentEncoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=315723">https://bugs.webkit.org/show_bug.cgi?id=315723</a>

Reviewed by NOBODY (OOPS!).

KeyedEncoderGeneric.cpp and KeyedDecoderGeneric.cpp pass size_t
directly to WTF::Persistence::Encoder/Decoder. Whether that resolves
to an existing overload depends on platform typedefs:

  MSVC LLP64:  size_t == unsigned __int64 == uint64_t -&gt; compiles
  Linux LP64:  size_t == unsigned long    == uint64_t -&gt; compiles
  Darwin LP64: size_t == unsigned long, uint64_t == unsigned long long
                                                   -&gt; distinct types
                                                   -&gt; no overload

Today the only ports building these files are PlayStation and
Windows, so the issue is latent. Any port that compiles these on
Darwin (e.g. a generic-style WebCore build on macOS) fails to build.

Cast to uint64_t at the call sites so the wire format is intentional
and the code is portable. Matches the convention already used in
Source/WebKit/Platform/IPC/ArgumentCoders.h:464.

* Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp:
(WebCore::KeyedEncoderGeneric::encodeString):
(WebCore::KeyedEncoderGeneric::encodeBytes): Widen span.size() /
bytes.size() to uint64_t before encoding.

* Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp:
(WebCore::readString):
(WebCore::KeyedDecoderGeneric::KeyedDecoderGeneric): Decode sizes as
uint64_t. Wire format is unchanged on the platforms that build these
files today.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/115e5b4c502e5d6a9c6c65ecb62734fe968a0a4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122136 "") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128144 "3 flakes 5 failures") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/122136 "") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29502 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28115 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29287 "") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/164312 "Passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->