### PR TITLE
ANGLE: IndexRange integer overflow bypasses vertex index validation

### DIFF
--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -892,6 +892,7 @@
 		7BED8E022F9A493200F15B70 /* AddDefaultReturnStatements.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BED8E012F9A493200F15B70 /* AddDefaultReturnStatements.cpp */; };
 		7BED8E042F9A493200F15B70 /* AddDefaultReturnStatements.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BED8E012F9A493200F15B70 /* AddDefaultReturnStatements.cpp */; };
 		7BED8E052F9A493200F15B70 /* AddDefaultReturnStatements.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BED8E002F9A493200F15B70 /* AddDefaultReturnStatements.h */; };
+		7BF0DF592F71612100F99E69 /* utilities_unittest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BF0DF582F71612100F99E69 /* utilities_unittest.cpp */; };
 		7BF554C42C81EF29002B101E /* libtranslator.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BF5549B2C81EDE0002B101E /* libtranslator.a */; };
 		7BF554C52C81EF4D002B101E /* TranslatorFuzzer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BF554A02C81EE51002B101E /* TranslatorFuzzer.cpp */; };
 		7BF554CD2C81F028002B101E /* TranslatorFuzzer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BF554A02C81EE51002B101E /* TranslatorFuzzer.cpp */; };
@@ -2467,6 +2468,7 @@
 		7BED5BE72F99F81200A240A7 /* TransformFeedback_unittest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TransformFeedback_unittest.cpp; sourceTree = "<group>"; };
 		7BED8E002F9A493200F15B70 /* AddDefaultReturnStatements.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AddDefaultReturnStatements.h; sourceTree = "<group>"; };
 		7BED8E012F9A493200F15B70 /* AddDefaultReturnStatements.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AddDefaultReturnStatements.cpp; sourceTree = "<group>"; };
+		7BF0DF582F71612100F99E69 /* utilities_unittest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = utilities_unittest.cpp; sourceTree = "<group>"; };
 		7BF5549B2C81EDE0002B101E /* libtranslator.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libtranslator.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		7BF554A02C81EE51002B101E /* TranslatorFuzzer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TranslatorFuzzer.cpp; sourceTree = "<group>"; };
 		7BF554A12C81EE77002B101E /* TranslatorFuzzerCoverage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TranslatorFuzzerCoverage.mm; sourceTree = "<group>"; };
@@ -3858,6 +3860,7 @@
 				7B5B1F0F2F0FC73B00B5D57B /* unsafe_buffers.h */,
 				5CC7D46819102620000B8C1F /* utilities.cpp */,
 				5CC7D46919102620000B8C1F /* utilities.h */,
+				7BF0DF582F71612100F99E69 /* utilities_unittest.cpp */,
 				31A331C51EA5ED5F00FD2203 /* vector_utils.h */,
 				7BFAF8DC2DE6EDE400327F7F /* vector_utils_unittest.cpp */,
 				3A2C66EF29236E7D00FEDF46 /* WorkerThread.cpp */,
@@ -6802,6 +6805,7 @@
 				7B8C09152F84EAB1007E37DE /* TestSuite.cpp in Sources */,
 				7BED5BE82F99F81200A240A7 /* TransformFeedback_unittest.cpp in Sources */,
 				7BFAF8C12DE6ECA700327F7F /* Type_test.cpp in Sources */,
+				7BF0DF592F71612100F99E69 /* utilities_unittest.cpp in Sources */,
 				7BFAF8BB2DE6ECA700327F7F /* VariablePacker_test.cpp in Sources */,
 				7BFAF8E22DE6EDE400327F7F /* vector_utils_unittest.cpp in Sources */,
 				7BFAF8E82DE6EDE400327F7F /* WorkerThread_unittest.cpp in Sources */,

--- a/Source/ThirdParty/ANGLE/src/common/mathutil.h
+++ b/Source/ThirdParty/ANGLE/src/common/mathutil.h
@@ -872,12 +872,8 @@ struct IndexRange
     {};
     IndexRange(Undefined) {}
     IndexRange() = default;
-    IndexRange(uint32_t start, uint32_t end)
-        : mStart(start), mEnd(end), mCount(static_cast<uint64_t>(end - start) + 1)
-    {
-        ASSERT(start <= end);
-    }
-    bool isEmpty() const { return mCount == 0; }
+    IndexRange(uint32_t start, uint32_t end) : mStart(start), mEnd(end) { ASSERT(mStart <= mEnd); }
+    bool isEmpty() const { return mStart > mEnd; }
     uint32_t start() const
     {
         ASSERT(!isEmpty());
@@ -890,21 +886,19 @@ struct IndexRange
     }
 
     // Number of vertices in the range.
-    uint64_t vertexCount() const { return mCount; }
+    // Range: [0, 0] == 1
+    // Range: [0, 0xFFFFFFFF] == 0x100000000 (needs size_t).
+    size_t vertexCount() const
+    {
+        // Note: unsigned underflow ok on isEmpty() == true.
+        return static_cast<size_t>(mEnd) - mStart + 1u;
+    }
 
   private:
-    uint32_t mStart{0};
+    uint32_t mStart{1};
     uint32_t mEnd{0};
-
-    // Since the range is inclusive, mCount == 0 indicates an empty range
-    uint64_t mCount{0};
+    friend bool operator==(const IndexRange &a, const IndexRange &b) noexcept = default;
 };
-
-inline bool operator==(const IndexRange &a, const IndexRange &b)
-{
-    return a.vertexCount() == b.vertexCount() &&
-           ((a.vertexCount() == 0) || (a.start() == b.start()));
-}
 
 std::ostream &operator<<(std::ostream &s, const IndexRange &a);
 

--- a/Source/ThirdParty/ANGLE/src/common/utilities_unittest.cpp
+++ b/Source/ThirdParty/ANGLE/src/common/utilities_unittest.cpp
@@ -256,6 +256,34 @@ TEST(Utilities, IndexRanges)
     EXPECT_EQ(ComputeIndexRange(b, vertices2, 2, false), gl::IndexRange(255, 255));
     EXPECT_EQ(ComputeIndexRange(b, vertices2, 3, true), gl::IndexRange(2, 2));
     EXPECT_EQ(ComputeIndexRange(b, vertices2, 3, false), gl::IndexRange(2, 255));
+
+    constexpr auto i     = gl::DrawElementsType::UnsignedInt;
+    uint32_t vertices3[] = {
+        0,
+        0xff,
+        0xffffffff,
+    };
+    EXPECT_EQ(ComputeIndexRange(i, vertices3, 1, true), gl::IndexRange(0, 0));
+    EXPECT_EQ(ComputeIndexRange(i, vertices3, 2, true), gl::IndexRange(0, 255));
+    EXPECT_EQ(ComputeIndexRange(i, vertices3, 2, false), gl::IndexRange(0, 255));
+    EXPECT_EQ(ComputeIndexRange(i, vertices3, 3, true), gl::IndexRange(0, 255));
+    EXPECT_EQ(ComputeIndexRange(i, vertices3, 3, false), gl::IndexRange(0, 0xffffffff));
+    EXPECT_EQ(ComputeIndexRange(i, vertices3 + 1, 2, true), gl::IndexRange(255, 255));
+    EXPECT_EQ(ComputeIndexRange(i, vertices3 + 1, 2, false), gl::IndexRange(255, 0xffffffff));
+
+    EXPECT_TRUE(gl::IndexRange().isEmpty());
+    EXPECT_FALSE(gl::IndexRange(0, 0).isEmpty());
+    EXPECT_FALSE(gl::IndexRange(0xfffffffe, 0xffffffff).isEmpty());
+    EXPECT_FALSE(gl::IndexRange(0xffffffff, 0xffffffff).isEmpty());
+
+    EXPECT_EQ(0u, gl::IndexRange().vertexCount());
+    EXPECT_EQ(1u, gl::IndexRange(0, 0).vertexCount());
+    EXPECT_EQ(1u, gl::IndexRange(255, 255).vertexCount());
+    EXPECT_EQ(255u, gl::IndexRange(1, 255).vertexCount());
+    EXPECT_EQ(256u, gl::IndexRange(0, 255).vertexCount());
+
+    EXPECT_EQ(0xffffffffu, gl::IndexRange(1, 0xffffffff).vertexCount());
+    EXPECT_EQ(static_cast<size_t>(0x100000000ull), gl::IndexRange(0, 0xffffffff).vertexCount());
 }
 
 }  // anonymous namespace

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp
@@ -1744,13 +1744,16 @@ void main()
     ANGLE_GL_PROGRAM(program, kVS, essl1_shaders::fs::Red());
     glUseProgram(program);
 
+    GLint posLocation = glGetAttribLocation(program, "a_Position");
+    ASSERT_NE(-1, posLocation);
+    glEnableVertexAttribArray(posLocation);
     constexpr float kVertexData[] = {
         1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f,
     };
-
     GLBuffer vertexBuffer;
     glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
     glBufferData(GL_ARRAY_BUFFER, sizeof(kVertexData), kVertexData, GL_STREAM_DRAW);
+    glVertexAttribPointer(posLocation, 4, GL_FLOAT, GL_FALSE, 0, nullptr);
 
     GLuint positionLocation = glGetAttribLocation(program, "a_Position");
     glEnableVertexAttribArray(positionLocation);
@@ -1778,6 +1781,33 @@ void main()
     // Neither index is representable as 32-bit int
     glDrawElements(GL_POINTS, 4, GL_UNSIGNED_INT, reinterpret_cast<void *>(sizeof(GLuint) * 2));
     EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+
+    constexpr GLuint kIndexData2[] = {
+        0,
+        std::numeric_limits<GLuint>::max(),
+    };
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(kIndexData2), kIndexData2, GL_DYNAMIC_DRAW);
+
+    glDrawElements(GL_LINES, 2, GL_UNSIGNED_INT, 0);
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+
+    glDrawElements(GL_LINES, 2, GL_UNSIGNED_SHORT, reinterpret_cast<void *>(2));
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+
+    glDrawElements(GL_LINES, 2, GL_UNSIGNED_BYTE, reinterpret_cast<void *>(3));
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+
+    constexpr GLuint kIndexData3[] = {0, 1};
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(kIndexData3), kIndexData3, GL_DYNAMIC_DRAW);
+
+    glDrawElements(GL_LINES, 2, GL_UNSIGNED_INT, 0);
+    EXPECT_GL_NO_ERROR();
+
+    glDrawElements(GL_LINES, 2, GL_UNSIGNED_SHORT, reinterpret_cast<void *>(2));
+    EXPECT_GL_NO_ERROR();
+
+    glDrawElements(GL_LINES, 2, GL_UNSIGNED_BYTE, reinterpret_cast<void *>(3));
+    EXPECT_GL_NO_ERROR();
 }
 
 // Test for drawing with a null index buffer


### PR DESCRIPTION
#### 56c55ddc3836f2d889530d66d5c452849e2c4b42
<pre>
ANGLE: IndexRange integer overflow bypasses vertex index validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=310535">https://bugs.webkit.org/show_bug.cgi?id=310535</a>
<a href="https://rdar.apple.com/173006046">rdar://173006046</a>

Reviewed by Dan Glastonbury.

IndexRange would mark up index range with uint32_t start, uint32_t count
which can not easily represent range [0, 0xFFFFFFFF].
Switch to start, end markup, with start &gt; end marking empty range.

* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:
* Source/ThirdParty/ANGLE/src/common/mathutil.h:
(gl::IndexRange::IndexRange):
(gl::IndexRange::isEmpty const):
(gl::IndexRange::end const):
(gl::IndexRange::vertexCount const):
(gl::operator==): Deleted.
* Source/ThirdParty/ANGLE/src/common/utilities_unittest.cpp:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp:

Originally-landed-as: 305413.563@rapid/safari-7624.2.5.110-branch (b0e22543a19b). <a href="https://rdar.apple.com/176061545">rdar://176061545</a>
Canonical link: <a href="https://commits.webkit.org/315326@main">https://commits.webkit.org/315326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98c1ca6a48f14b359479d8dce39fc9f396d6ec0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177941 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126316 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131258 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111769 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32701 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31408 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26636 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142687 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180540 "Built successfully") | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35572 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139700 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42180 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139557 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37602 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42868 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27906 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106553 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34840 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41372 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5989 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->