### PR TITLE
Add quirk on battle.net for login accessing loopback

### DIFF
--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -130,6 +130,13 @@ bool MixedContentChecker::canModifyRequest(const URL& url, FetchOptions::Destina
     return true;
 }
 
+static bool shouldAllowConnectionWithPotentiallyInsecureProtocol(Frame& frame, const URL& url, MixedContentChecker::IsUpgradable isUpgradable)
+{
+    if (RefPtr localFrame = dynamicDowncast<const LocalFrame>(frame); localFrame && protect(localFrame->document())->quirks().shouldAllowMixedContentConnectionToLoopback(url))
+        return true;
+    return (LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol()) || shouldTreatAsPotentiallyTrustworthy(url)) && isUpgradable == MixedContentChecker::IsUpgradable::Yes;
+}
+
 bool MixedContentChecker::shouldBlockRequest(Frame& frame, const URL& url, IsUpgradable isUpgradable)
 {
 #if ENABLE(CONTENT_FILTERING) && HAVE(WEBCONTENTRESTRICTIONS)
@@ -139,7 +146,7 @@ bool MixedContentChecker::shouldBlockRequest(Frame& frame, const URL& url, IsUpg
 
     if (!isMixedContent(frame, url))
         return false;
-    if ((LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol()) || shouldTreatAsPotentiallyTrustworthy(url)) && isUpgradable == IsUpgradable::Yes)
+    if (shouldAllowConnectionWithPotentiallyInsecureProtocol(frame, url, isUpgradable))
         return false;
     frame.reportMixedContentViolation(true, url);
     return true;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -32,6 +32,7 @@
 #include "ContainerNodeInlines.h"
 #include "Cookie.h"
 #include "CookieJar.h"
+#include "DNS.h"
 #include "DatasetDOMStringMap.h"
 #include "DeprecatedGlobalSettings.h"
 #include "DocumentLoader.h"
@@ -742,6 +743,16 @@ bool Quirks::shouldIgnoreInputModeNone() const
 #else
     return false;
 #endif
+}
+
+// rdar://176981763
+bool Quirks::shouldAllowMixedContentConnectionToLoopback(const URL& url)
+{
+    if (m_document->url().host() != "account.battle.net"_s || m_document->url().path().startsWith("/login"_s))
+        return false;
+    if (auto address = IPAddress::fromString(url.host().toStringWithoutCopying()))
+        return address->isLoopback();
+    return false;
 }
 
 // FIXME: Remove after the site is fixed, <rdar://problem/50374200>

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -139,6 +139,8 @@ public:
 
     WEBCORE_EXPORT bool static NODELETE shouldDisableBlobFileAccessEnforcement();
 
+    bool shouldAllowMixedContentConnectionToLoopback(const URL&);
+
     bool NODELETE needsGMailOverflowScrollQuirk() const;
     bool NODELETE needsYouTubeOverflowScrollQuirk() const;
     bool NODELETE needsFullscreenDisplayNoneQuirk() const;


### PR DESCRIPTION
#### 5318af2a52ea3454f4c8d33fea2ac44fc1fd708a
<pre>
Add quirk on battle.net for login accessing loopback
<a href="https://bugs.webkit.org/show_bug.cgi?id=315788">https://bugs.webkit.org/show_bug.cgi?id=315788</a>
<a href="https://rdar.apple.com/176981763">rdar://176981763</a>

Reviewed by Ben Nham.

This patch adds a new quirk for allowing access to <a href="http://127.0.0.1">http://127.0.0.1</a> on the
battle.net&apos;s login page. This seems like it might&apos;ve been caused by a recent
web site change.

* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::shouldAllowConnectionWithPotentiallyInsecureProtocol):
(WebCore::MixedContentChecker::shouldBlockRequest):
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/314907@main">https://commits.webkit.org/314907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c92a8f2a5bbf343018125d6d4eb95c0684b4f1a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175563 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123770 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e8bb0e8-76d2-49f1-88f8-2b05e752bbc2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129460 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91182 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/122a5333-334b-4eb7-90a2-9f1ed44b7761) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109985 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d26e01e6-221e-48fc-a53b-e4cc139e782d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30819 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29522 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23703 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178097 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30997 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137815 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137732 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37332 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149120 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103483 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33028 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25985 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39273 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112348 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38670 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4074 "") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38915 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38813 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->