### PR TITLE
Move Post-commit site-isolation Mac queues to Sequoia

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -134,31 +134,31 @@
                   },
                   {
                     "name": "bot10005",
-                    "platform": "mac-tahoe",
-                    "os": "macOS Tahoe 26.5-25F71",
+                    "platform": "mac-sequoia",
+                    "os": "macOS Sequoia 15.7.3-24G419",
                     "device": "Mac16,11",
-                    "xcode": "Xcode 26.5-17F42"
+                    "xcode": "Xcode 26.2-17C52"
                   },
                   {
                     "name": "bot10006",
-                    "platform": "mac-tahoe",
-                    "os": "macOS Tahoe 26.5-25F71",
+                    "platform": "mac-sequoia",
+                    "os": "macOS Sequoia 15.7.3-24G419",
                     "device": "Mac16,11",
-                    "xcode": "Xcode 26.5-17F42"
+                    "xcode": "Xcode 26.2-17C52"
                   },
                   {
                     "name": "bot10007",
-                    "platform": "mac-tahoe",
-                    "os": "macOS Tahoe 26.5-25F71",
+                    "platform": "mac-sequoia",
+                    "os": "macOS Sequoia 15.7.3-24G419",
                     "device": "Mac16,11",
-                    "xcode": "Xcode 26.5-17F42"
+                    "xcode": "Xcode 26.2-17C52"
                   },
                   {
                     "name": "bot10008",
-                    "platform": "mac-tahoe",
-                    "os": "macOS Tahoe 26.5-25F71",
+                    "platform": "mac-sequoia",
+                    "os": "macOS Sequoia 15.7.3-24G419",
                     "device": "Mac16,11",
-                    "xcode": "Xcode 26.5-17F42"
+                    "xcode": "Xcode 26.2-17C52"
                   },
                   {
                     "name": "bot10009",
@@ -272,7 +272,7 @@
                       "tahoe-release-tests-wk1", "tahoe-release-tests-wk2", "tahoe-release-perf-tests",
                       "tahoe-release-applesilicon-tests-wk1", "tahoe-release-applesilicon-tests-wk2",
                       "tahoe-applesilicon-release-tests-test262", "tahoe-release-tests-wk2-accessibility-isolated-tree", 
-                      "tahoe-release-tests-wk2-site-isolation-tree", "tahoe-release-world-leaks-tests"
+                      "tahoe-release-world-leaks-tests"
                   ],
                   "workernames": ["bot678", "bot10004"]
                   },
@@ -313,11 +313,6 @@
                     "platform": "mac-tahoe", "configuration": "release", "architectures": ["x86_64", "arm64"],
                     "additionalArguments": ["--no-retry-failures", "--accessibility-isolated-tree", "accessibility/"],
                     "workernames": ["bot179"]
-                  },
-                  { "name": "Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests", "factory": "TestLayoutAndAPIOnlyFactory",
-                  "platform": "mac-tahoe", "configuration": "release", "architectures": ["x86_64", "arm64"],
-                  "additionalArguments": ["--no-retry-failures", "--site-isolation"],
-                  "workernames": ["bot10005", "bot10006", "bot10007", "bot10008"]
                   },
                   { "name": "Apple-Tahoe-Debug-Build", "factory": "BuildFactory",
                   "platform": "mac-tahoe", "configuration": "debug", "architectures": ["x86_64", "arm64"],
@@ -363,9 +358,14 @@
                       "sequoia-release-tests-wk1", "sequoia-release-tests-wk2",
                       "sequoia-release-applesilicon-tests-wk2",
                       "sequoia-release-tests-test262", "sequoia-applesilicon-release-tests-jsc", 
-                      "sequoia-intel-release-tests-jsc"
+                      "sequoia-intel-release-tests-jsc", "sequoia-release-tests-wk2-site-isolation-tree"
                   ],
                   "workernames": ["bot279", "bot198"]
+                  },
+                  { "name": "Apple-Sequoia-Release-WK2-Site-Isolation-Tree-Tests", "factory": "TestLayoutAndAPIOnlyFactory",
+                  "platform": "mac-sequoia", "configuration": "release", "architectures": ["x86_64", "arm64"],
+                  "additionalArguments": ["--no-retry-failures", "--additional-header=SiteIsolationEnabled=true", "--additional-expectations=LayoutTests/platform/mac-site-isolation/TestExpectations"],
+                  "workernames": ["bot10005", "bot10006", "bot10007", "bot10008"]
                   },
                   { "name": "Apple-Sequoia-Release-WK1-Tests", "factory": "TestWebKit1AllButJSCFactory",
                   "platform": "mac-sequoia", "configuration": "release", "architectures": ["x86_64", "arm64"],
@@ -867,14 +867,14 @@
                   { "type": "Triggerable", "name": "tahoe-applesilicon-release-tests-test262",
                   "builderNames": ["Apple-Tahoe-Release-AppleSilicon-Test262-Tests"]
                   },
-                  { "type": "Triggerable", "name": "tahoe-release-tests-wk2-site-isolation-tree",
-                  "builderNames": ["Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests"]
-                  },
                   { "type": "Triggerable", "name": "tahoe-release-world-leaks-tests",
                     "builderNames": ["Apple-Tahoe-Release-World-Leaks-Tests"]
                   },
                   { "type": "PlatformSpecificScheduler", "platform": "mac-sequoia", "branch": "main", "treeStableTimer": 45.0,
                   "builderNames": ["Apple-Sequoia-Release-Build", "Apple-Sequoia-Debug-Build", "Apple-Sequoia-AppleSilicon-O3-Debug-JSC-BuildAndTest"]
+                  },
+                  { "type": "Triggerable", "name": "sequoia-release-tests-wk2-site-isolation-tree",
+                  "builderNames": ["Apple-Sequoia-Release-WK2-Site-Isolation-Tree-Tests"]
                   },
                   { "type": "Triggerable", "name": "sequoia-release-tests-wk1",
                   "builderNames": ["Apple-Sequoia-Release-WK1-Tests"]

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -330,26 +330,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-test-results',
             'set-permissions'
         ],
-        'Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'kill-old-processes',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'prune-coresymbolicationd-cache-if-too-large',
-            'download-built-product',
-            'extract-built-product',
-            'layout-test',
-            'dashboard-tests',
-            'archive-test-results',
-            'upload',
-            'extract-test-results',
-            'set-permissions',
-            'run-api-tests'
-        ],
         'Apple-Tahoe-Release-World-Leaks-Tests': [
             'configure-build',
             'configuration',
@@ -411,6 +391,26 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'prune-coresymbolicationd-cache-if-too-large',
             'compile-webkit',
             'trigger'
+        ],
+        'Apple-Sequoia-Release-WK2-Site-Isolation-Tree-Tests': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'prune-coresymbolicationd-cache-if-too-large',
+            'download-built-product',
+            'extract-built-product',
+            'layout-test',
+            'dashboard-tests',
+            'archive-test-results',
+            'upload',
+            'extract-test-results',
+            'set-permissions',
+            'run-api-tests'
         ],
         'Apple-Sequoia-Release-WK1-Tests': [
             'configure-build',


### PR DESCRIPTION
#### c84ee721c3e9f25d6fe714d74fe06d9532456075
<pre>
Move Post-commit site-isolation Mac queues to Sequoia
<a href="https://bugs.webkit.org/show_bug.cgi?id=315795">https://bugs.webkit.org/show_bug.cgi?id=315795</a>
<a href="https://rdar.apple.com/178186862">rdar://178186862</a>

Reviewed by Jonathan Bedard.

Site-isolation bots on EWS are on on Sequoia Release. We should have our
post-commit queues match that same configuration.

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):

Canonical link: <a href="https://commits.webkit.org/314188@main">https://commits.webkit.org/314188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bf0f9125f2bfcbee4875061e78a2ce4ce50110f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122362 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80e03aac-fe5c-471c-a628-32cc2912f354) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128305 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90309 "1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34a98bc7-da82-4817-9f4a-96795d8fcabf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108830 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29669 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28282 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21902 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139564 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176670 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136621 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/164509 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38664 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136563 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147854 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101662 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25163 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31841 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24721 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37864 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37261 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2797 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37507 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37405 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->