### PR TITLE
Race condition in JSSubscriber::visitAdditionalChildren during GC

### DIFF
--- a/Source/WebCore/bindings/js/JSSubscriberCustom.cpp
+++ b/Source/WebCore/bindings/js/JSSubscriberCustom.cpp
@@ -33,10 +33,7 @@ namespace WebCore {
 template<typename Visitor>
 void JSSubscriber::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    for (auto* teardown : wrapped().teardownCallbacksConcurrently())
-        teardown->visitJSFunctionInGCThread(visitor);
-
-    wrapped().observerConcurrently()->visitAdditionalChildrenInGCThread(visitor);
+    wrapped().visitAdditionalChildrenInGCThread(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSSubscriber);

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -157,28 +157,20 @@ void Subscriber::reportErrorObject(JSC::JSValue value)
     reportException(globalObject, JSC::Exception::create(vm, value));
 }
 
-Vector<VoidCallback*> Subscriber::teardownCallbacksConcurrently()
+template<typename Visitor>
+void Subscriber::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    Locker locker { m_teardownsLock };
-    return m_teardowns.map([](auto& callback) {
-        return callback.ptr();
-    });
+    // Do not ref anything in this function, which runs in a GC thread concurrently to the main thread.
+    {
+        Locker locker { m_teardownsLock };
+        SUPPRESS_UNCOUNTED_LOCAL for (auto& teardown : m_teardowns)
+            SUPPRESS_UNCOUNTED_ARG teardown->visitJSFunctionInGCThread(visitor);
+    }
+
+    SUPPRESS_UNRETAINED_ARG m_observer->visitAdditionalChildrenInGCThread(visitor);
 }
 
-InternalObserver* Subscriber::observerConcurrently()
-{
-    return &m_observer.get();
-}
-
-void Subscriber::visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor)
-{
-    // We cannot ref `teardown` here as this may get called from a GC thread.
-    SUPPRESS_UNRETAINED_ARG for (auto* teardown : teardownCallbacksConcurrently())
-        teardown->visitJSFunctionInGCThread(visitor);
-
-    // We cannot ref the observer here as this may get called from a GC thread.
-    SUPPRESS_UNRETAINED_ARG observerConcurrently()->visitAdditionalChildrenInGCThread(visitor);
-}
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(Subscriber);
 
 Subscriber::~Subscriber() = default;
 

--- a/Source/WebCore/dom/Subscriber.h
+++ b/Source/WebCore/dom/Subscriber.h
@@ -59,9 +59,7 @@ public:
     void reportErrorObject(JSC::JSValue);
 
     // JSCustomMarkFunction; for JSSubscriberCustom
-    Vector<VoidCallback*> teardownCallbacksConcurrently();
-    InternalObserver* NODELETE observerConcurrently();
-    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor&);
+    template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
 
 private:
     explicit Subscriber(ScriptExecutionContext&, Ref<InternalObserver>&&, const SubscribeOptions&);


### PR DESCRIPTION
#### db743cc33964a7d107f4f1c3ccd8d6122bb9f79e
<pre>
Race condition in JSSubscriber::visitAdditionalChildren during GC
<a href="https://bugs.webkit.org/show_bug.cgi?id=309773">https://bugs.webkit.org/show_bug.cgi?id=309773</a>
&lt;<a href="https://rdar.apple.com/172278544">rdar://172278544</a>&gt;

Reviewed by Chris Dumez.

This PR fixes a race condition in JSSubscriber::visitAdditionalChildren which results in
a use-after-free of VoidCallback objects in JSSubscriber::visitAdditionalChildren.

While Subscriber::teardownCallbacksConcurrently grabs a lock and creates a Vector of
VoidCallback*, the main thread can still go ahead and destroy VoidCallback while
a GC thread is calling visitJSFunction on that VoidCallback.

No new tests since there is no reliable reproduction.

* Source/WebCore/bindings/js/JSSubscriberCustom.cpp:
(WebCore::JSSubscriber::visitAdditionalChildren):
* Source/WebCore/dom/Subscriber.cpp:
(WebCore::Subscriber::visitAdditionalChildren):
(): Deleted.
(WebCore::Subscriber::observerConcurrently): Deleted.
* Source/WebCore/dom/Subscriber.h:

Originally-landed-as: 305413.461@safari-7624-branch (498a2ef7689e). <a href="https://rdar.apple.com/176061111">rdar://176061111</a>
Canonical link: <a href="https://commits.webkit.org/315368@main">https://commits.webkit.org/315368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c3951bd549baf15b3634861056341ff555a1aba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178145 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126521 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131448 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111952 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32890 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26840 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180746 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139896 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42385 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139740 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37622 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43074 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28095 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106828 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35022 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114841 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41577 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6183 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41228 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->