### PR TITLE
Cherry-pick(s) 9ada70cfc7e7. rdar://176059087

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1172,7 +1172,11 @@ void NODELETE secureZeroSpan(std::span<T, Extent> destination)
 #ifdef __STDC_LIB_EXT1__
     memset_s(destination.data(), destination.size_bytes(), 0, destination.size_bytes()); // NOLINT
 #else
+<<<<<<< HEAD
     memset(destination.data(), 0, destination.size_bytes()); // NOLINT
+=======
+    memset(destination.data(), byte, destination.size_bytes()); // NOLINT
+>>>>>>> 9ada70cfc7e7 (Use asm volatile annotation instead of volatile cast for memset)
     // Prevent the compiler from eliding the memset as a dead store.
     // Without this barrier, the compiler may prove that no well-defined
     // read follows and optimize away the write.


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176059087 to main. [9ada70cfc7e7] caused a merge conflict. 

```Use asm volatile annotation instead of volatile cast for memset
<https://bugs.webkit.org/show_bug.cgi?id=311783>
<rdar://171889004>

Reviewed by Gerald Squelart.

Use an asm volatile annotaion to guide the compiler to not eliminate the memset call.

Change it from a volatile cast as that was causing additional instructions to be
emitted and caused a slight perf regression on some hot paths.

No new tests, as no change in functionality.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::secureMemsetSpan):

Originally-landed-as: 305413.646@rapid/safari-7624.2.5.110-branch (9ada70cfc7e7). rdar://176059087

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec798ceb963c7302eb1f275302604e2353520e58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165134 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38625 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32202 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174176 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122391 "Hash ec798ceb for PR 65941 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38959 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38626 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/174176 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/122391 "Hash ec798ceb for PR 65941 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168093 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/38959 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/32202 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/174176 "Hash ec798ceb for PR 65941 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/38959 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/38626 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21931 "Hash ec798ceb for PR 65941 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157293 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/38959 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/32202 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176699 "Hash ec798ceb for PR 65941 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26029 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29572 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/32202 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/176699 "Hash ec798ceb for PR 65941 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38693 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/38626 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/176699 "Hash ec798ceb for PR 65941 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39383 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/32202 "Hash ec798ceb for PR 65941 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101691 "Built successfully") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/39383 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/32202 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197537 "Hash ec798ceb for PR 65941 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37893 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110965 "Failed to build and analyze WebKit") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/197537 "Hash ec798ceb for PR 65941 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37290 "Hash ec798ceb for PR 65941 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/32202 "Hash ec798ceb for PR 65941 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37536 "Hash ec798ceb for PR 65941 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37434 "Hash ec798ceb for PR 65941 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->