### PR TITLE
[Cocoa] Update the current cue's endTime when legible output sends an empty or NULL attributed array

### DIFF
--- a/LayoutTests/media/media-source/mp4-generator.js
+++ b/LayoutTests/media/media-source/mp4-generator.js
@@ -16,6 +16,21 @@
 //   sourceBuffer.appendBuffer(init);
 //   // ... wait for updateend ...
 //   sourceBuffer.appendBuffer(media);
+//
+// In-band CEA-608 captions: add a second track with type 'captions' and supply
+// caption samples built by Captions.buildPaintOnCueSamples() from caption-generator.js.
+//
+//   <script src="caption-generator.js"></script>
+//   <script src="mp4-generator.js"></script>
+//   const captionSamples = Captions.buildPaintOnCueSamples({ cues: [...], totalDurationTicks });
+//   const { init, media } = MP4.samples({
+//       timescale: 30000,
+//       tracks: [{ id: 1, type: 'video' }, { id: 2, type: 'captions' }],
+//       trackSamples: {
+//           1: videoSamples,
+//           2: captionSamples.map(s => ({ duration: s.duration, data: s.data, isSync: true, dts: FRAME_DURATION, pts: FRAME_DURATION })),
+//       },
+//   });
 
 const MP4 = (function() {
 
@@ -277,10 +292,33 @@ const MP4 = (function() {
         );
     }
 
+    // Closed-caption sample entry. QuickTime/ISO form: 6-byte reserved + 2-byte
+    // data_reference_index, with no codec-specific fields. Valid for both 'c608'
+    // and 'c708' — only the fourcc differs.
+    function c608Entry() {
+        return box('c608', zeros(6), uint16(1));
+    }
+
+    // Null media header — 12-byte fullbox with no payload. ISO BMFF standard
+    // header for non-av tracks (subtitles, metadata, captions).
+    function nmhd() {
+        return fullBox('nmhd', 0, 0);
+    }
+
     function stsd(trackType) {
+        let entry;
+        if (trackType === 'video')
+            entry = avc1();
+        else if (trackType === 'captions')
+            entry = c608Entry();
+        else if (trackType === 'audio')
+            entry = mp4a();
+        else
+            throw new Error(`stsd: unknown track type '${trackType}'`);
+
         return fullBox('stsd', 0, 0,
             uint32(1),
-            (trackType === 'video') ? avc1() : mp4a()
+            entry
         );
     }
 
@@ -295,27 +333,59 @@ const MP4 = (function() {
     }
 
     function minf(trackType) {
+        let header;
+        if (trackType === 'video')
+            header = vmhd();
+        else if (trackType === 'captions')
+            header = nmhd();
+        else if (trackType === 'audio')
+            header = smhd();
+        else
+            throw new Error(`minf: unknown track type '${trackType}'`);
+
         return box('minf',
-            (trackType === 'video') ? vmhd() : smhd(),
+            header,
             dinf(), stbl(trackType)
         );
     }
 
     function mdia(trackType, timescale, duration) {
-        const isVideo = trackType === 'video';
+        let handlerType, handlerName;
+        if (trackType === 'video') {
+            handlerType = 'vide';
+            handlerName = 'VideoHandler';
+        } else if (trackType === 'captions') {
+            handlerType = 'clcp';
+            handlerName = 'Closed Caption Media Handler';
+        } else if (trackType === 'audio') {
+            handlerType = 'soun';
+            handlerName = 'SoundHandler';
+        } else
+            throw new Error(`mdia: unknown track type '${trackType}'`);
+
         return box('mdia',
             mdhd(timescale, duration),
-            hdlr(isVideo ? 'vide' : 'soun', isVideo ? 'VideoHandler' : 'SoundHandler'),
+            hdlr(handlerType, handlerName),
             minf(trackType)
         );
     }
 
     function trak(trackDef) {
-        const timescale = trackDef.timescale
-            || ((trackDef.type === 'video') ? VIDEO_TIMESCALE_DEFAULT : AUDIO_TIMESCALE_DEFAULT);
-        const isAudio = trackDef.type === 'audio';
+        let defaultTimescale;
+        if (trackDef.type === 'video')
+            defaultTimescale = VIDEO_TIMESCALE_DEFAULT;
+        else if (trackDef.type === 'captions')
+            defaultTimescale = VIDEO_TIMESCALE_DEFAULT;
+        else if (trackDef.type === 'audio')
+            defaultTimescale = AUDIO_TIMESCALE_DEFAULT;
+        else
+            throw new Error(`trak: unknown track type '${trackDef.type}'`);
+
+        // 'captions' and 'audio' both want width/height = 0. Only 'video' carries geometry.
+        const isGeometric = trackDef.type === 'video';
+        const timescale = trackDef.timescale || defaultTimescale;
         return box('trak',
-            tkhd(trackDef.id, 0, VIDEO_WIDTH, VIDEO_HEIGHT, isAudio),
+            tkhd(trackDef.id, 0, VIDEO_WIDTH, VIDEO_HEIGHT, !isGeometric),
             mdia(trackDef.type, timescale, 0)
         );
     }
@@ -355,7 +425,10 @@ const MP4 = (function() {
     function sampleDataSize(isSync, trackType) {
         if (trackType === 'video')
             return isSync ? VIDEO_SYNC_SAMPLE.byteLength : VIDEO_NONSYNC_SAMPLE.byteLength;
-        return AUDIO_SAMPLE_DATA.byteLength;
+        if (trackType === 'audio')
+            return AUDIO_SAMPLE_DATA.byteLength;
+
+        throw new Error(`sampleDataSize: unknown track type '${trackType}'`);
     }
 
     function trun(samples, dataOffset, trackType) {
@@ -366,7 +439,7 @@ const MP4 = (function() {
 
         const entries = [];
         for (const sample of samples) {
-            const size = sample.size || sampleDataSize(sample.isSync, trackType);
+            const size = sample.size || (sample.data ? sample.data.byteLength : sampleDataSize(sample.isSync, trackType));
             // ISO 14496-12: sample_depends_on (bits 25-24), sample_is_non_sync_sample (bit 16)
             const sampleFlags = sample.isSync ? 0x01000000 : 0x02010000;
             const cto = sample.compositionTimeOffset || 0;
@@ -388,8 +461,10 @@ const MP4 = (function() {
                 parts.push(sample.data);
             else if (trackType === 'video')
                 parts.push(sample.isSync ? VIDEO_SYNC_SAMPLE : VIDEO_NONSYNC_SAMPLE);
-            else
+            else if (trackType === 'audio')
                 parts.push(AUDIO_SAMPLE_DATA.slice(0, sample.size || AUDIO_SAMPLE_DATA.byteLength));
+            else
+                throw new Error(`buildMdatData: unknown track type '${trackType}'`);
         }
         return concat(...parts);
     }
@@ -415,13 +490,19 @@ const MP4 = (function() {
         // options.timescale  - Movie-level timescale (default: first track's timescale)
         // options.tracks[]   - Array of track definitions:
         //   .id        - Track ID (integer)
-        //   .type      - 'video' or 'audio'
+        //   .type      - 'video', 'audio', or 'captions'
         //   .timescale - Track timescale (optional, defaults per type)
         initSegment(options) {
             const tracks = options.tracks || [{ id: 1, type: 'video' }];
-            for (const t of tracks) {
-                if (!t.timescale)
-                    t.timescale = (t.type === 'video') ? VIDEO_TIMESCALE_DEFAULT : AUDIO_TIMESCALE_DEFAULT;
+            for (const trackDef of tracks) {
+                if (!trackDef.timescale) {
+                    if (trackDef.type === 'video' || trackDef.type === 'captions')
+                        trackDef.timescale = VIDEO_TIMESCALE_DEFAULT;
+                    else if (trackDef.type === 'audio')
+                        trackDef.timescale = AUDIO_TIMESCALE_DEFAULT;
+                    else
+                        throw new Error(`initSegment: unknown track type '${trackDef.type}'`);
+                }
             }
             const movieTimescale = options.timescale || tracks[0].timescale;
             return concat(ftyp(), moov(movieTimescale, tracks));
@@ -580,3 +661,4 @@ const MP4 = (function() {
         },
     };
 })();
+

--- a/LayoutTests/media/track/caption-generator.js
+++ b/LayoutTests/media/track/caption-generator.js
@@ -1,0 +1,200 @@
+// caption-generator.js — CEA-608 closed-caption encoder for layout tests.
+//
+// Exposes a global `Captions` class with a nested `CEA608` class and two
+// methods for building caption samples for use with MP4.samples():
+//
+//   Captions.buildPaintOnCueSamples({ cues, totalDurationTicks })
+//     Paint-on style — text must be exactly 2 chars per cue.
+//
+//   Captions.buildPopOnCueSamples({ cues, totalDurationTicks })
+//     Pop-on style — text may be any length.
+//
+// Both return [{data: Uint8Array, duration: number}] suitable for passing as
+// the captions track in MP4.samples() trackSamples.
+
+// ============================================================================
+// Module-private helpers
+// ============================================================================
+
+// CEA-608 odd parity: bit 7 is set so the whole byte has an odd population count.
+function oddParity(byte) {
+    let bits = byte & 0x7F;
+    bits ^= bits >> 4;
+    bits ^= bits >> 2;
+    bits ^= bits >> 1;
+    return (bits & 1) ? (byte & 0x7F) : ((byte & 0x7F) | 0x80);
+}
+
+function pairsToBytes(pairs) {
+    const out = new Uint8Array(pairs.length * 2);
+    for (let i = 0; i < pairs.length; i++) {
+        out[i * 2]     = oddParity(pairs[i][0]);
+        out[i * 2 + 1] = oddParity(pairs[i][1]);
+    }
+    return out;
+}
+
+function cdatBox(bytes) {
+    const CDAT = Uint8Array.from('cdat', char => char.charCodeAt(0));
+    const out = new Uint8Array(8 + bytes.byteLength);
+    new DataView(out.buffer).setUint32(0, out.byteLength, false);
+    out.set(CDAT, 4);
+    out.set(bytes, 8);
+    return out;
+}
+
+// ============================================================================
+// CEA-608 — Channel 1 / Field 1
+// ============================================================================
+
+// Row → [byte1, isPair2]. Row 11 is pair-1 only (byte1 = 0x10 is special).
+const ROW_TABLE = [
+    [0x11, false], [0x11, true],
+    [0x12, false], [0x12, true],
+    [0x15, false], [0x15, true],
+    [0x16, false], [0x16, true],
+    [0x17, false], [0x17, true],
+    [0x10, false],
+    [0x13, false], [0x13, true],
+    [0x14, false], [0x14, true],
+];
+
+const COLOR_NIBBLE = {
+    white:   0x0,
+    green:   0x2,
+    blue:    0x4,
+    cyan:    0x6,
+    red:     0x8,
+    yellow:  0xA,
+    magenta: 0xC,
+};
+
+class CEA608 {
+    // Control-code byte pairs (no parity yet — pairsToBytes applies it).
+    static RCL = [0x14, 0x20];  // Resume Caption Loading (pop-on)
+    static RDC = [0x14, 0x29];  // Resume Direct Captioning (paint-on)
+    static ENM = [0x14, 0x2E];  // Erase Non-displayed Memory
+    static EDM = [0x14, 0x2C];  // Erase Displayed Memory
+    static EOC = [0x14, 0x2F];  // End Of Caption (swap + display)
+    static CR  = [0x14, 0x2D];  // Carriage Return
+
+    // Preamble Address Code. See CEA-608-E Table 3.
+    //   row    : 1..15
+    //   indent : 0, 4, 8, 12, 16, 20, 24, 28 (columns; 0 means color mode)
+    //   color  : one of COLOR_NIBBLE keys (used only when indent === 0)
+    //   italic : boolean (used only when indent === 0; overrides color)
+    //   underline : boolean
+    static pac(row, indent = 0, { color = 'white', underline = false, italic = false } = {}) {
+        const [byte1, pair2] = ROW_TABLE[row - 1];
+        const pair2Bit = pair2 ? 0x20 : 0;
+        if (indent > 0) {
+            const nibble = Math.min(14, Math.floor(indent / 4) * 2);
+            return [byte1, 0x50 | pair2Bit | nibble | (underline ? 0x01 : 0)];
+        }
+        const colorNibble = italic ? 0xE : (COLOR_NIBBLE[color] ?? 0x0);
+        return [byte1, 0x40 | pair2Bit | colorNibble | (underline ? 0x01 : 0)];
+    }
+
+    // Map ASCII to 7-bit byte pairs. Non-ASCII falls back to '?'. Odd-length
+    // strings pad the last pair's right byte with 0x00 (null — ignored by the decoder).
+    static textPairs(text) {
+        const safe = charCode => (charCode >= 0x20 && charCode <= 0x7F) ? charCode : 0x3F;
+        const pairs = [];
+        for (let i = 0; i < text.length; i += 2) {
+            const first  = safe(text.charCodeAt(i));
+            const second = (i + 1 < text.length) ? safe(text.charCodeAt(i + 1)) : 0x00;
+            pairs.push([first, second]);
+        }
+        return pairs;
+    }
+
+    // RCL + ENM + PAC + text + EOC, serialized with odd parity applied.
+    static popOn(text, { row = 15, indent = 0, ...style } = {}) {
+        return pairsToBytes([
+            CEA608.RCL,
+            CEA608.ENM,
+            CEA608.pac(row, indent, style),
+            ...CEA608.textPairs(text),
+            CEA608.EOC,
+        ]);
+    }
+
+    // EDM + RDC + PAC + 2-char text pair, serialized with odd parity applied.
+    // The leading EDM clears the display (closing the previous cue), then RDC
+    // sets paint-on mode and the single text pair writes directly to the display.
+    // Text must be exactly 2 chars — one pair produces exactly one delivery.
+    static paintOn(text, { row = 15, ...style } = {}) {
+        if (text.length !== 2)
+            throw new Error(`CEA608.paintOn: text must be exactly 2 chars, got "${text}"`);
+        return pairsToBytes([
+            CEA608.EDM,
+            CEA608.RDC,
+            CEA608.pac(row, 0, style),
+            ...CEA608.textPairs(text),
+        ]);
+    }
+
+    // EDM — clears displayed memory.
+    static clear() {
+        return pairsToBytes([CEA608.EDM]);
+    }
+
+    // Escape hatch: one raw pair with parity applied.
+    static raw(byte1, byte2) {
+        return pairsToBytes([[byte1, byte2]]);
+    }
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+class Captions {
+    static CEA608 = CEA608;
+
+    // Build caption samples using paint-on mode — one 2-char text pair per sample.
+    //
+    // RDC paint-on mode writes each 2-byte text pair directly to the display,
+    // producing exactly one attributed-string delivery per sample. Text must be
+    // exactly 2 chars. A final EDM sample is appended to close the last cue.
+    //
+    //   cues               — [{text: '2-char string', durationTicks}]
+    //   totalDurationTicks — total caption track duration
+    //
+    // Returns [{data: Uint8Array, duration: number}].
+    static buildPaintOnCueSamples({ cues, totalDurationTicks }) {
+        const samples = [];
+        let usedTicks = 0;
+        for (const { text, durationTicks } of cues) {
+            samples.push({ data: cdatBox(CEA608.paintOn(text)), duration: durationTicks });
+            usedTicks += durationTicks;
+        }
+
+        // Final EDM closes the last cue with a count=0 delivery.
+        samples.push({ data: cdatBox(CEA608.clear()), duration: totalDurationTicks - usedTicks });
+        return samples;
+    }
+
+    // Build caption samples using pop-on mode — one complete pop-on sequence per sample.
+    //
+    // Each sample contains RCL+ENM+PAC+text+EOC, which buffers the text invisibly
+    // and flips it to the display on EOC, producing exactly one attributed-string
+    // delivery regardless of text length. A final EDM sample closes the last cue.
+    //
+    //   cues               — [{text, durationTicks}]  (text may be any length)
+    //   totalDurationTicks — total caption track duration
+    //
+    // Returns [{data: Uint8Array, duration: number}].
+    static buildPopOnCueSamples({ cues, totalDurationTicks }) {
+        const samples = [];
+        let usedTicks = 0;
+        for (const { text, durationTicks } of cues) {
+            samples.push({ data: cdatBox(CEA608.popOn(text)), duration: durationTicks });
+            usedTicks += durationTicks;
+        }
+
+        // Final EDM closes the last cue with a count=0 delivery.
+        samples.push({ data: cdatBox(CEA608.clear()), duration: totalDurationTicks - usedTicks });
+        return samples;
+    }
+}

--- a/LayoutTests/media/track/track-inband-cea608-cue-endtime-expected.txt
+++ b/LayoutTests/media/track/track-inband-cea608-cue-endtime-expected.txt
@@ -1,0 +1,16 @@
+in-band CEA-608: cue endTime is set by EDM clear
+
+RUN(video.src = blobUrl)
+EVENT(addtrack)
+EVENT(canplaythrough)
+RUN(track = video.textTracks[0])
+RUN(track.mode = "showing")
+RUN(video.play())
+EXPECTED (video.currentTime > '0.5') OK
+EXPECTED (track.cues && track.cues.length >= '1') OK
+EXPECTED (track.cues[track.cues.length - 1] && track.cues[track.cues.length - 1].endTime < video.duration === 'true') OK
+RUN(video.pause())
+RUN(lastCue = track.cues[track.cues.length - 1])
+EXPECTED (lastCue.endTime < video.duration == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/track/track-inband-cea608-cue-endtime.html
+++ b/LayoutTests/media/track/track-inband-cea608-cue-endtime.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>in-band CEA-608: cue endTime is set by EDM clear</title>
+  <script src="../video-test.js"></script>
+  <script src="../media-source/mp4-generator.js"></script>
+  <script src="./caption-generator.js"></script>
+  <script>
+    window.addEventListener('load', async () => {
+      try {
+        findMediaElement();
+
+        const FRAME_COUNT    = 150;
+        const FRAME_DURATION = 1001;   // 30000/1001 ≈ 29.97fps
+        const TIMESCALE      = 30000;
+        const TOTAL_TICKS    = FRAME_COUNT * FRAME_DURATION;
+        const CUE_TICKS      = 20 * FRAME_DURATION;
+
+        // Offset the caption track start by enough frames to allow the media
+        // pipeline to initialize before the first cue is delivered.
+        const CAPTION_START_OFFSET = TIMESCALE; // 1 second
+
+        const captionSamples = Captions.buildPopOnCueSamples({
+            cues: [
+                { text: 'Cue 1', durationTicks: CUE_TICKS },
+                { text: 'Cue 2', durationTicks: CUE_TICKS },
+                { text: 'Cue 3', durationTicks: CUE_TICKS },
+                { text: 'Cue 4', durationTicks: CUE_TICKS },
+            ],
+            totalDurationTicks: TOTAL_TICKS,
+        });
+
+        const videoSamples = Array.from({ length: FRAME_COUNT }, (_, i) => ({
+            duration: FRAME_DURATION,
+            isSync: i % 30 === 0,
+            dts: i * FRAME_DURATION,
+            pts: i * FRAME_DURATION,
+        }));
+
+        const { init, media } = MP4.samples({
+            timescale: TIMESCALE,
+            tracks: [
+                { id: 1, type: 'video' },
+                { id: 2, type: 'captions' },
+            ],
+            trackSamples: {
+                1: videoSamples,
+                2: captionSamples.map(s => ({ duration: s.duration, data: s.data, isSync: true, dts: CAPTION_START_OFFSET, pts: CAPTION_START_OFFSET })),
+            },
+        });
+
+        // Concatenate init + media into a single buffer for direct playback via blob URL.
+        const combined = new Uint8Array(init.byteLength + media.byteLength);
+        combined.set(new Uint8Array(init), 0);
+        combined.set(new Uint8Array(media), init.byteLength);
+
+        window.blobUrl = URL.createObjectURL(new Blob([combined], { type: 'video/mp4' }));
+        run(`video.src = blobUrl`);
+        waitForEventAndFail('error');
+
+        const canPlayThrough = waitFor(video, 'canplaythrough');
+        await waitFor(video.textTracks, 'addtrack');
+        await canPlayThrough;
+
+        run('track = video.textTracks[0]');
+        run('track.mode = "showing"');
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        run('video.play()');
+
+        await testExpectedEventually('video.currentTime', 0.5, '>', 5000);
+        await testExpectedEventually('track.cues && track.cues.length', 1, '>=', 5000);
+        await testExpectedEventually('track.cues[track.cues.length - 1] && track.cues[track.cues.length - 1].endTime < video.duration', true, '===', 8000);
+
+        run('video.pause()');
+        run('lastCue = track.cues[track.cues.length - 1]');
+        testExpected('lastCue.endTime < video.duration', true);
+
+        endTest();
+      } catch (error) {
+        failTest(`Caught exception: "${error}"`);
+      }
+    });
+  </script>
+</head>
+
+<body>
+  <div>in-band CEA-608: cue endTime is set by EDM clear</div>
+  <video controls></video>
+</body>
+
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -341,8 +341,7 @@ void InbandTextTrackPrivateAVF::processCue(CFArrayRef attributedStrings, CFArray
     if (!hasClients())
         return;
 
-    if (attributedStrings && CFArrayGetCount(attributedStrings))
-        processAttributedStrings(attributedStrings, time);
+    processAttributedStrings(attributedStrings, time);
     if (nativeSamples && CFArrayGetCount(nativeSamples))
         processVTTSamples(nativeSamples, time);
 }
@@ -393,7 +392,7 @@ void InbandTextTrackPrivateAVF::processAttributedStrings(CFArrayRef attributedSt
                 bool currentCueIsExtended = (arrivingCues.size() != nonExtensionCues.size());
 
                 arrivingCues = WTF::move(nonExtensionCues);
-                
+
                 if (currentCueIsExtended)
                     continue;
 


### PR DESCRIPTION
#### 8b6f92de7d153ceed3dca1e96907c0884f4c3430
<pre>
[Cocoa] Update the current cue&apos;s endTime when legible output sends an empty or NULL attributed array
<a href="https://bugs.webkit.org/show_bug.cgi?id=315790">https://bugs.webkit.org/show_bug.cgi?id=315790</a>
<a href="https://rdar.apple.com/172758610">rdar://172758610</a>

Reviewed by Jer Noble.

Add layout test for CEA-608 cue endTime being set by an EDM clear

InbandTextTrackPrivateAVF::processCue() was guarding the call to
processAttributedStrings() with CFArrayGetCount(), which dropped the
null or empty attributed-string array AVFoundation delivers when captions
provided to the AVPlayerItemLegibleOutput delegate are cleared.
processAttributedStrings() already handles that case by calling
updateCurrentCueEndTimes(), so the last cue&apos;s endTime was never set.
Fix: always call `processAttributedStrings()`.

The new test (track-inband-cea608-cue-endtime.html) builds a
self-contained fMP4 in JavaScript using two helpers:

- caption-generator.js encodes CEA-608 byte sequences and packages
  them as cdat-box caption samples. CEA608.popOn() and CEA608.paintOn()
  produce complete caption events (mode + position + text), and
  Captions.buildPopOnCueSamples() / buildPaintOnCueSamples() return
  arrays of {data, duration} samples including a final EDM clear.

- mp4-generator.js is extended with a &apos;captions&apos; track type that emits
  a c608 sample entry, a null media header, and uses sample.data
  directly in trun / mdat when supplied by the caller.

The generated fMP4 is played via a blob URL; the test waits for at
least one cue to arrive, then waits for the final EDM clear to set the
last cue&apos;s endTime before asserting endTime &lt; video.duration.

Test: media/track/track-inband-cea608-cue-endtime.html

* LayoutTests/media/media-source/mp4-generator.js:
* LayoutTests/media/track/caption-generator.js: Added.
* LayoutTests/media/track/track-inband-cea608-cue-endtime-expected.txt: Added.
* LayoutTests/media/track/track-inband-cea608-cue-endtime.html: Added.
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp:
(WebCore::InbandTextTrackPrivateAVF::processCue):
(WebCore::InbandTextTrackPrivateAVF::processAttributedStrings):

Co-Authored-By: Claude Sonnet 4.6 &lt;noreply@anthropic.com&gt;
Canonical link: <a href="https://commits.webkit.org/314110@main">https://commits.webkit.org/314110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/000d2420eeddf295fbdc8e4529adbc8e1509a4f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174122 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122337 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128290 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd3acf52-29b3-478a-8cd4-da7c71d7a0a1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108816 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29644 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28267 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21877 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176645 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29515 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136604 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136547 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36817 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101636 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31826 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24701 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37839 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110911 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37236 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2777 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37482 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37380 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->