### PR TITLE
[Site Isolation] [intersection-observer] Project rect from local to absolute before intersecting with synced visibleRectOfChild

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/transformed-iframe-subframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/transformed-iframe-subframe.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #target {
+    position: absolute;
+    height: 150px;
+    width: 150px;
+    background-color: green;
+  }
+</style>
+
+<div id="target"></div>
+
+<script>
+  let observer = new IntersectionObserver((observations) => {
+    const lastObservation = observations[observations.length - 1];
+    window.top.postMessage({
+      isIntersecting: lastObservation.isIntersecting
+    }, "*");
+  });
+
+  observer.observe(document.getElementById("target"));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS Target is initially visible
+FAIL Scroll such that target is just out of view, target is not visible assert_false: expected false got true
+PASS Scroll to end of page, target is not visible
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: implicit root observer in iframe works when the iframe is transformed</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 300px;
+    height: 300px;
+    display: block;
+
+    transform: perspective(20px) rotateY(30deg);
+  }
+
+  .spacer {
+    height: 2000px;
+  }
+</style>
+
+<iframe id="iframe"></iframe>
+<div class="spacer"></div>
+
+<script>
+  isIntersecting = null;
+  window.addEventListener("message", event => {
+    isIntersecting = event.data.isIntersecting;
+  });
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = `${get_host_info().HTTP_NOTSAMESITE_ORIGIN}/intersection-observer/resources/transformed-iframe-subframe.html`;
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+    window.scrollTo(0, 0);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_true(isIntersecting);
+  }, "Target is initially visible");
+
+  promise_test(async (t) => {
+    window.scrollTo(0, 200);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Scroll such that target is just out of view, target is not visible");
+
+  promise_test(async (t) => {
+    window.scrollTo(0, document.body.scrollHeight);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Scroll to end of page, target is not visible");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-same-origin-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS Target is initially visible
+FAIL Scroll such that target is just out of view, target is not visible assert_false: expected false got true
+PASS Scroll to end of page, target is not visible
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-same-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-same-origin.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: implicit root observer in iframe works when the iframe is transformed</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/common/rendering-utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 300px;
+    height: 300px;
+    display: block;
+
+    transform: perspective(20px) rotateY(30deg);
+  }
+
+  .spacer {
+    height: 2000px;
+  }
+</style>
+
+<iframe id="iframe"></iframe>
+<div class="spacer"></div>
+
+<script>
+  isIntersecting = null;
+  window.addEventListener("message", event => {
+    isIntersecting = event.data.isIntersecting;
+  });
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = "resources/transformed-iframe-subframe.html";
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+    window.scrollTo(0, 0);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_true(isIntersecting);
+  }, "Target is initially visible");
+
+  promise_test(async (t) => {
+    window.scrollTo(0, 200);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Scroll such that target is just out of view, target is not visible");
+
+  promise_test(async (t) => {
+    window.scrollTo(0, document.body.scrollHeight);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Scroll to end of page, target is not visible");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin-expected.txt
@@ -1,0 +1,7 @@
+Text to reproduce the issue.
+
+
+
+PASS Target is initially visible
+PASS Scroll such that target is just out of view, target is not visible
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: implicit root observer in iframe works when the iframe is transformed</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 300px;
+    height: 300px;
+    display: block;
+
+    transform: perspective(600px) rotateY(-45deg) rotateX(80deg) rotateZ(20deg);
+  }
+
+  .spacer {
+    height: 2000px;
+  }
+</style>
+
+<p>Text to reproduce the issue.</p>
+<iframe id="iframe"></iframe>
+<div class="spacer"></div>
+
+<script>
+  isIntersecting = null;
+  window.addEventListener("message", event => {
+    isIntersecting = event.data.isIntersecting;
+  });
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = `${get_host_info().HTTP_NOTSAMESITE_ORIGIN}/intersection-observer/resources/transformed-iframe-subframe.html`;
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+    window.scrollTo(0, 0);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_true(isIntersecting);
+  }, "Target is initially visible");
+
+  promise_test(async (t) => {
+    window.scrollTo(0, 250);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Scroll such that target is just out of view, target is not visible");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-same-origin-expected.txt
@@ -1,0 +1,7 @@
+Text to reproduce the issue.
+
+
+
+PASS Target is initially visible
+PASS Scroll such that target is just out of view, target is not visible
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-same-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-same-origin.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: implicit root observer in iframe works when the iframe is transformed</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/common/rendering-utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 300px;
+    height: 300px;
+    display: block;
+
+    transform: perspective(600px) rotateY(-45deg) rotateX(80deg) rotateZ(20deg);
+  }
+
+  .spacer {
+    height: 2000px;
+  }
+</style>
+
+<p>Text to reproduce the issue.</p>
+<iframe id="iframe"></iframe>
+<div class="spacer"></div>
+
+<script>
+  isIntersecting = null;
+  window.addEventListener("message", event => {
+    isIntersecting = event.data.isIntersecting;
+  });
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = "resources/transformed-iframe-subframe.html";
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+    window.scrollTo(0, 0);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_true(isIntersecting);
+  }, "Target is initially visible");
+
+  promise_test(async (t) => {
+    window.scrollTo(0, 250);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Scroll such that target is just out of view, target is not visible");
+</script>

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -364,6 +364,8 @@ http/tests/security/frameNavigation/not-opener.html [ Failure ]
 
 # Intersection Observer x Site Isolation is not fully implemented.
 imported/w3c/web-platform-tests/intersection-observer/cross-origin-tall-iframe.sub.html [ Failure ]
+imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin.html [ Failure ]
+imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin.html [ Failure ]
 
 # rdar://178066625
 imported/w3c/web-platform-tests/html/user-activation/propagation-crossorigin.sub.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -471,6 +471,8 @@ inspector/unit-tests/target-manager.html [ Skip ]
 
 # Intersection Observer x Site Isolation is not fully implemented.
 imported/w3c/web-platform-tests/intersection-observer/cross-origin-tall-iframe.sub.html [ Failure ]
+imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin.html [ Failure ]
+imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin.html [ Failure ]
 
 # Inspector protocol commands (e.g. CSS.getMatchedStylesForNode) return
 # "Not yet implemented for frame targets" under site isolation.

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -136,6 +136,11 @@ public:
     // from its border box. This can be non-zero due to padding or border.
     virtual LayoutPoint childFrameOwnerContentBoxLocation(const Frame&) const = 0;
 
+    // Return the transformation matrix to convert a point/rect from the coordinate
+    // system of the child's frame owner to this FrameView's RenderView. Note this
+    // does not correspond to the absolute coordinate of this FrameView, as it doesn't
+    // include the page scale transform on the RenderView (if page is scaled).
+    virtual TransformationMatrix childFrameOwnerToRootContentTransform(const Frame&) const = 0;
 private:
     ScrollableArea* enclosingScrollableArea() const final;
 

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -366,6 +366,19 @@ static void expandRootBoundsWithRootMargin(FloatRect& rootBounds, const Intersec
     rootBounds.expand(rootMarginEdges);
 }
 
+// Given a rectangle in the coordinate space of rendererOrFrame, compute the visible
+// rectangle in the content coordinate space of the root's (main frame) RenderView.
+// This is done by computing the visible rectangle in the nearest frame, then its
+// parent frame, ... up to the main frame.
+//
+// If rendererOrFrame is a:
+// * Renderer: rect is in the coordinate space of the renderer.
+// * Frame: rect is in the coordinate space of the frame's owner renderer.
+//   This is only used in Site Isolation mode, when the frame is out-of-process
+//   and its owner renderer is not available.
+//
+// targetSecurityOrigin is the security origin of the target (the element that
+// originates the very first rect)
 static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const LayoutRect& rect, const SecurityOrigin& targetSecurityOrigin, Variant<const RenderElement*, const Frame*> rendererOrFrame, std::optional<IntersectionObserverMarginBox> scrollMargin)
 {
     RefPtr rendererOrFrameSecurityOrigin = WTF::visit(WTF::makeVisitor(
@@ -395,6 +408,11 @@ static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const Lay
     if (!enclosingFrame)
         return std::nullopt;
 
+    RefPtr<const FrameView> enclosingFrameView = enclosingFrame->virtualView();
+    ASSERT(enclosingFrameView);
+    if (!enclosingFrameView)
+        return std::nullopt;
+
     auto absoluteClippedRect = WTF::visit(WTF::makeVisitor(
         [&] (const RenderElement* renderer) {
             auto visibleRects = renderer->computeVisibleRectsInContainer(
@@ -416,15 +434,21 @@ static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const Lay
             return visibleRects.transform([] (auto&& repaintRects) { return repaintRects.clippedOverflowRect; } );
         },
         [&] (const Frame* frame) -> std::optional<LayoutRect> {
-            auto visibleRectInParentFrame = enclosingFrame->virtualView()->visibleRectOfChild(*frame);
+            // This rect is in coordinate space of parent frame. It doesn't account for
+            // scroll margin, which is fine as this codepath is only reached when Site
+            // Isolation is enabled, and the frame is cross-origin. Scroll margin doesn't
+            // get applied to cross-origin frames.
+            auto visibleRectInParentFrame = enclosingFrameView->visibleRectOfChild(*frame);
             if (!visibleRectInParentFrame)
                 return std::nullopt;
 
-            auto clippedRect = rect;
-            if (!clippedRect.edgeInclusiveIntersect(*visibleRectInParentFrame))
+            // rect is in coordinate space of the frame's owner renderer,
+            // it needs to be converted to parent frame's coordinate space first before intersecting.
+            auto absoluteRect = LayoutRect { enclosingFrameView->childFrameOwnerToRootContentTransform(*frame).mapRect(rect) };
+            if (!absoluteRect.edgeInclusiveIntersect(*visibleRectInParentFrame))
                 return std::nullopt;
 
-            return std::make_optional(clippedRect);
+            return std::make_optional(absoluteRect);
     }), rendererOrFrame);
 
     if (!absoluteClippedRect)
@@ -437,10 +461,7 @@ static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const Lay
     // The computed visible rect is in the coordinate space of enclosingFrame.
     // But only the iframe's viewport is visible, so clip by the iframe's viewport.
 
-    // Compute the frame's viewport (this is in the coordinate space of the document content box)
-    RefPtr<const FrameView> enclosingFrameView = enclosingFrame->virtualView();
-    ASSERT(enclosingFrameView);
-
+    // Compute the frame's viewport (this is in the coordinate space of enclosingFrame too.)
     auto frameRect = enclosingFrameView->layoutViewportRect();
     if (scrollMargin) {
         auto scrollMarginEdges = LayoutBoxExtent {

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -138,6 +138,7 @@
 #include "TextIterator.h"
 #include "TextResourceDecoder.h"
 #include "TiledBacking.h"
+#include "TransformState.h"
 #include "VelocityData.h"
 #include "VisualViewport.h"
 #include "WheelEventTestMonitor.h"
@@ -2179,6 +2180,23 @@ LayoutPoint LocalFrameView::childFrameOwnerContentBoxLocation(const Frame& child
     ASSERT(childOwnerRenderer->frame().frameID() == m_frame->frameID());
 
     return childOwnerRenderer->contentBoxLocation();
+}
+
+TransformationMatrix LocalFrameView::childFrameOwnerToRootContentTransform(const Frame& child) const
+{
+    CheckedPtr<RenderObject> childOwnerRenderer = child.ownerRenderer();
+    if (!childOwnerRenderer)
+        return { };
+
+    // Ensure |child| is a child of this frame.
+    ASSERT(child.tree().parent()->frameID() == m_frame->frameID());
+    ASSERT(childOwnerRenderer->frame().frameID() == m_frame->frameID());
+
+    // Identical to localToContainerQuad
+    TransformState transformState(TransformState::ApplyTransformDirection, FloatPoint { });
+    childOwnerRenderer->mapLocalToContainer(&childOwnerRenderer->view(), transformState, { MapCoordinatesMode::UseTransforms, MapCoordinatesMode::ApplyContainerFlip }, nullptr);
+
+    return *transformState.releaseTrackedTransform();
 }
 
 LayoutRect LocalFrameView::rectForFixedPositionLayout() const

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -326,7 +326,8 @@ public:
     std::optional<LayoutRect> visibleRectOfChild(const Frame&) const final;
     OptionSet<FrameOwnerElementAppearance> appearanceOfOwnerElementOfChildFrame(const Frame&) const final;
     LayoutPoint childFrameOwnerContentBoxLocation(const Frame&) const final;
-    
+    TransformationMatrix childFrameOwnerToRootContentTransform(const Frame&) const final;
+
     static LayoutRect visibleDocumentRect(const FloatRect& visibleContentRect, float headerHeight, float footerHeight, const FloatSize& totalContentsSize, float pageScaleFactor);
 
     // This is different than visibleContentRect() in that it ignores negative (or overly positive)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2193,6 +2193,7 @@ void Page::syncLocalFrameInfoToRemote()
         for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
             childrenFrameLayoutInfo.add(child->frameID(), RemoteFrameLayoutInfo::create(
                 frameView->visibleRectOfChild(*child.get()),
+                frameView->childFrameOwnerToRootContentTransform(*child),
                 frame.usedZoomForChild(*child),
                 frameView->childFrameOwnerContentBoxLocation(*child),
                 frameView->appearanceOfOwnerElementOfChildFrame(*child)

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
@@ -32,13 +32,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteFrameLayoutInfo);
 
-Ref<RemoteFrameLayoutInfo> RemoteFrameLayoutInfo::create(std::optional<LayoutRect> visibleRectInParent, float usedZoom, LayoutPoint contentBoxLocation, OptionSet<FrameOwnerElementAppearance> ownerElementAppearance)
+Ref<RemoteFrameLayoutInfo> RemoteFrameLayoutInfo::create(std::optional<LayoutRect> visibleRectInParent, TransformationMatrix childFrameOwnerToRootContentTransform, float usedZoom, LayoutPoint contentBoxLocation, OptionSet<FrameOwnerElementAppearance> ownerElementAppearance)
 {
-    return adoptRef(*new RemoteFrameLayoutInfo(visibleRectInParent, usedZoom, contentBoxLocation, ownerElementAppearance));
+    return adoptRef(*new RemoteFrameLayoutInfo(visibleRectInParent, WTF::move(childFrameOwnerToRootContentTransform), usedZoom, contentBoxLocation, ownerElementAppearance));
 }
 
-RemoteFrameLayoutInfo::RemoteFrameLayoutInfo(std::optional<LayoutRect> visibleRectInParent, float usedZoom, LayoutPoint contentBoxLocation, OptionSet<FrameOwnerElementAppearance> ownerElementAppearance)
+RemoteFrameLayoutInfo::RemoteFrameLayoutInfo(std::optional<LayoutRect> visibleRectInParent, TransformationMatrix childFrameOwnerToRootContentTransform, float usedZoom, LayoutPoint contentBoxLocation, OptionSet<FrameOwnerElementAppearance> ownerElementAppearance)
     : m_visibleRectInParent(visibleRectInParent)
+    , m_childFrameOwnerToRootContentTransform(WTF::move(childFrameOwnerToRootContentTransform))
     , m_usedZoom(usedZoom)
     , m_contentBoxLocation(contentBoxLocation)
     , m_ownerElementAppearance(ownerElementAppearance)

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.h
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/LayoutRect.h>
+#include <WebCore/TransformationMatrix.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -47,19 +48,26 @@ class RemoteFrameLayoutInfo : public RefCounted<RemoteFrameLayoutInfo> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(RemoteFrameLayoutInfo, WEBCORE_EXPORT);
 
 public:
-    WEBCORE_EXPORT static Ref<RemoteFrameLayoutInfo> create(std::optional<LayoutRect>, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
+    WEBCORE_EXPORT static Ref<RemoteFrameLayoutInfo> create(std::optional<LayoutRect>, TransformationMatrix, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
 
     std::optional<LayoutRect> visibleRectInParent() const { return m_visibleRectInParent; }
+    const TransformationMatrix& childFrameOwnerToRootContentTransform() const { return m_childFrameOwnerToRootContentTransform; }
     float usedZoom() const { return m_usedZoom; }
     LayoutPoint contentBoxLocation() const { return m_contentBoxLocation; }
     OptionSet<FrameOwnerElementAppearance> ownerElementAppearance() const { return m_ownerElementAppearance; }
 
 private:
-    RemoteFrameLayoutInfo(std::optional<LayoutRect>, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
+    RemoteFrameLayoutInfo(std::optional<LayoutRect>, TransformationMatrix, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
 
     // Rectangle of the visible portion of the frame in its parent frame,
     // in the coordinate space of the document of the parent frame.
     std::optional<LayoutRect> m_visibleRectInParent;
+
+    // The transformation matrix to project from the frame owner's
+    // coordinate space to its RenderView's (root) coordinate space.
+    // Note: this DOES NOT include the frame scale transform on the
+    // RenderView.
+    TransformationMatrix m_childFrameOwnerToRootContentTransform;
 
     // Style::ComputedStyle::usedZoom of the owner renderer of the frame.
     float m_usedZoom;

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -95,6 +95,14 @@ LayoutPoint RemoteFrameView::childFrameOwnerContentBoxLocation(const Frame& chil
     return { };
 }
 
+TransformationMatrix RemoteFrameView::childFrameOwnerToRootContentTransform(const Frame& child) const
+{
+    if (RefPtr info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.get(child.frameID()))
+        return info->childFrameOwnerToRootContentTransform();
+
+    return { };
+}
+
 // FIXME: Implement all the stubs below.
 
 bool RemoteFrameView::isScrollableOrRubberbandable()

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -54,6 +54,7 @@ public:
 
     OptionSet<FrameOwnerElementAppearance> appearanceOfOwnerElementOfChildFrame(const Frame&) const final;
     LayoutPoint childFrameOwnerContentBoxLocation(const Frame&) const final;
+    TransformationMatrix childFrameOwnerToRootContentTransform(const Frame&) const final;
 
 private:
     WEBCORE_EXPORT RemoteFrameView(RemoteFrame&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2208,6 +2208,7 @@ class WebCore::LayoutRect {
 
 [RefCounted] class WebCore::RemoteFrameLayoutInfo {
     std::optional<WebCore::LayoutRect> visibleRectInParent();
+    WebCore::TransformationMatrix childFrameOwnerToRootContentTransform();
     float usedZoom();
     WebCore::LayoutPoint contentBoxLocation();
     OptionSet<WebCore::FrameOwnerElementAppearance> ownerElementAppearance();


### PR DESCRIPTION
#### d376be4e979439224f404894a733b8a4000730c4
<pre>
[Site Isolation] [intersection-observer] Project rect from local to absolute before intersecting with synced visibleRectOfChild
<a href="https://rdar.apple.com/178172371">rdar://178172371</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315779">https://bugs.webkit.org/show_bug.cgi?id=315779</a>

Reviewed by Simon Fraser.

In computeClippedRectInRootContentsSpace, there&apos;s an alternative codepath
for computing visible rect when the frame owner renderer is not available
(as in the case when Site Isolation is enabled). In the process that contains
the frame owner renderer, we pre-compute the visible rect of the entire
renderer rect in its RenderView and synchronize it as visibleRectOfChild
using RemoteFrameLayoutInfo. In other processes, given a rectangle that&apos;s
entirely within the renderer rect, we can simply intersect it with
visibleRectOfChild (retrieved from FrameView::visibleRectOfChild) to get
the visible rect of tha rect.

Except that visibleRectOfChild is in the coordinate space of the enclosing
frame&apos;s RenderView, while the input rect to computeClippedRectInRootContentsSpace
is in the coordinate space of the frame owner renderer. So we have to project
the input rect to the coordinate space of the RenderView first. This is
usually done by using localToContainerQuad, but remember in Site
Isolation we don&apos;t have access to the frame owner renderer.

localToContainerQuad works by accumulating offsets and transforms from
a renderer up to the container into a TransformState, then applying
the transform on the input quad. This patch pre-computes the TransformState
to go from frame owner renderer -&gt; RenderView, then synchronize the
transform matrix using RemoteFrameLayoutInfo. Then other processes
can perform the conversion using the synchronized matrix.

This change should NOT affect non-SI usecases as it only changes the
SI codepath.

Tests: imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin.html
       imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-same-origin.html
       imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin.html
       imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-same-origin.html

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/transformed-iframe-subframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-same-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-same-origin.html: Added.
    - Add tests that check that intersection observer works in transformed iframes.
      These tests applies perspective transform on the iframes, and will fail if the
      synchronized matrix is reduced to affine form (instead of just flattened).
      There&apos;s one FAIL caused by existing code, tracked at webkit.org/b/315909

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-same-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-same-origin.html: Added.
    - Add tests similar to transformed-iframe-001-*.html

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
    - Mark cross-origin tests as failed - Intersection Observer x Site Isolation
      doesn&apos;t work (yet).

* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::computeClippedRectInRootContentsSpace):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::childFrameOwnerToRootContentTransform const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::syncLocalFrameInfoToRemote):
* Source/WebCore/page/RemoteFrameLayoutInfo.cpp:
(WebCore::RemoteFrameLayoutInfo::create):
(WebCore::RemoteFrameLayoutInfo::RemoteFrameLayoutInfo):
* Source/WebCore/page/RemoteFrameLayoutInfo.h:
(WebCore::RemoteFrameLayoutInfo::childFrameOwnerToRootContentTransform const):
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::childFrameOwnerToRootContentTransform const):
* Source/WebCore/page/RemoteFrameView.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/314685@main">https://commits.webkit.org/314685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ede173c2b06164dbf49ef631fd98e67d352a2622

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124091 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129728 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2b61e9d-20a7-423b-986f-6414bcd9256e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110254 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80917c6f-9b52-4706-9972-cb99d9dff4d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31106 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29805 "Passed tests") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141079 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178419 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31316 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138098 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138011 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37172 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149401 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103879 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33287 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26266 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39592 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112666 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38988 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4359 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39233 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39131 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->