### PR TITLE
[LBSE] Defer per-element SVG transform-attribute work without style recalc

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -190,6 +190,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
 #include "LocalFrameView.h"
+#include "LocalFrameViewLayoutContext.h"
 #include "Logging.h"
 #include "MediaCanStartListener.h"
 #include "MediaProducer.h"
@@ -253,6 +254,7 @@
 #include "RenderElementInlines.h"
 #include "RenderInline.h"
 #include "RenderLayerCompositor.h"
+#include "RenderLayerModelObject.h"
 #include "RenderLayoutState.h"
 #include "RenderLineBreak.h"
 #include "RenderObjectInlines.h"
@@ -323,6 +325,7 @@
 #include "StyleSheetContents.h"
 #include "StyleSheetList.h"
 #include "StyleTreeResolverInlines.h"
+#include "StyleUpdate.h"
 #include "StyleZoomPrimitivesInlines.h"
 #include "SubresourceLoader.h"
 #include "SystemPreviewInfo.h"
@@ -2916,10 +2919,20 @@ void Document::updateTextRenderer(Text& text, unsigned offsetOfReplacedText, uns
     ensurePendingRenderTreeUpdate().addText(text, { offsetOfReplacedText, lengthOfReplacedText, std::nullopt });
 }
 
-void Document::updateSVGRenderer(SVGElement& element)
+void Document::updateSVGRenderer(SVGElement& element, Style::SVGRendererUpdateType kind)
 {
     if (!hasLivingRenderTree())
         return;
+
+    // TransformAttributeOnly bypasses Style::Update so it does not flip needsStyleRecalc()
+    // true and force a resolveStyle pass every animation frame.
+    if (kind == Style::SVGRendererUpdateType::TransformAttributeOnly) {
+        if (CheckedPtr layerRenderer = dynamicDowncast<RenderLayerModelObject>(element.renderer())) {
+            if (RefPtr frameView = view())
+                frameView->layoutContext().addPendingSVGTransformAttributeUpdate(*layerRenderer);
+        }
+        return;
+    }
 
     ensurePendingRenderTreeUpdate().addSVGRendererUpdate(element);
 }
@@ -3062,6 +3075,11 @@ auto Document::updateLayout(OptionSet<LayoutOptions> layoutOptions, const Elemen
         if (updateStyleIfNeeded())
             result = UpdateLayoutResult::ChangesDone;
 
+        // LBSE: drain queued transform-attribute updates after style recalc so updateLayerTransform
+        // sees post-style geometry and re-enqueues from style callbacks land in this pass.
+        if (frameView)
+            frameView->layoutContext().flushPendingSVGTransformAttributeUpdatesIfNeeded();
+
         StackStats::LayoutCheckPoint layoutCheckPoint;
 
         if (frameView && renderView()) {
@@ -3191,6 +3209,12 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
 
     // Check for re-entrancy and assert (same code that is in updateLayout()).
     RefPtr frameView = view();
+
+    // LBSE: drain before the re-entrancy early-return so re-entrant geometry queries see
+    // the fresh layer transform.
+    if (frameView)
+        frameView->layoutContext().flushPendingSVGTransformAttributeUpdatesIfNeeded();
+
     if (frameView && frameView->layoutContext().isInRenderTreeLayout()) {
         // View layout should not be re-entrant.
         ASSERT_NOT_REACHED();
@@ -3210,6 +3234,11 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
     updateRelevancyOfContentVisibilityElements();
 
     updateStyleIfNeeded();
+
+    // LBSE: drain queued transform-attribute updates after style recalc so updateLayerTransform
+    // sees post-style geometry, and re-enqueues from style callbacks land here.
+    if (frameView)
+        frameView->layoutContext().flushPendingSVGTransformAttributeUpdatesIfNeeded();
 
     if (layoutOptions.containsAll({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible })) {
         if (CheckedPtr renderer = element.renderer(); renderer &&  renderer->style().isSkippedRootOrSkippedContent()) {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -383,6 +383,7 @@ class CustomPropertyRegistry;
 class Resolver;
 class Scope;
 class Update;
+enum class SVGRendererUpdateType : bool;
 }
 
 enum class PageshowEventPersistence : bool { NotPersisted, Persisted };
@@ -1625,7 +1626,7 @@ public:
     void NODELETE setIsResolvingTreeStyle(bool);
 
     void updateTextRenderer(Text&, unsigned offsetOfReplacedText, unsigned lengthOfReplacedText);
-    void updateSVGRenderer(SVGElement&);
+    void updateSVGRenderer(SVGElement&, Style::SVGRendererUpdateType = Style::SVGRendererUpdateType { });
 
     // Return a Locale for the default locale if the argument is null or empty.
     Locale& getCachedLocale(const AtomString& locale = nullAtom());

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -47,8 +47,11 @@
 #include "RenderDescendantIterator.h"
 #include "RenderElement.h"
 #include "RenderElementInlines.h"
+#include "RenderLayer.h"
 #include "RenderLayerCompositor.h"
+#include "RenderLayerModelObject.h"
 #include "RenderLayoutState.h"
+#include "RenderSVGText.h"
 #include "RenderObjectInlines.h"
 #include "RenderStyle+GettersInlines.h"
 #include "RenderStyle.h"
@@ -399,6 +402,11 @@ void LocalFrameViewLayoutContext::requestUpdateLayerPositions(bool needsFullRepa
 
 void LocalFrameViewLayoutContext::flushUpdateLayerPositions()
 {
+    // LBSE: scroll-driven entry points reach this without going through Document::updateLayout.
+    // Drain pending in-place SVG transform updates first so the position walk sees fresh transforms.
+    // The recursive call from flushPendingSVGTransformAttributeUpdatesIfNeeded finds an empty queue and returns.
+    flushPendingSVGTransformAttributeUpdatesIfNeeded();
+
     if (!m_pendingUpdateLayerPositions)
         return;
 
@@ -447,6 +455,121 @@ void LocalFrameViewLayoutContext::markForUpdateLayerPositionsAfterSVGTransformCh
 
     requestUpdateLayerPositions();
     view->page().scheduleRenderingUpdate({ RenderingUpdateStep::LayerFlush });
+}
+
+void LocalFrameViewLayoutContext::addPendingSVGTransformAttributeUpdate(RenderLayerModelObject& renderer)
+{
+    CheckedPtr view = renderView();
+    if (!view)
+        return;
+
+    if (renderer.isInPendingSVGTransformAttributeUpdates())
+        return;
+    renderer.setIsInPendingSVGTransformAttributeUpdates(true);
+
+    bool wasEmpty = m_pendingSVGTransformAttributeUpdates.isEmpty();
+    m_pendingSVGTransformAttributeUpdates.append(SingleThreadWeakPtr<RenderLayerModelObject> { renderer });
+
+    // Do not call requestUpdateLayerPositions() here - it would make needsLayout() true and
+    // force a layout pass every animation frame. The flush runs the position update inline,
+    // keeping needsLayout() false.
+    if (wasEmpty)
+        view->page().scheduleRenderingUpdate({ RenderingUpdateStep::LayerFlush });
+}
+
+void LocalFrameViewLayoutContext::flushPendingSVGTransformAttributeUpdatesIfNeeded()
+{
+    if (m_pendingSVGTransformAttributeUpdates.isEmpty())
+        return;
+
+    // Drain queue and dedup flags up front so re-enqueues during the flush land in the
+    // now-empty queue.
+    auto pending = std::exchange(m_pendingSVGTransformAttributeUpdates, { });
+    for (auto& weakRenderer : pending) {
+        if (CheckedPtr renderer = weakRenderer.get())
+            renderer->setIsInPendingSVGTransformAttributeUpdates(false);
+    }
+
+    // Pass 1: record each non-layered renderer's repaint rect before its transform changes.
+    // Pass 3 then uses this old rect to emit a delta repaint (just the corner and edge strips
+    // that moved) via repaintAfterLayoutIfNeeded(), rather than repainting the full old rect plus
+    // the full new one. This mirrors the legacy engine's LayoutRepainter, except the old and new
+    // rects span the deferred flush instead of a single layout.
+    //
+    // Three kinds of renderer are skipped here:
+    //   - Layered renderers, handled instead by Pass 2's cached-rect diff.
+    //   - RenderSVGText, whose rect depends on text metrics computed during relayout. A snapshot
+    //     taken now would already hold the new rect, not the old one.
+    //   - Renderers that already need layout, covered by the upcoming layout's own LayoutRepainter.
+    struct NonLayeredSnapshot {
+        SingleThreadWeakPtr<RenderLayerModelObject> renderer;
+        SingleThreadWeakPtr<const RenderLayerModelObject> repaintContainer;
+        RenderObject::RepaintRects oldRects;
+    };
+    Vector<NonLayeredSnapshot> nonLayeredSnapshots;
+    nonLayeredSnapshots.reserveInitialCapacity(pending.size());
+    for (auto& weakRenderer : pending) {
+        CheckedPtr renderer = weakRenderer.get();
+        if (!renderer || renderer->renderTreeBeingDestroyed())
+            continue;
+        if (renderer->hasLayer() || is<RenderSVGText>(*renderer) || renderer->needsLayout())
+            continue;
+        CheckedPtr repaintContainer = renderer->containerForRepaint().renderer;
+        nonLayeredSnapshots.append({
+            SingleThreadWeakPtr<RenderLayerModelObject> { *renderer },
+            SingleThreadWeakPtr<const RenderLayerModelObject> { repaintContainer.get() },
+            renderer->rectsForRepaintingAfterLayout(repaintContainer.get(), RepaintOutlineBounds::Yes)
+        });
+    }
+
+    bool anyWorkDone = false;
+    for (auto& weakRenderer : pending) {
+        CheckedPtr renderer = weakRenderer.get();
+        if (!renderer || renderer->renderTreeBeingDestroyed())
+            continue;
+        // Layered and text renderers issue their own post-mutation invalidation. Non-layered
+        // renderers defer it; Pass 3 emits the delta repaint using the Pass 1 snapshot.
+        auto repaintMode = (renderer->hasLayer() || is<RenderSVGText>(*renderer))
+            ? RenderLayerModelObject::SVGAttributeChangeRepaintMode::Issue
+            : RenderLayerModelObject::SVGAttributeChangeRepaintMode::Defer;
+        renderer->updateTransformAndRepaintForSVGAfterAttributeChange(repaintMode);
+        anyWorkDone = true;
+
+        // A container/root ancestor's objectBoundingBox()/strokeBoundingBox() folds in its
+        // descendants' transforms but is only refreshed at layout, which this path skips. Mark
+        // the container ancestor chain dirty so getBBox()/objectBoundingBox-units resources
+        // recompute lazily. Walking parent() covers layered and non-layered alike. Re-marking an
+        // already-dirty ancestor is a cheap idempotent bool write, so shared chains just re-touch.
+        for (CheckedPtr ancestor = renderer->parent(); ancestor; ancestor = ancestor->parent()) {
+            if (CheckedPtr svgAncestor = dynamicDowncast<RenderLayerModelObject>(ancestor.get()))
+                svgAncestor->invalidateCachedSVGTransformDependentBoundingBoxes();
+            if (ancestor->isRenderSVGRoot())
+                break;
+        }
+    }
+
+    // Pass 3: delta repaint per non-layered renderer. Pass 2 mutated every queued renderer's
+    // transform, so the post-mutation rect we capture here reflects the final state - even
+    // for descendants of other mutated entries.
+    for (auto& snapshot : nonLayeredSnapshots) {
+        CheckedPtr renderer = snapshot.renderer.get();
+        if (!renderer || renderer->renderTreeBeingDestroyed())
+            continue;
+        CheckedPtr repaintContainer = snapshot.repaintContainer.get();
+        auto newRects = renderer->rectsForRepaintingAfterLayout(repaintContainer.get(), RepaintOutlineBounds::Yes);
+        renderer->repaintAfterLayoutIfNeeded(WTF::move(snapshot.repaintContainer), RequiresFullRepaint::No, snapshot.oldRects, newRects);
+    }
+
+    if (!anyWorkDone)
+        return;
+
+    // Defer the position-update walk to the upcoming layout pass if style/layout is already
+    // dirty - walking against stale geometry would emit incorrect intermediate repaints.
+    // The hot path (clean style/layout) runs the walk inline and skips the layout phase.
+    bool deferToLayoutPass = needsLayout() || isInLayout();
+    requestUpdateLayerPositions();
+    if (!deferToLayoutPass)
+        flushUpdateLayerPositions();
 }
 
 void LocalFrameViewLayoutContext::updateCompositingLayersAfterLayout()

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -137,6 +137,11 @@ public:
     void flushUpdateLayerPositions();
     void markForUpdateLayerPositionsAfterSVGTransformChange();
 
+    // LBSE: batches synchronous transform-attribute mutations (SMIL, DOM) so the
+    // transform-refresh + delta-repaint runs once per renderer per frame.
+    void addPendingSVGTransformAttributeUpdate(RenderLayerModelObject&);
+    void flushPendingSVGTransformAttributeUpdatesIfNeeded();
+
     bool updateCompositingLayersAfterStyleChange();
     void updateCompositingLayersAfterLayout();
     // Returns true if a pending compositing layer update was done.
@@ -294,6 +299,10 @@ private:
         bool needsFullRepaint { false };
     };
     std::optional<UpdateLayerPositions> m_pendingUpdateLayerPositions;
+
+    // Vector + per-renderer dedup flag chosen over WeakHashSet - ~10x cheaper on the
+    // LBSE MotionMark/Suits rAF hot path (hash + weak-ptr lookup vs. a bit check).
+    Vector<SingleThreadWeakPtr<RenderLayerModelObject>> m_pendingSVGTransformAttributeUpdates;
 
     struct RepaintRectEnvironment {
         float m_deviceScaleFactor { 0 };

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -324,6 +324,10 @@ public:
     bool renderBoxHasShapeOutsideInfo() const { return m_renderBoxHasShapeOutsideInfo; }
     bool hasCachedSVGResource() const { return m_hasCachedSVGResource; }
 
+    // Dedup flag for LocalFrameViewLayoutContext::m_pendingSVGTransformAttributeUpdates.
+    bool isInPendingSVGTransformAttributeUpdates() const { return m_isInPendingSVGTransformAttributeUpdates; }
+    void setIsInPendingSVGTransformAttributeUpdates(bool b) { m_isInPendingSVGTransformAttributeUpdates = b; }
+
     bool isAnonymousBlock() const;
     bool shouldSkipForPercentageResolution() const { return isAnonymous() && !isViewTransitionPseudo() && !isRenderView(); }
     inline bool isBlockBox() const;
@@ -478,7 +482,8 @@ private:
     unsigned m_visibleInViewportState : 2;
     unsigned m_didContributeToVisuallyNonEmptyPixelCount : 1;
     unsigned m_scrollAnchoringSuppressionStyleChanged : 1 { false };
-    // 11 bits free.
+    unsigned m_isInPendingSVGTransformAttributeUpdates : 1 { false };
+    // 10 bits free.
 
     RenderStyle m_style;
 };

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -698,85 +698,96 @@ bool RenderLayerModelObject::pointInSVGClippingArea(const FloatPoint& point) con
     );
 }
 
-void RenderLayerModelObject::repaintOrRelayoutAfterSVGTransformChange()
+void RenderLayerModelObject::updateTransformAndRepaintForSVGAfterAttributeChange(SVGAttributeChangeRepaintMode repaintMode)
 {
     ASSERT(document().settings().layerBasedSVGEngineEnabled());
 
     updateHasSVGTransformFlags();
 
-    // LBSE shares the text rendering code with the legacy SVG engine, largely unmodified.
-    // At present text layout depends on transformations ('screen font scaling factor' is used to
-    // determine which font to use for layout / painting). Therefore if the x/y scaling factors
-    // of the transformation matrix changes due to the transform update, we have to recompute the text metrics
-    // of all RenderSVGText descendants of the renderer in the ancestor chain, that will receive the transform
-    // update.
-    //
-    // There is no intrinsic reason for that, besides historical ones. If we decouple
-    // the 'font size screen scaling factor' from layout and only use it during painting
-    // we can optimize transformations for text, simply by avoid the need for layout.
+    // Refresh the layer transform, returning the (previous, current) pair. Shared by the text
+    // fast-path and the non-text layered branch. Forces a stacking context on an identity to
+    // non-identity transition (the batched flush skips RenderLayer::styleChanged), then marks the
+    // layer subtree for a position update.
+    auto refreshLayerTransform = [&]() -> std::pair<AffineTransform, AffineTransform> {
+        auto previousTransform = layerTransform() ? layerTransform()->toAffineTransform() : identity;
+        updateLayerTransform();
+        auto currentTransform = layerTransform() ? layerTransform()->toAffineTransform() : identity;
+        if (previousTransform.isIdentity() && !currentTransform.isIdentity())
+            layer()->forceStackingContextIfNeeded();
+        layer()->setSelfAndDescendantsNeedPositionUpdate();
+        return { previousTransform, currentTransform };
+    };
+
+    // A re-layout is only necessary when the effective x/y scale changes: the next RenderSVGText
+    // layout then sees a different screen font scaling factor, text metrics, etc.
+    auto scaleChangedBetween = [](const AffineTransform& previousTransform, const AffineTransform& currentTransform) {
+        return previousTransform != currentTransform
+            && (!WTF::areEssentiallyEqual(previousTransform.xScale(), currentTransform.xScale())
+                || !WTF::areEssentiallyEqual(previousTransform.yScale(), currentTransform.yScale()));
+    };
+
+    // RenderSVGText fast-path: do not refresh the cached repaint rect between the transform
+    // write and the text relayout. Composing the new transform with pre-relayout text metrics
+    // would cache an intermediate-state rect and cause a spurious repaint - the post-layout
+    // walk diffs the pre-mutation rect against the post-relayout rect instead.
+    if (is<RenderSVGText>(*this)) {
+        AffineTransform previousTransform;
+        AffineTransform currentTransform;
+        if (hasLayer())
+            std::tie(previousTransform, currentTransform) = refreshLayerTransform();
+
+        if (scaleChangedBetween(previousTransform, currentTransform)) {
+            auto& text = downcast<RenderSVGText>(*this);
+            text.setNeedsTextMetricsUpdate();
+            // Dirty layout so the flush's deferToLayoutPass guard fires, otherwise the early
+            // position walk caches an intermediate-state rect against pre-relayout metrics.
+            text.setNeedsLayout();
+            return;
+        }
+
+        repaintClientsOfReferencedSVGResources();
+        return;
+    }
+
+    // Non-text path: dirty the position-update bit and let the batched flush emit the delta
+    // repaints, in place of per-element computeRepaintRectsIncludingDescendants() + repaint().
     AffineTransform previousTransform;
     AffineTransform currentTransform;
 
-    if (hasLayer()) {
-        // Layered path: use the layer's cached transform.
-        previousTransform = layerTransform() ? layerTransform()->toAffineTransform() : identity;
-        updateLayerTransform();
-        currentTransform = layerTransform() ? layerTransform()->toAffineTransform() : identity;
-
-        // We have to force a stacking context if we did not have a transform before. Normally
-        // RenderLayer::styleChanged does this for us but repaintOrRelayoutAfterSVGTransformChange
-        // does not end up calling it.
-        if (previousTransform.isIdentity() && !currentTransform.isIdentity())
-            layer()->forceStackingContextIfNeeded();
+    bool isLayered = hasLayer();
+    if (isLayered) {
+        // Non-layered old-position repaint runs in the Pass 1 loop of the batched flush.
+        std::tie(previousTransform, currentTransform) = refreshLayerTransform();
     } else if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(this)) {
-        // Non-layered path: use the renderer's cached local SVG transform.
-        // The local transform was set during initial layout/style update and still
-        // holds the old value, analogous to the layer's transform for layered elements.
         previousTransform = svgModel->localTransform();
         svgModel->updateLocalTransform();
         currentTransform = svgModel->localTransform();
     }
 
-    auto determineIfTransformChangeModifiesScale = [&]() -> bool {
-        if (previousTransform == currentTransform)
-            return false;
-
-        // Only if the effective x/y scale changes, a re-layout is necessary, due to changed on-screen scaling factors.
-        // The next RenderSVGText layout will see a different 'screen font scaling factor', different text metrics etc.
-        if (!WTF::areEssentiallyEqual(previousTransform.xScale(), currentTransform.xScale()))
-            return true;
-
-        if (!WTF::areEssentiallyEqual(previousTransform.yScale(), currentTransform.yScale()))
-            return true;
-
-        return false;
-    }();
-
-    if (determineIfTransformChangeModifiesScale) {
-        if (auto* textAffectedByTransformChange = dynamicDowncast<RenderSVGText>(this)) {
-            // Mark text metrics for update, and only trigger a relayout and not an explicit repaint.
-            textAffectedByTransformChange->setNeedsTextMetricsUpdate();
-            textAffectedByTransformChange->textElement().updateSVGRendererForElementChange();
-            return;
-        }
-
-        // Recursively mark text metrics for update in all descendant RenderSVGText objects.
+    if (scaleChangedBetween(previousTransform, currentTransform)) {
         bool markedAny = false;
         for (auto& textDescendantAffectedByTransformChange : descendantsOfType<RenderSVGText>(*this)) {
             textDescendantAffectedByTransformChange.setNeedsTextMetricsUpdate();
-            textDescendantAffectedByTransformChange.textElement().updateSVGRendererForElementChange();
-            if (!markedAny)
-                markedAny = true;
+            // Dirty layout so the flush's deferToLayoutPass guard fires, otherwise the early
+            // position walk caches an intermediate-state rect (new container transform composed
+            // with pre-relayout text metrics).
+            textDescendantAffectedByTransformChange.setNeedsLayout();
+            markedAny = true;
         }
 
-        // If we marked a text descendant for relayout, we are expecting a relayout ourselves, so no reason for an explicit repaint().
         if (markedAny)
             return;
     }
 
-    // Instead of performing a full-fledged layout (issuing repaints), just recompute the layer transform, and repaint.
-    // In LBSE transformations do not affect the layout (except for text, where it still does!) -- SVG follows closely the CSS/HTML route, to avoid costly layouts.
-    repaintRendererOrClientsOfReferencedSVGResources();
+    // New-position repaint: layered renderers ride the batched flush. Non-layered renderers
+    // either issue a full repaint here, or - when the caller has snapshotted a pre-mutation
+    // rect - defer to repaintAfterLayoutIfNeeded() for a corner/edge-strip delta repaint.
+    if (!isLayered && repaintMode == SVGAttributeChangeRepaintMode::Issue)
+        repaint();
+
+    // Renderers inside <clipPath>/<mask>/<pattern>/etc. don't paint directly - a transform
+    // change is only visible by repainting the resource's clients.
+    repaintClientsOfReferencedSVGResources();
 }
 
 void RenderLayerModelObject::paintSVGClippingMask(PaintInfo& paintInfo, const FloatRect& objectBoundingBox) const

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -98,7 +98,14 @@ public:
     void updateHasSVGTransformFlags();
     virtual bool needsHasSVGTransformFlags() const { ASSERT_NOT_REACHED(); return false; }
 
-    void repaintOrRelayoutAfterSVGTransformChange();
+    enum class SVGAttributeChangeRepaintMode : bool {
+        // Issue a full repaint at the new position from inside the function.
+        Issue,
+        // Skip the post-mutation repaint - the caller will emit a delta repaint
+        // (via repaintAfterLayoutIfNeeded()) using a pre-mutation rect snapshot.
+        Defer
+    };
+    void updateTransformAndRepaintForSVGAfterAttributeChange(SVGAttributeChangeRepaintMode = SVGAttributeChangeRepaintMode::Issue);
 
     LayoutPoint nominalSVGLayoutLocation() const { return flooredLayoutPoint(objectBoundingBoxWithoutTransformations().minXMinYCorner()); }
     virtual LayoutPoint currentSVGLayoutLocation() const { ASSERT_NOT_REACHED(); return { }; }
@@ -129,6 +136,12 @@ public:
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox) const;
 
     virtual void invalidateCachedVisualOverflowRect() { }
+
+    // LBSE: flag the transform-dependent bounding boxes (objectBoundingBox / strokeBoundingBox)
+    // for lazy recomputation. Overridden by RenderSVGContainer / RenderSVGRoot, which cache them.
+    // The deferred SVG transform-attribute flush uses it to dirty the container ancestor chain of
+    // a renderer whose transform changed without a layout. No-op otherwise.
+    virtual void invalidateCachedSVGTransformDependentBoundingBoxes() { }
 
     inline bool shouldUsePositionedClipping() const;
 

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -90,7 +90,11 @@ void RenderSVGContainer::layoutChildren()
     containerLayout.layoutChildren(selfNeedsLayout());
 
     SVGBoundingBoxComputation boundingBoxComputation(*this);
-    m_objectBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::objectBoundingBoxDecoration, &m_objectBoundingBoxValid);
+    // objectBoundingBox / strokeBoundingBox are recomputed lazily (see
+    // updateSVGTransformDependentBoundingBoxesIfNeeded). Layout only needs the without-transform
+    // box below for currentSVGLayoutRect, so just mark them dirty rather than pay a full subtree
+    // walk that is usually never read before the next layout.
+    m_transformDependentBoundingBoxesDirty = true;
     m_strokeBoundingBox = std::nullopt;
     m_cachedVisualOverflowRect = std::nullopt;
 
@@ -106,8 +110,14 @@ void RenderSVGContainer::layoutChildren()
     containerLayout.positionChildrenRelativeToContainer();
 }
 
+void RenderSVGContainer::updateSVGTransformDependentBoundingBoxesIfNeeded() const
+{
+    SVGBoundingBoxComputation::recomputeTransformDependentBoundingBoxes(*this, m_transformDependentBoundingBoxesDirty, m_objectBoundingBox, m_strokeBoundingBox, &m_objectBoundingBoxValid);
+}
+
 FloatRect RenderSVGContainer::strokeBoundingBox() const
 {
+    updateSVGTransformDependentBoundingBoxesIfNeeded();
     if (!m_strokeBoundingBox) {
         // Initialize m_strokeBoundingBox before calling computeDecoratedBoundingBox, since recursively referenced markers can cause us to re-enter here.
         m_strokeBoundingBox = FloatRect { };
@@ -226,7 +236,7 @@ bool RenderSVGContainer::nodeAtPoint(const HitTestRequest& request, HitTestResul
     }
 
     // Accessibility wants to return SVG containers, if appropriate.
-    if (request.type() & HitTestRequest::Type::AccessibilityHitTest && m_objectBoundingBox.contains(localPoint)) {
+    if (request.type() & HitTestRequest::Type::AccessibilityHitTest && objectBoundingBox().contains(localPoint)) {
         updateHitTestResult(result, locationInContainer.point() - toLayoutSize(adjustedLocation));
         if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer, visualOverflowRect) == HitTestProgress::Stop)
             return true;

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.h
@@ -38,13 +38,23 @@ public:
 
     void paint(PaintInfo&, const LayoutPoint&) override;
 
-    bool isObjectBoundingBoxValid() const { return m_objectBoundingBoxValid; }
+    bool isObjectBoundingBoxValid() const
+    {
+        updateSVGTransformDependentBoundingBoxesIfNeeded();
+        return m_objectBoundingBoxValid;
+    }
     bool isLayoutSizeChanged() const { return m_isLayoutSizeChanged; }
     bool didTransformToRootUpdate() const { return m_didTransformToRootUpdate; }
 
-    FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }
+    FloatRect objectBoundingBox() const final
+    {
+        updateSVGTransformDependentBoundingBoxesIfNeeded();
+        return m_objectBoundingBox;
+    }
     FloatRect objectBoundingBoxWithoutTransformations() const final { return m_objectBoundingBoxWithoutTransformations; }
     FloatRect strokeBoundingBox() const final;
+
+    void invalidateCachedSVGTransformDependentBoundingBoxes() final { m_transformDependentBoundingBoxesDirty = true; }
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
     FloatRect decoratedBoundingBox() const final { return SVGBoundingBoxComputation::computeDecoratedBoundingBox(*this); }
 
@@ -64,10 +74,19 @@ protected:
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
     void addFocusRingRects(Vector<LayoutRect>& rects, const LayoutPoint& additionalOffset, const RenderLayerModelObject* container) const override;
 
-    bool m_objectBoundingBoxValid { false };
     bool m_isLayoutSizeChanged { false };
     bool m_didTransformToRootUpdate { false };
-    FloatRect m_objectBoundingBox;
+
+private:
+    // Recompute m_objectBoundingBox / m_strokeBoundingBox lazily after a descendant transform
+    // changes via the deferred (layout-free) flush. Both fold in descendant transforms and go
+    // stale, unlike the without-transform and visual-overflow caches. Kept private so every read
+    // funnels through the getters above, which honor m_transformDependentBoundingBoxesDirty.
+    void updateSVGTransformDependentBoundingBoxesIfNeeded() const;
+
+    mutable bool m_objectBoundingBoxValid { false };
+    mutable bool m_transformDependentBoundingBoxesDirty { false };
+    mutable FloatRect m_objectBoundingBox;
     FloatRect m_objectBoundingBoxWithoutTransformations;
     mutable Markable<FloatRect> m_strokeBoundingBox;
 };

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -278,7 +278,11 @@ void RenderSVGRoot::layoutChildren()
     containerLayout.layoutChildren(selfNeedsLayout());
 
     SVGBoundingBoxComputation boundingBoxComputation(*this);
-    m_objectBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::objectBoundingBoxDecoration);
+    // The transform-dependent bounding boxes (objectBoundingBox / strokeBoundingBox) are
+    // recomputed lazily on demand in updateSVGTransformDependentBoundingBoxesIfNeeded(); layout
+    // only needs the without-transform box below for currentSVGLayoutRect, so just mark them
+    // dirty instead of paying a full subtree walk that is usually never read before the next layout.
+    m_transformDependentBoundingBoxesDirty = true;
     m_strokeBoundingBox = std::nullopt;
     m_cachedVisualOverflowRect = std::nullopt;
 
@@ -288,8 +292,14 @@ void RenderSVGRoot::layoutChildren()
     containerLayout.positionChildrenRelativeToContainer();
 }
 
+void RenderSVGRoot::updateSVGTransformDependentBoundingBoxesIfNeeded() const
+{
+    SVGBoundingBoxComputation::recomputeTransformDependentBoundingBoxes(*this, m_transformDependentBoundingBoxesDirty, m_objectBoundingBox, m_strokeBoundingBox);
+}
+
 FloatRect RenderSVGRoot::strokeBoundingBox() const
 {
+    updateSVGTransformDependentBoundingBoxesIfNeeded();
     if (!m_strokeBoundingBox) {
         // Initialize m_strokeBoundingBox before calling computeDecoratedBoundingBox, since recursively referenced markers can cause us to re-enter here.
         m_strokeBoundingBox = FloatRect { };

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -60,9 +60,15 @@ public:
 
     bool NODELETE shouldApplyViewportClip() const;
 
-    FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }
+    FloatRect objectBoundingBox() const final
+    {
+        updateSVGTransformDependentBoundingBoxesIfNeeded();
+        return m_objectBoundingBox;
+    }
     FloatRect objectBoundingBoxWithoutTransformations() const final { return m_objectBoundingBoxWithoutTransformations; }
     FloatRect strokeBoundingBox() const final;
+
+    void invalidateCachedSVGTransformDependentBoundingBoxes() final { m_transformDependentBoundingBoxesDirty = true; }
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
     FloatRect decoratedBoundingBox() const final { return SVGBoundingBoxComputation::computeDecoratedBoundingBox(*this); }
 
@@ -118,9 +124,14 @@ private:
     bool m_inLayout { false };
     bool m_didTransformToRootUpdate { false };
     bool m_isLayoutSizeChanged { false };
+    mutable bool m_transformDependentBoundingBoxesDirty { false };
+
+    // See RenderSVGContainer: lazily recompute the transform-dependent bounding boxes when a
+    // descendant transform changed via the deferred (layout-free) SVG transform-attribute flush.
+    void updateSVGTransformDependentBoundingBoxesIfNeeded() const;
 
     IntSize m_containerSize;
-    FloatRect m_objectBoundingBox;
+    mutable FloatRect m_objectBoundingBox;
     FloatRect m_objectBoundingBoxWithoutTransformations;
     mutable Markable<FloatRect> m_strokeBoundingBox;
     mutable std::optional<LayoutRect> m_cachedVisualOverflowRect;

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -47,6 +47,18 @@ SVGBoundingBoxComputation::SVGBoundingBoxComputation(const RenderLayerModelObjec
 {
 }
 
+void SVGBoundingBoxComputation::recomputeTransformDependentBoundingBoxes(const RenderLayerModelObject& renderer, bool& dirty, FloatRect& objectBoundingBox, Markable<FloatRect>& strokeBoundingBox, bool* objectBoundingBoxValid)
+{
+    if (!dirty)
+        return;
+    // Clear before recomputing so any re-entrant read sees a consistent state.
+    dirty = false;
+
+    SVGBoundingBoxComputation boundingBoxComputation(renderer);
+    objectBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(objectBoundingBoxDecoration, objectBoundingBoxValid);
+    strokeBoundingBox = std::nullopt;
+}
+
 FloatRect SVGBoundingBoxComputation::computeDecoratedBoundingBox(const SVGBoundingBoxComputation::DecorationOptions& options, bool* boundingBoxValid) const
 {
     // SVG2: Bounding boxes algorithm (https://svgwg.org/svg2-draft/coords.html#BoundingBoxes)

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.h
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.h
@@ -19,13 +19,13 @@
 
 #pragma once
 
+#include "FloatRect.h"
 #include <WebCore/RenderLayerModelObject.h>
+#include <wtf/Markable.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/OptionSet.h>
 
 namespace WebCore {
-
-class FloatRect;
 
 class SVGBoundingBoxComputation {
     WTF_MAKE_NONCOPYABLE(SVGBoundingBoxComputation);
@@ -74,6 +74,11 @@ public:
     }
 
     static LayoutRect computeVisualOverflowRect(const RenderLayerModelObject&);
+
+    // Recompute the transform-dependent bounding boxes shared by RenderSVGContainer and
+    // RenderSVGRoot after a descendant transform changed outside layout. Pass objectBoundingBoxValid
+    // where the caller tracks it (RenderSVGContainer), else omit it (RenderSVGRoot).
+    static void recomputeTransformDependentBoundingBoxes(const RenderLayerModelObject& renderer, bool& dirty, FloatRect& objectBoundingBox, Markable<FloatRect>& strokeBoundingBox, bool* objectBoundingBoxValid = nullptr);
 
 private:
     FloatRect handleShapeOrTextOrInline(const DecorationOptions&, bool* boundingBoxValid = nullptr) const;

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -43,6 +43,11 @@ class Text;
 
 namespace Style {
 
+enum class SVGRendererUpdateType : bool {
+    Default, // Routes through Style::Update -> RenderTreeUpdater::updateSVGRenderer.
+    TransformAttributeOnly // LBSE in-place transform refresh, bypasses Style::Update.
+};
+
 struct ElementUpdate {
     std::unique_ptr<RenderStyle> style;
     OptionSet<Change> changes { };

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -29,7 +29,6 @@
 #include "ElementChildIteratorInlines.h"
 #include "LegacyRenderSVGResource.h"
 #include "PathTraversalState.h"
-#include "RenderLayerModelObject.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGImageElement.h"
 #include "SVGMPathElement.h"
@@ -39,6 +38,7 @@
 #include "SVGPathElement.h"
 #include "SVGPathUtilities.h"
 #include "Settings.h"
+#include "StyleUpdate.h"
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -256,9 +256,7 @@ void SVGAnimateMotionElement::applyResultsToTarget()
 
     auto updateTargetElement = [](SVGElement& element) {
         if (element.document().settings().layerBasedSVGEngineEnabled()) {
-            if (CheckedPtr layerRenderer = dynamicDowncast<RenderLayerModelObject>(element.renderer()))
-                layerRenderer->repaintOrRelayoutAfterSVGTransformChange();
-            element.updateSVGRendererForElementChange();
+            element.updateSVGRendererForElementChange(Style::SVGRendererUpdateType::TransformAttributeOnly);
             return;
         }
         if (CheckedPtr renderer = element.renderer())

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -68,6 +68,7 @@
 #include "StyleExtractor.h"
 #include "StyleKeyword+Mappings.h"
 #include "StyleResolver.h"
+#include "StyleUpdate.h"
 #include "XMLNames.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
@@ -1028,10 +1029,10 @@ void SVGElement::collectPresentationalHintsForAttribute(const QualifiedName& nam
         mapLanguageAttributeToLocale(value, style);
 }
 
-void SVGElement::updateSVGRendererForElementChange()
+void SVGElement::updateSVGRendererForElementChange(Style::SVGRendererUpdateType kind)
 {
     Ref<Document> document = this->document();
-    document->updateSVGRenderer(*this);
+    document->updateSVGRenderer(*this, kind);
 }
 
 void SVGElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -57,6 +57,10 @@ enum class CTMScope : bool;
 enum class CalcMode : uint8_t;
 enum class SVGParsingError : uint8_t;
 
+namespace Style {
+enum class SVGRendererUpdateType : bool;
+}
+
 template<typename PropertyType>
 class SVGAnimatedPrimitiveProperty;
 
@@ -113,7 +117,7 @@ public:
 
     inline void setAnimatedSVGAttributesAreDirty();
     inline void setPresentationalHintStyleIsDirty();
-    void updateSVGRendererForElementChange();
+    void updateSVGRendererForElementChange(Style::SVGRendererUpdateType = Style::SVGRendererUpdateType { });
 
     // The instances of an element are clones made in shadow trees to implement <use>.
     const WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>& NODELETE instances() const;

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -50,6 +50,7 @@
 #include "SVGTransformComputation.h"
 #include "Settings.h"
 #include "StyleTransformResolver.h"
+#include "StyleUpdate.h"
 #include "TransformOperationData.h"
 #include "TransformState.h"
 #include <wtf/NeverDestroyed.h>
@@ -231,8 +232,7 @@ void SVGGraphicsElement::svgAttributeChanged(const QualifiedName& attrName)
         InstanceInvalidationGuard guard(*this);
 
         if (document().settings().layerBasedSVGEngineEnabled()) {
-            if (CheckedPtr layerRenderer = dynamicDowncast<RenderLayerModelObject>(renderer()))
-                layerRenderer->repaintOrRelayoutAfterSVGTransformChange();
+            updateSVGRendererForElementChange(Style::SVGRendererUpdateType::TransformAttributeOnly);
             return;
         }
 


### PR DESCRIPTION
#### ec9eb9ff1b64602920ebc3ffd9d238822c57be22
<pre>
[LBSE] Defer per-element SVG transform-attribute work without style recalc
<a href="https://bugs.webkit.org/show_bug.cgi?id=315782">https://bugs.webkit.org/show_bug.cgi?id=315782</a>

Reviewed by Rob Buis.

SVGGraphicsElement::svgAttributeChanged and SVGAnimateMotionElement used
to call repaintOrRelayoutAfterSVGTransformChange() synchronously per
attribute mutation. On MotionMark/Suits that produced 2N repaint() calls
per frame and dominated the profile.

To fix that, batch the per-element work into a once-per-frame queue on
LocalFrameViewLayoutContext, deduplicated by a single bit on RenderElement.
The queue is flushed from Document::updateLayout (after updateStyleIfNeeded,
so updateLayerTransform sees post-style geometry) and from
flushUpdateLayerPositions for scroll-driven walks.

The flush runs in three phases:

 1. Snapshot pre-mutation repaint rects for non-layered renderers.
 2. Mutate transforms - for layered renderers this just dirties the batched
    position-update bit.
 3. Emit a delta repaint from the snapshot via repaintAfterLayoutIfNeeded(),
    like the legacy engine&apos;s LayoutRepainter but spanning the whole flush.

I&apos;ve experimented with single passes, batching, etc. in the end this approach
led to most improvments in MotionMark/Suits.

With this layout/style-recalc free approach, we need to ddress bounding-box
correctness: a container/root caches objectBoundingBox()/strokeBoundingBox(),
which fold in descendant transforms but were only refreshed at layout -- this
step is skipped in the new path, so getBBox() could go stale. A dirty bit on
RenderSVGContainer/RenderSVGRoot fixes this: the second phase marks the
container ancestor chain (walking parent(), so layered and non-layered renderers
are handled alike), and the boxes recompute lazily on _read_ via
SVGBoundingBoxComputation::recomputeTransformDependentBoundingBoxes().
layoutChildren() now defers them the same way, so the subtree walk is only
paid when something actually reads a box.

This again improves MotionMark/Suits performance by ~10% on LBSE.
Covered by existing tests (svg/repaint).

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateSVGRenderer):
(WebCore::Document::updateLayout):
(WebCore::Document::updateLayoutIfDimensionsOutOfDate):
* Source/WebCore/dom/Document.h:
(WebCore::Document::updateSVGRenderer):
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::flushUpdateLayerPositions):
(WebCore::LocalFrameViewLayoutContext::addPendingSVGTransformAttributeUpdate):
(WebCore::LocalFrameViewLayoutContext::flushPendingSVGTransformAttributeUpdatesIfNeeded):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::isInPendingSVGTransformAttributeUpdates const):
(WebCore::RenderElement::setIsInPendingSVGTransformAttributeUpdates):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::updateTransformAndRepaintForSVGAfterAttributeChange):
(WebCore::RenderLayerModelObject::repaintOrRelayoutAfterSVGTransformChange): Deleted.
* Source/WebCore/rendering/RenderLayerModelObject.h:
(WebCore::RenderLayerModelObject::invalidateCachedSVGTransformDependentBoundingBoxes):
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::layoutChildren):
(WebCore::RenderSVGContainer::updateSVGTransformDependentBoundingBoxesIfNeeded const):
(WebCore::RenderSVGContainer::strokeBoundingBox const):
(WebCore::RenderSVGContainer::nodeAtPoint):
* Source/WebCore/rendering/svg/RenderSVGContainer.h:
(WebCore::RenderSVGContainer::isObjectBoundingBoxValid const):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::layoutChildren):
(WebCore::RenderSVGRoot::updateSVGTransformDependentBoundingBoxesIfNeeded const):
(WebCore::RenderSVGRoot::strokeBoundingBox const):
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::recomputeTransformDependentBoundingBoxes):
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.h:
* Source/WebCore/style/StyleUpdate.h:
* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::applyResultsToTarget):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::updateSVGRendererForElementChange):
* Source/WebCore/svg/SVGElement.h:
(WebCore::SVGElement::updateSVGRendererForElementChange):
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::svgAttributeChanged):

Canonical link: <a href="https://commits.webkit.org/314458@main">https://commits.webkit.org/314458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08396543fc7d2de56038bd5fd0738137f9b3d3ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175244 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123452 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129180 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109705 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23385 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177777 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30679 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28734 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137527 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137455 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37023 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148824 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103074 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32747 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25691 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38955 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112029 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38352 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3777 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->