### PR TITLE
Cherry-pick(s) 6ef1f5a9c30e. rdar://176061766

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -502,7 +502,11 @@ void ScrollerMac::visibilityChanged(bool isVisible)
     RefPtr pair = m_pair.get();
     if (!pair)
         return;
+<<<<<<< HEAD
     if (RefPtr node = pair->node())
+=======
+    if (RefPtr node = pair->protectedNode())
+>>>>>>> 6ef1f5a9c30e (Crash in -[WebScrollbarPartAnimationMac setCurrentProgress:])
         node->scrollbarVisibilityDidChange(m_orientation, isVisible);
 }
 
@@ -515,7 +519,11 @@ void ScrollerMac::updateMinimumKnobLength(int minimumKnobLength)
     RefPtr pair = m_pair.get();
     if (!pair)
         return;
+<<<<<<< HEAD
     if (RefPtr node = pair->node())
+=======
+    if (RefPtr node = pair->protectedNode())
+>>>>>>> 6ef1f5a9c30e (Crash in -[WebScrollbarPartAnimationMac setCurrentProgress:])
         node->scrollbarMinimumThumbLengthDidChange(m_orientation, m_minimumKnobLength);
 }
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176061766 to main. The following sources [a926a679cffa] will still need to be cherry-picked once the conflict is resolved.

```Crash in -[WebScrollbarPartAnimationMac setCurrentProgress:]
<https://bugs.webkit.org/show_bug.cgi?id=310238>
<rdar://162407650>

Reviewed by Chris Dumez.

A cross-thread crash occurs in
`-[WebScrollbarPartAnimationMac setCurrentProgress:]` on the
"WebCore: Scrolling" thread when an in-flight `NSAnimation`
display-link callback accesses a `ScrollerMac` object that has
already been destroyed on the main thread by the
`ScrollerPairMac` destructor.

Make `ScrollerMac` thread-safe ref-counted to fix the crash.  This allows
`WebScrollbarPartAnimationMac` and `WebScrollerImpDelegateMac` to
hold `ThreadSafeWeakPtr<ScrollerMac>` instead of `CheckedPtr<ScrollerMac>`.
Use `WTF::DestructionThread::Main` to ensure `ScrollerMac` is always
destroyed on the main thread, and remove the now-unnecessary
`takeScrollerImp()` captures from `~ScrollerPairMac()`'s
`ensureOnMainThread` block.

Add null guards for `m_pair` in `lastKnownMousePositionInScrollbar()`,
`visibilityChanged()`, and `updateMinimumKnobLength()` since a
`RefPtr` from an in-flight callback can briefly keep `ScrollerMac`
alive after `ScrollerPairMac` drops its `Ref`.

Covered by existing scrollbar tests.

* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
(WebCore::ScrollerMac): Use `WTF::DestructionThread::Main`.
(WebCore::ScrollerMac::create): Add.
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::~ScrollerMac):
- Add `ASSERT(isMainThread())`.
(-[WebScrollbarPartAnimationMac startAnimation]):
(-[WebScrollbarPartAnimationMac setCurrentProgress:]):
(-[WebScrollerImpDelegateMac mouseLocationInScrollerForScrollerImp:]):
(-[WebScrollerImpDelegateMac effectiveAppearanceForScrollerImp:]):
(-[WebScrollerImpDelegateMac setUpAlphaAnimation:featureToAnimate:animateAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateKnobAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateTrackAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateUIStateTransitionWithDuration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateExpansionTransitionWithDuration:]):
(-[WebScrollerImpDelegateMac invalidate]):
(WebCore::ScrollerMac::create): Add.
(WebCore::ScrollerMac::lastKnownMousePositionInScrollbar const):
(WebCore::ScrollerMac::visibilityChanged):
(WebCore::ScrollerMac::updateMinimumKnobLength):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(-[WebScrollerImpPairDelegateMac scrollerImpPair:convertContentPoint:toScrollerImp:]):
- Hold `ScrollerMac` as `Ref<ScrollerMac>` per SaferCPP guidelines.
(WebCore::ScrollerPairMac::~ScrollerPairMac):
- Simplify `ensureOnMainThread` block to only capture `m_scrollerImpPair`.
(WebCore::ScrollerPairMac::ScrollerPairMac):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode):

Originally-landed-as: 305413.553@rapid/safari-7624.2.5.110-branch (6ef1f5a9c30e). rdar://176061766

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb8fde5aca93bb1c4bf7e9c7052f7c4a6c7f2c12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165082 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38573 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32150 "Hash eb8fde5a for PR 65918 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174124 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122339 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38907 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38574 "Hash eb8fde5a for PR 65918 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128291 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90303 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30599 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/32150 "Hash eb8fde5a for PR 65918 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29646 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/38574 "Hash eb8fde5a for PR 65918 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21879 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139541 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/32150 "Hash eb8fde5a for PR 65918 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176647 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29508 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/32150 "Hash eb8fde5a for PR 65918 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136607 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38641 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/38574 "Hash eb8fde5a for PR 65918 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136550 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39331 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/32150 "Hash eb8fde5a for PR 65918 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101638 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31829 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/32150 "Hash eb8fde5a for PR 65918 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37841 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110913 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37238 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/32150 "Hash eb8fde5a for PR 65918 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37484 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->