### PR TITLE
HTMLImageElement.decode() resolves spuriously after adoption, src change, or cached-image race

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2310,8 +2310,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/t
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/src-repeated-in-ancestor.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-iframe.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/invalid-src.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-w-reselect-on-resize.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-events.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-expected.txt
@@ -5,7 +5,7 @@ PASS HTMLImageElement.prototype.decode(), basic tests. Image with PNG data URL s
 PASS HTMLImageElement.prototype.decode(), basic tests. Image with SVG src decodes with undefined.
 PASS HTMLImageElement.prototype.decode(), basic tests. Non-existent src fails decode.
 PASS HTMLImageElement.prototype.decode(), basic tests. Inactive document fails decode.
-FAIL HTMLImageElement.prototype.decode(), basic tests. Adopted active image into inactive document fails decode. assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS HTMLImageElement.prototype.decode(), basic tests. Adopted active image into inactive document fails decode.
 PASS HTMLImageElement.prototype.decode(), basic tests. Adopted inactive image into active document succeeds.
 PASS HTMLImageElement.prototype.decode(), basic tests. Corrupt image in src fails decode.
 PASS HTMLImageElement.prototype.decode(), basic tests. Image (legacy) without src/srcset fails decode.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-expected.txt
@@ -1,0 +1,10 @@
+
+PASS HTMLImageElement.prototype.decode(), src/srcset mutation tests. src changes fail decode.
+PASS HTMLImageElement.prototype.decode(), src/srcset mutation tests. src changes fail decode; following good png decode succeeds.
+PASS HTMLImageElement.prototype.decode(), src/srcset mutation tests. src changes fail decode; following good svg decode succeeds.
+PASS HTMLImageElement.prototype.decode(), src/srcset mutation tests. src changes fail decode; following bad decode fails.
+PASS HTMLImageElement.prototype.decode(), src/srcset mutation tests. src changes to the same path succeed.
+PASS HTMLImageElement.prototype.decode(), src/srcset mutation tests. srcset changes fail decode.
+PASS HTMLImageElement.prototype.decode(), src/srcset mutation tests. srcset changes fail decode; following good decode succeeds.
+PASS HTMLImageElement.prototype.decode(), src/srcset mutation tests. srcset changes fail decode; following bad decode fails.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-svg.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-svg.tentative-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL SVGImageElement.prototype.decode(), href mutation tests. xlink:href changes fail decode. assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL SVGImageElement.prototype.decode(), href mutation tests. href changes fail decode. assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL SVGImageElement.prototype.decode(), href mutation tests. xlink:href changes fail decode; following good decode succeeds. assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL SVGImageElement.prototype.decode(), href mutation tests. href changes fail decode; following good decode succeeds. assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS SVGImageElement.prototype.decode(), href mutation tests. xlink:href changes fail decode.
+PASS SVGImageElement.prototype.decode(), href mutation tests. href changes fail decode.
+PASS SVGImageElement.prototype.decode(), href mutation tests. xlink:href changes fail decode; following good decode succeeds.
+PASS SVGImageElement.prototype.decode(), href mutation tests. href changes fail decode; following good decode succeeds.
 PASS SVGImageElement.prototype.decode(), href mutation tests. xlink:href changes fail decode; following bad decode fails.
 PASS SVGImageElement.prototype.decode(), href mutation tests. href changes fail decode; following bad decode fails.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-with-quick-attach-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-with-quick-attach-expected.txt
@@ -6,7 +6,7 @@ PASS HTMLImageElement.prototype.decode(), attach to DOM before promise resolves.
 FAIL HTMLImageElement.prototype.decode(), attach to DOM before promise resolves.: src in empty picture not cached assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS HTMLImageElement.prototype.decode(), attach to DOM before promise resolves.: src in empty picture cached
 FAIL HTMLImageElement.prototype.decode(), attach to DOM before promise resolves.: srcset in empty picture assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL HTMLImageElement.prototype.decode(), attach to DOM before promise resolves.: src in picture with source not cached assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL HTMLImageElement.prototype.decode(), attach to DOM before promise resolves.: src in picture with source cached assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL HTMLImageElement.prototype.decode(), attach to DOM before promise resolves.: srcset in picture with source assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS HTMLImageElement.prototype.decode(), attach to DOM before promise resolves.: src in picture with source not cached
+PASS HTMLImageElement.prototype.decode(), attach to DOM before promise resolves.: src in picture with source cached
+PASS HTMLImageElement.prototype.decode(), attach to DOM before promise resolves.: srcset in picture with source
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2162,9 +2162,6 @@ imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-upright-s
 [ Sonoma+ ] http/tests/media/video-served-as-text.html [ Failure ]
 [ Sonoma+ ] http/tests/media/video-throttled-load-metadata.html [ Failure ]
 
-# webkit.org/b/280091 REGRESSION (283643@main) : [ macOS  ] imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-svg.tentative.html is a flaky failure.
-imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-svg.tentative.html [ Pass Failure ]
-
 # webkit.org/b/280193 [ Sequoia ] fast/inline/justify-emphasi s-inline-box.html is a constant failure. 
 fast/inline/justify-emphasis-inline-box.html [ Failure ]
 

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -38,6 +38,7 @@
 #include "DocumentView.h"
 #include "ElementInlines.h"
 #include "Event.h"
+#include "EventLoop.h"
 #include "EventNames.h"
 #include "EventSender.h"
 #include "FrameDestructionObserverInlines.h"
@@ -353,6 +354,9 @@ void ImageLoader::didUpdateCachedImage(RelevantMutation relevantMutation, RefPtr
     if (newImage != oldImage || relevantMutation == RelevantMutation::Yes) {
         LOG_WITH_STREAM(LazyLoading, stream << " switching from old image " << oldImage.get() << " to image " << newImage.get() << " " << (newImage ? newImage->url() : URL()));
 
+        if (newImage != oldImage && hasPendingDecodePromises())
+            rejectDecodePromises("Aborted by source change."_s);
+
         m_hasPendingBeforeLoadEvent = false;
         if (m_hasPendingLoadEvent) {
             loadEventSender().cancelEvent(*this, eventNames().loadEvent);
@@ -510,8 +514,7 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
 
         setImageCompleteAndMaybeUpdateRenderer();
 
-        if (hasPendingDecodePromises())
-            decode();
+        decode();
         loadEventSender().dispatchEventSoon(*this, eventNames().loadEvent);
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
@@ -610,13 +613,21 @@ void ImageLoader::decode(Ref<DeferredPromise>&& promise)
         return;
     }
 
-    if (m_imageComplete)
-        decode();
+    if (m_imageComplete) {
+        Ref document = element().document();
+        document->eventLoop().queueMicrotask(document->vm(), [weakThis = WeakPtr { *this }]() mutable {
+            RefPtr protectedThis = weakThis;
+            if (!protectedThis || !protectedThis->m_imageComplete)
+                return;
+            protectedThis->decode();
+        });
+    }
 }
 
 void ImageLoader::decode()
 {
-    ASSERT(hasPendingDecodePromises());
+    if (!hasPendingDecodePromises())
+        return;
     
     if (!element().document().window()) {
         rejectDecodePromises("Inactive document."_s);
@@ -718,6 +729,8 @@ void ImageLoader::dispatchPendingLoadEvents(Page* page)
 
 void ImageLoader::elementDidMoveToNewDocument(Document& oldDocument)
 {
+    if (hasPendingDecodePromises())
+        rejectDecodePromises("Inactive document."_s);
     clearFailedLoadURL();
     clearImage();
     resetLazyImageLoading(oldDocument);


### PR DESCRIPTION
#### 7d9d2b24cc14a3246f0e777d7e791892ed6e89c4
<pre>
HTMLImageElement.decode() resolves spuriously after adoption, src change, or cached-image race
<a href="https://bugs.webkit.org/show_bug.cgi?id=315733">https://bugs.webkit.org/show_bug.cgi?id=315733</a>
<a href="https://rdar.apple.com/178118012">rdar://178118012</a>

Reviewed by Said Abou-Hallawa and Chris Dumez.

If ImageLoader is loading a new image or if the HTMLImageElement is moved
to another document, reject all the pending DecodePromises.

Calling the parameterless ImageLoader::decode() also has to be enqueued as
a microtask, per the HTML spec for HTMLImageElement.decode() [1].

[1] <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decode">https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decode</a>

* LayoutTests/TestExpectations: Unskip skipped test cases (since they were hanging before)
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-svg.tentative-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-with-quick-attach-expected.txt: Ditto
* LayoutTests/platform/mac/TestExpectations: Unskip skipped test case (because it was flaky earlier)
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::didUpdateCachedImage):
(WebCore::ImageLoader::notifyFinished):
(WebCore::ImageLoader::decode):
(WebCore::ImageLoader::elementDidMoveToNewDocument):

Canonical link: <a href="https://commits.webkit.org/314536@main">https://commits.webkit.org/314536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8afebd53f08553bad117792741e208494ec602d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123624 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129327 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31708 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109852 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30685 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29385 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23557 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177950 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30851 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137682 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137601 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37083 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148977 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103275 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32892 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25843 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39127 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112202 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38524 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3929 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38769 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38667 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->