### PR TITLE
[Site Isolation] Approve file URLs from the back-forward target item on the new process, and tighten BrowsingContextGroup processMap invariants

### DIFF
--- a/LayoutTests/fast/history/site-isolation/go-back-then-navigate-subframe-expected.txt
+++ b/LayoutTests/fast/history/site-isolation/go-back-then-navigate-subframe-expected.txt
@@ -1,0 +1,9 @@
+Tests that navigating an iframe after going back does not create a new main frame history item.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/history/site-isolation/go-back-then-navigate-subframe.html
+++ b/LayoutTests/fast/history/site-isolation/go-back-then-navigate-subframe.html
@@ -1,0 +1,28 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true MultiProcessBackForwardCacheEnabled=true ] -->
+<script src="../../../resources/js-test.js"></script>
+<script>
+description("Tests that navigating an iframe after going back does not create a new main frame history item.");
+jsTestIsAsync = true;
+
+function runTest() {
+    if (sessionStorage.didNavigate) {
+        delete sessionStorage.didNavigate;
+        setTimeout(() => {
+            const iframe = document.getElementById("frame");
+            iframe.src = "about:blank";
+            iframe.addEventListener("load", () => {
+                iframe.addEventListener("load", () => {
+                    finishJSTest();
+                });
+                history.back();
+            });
+        }, 0);
+    } else {
+        setTimeout(() => {
+            location.href = 'data:text/html,<script> history.back(); <\/script>';
+        }, 0);
+        sessionStorage.didNavigate = true;
+    }
+}
+</script>
+<iframe id="frame" src="../resources/frame-initial-url.html#noalert"></iframe>

--- a/LayoutTests/fast/history/site-isolation/history-back-initial-vs-final-url-expected.txt
+++ b/LayoutTests/fast/history/site-isolation/history-back-initial-vs-final-url-expected.txt
@@ -1,0 +1,22 @@
+ALERT: Initial URL loaded.
+ALERT: Final URL loaded.
+ALERT: Going back.
+ALERT: Final URL loaded.
+Checks that when going back to a page that frames that were navigated, that the final URL of the frames is loaded directly, instead the initial URL. Four alerts should appear, in this order:
+
+Initial URL loaded.
+Final URL loaded.
+Going back.
+Final URL loaded.
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+final page contents
+
+============== Back Forward List ==============
+curr->  (file test):fast/history/site-isolation/history-back-initial-vs-final-url.html
+            (file test):fast/history/resources/frame-final-url.html (in frame "<!--frame1-->")
+        data:text/html,<script>alert("Going back.");history.back();</script>
+===============================================

--- a/LayoutTests/fast/history/site-isolation/history-back-initial-vs-final-url.html
+++ b/LayoutTests/fast/history/site-isolation/history-back-initial-vs-final-url.html
@@ -1,0 +1,42 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true MultiProcessBackForwardCacheEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+
+<p>Checks that when going back to a page that frames that were navigated, that the final URL of the frames is loaded directly, instead the initial URL. Four alerts should appear, in this order:</p>
+
+<ol>
+    <li>Initial URL loaded.</li>
+    <li>Final URL loaded.</li>
+    <li>Going back.</li>
+    <li>Final URL loaded.</li>
+</ol>
+
+<iframe a width="200" height="200" onunload="" src="../resources/frame-initial-url.html"></iframe>
+
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.dumpChildFramesAsText();
+    testRunner.waitUntilDone();
+    testRunner.dumpBackForwardList();
+} else {
+    // Disable page cache when not running under the DRT.
+    onunload = function() {};
+}
+
+function runTest() 
+{
+    if (sessionStorage.didNav) {
+        delete sessionStorage.didNav;
+        if (window.testRunner)
+            testRunner.notifyDone();
+    } else {
+        // Navigate a timeout to make sure we generate a history entry that we can go back to.
+        setTimeout(function() {location.href = 'data:text/html,<script>alert("Going back.");history.back();</' + 'script>';}, 0);
+        sessionStorage.didNav = true;
+    }
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/loader/site-isolation/form-state-restore-with-frames-expected.txt
+++ b/LayoutTests/fast/loader/site-isolation/form-state-restore-with-frames-expected.txt
@@ -1,0 +1,7 @@
+PASS frame$($("frame1"), "input2").value is "value2"
+PASS frame$(frame$($("frame1"), "frame2"), "input3").value is "value3"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/loader/site-isolation/form-state-restore-with-frames.html
+++ b/LayoutTests/fast/loader/site-isolation/form-state-restore-with-frames.html
@@ -1,0 +1,42 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true MultiProcessBackForwardCacheEnabled=true ] -->
+<!DOCTYPE html>
+<head>
+<script src="../../../resources/js-test-pre.js"></script>
+<meta http-equiv="pragma" content="no-cache">
+<meta http-equiv="cache-control" content="no-cache">
+</head>
+<body onload="startTest()">
+<input name="name1" id="input1">
+<iframe id="frame1" src="../resources/form-state-restore-with-frames-1.html">
+</iframe>
+<form id="form1" action="data:text/html,&lt;script>history.back();&lt;/script>">
+<input type="submit">
+</form>
+
+<script>
+function $(id) {
+    return document.getElementById(id);
+}
+function frame$(frame, id) {
+    return frame.contentDocument.getElementById(id);
+}
+
+function startTest() {
+    if ($('input1').value == 'visited') {
+        shouldBeEqualToString('frame$($("frame1"), "input2").value', 'value2');
+        shouldBeEqualToString('frame$(frame$($("frame1"), "frame2"), "input3").value', 'value3');
+        finishJSTest();
+    } else {
+        setTimeout(function() {
+            $('input1').value = 'visited';
+            frame$($('frame1'), 'input2').value = 'value2';
+            frame$(frame$($('frame1'), 'frame2'), 'input3').value = 'value3';
+            $('form1').submit();
+        }, 0);
+    }
+}
+
+jsTestIsAsync = true;
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -173,12 +173,27 @@ void BrowsingContextGroup::addFrameProcessAndInjectPageContextIf(FrameProcess& p
     }
 }
 
+#if ASSERT_ENABLED
+// True when the previous FrameProcess registered for a site can be safely replaced.
+// In addition to the obvious terminated case, sites with an empty registrable domain
+// (e.g. data:, blob:, file:) all collapse to the same key in m_processMap, so they
+// never represented a unique site-to-process binding; replacing them is benign.
+static bool canReplaceFrameProcessInProcessMap(const WebCore::Site& site, FrameProcess& existing)
+{
+    if (existing.process().state() == WebProcessProxy::State::Terminated)
+        return true;
+    if (site.isEmpty())
+        return true;
+    return false;
+}
+#endif
+
 bool BrowsingContextGroup::addFrameProcessWithoutInjectingPageContext(FrameProcess& process)
 {
     auto& site = *process.site();
     if (m_processMap.get(site) == &process)
         return false;
-    ASSERT(!m_processMap.get(site) || m_processMap.get(site)->process().state() == WebProcessProxy::State::Terminated);
+    ASSERT(!m_processMap.get(site) || canReplaceFrameProcessInProcessMap(site, *m_processMap.get(site)));
     m_processMap.set(site, process);
     return true;
 }
@@ -190,8 +205,12 @@ void BrowsingContextGroup::removeFrameProcess(FrameProcess& process)
         m_sharedProcessSites.clear();
     } else {
         auto& site = *process.site();
-        ASSERT(site.isEmpty() || m_processMap.get(site) == &process || process.process().state() == WebProcessProxy::State::Terminated);
-        m_processMap.remove(site);
+        // Either we are still the current entry for this site (normal teardown), or a
+        // later navigation already replaced us under the same conditions used by
+        // addFrameProcess.
+        ASSERT(m_processMap.get(site) == &process || canReplaceFrameProcessInProcessMap(site, process));
+        if (m_processMap.get(site) == &process)
+            m_processMap.remove(site);
     }
     m_remotePages.removeIf([&] (auto& pair) {
         auto& set = pair.value;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5905,6 +5905,13 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
     if (navigation.currentRequest().url().protocolIsFile())
         newProcess->addPreviouslyApprovedFileURL(navigation.currentRequest().url());
 
+    // Approve file URLs from the target BF item now; BackForwardUpdateItem IPC can surface
+    // iframe file:// URLs before the new process is otherwise seeded with them.
+    if (RefPtr targetItem = navigation.targetItem()) {
+        Ref targetFrameState = targetItem->copyMainFrameStateWithChildren();
+        newProcess->addPreviouslyApprovedFileURLsFromFrameStateTree(targetFrameState.get());
+    }
+
     if (RefPtr provisionalPage = m_provisionalPage; provisionalPage && frame.isMainFrame()) {
         WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "continueNavigationInNewProcess: There is already a pending provisional load, cancelling it (provisonalNavigationID=%" PRIu64 ", navigationID=%" PRIu64 ")", m_provisionalPage->navigationID().toUInt64(), navigation.navigationID().toUInt64());
         if (provisionalPage->navigationID() != navigation.navigationID())

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -51,6 +51,7 @@
 #include "RemotePageProxy.h"
 #include "RemoteWorkerType.h"
 #include "ServiceWorkerNotificationHandler.h"
+#include "SessionState.h"
 #include "SpeechRecognitionPermissionRequest.h"
 #include "SpeechRecognitionRemoteRealtimeMediaSourceManager.h"
 #include "SpeechRecognitionRemoteRealtimeMediaSourceManagerMessages.h"
@@ -1556,6 +1557,18 @@ void WebProcessProxy::addPreviouslyApprovedFileURL(const URL& url)
     auto fileSystemPath = url.fileSystemPath();
     if (!fileSystemPath.isEmpty())
         m_previouslyApprovedFilePaths.add(fileSystemPath);
+}
+
+void WebProcessProxy::addPreviouslyApprovedFileURLsFromFrameStateTree(const FrameState& frameState)
+{
+    URL url { frameState.urlString };
+    if (url.protocolIsFile())
+        addPreviouslyApprovedFileURL(url);
+    URL originalURL { frameState.originalURLString };
+    if (originalURL.protocolIsFile())
+        addPreviouslyApprovedFileURL(originalURL);
+    for (auto& child : frameState.children)
+        addPreviouslyApprovedFileURLsFromFrameStateTree(child.get());
 }
 
 bool WebProcessProxy::wasPreviouslyApprovedFileURL(const URL& url) const

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -321,6 +321,7 @@ public:
     VisibleWebPageToken visiblePageToken() const;
 
     void addPreviouslyApprovedFileURL(const URL&);
+    void addPreviouslyApprovedFileURLsFromFrameStateTree(const FrameState&);
     bool wasPreviouslyApprovedFileURL(const URL&) const;
 
     void updateTextCheckerState();


### PR DESCRIPTION
#### ceb4d817be51a2f1fd44eb46cd575598358abbdc
<pre>
[Site Isolation] Approve file URLs from the back-forward target item on the new process, and tighten BrowsingContextGroup processMap invariants
<a href="https://bugs.webkit.org/show_bug.cgi?id=315787">https://bugs.webkit.org/show_bug.cgi?id=315787</a>
<a href="https://rdar.apple.com/178185140">rdar://178185140</a>

Reviewed by Sihui Liu.

Two related fixes uncovered by the same set of layout tests.

1. File URL approval gap across process swap.
When continueNavigationInNewProcess swaps to a fresh WebContent process, the
new process inherits the page&apos;s back/forward list. Once it commits, it can
surface child-frame history items via BackForwardUpdateItem IPC. The per-
process file URL approval gate at WebBackForwardList.cpp:768 then trips
because the new process was only seeded with the top-level navigation URL,
not with iframe URLs in the target back/forward item&apos;s frame-state tree.

Add WebProcessProxy::addPreviouslyApprovedFileURLsFromFrameStateTree, which
recursively approves both urlString and originalURLString file URLs in a
FrameState tree on the process. continueNavigationInNewProcess calls it for
navigation.targetItem() (assembled via copyMainFrameStateWithChildren(), since
FrameState::children is cleared by WebBackForwardListFrameItem::setFrameState),
before the new process can send any IPC referencing those URLs.

2. BrowsingContextGroup processMap conflict on data:/empty-site replacement.
A history navigation that swaps to a data: page (which carries an empty
registrable domain) followed by history.back() registers a fresh FrameProcess
for the data: site in a BrowsingContextGroup that already has one. The old
ASSERT in addFrameProcessWithoutInjectingPageContext insisted the existing
entry be terminated; for empty-domain sites that is not the case, and the
ASSERT trips. The same constraint in removeFrameProcess silently overwrote
the wrong entry in Release.

Replace m_processMap.remove with a guarded removal that only fires when the
process is still the current entry for its site, and gate both ASSERTs on a
shared canReplaceFrameProcessInProcessMap helper that recognises terminated
processes and empty-site keys as legitimate replacements.

Tests: Site Isolation copies of existing back/forward navigation layout tests
that use file:// iframes. Each enables SiteIsolationEnabled +
MultiProcessBackForwardCacheEnabled and crashes the UI process via the
WebBackForwardList.cpp MESSAGE_CHECK before this change; each passes after it.
history-back-initial-vs-final-url.html additionally exercises the data: process
swap that triggers the BCG processMap conflict and asserts in Debug builds.

* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::canReplaceFrameProcessInProcessMap): Added. Returns true when the
existing entry is terminated or its site has an empty registrable domain.
(WebKit::BrowsingContextGroup::addFrameProcessWithoutInjectingPageContext):
ASSERT via the new helper; allow replacement when the helper accepts.
(WebKit::BrowsingContextGroup::removeFrameProcess): ASSERT via the new helper
and only remove the m_processMap entry when this process is still current.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess): Approve file URLs from
the back-forward target item on newProcess via the new WebProcessProxy helper.
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::addPreviouslyApprovedFileURLsFromFrameStateTree):
Added. Recursively approve file URLs in a FrameState tree.
* Source/WebKit/UIProcess/WebProcessProxy.h:
* LayoutTests/fast/history/site-isolation/go-back-then-navigate-subframe.html: Added.
* LayoutTests/fast/history/site-isolation/go-back-then-navigate-subframe-expected.txt: Added.
* LayoutTests/fast/history/site-isolation/history-back-initial-vs-final-url.html: Added.
* LayoutTests/fast/history/site-isolation/history-back-initial-vs-final-url-expected.txt: Added.
* LayoutTests/fast/loader/site-isolation/form-state-restore-with-frames.html: Added.
* LayoutTests/fast/loader/site-isolation/form-state-restore-with-frames-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/314518@main">https://commits.webkit.org/314518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92c838dc4f700a13eda8090e4fec69661b170bca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175406 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c43436d0-b9be-45aa-8598-25d43c140f4f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129317 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169317 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109842 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d0dde5f-f98d-4f6d-8dfa-af7cc9d2e996) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23546 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177938 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137671 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39918 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137591 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37068 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148968 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103261 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32880 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39116 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38513 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3920 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38758 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38656 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->