### PR TITLE
Simplify NameValidation by using contains and containsOnly

### DIFF
--- a/Source/WebCore/dom/NameValidation.cpp
+++ b/Source/WebCore/dom/NameValidation.cpp
@@ -63,6 +63,11 @@ static constexpr bool NODELETE isInvalidDoctypeNameCharacter(char16_t c)
     return !c || isASCIIWhitespace(c) || c == '>';
 }
 
+static constexpr bool NODELETE isValidASCIIXMLNamePart(char16_t c)
+{
+    return isASCIIAlphanumeric(c) || c == ':' || c == '_' || c == '-' || c == '.';
+}
+
 // https://dom.spec.whatwg.org/#valid-element-name
 bool isValidElementName(StringView name)
 {
@@ -71,21 +76,11 @@ bool isValidElementName(StringView name)
 
     auto firstCharacter = name[0];
 
-    if (isASCIIAlpha(firstCharacter)) {
-        for (unsigned i = 1; i < name.length(); ++i) {
-            if (isInvalidElementNameCharacterAfterAlphaStart(name[i]))
-                return false;
-        }
-        return true;
-    }
+    if (isASCIIAlpha(firstCharacter))
+        return !name.contains(isInvalidElementNameCharacterAfterAlphaStart);
 
-    if (firstCharacter == ':' || firstCharacter == '_' || firstCharacter >= 0x80) {
-        for (unsigned i = 1; i < name.length(); ++i) {
-            if (!isValidElementNameContinuationCharacter(name[i]))
-                return false;
-        }
-        return true;
-    }
+    if (firstCharacter == ':' || firstCharacter == '_' || firstCharacter >= 0x80)
+        return name.containsOnly<isValidElementNameContinuationCharacter>();
 
     return false;
 }
@@ -98,37 +93,19 @@ bool isValidElementName(const QualifiedName& name)
 // https://dom.spec.whatwg.org/#valid-attribute-name
 bool isValidAttributeName(StringView name)
 {
-    if (name.isEmpty())
-        return false;
-
-    for (auto codeUnit : name.codeUnits()) {
-        if (isInvalidAttributeNameCharacter(codeUnit))
-            return false;
-    }
-    return true;
+    return !name.isEmpty() && !name.contains(isInvalidAttributeNameCharacter);
 }
 
 // https://dom.spec.whatwg.org/#valid-namespace-prefix
 static bool isValidNamespacePrefix(StringView prefix)
 {
-    if (prefix.isEmpty())
-        return false;
-
-    for (auto codeUnit : prefix.codeUnits()) {
-        if (isInvalidNamespacePrefixCharacter(codeUnit))
-            return false;
-    }
-    return true;
+    return !prefix.isEmpty() && !prefix.contains(isInvalidNamespacePrefixCharacter);
 }
 
 // https://dom.spec.whatwg.org/#valid-doctype-name
 bool isValidDoctypeName(StringView name)
 {
-    for (auto codeUnit : name.codeUnits()) {
-        if (isInvalidDoctypeNameCharacter(codeUnit))
-            return false;
-    }
-    return true;
+    return !name.contains(isInvalidDoctypeNameCharacter);
 }
 
 static inline bool NODELETE isValidASCIIXMLName(StringView name)
@@ -137,15 +114,10 @@ static inline bool NODELETE isValidASCIIXMLName(StringView name)
         return false;
 
     auto firstCharacter = name[0];
-    if (!(isASCIIAlpha(firstCharacter) || firstCharacter == ':' || firstCharacter == '_'))
+    if (!isASCIIAlpha(firstCharacter) && firstCharacter != ':' && firstCharacter != '_')
         return false;
 
-    for (unsigned i = 1; i < name.length(); ++i) {
-        auto c = name[i];
-        if (!(isASCIIAlphanumeric(c) || c == ':' || c == '_' || c == '-' || c == '.'))
-            return false;
-    }
-    return true;
+    return name.containsOnly<isValidASCIIXMLNamePart>();
 }
 
 // https://www.w3.org/TR/xml/#NT-NameStartChar


### PR DESCRIPTION
#### dd8ad147dd6b32cbd484a0974aead0792967eacb
<pre>
Simplify NameValidation by using contains and containsOnly
<a href="https://bugs.webkit.org/show_bug.cgi?id=315737">https://bugs.webkit.org/show_bug.cgi?id=315737</a>
<a href="https://rdar.apple.com/178698891">rdar://178698891</a>

Reviewed by Ryosuke Niwa and Darin Adler.

This does result in the first code unit being checked twice for the
checks that have special rules for the first code unit, but using
substring seemed more expensive. And using contains and containsOnly
should be more efficient as there&apos;s less is8Bit branching.

Tested neutral on Speedometer.

Canonical link: <a href="https://commits.webkit.org/314632@main">https://commits.webkit.org/314632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f37ad0e51088495ce018456e805362a579dda3ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175719 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123928 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129588 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110113 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30957 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29660 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23860 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140928 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178253 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31153 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29161 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137948 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137865 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149252 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103690 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25370 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33151 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26117 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39430 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112504 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38826 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4207 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39071 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38969 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->