### PR TITLE
[Tahoe arm64] media/track/audio-track.html is a flaky text failure.

### DIFF
--- a/LayoutTests/media/track/audio-track.html
+++ b/LayoutTests/media/track/audio-track.html
@@ -40,8 +40,13 @@
             {
                 findMediaElement();
                 video.audioTracks.addEventListener("addtrack", trackAdded);
+                let addtrackFired = waitFor(video.audioTracks, "addtrack", true);
+                let canplaythroughFired = waitFor(video, "canplaythrough", true);
                 video.src = findMediaFile('audio', '../content/silence');
-                waitForEvent('canplaythrough', canplaythrough);
+                Promise.all([addtrackFired, canplaythroughFired]).then(() => {
+                    consoleWrite("EVENT(canplaythrough)");
+                    canplaythrough();
+                });
             }
 
         </script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2206,8 +2206,6 @@ webkit.org/b/307691 [ Tahoe Release arm64 ] svg/gradients/spreadMethod.svg [ Ima
 
 webkit.org/b/309370 fast/css/vertical-text-overflow-ellipsis-text-align-center.html [ Failure Pass ]
 
-webkit.org/b/315773 media/track/audio-track.html [ Pass Failure ]
-
 webkit.org/b/306436 http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https.html [ Pass Failure ]
 
 # webkit.org/b/309529 3x imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-collapsed-selection.tentative.html are flaky text failures


### PR DESCRIPTION
#### 8e467c772a3bb8c9b463a6d88ad46ed58cdc1223
<pre>
[Tahoe arm64] media/track/audio-track.html is a flaky text failure.
<a href="https://rdar.apple.com/178167011">rdar://178167011</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315773">https://bugs.webkit.org/show_bug.cgi?id=315773</a>

Reviewed by NOBODY (OOPS!).

The test assumes the in-band `addtrack` event will fire before `canplaythrough`,
but the ordering is not guaranteed; when addtrack is dispatched on a queued task
that runs after canplaythrough&apos;s handler, `endTest()` has already set `testEnded=true`
and `consoleWrite` (video-test.js:466-468) silently drops the addtrack output.

* LayoutTests/media/track/audio-track.html: gate `canplaythrough()` (and thus `endTest()`)
on both the `canplaythrough` and `addtrack` events having fired, using a silent `waitFor`
so we don&apos;t double-log, and emit the deterministic `EVENT(canplaythrough)` line manually
after both promises settle.
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e467c772a3bb8c9b463a6d88ad46ed58cdc1223

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122293 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b06e06e7-7b53-4fb3-b923-db5cb5923a7d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128253 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90279 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04393bb5-7702-46ab-af08-7190a58d596d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108779 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00308c9f-39f8-4b96-93ca-1f9cbde596ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29611 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28228 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21834 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139506 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176602 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136574 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136518 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36929 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147794 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101585 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31791 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24661 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37796 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37193 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2736 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37439 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37337 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->