### PR TITLE
[css-images] Add support for image(<color>)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4335,8 +4335,6 @@ imported/w3c/web-platform-tests/css/css-images/cross-fade-cross-origin-orientati
 imported/w3c/web-platform-tests/css/css-images/cross-fade-natural-size.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-images/cross-fade-premultiplied-alpha.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-images/cross-fade-target-alpha.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-images/image-color-basic.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-images/image-color-layered.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-images/image-color-cross-fade.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-images/image-light-dark.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-images/gradient/gradient-eval-004.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-combined-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-combined-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS reftest reference: image(&lt;color&gt;) with background-size, background-position, and background-repeat</title>
+<style>
+  .container {
+    width: 120px;
+    height: 120px;
+    display: inline-block;
+    vertical-align: top;
+    background-color: red;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .green {
+    position: absolute;
+    background-color: green;
+  }
+
+  /* center no-repeat: 40×40 tile at ((120-40)/2, (120-40)/2) = (40px, 40px) */
+  .center-no-repeat > .green     { top: 40px; left: 40px; width: 40px; height: 40px; }
+
+  /* repeat-x centered vertically: full-width row at y=(120-40)/2=40px, height 40px */
+  .repeat-x-center > .green      { top: 40px; left: 0;    width: 120px; height: 40px; }
+
+  /* repeat-y centered horizontally: full-height column at x=(120-40)/2=40px, width 40px */
+  .repeat-y-center > .green      { top: 0;    left: 40px; width: 40px;  height: 120px; }
+
+  /* bottom-right no-repeat: 60×60 tile at (120-60, 120-60) = (60px, 60px) */
+  .bottom-right-no-repeat > .green { top: 60px; left: 60px; width: 60px; height: 60px; }
+</style>
+<p>Four 120×120 squares on red: centered 40×40 green (no-repeat), full-width 40px green band at vertical center (repeat-x), full-height 40px green band at horizontal center (repeat-y), 60×60 green at bottom-right (no-repeat).</p>
+<div class="container center-no-repeat"><div class="green"></div></div>
+<div class="container repeat-x-center"><div class="green"></div></div>
+<div class="container repeat-y-center"><div class="green"></div></div>
+<div class="container bottom-right-no-repeat"><div class="green"></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-combined-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-combined-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS reftest reference: image(&lt;color&gt;) with background-size, background-position, and background-repeat</title>
+<style>
+  .container {
+    width: 120px;
+    height: 120px;
+    display: inline-block;
+    vertical-align: top;
+    background-color: red;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .green {
+    position: absolute;
+    background-color: green;
+  }
+
+  /* center no-repeat: 40×40 tile at ((120-40)/2, (120-40)/2) = (40px, 40px) */
+  .center-no-repeat > .green     { top: 40px; left: 40px; width: 40px; height: 40px; }
+
+  /* repeat-x centered vertically: full-width row at y=(120-40)/2=40px, height 40px */
+  .repeat-x-center > .green      { top: 40px; left: 0;    width: 120px; height: 40px; }
+
+  /* repeat-y centered horizontally: full-height column at x=(120-40)/2=40px, width 40px */
+  .repeat-y-center > .green      { top: 0;    left: 40px; width: 40px;  height: 120px; }
+
+  /* bottom-right no-repeat: 60×60 tile at (120-60, 120-60) = (60px, 60px) */
+  .bottom-right-no-repeat > .green { top: 60px; left: 60px; width: 60px; height: 60px; }
+</style>
+<p>Four 120×120 squares on red: centered 40×40 green (no-repeat), full-width 40px green band at vertical center (repeat-x), full-height 40px green band at horizontal center (repeat-y), 60×60 green at bottom-right (no-repeat).</p>
+<div class="container center-no-repeat"><div class="green"></div></div>
+<div class="container repeat-x-center"><div class="green"></div></div>
+<div class="container repeat-y-center"><div class="green"></div></div>
+<div class="container bottom-right-no-repeat"><div class="green"></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-combined.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-combined.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Images Module Level 4: image(&lt;color&gt;) with background-size, background-position, and background-repeat</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#image-notation">
+<link rel="match" href="image-color-background-combined-ref.html">
+<style>
+  .container {
+    width: 120px;
+    height: 120px;
+    display: inline-block;
+    vertical-align: top;
+    background-color: red;
+    background-image: image(green);
+  }
+
+  /* Single 40×40 tile centered */
+  .center-no-repeat {
+    background-size: 40px 40px;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+
+  /* 40×40 tiles tiled horizontally, row centered vertically */
+  .repeat-x-center {
+    background-size: 40px 40px;
+    background-position: 0 center;
+    background-repeat: repeat-x;
+  }
+
+  /* 40×40 tiles tiled vertically, column centered horizontally */
+  .repeat-y-center {
+    background-size: 40px 40px;
+    background-position: center 0;
+    background-repeat: repeat-y;
+  }
+
+  /* Single 60×60 tile pinned to bottom-right */
+  .bottom-right-no-repeat {
+    background-size: 60px 60px;
+    background-position: right bottom;
+    background-repeat: no-repeat;
+  }
+</style>
+<p>Four 120×120 squares on red: centered 40×40 green (no-repeat), full-width 40px green band at vertical center (repeat-x), full-height 40px green band at horizontal center (repeat-y), 60×60 green at bottom-right (no-repeat).</p>
+<div class="container center-no-repeat"></div>
+<div class="container repeat-x-center"></div>
+<div class="container repeat-y-center"></div>
+<div class="container bottom-right-no-repeat"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-position-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-position-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS reftest reference: image(&lt;color&gt;) with background-position</title>
+<style>
+  .container {
+    width: 100px;
+    height: 100px;
+    display: inline-block;
+    vertical-align: top;
+    background-color: red;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .green {
+    position: absolute;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+  }
+
+  /* 0% 0% → (0, 0) */
+  .top-left > .green     { top: 0;    left: 0; }
+
+  /* center → ((100-50)/2, (100-50)/2) = (25px, 25px) */
+  .center > .green       { top: 25px; left: 25px; }
+
+  /* right bottom → (100-50, 100-50) = (50px, 50px) */
+  .bottom-right > .green { top: 50px; left: 50px; }
+
+  /* 25px 25px */
+  .offset > .green       { top: 25px; left: 25px; }
+</style>
+<p>Four 100×100 squares with a 50×50 green tile on red at: top-left, center, bottom-right, 25px offset.</p>
+<div class="container top-left"><div class="green"></div></div>
+<div class="container center"><div class="green"></div></div>
+<div class="container bottom-right"><div class="green"></div></div>
+<div class="container offset"><div class="green"></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-position-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-position-ref.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS reftest reference: image(&lt;color&gt;) with background-position</title>
+<style>
+  .container {
+    width: 100px;
+    height: 100px;
+    display: inline-block;
+    vertical-align: top;
+    background-color: red;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .green {
+    position: absolute;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+  }
+
+  /* 0% 0% → (0, 0) */
+  .top-left > .green     { top: 0;    left: 0; }
+
+  /* center → ((100-50)/2, (100-50)/2) = (25px, 25px) */
+  .center > .green       { top: 25px; left: 25px; }
+
+  /* right bottom → (100-50, 100-50) = (50px, 50px) */
+  .bottom-right > .green { top: 50px; left: 50px; }
+
+  /* 25px 25px */
+  .offset > .green       { top: 25px; left: 25px; }
+</style>
+<p>Four 100×100 squares with a 50×50 green tile on red at: top-left, center, bottom-right, 25px offset.</p>
+<div class="container top-left"><div class="green"></div></div>
+<div class="container center"><div class="green"></div></div>
+<div class="container bottom-right"><div class="green"></div></div>
+<div class="container offset"><div class="green"></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-position.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-position.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Images Module Level 4: image(&lt;color&gt;) with background-position</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#image-notation">
+<link rel="match" href="image-color-background-position-ref.html">
+<style>
+  .container {
+    width: 100px;
+    height: 100px;
+    display: inline-block;
+    vertical-align: top;
+    background-color: red;
+    background-image: image(green);
+    background-size: 50px 50px;
+    background-repeat: no-repeat;
+  }
+
+  .top-left     { background-position: 0% 0%; }
+  .center       { background-position: center; }
+  .bottom-right { background-position: right bottom; }
+  .offset       { background-position: 25px 25px; }
+</style>
+<p>Four 100×100 squares with a 50×50 green tile on red at: top-left, center, bottom-right, 25px offset.</p>
+<div class="container top-left"></div>
+<div class="container center"></div>
+<div class="container bottom-right"></div>
+<div class="container offset"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-repeat-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-repeat-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS reftest reference: image(&lt;color&gt;) with background-repeat</title>
+<style>
+  .container {
+    width: 200px;
+    height: 200px;
+    display: inline-block;
+    vertical-align: top;
+    background-color: red;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .green {
+    position: absolute;
+    background-color: green;
+  }
+
+  /* repeat: 2×2 tiles cover the full 200×200 box */
+  .repeat > .green    { inset: 0; }
+
+  /* no-repeat: single 100×100 tile at top-left */
+  .no-repeat > .green { top: 0; left: 0; width: 100px; height: 100px; }
+
+  /* repeat-x: top 100px row */
+  .repeat-x > .green  { top: 0; left: 0; width: 200px; height: 100px; }
+
+  /* repeat-y: left 100px column */
+  .repeat-y > .green  { top: 0; left: 0; width: 100px; height: 200px; }
+</style>
+<p>Four 200×200 squares: fully green (repeat), top-left quadrant green (no-repeat),
+top half green (repeat-x), left half green (repeat-y).</p>
+<div class="container repeat"><div class="green"></div></div>
+<div class="container no-repeat"><div class="green"></div></div>
+<div class="container repeat-x"><div class="green"></div></div>
+<div class="container repeat-y"><div class="green"></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-repeat-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-repeat-ref.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS reftest reference: image(&lt;color&gt;) with background-repeat</title>
+<style>
+  .container {
+    width: 200px;
+    height: 200px;
+    display: inline-block;
+    vertical-align: top;
+    background-color: red;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .green {
+    position: absolute;
+    background-color: green;
+  }
+
+  /* repeat: 2×2 tiles cover the full 200×200 box */
+  .repeat > .green    { inset: 0; }
+
+  /* no-repeat: single 100×100 tile at top-left */
+  .no-repeat > .green { top: 0; left: 0; width: 100px; height: 100px; }
+
+  /* repeat-x: top 100px row */
+  .repeat-x > .green  { top: 0; left: 0; width: 200px; height: 100px; }
+
+  /* repeat-y: left 100px column */
+  .repeat-y > .green  { top: 0; left: 0; width: 100px; height: 200px; }
+</style>
+<p>Four 200×200 squares: fully green (repeat), top-left quadrant green (no-repeat),
+top half green (repeat-x), left half green (repeat-y).</p>
+<div class="container repeat"><div class="green"></div></div>
+<div class="container no-repeat"><div class="green"></div></div>
+<div class="container repeat-x"><div class="green"></div></div>
+<div class="container repeat-y"><div class="green"></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-repeat.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-repeat.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Images Module Level 4: image(&lt;color&gt;) with background-repeat</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#image-notation">
+<link rel="match" href="image-color-background-repeat-ref.html">
+<style>
+  .container {
+    width: 200px;
+    height: 200px;
+    display: inline-block;
+    vertical-align: top;
+    background-color: red;
+    background-image: image(green);
+    background-size: 100px 100px;
+    background-position: 0 0;
+  }
+
+  /* 2×2 grid of tiles fills the 200×200 box entirely */
+  .repeat    { background-repeat: repeat; }
+
+  /* single tile at top-left */
+  .no-repeat { background-repeat: no-repeat; }
+
+  /* two tiles in a row along the top */
+  .repeat-x  { background-repeat: repeat-x; }
+
+  /* two tiles in a column along the left */
+  .repeat-y  { background-repeat: repeat-y; }
+</style>
+<p>Four 200×200 squares: fully green (repeat), top-left quadrant green (no-repeat),
+top half green (repeat-x), left half green (repeat-y).</p>
+<div class="container repeat"></div>
+<div class="container no-repeat"></div>
+<div class="container repeat-x"></div>
+<div class="container repeat-y"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-size-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS reftest reference: image(&lt;color&gt;) with background-size</title>
+<style>
+  .container {
+    width: 100px;
+    height: 100px;
+    display: inline-block;
+    vertical-align: top;
+    background-color: red;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .green {
+    position: absolute;
+    background-color: green;
+  }
+
+  .auto > .green,
+  .cover > .green,
+  .contain > .green { inset: 0; }
+
+  .half-width > .green  { top: 0; left: 0; width: 50px;  height: 100px; }
+  .half-height > .green { top: 0; left: 0; width: 100px; height: 50px;  }
+  .quarter > .green     { top: 0; left: 0; width: 50px;  height: 50px;  }
+</style>
+<p>Six squares: first three fully green, then left-half green, top-half green, top-left quarter green.</p>
+<div class="container auto"><div class="green"></div></div>
+<div class="container cover"><div class="green"></div></div>
+<div class="container contain"><div class="green"></div></div>
+<div class="container half-width"><div class="green"></div></div>
+<div class="container half-height"><div class="green"></div></div>
+<div class="container quarter"><div class="green"></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-size-ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS reftest reference: image(&lt;color&gt;) with background-size</title>
+<style>
+  .container {
+    width: 100px;
+    height: 100px;
+    display: inline-block;
+    vertical-align: top;
+    background-color: red;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .green {
+    position: absolute;
+    background-color: green;
+  }
+
+  .auto > .green,
+  .cover > .green,
+  .contain > .green { inset: 0; }
+
+  .half-width > .green  { top: 0; left: 0; width: 50px;  height: 100px; }
+  .half-height > .green { top: 0; left: 0; width: 100px; height: 50px;  }
+  .quarter > .green     { top: 0; left: 0; width: 50px;  height: 50px;  }
+</style>
+<p>Six squares: first three fully green, then left-half green, top-half green, top-left quarter green.</p>
+<div class="container auto"><div class="green"></div></div>
+<div class="container cover"><div class="green"></div></div>
+<div class="container contain"><div class="green"></div></div>
+<div class="container half-width"><div class="green"></div></div>
+<div class="container half-height"><div class="green"></div></div>
+<div class="container quarter"><div class="green"></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-size.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Images Module Level 4: image(&lt;color&gt;) with background-size</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#image-notation">
+<link rel="match" href="image-color-background-size-ref.html">
+<style>
+  .container {
+    width: 100px;
+    height: 100px;
+    display: inline-block;
+    vertical-align: top;
+    background-color: red;
+  }
+
+  /* auto: color image has no intrinsic size, so auto resolves to the positioning area */
+  .auto {
+    background-image: image(green);
+  }
+
+  /* cover and contain likewise fill the entire area */
+  .cover {
+    background-image: image(green);
+    background-size: cover;
+  }
+
+  .contain {
+    background-image: image(green);
+    background-size: contain;
+  }
+
+  /* explicit percentage */
+  .half-width {
+    background-image: image(green);
+    background-size: 50% 100%;
+    background-repeat: no-repeat;
+  }
+
+  .half-height {
+    background-image: image(green);
+    background-size: 100% 50%;
+    background-repeat: no-repeat;
+  }
+
+  /* explicit pixel size */
+  .quarter {
+    background-image: image(green);
+    background-size: 50px 50px;
+    background-repeat: no-repeat;
+  }
+</style>
+<p>Six squares: first three fully green, then left-half green, top-half green, top-left quarter green.</p>
+<div class="container auto"></div>
+<div class="container cover"></div>
+<div class="container contain"></div>
+<div class="container half-width"></div>
+<div class="container half-height"></div>
+<div class="container quarter"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/parsing/image-function-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/parsing/image-function-computed-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Property background-image value 'image(red)' assert_true: 'image(red)' is a supported value for background-image. expected true got false
-FAIL Property background-image value 'image(rgba(0, 128, 255, 0.5))' assert_true: 'image(rgba(0, 128, 255, 0.5))' is a supported value for background-image. expected true got false
-FAIL Property background-image value 'image(transparent)' assert_true: 'image(transparent)' is a supported value for background-image. expected true got false
+PASS Property background-image value 'image(red)'
+PASS Property background-image value 'image(rgba(0, 128, 255, 0.5))'
+PASS Property background-image value 'image(transparent)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/parsing/image-function-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/parsing/image-function-valid-expected.txt
@@ -1,15 +1,15 @@
 
-FAIL e.style['background-image'] = "image(red)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['background-image'] = "image(transparent)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['background-image'] = "image(rgb(0 128 255))" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['background-image'] = "image(currentcolor)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['background-image'] = "image(light-dark(black, white))" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['background-image'] = "image(color-mix(in srgb, red, blue))" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['background-image'] = "image(rgb(from red r g b))" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['background-image'] = "image(rgba(0, 0, 255, 0.5)), linear-gradient(red, blue)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['background-image'] = "image(red)" should set the property value
+PASS e.style['background-image'] = "image(transparent)" should set the property value
+PASS e.style['background-image'] = "image(rgb(0 128 255))" should set the property value
+PASS e.style['background-image'] = "image(currentcolor)" should set the property value
+PASS e.style['background-image'] = "image(light-dark(black, white))" should set the property value
+PASS e.style['background-image'] = "image(color-mix(in srgb, red, blue))" should set the property value
+PASS e.style['background-image'] = "image(rgb(from red r g b))" should set the property value
+PASS e.style['background-image'] = "image(rgba(0, 0, 255, 0.5)), linear-gradient(red, blue)" should set the property value
 FAIL e.style['background-image'] = "cross-fade(image(green), red)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['border-image-source'] = "image(red)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['mask-image'] = "image(red)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['shape-outside'] = "image(red)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['list-style-image'] = "image(red)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['border-image-source'] = "image(red)" should set the property value
+PASS e.style['mask-image'] = "image(red)" should set the property value
+PASS e.style['shape-outside'] = "image(red)" should set the property value
+PASS e.style['list-style-image'] = "image(red)" should set the property value
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -896,6 +896,7 @@ css/CSSBorderImageWidthValue.cpp
 css/CSSBoxShadowPropertyValue.cpp
 css/CSSCanvasValue.cpp
 css/CSSClipValue.cpp
+css/CSSColorImageValue.cpp
 css/CSSColorSchemeValue.cpp
 css/CSSColorValue.cpp
 css/CSSComputedStyleDeclaration.cpp @header:RenderStyleGetters
@@ -2666,6 +2667,7 @@ platform/graphics/MediaSampleConverter.cpp
 platform/graphics/MediaSourcePrivate.cpp
 platform/graphics/Model.cpp
 platform/graphics/ModelContext.cpp
+platform/graphics/ColorImageGeneratedImage.cpp
 platform/graphics/NamedImageGeneratedImage.cpp
 platform/graphics/NativeImage.cpp
 platform/graphics/NativeImageSource.cpp
@@ -3388,6 +3390,7 @@ style/values/images/kinds/StyleGradientImage.cpp @header:RenderStyleGetters
 style/values/images/kinds/StyleImageSet.cpp
 style/values/images/kinds/StyleInvalidImage.cpp
 style/values/images/kinds/StyleMultiImage.cpp
+style/values/images/kinds/StyleColorImage.cpp
 style/values/images/kinds/StyleNamedImage.cpp
 style/values/images/kinds/StylePaintImage.cpp @header:RenderStyleGetters
 style/values/images/StyleGradient.cpp @header:RenderStyleGetters

--- a/Source/WebCore/css/CSSColorImageValue.cpp
+++ b/Source/WebCore/css/CSSColorImageValue.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSColorImageValue.h"
+
+#include "StyleBuilderState.h"
+#include "StyleColor.h"
+#include "StyleColorImage.h"
+
+namespace WebCore {
+
+Ref<CSSColorImageValue> CSSColorImageValue::create(CSS::Color&& color)
+{
+    return adoptRef(*new CSSColorImageValue(WTF::move(color)));
+}
+
+CSSColorImageValue::CSSColorImageValue(CSS::Color&& color)
+    : CSSValue { ClassType::ColorImage }
+    , m_color { WTF::move(color) }
+{
+}
+
+CSSColorImageValue::~CSSColorImageValue() = default;
+
+String CSSColorImageValue::customCSSText(const CSS::SerializationContext& context) const
+{
+    return makeString("image("_s, CSS::serializationForCSS(context, m_color), ')');
+}
+
+bool CSSColorImageValue::equals(const CSSColorImageValue& other) const
+{
+    return m_color == other.m_color;
+}
+
+RefPtr<Style::Image> CSSColorImageValue::createStyleImage(const Style::BuilderState& state) const
+{
+    return Style::ColorImage::create(Style::toStyle(m_color, state));
+}
+
+IterationStatus CSSColorImageValue::customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
+{
+    return CSS::visitCSSValueChildren(func, m_color);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSColorImageValue.h
+++ b/Source/WebCore/css/CSSColorImageValue.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSColor.h"
+#include "CSSValue.h"
+
+namespace WebCore {
+
+namespace Style {
+class BuilderState;
+class Image;
+}
+
+class CSSColorImageValue final : public CSSValue {
+public:
+    static Ref<CSSColorImageValue> create(CSS::Color&&);
+    ~CSSColorImageValue();
+
+    const CSS::Color& color() const LIFETIME_BOUND { return m_color; }
+
+    String customCSSText(const CSS::SerializationContext&) const;
+    bool equals(const CSSColorImageValue&) const;
+
+    RefPtr<Style::Image> createStyleImage(const Style::BuilderState&) const;
+
+    IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
+
+private:
+    explicit CSSColorImageValue(CSS::Color&&);
+
+    CSS::Color m_color;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSColorImageValue, isColorImageValue())

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -42,6 +42,7 @@
 #include "CSSBoxShadowPropertyValue.h"
 #include "CSSCanvasValue.h"
 #include "CSSClipValue.h"
+#include "CSSColorImageValue.h"
 #include "CSSColorSchemeValue.h"
 #include "CSSColorValue.h"
 #include "CSSContentValue.h"
@@ -216,6 +217,8 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSMaskBorderSourceValue>(*this));
     case MaskBorderWidth:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSMaskBorderWidthValue>(*this));
+    case ColorImage:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSColorImageValue>(*this));
     case NamedImage:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSNamedImageValue>(*this));
     case OffsetRotate:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -78,6 +78,7 @@ public:
     bool isBorderImageSourceValue() const { return m_classType == ClassType::BorderImageSource; }
     bool isBorderImageWidthValue() const { return m_classType == ClassType::BorderImageWidth; }
     bool isBoxShadowPropertyValue() const { return m_classType == ClassType::BoxShadowProperty; }
+    bool isColorImageValue() const { return m_classType == ClassType::ColorImage; }
     bool isCanvasValue() const { return m_classType == ClassType::Canvas; }
     bool isClipValue() const { return m_classType == ClassType::Clip; }
     bool isColor() const { return m_classType == ClassType::Color; }
@@ -204,6 +205,7 @@ protected:
         Canvas,
         PaintImage,
         NamedImage,
+        ColorImage,
         Crossfade,
         FilterImage,
         Gradient,

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1329,6 +1329,7 @@ scale-down
 // background-image, etc.
 container-scroll
 cross-fade
+image
 image-set
 linear-gradient
 radial-gradient

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -28,6 +28,7 @@
 #include "CSSCalcSymbolTable.h"
 #include "CSSCanvasValue.h"
 #include "CSSColor.h"
+#include "CSSColorImageValue.h"
 #include "CSSCrossfadeValue.h"
 #include "CSSCursorImageValue.h"
 #include "CSSFilterImageValue.h"
@@ -1020,6 +1021,17 @@ static RefPtr<CSSValue> consumeWebkitNamedImage(CSSParserTokenRange& args)
     return CSSNamedImageValue::create(CSS::CustomIdent { args.consumeIncludingWhitespace().value().toAtomString() });
 }
 
+// MARK: <image()>
+// https://drafts.csswg.org/css-images-4/#funcdef-image
+
+static RefPtr<CSSValue> consumeColorImage(CSSParserTokenRange& args, CSS::PropertyParserState& state)
+{
+    auto color = consumeUnresolvedColor(args, state);
+    if (!color)
+        return nullptr;
+    return CSSColorImageValue::create(WTF::move(*color));
+}
+
 // MARK: <filter()>
 
 static RefPtr<CSSValue> consumeFilterImage(CSSParserTokenRange& args, CSS::PropertyParserState& state)
@@ -1225,6 +1237,8 @@ RefPtr<CSSValue> consumeImage(CSSParserTokenRange& range, CSS::PropertyParserSta
             return consumeGeneratedImage([&](auto& args) { return consumeWebkitCanvas(args); });
         case CSSValueWebkitNamedImage:
             return consumeGeneratedImage([&](auto& args) { return consumeWebkitNamedImage(args); });
+        case CSSValueImage:
+            return consumeGeneratedImage([&](auto& args) { return consumeColorImage(args, state); });
         case CSSValueWebkitFilter:
         case CSSValueFilter:
             return consumeGeneratedImage([&](auto& args) { return consumeFilterImage(args, state); });

--- a/Source/WebCore/platform/graphics/ColorImageGeneratedImage.cpp
+++ b/Source/WebCore/platform/graphics/ColorImageGeneratedImage.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ColorImageGeneratedImage.h"
+
+#include "FloatRect.h"
+#include "GraphicsContext.h"
+#include "Image.h"
+#include "ImageBuffer.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+ColorImageGeneratedImage::ColorImageGeneratedImage(const Color& color, const FloatSize& size)
+    : m_color(color)
+{
+    setContainerSize(size);
+}
+
+ImageDrawResult ColorImageGeneratedImage::draw(GraphicsContext& context, const FloatRect& destinationRect, const FloatRect&, ImagePaintingOptions options)
+{
+    Image::fillWithSolidColor(context, destinationRect, m_color, options.compositeOperator());
+    return ImageDrawResult::DidDraw;
+}
+
+void ColorImageGeneratedImage::drawPattern(GraphicsContext& context, const FloatRect& destinationRect, const FloatRect& sourceRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
+{
+    if (spacing.isZero()) {
+        Image::fillWithSolidColor(context, destinationRect, m_color, options.compositeOperator());
+        return;
+    }
+
+    auto imageBuffer = context.createAlignedImageBuffer(size());
+    if (!imageBuffer)
+        return;
+
+    imageBuffer->context().fillRect(FloatRect { { }, size() }, m_color);
+    context.drawPattern(*imageBuffer, destinationRect, sourceRect, patternTransform, phase, spacing, options);
+}
+
+void ColorImageGeneratedImage::dump(TextStream& ts) const
+{
+    GeneratedImage::dump(ts);
+    ts.dumpProperty("color"_s, m_color);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ColorImageGeneratedImage.h
+++ b/Source/WebCore/platform/graphics/ColorImageGeneratedImage.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Color.h"
+#include "GeneratedImage.h"
+
+namespace WebCore {
+
+class FloatSize;
+
+class ColorImageGeneratedImage final : public GeneratedImage {
+public:
+    static Ref<ColorImageGeneratedImage> create(const Color& color, const FloatSize& size)
+    {
+        return adoptRef(*new ColorImageGeneratedImage(color, size));
+    }
+
+private:
+    ColorImageGeneratedImage(const Color&, const FloatSize&);
+
+    ImageDrawResult draw(GraphicsContext&, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions = { }) override;
+    void drawPattern(GraphicsContext&, const FloatRect& destinationRect, const FloatRect& sourceRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) override;
+
+    void dump(WTF::TextStream&) const override;
+
+    Color m_color;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -33,6 +33,7 @@
 
 #include "CSSCalcRandomCachingKey.h"
 #include "CSSCanvasValue.h"
+#include "CSSColorImageValue.h"
 #include "CSSColorValue.h"
 #include "CSSCrossfadeValue.h"
 #include "CSSCursorImageValue.h"
@@ -146,6 +147,8 @@ RefPtr<Image> BuilderState::createStyleImage(const CSSValue& value) const
         return filterImageValue->createStyleImage(*this);
     if (auto* gradientValue = dynamicDowncast<CSSGradientValue>(value))
         return gradientValue->createStyleImage(*this);
+    if (auto* colorImageValue = dynamicDowncast<CSSColorImageValue>(value))
+        return colorImageValue->createStyleImage(*this);
     if (auto* paintImageValue = dynamicDowncast<CSSPaintImageValue>(value))
         return paintImageValue->createStyleImage(*this);
     return nullptr;

--- a/Source/WebCore/style/calc/StyleCalculationTree+Conversion.h
+++ b/Source/WebCore/style/calc/StyleCalculationTree+Conversion.h
@@ -27,10 +27,9 @@
 #include "CSSCalcSymbolTable.h"
 #include "CSSPrimitiveNumericRange.h"
 #include "CSSToLengthConversionData.h"
+#include "RenderStyle.h"
 
 namespace WebCore {
-
-class RenderStyle;
 
 namespace CSS {
 enum class Category : uint8_t;

--- a/Source/WebCore/style/values/images/kinds/StyleColorImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleColorImage.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleColorImage.h"
+
+#include "CSSColorImageValue.h"
+#include "ColorImageGeneratedImage.h"
+#include "DeprecatedCSSOMValue.h"
+#include "RenderElement.h"
+#include "StyleColorResolver.h"
+
+namespace WebCore {
+namespace Style {
+
+ColorImage::ColorImage(Color&& color)
+    : GeneratedImage { Type::ColorImage, ColorImage::isFixedSize }
+    , m_color { WTF::move(color) }
+{
+}
+
+ColorImage::~ColorImage() = default;
+
+bool ColorImage::operator==(const Image& other) const
+{
+    auto* otherColorImage = dynamicDowncast<ColorImage>(other);
+    return otherColorImage && equals(*otherColorImage);
+}
+
+bool ColorImage::equals(const ColorImage& other) const
+{
+    return m_color == other.m_color;
+}
+
+Ref<CSSValue> ColorImage::computedStyleValue(const RenderStyle& style) const
+{
+    return CSSColorImageValue::create(toCSS(m_color, style));
+}
+
+Ref<DeprecatedCSSOMValue> ColorImage::computedStyleDeprecatedCSSOMValue(CSSValuePool&, const RenderStyle& style, CSSStyleDeclaration& owner) const
+{
+    return computedStyleValue(style)->createDeprecatedCSSOMWrapper(owner);
+}
+
+bool ColorImage::isPending() const
+{
+    return false;
+}
+
+void ColorImage::load(CachedResourceLoader&, const ResourceLoaderOptions&)
+{
+}
+
+RefPtr<WebCore::Image> ColorImage::image(const RenderElement* renderer, const FloatSize& size, const GraphicsContext&, bool) const
+{
+    if (!renderer)
+        return &WebCore::Image::nullImage();
+
+    if (size.isEmpty())
+        return nullptr;
+
+    auto color = ColorResolver { renderer->style() }.colorResolvingCurrentColor(m_color);
+    return ColorImageGeneratedImage::create(color, size);
+}
+
+bool ColorImage::knownToBeOpaque(const RenderElement& renderer) const
+{
+    return ColorResolver { renderer.style() }.colorResolvingCurrentColor(m_color).isOpaque();
+}
+
+FloatSize ColorImage::fixedSize(const RenderElement&) const
+{
+    return { };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/images/kinds/StyleColorImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleColorImage.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleColor.h"
+#include "StyleGeneratedImage.h"
+
+namespace WebCore {
+namespace Style {
+
+class ColorImage final : public GeneratedImage {
+public:
+    static Ref<ColorImage> create(Color&& color)
+    {
+        return adoptRef(*new ColorImage(WTF::move(color)));
+    }
+    virtual ~ColorImage();
+
+    bool operator==(const Image&) const final;
+    bool equals(const ColorImage&) const;
+
+    static constexpr bool isFixedSize = false;
+
+private:
+    explicit ColorImage(Color&&);
+
+    Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
+    Ref<DeprecatedCSSOMValue> computedStyleDeprecatedCSSOMValue(CSSValuePool&, const RenderStyle&, CSSStyleDeclaration&) const final;
+    bool isPending() const final;
+    void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
+    RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext&, bool isForFirstLine) const final;
+    bool knownToBeOpaque(const RenderElement&) const final;
+    FloatSize fixedSize(const RenderElement&) const final;
+    void didAddClient(RenderElement&) final { }
+    void didRemoveClient(RenderElement&) final { }
+
+    Color m_color;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_STYLE_IMAGE(ColorImage, isColorImage)

--- a/Source/WebCore/style/values/images/kinds/StyleImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleImage.h
@@ -105,12 +105,13 @@ public:
     ALWAYS_INLINE bool isCachedImage() const { return m_type == Type::CachedImage; }
     ALWAYS_INLINE bool isCursorImage() const { return m_type == Type::CursorImage; }
     ALWAYS_INLINE bool isImageSet() const { return m_type == Type::ImageSet; }
-    ALWAYS_INLINE bool isGeneratedImage() const { return isFilterImage() || isCanvasImage() || isCrossfadeImage() || isGradientImage() || isNamedImage() || isPaintImage() || isInvalidImage(); }
+    ALWAYS_INLINE bool isGeneratedImage() const { return isFilterImage() || isCanvasImage() || isCrossfadeImage() || isGradientImage() || isNamedImage() || isColorImage() || isPaintImage() || isInvalidImage(); }
     ALWAYS_INLINE bool isFilterImage() const { return m_type == Type::FilterImage; }
     ALWAYS_INLINE bool isCanvasImage() const { return m_type == Type::CanvasImage; }
     ALWAYS_INLINE bool isCrossfadeImage() const { return m_type == Type::CrossfadeImage; }
     ALWAYS_INLINE bool isGradientImage() const { return m_type == Type::GradientImage; }
     ALWAYS_INLINE bool isNamedImage() const { return m_type == Type::NamedImage; }
+    ALWAYS_INLINE bool isColorImage() const { return m_type == Type::ColorImage; }
     ALWAYS_INLINE bool isPaintImage() const { return m_type == Type::PaintImage; }
     ALWAYS_INLINE bool isInvalidImage() const { return m_type == Type::InvalidImage; }
 
@@ -126,6 +127,7 @@ protected:
         CrossfadeImage,
         GradientImage,
         NamedImage,
+        ColorImage,
         InvalidImage,
         PaintImage,
     };


### PR DESCRIPTION
#### bb6126cd09c74096882dba02433baed4721159f5
<pre>
[css-images] Add support for image(&lt;color&gt;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=315799">https://bugs.webkit.org/show_bug.cgi?id=315799</a>
<a href="https://rdar.apple.com/178189616">rdar://178189616</a>

Reviewed by Simon Fraser.

image(&lt;color&gt;) renders a solid color.

<a href="https://drafts.csswg.org/css-images-4/#image-notation">https://drafts.csswg.org/css-images-4/#image-notation</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-combined-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-combined-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-combined.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-position-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-position-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-position.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-repeat-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-repeat-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-repeat.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-size-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-color-background-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/parsing/image-function-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/parsing/image-function-valid-expected.txt:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSColorImageValue.cpp: Added.
(WebCore::CSSColorImageValue::create):
(WebCore::CSSColorImageValue::CSSColorImageValue):
(WebCore::CSSColorImageValue::customCSSText const):
(WebCore::CSSColorImageValue::equals const):
(WebCore::CSSColorImageValue::createStyleImage const):
(WebCore::CSSColorImageValue::customVisitChildren const):
* Source/WebCore/css/CSSColorImageValue.h: Added.
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitDerived):
* Source/WebCore/css/CSSValue.h:
(WebCore::CSSValue::isColorImageValue const):
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
(WebCore::CSSPropertyParserHelpers::consumeColorImage):
(WebCore::CSSPropertyParserHelpers::consumeImage):
* Source/WebCore/platform/graphics/ColorImageGeneratedImage.cpp: Added.
(WebCore::ColorImageGeneratedImage::ColorImageGeneratedImage):
(WebCore::ColorImageGeneratedImage::draw):
(WebCore::ColorImageGeneratedImage::drawPattern):
(WebCore::ColorImageGeneratedImage::dump const):
* Source/WebCore/platform/graphics/ColorImageGeneratedImage.h: Added.
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::createStyleImage const):
* Source/WebCore/style/calc/StyleCalculationTree+Conversion.h:
* Source/WebCore/style/values/images/kinds/StyleColorImage.cpp: Added.
(WebCore::Style::ColorImage::ColorImage):
(WebCore::Style::ColorImage::operator== const):
(WebCore::Style::ColorImage::equals const):
(WebCore::Style::ColorImage::computedStyleValue const):
(WebCore::Style::ColorImage::computedStyleDeprecatedCSSOMValue const):
(WebCore::Style::ColorImage::isPending const):
(WebCore::Style::ColorImage::load):
(WebCore::Style::ColorImage::image const):
(WebCore::Style::ColorImage::knownToBeOpaque const):
(WebCore::Style::ColorImage::fixedSize const):
* Source/WebCore/style/values/images/kinds/StyleColorImage.h: Added.
* Source/WebCore/style/values/images/kinds/StyleImage.h:
(WebCore::Style::Image::isGeneratedImage const):
(WebCore::Style::Image::isColorImage const):

Canonical link: <a href="https://commits.webkit.org/314204@main">https://commits.webkit.org/314204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9e281fa7566c692ce188efbbe74e6356251347c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165429 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122684 "Built successfully") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128553 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e42afe25-fb0e-43b2-a802-a4f1b0d1bd7d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168388 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/30865 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109078 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28540 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22546 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176995 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29901 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28027 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136878 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136814 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/36879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148118 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102046 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25171 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32085 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24985 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38186 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111260 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37583 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3065 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37829 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37727 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->