### PR TITLE
Cherry-pick(s) 4966a0d102e7. rdar://176058780

### DIFF
--- a/LayoutTests/fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash-expected.txt
+++ b/LayoutTests/fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash-expected.txt
@@ -1,0 +1,4 @@
+This tests calling createContextualFragment with trusted types createHTML callback which clears range's endpoints.
+WebKit should not crash or hit any assertions under ASAN and you should see PASS below:
+
+PASS

--- a/LayoutTests/fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash.html
+++ b/LayoutTests/fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+</head>
+<body>
+<p>This tests calling createContextualFragment with trusted types createHTML callback which clears range's endpoints.<br>
+WebKit should not crash or hit any assertions under ASAN and you should see PASS below:</p>
+<div id="result"></div>
+<script src="../../../resources/gc.js"></script>
+<script>
+globalThis?.testRunner.dumpAsText();
+
+const range = document.createRange();
+let div = document.createElement('div');
+range.setStart(div, 0);
+range.setEnd(div, 0);
+
+let didRun = false;
+trustedTypes.createPolicy('default', {
+  createHTML(string) {
+    if (didRun)
+      return;
+    didRun = true;
+
+    range.setEnd(document, 0); // drops range references to 'v'
+    div = null; // drops JS wrapper reference to 'v'
+    gc(); // wrapper GC'd -> C++ object GC'd
+
+    return string;
+  }
+});
+
+range.createContextualFragment('x');
+
+result.textContent = 'PASS';
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -741,12 +741,20 @@ ExceptionOr<Ref<DocumentFragment>> Range::createContextualFragment(Variant<Ref<T
     RefPtr<Element> element;
     if (isAnyOf<Document, DocumentFragment>(node))
         element = nullptr;
+<<<<<<< HEAD
     else if (auto* maybeElement = dynamicDowncast<Element>(node.ptr()))
+=======
+    else if (auto* maybeElement = dynamicDowncast<Element>(node.get()))
+>>>>>>> 4966a0d102e7 (Use-after-free of Node in Range::createContextualFragment)
         element = maybeElement;
     else
         element = node->parentElement();
     if (!element || (element->document().isHTMLDocument() && is<HTMLHtmlElement>(*element)))
+<<<<<<< HEAD
         element = HTMLBodyElement::create(protect(node->document()));
+=======
+        element = HTMLBodyElement::create(node->protectedDocument());
+>>>>>>> 4966a0d102e7 (Use-after-free of Node in Range::createContextualFragment)
     return WebCore::createContextualFragment(*element, stringValueHolder.releaseReturnValue(), { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::DoNotMarkAlreadyStarted });
 }
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176058780 to main. [4966a0d102e7] caused a merge conflict. 

```Use-after-free of Node in Range::createContextualFragment
https://bugs.webkit.org/show_bug.cgi?id=312244
rdar://174489535

Reviewed by Chris Dumez.

Fixed the bug by deploying more smart pointers.

Test: fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash.html

* LayoutTests/fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash-expected.txt: Added.
* LayoutTests/fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash.html: Added.
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::createContextualFragment):

Originally-landed-as: 305413.665@safari-7624-branch (4966a0d102e7). rdar://176058780

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/235f82aed2196ac15e4dee168f52a9a4d36d57e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165145 "3 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38636 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32213 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174187 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122402 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167013 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38970 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38637 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/174187 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122402 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/168104 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38970 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/32213 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174187 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38970 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38637 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/21942 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38970 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/32213 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176710 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29586 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32213 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/176710 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38704 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/38637 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176710 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/39394 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/32213 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101703 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/39394 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32213 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37904 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110976 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/37301 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/32213 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37547 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/37445 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->