### PR TITLE
[YARR] Optimize character-classes / patterns with shared lead-surrogate

### DIFF
--- a/JSTests/stress/yarr-jit-shared-lead-prefilter.js
+++ b/JSTests/stress/yarr-jit-shared-lead-prefilter.js
@@ -1,0 +1,421 @@
+// Tests for the YarrJIT BodyAlternative shared-lead-surrogate prefilter and the
+// per-term shared-lead trail-only fast path. These optimizations only fire under
+// /u or /v on Char16 input; the tests exercise both the positive paths
+// (alternations whose first consuming term shares a UTF-16 lead surrogate) and
+// the negatives that must NOT trigger the prefilter.
+
+function shouldBe(actual, expected, message)
+{
+    if (actual !== expected)
+        throw new Error(message + ": expected " + String(expected) + " but got " + String(actual));
+}
+
+function shouldBeArray(actual, expected, message)
+{
+    if (actual === null && expected === null)
+        return;
+    if (actual === null || expected === null)
+        throw new Error(message + ": one of actual/expected is null (actual=" + String(actual) + ", expected=" + String(expected) + ")");
+    if (actual.length !== expected.length)
+        throw new Error(message + ": length mismatch — expected " + expected.length + " got " + actual.length);
+    for (let i = 0; i < expected.length; ++i) {
+        if (actual[i] !== expected[i])
+            throw new Error(message + "[" + i + "]: expected " + String(expected[i]) + " got " + String(actual[i]));
+    }
+}
+
+// Run a regex twice — once on a fresh literal, once on a String constructor
+// result — so both Char8/Char16 representations of the haystack are exercised.
+function execBoth(reSource, flags, input, expectedMatch)
+{
+    let re1 = new RegExp(reSource, flags);
+    let m1 = re1.exec(input);
+    if (expectedMatch === null)
+        shouldBe(m1, null, "exec(" + JSON.stringify(input) + ") via RegExp(" + JSON.stringify(reSource) + "," + JSON.stringify(flags) + ")");
+    else {
+        shouldBe(m1 !== null, true, "exec must match: " + JSON.stringify(reSource) + " on " + JSON.stringify(input));
+        shouldBe(m1[0], expectedMatch, "exec[0]: " + JSON.stringify(reSource) + " on " + JSON.stringify(input));
+    }
+
+    let re2 = new RegExp(reSource, flags);
+    let m2 = re2.test(input);
+    shouldBe(m2, expectedMatch !== null, "test(): " + JSON.stringify(reSource) + " on " + JSON.stringify(input));
+}
+
+// ----------------------------------------------------------------------------
+// 1. PatternCharacter alternation, all sharing UTF-16 lead 0xD83C.
+//    This exercises the new findFirstTermSharedLead PatternCharacter branch.
+// ----------------------------------------------------------------------------
+{
+    let re = /\u{1F0A1}|\u{1F0B1}|\u{1F0C1}|\u{1F0D1}/u;
+
+    shouldBe(re.test("\u{1F0A1}"), true, "literal-alt: AS");
+    shouldBe(re.test("\u{1F0B1}"), true, "literal-alt: HS");
+    shouldBe(re.test("\u{1F0C1}"), true, "literal-alt: DS");
+    shouldBe(re.test("\u{1F0D1}"), true, "literal-alt: CS");
+
+    // Same lead, codepoint not in the alternation — must reject.
+    shouldBe(re.test("\u{1F0A2}"), false, "literal-alt: same lead but not enumerated");
+    shouldBe(re.test("\u{1F0DE}"), false, "literal-alt: end-of-card-range, not enumerated");
+
+    // Different lead surrogate — must reject without misreading the pair.
+    shouldBe(re.test("\u{1F1E6}"), false, "literal-alt: different lead 0xD83C->0xD83C, low pair differs");
+    shouldBe(re.test("\u{20000}"), false, "literal-alt: different lead 0xD840");
+
+    // BMP haystack — no surrogate pair at all.
+    shouldBe(re.test("ABCD"), false, "literal-alt: BMP haystack");
+    shouldBe(re.test(""), false, "literal-alt: empty haystack");
+
+    // Lone surrogate — must not match (no pair to decode).
+    shouldBe(re.test("\uD83C"), false, "literal-alt: lone lead surrogate");
+    shouldBe(re.test("\uDCA1"), false, "literal-alt: lone trail surrogate");
+
+    // Match anywhere in the string (non-anchored).
+    shouldBeArray(re.exec("foo\u{1F0B1}bar"), ["\u{1F0B1}"], "literal-alt: middle of string");
+    shouldBeArray(re.exec("\u{1F600}\u{1F0C1}"), ["\u{1F0C1}"], "literal-alt: after another non-BMP char");
+}
+
+// ----------------------------------------------------------------------------
+// 2. PatternCharacter alternation, mixed lead surrogates.
+//    Prefilter must NOT fire (or must fire with no shared lead) but the regex
+//    must still match correctly.
+// ----------------------------------------------------------------------------
+{
+    let re = /\u{1F0A1}|\u{1F1E6}|\u{20000}/u;
+    shouldBe(re.test("\u{1F0A1}"), true, "mixed-lead: 1F0A1");
+    shouldBe(re.test("\u{1F1E6}"), true, "mixed-lead: 1F1E6");
+    shouldBe(re.test("\u{20000}"), true, "mixed-lead: 20000");
+    shouldBe(re.test("\u{1F0A2}"), false, "mixed-lead: not in set");
+    shouldBe(re.test("ABC"), false, "mixed-lead: BMP haystack");
+}
+
+// ----------------------------------------------------------------------------
+// 3. CharacterClass shared-lead — the original UniPoker shape.
+// ----------------------------------------------------------------------------
+{
+    let re = /[\u{1F0A1}-\u{1F0DE}]/u;
+    for (let cp = 0x1F0A1; cp <= 0x1F0DE; ++cp)
+        shouldBe(re.test(String.fromCodePoint(cp)), true, "card-class: " + cp.toString(16));
+
+    shouldBe(re.test("\u{1F0A0}"), false, "card-class: just below");
+    shouldBe(re.test("\u{1F0DF}"), false, "card-class: just above");
+    shouldBe(re.test("\u{1F600}"), false, "card-class: same lead, different trail");
+    shouldBe(re.test("A"), false, "card-class: BMP");
+}
+
+// ----------------------------------------------------------------------------
+// 4. CharacterClass alternation — multiple classes all sharing a lead.
+//    Each first-term is a class with hasSharedLeadSurrogate(); the prefilter
+//    should compute a single shared lead across all alternatives.
+// ----------------------------------------------------------------------------
+{
+    let re = /[\u{1F0A1}\u{1F0A2}]|[\u{1F0B1}\u{1F0B2}]|[\u{1F0C1}\u{1F0C2}]/u;
+    shouldBe(re.test("\u{1F0A1}"), true, "class-alt: 1F0A1");
+    shouldBe(re.test("\u{1F0B2}"), true, "class-alt: 1F0B2");
+    shouldBe(re.test("\u{1F0C1}"), true, "class-alt: 1F0C1");
+    shouldBe(re.test("\u{1F0A3}"), false, "class-alt: 1F0A3 (same lead, not enumerated)");
+    shouldBe(re.test("\u{1F600}"), false, "class-alt: same lead, different trail");
+}
+
+// ----------------------------------------------------------------------------
+// 5. Mixed PatternCharacter + CharacterClass alternation, shared lead.
+// ----------------------------------------------------------------------------
+{
+    let re = /\u{1F0A1}|[\u{1F0B1}-\u{1F0BE}]|\u{1F0C1}/u;
+    shouldBe(re.test("\u{1F0A1}"), true, "mixed: literal A");
+    shouldBe(re.test("\u{1F0B5}"), true, "mixed: range middle");
+    shouldBe(re.test("\u{1F0C1}"), true, "mixed: literal C");
+    shouldBe(re.test("\u{1F0BF}"), false, "mixed: just past range");
+    shouldBe(re.test("\u{1F0D1}"), false, "mixed: same lead, not enumerated");
+}
+
+// ----------------------------------------------------------------------------
+// 6. ParenthesesSubpattern wrapper — single-alternative group around a literal
+//    or class. Prefilter recurses through these.
+// ----------------------------------------------------------------------------
+{
+    let re = /(\u{1F0A1})|(\u{1F0B1})|(\u{1F0C1})/u;
+    let m = re.exec("\u{1F0B1}");
+    shouldBe(m !== null, true, "paren: matched");
+    shouldBe(m[0], "\u{1F0B1}", "paren: full match");
+    shouldBe(m[1], undefined, "paren: cap1 empty");
+    shouldBe(m[2], "\u{1F0B1}", "paren: cap2 captured");
+    shouldBe(m[3], undefined, "paren: cap3 empty");
+    shouldBe(re.test("\u{1F0A2}"), false, "paren: same lead not enumerated");
+}
+
+// ----------------------------------------------------------------------------
+// 7. ParenthesesSubpattern with multiple internal alternatives — must NOT be
+//    transparent for the prefilter (the body-alt prefilter only recurses into
+//    single-alternative groups). Match correctness is what we check here.
+// ----------------------------------------------------------------------------
+{
+    let re = /(\u{1F0A1}|\u{1F0B1})\u{1F0C1}/u;
+    shouldBe(re.test("\u{1F0A1}\u{1F0C1}"), true, "multi-alt-paren: A then C");
+    shouldBe(re.test("\u{1F0B1}\u{1F0C1}"), true, "multi-alt-paren: B then C");
+    shouldBe(re.test("\u{1F0C1}\u{1F0C1}"), false, "multi-alt-paren: C then C");
+    shouldBe(re.test("\u{1F0A1}\u{1F0D1}"), false, "multi-alt-paren: A then D");
+}
+
+// ----------------------------------------------------------------------------
+// 8. Negative — inverted character class must disable the per-term shared-lead
+//    fast path (and the prefilter must not over-reject).
+// ----------------------------------------------------------------------------
+{
+    let re = /[^\u{1F0A1}-\u{1F0DE}]/u;
+    shouldBe(re.test("\u{1F0A0}"), true, "inverted: just below range");
+    shouldBe(re.test("A"), true, "inverted: BMP");
+    shouldBe(re.test("\u{1F0A1}"), false, "inverted: in range");
+    shouldBe(re.test("\u{1F0DE}"), false, "inverted: range end");
+}
+
+// ----------------------------------------------------------------------------
+// 9. Negative — BMP-only alternation. Must not engage shared-lead path; must
+//    still match correctly under /u.
+// ----------------------------------------------------------------------------
+{
+    let re = /A|B|C/u;
+    shouldBe(re.test("A"), true, "bmp: A");
+    shouldBe(re.test("D"), false, "bmp: D");
+}
+
+// ----------------------------------------------------------------------------
+// 10. /v flag (UnicodeSets). The optimization is gated on m_pattern.eitherUnicode()
+//     which is true for both /u and /v.
+// ----------------------------------------------------------------------------
+{
+    let re = /\u{1F0A1}|\u{1F0B1}|\u{1F0C1}/v;
+    shouldBe(re.test("\u{1F0A1}"), true, "/v literal-alt: A");
+    shouldBe(re.test("\u{1F0B1}"), true, "/v literal-alt: B");
+    shouldBe(re.test("\u{1F0A2}"), false, "/v literal-alt: not enumerated");
+    shouldBe(re.test("\u{1F600}"), false, "/v literal-alt: same lead diff trail");
+}
+
+// ----------------------------------------------------------------------------
+// 11. ignoreCase — non-BMP characters that are CanonicalizeUnique survive as
+//     PatternCharacter. Mathematical italic codepoints are unique-cased (no
+//     case fold equivalent).
+// ----------------------------------------------------------------------------
+{
+    let re = /\u{1D400}|\u{1D401}/iu;  // 𝐀 𝐁 — bold mathematical A/B
+    shouldBe(re.test("\u{1D400}"), true, "iu unique: A");
+    shouldBe(re.test("\u{1D401}"), true, "iu unique: B");
+    shouldBe(re.test("\u{1D402}"), false, "iu unique: C (not enumerated)");
+    // Same lead 0xD835, but trail differs.
+    shouldBe(re.test("\u{1D403}"), false, "iu unique: same lead, different trail");
+}
+
+// ----------------------------------------------------------------------------
+// 12. Quantifiers on the first term — quantityMinCount must be > 0 for the
+//     prefilter to engage. quantityMinCount = 0 (e.g., \u{1F0A1}?) means the
+//     first consumed character isn't necessarily the literal — must still
+//     match correctly even if prefilter is skipped.
+// ----------------------------------------------------------------------------
+{
+    let re = /\u{1F0A1}?\u{1F0B1}/u;
+    shouldBe(re.test("\u{1F0B1}"), true, "?-quant: B alone");
+    shouldBe(re.test("\u{1F0A1}\u{1F0B1}"), true, "?-quant: A then B");
+    shouldBe(re.test("\u{1F0A1}"), false, "?-quant: A alone");
+}
+
+// ----------------------------------------------------------------------------
+// 13. Fixed-count quantifier > 1 on the leading term — exercises the
+//     generateCharacterClassFixed shared-lead inner loop.
+// ----------------------------------------------------------------------------
+{
+    let re = /[\u{1F0A1}-\u{1F0DE}]{4}/u;
+    shouldBe(re.test("\u{1F0A1}\u{1F0B1}\u{1F0C1}\u{1F0D1}"), true, "fixed-4: matches");
+    shouldBe(re.test("\u{1F0A1}\u{1F0B1}\u{1F0C1}"), false, "fixed-4: only 3");
+    shouldBe(re.test("\u{1F0A1}\u{1F0B1}\u{1F0C1}A"), false, "fixed-4: 3 + BMP");
+    shouldBe(re.test("\u{1F0A1}\u{1F0B1}\u{1F0C1}\u{1F600}"), false, "fixed-4: 3 + same-lead other");
+}
+
+// ----------------------------------------------------------------------------
+// 14. Greedy quantifier on the leading term — exercises the
+//     generateCharacterClassGreedy shared-lead path.
+// ----------------------------------------------------------------------------
+{
+    let re = /[\u{1F0A1}-\u{1F0DE}]+/u;
+    let s = "\u{1F0A1}\u{1F0B1}\u{1F0C1}\u{1F0D1}foo";
+    let m = re.exec(s);
+    shouldBe(m !== null, true, "greedy: matched");
+    shouldBe(m[0], "\u{1F0A1}\u{1F0B1}\u{1F0C1}\u{1F0D1}", "greedy: full prefix");
+
+    let re2 = /[\u{1F0A1}-\u{1F0DE}]+/u;
+    shouldBe(re2.test("foo"), false, "greedy: BMP only");
+    shouldBe(re2.test("\u{1F600}"), false, "greedy: same lead, different trail");
+}
+
+// ----------------------------------------------------------------------------
+// 15. Non-anchored search — string starts with non-matching content; the
+//     prefilter advances by the right amount and the actual match is found
+//     deeper in the haystack.
+// ----------------------------------------------------------------------------
+{
+    let re = /\u{1F0A1}|\u{1F0B1}/u;
+    let prefix = "abc\u{1F600}def🄀ghi";  // includes mixed-lead non-BMP and \u{1F100}
+    let target = prefix + "\u{1F0B1}tail";
+    let m = re.exec(target);
+    shouldBe(m !== null, true, "advance: matched");
+    shouldBe(m[0], "\u{1F0B1}", "advance: full match");
+    shouldBe(m.index, prefix.length, "advance: index correct");
+}
+
+// ----------------------------------------------------------------------------
+// 16. Sticky and global flags — sticky disables the prefilter via the
+//     `!m_pattern.sticky()` guard at the BodyAlternativeBegin site. Match
+//     semantics must remain correct.
+// ----------------------------------------------------------------------------
+{
+    let re = /\u{1F0A1}|\u{1F0B1}/uy;
+    re.lastIndex = 0;
+    shouldBe(re.test("\u{1F0B1}foo"), true, "sticky: at 0");
+    re.lastIndex = 0;
+    shouldBe(re.test("foo\u{1F0B1}"), false, "sticky: not at 0");
+    re.lastIndex = 3;
+    shouldBe(re.test("foo\u{1F0B1}"), true, "sticky: at 3");
+}
+
+// ----------------------------------------------------------------------------
+// 17. Capture preservation — the prefilter is just a fast reject; once we
+//     fall through to per-alternative codegen, captures must be filled
+//     correctly.
+// ----------------------------------------------------------------------------
+{
+    let re = /(\u{1F0A1})|(\u{1F0B1})|(\u{1F0C1})/u;
+    let m = re.exec("xx\u{1F0C1}yy");
+    shouldBe(m !== null, true, "capture: matched");
+    shouldBe(m[0], "\u{1F0C1}", "capture: full match");
+    shouldBe(m[1], undefined, "capture: cap1 empty");
+    shouldBe(m[2], undefined, "capture: cap2 empty");
+    shouldBe(m[3], "\u{1F0C1}", "capture: cap3 set");
+    shouldBe(m.index, 2, "capture: index");
+}
+
+// ----------------------------------------------------------------------------
+// 18. JIT-tier coverage — recompile and re-execute many times so the regex
+//     escapes the bytecode interpreter and reaches the JIT, then matches both
+//     fast-path acceptances and prefilter rejections.
+// ----------------------------------------------------------------------------
+{
+    let re = /\u{1F0A1}|\u{1F0B1}|\u{1F0C1}|[\u{1F0D1}-\u{1F0DE}]/u;
+    let pos = ["\u{1F0A1}", "\u{1F0B1}", "\u{1F0C1}", "\u{1F0D5}"];
+    let neg = ["A", "\u{1F600}", "\u{1F0DF}", "\u{1F0A0}", ""];
+    for (let i = 0; i < 5000; ++i) {
+        for (let p of pos) {
+            if (!re.test(p))
+                throw new Error("hot: should match " + p);
+        }
+        for (let n of neg) {
+            if (re.test(n))
+                throw new Error("hot: should reject " + JSON.stringify(n));
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// 19. Slow-path trail-only class — multiple ranges. The synthetic trail-only
+//     class has m_rangesUnicode.size() >= 2, which fails both fast-path
+//     detectors in readPairAndMatchTrailForSharedLead and falls through to
+//     matchCharacterClass. matchCharacterClass asserts that m_rangesUnicode is
+//     sorted, so this exercises the std::ranges::sort on m_rangesUnicode in
+//     buildTrailsOnlyClass.
+// ----------------------------------------------------------------------------
+{
+    let re = /[\u{1F0A1}-\u{1F0A3}\u{1F0B1}-\u{1F0B3}\u{1F0C1}-\u{1F0C3}]/u;
+
+    // Members of the union — must match.
+    for (let cp of [0x1F0A1, 0x1F0A2, 0x1F0A3,
+                    0x1F0B1, 0x1F0B2, 0x1F0B3,
+                    0x1F0C1, 0x1F0C2, 0x1F0C3]) {
+        shouldBe(re.test(String.fromCodePoint(cp)), true, "slow-multi-range: " + cp.toString(16));
+    }
+
+    // Same lead 0xD83C, trails NOT in any range — must reject.
+    for (let cp of [0x1F0A0, 0x1F0A4, 0x1F0AF,
+                    0x1F0B0, 0x1F0B4, 0x1F0BF,
+                    0x1F0C0, 0x1F0C4, 0x1F0FF,
+                    0x1F600, 0x1F300]) {
+        shouldBe(re.test(String.fromCodePoint(cp)), false, "slow-multi-range: not in set " + cp.toString(16));
+    }
+
+    // Different lead surrogate — must reject (lead check kicks before trail).
+    shouldBe(re.test("\u{20000}"), false, "slow-multi-range: different lead");
+
+    // BMP haystack — no surrogate pair.
+    shouldBe(re.test("ABC"), false, "slow-multi-range: BMP");
+}
+
+// ----------------------------------------------------------------------------
+// 20. Slow-path trail-only class — mixed matches + ranges. Both
+//     m_matchesUnicode and m_rangesUnicode are populated on the synthetic
+//     class, so neither fast-path detector fires. Exercises the unifyMatches /
+//     unifyRanges logic in matchCharacterClass against the synthetic class.
+// ----------------------------------------------------------------------------
+{
+    // \u{1F0A1} → match; \u{1F0A5}-\u{1F0A8} → range; \u{1F0AA} → match.
+    // After dedup/canonicalization the source class will have m_matchesUnicode
+    // = {1F0A1, 1F0AA} and m_rangesUnicode = {[1F0A5,1F0A8]}.
+    let re = /[\u{1F0A1}\u{1F0A5}-\u{1F0A8}\u{1F0AA}]/u;
+
+    for (let cp of [0x1F0A1, 0x1F0A5, 0x1F0A6, 0x1F0A7, 0x1F0A8, 0x1F0AA])
+        shouldBe(re.test(String.fromCodePoint(cp)), true, "slow-mixed: " + cp.toString(16));
+
+    for (let cp of [0x1F0A0, 0x1F0A2, 0x1F0A3, 0x1F0A4, 0x1F0A9, 0x1F0AB, 0x1F0DE])
+        shouldBe(re.test(String.fromCodePoint(cp)), false, "slow-mixed: not in set " + cp.toString(16));
+
+    shouldBe(re.test("A"), false, "slow-mixed: BMP");
+    shouldBe(re.test("\u{20000}"), false, "slow-mixed: different lead");
+}
+
+// ----------------------------------------------------------------------------
+// 21. Slow-path with quantifier — exercises the slow path inside a
+//     fixed-count quantifier loop, where the synthetic class is built once and
+//     read on every iteration. If the sort were missing or wrong, the
+//     std::is_sorted assertion in matchCharacterClass would fire on debug
+//     builds; on release we'd silently miscompile and the wrong characters
+//     would match.
+// ----------------------------------------------------------------------------
+{
+    let re = /[\u{1F0A1}-\u{1F0A3}\u{1F0B1}-\u{1F0B3}\u{1F0C1}-\u{1F0C3}]{3}/u;
+
+    let goodSeqs = [
+        "\u{1F0A1}\u{1F0B2}\u{1F0C3}",
+        "\u{1F0A2}\u{1F0A3}\u{1F0B1}",
+        "\u{1F0C1}\u{1F0C2}\u{1F0C3}",
+    ];
+    for (let s of goodSeqs)
+        shouldBe(re.test(s), true, "slow-quant: should match " + s.codePointAt(0).toString(16) + "..");
+
+    let badSeqs = [
+        "\u{1F0A4}\u{1F0B2}\u{1F0C3}",  // first char outside
+        "\u{1F0A1}\u{1F0B4}\u{1F0C3}",  // middle char outside
+        "\u{1F0A1}\u{1F0B2}\u{1F0DE}",  // last char outside, same lead
+        "\u{1F0A1}\u{1F0B2}A",          // last char BMP
+    ];
+    for (let s of badSeqs)
+        shouldBe(re.test(s), false, "slow-quant: should reject " + s);
+}
+
+// ----------------------------------------------------------------------------
+// 22. Slow-path JIT-tier hot loop — drives the slow-path codegen across
+//     thousands of iterations to escape the interpreter and stress the
+//     compiled JIT code on a class large enough to bypass both fast paths.
+// ----------------------------------------------------------------------------
+{
+    let re = /[\u{1F0A1}-\u{1F0A3}\u{1F0A5}\u{1F0A7}\u{1F0B1}-\u{1F0B3}\u{1F0C1}-\u{1F0C3}]/u;
+    let pos = ["\u{1F0A1}", "\u{1F0A2}", "\u{1F0A3}", "\u{1F0A5}", "\u{1F0A7}",
+               "\u{1F0B1}", "\u{1F0B2}", "\u{1F0B3}", "\u{1F0C1}", "\u{1F0C2}", "\u{1F0C3}"];
+    let neg = ["\u{1F0A0}", "\u{1F0A4}", "\u{1F0A6}", "\u{1F0A8}", "\u{1F0AF}",
+               "\u{1F0B0}", "\u{1F0B4}", "\u{1F0C0}", "\u{1F0C4}", "\u{1F600}", "A", ""];
+    for (let i = 0; i < 3000; ++i) {
+        for (let p of pos) {
+            if (!re.test(p))
+                throw new Error("slow-hot: should match " + p);
+        }
+        for (let n of neg) {
+            if (re.test(n))
+                throw new Error("slow-hot: should reject " + JSON.stringify(n));
+        }
+    }
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1328,6 +1328,126 @@ class YarrGenerator final : public YarrJITInfo {
         m_jit.getEffectiveAddress(address, m_regs.regUnicodeInputAndTrail);
         tryReadUnicodeCharImpl<TryReadUnicodeCharGenFirstNonBMPOptimization::DontUseOptimization>(*m_vm, m_jit, resultReg);
     }
+
+    // Specialized read+match for character classes whose codepoints all share a single UTF-16
+    // lead surrogate. Loads the (lead, trail) pair as a single 32-bit value, branches to
+    // |failures| if the lead doesn't match |sharedLead|, otherwise leaves the trail surrogate
+    // in |character| and matches it against |trailsOnlyClass| (a transient class containing
+    // only the trail surrogate values from the source class). Skips the full surrogate-pair
+    // decode that tryReadUnicodeCharImpl would emit (~16 instructions).
+    void readSurrogatePairAndMatchTrailForSharedLead(Checked<unsigned> negativeCharacterOffset,
+        MacroAssembler::RegisterID character,
+        MacroAssembler::RegisterID scratch,
+        MacroAssembler::RegisterID indexReg,
+        char16_t sharedLead,
+        const CharacterClass* trailsOnlyClass,
+        MacroAssembler::JumpList& failures)
+    {
+        ASSERT(m_charSize == CharSize::Char16);
+        ASSERT(trailsOnlyClass->m_matches.isEmpty());
+        ASSERT(trailsOnlyClass->m_ranges.isEmpty());
+
+        MacroAssembler::BaseIndex address = negativeOffsetIndexedAddress(negativeCharacterOffset, character, indexReg);
+        m_jit.getEffectiveAddress(address, m_regs.regUnicodeInputAndTrail);
+        m_jit.load32(MacroAssembler::Address(m_regs.regUnicodeInputAndTrail), character);
+
+        // Fast path for a small matches-only trail set (e.g., OfAKindRegExp's
+        // {0xa1,0xb1,0xc1,0xd1}): compare the loaded 32-bit pair directly against
+        // ((trail << 16) | sharedLead) for each match. This folds the lead check
+        // into each cmp — no separate and+cmp+lsr needed. ARM64's cached-temp
+        // tracker emits movk-only updates between consecutive compares since only
+        // the upper 16 bits change.
+        if (trailsOnlyClass->m_rangesUnicode.isEmpty() && !trailsOnlyClass->m_matchesUnicode.isEmpty()) {
+            const auto& matches = trailsOnlyClass->m_matchesUnicode;
+#if CPU(ARM64)
+            // For 2+ matches, fold the chain into cmp + ccmp(NE, Z=1) ... + b.ne.
+            // ccmp keeps the EQ flag sticky once any compare matches, so the
+            // entire alternation collapses to a single conditional branch. Saves
+            // (matches.size() - 1) branches and avoids creating a matchDest label
+            // (which would invalidate the cached temp register holding sharedLead).
+            if (matches.size() >= 2) {
+                constexpr int32_t nzcvEqual = 0x4; // Z=1 → flag is Equal.
+                unsigned expected0 = (static_cast<unsigned>(matches[0]) << 16) | static_cast<unsigned>(sharedLead);
+                m_jit.compareOnFlags32(character, MacroAssembler::TrustedImm32(expected0));
+                for (size_t i = 1; i < matches.size(); ++i) {
+                    unsigned expected = (static_cast<unsigned>(matches[i]) << 16) | static_cast<unsigned>(sharedLead);
+                    m_jit.compareConditionallyOnFlags32(character, MacroAssembler::TrustedImm32(expected), MacroAssembler::TrustedImm32(nzcvEqual), MacroAssembler::NotEqual);
+                }
+                failures.append(m_jit.branchOnFlags(MacroAssembler::NotEqual));
+                return;
+            }
+#endif
+            MacroAssembler::JumpList matchDest;
+            for (size_t i = 0; i + 1 < matches.size(); ++i) {
+                unsigned expected = (static_cast<unsigned>(matches[i]) << 16) | static_cast<unsigned>(sharedLead);
+                matchDest.append(m_jit.branch32(MacroAssembler::Equal, character, MacroAssembler::Imm32(expected)));
+            }
+            unsigned expected = (static_cast<unsigned>(matches[matches.size() - 1]) << 16) | static_cast<unsigned>(sharedLead);
+            failures.append(m_jit.branch32(MacroAssembler::NotEqual, character, MacroAssembler::Imm32(expected)));
+            matchDest.link(&m_jit);
+            return;
+        }
+
+        // Fast path for a single trail-only range (e.g., FlushRegExp's [0xa1-0xae]):
+        // emit a single sub+cmp+b.hi straight to outer failures with no trampolines.
+        if (trailsOnlyClass->m_matchesUnicode.isEmpty() && trailsOnlyClass->m_rangesUnicode.size() == 1) {
+            const auto& range = trailsOnlyClass->m_rangesUnicode[0];
+#if CPU(ARM64)
+            // Fold the lead-check and range-check into a single conditional branch
+            // via ccmp. Saves one instruction and one branch per inner iteration.
+            //   uxth   scratch, character           ; scratch = lead (low 16, zero-extended)
+            //   cmp    scratch, sharedLead          ; Z=1 iff lead matches
+            //   lsr    character, character, 16     ; trail (no flags)
+            //   sub    scratch, character, begin    ; biased trail (no flags)
+            //   ccmp   scratch, biasedEnd, #2, eq   ; if lead matched: real cmp; else NZCV→hi
+            //   b.hi   failures
+            unsigned biasedEnd = range.end - range.begin;
+            constexpr int32_t nzcvHi = 0x2; // C=1, Z=0 → b.hi takes when lead mismatched
+            m_jit.zeroExtend16To32(character, scratch);
+            m_jit.compareOnFlags32(scratch, MacroAssembler::TrustedImm32(sharedLead));
+            m_jit.urshift32(character, MacroAssembler::TrustedImm32(16), character);
+            m_jit.sub32(character, MacroAssembler::Imm32(static_cast<unsigned>(range.begin)), scratch);
+            m_jit.compareConditionallyOnFlags32(scratch, MacroAssembler::TrustedImm32(biasedEnd), MacroAssembler::TrustedImm32(nzcvHi), MacroAssembler::Equal);
+            failures.append(m_jit.branchOnFlags(MacroAssembler::Above));
+            return;
+#else
+            m_jit.zeroExtend16To32(character, scratch);
+            failures.append(m_jit.branch32(MacroAssembler::NotEqual, scratch, MacroAssembler::TrustedImm32(sharedLead)));
+            m_jit.urshift32(character, MacroAssembler::TrustedImm32(16), character);
+            matchCharacterClassOnlyOneRange(character, scratch, failures, range);
+            return;
+#endif
+        }
+
+        m_jit.zeroExtend16To32(character, scratch);
+        failures.append(m_jit.branch32(MacroAssembler::NotEqual, scratch, MacroAssembler::TrustedImm32(sharedLead)));
+
+        m_jit.urshift32(character, MacroAssembler::TrustedImm32(16), character);
+
+        MacroAssembler::JumpList matchDest;
+        matchCharacterClass(character, scratch, MatchTargets(matchDest, failures, MatchTargets::PreferredTarget::MatchSuccessFallThrough), trailsOnlyClass);
+        if (!matchDest.empty())
+            failures.append(m_jit.jump());
+        matchDest.link(&m_jit);
+    }
+
+    static void buildTrailsOnlyClass(const CharacterClass& source, CharacterClass& dest)
+    {
+        for (auto cp : source.m_matchesUnicode) {
+            ASSERT(!U_IS_BMP(cp));
+            dest.m_matchesUnicode.append(U16_TRAIL(cp));
+        }
+
+        for (auto& range : source.m_rangesUnicode) {
+            ASSERT(!U_IS_BMP(range.begin));
+            ASSERT(!U_IS_BMP(range.end));
+            char32_t trailBegin = U16_TRAIL(range.begin);
+            char32_t trailEnd = U16_TRAIL(range.end);
+            dest.m_rangesUnicode.append(CharacterRange(trailBegin, trailEnd));
+        }
+        std::ranges::sort(dest.m_matchesUnicode);
+        std::ranges::sort(dest.m_rangesUnicode, [](auto& a, auto& b) { return a.begin < b.begin; });
+    }
 #endif
 
     void readCharacter(Checked<unsigned> negativeCharacterOffset, MacroAssembler::RegisterID resultReg)
@@ -1676,6 +1796,9 @@ class YarrGenerator final : public YarrJITInfo {
 
         BoyerMooreInfo* m_bmInfo { nullptr };
         MaskedAlternativeInfo* m_maskedAltInfo { nullptr };
+
+        // Shared UTF-16 lead surrogate across all repeated alternatives' first character.
+        std::optional<char16_t> m_bodyAltSharedLead;
 
         // For single-alt FixedCount with backtrackable content: label for content's backtrack entry.
         // BEGIN.bt jumps here for within-iteration backtracking.
@@ -2924,6 +3047,17 @@ class YarrGenerator final : public YarrJITInfo {
             storeToFrame(m_regs.index, term->frameLocation + BackTrackInfoCharacterClass::beginIndex());
         }
 
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
+        if (m_decodeSurrogatePairs && !term->invert()) {
+            if (auto sharedLead = term->characterClass->hasSharedLeadSurrogate()) {
+                CharacterClass trailsOnlyClass;
+                buildTrailsOnlyClass(*term->characterClass, trailsOnlyClass);
+                readSurrogatePairAndMatchTrailForSharedLead(op.m_checkedOffset - term->inputPosition, character, scratch, m_regs.index, sharedLead.value(), &trailsOnlyClass, op.m_jumps);
+                return;
+            }
+        }
+#endif
+
         readCharacter(op.m_checkedOffset - term->inputPosition, character);
 
         matchCharacterClassTermInner(term, op.m_jumps, character, scratch);
@@ -2975,13 +3109,31 @@ class YarrGenerator final : public YarrJITInfo {
         }
 
         Checked<unsigned> scaledMaxCount = term->quantityMaxCount;
+
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
         bool nonBMPOnly = false;
-        if (m_decodeSurrogatePairs && term->characterClass->hasOnlyNonBMPCharacters() && !term->invert()) {
+        if (m_decodeSurrogatePairs && !term->invert() && term->characterClass->hasOnlyNonBMPCharacters()) {
             scaledMaxCount *= 2;
             nonBMPOnly = true;
+
+            if (auto sharedLead = term->characterClass->hasSharedLeadSurrogate()) {
+                // Replace tryReadUnicodeCharImpl + full-codepoint class match
+                // with a single 32-bit pair load + lead check + trail-only class match.
+                ASSERT(term->isFixedWidthCharacterClass());
+                CharacterClass trailsOnlyClass;
+                buildTrailsOnlyClass(*term->characterClass, trailsOnlyClass);
+
+                m_jit.sub32(m_regs.index, MacroAssembler::Imm32(scaledMaxCount), countRegister);
+
+                MacroAssembler::Label sharedLoop(&m_jit);
+                readSurrogatePairAndMatchTrailForSharedLead(op.m_checkedOffset - term->inputPosition - scaledMaxCount, character, scratch, countRegister, sharedLead.value(), &trailsOnlyClass, op.m_jumps);
+                m_jit.add32(MacroAssembler::TrustedImm32(2), countRegister);
+                m_jit.branch32(MacroAssembler::NotEqual, countRegister, m_regs.index).linkTo(sharedLoop, &m_jit);
+                return;
+            }
         }
 #endif
+
         m_jit.sub32(m_regs.index, MacroAssembler::Imm32(scaledMaxCount), countRegister);
 
         MacroAssembler::Label loop(&m_jit);
@@ -3050,6 +3202,38 @@ class YarrGenerator final : public YarrJITInfo {
         if (m_decodeSurrogatePairs && (!term->characterClass->hasOneCharacterSize() || term->invert()))
             storeToFrame(m_regs.index, term->frameLocation + BackTrackInfoCharacterClass::beginIndex());
         m_jit.move(MacroAssembler::TrustedImm32(0), countRegister);
+
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
+        if (m_decodeSurrogatePairs && !term->invert()) {
+            if (auto sharedLead = term->characterClass->hasSharedLeadSurrogate()) {
+                ASSERT(term->isFixedWidthCharacterClass());
+                CharacterClass trailsOnlyClass;
+                buildTrailsOnlyClass(*term->characterClass, trailsOnlyClass);
+
+                MacroAssembler::JumpList sharedFailures;
+                MacroAssembler::Label sharedLoop(&m_jit);
+
+                // Need at least 2 code units remaining: index + 2 <= length.
+                m_jit.add32(MacroAssembler::TrustedImm32(2), m_regs.index, scratch);
+                sharedFailures.append(m_jit.branch32(MacroAssembler::Above, scratch, m_regs.length));
+
+                readSurrogatePairAndMatchTrailForSharedLead(op.m_checkedOffset - term->inputPosition, character, scratch, m_regs.index, sharedLead.value(), &trailsOnlyClass, sharedFailures);
+
+                m_jit.add32(MacroAssembler::TrustedImm32(2), m_regs.index);
+                m_jit.add32(MacroAssembler::TrustedImm32(1), countRegister);
+
+                if (term->quantityMaxCount == quantifyInfinite)
+                    m_jit.jump(sharedLoop);
+                else
+                    m_jit.branch32(MacroAssembler::NotEqual, countRegister, MacroAssembler::Imm32(term->quantityMaxCount)).linkTo(sharedLoop, &m_jit);
+
+                sharedFailures.link(&m_jit);
+                defineReentryLabel(op);
+                storeToFrame(countRegister, term->frameLocation + BackTrackInfoCharacterClass::matchAmountIndex());
+                return;
+            }
+        }
+#endif
 
         MacroAssembler::JumpList failures;
         MacroAssembler::JumpList failuresDecrementIndex;
@@ -3607,9 +3791,8 @@ class YarrGenerator final : public YarrJITInfo {
                                 setMatchStart(m_regs.regT0);
                             } else
                                 setMatchStart(m_regs.index);
-                            op.m_jumps.append(m_jit.jump());
-                        } else
-                            op.m_jumps.append(m_jit.jump());
+                        }
+                        op.m_jumps.append(m_jit.jump());
 
                         matched.link(&m_jit);
                         // If the pattern size is not fixed, then store the start index for use if we match.
@@ -3625,6 +3808,43 @@ class YarrGenerator final : public YarrJITInfo {
                     } else
                         dataLogLnIf(Options::verboseRegExpCompilation(), "BM search candidates were not efficient enough. Not using BM search");
                     break;
+                }
+
+                if (op.m_bodyAltSharedLead) {
+                    // Shared-lead per-position prefilter for /u patterns whose alternatives all
+                    // start with non-BMP character classes sharing the same UTF-16 lead surrogate.
+                    // We scan input one UTF-16 unit at a time, falling through to per-alt dispatch
+                    // only when the lead matches. Mismatch advances index by 1 and retries.
+                    ASSERT(m_decodeSurrogatePairs);
+                    char16_t sharedLeadSurrogate = op.m_bodyAltSharedLead.value();
+
+                    // We are intentionally not using tryReadUnicodeChar here as we decomposed a non-BMP character into lead and trail surrogates
+                    // and searching for a shared lead surrogate.
+                    JIT_COMMENT(m_jit, "Shared-lead-surrogate body-alt filter");
+                    auto loopHead = m_jit.label();
+                    MacroAssembler::BaseIndex address = negativeOffsetIndexedAddress(op.m_checkedOffset, m_regs.regT0);
+                    m_jit.load16Unaligned(address, m_regs.regT0);
+                    auto matched = m_jit.branch32(MacroAssembler::Equal, m_regs.regT0, MacroAssembler::TrustedImm32(sharedLeadSurrogate));
+                    jumpIfAvailableInput(1).linkTo(loopHead, &m_jit);
+
+                    // Out of input: hand off to alt failure path.
+                    if (!m_pattern.m_body->m_hasFixedSize) {
+                        if (alternative->m_minimumSize) {
+                            m_jit.sub32(m_regs.index, MacroAssembler::Imm32(alternative->m_minimumSize), m_regs.regT0);
+                            setMatchStart(m_regs.regT0);
+                        } else
+                            setMatchStart(m_regs.index);
+                    }
+                    op.m_jumps.append(m_jit.jump());
+
+                    matched.link(&m_jit);
+                    if (!m_pattern.m_body->m_hasFixedSize) {
+                        if (alternative->m_minimumSize) {
+                            m_jit.sub32(m_regs.index, MacroAssembler::Imm32(alternative->m_minimumSize), m_regs.regT0);
+                            setMatchStart(m_regs.regT0);
+                        } else
+                            setMatchStart(m_regs.index);
+                    }
                 }
                 break;
             }
@@ -5600,36 +5820,65 @@ class YarrGenerator final : public YarrJITInfo {
         size_t repeatLoop = m_ops.size();
         appendOp(YarrOp(YarrOpCode::BodyAlternativeBegin));
         m_ops.last().m_previousOp = notFound;
-        // Collect BoyerMooreInfo if it is possible and profitable. BoyerMooreInfo will be used to emit fast skip path with large stride
-        // at the beginning of the body alternatives.
-        // We do not emit these fast path when RegExp has sticky or unicode flag. Sticky case does not need this since
-        // it fails when the body alternatives fail to match with the current offset.
-        // FIXME: Support unicode flag.
-        // https://bugs.webkit.org/show_bug.cgi?id=228611
-        if (disjunction->m_minimumSize && !m_pattern.sticky() && !m_pattern.eitherUnicode()) {
-            auto bmInfo = BoyerMooreInfo::create(m_charSize, std::min<unsigned>(disjunction->m_minimumSize, BoyerMooreInfo::maxLength));
-            if (collectBoyerMooreInfo(disjunction, currentAlternativeIndex, bmInfo.get())) {
-                dataLogLnIf(YarrJITInternal::verbose, bmInfo.get());
-                m_ops.last().m_bmInfo = bmInfo.ptr();
-                m_bmInfos.append(WTF::move(bmInfo));
-                m_usesT2 = true;
-                if (m_sampleString)
-                    m_sampler.sample(m_sampleString.value());
-            } else
-                dataLogLnIf(YarrJITInternal::verbose, "BM collection failed");
+
+        if (disjunction->m_minimumSize && !m_pattern.sticky()) {
+            if (!m_pattern.eitherUnicode()) {
+                // Collect BoyerMooreInfo if it is possible and profitable. BoyerMooreInfo will be used to emit fast skip path with large stride
+                // at the beginning of the body alternatives.
+                // We do not emit these fast path when RegExp has sticky or unicode flag. Sticky case does not need this since
+                // it fails when the body alternatives fail to match with the current offset.
+                // FIXME: Support unicode flag.
+                // https://bugs.webkit.org/show_bug.cgi?id=228611
+                auto bmInfo = BoyerMooreInfo::create(m_charSize, std::min<unsigned>(disjunction->m_minimumSize, BoyerMooreInfo::maxLength));
+                if (collectBoyerMooreInfo(disjunction, currentAlternativeIndex, bmInfo.get())) {
+                    dataLogLnIf(YarrJITInternal::verbose, bmInfo.get());
+                    m_ops.last().m_bmInfo = bmInfo.ptr();
+                    m_bmInfos.append(WTF::move(bmInfo));
+                    m_usesT2 = true;
+                    if (m_sampleString)
+                        m_sampler.sample(m_sampleString.value());
+                } else
+                    dataLogLnIf(YarrJITInternal::verbose, "BM collection failed");
 
 #if CPU(ARM64) || CPU(X86_64)
-            // Try multi-pattern SIMD search for alternations with 2 fixed alternatives
-            // This is more effective than bitmap lookahead for patterns like /agggtaaa|tttaccct/i
-            if (m_charSize == CharSize::Char8 && alternatives.size() >= 2) {
-                if (auto maskedInfo = MaskedAlternativeInfo::create(*disjunction, m_pattern.ignoreCase(), m_charSize)) {
-                    dataLogLnIf(Options::verboseRegExpCompilation(), "Found multi-pattern SIMD candidate: ", alternatives.size(), " alternatives, minLen=", maskedInfo->minPatternLength);
-                    auto info = makeUniqueRef<MaskedAlternativeInfo>(*maskedInfo);
-                    m_ops.last().m_maskedAltInfo = info.ptr();
-                    m_maskedAltInfos.append(WTF::move(info));
+                // Try multi-pattern SIMD search for alternations with 2 fixed alternatives
+                // This is more effective than bitmap lookahead for patterns like /agggtaaa|tttaccct/i
+                if (m_charSize == CharSize::Char8 && alternatives.size() >= 2) {
+                    if (auto maskedInfo = MaskedAlternativeInfo::create(*disjunction, m_pattern.ignoreCase(), m_charSize)) {
+                        dataLogLnIf(Options::verboseRegExpCompilation(), "Found multi-pattern SIMD candidate: ", alternatives.size(), " alternatives, minLen=", maskedInfo->minPatternLength);
+                        auto info = makeUniqueRef<MaskedAlternativeInfo>(*maskedInfo);
+                        m_ops.last().m_maskedAltInfo = info.ptr();
+                        m_maskedAltInfos.append(WTF::move(info));
+                    }
+                }
+#endif
+            }
+
+            // If every repeated alternative starts with a non-BMP character class whose members
+            // all share the same UTF-16 lead surrogate, then any candidate match position must
+            // have that lead at the first character. We hoist a single load+compare above the
+            // per-alt dispatch and skip positions that cannot match any alternative.
+            if (m_decodeSurrogatePairs && !m_ops.last().m_maskedAltInfo) {
+                std::optional<char16_t> sharedLead;
+                for (size_t i = currentAlternativeIndex; i < alternatives.size(); ++i) {
+                    auto lead = findFirstTermSharedLead(alternatives[i].get());
+                    if (!lead) {
+                        sharedLead = std::nullopt;
+                        break;
+                    }
+
+                    if (!sharedLead)
+                        sharedLead = lead;
+                    else if (sharedLead.value() != lead.value()) {
+                        sharedLead = std::nullopt;
+                        break;
+                    }
+                }
+                if (sharedLead) {
+                    dataLogLnIf(Options::verboseRegExpCompilation(), "Found shared-lead body-alt prefilter: U+", hex(sharedLead.value()));
+                    m_ops.last().m_bodyAltSharedLead = sharedLead;
                 }
             }
-#endif
         }
 
         do {
@@ -5658,6 +5907,52 @@ class YarrGenerator final : public YarrJITInfo {
         lastOp.m_alternative = nullptr;
         lastOp.m_nextOp = repeatLoop;
         lastOp.m_checkedOffset = 0;
+    }
+
+    // Walk an alternative's first significant term and report the shared UTF-16 lead surrogate
+    // of its character class, if every codepoint that could match at position 0 shares the same
+    // UTF-16 lead surrogate. Recurses through single-alternative groups so that capture groups
+    // and non-capturing groups are transparent.
+    std::optional<char16_t> findFirstTermSharedLead(PatternAlternative* alt)
+    {
+        if (alt->m_terms.isEmpty())
+            return std::nullopt;
+
+        PatternTerm& firstTerm = alt->m_terms[0];
+        switch (firstTerm.type) {
+        case PatternTerm::Type::PatternCharacter: {
+            if (!firstTerm.quantityMinCount)
+                return std::nullopt;
+            char32_t cp = firstTerm.patternCharacter;
+            if (U_IS_BMP(cp))
+                return std::nullopt;
+            return static_cast<char16_t>(U16_LEAD(cp));
+        }
+
+        case PatternTerm::Type::CharacterClass: {
+            if (firstTerm.invert())
+                return std::nullopt;
+            if (!firstTerm.quantityMinCount)
+                return std::nullopt;
+            return firstTerm.characterClass->hasSharedLeadSurrogate();
+        }
+
+        case PatternTerm::Type::ParenthesesSubpattern: {
+            if (!firstTerm.quantityMinCount)
+                return std::nullopt;
+            if (firstTerm.m_matchDirection != MatchDirection::Forward)
+                return std::nullopt;
+            if (firstTerm.m_invert)
+                return std::nullopt;
+            PatternDisjunction* sub = firstTerm.parentheses.disjunction;
+            if (sub->m_alternatives.size() != 1)
+                return std::nullopt;
+            return findFirstTermSharedLead(sub->m_alternatives[0].get());
+        }
+
+        default:
+            return std::nullopt;
+        }
     }
 
     std::optional<unsigned> collectBoyerMooreInfoFromTerm(PatternTerm& term, unsigned cursor, BoyerMooreInfo& bmInfo)

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -3086,6 +3086,43 @@ void CharacterClass::copyOnly8BitCharacterData(const CharacterClass& other)
         m_anyCharacter = true;
 }
 
+std::optional<char16_t> CharacterClass::hasSharedLeadSurrogate() const
+{
+    if (!hasOnlyNonBMPCharacters())
+        return std::nullopt;
+    if (!m_strings.isEmpty())
+        return std::nullopt;
+
+    ASSERT(m_matches.isEmpty());
+    ASSERT(m_ranges.isEmpty());
+
+    std::optional<char16_t> commonLeadSurrogate;
+    for (auto cp : m_matchesUnicode) {
+        ASSERT(!U_IS_BMP(cp));
+        char16_t leadSurrogate = U16_LEAD(cp);
+        if (!commonLeadSurrogate)
+            commonLeadSurrogate = leadSurrogate;
+        else if (leadSurrogate != commonLeadSurrogate.value())
+            return std::nullopt;
+    }
+
+    for (auto& range : m_rangesUnicode) {
+        ASSERT(!U_IS_BMP(range.begin));
+        ASSERT(!U_IS_BMP(range.end));
+        char16_t leadSurrogateBegin = U16_LEAD(range.begin);
+        char16_t leadSurrogateEnd = U16_LEAD(range.end);
+        if (leadSurrogateBegin != leadSurrogateEnd)
+            return std::nullopt;
+
+        if (!commonLeadSurrogate)
+            commonLeadSurrogate = leadSurrogateBegin;
+        else if (leadSurrogateBegin != commonLeadSurrogate.value())
+            return std::nullopt;
+    }
+
+    return commonLeadSurrogate;
+}
+
 } } // namespace JSC::Yarr
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -140,7 +140,9 @@ public:
     bool hasOnlyNonBMPCharacters() const { return m_characterWidths == CharacterClassWidths::HasNonBMPChars; }
     bool hasStrings() const { return !m_strings.isEmpty(); }
     bool hasSingleCharacters() const { return !m_matches.isEmpty() || !m_ranges.isEmpty() || !m_matchesUnicode.isEmpty() || !m_rangesUnicode.isEmpty(); }
-    
+
+    std::optional<char16_t> hasSharedLeadSurrogate() const;
+
     Vector<Vector<char32_t>> m_strings;
     Vector<char32_t> m_matches;
     Vector<CharacterRange> m_ranges;


### PR DESCRIPTION
#### 6eff2e74e0486893a0f88f83b56a7246700538e6
<pre>
[YARR] Optimize character-classes / patterns with shared lead-surrogate
<a href="https://bugs.webkit.org/show_bug.cgi?id=315803">https://bugs.webkit.org/show_bug.cgi?id=315803</a>
<a href="https://rdar.apple.com/178192192">rdar://178192192</a>

Reviewed by Sosuke Suzuki.

This patch optimizes the case where we have shared lead-surrogate.
Similar non-BMP Unicode characters is clustered into particular range,
thus it is possible that they are having the same lead-surrogate. This
patch leverages this characteristics to optimize things.

We add hasSharedLeadSurrogate which extracts a shared lead-surrogate
from non-BMP characters. And then using this for quick-check filtering
and character-class matching.

Test: JSTests/stress/yarr-jit-shared-lead-prefilter.js

* JSTests/stress/yarr-jit-shared-lead-prefilter.js: Added.
(shouldBe):
(shouldBeArray):
(execBoth):
(shouldBeArray.re.exec):
(throw.new.Error):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClass::hasSharedLeadSurrogate const):
* Source/JavaScriptCore/yarr/YarrPattern.h:

Canonical link: <a href="https://commits.webkit.org/314122@main">https://commits.webkit.org/314122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c6d4950f27a68de47c498ab07cbe5dfbdcffc79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38712 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38713 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/174264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168180 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/30695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/148442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/22018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157380 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/26140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176786 "Failed to checkout and rebase branch from PR 65928") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26116 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/27845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/176786 "Failed to checkout and rebase branch from PR 65928") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38780 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/176786 "Failed to checkout and rebase branch from PR 65928") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39470 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/147936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101782 "Failed to checkout and rebase branch from PR 65928") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25129 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/31920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111053 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37377 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/2881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37521 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->