### PR TITLE
Potential use-after-free under JSAttr::visitAdditionalChildren()

### DIFF
--- a/Source/WebCore/bindings/js/JSAttrCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAttrCustom.cpp
@@ -30,15 +30,13 @@
 #include "JSAttr.h"
 
 #include "Element.h"
-#include "WebCoreOpaqueRootInlines.h"
 
 namespace WebCore {
 
 template<typename Visitor>
 void JSAttr::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    if (SUPPRESS_UNCHECKED_LOCAL auto* element = wrapped().ownerElement())
-        addWebCoreOpaqueRoot(visitor, *element);
+    SUPPRESS_UNCHECKED_ARG wrapped().visitOwnerElementInGCThread(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSAttr);

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -38,8 +38,14 @@
 #include "TextNodeTraversal.h"
 #include "TreeScopeInlines.h"
 #include "TrustedType.h"
+#include "WebCoreOpaqueRootInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>
+
+namespace JSC {
+class AbstractSlotVisitor;
+class SlotVisitor;
+}
 
 namespace WebCore {
 
@@ -150,16 +156,33 @@ void Attr::detachFromElementWithValue(const AtomString& value)
     ASSERT(m_element);
     ASSERT(m_standaloneValue.isNull());
     m_standaloneValue = value;
-    m_element = nullptr;
+    {
+        Locker locker { m_elementLockForGC };
+        m_element = nullptr;
+    }
     setTreeScopeRecursively(Ref<Document> { document() });
 }
 
 void Attr::attachToElement(Element& element)
 {
     ASSERT(!m_element);
-    m_element = element;
+    {
+        Locker locker { m_elementLockForGC };
+        m_element = &element;
+    }
     m_standaloneValue = nullAtom();
     setTreeScopeRecursively(element.treeScope());
 }
+
+template<typename Visitor>
+void Attr::visitOwnerElementInGCThread(Visitor& visitor)
+{
+    Locker locker { m_elementLockForGC };
+    if (m_element)
+        addWebCoreOpaqueRoot(visitor, *m_element);
+}
+
+template void Attr::visitOwnerElementInGCThread(JSC::AbstractSlotVisitor&);
+template void Attr::visitOwnerElementInGCThread(JSC::SlotVisitor&);
 
 }

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -26,6 +26,7 @@
 
 #include <WebCore/Node.h>
 #include <WebCore/QualifiedName.h>
+#include <wtf/Lock.h>
 
 namespace WebCore {
 
@@ -54,6 +55,8 @@ public:
 
     void attachToElement(Element&);
     void detachFromElementWithValue(const AtomString&);
+    
+    template<typename Visitor> void visitOwnerElementInGCThread(Visitor&);
 
     const AtomString& NODELETE namespaceURI() const LIFETIME_BOUND final { return m_name.namespaceURI(); }
     const AtomString& NODELETE localName() const LIFETIME_BOUND final { return m_name.localName(); }
@@ -75,11 +78,11 @@ private:
 
     // Attr wraps either an element/name, or a name/value pair (when it's a standalone Node.)
     // Note that m_name is always set, but m_element/m_standaloneValue may be null.
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;
+    CheckedPtr<Element> m_element;
     QualifiedName m_name;
     AtomString m_standaloneValue;
-
     RefPtr<MutableStyleProperties> m_style;
+    mutable Lock m_elementLockForGC;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 8d71b72447bbb496e34da88b62804db96401bed6
<pre>
Potential use-after-free under JSAttr::visitAdditionalChildren()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311242">https://bugs.webkit.org/show_bug.cgi?id=311242</a>
<a href="https://rdar.apple.com/173693441">rdar://173693441</a>

Reviewed by Ryosuke Niwa.

The GC thread was dereferncing Attr::m_element to call opaqueRoot() on
it. This could lead to use-after-free when the Attr&apos;s element gets
destroyed concurrently by the main thread.

Address the issue by making the following two changes:
- Make Attr::m_element a CheckedPtr instead of a WeakPtr, to make it clear
  it only gets nulled out by Attr::detachFromElementWithValue().
- Introduce a Lock that gets acquired by m_element gets updated on the
  main thread and then the GC thread is accessing it.

* Source/WebCore/bindings/js/JSAttrCustom.cpp:
(WebCore::JSAttr::visitAdditionalChildren):
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::detachFromElementWithValue):
(WebCore::Attr::attachToElement):
(WebCore::Attr::visitOwnerElementInGCThread):
* Source/WebCore/dom/Attr.h:

Originally-landed-as: 305413.607@rapid/safari-7624.2.5.110-branch (58480401ef67). <a href="https://rdar.apple.com/176061076">rdar://176061076</a>
Canonical link: <a href="https://commits.webkit.org/315255@main">https://commits.webkit.org/315255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfa0043072867cc6cd155b36ef5b26adde5ec15b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168397 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126098 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131057 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92150 "5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151332 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111568 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32509 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31211 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26421 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142495 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180325 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139492 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41966 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35372 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139356 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37554 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42654 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106246 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27706 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41158 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114414 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40555 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5791 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40806 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40700 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->