### PR TITLE
Heap needs to protect swaped JSString Impls for GCOwnedDataScope

### DIFF
--- a/JSTests/stress/stringProtoFuncAt-GCOwnedDataScope-atomstring-swap.js
+++ b/JSTests/stress/stringProtoFuncAt-GCOwnedDataScope-atomstring-swap.js
@@ -1,0 +1,25 @@
+const target = "A".repeat(128);
+const dummy = {};
+Reflect.set(dummy, target, 1);
+
+const freshRope = "A".repeat(128);
+
+let nonAtom = "D".repeat(64) + "D".repeat(64);
+String.prototype.at.call(nonAtom, 0);
+
+let thatObj = {
+    [Symbol.toPrimitive]() {
+        // Trigger atomization via Reflect.set to avoid Inline Cache holding the string
+        Reflect.set(dummy, freshRope, 1);
+
+        // Overwrite the VM's lastAtomizedIdentifierStringImpl cache
+        Reflect.set(dummy, nonAtom, 1);
+
+        gc();
+
+        return 0;
+    }
+};
+
+// Verify that GCOwnedDataScope/Heap keeps the StringImpl alive across the callback
+String.prototype.at.call(freshRope, thatObj);

--- a/JSTests/stress/stringProtoFuncEndsWith-GCOwnedDataScope-atomstring-swap.js
+++ b/JSTests/stress/stringProtoFuncEndsWith-GCOwnedDataScope-atomstring-swap.js
@@ -1,0 +1,23 @@
+const target = "A".repeat(128);
+const dummy = {};
+Reflect.set(dummy, target, 1);
+
+const freshRope = "A".repeat(128);
+
+let nonAtom = "D".repeat(64) + "D".repeat(64);
+String.prototype.endsWith.call(nonAtom, "E");
+
+let thatObj = {
+    toString() {
+        // Trigger atomization via Reflect.set to avoid Inline Cache holding the string
+        Reflect.set(dummy, freshRope, 1);
+        // Overwrite the VM's lastAtomizedIdentifierStringImpl cache
+        Reflect.set(dummy, nonAtom, 1);
+
+        gc();
+        return "B";
+    }
+};
+
+// Verify that GCOwnedDataScope/Heap keeps the StringImpl alive across the callback
+String.prototype.endsWith.call(freshRope, thatObj);

--- a/JSTests/stress/stringProtoFuncLocaleCompare-GCOwnedDataScope-atomstring-swap.js
+++ b/JSTests/stress/stringProtoFuncLocaleCompare-GCOwnedDataScope-atomstring-swap.js
@@ -1,0 +1,23 @@
+const target = "A".repeat(128);
+const dummy = {};
+Reflect.set(dummy, target, 1);
+
+const freshRope = "A".repeat(128);
+
+let nonAtom = "D".repeat(64) + "D".repeat(64);
+String.prototype.localeCompare.call(nonAtom, "E");
+
+let thatObj = {
+    toString() {
+        // Trigger atomization via Reflect.set to avoid Inline Cache holding the string
+        Reflect.set(dummy, freshRope, 1);
+        // Overwrite the VM's lastAtomizedIdentifierStringImpl cache
+        Reflect.set(dummy, nonAtom, 1);
+
+        gc();
+        return "B";
+    }
+};
+
+// Verify that GCOwnedDataScope/Heap keeps the StringImpl alive across the callback
+String.prototype.localeCompare.call(freshRope, thatObj);

--- a/JSTests/stress/stringProtoFuncStartsWith-GCOwnedDataScope-atomstring-swap.js
+++ b/JSTests/stress/stringProtoFuncStartsWith-GCOwnedDataScope-atomstring-swap.js
@@ -1,0 +1,23 @@
+const target = "A".repeat(128);
+const dummy = {};
+Reflect.set(dummy, target, 1);
+
+const freshRope = "A".repeat(128);
+
+let nonAtom = "D".repeat(64) + "D".repeat(64);
+String.prototype.startsWith.call(nonAtom, "E");
+
+let thatObj = {
+    toString() {
+        // Trigger atomization via Reflect.set to avoid Inline Cache holding the string
+        Reflect.set(dummy, freshRope, 1);
+        // Overwrite the VM's lastAtomizedIdentifierStringImpl cache
+        Reflect.set(dummy, nonAtom, 1);
+
+        gc();
+        return "B";
+    }
+};
+
+// Verify that GCOwnedDataScope/Heap keeps the StringImpl alive across the callback
+String.prototype.startsWith.call(freshRope, thatObj);

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -4698,6 +4698,7 @@
 		53F40E921D5A4AB30099A1B6 /* WasmOMGIRGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmOMGIRGenerator.h; sourceTree = "<group>"; };
 		53F6BF6C1C3F060A00F41E5D /* InternalFunctionAllocationProfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InternalFunctionAllocationProfile.h; sourceTree = "<group>"; };
 		53F9DD762BEFD76D004A17B7 /* GCOwnedDataScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GCOwnedDataScope.h; sourceTree = "<group>"; };
+		53F9DD782BEFD76D004A17B7 /* GCOwnedDataScope.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GCOwnedDataScope.cpp; sourceTree = "<group>"; };
 		53FA2AE01CF37F3F0022711D /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LLIntPrototypeLoadAdaptiveStructureWatchpoint.h; sourceTree = "<group>"; };
 		53FA2AE21CF380390022711D /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp; sourceTree = "<group>"; };
 		53FD04D11D7AB187003287D3 /* WasmCallingConvention.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmCallingConvention.cpp; sourceTree = "<group>"; };
@@ -7647,6 +7648,7 @@
 				2ADFA26218EF3540004F9FCC /* GCLogging.cpp */,
 				2AABCDE618EF294200002096 /* GCLogging.h */,
 				5272987B235FC8BA005C982C /* GCMemoryOperations.h */,
+				53F9DD782BEFD76D004A17B7 /* GCOwnedDataScope.cpp */,
 				53F9DD762BEFD76D004A17B7 /* GCOwnedDataScope.h */,
 				0F97152E1EB28BE900A1645D /* GCRequest.cpp */,
 				0F97152F1EB28BE900A1645D /* GCRequest.h */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -535,6 +535,7 @@ heap/FreeList.cpp
 heap/GCActivityCallback.cpp
 heap/GCConductor.cpp
 heap/GCLogging.cpp
+heap/GCOwnedDataScope.cpp
 heap/GCRequest.cpp
 heap/GCSegmentedArray.cpp
 heap/GigacageAlignedMemoryAllocator.cpp

--- a/Source/JavaScriptCore/heap/ConservativeRoots.cpp
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.cpp
@@ -31,6 +31,7 @@
 #include "CodeBlockSetInlines.h"
 #include "JITStubRoutineSet.h"
 #include "JSCast.h"
+#include "JSString.h"
 #include "MarkedBlockInlines.h"
 #include "WasmCallee.h"
 #include <wtf/OSAllocator.h>
@@ -161,7 +162,15 @@ inline void ConservativeRoots::genericAddPointer(char* pointer, HeapVersion mark
         // Only return early if we are marking a non-butterfly, since butterflies without indexed properties could point past the end of their allocation.
         // If we do, and there is another live butterfly immediately following the first, we will mark the latter one here but we still need to
         // mark the former.
-        return isLive && !mayHaveIndexingHeader(cellKind);
+        if (isLive && !mayHaveIndexingHeader(cellKind)) {
+            static_assert(!JSString::numberOfLowerTierPreciseCells && !JSRopeString::numberOfLowerTierPreciseCells, "We only check for strings in MarkedBlocks so Strings better not have precise allocations");
+            // Since we're looking for strings we only need to check if we know we're not looking at an allocation with an IndexingHeader.
+            // FIXME: If we wanted to make this more performant we could have a JSString HeapCell::Kind or embed the JSType in the MarkedBlock::Handle.
+            if (auto* string = dynamicDowncast<const JSString>(std::bit_cast<const JSCell*>(pointer)))
+                m_heap.m_discoveredAccessedStringsFromGCOwnedDataScope.add(string);
+            return true;
+        }
+        return false;
     };
 
     if (isJSCellKind(cellKind)) {

--- a/Source/JavaScriptCore/heap/GCOwnedDataScope.cpp
+++ b/Source/JavaScriptCore/heap/GCOwnedDataScope.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GCOwnedDataScope.h"
+
+#include "HeapCellInlines.h"
+
+namespace JSC {
+
+#if ASSERT_ENABLED
+
+void setTopGCOwnedDataScopeIfNeeded(const JSCell* cell, const void* scope)
+{
+    if (!cell)
+        return;
+    if (!cell->vm().heap.m_topGCOwnedDataScope)
+        cell->vm().heap.m_topGCOwnedDataScope = scope;
+}
+
+void clearTopGCOwnedDataScopeIfNeeded(const JSCell* cell, const void* scope)
+{
+    if (!cell)
+        return;
+    if (cell->vm().heap.m_topGCOwnedDataScope == scope)
+        cell->vm().heap.m_topGCOwnedDataScope = nullptr;
+}
+
+#endif // ASSERT_ENABLED
+
+} // namespace JSC
+

--- a/Source/JavaScriptCore/heap/GCOwnedDataScope.h
+++ b/Source/JavaScriptCore/heap/GCOwnedDataScope.h
@@ -26,11 +26,16 @@
 #pragma once
 
 #include <JavaScriptCore/EnsureStillAliveHere.h>
+#include <JavaScriptCore/JSCell.h>
+#include <JavaScriptCore/VM.h>
 #include <wtf/text/StringView.h>
 
 namespace JSC {
 
-class JSCell;
+#if ASSERT_ENABLED
+JS_EXPORT_PRIVATE void setTopGCOwnedDataScopeIfNeeded(const JSCell* cell, const void* scope);
+JS_EXPORT_PRIVATE void clearTopGCOwnedDataScopeIfNeeded(const JSCell* cell, const void* scope);
+#endif
 
 // This class is used return data owned by a JSCell. Consider:
 // int foo(JSString* jsString)
@@ -74,9 +79,19 @@ public:
     GCOwnedDataScope(const JSCell* cell, T value)
         : owner(cell)
         , data(value)
-    { }
+    {
+#if ASSERT_ENABLED
+        setTopGCOwnedDataScopeIfNeeded(owner, this);
+#endif
+    }
 
-    ~GCOwnedDataScope() { ensureStillAliveHere(owner); }
+    ~GCOwnedDataScope()
+    {
+#if ASSERT_ENABLED
+        clearTopGCOwnedDataScopeIfNeeded(owner, this);
+#endif
+        ensureStillAliveHere(owner);
+    }
 
     operator const T() const LIFETIME_BOUND { return data; }
     operator T() LIFETIME_BOUND { return data; }

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1238,6 +1238,33 @@ void Heap::addToRememberedSet(const JSCell* constCell)
     m_mutatorMarkStack->append(cell);
 }
 
+void Heap::clearConcurrentRetainedDataIfPossible()
+{
+
+    // FIXME: It's weird that we drive the runloop in the middle of a JS stack. But a few places in WebCore testing/debugger code do that so clearing would otherwise be invalid there. This is technically not strong enough to catch any bad code but it seems to work for the testing/debugger code in question.
+    if (vm().entryScope) [[unlikely]]
+        return;
+
+    // It wouldn't be safe to clear the list if it's possible to have a GCOwnedDataScope on the stack since
+    // m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope
+    // is what's keeping the backing bytes alive.
+    ASSERT(!m_topGCOwnedDataScope);
+
+    if (!m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope.size())
+        return;
+#if ENABLE(JIT)
+    auto* worklist = JITWorklist::existingGlobalWorklistOrNull();
+    // We need to make sure no JIT thread could be looking at one of our old strings. Any thread that starts after
+    // this check will load the new StringImpl rather than the one in this list so we're safe to delete these as
+    // long as none were running at the time of this check.
+    if (!worklist || !worklist->totalOngoingCompilations()) {
+#else
+    {
+#endif
+        m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope.clear();
+    }
+}
+
 void Heap::sweepSynchronously()
 {
     if (!Options::useGC()) [[unlikely]]
@@ -2322,7 +2349,10 @@ void Heap::finalize()
     vm().stringSplitCache.clear();
     vm().jsonAtomStringCache.clearJSStrings();
 
-    m_possiblyAccessedStringsFromConcurrentThreads.clear();
+    m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope.removeAllMatching([&](const auto& iter) {
+        return !m_discoveredAccessedStringsFromGCOwnedDataScope.contains(iter.first);
+    });
+    m_discoveredAccessedStringsFromGCOwnedDataScope.clear();
 
     immutableButterflyToStringCache.clear();
     
@@ -3018,7 +3048,6 @@ void Heap::addCoreConstraints()
                 // If we tried to scan while not under a safepoint we could stop a thread that's in the process of calling
                 // one of the callees we are looking for.
                 // FIXME: Should we have two constraints for this? One for concurrent and one under safepoint at the bitter end.
-                // TODO: Verify this part only runs on one thread.
                 ASSERT(worldIsStopped());
                 ConservativeRoots conservativeRoots(*this);
 

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -55,6 +55,7 @@
 #include <wtf/Markable.h>
 #include <wtf/NotFound.h>
 #include <wtf/ParallelHelperPool.h>
+#include <wtf/SegmentedVector.h>
 #include <wtf/Threading.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -626,10 +627,12 @@ public:
     void setKeepVerifierSlotVisitor();
     void clearVerifierSlotVisitor();
 
-    void appendPossiblyAccessedStringFromConcurrentThreads(String&& string)
+    void appendPossiblyAccessedStringFromConcurrentThreadsOrGCOwnedDataScope(const JSString* owner, String&& string)
     {
-        m_possiblyAccessedStringsFromConcurrentThreads.append(WTF::move(string));
+        m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope.constructAndAppend(owner, WTF::move(string));
     }
+
+    void clearConcurrentRetainedDataIfPossible();
 
     bool isInPhase(CollectorPhase phase) const { return m_currentPhase == phase; }
 
@@ -926,7 +929,16 @@ private:
     Vector<WeakBlock*> m_logicallyEmptyWeakBlocks;
     size_t m_indexOfNextLogicallyEmptyWeakBlockToSweep { WTF::notFound };
 
-    Vector<String> m_possiblyAccessedStringsFromConcurrentThreads;
+#if ASSERT_ENABLED
+    friend void setTopGCOwnedDataScopeIfNeeded(const JSCell*, const void*);
+    friend void clearTopGCOwnedDataScopeIfNeeded(const JSCell*, const void*);
+    const void* m_topGCOwnedDataScope { nullptr };
+#endif
+    // Use a SegmentedVector rather than a Vector because we don't want to have to copy in order to grow the buffer.
+    // Since this list is walked once to deref all the strings
+    // We don't need fast access.
+    SegmentedVector<std::pair<const JSString*, String>, 256, 10, SegmentedVectorGrowthPolicy::Doubling> m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope;
+   UncheckedKeyHashSet<const JSString*> m_discoveredAccessedStringsFromGCOwnedDataScope;
     
     RefPtr<GCActivityCallback> m_fullActivityCallback;
     RefPtr<GCActivityCallback> m_edenActivityCallback;

--- a/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
@@ -74,6 +74,8 @@ void IncrementalSweeper::doSweep(VM& vm, MonotonicTime deadline, SweepTrigger tr
     if (Options::useTracePoints()) [[unlikely]]
         traceScope.emplace(IncrementalSweepStart, IncrementalSweepEnd, vm.heap.size(), vm.heap.capacity());
 
+    vm.heap.clearConcurrentRetainedDataIfPossible();
+
     while (sweepNextBlock(vm, trigger)) {
         if (MonotonicTime::now() < deadline)
             continue;

--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -206,6 +206,12 @@ size_t JITWorklist::queueLength(const AbstractLocker&) const
     return queueLength;
 }
 
+size_t JITWorklist::totalOngoingCompilations() const
+{
+    Locker locker { *m_lock };
+    return totalOngoingCompilations(locker);
+}
+
 size_t JITWorklist::totalOngoingCompilations(const AbstractLocker&) const
 {
     size_t total = 0;

--- a/Source/JavaScriptCore/jit/JITWorklist.h
+++ b/Source/JavaScriptCore/jit/JITWorklist.h
@@ -86,6 +86,8 @@ public:
 
     void dump(PrintStream&) const;
 
+    size_t totalOngoingCompilations() const;
+
 private:
     JITWorklist();
 

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -850,15 +850,19 @@ ALWAYS_INLINE Identifier JSRopeString::toIdentifier(JSGlobalObject* globalObject
 
 ALWAYS_INLINE void JSString::swapToAtomString(VM& vm, RefPtr<AtomStringImpl>&& atom) const
 {
-    // We replace currently held string with new AtomString. But the old string can be accessed from concurrent compilers and GC threads at any time.
-    // So, we keep the old string alive by appending it to Heap::m_possiblyAccessedStringsFromConcurrentThreads. And GC clears that list when GC finishes.
-    // This is OK since (1) when finishing GC concurrent compiler threads and GC threads are stopped, and (2) AtomString is already held in the atom table,
-    // and we anyway keep this old string until this JSString* is GC-ed. So it does not increase any memory pressure, we release at the same timing.
+    // When we swap a JSString's value to an AtomString, the old StringImpl can still be accessed
+    // by concurrent JIT compiler threads, GC threads, or via GCOwnedDataScope references on the stack.
+    // We keep the old string alive by appending it (paired with its owning JSString*) to
+    // Heap::m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope.
+    // During GC, conservative root scanning discovers which JSStrings are still on the stack; at GC
+    // end we prune entries whose JSString was not discovered. Between GCs,
+    // Heap::clearConcurrentRetainedDataIfPossible clears the vector entirely when no JS is executing
+    // and no JIT compilations are in progress.
     ASSERT(!isCompilationThread() && !Thread::mayBeGCThread());
     String target(WTF::move(atom));
     WTF::storeStoreFence(); // Ensure AtomStringImpl's string is fully initialized when it is exposed to concurrent threads.
     valueInternal().swap(target);
-    vm.heap.appendPossiblyAccessedStringFromConcurrentThreads(WTF::move(target));
+    vm.heap.appendPossiblyAccessedStringFromConcurrentThreadsOrGCOwnedDataScope(this, WTF::move(target));
 }
 
 ALWAYS_INLINE Identifier JSString::toIdentifier(JSGlobalObject* globalObject) const

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -127,7 +127,8 @@ template<typename, size_t = 0> class Deque;
 template<typename Key, typename, Key> class EnumeratedArray;
 template<typename> class EnumSet;
 template<typename, typename = EmbeddedFixedVectorMalloc> class FixedVector;
-template<typename, size_t = 8, size_t = 0, typename = SegmentedVectorMalloc> class SegmentedVector;
+enum class SegmentedVectorGrowthPolicy : uint8_t { Constant, Doubling };
+template<typename, size_t = 8, size_t = 0, SegmentedVectorGrowthPolicy = SegmentedVectorGrowthPolicy::Constant, typename = SegmentedVectorMalloc> class SegmentedVector;
 template<typename> class Function;
 template<typename> struct FlatteningVariantTraits;
 template<typename> struct IsSmartPtr;
@@ -171,7 +172,7 @@ template<typename T, typename = NoTaggingTraits<T>> class ThreadSafeWeakPtr;
 template<typename T, typename = NoTaggingTraits<T>> class ThreadSafeWeakRef;
 
 template <typename T>
-using SaSegmentedVector = SegmentedVector<T, 8, 0, SequesteredArenaMalloc>;
+using SaSegmentedVector = SegmentedVector<T, 8, 0, SegmentedVectorGrowthPolicy::Constant, SequesteredArenaMalloc>;
 template <typename T>
 using SaFixedVector = FixedVector<T, SequesteredArenaMalloc>;
 template <typename T>

--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -35,13 +35,13 @@ namespace WTF {
     DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SegmentedVector);
 
     // An iterator for SegmentedVector. It supports only the pre ++ operator
-    template <typename T, size_t SegmentSize, size_t InlineCapacity, typename Malloc> class SegmentedVector;
-    template <typename T, size_t SegmentSize = 8, size_t InlineCapacity = 0, typename Malloc = SegmentedVectorMalloc> class SegmentedVectorIterator {
+    template <typename T, size_t SegmentSize, size_t InlineCapacity, SegmentedVectorGrowthPolicy GrowthPolicy, typename Malloc> class SegmentedVector;
+    template <typename T, size_t SegmentSize = 8, size_t InlineCapacity = 0, SegmentedVectorGrowthPolicy GrowthPolicy = SegmentedVectorGrowthPolicy::Constant, typename Malloc = SegmentedVectorMalloc> class SegmentedVectorIterator {
         WTF_MAKE_CONFIGURABLE_ALLOCATED(FastMalloc);
     private:
-        friend class SegmentedVector<T, SegmentSize, InlineCapacity, Malloc>;
+        friend class SegmentedVector<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc>;
     public:
-        typedef SegmentedVectorIterator<T, SegmentSize, InlineCapacity, Malloc> Iterator;
+        typedef SegmentedVectorIterator<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc> Iterator;
 
         using iterator_category = std::forward_iterator_tag;
         using value_type = T;
@@ -66,7 +66,7 @@ namespace WTF {
             return m_index == other.m_index && &m_vector == &other.m_vector;
         }
 
-        SegmentedVectorIterator& operator=(const SegmentedVectorIterator<T, SegmentSize, InlineCapacity, Malloc>& other)
+        SegmentedVectorIterator& operator=(const SegmentedVectorIterator<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc>& other)
         {
             m_vector = other.m_vector;
             m_index = other.m_index;
@@ -74,13 +74,13 @@ namespace WTF {
         }
 
     private:
-        SegmentedVectorIterator(SegmentedVector<T, SegmentSize, InlineCapacity, Malloc>& vector, size_t index)
+        SegmentedVectorIterator(SegmentedVector<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc>& vector, size_t index)
             : m_vector(vector)
             , m_index(index)
         {
         }
 
-        SegmentedVector<T, SegmentSize, InlineCapacity, Malloc>& m_vector;
+        SegmentedVector<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc>& m_vector;
         size_t m_index;
     };
 
@@ -95,16 +95,16 @@ namespace WTF {
     // small vectors. Additional elements are stored in heap-allocated segments
     // of SegmentSize elements each. Vectors with inline storage are not
     // movable, as moving would invalidate pointers to elements stored inline.
-    template <typename T, size_t SegmentSize, size_t InlineCapacity, typename Malloc>
+    template <typename T, size_t SegmentSize, size_t InlineCapacity, SegmentedVectorGrowthPolicy GrowthPolicy, typename Malloc>
     class SegmentedVector final {
-        friend class SegmentedVectorIterator<T, SegmentSize, InlineCapacity, Malloc>;
+        friend class SegmentedVectorIterator<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc>;
         WTF_MAKE_NONCOPYABLE(SegmentedVector);
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SegmentedVector);
 
         static constexpr bool hasInlineStorage = InlineCapacity > 0;
 
     public:
-        using Iterator = SegmentedVectorIterator<T, SegmentSize, InlineCapacity, Malloc>;
+        using Iterator = SegmentedVectorIterator<T, SegmentSize, InlineCapacity, GrowthPolicy, Malloc>;
 
         using value_type = T;
         using iterator = Iterator;
@@ -221,7 +221,7 @@ namespace WTF {
             size_t oldSize = m_size;
             m_size = size;
             for (size_t i = oldSize; i < m_size; ++i)
-                new (NotNull, &at(i)) T();
+                new (NotNull, addressAt(i)) T();
         }
 
         void clear()
@@ -236,10 +236,61 @@ namespace WTF {
 
         void shrinkToFit() { m_segments.shrinkToFit(); }
 
+        unsigned removeAllMatching(NOESCAPE const Invocable<bool(T&)> auto& matches)
+        {
+            unsigned writeIndex = 0;
+            unsigned matchCount = 0;
+            for (unsigned readIndex = 0; readIndex < m_size; ++readIndex) {
+                T* readPtr = addressAt(readIndex);
+                if (matches(*readPtr)) {
+                    std::destroy_at(readPtr);
+                    ++matchCount;
+                } else {
+                    if (writeIndex != readIndex) {
+                        T* writePtr = addressAt(writeIndex);
+                        new (NotNull, writePtr) T(WTF::move(*readPtr));
+                        std::destroy_at(readPtr);
+                    }
+                    ++writeIndex;
+                }
+            }
+            m_size = writeIndex;
+            shrinkToFit();
+            return matchCount;
+        }
+
     private:
+        struct SegmentLocation {
+            size_t segmentIndex;
+            size_t offsetInSegment;
+        };
+
+        ALWAYS_INLINE static SegmentLocation segmentLocationFor(size_t index)
+        {
+            if constexpr (GrowthPolicy == SegmentedVectorGrowthPolicy::Doubling) {
+                size_t n = index / SegmentSize + 1;
+                size_t segmentIndex = (sizeof(size_t) * CHAR_BIT - 1) - WTF::clz(n);
+                size_t offset = index - (SegmentSize * ((static_cast<size_t>(1) << segmentIndex) - 1));
+                return { segmentIndex, offset };
+            } else
+                return { index / SegmentSize, index % SegmentSize };
+        }
+
+        ALWAYS_INLINE static size_t sizeOfSegment(size_t segmentIndex)
+        {
+            if constexpr (GrowthPolicy == SegmentedVectorGrowthPolicy::Doubling)
+                return SegmentSize << segmentIndex;
+            else
+                return SegmentSize;
+        }
+
         class Segment {
         public:
-            std::span<T, SegmentSize> entries() { return unsafeMakeSpan<T, SegmentSize>(m_entries, SegmentSize); }
+            std::span<T, SegmentSize> entries() requires (GrowthPolicy == SegmentedVectorGrowthPolicy::Constant)
+            {
+                return unsafeMakeSpan<T, SegmentSize>(m_entries, SegmentSize);
+            }
+            T* data() { return m_entries; }
 
         private:
             T m_entries[0];
@@ -269,10 +320,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             if constexpr (hasInlineStorage) {
                 if (index < InlineCapacity) [[likely]]
                     return &inlineStorage()[index];
-                size_t heapIndex = index - InlineCapacity;
-                return &m_segments[heapIndex / SegmentSize].get()->entries()[heapIndex % SegmentSize];
-            } else
-                return &m_segments[index / SegmentSize].get()->entries()[index % SegmentSize];
+                index -= InlineCapacity;
+            }
+            auto [segmentIndex, offset] = segmentLocationFor(index);
+            return &m_segments[segmentIndex].get()->data()[offset];
         }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
@@ -290,16 +341,16 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                     return true;
                 return heapSegmentExistsFor(index);
             } else
-                return index / SegmentSize < m_segments.size();
+                return segmentLocationFor(index).segmentIndex < m_segments.size();
         }
 
         ALWAYS_INLINE bool heapSegmentExistsFor(size_t index)
         {
             if constexpr (hasInlineStorage) {
                 ASSERT(index >= InlineCapacity);
-                return (index - InlineCapacity) / SegmentSize < m_segments.size();
+                return segmentLocationFor(index - InlineCapacity).segmentIndex < m_segments.size();
             } else
-                return index / SegmentSize < m_segments.size();
+                return segmentLocationFor(index).segmentIndex < m_segments.size();
         }
 
         void ensureSegmentsFor(size_t size)
@@ -308,12 +359,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 if (size <= InlineCapacity)
                     return;
                 size_t currentSegmentCount = m_segments.size();
-                size_t requiredSegmentCount = (size - InlineCapacity + SegmentSize - 1) / SegmentSize;
+                size_t requiredSegmentCount = segmentLocationFor(size - InlineCapacity - 1).segmentIndex + 1;
                 for (size_t i = currentSegmentCount; i < requiredSegmentCount; ++i)
                     allocateSegment();
             } else {
-                size_t segmentCount = (m_size + SegmentSize - 1) / SegmentSize;
-                size_t requiredSegmentCount = (size + SegmentSize - 1) / SegmentSize;
+                size_t segmentCount = m_size ? segmentLocationFor(m_size - 1).segmentIndex + 1 : 0;
+                size_t requiredSegmentCount = segmentLocationFor(size - 1).segmentIndex + 1;
                 for (size_t i = segmentCount ? segmentCount - 1 : 0; i < requiredSegmentCount; ++i)
                     ensureSegment(i);
             }
@@ -328,7 +379,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         void allocateSegment()
         {
-            auto* ptr = static_cast<Segment*>(Malloc::malloc(sizeof(T) * SegmentSize));
+            size_t segSize = sizeOfSegment(m_segments.size());
+            auto* ptr = static_cast<Segment*>(Malloc::malloc(sizeof(T) * segSize));
             m_segments.append(SegmentPtr(ptr, { }));
         }
 
@@ -340,3 +392,4 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 } // namespace WTF
 
 using WTF::SegmentedVector;
+using WTF::SegmentedVectorGrowthPolicy;

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -8,6 +8,7 @@ Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.cpp
 Modules/WebGPU/Implementation/WebGPUComputePipelineImpl.cpp
 Modules/WebGPU/Implementation/WebGPUCreateImpl.cpp
 Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+Modules/WebGPU/Implementation/WebGPUExternalTextureImpl.cpp
 Modules/WebGPU/Implementation/WebGPUImpl.cpp
 Modules/WebGPU/Implementation/WebGPUPipelineLayoutImpl.cpp
 Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp


### PR DESCRIPTION
#### e69c47917811c2d01befd9e16205c756c86e06a6
<pre>
Heap needs to protect swaped JSString Impls for GCOwnedDataScope
<a href="https://bugs.webkit.org/show_bug.cgi?id=311420">https://bugs.webkit.org/show_bug.cgi?id=311420</a>
<a href="https://rdar.apple.com/172467032">rdar://172467032</a>

Reviewed by Yusuke Suzuki and Dan Hecht.

When JSString::swapToAtomString replaces a StringImpl with its atomized
equivalent, the old StringImpl was kept alive only until the next GC
via
Heap::m_possiblyAccessedStringsFromConcurrentThreads. However if a
GCOwnedDataScope is on the stack it&apos;s possible for the buffer to get
freed before the ~GCOwnedDataScope runs, leaving the buffer as a
dangling pointer.

Fix this by:

 1. Renaming m_possiblyAccessedStringsFromConcurrentThreads to
    m_possiblyAccessedStringsFromConcurrentThreadsOrGCOwnedDataScope and
    storing (JSString*, String) pairs so we can track ownership.

 2. During conservative root scanning, discover all JSStrings that are
    still referenced on the stack and record them in
    m_discoveredAccessedStringsFromGCOwnedDataScope.

 3. At GC finalize, pruning entries whose JSString was not discovered on
    the stack rather than clearing the list entirely.

 4. Between GCs, clearing the retained list in IncrementalSweeper when
    no JS is executing and no JIT compilations are in progress.
    Previously the list was only cleared during GC finalize, so it could
    grow unboundedly between collections. Without this Speedometer
    appeared to be regressed, with this it seems like a .2% progression.

 5. Switching from Vector to SegmentedVector with a new doubling growth
    policy to avoid copying entries when resizing the Vector. Since this
    list gets very big 200,000+ entries, avoiding copies is valuable.

Tests: JSTests/stress/stringProtoFuncAt-GCOwnedDataScope-atomstring-swap.js
       JSTests/stress/stringProtoFuncEndsWith-GCOwnedDataScope-atomstring-swap.js
       JSTests/stress/stringProtoFuncLocaleCompare-GCOwnedDataScope-atomstring-swap.js
       JSTests/stress/stringProtoFuncStartsWith-GCOwnedDataScope-atomstring-swap.js

Originally-landed-as: 305413.614@rapid/safari-7624.2.5.110-branch (ffdd4a695d15). <a href="https://rdar.apple.com/176061081">rdar://176061081</a>
Canonical link: <a href="https://commits.webkit.org/314730@main">https://commits.webkit.org/314730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f0b43682fb022598a6148023c1bd4dc909a9923

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166915 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129799 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91405 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110324 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31174 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29876 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24699 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159072 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178501 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27809 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31399 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138168 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138079 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149473 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103996 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25419 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33352 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26338 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199594 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112748 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53668 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39070 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4436 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->