### PR TITLE
Cherry-pick(s) 0de76a6ef7c5. rdar://176062384

### DIFF
--- a/Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp
@@ -45,7 +45,11 @@ using namespace JSC;
 template<typename Visitor>
 void JSXMLHttpRequest::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
+<<<<<<< HEAD
     wrapped().visitAdditionalChildrenInGCThread(visitor);
+=======
+    wrapped().visitAdditionalChildren(visitor);
+>>>>>>> 0de76a6ef7c5 (Potential use after free of m_responseDocument in XMLHttpRequest::visitAdditionalChildren())
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSXMLHttpRequest);

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -656,7 +656,11 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
                 Locker locker { m_gcLock };
                 return m_upload.get();
             }();
+<<<<<<< HEAD
             upload->dispatchProgressEvent(eventNames().loadstartEvent, 0, protect(request.httpBody())->lengthInBytes());
+=======
+            upload->dispatchProgressEvent(eventNames().loadstartEvent, 0, request.httpBody()->lengthInBytes());
+>>>>>>> 0de76a6ef7c5 (Potential use after free of m_responseDocument in XMLHttpRequest::visitAdditionalChildren())
         }
         if (readyState() != OPENED || !m_sendFlag || m_loadingActivity)
             return { };
@@ -1263,6 +1267,21 @@ void XMLHttpRequest::visitAdditionalChildrenInGCThread(Visitor& visitor)
         addWebCoreOpaqueRoot(visitor, *document);
 }
 
+<<<<<<< HEAD
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(XMLHttpRequest);
+=======
+template<typename Visitor>
+void XMLHttpRequest::visitAdditionalChildren(Visitor& visitor)
+{
+    Locker locker { m_gcLock };
+    if (m_upload)
+        addWebCoreOpaqueRoot(visitor, *m_upload);
+
+    if (m_responseDocument)
+        addWebCoreOpaqueRoot(visitor, *m_responseDocument);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(XMLHttpRequest);
+>>>>>>> 0de76a6ef7c5 (Potential use after free of m_responseDocument in XMLHttpRequest::visitAdditionalChildren())
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -140,7 +140,11 @@ public:
 
     void dispatchThrottledProgressEventIfNeeded();
 
+<<<<<<< HEAD
     template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
+=======
+    template<typename Visitor> void visitAdditionalChildren(Visitor&);
+>>>>>>> 0de76a6ef7c5 (Potential use after free of m_responseDocument in XMLHttpRequest::visitAdditionalChildren())
 
 private:
     friend class XMLHttpRequestUpload;


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176062384 to main. The following sources [a814080321a1] will still need to be cherry-picked once the conflict is resolved.

```Potential use after free of m_responseDocument in XMLHttpRequest::visitAdditionalChildren()
https://bugs.webkit.org/show_bug.cgi?id=309947
rdar://172537101

Reviewed by Ryosuke Niwa.

Potential use after free of m_responseDocument in XMLHttpRequest::visitAdditionalChildren()
due to multi-threading. visitAdditionalChildren() dereferences m_responseDocument
on the GC thread while the main thread is running and may null out the RefPtr.

Address the issue via locking.

* Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp:
(WebCore::JSXMLHttpRequest::visitAdditionalChildren):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::upload):
(WebCore::XMLHttpRequest::send):
(WebCore::XMLHttpRequest::sendBytesData):
(WebCore::XMLHttpRequest::createRequest):
(WebCore::XMLHttpRequest::clearResponseBuffers):
(WebCore::XMLHttpRequest::didSendData):
(WebCore::XMLHttpRequest::dispatchErrorEvents):
(WebCore::XMLHttpRequest::updateHasRelevantEventListener):
(WebCore::XMLHttpRequest::visitAdditionalChildren):
* Source/WebCore/xml/XMLHttpRequest.h:

Originally-landed-as: 305413.477@rapid/safari-7624.2.5.110-branch (0de76a6ef7c5). rdar://176062384

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccabf01359d9feb023edc89d2aba4033851c36a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164992 "5 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38483 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174034 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122248 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/166860 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38484 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/174034 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122248 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/167951 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/32060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174034 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38484 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/21789 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/32060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176557 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29409 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/176557 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38551 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/38484 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176557 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/39241 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/32060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101540 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/39241 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37751 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110822 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/37148 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/32060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37394 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/37292 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->