### PR TITLE
Re-import MediaSession WPT

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -556,6 +556,13 @@ webkit.org/b/176929 imported/w3c/web-platform-tests/html/semantics/embedded-cont
 
 webkit.org/b/311501 imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch.https.html [ Pass Failure ]
 
+# Media Session tests: rdar://178443322
+imported/w3c/web-platform-tests/mediasession/idlharness.window.html [ Failure ]
+imported/w3c/web-platform-tests/mediasession/mediametadata.html [ Failure ]
+imported/w3c/web-platform-tests/mediasession/setactionhandler.html [ Failure ]
+imported/w3c/web-platform-tests/mediasession/setcameraactive.html [ Pass Failure ]
+imported/w3c/web-platform-tests/mediasession/setmicrophoneactive.html [ Pass Failure ]
+
 # Requires additional test infrastructure.
 imported/w3c/web-platform-tests/service-workers/service-worker/update-after-oneday.https.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/META.yml
@@ -1,3 +1,3 @@
-spec: https://wicg.github.io/mediasession/
+spec: https://w3c.github.io/mediasession/
 suggested_reviewers:
   - mounirlamouri

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: media-session
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/artwork-url-encoding-euc-kr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/artwork-url-encoding-euc-kr.html
@@ -7,9 +7,9 @@
 
   test(() => {
     // "icon" in Korean language
-    const iconKorean = "\uc544\uc744\ucf58";
+    const iconKorean = "\uc544\uc774\ucf58";
     const metadata = new MediaMetadata({ artwork: [{ src: `?icon=${iconKorean}` }] });
 
-    assert_equals(new URL(metadata.artwork[0].src).search, "?icon=%EC%95%84%EC%9D%84%EC%BD%98", "artwork src encoded with utf-8");
+    assert_equals(new URL(metadata.artwork[0].src).search, "?icon=%EC%95%84%EC%9D%B4%EC%BD%98", "artwork src encoded with utf-8");
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/helper/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/helper/w3c-import.log
@@ -14,4 +14,4 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
-/LayoutTests/imported/w3c/mediasession/helper/artwork-generator.html
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/helper/artwork-generator.html

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/idlharness.window-expected.txt
@@ -50,23 +50,23 @@ PASS MediaMetadata interface: attribute title
 PASS MediaMetadata interface: attribute artist
 PASS MediaMetadata interface: attribute album
 PASS MediaMetadata interface: attribute artwork
-FAIL MediaMetadata interface: attribute chapterInfo assert_true: The prototype object must have a property "chapterInfo" expected true got false
+PASS MediaMetadata interface: attribute chapterInfo
 PASS MediaMetadata must be primary interface of new MediaMetadata()
 PASS Stringification of new MediaMetadata()
 PASS MediaMetadata interface: new MediaMetadata() must inherit property "title" with the proper type
 PASS MediaMetadata interface: new MediaMetadata() must inherit property "artist" with the proper type
 PASS MediaMetadata interface: new MediaMetadata() must inherit property "album" with the proper type
 PASS MediaMetadata interface: new MediaMetadata() must inherit property "artwork" with the proper type
-FAIL MediaMetadata interface: new MediaMetadata() must inherit property "chapterInfo" with the proper type assert_inherits: property "chapterInfo" not found in prototype chain
-FAIL ChapterInformation interface: existence and properties of interface object assert_own_property: self does not have own property "ChapterInformation" expected property "ChapterInformation" missing
-FAIL ChapterInformation interface object length assert_own_property: self does not have own property "ChapterInformation" expected property "ChapterInformation" missing
-FAIL ChapterInformation interface object name assert_own_property: self does not have own property "ChapterInformation" expected property "ChapterInformation" missing
-FAIL ChapterInformation interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ChapterInformation" expected property "ChapterInformation" missing
-FAIL ChapterInformation interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ChapterInformation" expected property "ChapterInformation" missing
-FAIL ChapterInformation interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ChapterInformation" expected property "ChapterInformation" missing
-FAIL ChapterInformation interface: attribute title assert_own_property: self does not have own property "ChapterInformation" expected property "ChapterInformation" missing
-FAIL ChapterInformation interface: attribute startTime assert_own_property: self does not have own property "ChapterInformation" expected property "ChapterInformation" missing
-FAIL ChapterInformation interface: attribute artwork assert_own_property: self does not have own property "ChapterInformation" expected property "ChapterInformation" missing
+PASS MediaMetadata interface: new MediaMetadata() must inherit property "chapterInfo" with the proper type
+PASS ChapterInformation interface: existence and properties of interface object
+PASS ChapterInformation interface object length
+PASS ChapterInformation interface object name
+PASS ChapterInformation interface: existence and properties of interface prototype object
+PASS ChapterInformation interface: existence and properties of interface prototype object's "constructor"
+PASS ChapterInformation interface: existence and properties of interface prototype object's @@unscopables property
+PASS ChapterInformation interface: attribute title
+PASS ChapterInformation interface: attribute startTime
+PASS ChapterInformation interface: attribute artwork
 PASS Navigator interface: attribute mediaSession
 PASS Navigator interface: navigator must inherit property "mediaSession" with the proper type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/mediametadata-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/mediametadata-expected.txt
@@ -9,12 +9,14 @@ PASS Test the default values for MediaMetadata with empty init dictionary
 PASS Test the default values for MediaMetadata with no init dictionary
 PASS Test that passing unknown values to the dictionary is a no-op
 PASS Test that MediaMetadata is read/write
-PASS Test that MediaMetadat.artwork can't be modified
+PASS Test that MediaMetadata.artwork can't be modified
 PASS Test that MediaMetadata.artwork will not expose unknown properties
-FAIL Test that MediaMetadata.artwork is Frozen assert_true: expected true got false
+PASS Test that MediaMetadata.artwork is Frozen
+PASS Test that MediaMetadata.chapterInfo is Frozen
 PASS Test that MediaMetadata.artwork returns parsed urls
+PASS Test that MediaMetadata.chapterInfo's artwork returns parsed urls
 PASS Test that MediaMetadata throws when setting an invalid url
 PASS Test MediaImage default values
 PASS Test that MediaImage.src is required
-FAIL Test that the base URL of MediaImage is the base URL of entry setting object assert_equals: expected "http://web-platform.test:8800/foo" but got "http://web-platform.test:8800/mediasession/foo"
+PASS Test that the base URL of MediaImage is the base URL of entry setting object
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/mediametadata.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/mediametadata.html
@@ -50,8 +50,27 @@ test(function() {
 test(function() {
   var image1 = { src: 'http://example.com/1', sizes: 'sizes1', type: 'type1' };
   var image2 = { src: 'http://example.com/2', sizes: 'sizes2', type: 'type2' };
+  var chapter1_image1 = { src: 'http://chapterexample.com/1', sizes: '128x128', type: 'image/png' };
+  var chapter1_image2 = { src: 'http://chapterexample.com/2', sizes: '512x512', type: 'image/png' };
+  var chapter2_image1 = { src: 'http://chapterexample.com/3', sizes: '128x128', type: 'image/png' };
+  var chapter2_image2 = { src: 'http://chapterexample.com/4', sizes: '512x512', type: 'image/png' };
   var metadata = new MediaMetadata({
-      title: 'foo', album: 'bar', artist: 'plop', artwork: [ image1, image2 ]
+    title: 'foo', album: 'bar', artist: 'plop', artwork: [image1, image2],
+    chapterInfo: [{
+      title: 'Chapter 1',
+      startTime: 0,
+      artwork: [
+        chapter1_image1,
+        chapter1_image2
+      ]
+    }, {
+      title: 'Chapter 2',
+      startTime: 16,
+      artwork: [
+        chapter2_image1,
+        chapter2_image2,
+      ]
+    }]
   });
 
   assert_equals(metadata.title, 'foo');
@@ -64,6 +83,22 @@ test(function() {
   assert_equals(metadata.artwork[1].src, image2.src);
   assert_equals(metadata.artwork[1].sizes, image2.sizes);
   assert_equals(metadata.artwork[1].type, image2.type);
+  assert_equals(metadata.chapterInfo[0].title, 'Chapter 1');
+  assert_equals(metadata.chapterInfo[0].startTime, 0);
+  assert_equals(metadata.chapterInfo[0].artwork[0].src, chapter1_image1.src);
+  assert_equals(metadata.chapterInfo[0].artwork[1].src, chapter1_image2.src);
+  assert_equals(metadata.chapterInfo[0].artwork[0].sizes, chapter1_image1.sizes);
+  assert_equals(metadata.chapterInfo[0].artwork[1].sizes, chapter1_image2.sizes);
+  assert_equals(metadata.chapterInfo[0].artwork[0].type, chapter1_image1.type);
+  assert_equals(metadata.chapterInfo[0].artwork[1].type, chapter1_image2.type);
+  assert_equals(metadata.chapterInfo[1].title, 'Chapter 2');
+  assert_equals(metadata.chapterInfo[1].startTime, 16);
+  assert_equals(metadata.chapterInfo[1].artwork[0].src, chapter2_image1.src);
+  assert_equals(metadata.chapterInfo[1].artwork[1].src, chapter2_image2.src);
+  assert_equals(metadata.chapterInfo[1].artwork[0].sizes, chapter2_image1.sizes);
+  assert_equals(metadata.chapterInfo[1].artwork[1].sizes, chapter2_image2.sizes);
+  assert_equals(metadata.chapterInfo[1].artwork[0].type, chapter2_image1.type);
+  assert_equals(metadata.chapterInfo[1].artwork[1].type, chapter2_image2.type);
 }, 'Test the different values allowed in MediaMetadata init dictionary');
 
 test(function() {
@@ -72,6 +107,7 @@ test(function() {
   assert_equals(metadata.artist, '');
   assert_equals(metadata.album, '');
   assert_equals(0, metadata.artwork.length);
+  assert_equals(0, metadata.chapterInfo.length);
 }, 'Test the default values for MediaMetadata with empty init dictionary');
 
 test(function() {
@@ -80,6 +116,7 @@ test(function() {
   assert_equals(metadata.artist, '');
   assert_equals(metadata.album, '');
   assert_equals(0, metadata.artwork.length);
+  assert_equals(0, metadata.chapterInfo.length);
 }, 'Test the default values for MediaMetadata with no init dictionary');
 
 test(function() {
@@ -90,8 +127,28 @@ test(function() {
 test(function() {
   var image1 = { src: 'http://example.com/1', sizes: 'sizes1', type: 'type1' };
   var image2 = { src: 'http://example.com/2', sizes: 'sizes2', type: 'type2' };
+  var chapter1_image1 = { src: 'http://chapterexample.com/1', sizes: '128x128', type: 'image/png' };
+  var chapter1_image2 = { src: 'http://chapterexample.com/2', sizes: '512x512', type: 'image/png' };
+  var chapter2_image1 = { src: 'http://chapterexample.com/3', sizes: '128x128', type: 'image/png' };
+  var chapter2_image2 = { src: 'http://chapterexample.com/4', sizes: '512x512', type: 'image/png' };
+
   var metadata = new MediaMetadata({
-    title: 'foo', album: 'bar', artist: 'plop', artwork: [ image1, image2 ]
+    title: 'foo', album: 'bar', artist: 'plop', artwork: [image1, image2],
+    chapterInfo: [{
+      title: 'Chapter 1',
+      startTime: 0,
+      artwork: [
+        chapter1_image1,
+        chapter1_image2
+      ]
+    }, {
+      title: 'Chapter 2',
+      startTime: 16,
+      artwork: [
+        chapter2_image1,
+        chapter2_image2,
+      ]
+    }]
   });
 
   metadata.title = 'something else';
@@ -109,6 +166,18 @@ test(function() {
   assert_equals(metadata.artwork[0].src, 'http://example.com/');
   assert_equals(metadata.artwork[0].sizes, '40x40');
   assert_equals(metadata.artwork[0].type, 'image/png');
+
+  // The chapterInfo cannot be modified.
+  var chapter_image = { src: 'http://example.com/', sizes: '40x40', type: 'image/png' };
+  var chapter = {
+    title: 'Chapter 3',
+    startTime: 22,
+    artwork: [chapter_image]
+  };
+  metadata.chapterInfo = [chapter];
+  assert_equals(metadata.chapterInfo[0].title, 'Chapter 1');
+  assert_equals(metadata.chapterInfo[0].startTime, 0);
+  assert_equals(metadata.chapterInfo.length, 2);
 }, "Test that MediaMetadata is read/write");
 
 test(function() {
@@ -121,7 +190,7 @@ test(function() {
 
   metadata.artwork[0].src = 'bar';
   assert_equals(metadata.artwork[0].src, 'http://foo.com/');
-}, "Test that MediaMetadat.artwork can't be modified");
+}, "Test that MediaMetadata.artwork can't be modified");
 
 test(function() {
   var metadata = new MediaMetadata({ artwork: [{
@@ -149,6 +218,34 @@ test(function() {
 }, "Test that MediaMetadata.artwork is Frozen");
 
 test(function() {
+  var chapter1_image1 = { src: 'http://chapterexample.com/1', sizes: '128x128', type: 'image/png' };
+  var chapter1_image2 = { src: 'http://chapterexample.com/2', sizes: '512x512', type: 'image/png' };
+  var chapter2_image1 = { src: 'http://chapterexample.com/3', sizes: '128x128', type: 'image/png' };
+  var chapter2_image2 = { src: 'http://chapterexample.com/4', sizes: '512x512', type: 'image/png' };
+  var metadata = new MediaMetadata({
+    chapterInfo: [{
+      title: 'Chapter 1',
+      startTime: 0,
+      artwork: [
+        chapter1_image1,
+        chapter1_image2
+      ]
+    }, {
+      title: 'Chapter 2',
+      startTime: 16,
+      artwork: [
+        chapter2_image1,
+        chapter2_image2,
+      ]
+    }]
+  });
+
+  assert_true(Object.isFrozen(metadata.chapterInfo));
+  for (var i = 0; i < metadata.chapterInfo.length; ++i)
+    assert_true(Object.isFrozen(metadata.chapterInfo[i]));
+}, "Test that MediaMetadata.chapterInfo is Frozen");
+
+test(function() {
   var metadata = new MediaMetadata({ artwork: [
     { src: 'http://example.com', sizes: '40x40', type: 'image/png' },
     { src: '../foo', sizes: '40x40', type: 'image/png' },
@@ -161,10 +258,43 @@ test(function() {
 }, "Test that MediaMetadata.artwork returns parsed urls");
 
 test(function() {
+  var chapter1_image1 = { src: 'http://chapterexample.com/1', sizes: '128x128', type: 'image/png' };
+  var chapter1_image2 = { src: 'http://chapterexample.com/2', sizes: '512x512', type: 'image/png' };
+  var chapter2_image1 = { src: 'http://chapterexample.com/3', sizes: '128x128', type: 'image/png' };
+  var chapter2_image2 = { src: 'http://chapterexample.com/4', sizes: '512x512', type: 'image/png' };
+  var metadata = new MediaMetadata({
+    chapterInfo: [{
+      title: 'Chapter 1',
+      startTime: 0,
+      artwork: [
+        chapter1_image1,
+        chapter1_image2
+      ]
+    }, {
+      title: 'Chapter 2',
+      startTime: 16,
+      artwork: [
+        chapter2_image1,
+        chapter2_image2,
+      ]
+    }]
+  });
+
+  assert_equals(metadata.chapterInfo[0].artwork[0].src,
+    new URL('http://chapterexample.com/1', document.URL).href)
+  assert_equals(metadata.chapterInfo[0].artwork[1].src,
+    new URL('http://chapterexample.com/2', document.URL).href)
+  assert_equals(metadata.chapterInfo[1].artwork[0].src,
+    new URL('http://chapterexample.com/3', document.URL).href)
+  assert_equals(metadata.chapterInfo[1].artwork[1].src,
+    new URL('http://chapterexample.com/4', document.URL).href)
+}, "Test that MediaMetadata.chapterInfo's artwork returns parsed urls");
+
+test(function() {
   var metadata = 42;
 
   assert_throws_js(TypeError, _ => {
-    metadata
+    metadata =
       new MediaMetadata({ artwork: [ { src: 'http://[example.com]' }] });
   });
   assert_equals(metadata, 42);
@@ -180,6 +310,22 @@ test(function() {
   });
   assert_equals(metadata.artwork.length, 0);
 
+  assert_throws_js(TypeError, _ => {
+    metadata =
+    new MediaMetadata({
+      chapterInfo: [{
+        title: 'Chapter 1',
+        startTime: 0,
+        artwork: [
+          // Valid url.
+          { src: 'http://example.com' },
+          // Invalid url.
+          { src: 'http://example.com:demo' },
+        ]
+      }]
+    });
+  });
+  assert_equals(metadata.chapterInfo.length, 0);
 }, "Test that MediaMetadata throws when setting an invalid url");
 
 test(function() {
@@ -190,12 +336,23 @@ test(function() {
 
 test(function() {
   assert_throws_js(TypeError, _ => {
-    new MediaMetadata({ artwork: [ {} ] });
+    new MediaMetadata({ artwork: [ {} ] })
   });
 
   var metadata = new MediaMetadata();
   assert_throws_js(TypeError, _ => {
     metadata.artwork = [ { type: 'image/png', sizes: '40x40' } ];
+  });
+
+  assert_throws_js(TypeError, _ => {
+    metadata =
+    new MediaMetadata({
+      chapterInfo: [{
+        title: 'Chapter 1',
+        startTime: 0,
+        artwork: [{ type: 'image/png', sizes: '40x40' }]
+      }]
+    });
   });
 }, "Test that MediaImage.src is required")
 
@@ -212,7 +369,7 @@ promise_test(async t => {
 
   assert_equals(artwork.length, URLs.length);
   for (let i = 0 ; i < artwork.length ; ++i) {
-    assert_equals(artwork[i].src, new URL(URLs[i], document.URL).href);
+    assert_equals(artwork[i].src, new URL(URLs[i], subframe.contentDocument.URL).href);
   }
 }, 'Test that the base URL of MediaImage is the base URL of entry setting object');
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/setactionhandler-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/setactionhandler-expected.txt
@@ -1,4 +1,20 @@
 
-PASS Test that setActionHandler() can be executed for supported actions
+PASS Test that setActionHandler("play") succeeds
+PASS Test that setActionHandler("pause") succeeds
+PASS Test that setActionHandler("previoustrack") succeeds
+PASS Test that setActionHandler("nexttrack") succeeds
+PASS Test that setActionHandler("seekbackward") succeeds
+PASS Test that setActionHandler("seekforward") succeeds
+PASS Test that setActionHandler("stop") succeeds
+PASS Test that setActionHandler("seekto") succeeds
+PASS Test that setActionHandler("skipad") succeeds
+PASS Test that setActionHandler("togglemicrophone") succeeds
+PASS Test that setActionHandler("togglecamera") succeeds
+PASS Test that setActionHandler("togglescreenshare") succeeds
+PASS Test that setActionHandler("hangup") succeeds
+PASS Test that setActionHandler("previousslide") succeeds
+PASS Test that setActionHandler("nextslide") succeeds
+PASS Test that setActionHandler("enterpictureinpicture") succeeds
+PASS Test that setActionHandler("voiceactivity") succeeds
 PASS Test that setActionHandler() throws exception for unsupported actions
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/setactionhandler.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/setactionhandler.html
@@ -1,20 +1,33 @@
 <!DOCTYPE html>
 <title>Test that setting MediaSession event handler should notify the service</title>
+<link rel="help" href="https://w3c.github.io/mediasession/#media-session-action" />
 <script src=/resources/testharness.js></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
 
-test(function(t) {
-  window.navigator.mediaSession.setActionHandler("play", null);
-  window.navigator.mediaSession.setActionHandler("pause", null);
-  window.navigator.mediaSession.setActionHandler("previoustrack", null);
-  window.navigator.mediaSession.setActionHandler("nexttrack", null);
-  window.navigator.mediaSession.setActionHandler("seekbackward", null);
-  window.navigator.mediaSession.setActionHandler("seekforward", null);
-  window.navigator.mediaSession.setActionHandler("stop", null);
-  window.navigator.mediaSession.setActionHandler("seekto", null);
-  window.navigator.mediaSession.setActionHandler("skipad", null);
-}, "Test that setActionHandler() can be executed for supported actions");
+[
+  "play",
+  "pause",
+  "previoustrack",
+  "nexttrack",
+  "seekbackward",
+  "seekforward",
+  "stop",
+  "seekto",
+  "skipad",
+  "togglemicrophone",
+  "togglecamera",
+  "togglescreenshare",
+  "hangup",
+  "previousslide",
+  "nextslide",
+  "enterpictureinpicture",
+  "voiceactivity"
+].forEach((action) =>
+  test((t) => {
+    window.navigator.mediaSession.setActionHandler(action, null);
+  }, `Test that setActionHandler("${action}") succeeds`)
+);
 
 test(function(t) {
   assert_throws_js(

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/setcameraactive-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/setcameraactive-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that setCameraActive() can be executed for boolean values
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/setcameraactive.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/setcameraactive.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>MediaSession.setCameraActive</title>
+<script src=/resources/testharness.js></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+test(function(t) {
+  window.navigator.mediaSession.setCameraActive(true);
+  window.navigator.mediaSession.setCameraActive(false);
+}, "Test that setCameraActive() can be executed for boolean values");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/setmicrophoneactive-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/setmicrophoneactive-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that setMicrophoneActive() can be executed for boolean values
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/setmicrophoneactive.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/setmicrophoneactive.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>MediaSession.setMicrophoneActive</title>
+<script src=/resources/testharness.js></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+test(function(t) {
+  window.navigator.mediaSession.setMicrophoneActive(true);
+  window.navigator.mediaSession.setMicrophoneActive(false);
+}, "Test that setMicrophoneActive() can be executed for boolean values");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/w3c-import.log
@@ -14,10 +14,16 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
-/LayoutTests/imported/w3c/mediasession/META.yml
-/LayoutTests/imported/w3c/mediasession/README.md
-/LayoutTests/imported/w3c/mediasession/idlharness.window.js
-/LayoutTests/imported/w3c/mediasession/mediametadata.html
-/LayoutTests/imported/w3c/mediasession/playbackstate.html
-/LayoutTests/imported/w3c/mediasession/positionstate.html
-/LayoutTests/imported/w3c/mediasession/setactionhandler.html
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/README.md
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/artwork-url-encoding-euc-kr.html
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/idlharness.window.js
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch-service-worker.js
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/media-session-artwork-fetch.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/mediametadata.html
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/playbackstate.html
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/positionstate.html
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/setactionhandler.html
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/setcameraactive.html
+/LayoutTests/imported/w3c/web-platform-tests/mediasession/setmicrophoneactive.html


### PR DESCRIPTION
#### 4697505dc41536135b0909fd919c2f20cde40a5a
<pre>
Re-import MediaSession WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=315785">https://bugs.webkit.org/show_bug.cgi?id=315785</a>
<a href="https://rdar.apple.com/178181144">rdar://178181144</a>

Reviewed by Tim Nguyen.

Re-import MediaSession WPT and update -expected.txt files and test expectations.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/0e327c7a1208ad0659de9c99178d5f608b1ad585">https://github.com/web-platform-tests/wpt/commit/0e327c7a1208ad0659de9c99178d5f608b1ad585</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/mediasession/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/mediasession/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediasession/artwork-url-encoding-euc-kr.html:
* LayoutTests/imported/w3c/web-platform-tests/mediasession/helper/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/mediasession/idlharness.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediasession/mediametadata-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediasession/mediametadata.html:
* LayoutTests/imported/w3c/web-platform-tests/mediasession/setactionhandler-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediasession/setactionhandler.html:
* LayoutTests/imported/w3c/web-platform-tests/mediasession/setcameraactive-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediasession/setcameraactive.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediasession/setmicrophoneactive-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediasession/setmicrophoneactive.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediasession/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/314332@main">https://commits.webkit.org/314332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/705ecc7da715fc25afdedcf56c6d03508511b399

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123043 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3f8324d-7b0f-4d13-a536-9d65657341f5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128842 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64f2713c-e25d-4097-aedb-796e7edff586) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168747 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109366 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/978051db-0c05-4eb9-9327-934b4c2eb6e3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28861 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22913 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177355 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137176 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137104 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148448 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102566 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25241 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25315 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38546 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37942 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3397 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38188 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38086 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->