### PR TITLE
Crash under WebPageProxy::createSandboxExtensionsIfNeeded()

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11616,6 +11616,12 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
         capturedDragData.setFileNames(filenames);
 
         Ref page = *retainedSelf->_page;
+        if (!page->hasRunningProcess()) {
+            if (RefPtr pageClient = page->pageClient())
+                pageClient->didPerformDragOperation(false);
+            return;
+        }
+
         WebKit::SandboxExtensionHandle sandboxExtensionHandle;
         Vector<WebKit::SandboxExtensionHandle> sandboxExtensionForUpload;
         auto dragPasteboardName = WebCore::Pasteboard::nameOfDragPasteboard();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4490,6 +4490,12 @@ static void performDragWithLegacyFiles(WebPageProxy& page, Box<Vector<String>>&&
     if (!networkProcess)
         return;
     networkProcess->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(page.legacyMainFrameProcess().coreProcessIdentifier(), *fileNames), [page = protect(page), fileNames, dragData, pasteboardName]() mutable {
+        if (!page->hasRunningProcess()) {
+            if (RefPtr pageClient = page->pageClient())
+                pageClient->didPerformDragOperation(false);
+            return;
+        }
+
         SandboxExtension::Handle sandboxExtensionHandle;
         Vector<SandboxExtension::Handle> sandboxExtensionForUpload;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm
@@ -1453,6 +1453,37 @@ TEST(DragAndDropTests, WebProcessTerminationDuringDrag)
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(300, 50)];
 }
 
+TEST(DragAndDropTests, PerformDropAfterWebProcessTermination)
+{
+    // Regression test: -[WKContentView dropInteraction:performDrop:] schedules a
+    // doAfterLoadingProvidedContentIntoFileURLs: callback whose body calls
+    // WebPageProxy::createSandboxExtensionsIfNeeded, which dereferences the
+    // legacyMainFrameProcess connection. If the WebProcess is gone by the time
+    // the callback fires, this used to RELEASE_ASSERT in
+    // AuxiliaryProcessProxy::connection().
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
+
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    NSData *imageData = UIImageJPEGRepresentation(testIconImage(), 0.5);
+    [itemProvider registerDataRepresentationForTypeIdentifier:UTTypeJPEG.identifier withData:imageData];
+
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    [simulator setExternalItemProviders:@[ itemProvider.get() ]];
+
+    // Tear down the WebProcess connection synchronously, just before
+    // -[WKContentView dropInteraction:performDrop:] schedules its file-loading
+    // callback. The callback then fires asynchronously after the connection is
+    // gone, exercising the early-return path in dropInteraction:performDrop:.
+    [simulator setOverridePerformDropBlock:^NSArray<UIDragItem *> *(id<UIDropSession> session) {
+        [webView _killWebContentProcessAndResetState];
+        return session.items;
+    }];
+
+    [simulator runFrom:CGPointMake(200, 100) to:CGPointMake(100, 100)];
+}
+
 TEST(DragAndDropTests, WebViewRemovedFromViewHierarchyDuringDrag)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
@@ -35,6 +35,7 @@
 #import <WebCore/PasteboardCustomData.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
+#import <wtf/FileSystem.h>
 
 #if ENABLE(DRAG_SUPPORT) && PLATFORM(MAC)
 
@@ -60,6 +61,45 @@ TEST(DragAndDropTests, NumberOfValidItemsForDrop)
     EXPECT_TRUE([webView stringByEvaluatingJavaScript:@"observedDragOver"].boolValue);
     EXPECT_TRUE([webView stringByEvaluatingJavaScript:@"observedDrop"].boolValue);
     EXPECT_EQ(1U, numberOfValidItemsForDrop);
+}
+
+TEST(DragAndDropTests, PerformDragWithLegacyFilesAfterWebProcessTermination)
+{
+    // Regression test: dropping files (legacy NSFilenamesPboardType) sends an async
+    // AllowFilesAccessFromWebProcess IPC to the NetworkProcess, and the reply lambda
+    // calls WebPageProxy::createSandboxExtensionsIfNeeded, which dereferences the
+    // legacyMainFrameProcess connection. If the WebProcess is gone by then, this
+    // used to RELEASE_ASSERT in AuxiliaryProcessProxy::connection().
+
+    RetainPtr tempDirectory = FileSystem::createTemporaryDirectory(@"WebKitDragAndDropTest");
+    RetainPtr tempFilePath = [tempDirectory stringByAppendingPathComponent:@"dropped-file.txt"];
+    [@"hello" writeToFile:tempFilePath.get() atomically:YES encoding:NSUTF8StringEncoding error:nil];
+
+    NSPasteboard *pasteboard = [NSPasteboard pasteboardWithUniqueName];
+    [pasteboard declareTypes:@[NSFilenamesPboardType] owner:nil];
+    [pasteboard setPropertyList:@[tempFilePath.get()] forType:NSFilenamesPboardType];
+
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    TestWKWebView *webView = [simulator webView];
+    [simulator setExternalDragPasteboard:pasteboard];
+    [webView synchronouslyLoadTestPageNamed:@"full-page-dropzone"];
+
+    // Tear down the WebProcess connection synchronously right before the drop
+    // is performed. _killWebContentProcessAndResetState routes through
+    // requestTermination -> processDidTerminateOrFailedToLaunch -> shutDownProcess,
+    // which sets m_connection to nullptr immediately.
+    [simulator setWillEndDraggingHandler:[webView] {
+        [webView _killWebContentProcessAndResetState];
+    }];
+
+    [simulator runFrom:NSMakePoint(0, 0) to:NSMakePoint(200, 200)];
+
+    // Pump the runloop long enough for the AllowFilesAccessFromWebProcess reply
+    // to be delivered. Prior to fix, this would RELEASE_ASSERT in
+    // AuxiliaryProcessProxy::connection() inside the reply lambda.
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    [[NSFileManager defaultManager] removeItemAtPath:tempDirectory.get() error:nil];
 }
 
 TEST(DragAndDropTests, DragEndEventCoordinatesWithNestedIframes)


### PR DESCRIPTION
#### 5f39d2e3104ac9a2de8e76c4af7243be54fd4e1c
<pre>
Crash under WebPageProxy::createSandboxExtensionsIfNeeded()
<a href="https://bugs.webkit.org/show_bug.cgi?id=315745">https://bugs.webkit.org/show_bug.cgi?id=315745</a>
<a href="https://rdar.apple.com/170160413">rdar://170160413</a>

Reviewed by Per Arne Vollan.

When dropping files via the legacy NSFilenamesPboardType / file
promise pasteboard, performDragWithLegacyFiles() sends an async
AllowFilesAccessFromWebProcess IPC to the NetworkProcess and, on
reply, calls WebPageProxy::createSandboxExtensionsIfNeeded(), which
dereferences the legacy main-frame WebProcess connection. If that
WebProcess is gone by the time the reply lands, the access in
AuxiliaryProcessProxy::connection() fires its
RELEASE_ASSERT(m_connection) and crashes the UIProcess.

Bail out of the reply lambdas (both macOS and iOS drop paths) when
the page no longer has a running process. To avoid leaking drop
state in that case, also notify the page client via
didPerformDragOperation(false) so:

    - On macOS, _webView:didPerformDragOperation: fires on the UI
      delegate.
    - On iOS, _didPerformDragOperation: runs and decrements
      WebItemProviderPasteboard&apos;s pending-operation count, notifies
      the delegate, and cleans up drop session state.

Without this, a WebProcess crash mid-drop would leave clients
waiting on a delegate callback that never fires (and on iOS, leak
the pasteboard pending-operation count).

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView dropInteraction:performDrop:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::performDragWithLegacyFiles):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm:
(TEST(DragAndDropTests, PerformDropAfterWebProcessTermination)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm:
(TEST(DragAndDropTests, PerformDragWithLegacyFilesAfterWebProcessTermination)):

Canonical link: <a href="https://commits.webkit.org/314085@main">https://commits.webkit.org/314085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43bf288ce208758041f5b931eb1cd70d56b09eb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122209 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128181 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90225 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108707 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb098c65-a282-4358-bfcd-701e420cdb50) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29538 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28150 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21750 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176517 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29368 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136501 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136447 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36800 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101471 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31719 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24582 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37711 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110782 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37108 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2656 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37354 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37252 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->