### PR TITLE
Web Inspector: Properties added to the Style Attribute of an element sometimes disappear mid-typing

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js
@@ -131,7 +131,15 @@ WI.CSSStyleDeclaration = class CSSStyleDeclaration extends WI.Object
     }
 
     get locked() { return this._locked; }
-    set locked(value) { this._locked = value; }
+
+    set locked(value) {
+        if (this._locked === value)
+            return;
+
+        this._locked = value;
+
+        this.dispatchEventToListeners(WI.CSSStyleDeclaration.Event.LockedChanged);
+    }
 
     variablesForType(type)
     {
@@ -638,6 +646,7 @@ WI.CSSStyleDeclaration = class CSSStyleDeclaration extends WI.Object
 
 WI.CSSStyleDeclaration.Event = {
     PropertiesChanged: "css-style-declaration-properties-changed",
+    LockedChanged: "css-style-declaration-locked-changed",
 };
 
 WI.CSSStyleDeclaration.Type = {

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationEditor.js
@@ -171,13 +171,17 @@ WI.SpreadsheetCSSStyleDeclarationEditor = class SpreadsheetCSSStyleDeclarationEd
         if (this._style === style)
             return;
 
-        if (this._style)
+        if (this._style) {
             this._style.removeEventListener(WI.CSSStyleDeclaration.Event.PropertiesChanged, this._propertiesChanged, this);
+            this._style.removeEventListener(WI.CSSStyleDeclaration.Event.LockedChanged, this._handleLockedChanged, this);
+        }
 
         this._style = style || null;
 
-        if (this._style)
+        if (this._style) {
             this._style.addEventListener(WI.CSSStyleDeclaration.Event.PropertiesChanged, this._propertiesChanged, this);
+            this._style.addEventListener(WI.CSSStyleDeclaration.Event.LockedChanged, this._handleLockedChanged, this);
+        }
 
         this.needsLayout();
     }
@@ -645,6 +649,11 @@ WI.SpreadsheetCSSStyleDeclarationEditor = class SpreadsheetCSSStyleDeclarationEd
 
         this._copySelectedProperties(event);
         this._removeSelectedProperties();
+    }
+
+    _handleLockedChanged(event)
+    {
+        this._delegate?.spreadsheetCSSStyleDeclarationEditorStyleLockedChanged?.(this, event.target.locked);
     }
 
     _copySelectedProperties(event)

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.js
@@ -308,6 +308,11 @@ WI.SpreadsheetCSSStyleDeclarationSection = class SpreadsheetCSSStyleDeclarationS
         this._delegate?.spreadsheetCSSStyleDeclarationSectionSetAllPropertyVisibilityMode?.(this, propertyVisibilityMode);
     }
 
+    spreadsheetCSSStyleDeclarationEditorStyleLockedChanged(editor, locked)
+    {
+        this._delegate?.spreadsheetCSSStyleDeclarationSectionStyleLockedChanged(this, locked);
+    }
+
     applyFilter(filterText)
     {
         this._filterText = filterText;

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js
@@ -222,11 +222,23 @@ WI.SpreadsheetRulesStyleDetailsPanel = class SpreadsheetRulesStyleDetailsPanel e
             section.propertyVisibilityMode = propertyVisibilityMode;
     }
 
+    spreadsheetCSSStyleDeclarationSectionStyleLockedChanged(section, locked)
+    {
+        if (locked)
+            return;
+
+        if (this._shouldRefreshSubviews)
+            this.needsLayout();
+    }
+
     // Protected
 
     layout()
     {
         if (!this._shouldRefreshSubviews)
+            return;
+
+        if (this._sections.some((section) => section.style.locked))
             return;
 
         this._shouldRefreshSubviews = false;


### PR DESCRIPTION
#### 05e8b33d1f25ec040b3b5b62471d7a03bf775754
<pre>
Web Inspector: Properties added to the Style Attribute of an element sometimes disappear mid-typing
<a href="https://bugs.webkit.org/show_bug.cgi?id=315663">https://bugs.webkit.org/show_bug.cgi?id=315663</a>
<a href="https://rdar.apple.com/178053421">rdar://178053421</a>

Reviewed by Devin Rousso.

When typing a CSS property in the inline style of an element that causes another CSS rule
in the stylesheet to match, for example `:where([style*=property])`, the other rule is added to
`WI.DOMNodeStyles` which triggers a styles refresh event that&apos;s considered a `significantChange`.

This triggers re-layout of the Styles panel which removes all nested subviews,
including the `WI.SpreadsheetCSSStyleDeclarationEditor` that the user is typing into.

It is an edge-case with the inline style attribute because its value can be used in selectors.
Regular CSS style rules do not cause this.

This patch addresses the issue by preventing the Styles panel re-layout while a style is locked (i.e. during editing),
running it after it&apos;s unlocked if a pending `WI.SpreadsheetRulesStyleDetailsPanel._shouldRefreshSubviews` exists.

A similar behavior exits for editing the selector of a CSS rule to something that no longer matches
to prevent the `significantChange` style refresh from causing re-layout and removing it immediately.

* Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js:
(WI.CSSStyleDeclaration.prototype.set locked):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationEditor.js:
(WI.SpreadsheetCSSStyleDeclarationEditor.prototype.set style):
(WI.SpreadsheetCSSStyleDeclarationEditor):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.js:
(WI.SpreadsheetCSSStyleDeclarationSection.prototype.spreadsheetCSSStyleDeclarationEditorStyleLockedChanged):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js:
(WI.SpreadsheetRulesStyleDetailsPanel.prototype.spreadsheetCSSStyleDeclarationSectionStyleLockedChanged):
(WI.SpreadsheetRulesStyleDetailsPanel.prototype.layout):

Canonical link: <a href="https://commits.webkit.org/314467@main">https://commits.webkit.org/314467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/039605d526d662362b04d04824baaed11ca7c0d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123473 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129198 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109723 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23406 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177798 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28752 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137546 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37033 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148842 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103099 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32768 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25709 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38976 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112050 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38373 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3795 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38618 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38516 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->