### PR TITLE
Use-after-free in NamedSlotAssignment::resolveSlotsAfterSlotMutation

### DIFF
--- a/LayoutTests/fast/shadow-dom/named-slot-assignment-resolve-after-mutation-crash-expected.txt
+++ b/LayoutTests/fast/shadow-dom/named-slot-assignment-resolve-after-mutation-crash-expected.txt
@@ -1,0 +1,4 @@
+This tests inserting a bunch of nodes with slot attributes under shadow host.
+WebKit should not crash or hit assertions under ASAN, and you should see PASS below:
+
+PASS

--- a/LayoutTests/fast/shadow-dom/named-slot-assignment-resolve-after-mutation-crash.html
+++ b/LayoutTests/fast/shadow-dom/named-slot-assignment-resolve-after-mutation-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<body>
+<p>This tests inserting a bunch of nodes with slot attributes under shadow host.<br>
+WebKit should not crash or hit assertions under ASAN, and you should see PASS below:</p>
+<script>
+
+globalThis?.testRunner.dumpAsText();
+
+const host = document.createElement('div');
+document.body.appendChild(host);
+const shadowRoot = host.attachShadow({mode:'open'}); // NamedSlotAssignment (default)
+
+// Shadow tree: shadowRoot -> c -> [slot1(name=X), slot2(name=X)]
+const container = document.createElement('div');
+shadowRoot.appendChild(container);
+
+const slot1 = document.createElement('slot');
+slot1.setAttribute('name','X');
+container.appendChild(slot1);
+
+const slot2 = document.createElement('slot');
+slot2.setAttribute('name','X');
+container.appendChild(slot2);
+
+// Host child with slot='X' -> didChangeSlot('X') -> m_slotAssignmentsIsValid=false
+const spanChild = document.createElement('span');
+spanChild.setAttribute('slot','X');
+host.appendChild(spanChild);
+
+// Many host children with FRESH slot names not in m_slots.
+for (let i = 0; i < 10; i++) {
+    const span = document.createElement('span');
+    span.setAttribute('slot', 'new' + i);
+    host.appendChild(span);
+}
+
+// Trigger: removeAllChildren on container (inside shadow tree).
+container.replaceChildren();
+
+document.write('PASS');
+
+</script>

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -265,6 +265,9 @@ void NamedSlotAssignment::resolveSlotsAfterSlotMutation(ShadowRoot& shadowRoot, 
         return;
     }
 
+    if (!m_slotAssignmentsIsValid)
+        assignSlots(shadowRoot);
+
     for (auto& slot : m_slots.values()) {
         if (slot->seenFirstElement)
             continue;
@@ -276,7 +279,7 @@ void NamedSlotAssignment::resolveSlotsAfterSlotMutation(ShadowRoot& shadowRoot, 
         // All slot elements have been removed for this slot.
         slot->seenFirstElement = true;
         ASSERT(slot->element);
-        if (hasAssignedNodes(shadowRoot, *slot))
+        if (!slot->assignedNodes.isEmpty())
             slot->oldElement = WTF::move(slot->element);
         slot->element = nullptr;
     }


### PR DESCRIPTION
#### 20beac1f6ec3a8dae04a9e38e4af992ee8c1e134
<pre>
Use-after-free in NamedSlotAssignment::resolveSlotsAfterSlotMutation
<a href="https://bugs.webkit.org/show_bug.cgi?id=312247">https://bugs.webkit.org/show_bug.cgi?id=312247</a>
<a href="https://rdar.apple.com/174493428">rdar://174493428</a>

Reviewed by Chris Dumez and Anne van Kesteren.

The bug was caused by hasAssignedNodes updating m_slots as a part of resolving slot assignments while
we&apos;re iterating over m_slots in NamedSlotAssignment::resolveSlotsAfterSlotMutation. Fixed the bug by
avoiding updating slot assignments upfront and simply checking slot-&gt;assignedNodes.isEmpty() instead.

Test: fast/shadow-dom/named-slot-assignment-resolve-after-mutation-crash.html

* LayoutTests/fast/shadow-dom/named-slot-assignment-resolve-after-mutation-crash-expected.txt: Added.
* LayoutTests/fast/shadow-dom/named-slot-assignment-resolve-after-mutation-crash.html: Added.
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::NamedSlotAssignment::resolveSlotsAfterSlotMutation):

Originally-landed-as: 305413.669@safari-7624-branch (cbcbdcfa297d). <a href="https://rdar.apple.com/176058656">rdar://176058656</a>
Canonical link: <a href="https://commits.webkit.org/314129@main">https://commits.webkit.org/314129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1abe395e8c44d38570dfdf605eb6d544ecefe65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174185 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122400 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128334 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108859 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29692 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28315 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21940 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176708 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29584 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136656 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136593 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36832 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147883 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101701 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31871 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24750 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110974 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37299 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2827 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37545 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37443 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->