### PR TITLE
CreateModelPlayer Uses ASSERT Instead of MESSAGE_CHECK for Duplicate Identifier

### DIFF
--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
@@ -31,6 +31,8 @@
 #include "ModelProcessModelPlayerProxy.h"
 #include <wtf/TZoneMallocInlines.h>
 
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_modelConnectionToWebProcess->connection())
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -67,7 +69,7 @@ void ModelProcessModelPlayerManagerProxy::createModelPlayer(WebCore::ModelPlayer
 {
     ASSERT(RunLoop::isMain());
     ASSERT(m_modelConnectionToWebProcess);
-    ASSERT(!m_proxies.contains(identifier));
+    MESSAGE_CHECK(!m_proxies.contains(identifier));
 
     auto proxy = ModelProcessModelPlayerProxy::create(*this, identifier, protect(m_modelConnectionToWebProcess->connection()), m_modelConnectionToWebProcess->attributionTaskID(), m_modelConnectionToWebProcess->debugEntityMemoryLimit());
     m_proxies.add(identifier, WTF::move(proxy));
@@ -76,6 +78,7 @@ void ModelProcessModelPlayerManagerProxy::createModelPlayer(WebCore::ModelPlayer
 void ModelProcessModelPlayerManagerProxy::deleteModelPlayer(WebCore::ModelPlayerIdentifier identifier)
 {
     ASSERT(RunLoop::isMain());
+    MESSAGE_CHECK(m_proxies.contains(identifier));
 
     if (auto proxy = m_proxies.take(identifier))
         proxy->invalidate();
@@ -87,6 +90,7 @@ void ModelProcessModelPlayerManagerProxy::deleteModelPlayer(WebCore::ModelPlayer
 void ModelProcessModelPlayerManagerProxy::unloadModelPlayer(WebCore::ModelPlayerIdentifier identifier)
 {
     ASSERT(RunLoop::isMain());
+    MESSAGE_CHECK(m_proxies.contains(identifier));
 
     deleteModelPlayer(identifier);
     m_modelConnectionToWebProcess->didUnloadModelPlayer(identifier);
@@ -105,5 +109,7 @@ void ModelProcessModelPlayerManagerProxy::didReceivePlayerMessage(IPC::Connectio
 }
 
 } // namespace WebKit
+
+#undef MESSAGE_CHECK
 
 #endif // ENABLE(MODEL_PROCESS)


### PR DESCRIPTION
#### 69ff7c4b9138edacf991e467eaec1820d2d075f4
<pre>
CreateModelPlayer Uses ASSERT Instead of MESSAGE_CHECK for Duplicate Identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=311574">https://bugs.webkit.org/show_bug.cgi?id=311574</a>
<a href="https://rdar.apple.com/172394870">rdar://172394870</a>

Reviewed by Mike Wyrzykowski.

Switch from ASSERT to MESSAGE_CHECK to make sure it checks in release builds

* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp:
(WebKit::ModelProcessModelPlayerManagerProxy::createModelPlayer):

Originally-landed-as: 305413.626@rapid/safari-7624.2.5.110-branch (c164990e07cc). <a href="https://rdar.apple.com/176059166">rdar://176059166</a>
Canonical link: <a href="https://commits.webkit.org/314126@main">https://commits.webkit.org/314126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f5c6b9b3fe5c8e5ed68070477e61d05a49a738c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174178 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122393 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128329 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108854 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29687 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28311 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21933 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139582 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176701 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29574 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136647 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136589 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36829 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147884 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101693 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31868 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24751 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110967 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37292 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2828 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->