### PR TITLE
moveBefore() should run node iterator and live range pre-remove steps

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/live-range-updates-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/live-range-updates-expected.txt
@@ -2,12 +2,7 @@ RangeStartTarget
 Middle
 RangeEndTarget
 
-FAIL moveBefore still results in range startContainer snapping up to parent when startContainer is moved assert_equals: startContainer updates during move expected Element node <div id="old_parent">
-
-      <span id="middle">Midd... but got Element node <span id="start">RangeStartTarget</span>
-FAIL moveBefore still causes range startContainer to snap up to parent, when startContainer ancestor is moved assert_equals: startContainer still updates during move, to snap to parent expected Element node <div id="old_parent">
-
-      <span id="end">RangeEn... but got Element node <span id="start">RangeStartTarget</span>
-FAIL moveBefore still causes range endContainer to snap up to parent, when endContainer ancestor is moved assert_equals: endContainer still snaps up to parent after move expected Element node <div id="old_parent">
-      <span id="start">RangeStartTa... but got Element node <span id="end">RangeEndTarget</span>
+PASS moveBefore still results in range startContainer snapping up to parent when startContainer is moved
+PASS moveBefore still causes range startContainer to snap up to parent, when startContainer ancestor is moved
+PASS moveBefore still causes range endContainer to snap up to parent, when endContainer ancestor is moved
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-nodeiterator-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-nodeiterator-expected.txt
@@ -1,0 +1,3 @@
+
+PASS moveBefore() runs NodeIterator pre-remove steps
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-nodeiterator.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-nodeiterator.html
@@ -1,0 +1,39 @@
+<!-- webkit-test-runner [ MoveBeforeEnabled=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<title>NodeIterator + moveBefore() pre-remove steps</title>
+
+<div id="oldParent">
+    <div id="a"></div>
+    <div id="target">
+        <div id="inner"></div>
+    </div>
+    <div id="b"></div>
+</div>
+
+<div id="newParent"></div>
+
+<script>
+test(() => {
+    const oldParent = document.getElementById("oldParent");
+    const newParent = document.getElementById("newParent");
+    const target = document.getElementById("target");
+    const b = document.getElementById("b");
+
+    const iterator = document.createNodeIterator(
+        oldParent,
+        NodeFilter.SHOW_ELEMENT
+    );
+
+    assert_equals(iterator.nextNode().id, "oldParent");
+    assert_equals(iterator.nextNode().id, "a");
+    assert_equals(iterator.nextNode().id, "target");
+    assert_equals(iterator.nextNode().id, "inner");
+
+    newParent.moveBefore(target, null);
+
+    assert_equals(iterator.nextNode(), b);
+}, "moveBefore() runs NodeIterator pre-remove steps");
+</script>

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1469,14 +1469,14 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
     RefPtr oldPreviousSibling = node.previousSibling();
     RefPtr oldNextSibling = node.nextSibling();
 
-    // FIXME(281223): Run NodeIterator and live range pre-remove steps.
-
     auto removalChildChange = makeChildChangeForRemoval(node, ChildChange::Source::API);
 
     {
+        Ref nodeDocument = node.document();
         WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         ChildListMutationScope(*oldParent).willRemoveChild(node);
+        nodeDocument->nodeWillBeMoved(node);
 
         if (oldNextSibling) {
             oldNextSibling->setPreviousSibling(oldPreviousSibling.get());

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6867,6 +6867,17 @@ void Document::nodeWillBeRemoved(Node& node)
         m_markers->removeMarkers(node);
 }
 
+void Document::nodeWillBeMoved(Node& node)
+{
+    ASSERT(ScriptDisallowedScope::InMainThread::hasDisallowedScope());
+
+    for (Ref nodeIterator : m_nodeIterators)
+        nodeIterator->nodeWillBeRemoved(node);
+
+    for (Ref range : m_ranges)
+        range->nodeWillBeRemoved(node);
+}
+
 void Document::parentlessNodeMovedToNewDocument(Node& node)
 {
     Vector<Ref<Range>, 5> rangesAffected;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1065,6 +1065,7 @@ public:
     void nodeChildrenWillBeRemoved(ContainerNode&);
     // nodeWillBeRemoved is only safe when removing one node at a time.
     void nodeWillBeRemoved(Node&);
+    void nodeWillBeMoved(Node&);
     void parentlessNodeMovedToNewDocument(Node&);
 
     enum class AcceptChildOperation : bool { Replace, InsertOrAdd };


### PR DESCRIPTION
#### d1eb42e417eb4b68aba5d7db42aabeba7be2dfc0
<pre>
moveBefore() should run node iterator and live range pre-remove steps
<a href="https://bugs.webkit.org/show_bug.cgi?id=315754">https://bugs.webkit.org/show_bug.cgi?id=315754</a>

Reviewed by Ryosuke Niwa.

This adds a new nodeWillBeMoved() function to Document and calls it from within
ContainerNode::moveBefore(). This function calls the pre-remove steps.

Also adds a new WPT to excercise the node iterator steps as coverage was lacking.

Test: imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-nodeiterator.html

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/live-range-updates-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-nodeiterator-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-nodeiterator.html: Added.
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::moveBefore):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::nodeWillBeMoved):
* Source/WebCore/dom/Document.h:

Canonical link: <a href="https://commits.webkit.org/314384@main">https://commits.webkit.org/314384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5de1be9a3d22689e71f944acb9d8d1c0eaabe37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123181 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128965 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109492 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28987 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23113 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140279 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177502 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30408 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28482 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137303 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137232 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36983 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40173 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148571 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Passed layout tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102756 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32517 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25438 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38684 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111757 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38081 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3520 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->