### PR TITLE
postMessage can indefinitely extend the lifetime of a user gesture token

### DIFF
--- a/LayoutTests/fast/events/popup-blocked-after-user-gesture-is-expired-after-post-message-expected.txt
+++ b/LayoutTests/fast/events/popup-blocked-after-user-gesture-is-expired-after-post-message-expected.txt
@@ -1,0 +1,4 @@
+This tests opening a window after a series of postMessage with a delay. WebKit should prevent a popup window from being opened after 1s.
+
+Start test
+PASS

--- a/LayoutTests/fast/events/popup-blocked-after-user-gesture-is-expired-after-post-message.html
+++ b/LayoutTests/fast/events/popup-blocked-after-user-gesture-is-expired-after-post-message.html
@@ -1,0 +1,47 @@
+<html><!-- webkit-test-runner [ JavaScriptCanOpenWindowsAutomatically=false ] -->
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function start()
+{
+    if (!window.testRunner)
+        return;
+    UIHelper.activateElement(target);
+}
+
+window.didOpenWindow = false;
+function runTest(target)
+{
+    postMessageLoop(() => {
+        const newWindow = window.open('about:blank', '_blank');
+        if (newWindow && newWindow.document) {
+            newWindow.document.open();
+            newWindow.document.write('<!DOCTYPE html><body><script>opener.didOpenWindow = true;</' + 'script>');
+        }
+        result.textContent = didOpenWindow ? 'FAIL - window did open' : 'PASS';
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+}
+
+function postMessageLoop(callback)
+{
+    const start = Date.now();
+    window.onmessage = function () {
+        if (Date.now() > start + 2000)
+            return callback();
+        postMessage({}, '*');
+    };
+    postMessage({}, '*');
+}
+
+</script>
+<body onload="start()">
+<p>This tests opening a window after a series of postMessage with a delay. WebKit should prevent a popup window from being opened after 1s.</p>
+<a id="target" href="#" onclick="runTest(event.target); event.preventDefault();">Start test</a>
+<div id="result"></div>

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1001,6 +1001,9 @@ void LocalDOMWindow::processPostMessage(JSC::JSGlobalObject& lexicalGlobalObject
         auto& vm = globalObject->vm();
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
+        if (userGestureToForward && userGestureToForward->hasExpired(UserGestureToken::maximumIntervalForUserGestureForwarding))
+            userGestureToForward = nullptr;
+
         UserGestureIndicator userGestureIndicator(userGestureToForward);
         InspectorInstrumentation::willDispatchPostMessage(frame, postMessageIdentifier);
 


### PR DESCRIPTION
#### cfbce92003b43e255d602b612edd120c86b83ca3
<pre>
postMessage can indefinitely extend the lifetime of a user gesture token
<a href="https://bugs.webkit.org/show_bug.cgi?id=310863">https://bugs.webkit.org/show_bug.cgi?id=310863</a>
<a href="https://rdar.apple.com/173355201">rdar://173355201</a>

Reviewed by Chris Dumez.

Clear the user gesture token if it has been expired after postMessage.

Test: fast/events/popup-blocked-after-user-gesture-is-expired-after-post-message.html

* LayoutTests/fast/events/popup-blocked-after-user-gesture-is-expired-after-post-message-expected.txt: Added.
* LayoutTests/fast/events/popup-blocked-after-user-gesture-is-expired-after-post-message.html: Added.
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::processPostMessage):

Originally-landed-as: 305413.591@rapid/safari-7624.2.5.110-branch (cb335a3aea4b). <a href="https://rdar.apple.com/176061151">rdar://176061151</a>
Canonical link: <a href="https://commits.webkit.org/314124@main">https://commits.webkit.org/314124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57edc31a6dbed618108921a5a918541aaecee233

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122384 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128323 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29684 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28304 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21924 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176692 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29576 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27786 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136641 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136583 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36828 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147877 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101684 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31861 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24744 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37886 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110958 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37283 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2821 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37529 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->