### PR TITLE
[IndexedDB] IDBKeyData operator== and operator<=> define different equivalence classes

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
@@ -256,8 +256,10 @@ std::weak_ordering operator<=>(const IDBKeyData& a, const IDBKeyData& b)
     if (aType == IndexedDB::KeyType::Invalid) {
         if (bType != IndexedDB::KeyType::Invalid)
             return std::weak_ordering::less;
-        if (bType == IndexedDB::KeyType::Invalid)
-            return std::weak_ordering::equivalent;
+        // Distinguish nullptr_t and Invalid{} to match operator==.
+        if (a.isNull() != b.isNull())
+            return a.isNull() ? std::weak_ordering::less : std::weak_ordering::greater;
+        return std::weak_ordering::equivalent;
     } else if (bType == IndexedDB::KeyType::Invalid)
         return std::weak_ordering::greater;
 
@@ -282,9 +284,15 @@ std::weak_ordering operator<=>(const IDBKeyData& a, const IDBKeyData& b)
     }
     case IndexedDB::KeyType::Binary:
         return compareBinaryKeyData(std::get<ThreadSafeDataBuffer>(a.m_value), std::get<ThreadSafeDataBuffer>(b.m_value));
-    case IndexedDB::KeyType::String:
-        return codePointCompare(std::get<String>(a.m_value), std::get<String>(b.m_value));
-    case IndexedDB::KeyType::Date:
+    case IndexedDB::KeyType::String: {
+        auto& aStr = std::get<String>(a.m_value);
+        auto& bStr = std::get<String>(b.m_value);
+        // Distinguish null String from empty String to match operator==;
+        // codePointCompare treats them as equivalent.
+        if (aStr.isNull() != bStr.isNull())
+            return aStr.isNull() ? std::weak_ordering::less : std::weak_ordering::greater;
+        return codePointCompare(aStr, bStr);
+    } case IndexedDB::KeyType::Date:
         return weakOrderingCast(std::get<IDBKeyData::Date>(a.m_value).value <=> std::get<IDBKeyData::Date>(b.m_value).value);
     case IndexedDB::KeyType::Number:
         return weakOrderingCast(std::get<double>(a.m_value) <=> std::get<double>(b.m_value));

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.h
@@ -99,11 +99,11 @@ public:
     bool isNull() const { return std::holds_alternative<std::nullptr_t>(m_value); }
     bool isValid() const;
     WEBCORE_EXPORT static bool isValidValue(const ValueVariant&);
-    IndexedDB::KeyType NODELETE type() const;
+    WEBCORE_EXPORT IndexedDB::KeyType type() const;
 
     WEBCORE_EXPORT friend std::weak_ordering operator<=>(const IDBKeyData&, const IDBKeyData&);
 
-    bool operator==(const IDBKeyData& other) const;
+    WEBCORE_EXPORT bool operator==(const IDBKeyData& other) const;
 
     String string() const
     {

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -222,6 +222,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/GridPosition.cpp
         Tests/WebCore/HTMLParserIdioms.cpp
         Tests/WebCore/HTTPParsers.cpp
+        Tests/WebCore/IDBKeyData.cpp
         Tests/WebCore/IDBSerializationTest.cpp
         Tests/WebCore/ImageBufferTests.cpp
         Tests/WebCore/IntPointTests.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -716,6 +716,7 @@
 				WebCore/HTTPHeaderMap.cpp,
 				WebCore/HTTPParsers.cpp,
 				WebCore/HysteresisActivityTests.cpp,
+				WebCore/IDBKeyData.cpp,
 				WebCore/IDBSerializationTest.cpp,
 				WebCore/ImageBufferTests.cpp,
 				WebCore/IntPointTests.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/IDBKeyData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IDBKeyData.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Helpers/Test.h"
+#include <WebCore/IDBKeyData.h>
+#include <wtf/StdSet.h>
+
+using namespace WebCore;
+
+namespace TestWebKitAPI {
+
+TEST(IDBKeyData, NullAndInvalidAreNotEquivalentInvalidKey)
+{
+    IDBKeyData null;
+    IDBKeyData invalid(IDBKeyData::Invalid { });
+
+    EXPECT_TRUE(null.isNull());
+    EXPECT_FALSE(invalid.isNull());
+    EXPECT_EQ(null.type(), IndexedDB::KeyType::Invalid);
+    EXPECT_EQ(invalid.type(), IndexedDB::KeyType::Invalid);
+
+    // operator== and operator<=> must agree: these are not equal.
+    EXPECT_NE(null, invalid);
+    EXPECT_TRUE(is_neq(null <=> invalid));
+
+    // Reflexivity.
+    EXPECT_EQ(null, null);
+    EXPECT_EQ(invalid, invalid);
+}
+
+TEST(IDBKeyData, NullStringAndEmptyStringAreNotEquivalentStringKey)
+{
+    IDBKeyData nullStr(String { });
+    IDBKeyData emptyStr(emptyString());
+
+    EXPECT_TRUE(std::get<String>(nullStr.value()).isNull());
+    EXPECT_FALSE(std::get<String>(emptyStr.value()).isNull());
+
+    // operator== and operator<=> must agree: these are not equal.
+    EXPECT_NE(nullStr, emptyStr);
+    EXPECT_TRUE(is_neq(nullStr <=> emptyStr));
+
+    // Two null-string keys are equal.
+    IDBKeyData nullStr2(String { });
+    EXPECT_EQ(nullStr, nullStr2);
+
+    // Two empty-string keys are equal.
+    IDBKeyData emptyStr2(emptyString());
+    EXPECT_EQ(emptyStr, emptyStr2);
+}
+
+TEST(IDBKeyData, SetDistinguishesNullAndInvalid)
+{
+    IDBKeyData null;
+    IDBKeyData invalid(IDBKeyData::Invalid { });
+
+    IDBKeyDataSet set;
+    set.insert(null);
+    set.insert(invalid);
+    EXPECT_EQ(set.size(), 2u);
+}
+
+TEST(IDBKeyData, SetDistinguishesNullStringAndEmptyString)
+{
+    IDBKeyData nullStr(String { });
+    IDBKeyData emptyStr(emptyString());
+
+    IDBKeyDataSet set;
+    set.insert(nullStr);
+    set.insert(emptyStr);
+    EXPECT_EQ(set.size(), 2u);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### d919344236c47b610930636d3310f00380624d43
<pre>
[IndexedDB] IDBKeyData operator== and operator&lt;=&gt; define different equivalence classes
<a href="https://rdar.apple.com/174327363">rdar://174327363</a>

Reviewed by Brady Eidson.

IDBKeyData::operator== and IDBKeyData::operator&lt;=&gt; currently disagree in two cases:
1. String-typed keys: operator== (via WTF::String::operator==) distinguishes null String from empty String, but
operator&lt;=&gt; (via codePointCompare) treats them as equivalent.
2. Invalid-typed keys: operator== checks isNull() to distinguish nullptr_t from Invalid{}, but operator&lt;=&gt; treats all
Invalid-typed keys as equivalent.

This could cause inconsistency in containers of MemoryIDBBackingStore, specifically HashMap keyed by operator== and
std::set ordered by operator&lt;=&gt;, and defeats cursor-invalidation guards (which compare with operator== while erases use
operator&lt;). This patch makes sure IDBKeyData::operator&lt;=&gt; match IDBKeyData::operator== for equality check.

API tests: IDBKeyData.NullAndInvalidAreNotEquivalentInvalidKey
           IDBKeyData.NullStringAndEmptyStringAreNotEquivalentStringKey
           IDBKeyData.SetDistinguishesNullAndInvalid
           IDBKeyData.SetDistinguishesNullStringAndEmptyString

* Source/WebCore/Modules/indexeddb/IDBKeyData.cpp:
(WebCore::operator&lt;=&gt;):
* Source/WebCore/Modules/indexeddb/IDBKeyData.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/IDBKeyData.cpp: Added.
(TestWebKitAPI::TEST(IDBKeyData, NullAndInvalidAreNotEquivalentInvalidKey)):
(TestWebKitAPI::TEST(IDBKeyData, NullStringAndEmptyStringAreNotEquivalentStringKey)):
(TestWebKitAPI::TEST(IDBKeyData, SetDistinguishesNullAndInvalid)):
(TestWebKitAPI::TEST(IDBKeyData, SetDistinguishesNullStringAndEmptyString)):

Originally-landed-as: 305413.663@safari-7624-branch (3efb02c6bee1). <a href="https://rdar.apple.com/176058928">rdar://176058928</a>
Canonical link: <a href="https://commits.webkit.org/314463@main">https://commits.webkit.org/314463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a9723904d4999584157844630b6a8e59354013f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166147 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175194 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123402 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168013 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129135 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109661 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30490 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29181 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23335 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177727 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30629 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137482 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137410 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37032 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148772 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102997 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25639 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38905 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111979 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38302 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3725 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->