### PR TITLE
[resultsdbpy] ArchiveView URL rewriter doesn't propagate query into current results.html link templates

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/archive_view.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/archive_view.py
@@ -20,11 +20,12 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from flask import abort, jsonify, request, Response
+from flask import abort, jsonify, redirect, request, Response
 from resultsdbpy.controller.commit_controller import uuid_range_for_query, HasCommitContext
 from resultsdbpy.controller.configuration_controller import configuration_for_query
 from resultsdbpy.controller.suite_controller import time_range_for_query
 from resultsdbpy.view.site_menu import SiteMenu
+from urllib.parse import urlparse
 from webkitflaskpy.util import AssertRequest, boolean_query, cache_for, limit_for_query, query_as_kwargs, query_as_string
 
 
@@ -70,6 +71,20 @@ class ArchiveView(HasCommitContext):
     ):
         AssertRequest.is_type(['GET'])
         AssertRequest.query_kwargs_empty(**kwargs)
+
+        # When a file (not a listing) is requested with no narrowing query,
+        # fall back to the parent page's query via the Referer header.
+        # Result-file links inside served results.html (e.g. *-diff.txt)
+        # are sometimes built by JS templates that we don't rewrite, so
+        # they navigate without our query and would otherwise match every
+        # recent archive across configs. Listings are deliberately
+        # exempted so cross-page navigation never silently narrows them.
+        is_listing = not path or path.endswith('/')
+        if not is_listing and not request.query_string and request.referrer:
+            referrer = urlparse(request.referrer)
+            if referrer.netloc == request.host and referrer.query:
+                return redirect(f'{request.path}?{referrer.query}')
+
         recent = boolean_query(*recent)[0] if recent else True
 
         if not suite:
@@ -82,12 +97,16 @@ class ArchiveView(HasCommitContext):
         result = None
         with self.archive_context, self.upload_context:
             for suite in suites:
-                for files in self.archive_context.file(
-                    path=path,
-                    configurations=configurations, suite=suite, branch=branch[0],
-                    begin=begin, end=end, recent=recent, limit=2,
-                    begin_query_time=begin_query_time, end_query_time=end_query_time,
-                ).values():
+                try:
+                    matches = self.archive_context.file(
+                        path=path,
+                        configurations=configurations, suite=suite, branch=branch[0],
+                        begin=begin, end=end, recent=recent, limit=2,
+                        begin_query_time=begin_query_time, end_query_time=end_query_time,
+                    )
+                except RuntimeError as error:
+                    abort(400, f'Query too broad to fetch archives: {error}. Narrow by uuid or configuration.')
+                for files in matches.values():
                     for file in files:
                         candidate = file.get('file')
                         if not candidate:
@@ -116,15 +135,25 @@ class ArchiveView(HasCommitContext):
             mimetype = self.FORMAT.get(path.split('.')[-1])
         mimetype = mimetype or 'text/plain'
 
-        # A bit of a hack to add the right query arguments into results.html
-        # Ideally, this should be done with changes to results.html, but we
-        # have legacy results to handle.
+        # Patch link templates in served results.html to carry our query
+        # string. Each pattern is a JS string concatenation we expect to
+        # find verbatim; results.html has been rewritten more than once,
+        # so we handle every variant we still ship and the variants that
+        # exist in older archives we still serve.
         if mimetype == 'text/html':
             query = query_as_string()
-            result = result.replace(
-                "href=\"' + testPrefix + suffix + '\"".encode('utf-8'),
-                f"href=\"' + testPrefix + suffix + '{query}' + '\"".encode('utf-8'),
+            link_rewrites = (
+                (
+                    b"href=\"' + encodeURI(path + suffix) + '\"",
+                    f"href=\"' + encodeURI(path + suffix) + '{query}' + '\"".encode('utf-8'),
+                ),
+                (
+                    b"href=\"' + testPrefix + suffix + '\"",
+                    f"href=\"' + testPrefix + suffix + '{query}' + '\"".encode('utf-8'),
+                ),
             )
+            for old, new in link_rewrites:
+                result = result.replace(old, new)
 
             for include_to_strip in ['js/status-bubble.js', 'code-review.js?version=48']:
                 result = result.replace(f'<script src="{include_to_strip}"></script>'.encode('utf-8'), ''.encode('utf-8'))

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/archive_view_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/archive_view_unittest.py
@@ -21,10 +21,16 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import base64
+import io
 import json
+import zipfile
+from unittest.mock import patch
 
+import requests
 from fakeredis import FakeStrictRedis
 from resultsdbpy.controller.configuration import Configuration
+from resultsdbpy.flask_support.flask_testcase import FlaskTestCase
+from resultsdbpy.model.archive_context import ArchiveContext
 from resultsdbpy.model.configuration_context_unittest import ConfigurationContextTest
 from resultsdbpy.model.mock_cassandra_context import MockCassandraContext
 from resultsdbpy.model.mock_model_factory import MockModelFactory
@@ -34,32 +40,53 @@ from webkitscmpy import Commit
 
 
 class ArchiveViewUnittest(WebSiteTestCase):
-    def register_archive(self, client):
-        response = client.post(
-            self.URL + '/api/upload/archive',
-            data=dict(
-                configuration=json.dumps(ConfigurationContextTest.CONFIGURATIONS[0], cls=Configuration.Encoder),
-                suite='layout-tests',
-                commits=json.dumps([dict(
-                    repository_id='safari',
-                    id='d8bce26fa65c6fc8f39c17927abb77f69fab82fc',
-                    branch='main',
-                    timestamp=1601668000,
-                    order=1,
-                    committer='jbedard@apple.com',
-                    message='Patch Series\n',
-                ), dict(
-                    repository_id='webkit',
-                    id='6',
-                    branch='main',
-                    timestamp=1601665100,
-                    order=0,
-                    committer='jbedard@apple.com',
-                    message='6th commit\n',
-                )], cls=Commit.Encoder),
-            ),
-            files=dict(file=base64.b64decode(MockModelFactory.ARCHIVE_ZIP)),
+    COMMITS = [
+        dict(
+            repository_id='safari',
+            id='d8bce26fa65c6fc8f39c17927abb77f69fab82fc',
+            branch='main',
+            timestamp=1601668000,
+            order=1,
+            committer='jbedard@apple.com',
+            message='Patch Series\n',
+        ),
+        dict(
+            repository_id='webkit',
+            id='6',
+            branch='main',
+            timestamp=1601665100,
+            order=0,
+            committer='jbedard@apple.com',
+            message='6th commit\n',
+        ),
+    ]
+
+    @classmethod
+    def upload_archive(cls, client, content):
+        # Uploads work differently in the flask client than in requests.
+        meta = dict(
+            configuration=json.dumps(ConfigurationContextTest.CONFIGURATIONS[0], cls=Configuration.Encoder),
+            suite='layout-tests',
+            commits=json.dumps(cls.COMMITS, cls=Commit.Encoder),
         )
+        url = cls.URL + '/api/upload/archive'
+        if client == requests:
+            return client.post(url, data=meta, files=dict(file=content))
+        return client.post(url, data=dict(file=(io.BytesIO(content), 'archive.zip'), **meta))
+
+    def register_archive(self, client):
+        response = self.upload_archive(client, base64.b64decode(MockModelFactory.ARCHIVE_ZIP))
+        self.assertEqual(response.status_code, 200)
+
+    def register_archive_with_files(self, client, files):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, 'w') as archive:
+            archive.writestr(zipfile.ZipInfo('archive/'), '')
+            for name, content in files.items():
+                if isinstance(content, str):
+                    content = content.encode('utf-8')
+                archive.writestr(f'archive/{name}', content)
+        response = self.upload_archive(client, buffer.getvalue())
         self.assertEqual(response.status_code, 200)
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
@@ -87,3 +114,72 @@ class ArchiveViewUnittest(WebSiteTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, 'data')
         self.assertEqual(response.headers.get('Cache-Control'), 'public,max-age=43200')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_html_rewrites_modern_link_template(self, client, **kwargs):
+        template = b"<a href=\"' + encodeURI(path + suffix) + '\">x</a>"
+        self.register_archive_with_files(client, {'index.html': template})
+        response = client.get(f'{self.URL}/archive/index.html?platform=mac&suite=layout-tests')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            b"href=\"' + encodeURI(path + suffix) + '?platform=mac&suite=layout-tests' + '\"",
+            response.data,
+        )
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_html_rewrites_legacy_link_template(self, client, **kwargs):
+        template = b"<a href=\"' + testPrefix + suffix + '\">x</a>"
+        self.register_archive_with_files(client, {'legacy.html': template})
+        response = client.get(f'{self.URL}/archive/legacy.html?platform=mac&suite=layout-tests')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            b"href=\"' + testPrefix + suffix + '?platform=mac&suite=layout-tests' + '\"",
+            response.data,
+        )
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_extract_uses_referer_when_query_missing(self, client, **kwargs):
+        self.register_archive(client)
+        response = client.get(
+            f'{self.URL}/archive/file.txt',
+            headers={'Referer': f'{self.URL}/archive/index.html?platform=mac&suite=layout-tests'},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            response.headers['Location'].endswith('/archive/file.txt?platform=mac&suite=layout-tests'),
+            f'unexpected redirect target: {response.headers["Location"]}',
+        )
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_extract_ignores_cross_origin_referer(self, client, **kwargs):
+        self.register_archive(client)
+        response = client.get(
+            f'{self.URL}/archive/file.txt',
+            headers={'Referer': 'https://attacker.example/?platform=mac'},
+        )
+        self.assertNotEqual(response.status_code, 302)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_extract_listing_does_not_redirect_via_referer(self, client, **kwargs):
+        self.register_archive(client)
+        response = client.get(
+            f'{self.URL}/archive/',
+            headers={'Referer': f'{self.URL}/suites?platform=mac'},
+        )
+        self.assertNotEqual(response.status_code, 302)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_memory_cap_returns_400(self, client, **kwargs):
+        self.register_archive(client)
+        with patch.object(
+            ArchiveContext, 'file',
+            side_effect=RuntimeError('Hit soft-memory cap when fetching archives, aborting'),
+        ):
+            response = client.get(f'{self.URL}/archive/file.txt?platform=mac&suite=layout-tests')
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
#### 08c168d0f1f672e1ac5c3082fd466d3a5f678457
<pre>
[resultsdbpy] ArchiveView URL rewriter doesn&apos;t propagate query into current results.html link templates
<a href="https://bugs.webkit.org/show_bug.cgi?id=315792">https://bugs.webkit.org/show_bug.cgi?id=315792</a>
<a href="https://rdar.apple.com/178185668">rdar://178185668</a>

Reviewed by Jonathan Bedard.

This fixes the url rewriter.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/archive_view.py:
(ArchiveView):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/archive_view_unittest.py:
(ArchiveViewUnittest):
(ArchiveViewUnittest.register_archive):
(ArchiveViewUnittest.register_archive_with_files):
(ArchiveViewUnittest.test_file):
(ArchiveViewUnittest.test_html_rewrites_modern_link_template):
(ArchiveViewUnittest.test_html_rewrites_legacy_link_template):
(ArchiveViewUnittest.test_extract_uses_referer_when_query_missing):
(ArchiveViewUnittest.test_extract_ignores_cross_origin_referer):
(ArchiveViewUnittest.test_extract_listing_does_not_redirect_via_referer):
(ArchiveViewUnittest.test_memory_cap_returns_400):

Canonical link: <a href="https://commits.webkit.org/314116@main">https://commits.webkit.org/314116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1466767f0f0c857db2a56b8fd89a8f7655f6854e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174128 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122343 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42a679ea-2000-45cc-82bc-2ee8b7deb182) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128293 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108819 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da0e0084-8dd5-4cbf-9c83-9e136374a2a2) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/164406 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29648 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28269 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21883 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176651 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136610 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/164490 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136553 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36823 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147837 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101643 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24704 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37845 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37242 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2780 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37488 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37386 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->