### PR TITLE
WebGL: Crash when reading pixels to PBO with an offset

### DIFF
--- a/LayoutTests/webgl/readpixels-pbo-offset-validation-expected.txt
+++ b/LayoutTests/webgl/readpixels-pbo-offset-validation-expected.txt
@@ -1,0 +1,54 @@
+Test that readPixels with invalid PBO offsets are properly validated and don't cause crashes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 45 PASS, 0 FAIL
+
+PASS getError was expected value: NO_ERROR : offset==0
+PASS pixels is expected
+PASS getError was expected value: NO_ERROR : 32x32, offset=256
+PASS pixels is expected
+PASS pixels is [0, 0, 0, 0]
+PASS getError was expected value: INVALID_VALUE : offset=-1
+PASS getError was expected value: INVALID_OPERATION : offset==4
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize - 1
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFF
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFD
+PASS getError was expected value: NO_ERROR : offset==0
+PASS pixels is expected
+PASS getError was expected value: NO_ERROR : 32x32, offset=256
+PASS pixels is expected
+PASS pixels is [0, 0, 0, 0]
+PASS getError was expected value: INVALID_VALUE : offset=-1
+PASS getError was expected value: INVALID_OPERATION : offset==4
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize - 1
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFF
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFD
+PASS getError was expected value: NO_ERROR : offset==0
+PASS pixels is expectedNoAlpha
+PASS getError was expected value: NO_ERROR : 32x32, offset=256
+PASS pixels is expectedNoAlpha
+PASS pixels is [0, 0, 0, 0]
+PASS getError was expected value: INVALID_VALUE : offset=-1
+PASS getError was expected value: INVALID_OPERATION : offset==4
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize - 1
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFF
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFD
+PASS getError was expected value: NO_ERROR : offset==0
+PASS pixels is expectedNoAlpha
+PASS getError was expected value: NO_ERROR : 32x32, offset=256
+PASS pixels is expectedNoAlpha
+PASS pixels is [0, 0, 0, 0]
+PASS getError was expected value: INVALID_VALUE : offset=-1
+PASS getError was expected value: INVALID_OPERATION : offset==4
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize
+PASS getError was expected value: INVALID_OPERATION : offset==bufferSize - 1
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFF
+PASS getError was expected value: INVALID_OPERATION : offset==0x7FFFFFFD
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/readpixels-pbo-offset-validation.html
+++ b/LayoutTests/webgl/readpixels-pbo-offset-validation.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+
+description("Test that readPixels with invalid PBO offsets are properly validated and don't cause crashes.");
+
+var wtu = WebGLTestUtils;
+var gl;
+var expected = [51, 102, 204, 204];
+var expectedNoAlpha = [51, 102, 204, 255];
+var pixels;
+
+function runTest(contextOptions) {
+    var canvas = document.createElement("canvas");
+    var gl = wtu.create3DContext(canvas, contextOptions, 2);
+
+    gl.clearColor(0.2, 0.4, 0.8, 0.8);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    var pbo = gl.createBuffer();
+    gl.bindBuffer(gl.PIXEL_PACK_BUFFER, pbo);
+    var bufferSize = 64 * 64 * 4;
+    gl.bufferData(gl.PIXEL_PACK_BUFFER, bufferSize, gl.DYNAMIC_READ);
+    gl.bindBuffer(gl.COPY_READ_BUFFER, pbo); // For verification getBufferSubData() calls below.
+
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null);
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "offset==0");
+    pixels = new Uint8Array(4);
+    gl.getBufferSubData(gl.COPY_READ_BUFFER, 0, pixels);
+    if (contextOptions.alpha)
+        shouldBe("pixels", "expected");
+    else
+        shouldBe("pixels", "expectedNoAlpha");
+
+
+    gl.bufferData(gl.COPY_READ_BUFFER, bufferSize, gl.DYNAMIC_READ);
+    gl.readPixels(0, 0, 32, 32, gl.RGBA, gl.UNSIGNED_BYTE, 256);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "32x32, offset=256");
+    pixels = new Uint8Array(4);
+    gl.getBufferSubData(gl.COPY_READ_BUFFER, 256, pixels);
+    if (contextOptions.alpha)
+        shouldBe("pixels", "expected");
+    else
+        shouldBe("pixels", "expectedNoAlpha");
+    pixels = new Uint8Array(4);
+    gl.getBufferSubData(gl.COPY_READ_BUFFER, 0, pixels);
+    shouldBe("pixels", "[0, 0, 0, 0]");
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, -1);
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "offset=-1");
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, 4);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "offset==4");
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, bufferSize);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "offset==bufferSize");
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, bufferSize - 1);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "offset==bufferSize - 1");
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, 0x7FFFFFFF);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "offset==0x7FFFFFFF");
+
+    gl.readPixels(0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, 0x7FFFFFFD);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "offset==0x7FFFFFFD");
+}
+
+for (let alpha of [true, false]) {
+    for (let antialias of [true, false])
+        runTest({alpha, antialias});
+}
+finishTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -51,7 +51,6 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/CStringView.h>
 #include <wtf/text/StringBuilder.h>
-
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
 #include "GraphicsContextGLCVCocoa.h"
 #endif
@@ -709,14 +708,34 @@ void GraphicsContextGLANGLE::readPixelsBufferObject(IntRect rect, GCGLenum forma
 {
     if (!makeContextCurrent())
         return;
+
+    if (!m_isForWebGL2) {
+        addError(GCGLErrorCode::InvalidOperation);
+        return;
+    }
+
+    GCGLuint pixelPackBuffer = 0;
+    GL_GetIntegerv(GL_PIXEL_PACK_BUFFER_BINDING, reinterpret_cast<GCGLint*>(&pixelPackBuffer));
+    if (!pixelPackBuffer) {
+        addError(GCGLErrorCode::InvalidOperation);
+        return;
+    }
+
+    auto attrs = contextAttributes();
+    if (attrs.antialias && m_state.boundReadFBO == m_multisampleFBO) {
+        resolveMultisamplingIfNecessary(rect);
+        GL_BindFramebuffer(GraphicsContextGL::READ_FRAMEBUFFER, m_fbo);
+    }
+
     setPackParameters(alignment, rowLength, false);
-    GLsizei bufferSize = 0;
-    GL_GetBufferParameterivRobustANGLE(GL_PIXEL_PACK_BUFFER, GL_BUFFER_SIZE, 1, nullptr, &bufferSize);
-    // FIXME: Remove redundant use of unsafe std::span by calling GL_ReadPixelsRobustANGLE directly.
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    std::span<uint8_t> data(reinterpret_cast<uint8_t*>(offset), static_cast<size_t>(bufferSize));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-    readPixelsImpl(rect, format, type, data);
+
+    // ANGLE validates the read size against the PBO size.
+    GLsizei bufferSize = std::numeric_limits<GLsizei>::max();
+
+    GL_ReadPixelsRobustANGLE(rect.x(), rect.y(), rect.width(), rect.height(), format, type, bufferSize, nullptr, nullptr, nullptr, reinterpret_cast<void*>(offset));
+
+    if (attrs.antialias && m_state.boundReadFBO == m_multisampleFBO)
+        GL_BindFramebuffer(GraphicsContextGL::READ_FRAMEBUFFER, m_multisampleFBO);
 }
 
 std::optional<IntSize> GraphicsContextGLANGLE::readPixelsImpl(IntRect rect, GCGLenum format, GCGLenum type, std::span<uint8_t> data)


### PR DESCRIPTION
#### d0000cab59a2bb2ae9dbb8afa66920ff2c2f59ff
<pre>
WebGL: Crash when reading pixels to PBO with an offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=310333">https://bugs.webkit.org/show_bug.cgi?id=310333</a>
<a href="https://rdar.apple.com/171685583">rdar://171685583</a>

Reviewed by Dan Glastonbury.

Avoid using the client buffer path when reading pixels to PBO.
The legacy wipeAlphaChannelFromPixels would be run if PBO was
read to with an offset.

Test: webgl/readpixels-pbo-offset-validation.html

* LayoutTests/webgl/readpixels-pbo-offset-validation-expected.txt: Added.
* LayoutTests/webgl/readpixels-pbo-offset-validation.html: Added.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::readPixelsBufferObject):

Originally-landed-as: 305413.554@rapid/safari-7624.2.5.110-branch (50c79b41fc8e). <a href="https://rdar.apple.com/176061698">rdar://176061698</a>
Canonical link: <a href="https://commits.webkit.org/315324@main">https://commits.webkit.org/315324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5db482b0f863d15b685b5d0c1fc29c682322af4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126324 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131266 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171578 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32713 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31413 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26644 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180550 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139709 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42188 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139565 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37597 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42876 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27917 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106562 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34846 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114636 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41380 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6000 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40777 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41028 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->