### PR TITLE
AX: AXObjectCache::updateCurrentModalNode() is O(N * m_modalElements) per modalNode() call, causing hangs on pages with many large modals

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -546,6 +546,39 @@ void AXObjectCache::findModalNodes()
     m_modalNodesInitialized = true;
 }
 
+static bool isNodeAccessible(const Node* node)
+{
+    RefPtr element = dynamicDowncast<Element>(node);
+    if (!element)
+        return false;
+
+    CheckedPtr renderer = element->renderer();
+    if (!renderer)
+        return false;
+
+    CheckedRef style = renderer->style();
+    if (style->display() == Style::DisplayType::None)
+        return false;
+
+    if (style->effectiveInert())
+        return false;
+
+    CheckedPtr renderLayer = renderer->enclosingLayer();
+    if (isVisibilityHidden(style) && renderLayer && !renderLayer->hasVisibleContent())
+        return false;
+
+    // Check whether this object or any of its ancestors has opacity 0.
+    // The resulting opacity of a RenderObject is computed as the multiplication
+    // of its opacity times the opacities of its ancestors.
+    for (auto* ancestor = renderer.get(); ancestor; ancestor = ancestor->parent()) {
+        if (ancestor->style().opacity().isTransparent())
+            return false;
+    }
+
+    // We also need to consider aria hidden status.
+    return !equalLettersIgnoringASCIICase(element->attributeWithDefaultARIA(aria_hiddenAttr), "true"_s) || element->focused();
+}
+
 bool AXObjectCache::modalElementHasAccessibleContent(Element& element)
 {
     // Unless you're trying to compute the new modal node, determining whether an element
@@ -572,8 +605,9 @@ bool AXObjectCache::modalElementHasAccessibleContent(Element& element)
 #endif
             }
 
-            // Don't descend into subtrees for non-visible nodes.
-            if (isNodeVisible(node.get()))
+            // Don't descend into subtrees for non-accessible nodes — isNodeAccessible
+            // also skips aria-hidden and inert subtrees, so nothing inside can be accessible content.
+            if (isNodeAccessible(node.get()))
                 nodeStack.append(node->firstChild());
         }
     }
@@ -599,38 +633,36 @@ void AXObjectCache::updateCurrentModalNode()
         }
 
         SetForScope retrievingCurrentModalNode(m_isRetrievingCurrentModalNode, true);
-        // If any of the modal nodes contains the keyboard focus, we want to pick that one.
-        // If multiple contain the keyboard focus, we want the deepest.
-        // If no modal contains focus, we want to pick the last visible dialog in the DOM.
+        // We only ever return a modal that contains the keyboard focus, so
+        // walk up from the focused element to find the deepest focus-containing
+        // modal that's also visible and has accessible content.
         RefPtr<Element> focusedElement = document->focusedElement();
+        if (!focusedElement)
+            return nullptr;
         RefPtr<Element> modalElementToReturn;
-        bool foundModalWithFocusInside = false;
-        for (auto& element : m_modalElements) {
-            // Elements in m_modalElementsSet may have become un-modal since we added them, but not yet removed
-            // as part of the asynchronous m_deferredModalChangedList handling. Skip these.
-            if (!element || !isModalElement(*element))
+        for (RefPtr ancestor = focusedElement; ancestor; ancestor = ancestor->parentOrShadowHostElement()) {
+
+            if (!m_modalElements.containsIf([&ancestor] (auto& modal) {
+                return modal.get() == ancestor.get();
+            }))
                 continue;
 
-            // To avoid trapping users in an empty modal, skip any non-visible element, or any element without accessible content.
-            if (!isNodeVisible(element.get()) || !modalElementHasAccessibleContent(*element))
+            // Elements in m_modalElementsSet may have become un-modal since we added them,
+            // but not yet removed as part of the asynchronous m_deferredModalChangedList
+            // handling. Skip these.
+            if (!isModalElement(*ancestor))
                 continue;
 
-            bool focusIsInsideElement = focusedElement && focusedElement->isInclusiveDescendantOf(*element);
-
-            // If the modal we found previously is a descendant of this one, prefer the descendant and skip this one.
-            if (modalElementToReturn && foundModalWithFocusInside && modalElementToReturn->isDescendantOf(*element))
+            // To avoid trapping users in an empty modal, skip any non-visible
+            // element, or any element without accessible content. Continue
+            // walking the ancestry in case a containing modal is visible and contentful.
+            if (!isNodeAccessible(ancestor.get()) || !modalElementHasAccessibleContent(*ancestor))
                 continue;
-
-            // If we already found a modal that focus is inside, and this one doesn't have focus inside, skip in favor of the one with focus inside.
-            if (modalElementToReturn && foundModalWithFocusInside && !focusIsInsideElement)
-                continue;
-
-            modalElementToReturn = element.get();
-            if (focusIsInsideElement)
-                foundModalWithFocusInside = true;
+            modalElementToReturn = ancestor;
+            break;
         }
 
-        if (!focusedElement || !foundModalWithFocusInside)
+        if (!modalElementToReturn)
             return nullptr;
 
         RefPtr object = getOrCreate(modalElementToReturn.get());
@@ -651,36 +683,6 @@ void AXObjectCache::updateCurrentModalNode()
     }
 }
 
-bool AXObjectCache::isNodeVisible(const Node* node) const
-{
-    RefPtr element = dynamicDowncast<Element>(node);
-    if (!element)
-        return false;
-
-    CheckedPtr renderer = element->renderer();
-    if (!renderer)
-        return false;
-
-    CheckedRef style = renderer->style();
-    if (style->display() == Style::DisplayType::None)
-        return false;
-
-    CheckedPtr renderLayer = renderer->enclosingLayer();
-    if (isVisibilityHidden(style) && renderLayer && !renderLayer->hasVisibleContent())
-        return false;
-
-    // Check whether this object or any of its ancestors has opacity 0.
-    // The resulting opacity of a RenderObject is computed as the multiplication
-    // of its opacity times the opacities of its ancestors.
-    for (auto* ancestor = renderer.get(); ancestor; ancestor = ancestor->parent()) {
-        if (ancestor->style().opacity().isTransparent())
-            return false;
-    }
-
-    // We also need to consider aria hidden status.
-    return !equalLettersIgnoringASCIICase(element->attributeWithDefaultARIA(aria_hiddenAttr), "true"_s) || element->focused();
-}
-
 // This function returns the valid aria modal node.
 Node* AXObjectCache::modalNode()
 {
@@ -692,7 +694,7 @@ Node* AXObjectCache::modalNode()
 
     // Check the cached current valid aria modal node first.
     // Usually when one dialog sets aria-modal=true, that dialog is the one we want.
-    if (isNodeVisible(m_currentModalElement))
+    if (isNodeAccessible(m_currentModalElement))
         return m_currentModalElement;
 
     // Recompute the valid aria modal node when m_currentModalElement is null or hidden.

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -933,7 +933,6 @@ private:
     bool isModalElement(Element&) const;
     void findModalNodes();
     void updateCurrentModalNode();
-    bool isNodeVisible(const Node*) const;
     bool modalElementHasAccessibleContent(Element&);
 
     void setDirtyStitchGroups(const RenderBlock&);


### PR DESCRIPTION
#### b5639a26a2d81b24b253095bfaba536f2255987e
<pre>
AX: AXObjectCache::updateCurrentModalNode() is O(N * m_modalElements) per modalNode() call, causing hangs on pages with many large modals
<a href="https://bugs.webkit.org/show_bug.cgi?id=315797">https://bugs.webkit.org/show_bug.cgi?id=315797</a>
<a href="https://rdar.apple.com/167441819">rdar://167441819</a>

Reviewed by Dominic Mazzoni.

modalNode() is required to compute ignoredFromModalPresence(), which is
part of computeIsIgnored(), a very hot function. Prior to this commit,
when there are m_modalElements but none are active (e.g., because they
don&apos;t have accessible content or don&apos;t contain focus), we would walk
every single descendant of every modal, resulting in O(m_modalElements * num_descendants)
work.

With this commit, we take advantage of the fact that in order for a
modal to be active, it must have focus within, and now only walk the
descendants of a modal in search of accessible content when it actually
has focus within it.

We also don&apos;t bother searching for accessible content inside inert
subtrees inside the modal -- we know none of this will be accessible and
don&apos;t need to walk it.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::isNodeAccessible):
(WebCore::AXObjectCache::modalElementHasAccessibleContent):
(WebCore::AXObjectCache::updateCurrentModalNode):
(WebCore::AXObjectCache::modalNode):
(WebCore::AXObjectCache::isNodeVisible const): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:

Canonical link: <a href="https://commits.webkit.org/314114@main">https://commits.webkit.org/314114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71ab0e6d3ee28cce71fba7470539f3463edbe0fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122344 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/162997a2-05e6-4e13-8b00-16310e417c0e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128296 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e527c5b-5dfe-45ba-a847-66092b68b5db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108822 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83d50091-8a9c-47e5-ad92-9d30d633e264) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29649 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28271 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21884 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139544 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176652 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136612 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136555 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36821 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147839 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101644 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31832 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24706 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37846 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110918 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37243 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2782 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37489 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->