### PR TITLE
[WPE][cross-toolchain-helper] REGRESSION(313950@main) REGRESSION(313986@main): repeated info messages and wrong warning when building WebKit

### DIFF
--- a/Tools/Scripts/cross-toolchain-helper
+++ b/Tools/Scripts/cross-toolchain-helper
@@ -60,9 +60,9 @@ def configure_logging(selected_log_level='info'):
     elif selected_log_level == 'info':
         log_level = logging.INFO
     elif selected_log_level == 'quiet':
-        log_level = logging.NOTSET
+        log_level = logging.CRITICAL + 1
     elif selected_log_level == 'minimal':
-        log_level = logging.getLevelName(LOG_MESSAGE)
+        log_level = LOG_MESSAGE
 
     handler = LogHandler(sys.stdout)
     logger = logging.getLogger()
@@ -655,7 +655,7 @@ class YoctoCrossBuilder():
             fw.write('echo "${COMPNAME} version: $($CC -dumpversion)"\n')
             fw.write('echo "${COMPNAME} target: $($CC -dumpmachine)"\n')
             fw.write('echo -e "\\nCall the cross compiler/debugger"\n')
-            fw.write('echo "with env vars: \$CC / \$CXX / \$GDB"\n')
+            fw.write('echo "with env vars: \\$CC / \\$CXX / \\$GDB"\n')
             fw.write('echo "##################################"\n')
             fw.write('export PS1="(WKCrossDevShell:{target}) ${{PS1}}"\n'.format(target=self._target))
         assert (os.path.isfile(custom_rc_file))

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -578,11 +578,13 @@ sub determineArchitecture
             if (shouldBuildForCrossTarget()) {
                 my $helper = File::Spec->catfile(sourceDir(), "Tools", "Scripts", "cross-toolchain-helper");
                 my $target = getCrossTargetName();
-                # Pre-build the toolchain so its (potentially multi-hour) bitbake output reaches
+                # Pre-build the toolchain if needed so its (potentially multi-hour) bitbake output reaches
                 # the terminal instead of being swallowed by the pipe opened below.
-                system($helper, "--cross-target=$target", "--build-toolchain") == 0
+                # Pass --log-level=quiet here to avoid repeated info messages from the tool, those info messages
+                # would be printed later when the build is started later at runInCrossTargetEnvironment()
+                system($helper, "--log-level=quiet", "--cross-target=$target", "--build-toolchain") == 0
                     or die "cross-toolchain-helper --build-toolchain failed for $target\n";
-                $prefix = "$helper --cross-target=$target --cross-toolchain-run-cmd";
+                $prefix = "$helper --log-level=quiet --cross-target=$target --cross-toolchain-run-cmd";
             }
             if (open my $cmake_sysinfo, "$prefix cmake --system-information |") {
                 while (<$cmake_sysinfo>) {
@@ -2943,14 +2945,15 @@ sub generateBuildSystemFromCMakeProject
     # The GTK and WPE bots build and test with -DENABLE_ASSERTS=ON (both on Release and Debug).
     # Warn when the local build differs from the CI configuration.
     if (isGtk() || isWPE()) {
+        # configuration() is the name of the build config and directory, and in the case of a cross-toolchain
+        # build it is something like "Release_rpi4-64bits-mesa" (for example), so this doesn't trigger in that case.
+        # That is intentional: the CI does not enable assertions for cross-toolchain builds, so no need to warn.
         if (configuration() eq "Release") {
             my $assertsOn = grep { /^-DENABLE_ASSERTS=ON\b/i } @args;
             print STDERR "WARNING: Building Release without assertions. Pass --asserts to match the CI build.\n" unless $assertsOn;
         } elsif (configuration() eq "Debug") {
             my $assertsOff = grep { /^-DENABLE_ASSERTS=OFF\b/i } @args;
             print STDERR "WARNING: Building Debug with assertions disabled. Drop --no-asserts to match the CI build.\n" if $assertsOff;
-        } else {
-            print STDERR "WARNING: Building " . configuration() . ". This is not tested on the CI.\n";
         }
     }
 


### PR DESCRIPTION
#### 778e858024a409552b4df90369221965152f9b27
<pre>
[WPE][cross-toolchain-helper] REGRESSION(313950@main) REGRESSION(313986@main): repeated info messages and wrong warning when building WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=315783">https://bugs.webkit.org/show_bug.cgi?id=315783</a>

Reviewed by Nikolas Zimmermann.

After 313950@main cross-toolchain-helper is called twice with output stdout
(not captured) and each time it gets executed it prints several info messages,
so it ends printing those info messages twice.
Fix that by suppressing the info messages on the first run.
And also fix a bug in the logger level of cross-toolchain-helper, because
&quot;quiet&quot; was not working.

After 313986@main when doing a cross-toolchain-helper it printed this:
  WARNING: Building Release_rpi4-64bits-mesa. This is not tested on the CI.
That is wrong, so fix it also.

* Tools/Scripts/cross-toolchain-helper:
(configure_logging):
(YoctoCrossBuilder.cross_dev_shell):
* Tools/Scripts/webkitdirs.pm:
(determineArchitecture):
(generateBuildSystemFromCMakeProject):

Canonical link: <a href="https://commits.webkit.org/314131@main">https://commits.webkit.org/314131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06534a0decbfb5f43b87b2a10cef33da5631eb34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38746 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174298 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38747 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/128409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30722 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/148473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108934 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22052 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157414 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139665 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/26171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176820 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26150 "Built successfully and passed tests") | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/27876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/136731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38814 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/136670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39504 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/147967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101835 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25132 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31949 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38014 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37411 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/2912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37555 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->