### PR TITLE
imported/w3c/web-platform-tests/gpc/sec-gpc.https.html is flaky

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/sec-gpc.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/sec-gpc.https-expected.txt
@@ -5,10 +5,16 @@ PASS Expected Sec-GPC value (true) is on the script fetch
 PASS Expected Sec-GPC value (true) is on the iframe fetch
 PASS Expected Sec-GPC value (true) is on the framed image fetch
 PASS Expected Sec-GPC value (true) is on the framed script fetch
+PASS Expected Sec-GPC value (true) is on the worker fetch
+PASS Expected Sec-GPC value (true) is on the sharedworker fetch
+PASS Expected Sec-GPC value (true) is on the serviceworker fetch
 PASS Expected Sec-GPC value (false) is on the document fetch
 PASS Expected Sec-GPC value (false) is on the image fetch
 PASS Expected Sec-GPC value (false) is on the script fetch
 PASS Expected Sec-GPC value (false) is on the iframe fetch
 PASS Expected Sec-GPC value (false) is on the framed image fetch
 PASS Expected Sec-GPC value (false) is on the framed script fetch
+PASS Expected Sec-GPC value (false) is on the worker fetch
+PASS Expected Sec-GPC value (false) is on the sharedworker fetch
+PASS Expected Sec-GPC value (false) is on the serviceworker fetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/support/getGPC.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/support/getGPC.py
@@ -28,6 +28,7 @@ def main(request, response):
   <div id="log"></div>
   <img id="imageTest">
   <script>
+    {"setup({explicit_done: true});" if destination == "document" else ""}
     test(function(t) {{
       assert_equals({maybeBoolToJavascriptLiteral(gpcValue)}, {maybeBoolToJavascriptLiteral(expectedGPCValue)}, "Expected Sec-GPC value ({maybeBoolToJavascriptLiteral(expectedGPCValue)}) is on the {destinationDescription} fetch");
     }}, `Expected Sec-GPC value ({maybeBoolToJavascriptLiteral(expectedGPCValue)}) is on the {destinationDescription} fetch`);
@@ -47,9 +48,6 @@ def main(request, response):
     iframe.src = "getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}";
     document.body.appendChild(iframe);
     async function run() {{
-      await fetch_tests_from_window(iframe.contentWindow);
-      await fetch_tests_from_worker(new Worker("getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}"));
-      await fetch_tests_from_worker(new SharedWorker("getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}"));
       await new Promise((resolve, reject) => {{
         const script = document.createElement("script");
         script.src = "getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}";
@@ -57,17 +55,20 @@ def main(request, response):
         script.onerror = reject;
         document.head.appendChild(script);
       }});
+      await fetch_tests_from_window(iframe.contentWindow);
+      await fetch_tests_from_worker(new Worker("getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}"));
+      await fetch_tests_from_worker(new SharedWorker("getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}"));
       let r = await navigator.serviceWorker.register(
         "getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}",
         {{scope: "./blank.html"}});
       let sw = r.active || r.installing || r.waiting;
       await fetch_tests_from_worker(sw);
       await r.unregister();
+      done();
     }}
     run();
   </script>
-  """ if destination == "document" else "") + f"""
-  <script src="getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}{"&framed" if destination == "iframe" or inFrame else ""}"></script>
+  """ if destination == "document" else "") + (f'  <script src="getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}{"&framed" if destination == "iframe" or inFrame else ""}"></script>\n' if destination != "document" else "") + """
 </body>
 </html>
 """


### PR DESCRIPTION
#### 3abbfb967088cb985767a2776daca74e65f4af3d
<pre>
imported/w3c/web-platform-tests/gpc/sec-gpc.https.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=315807">https://bugs.webkit.org/show_bug.cgi?id=315807</a>
<a href="https://rdar.apple.com/177976784">rdar://177976784</a>

Reviewed by Matthew Finkel.

The document response from getGPC.py had two things happening simultaneously with
no ordering guarantee:

  1. A static &lt;script src=&quot;getGPC.py?gpc=true&quot;&gt; tag sitting at the bottom of the HTML
      body so the browse fetches this automatically as part of parsing the page.
  2. The run() async function, which called await
      fetch_tests_from_window(iframe.contentWindow). This waits for the iframe to fully load
      and collect all its sub-tests (iframe fetch, framed image fetch, framed script fetch).

Both kicked off at the same time. The &quot;script fetch&quot; test completed whenever the browser
finished fetching that static script tag, and the iframe tests completed whenever the iframe
and its resources finished loading. Since these were independent network requests with no
sequencing between them, whichever came back first would report its test result first and make
the &quot;script fetch&quot; result land unpredictably before or after the iframe&apos;s “framed image fetch&quot;.

The fix forces strict sequencing inside run(): the script is now loaded as a dynamic &lt;script&gt;
element and explicitly awaited as the first step, before the iframe&apos;s tests are collected.
So the order is always: document → image → script → iframe → framed image → framed script.

This fix also ensures the child document waits for all worker results before signaling completion.
Previously, worker, sharedworker, and serviceworker fetchctests were never collected .
The harness auto-completed before run() reached those calls.

* LayoutTests/imported/w3c/web-platform-tests/gpc/sec-gpc.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/gpc/support/getGPC.py:

Canonical link: <a href="https://commits.webkit.org/314317@main">https://commits.webkit.org/314317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9018ed6b76864b4363bfd3295ecc894707f9712

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123013 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b1f66b6-f4e8-4f25-81b6-8ec462d059f3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128818 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14b821b9-1165-4336-bf37-33f8f16c85ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109342 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a6bd73a-4e0b-40aa-a00f-03073a42074c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30129 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28834 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22883 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140098 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177325 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28328 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137152 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137080 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36937 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148417 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102532 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32366 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25284 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38516 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37912 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3366 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38158 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38056 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->