### PR TITLE
[cleanup] Use [] instead of [&] for empty-body lambdas in HTMLModelElement

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -680,7 +680,7 @@ void HTMLModelElement::createModelPlayer()
 #if ENABLE(MODEL_ELEMENT_ANIMATIONS_CONTROL)
     modelPlayer->setAutoplay(autoplay());
     modelPlayer->setLoop(loop());
-    modelPlayer->setPlaybackRate(m_playbackRate, [&](double) { });
+    modelPlayer->setPlaybackRate(m_playbackRate, [](double) { });
 #endif
 
 #if ENABLE(MODEL_ELEMENT_PORTAL)
@@ -1250,7 +1250,7 @@ void HTMLModelElement::setPlaybackRate(double playbackRate)
     m_playbackRate = playbackRate;
 
     if (m_modelPlayer)
-        m_modelPlayer->setPlaybackRate(playbackRate, [&](double) { });
+        m_modelPlayer->setPlaybackRate(playbackRate, [](double) { });
 }
 
 double HTMLModelElement::duration() const
@@ -1318,7 +1318,7 @@ double HTMLModelElement::currentTime() const
 void HTMLModelElement::setCurrentTime(double currentTime)
 {
     if (m_modelPlayer)
-        m_modelPlayer->setCurrentTime(Seconds(currentTime), [&] { });
+        m_modelPlayer->setCurrentTime(Seconds(currentTime), [] { });
 }
 
 #endif


### PR DESCRIPTION
#### c0c5452af3cf789d198db7428b91b7a429545537
<pre>
[cleanup] Use [] instead of [&amp;] for empty-body lambdas in HTMLModelElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=315810">https://bugs.webkit.org/show_bug.cgi?id=315810</a>
<a href="https://rdar.apple.com/178195769">rdar://178195769</a>

Reviewed by Mike Wyrzykowski.

Three lambdas in HTMLModelElement.cpp use [&amp;] as their capture-default
despite having empty bodies, so nothing is actually captured.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::setPlaybackRate):
(WebCore::HTMLModelElement::setCurrentTime):

Canonical link: <a href="https://commits.webkit.org/314123@main">https://commits.webkit.org/314123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e666bfef5726dcc392bbd5bb7ad322cf7f770fee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174162 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122377 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd0318c9-5f8b-44ef-95c3-42131063ee69) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128319 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fab0fcc5-6929-4f49-8c51-f8eec0fd33ec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108844 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3f18c91-d1b1-453c-939b-438288312301) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29677 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28300 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21917 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176685 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29555 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136637 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136579 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36827 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147870 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101677 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31857 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24737 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37879 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110951 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37276 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2813 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37522 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37420 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->