### PR TITLE
[JSC] Inline-allocate cells for `NewWeakMap` and `NewWeakSet`

### DIFF
--- a/JSTests/stress/weak-map-weak-set-lazy-buffer.js
+++ b/JSTests/stress/weak-map-weak-set-lazy-buffer.js
@@ -1,0 +1,154 @@
+// Exercises the lazily-allocated WeakMap/WeakSet buffer: a freshly constructed instance
+// shares an immortal empty buffer (capacity 1) and only allocates a real buffer on the
+// first insertion. All read paths must work against that shared empty buffer, and the
+// getOrInsert fast path (findBucketIndex + addBucket) must not write into it.
+
+function assert(b, message) {
+    if (!b)
+        throw new Error("bad assertion: " + message);
+}
+
+function makeWeakMap() {
+    return new WeakMap();
+}
+noInline(makeWeakMap);
+
+function makeWeakSet() {
+    return new WeakSet();
+}
+noInline(makeWeakSet);
+
+// 1. Reads against the shared empty buffer must miss, and delete must report false.
+for (var i = 0; i < 1e5; ++i) {
+    var key = {};
+    var map = makeWeakMap();
+    assert(map.get(key) === undefined, "empty map get");
+    assert(!map.has(key), "empty map has");
+    assert(!map.delete(key), "empty map delete");
+
+    var set = makeWeakSet();
+    assert(!set.has(key), "empty set has");
+    assert(!set.delete(key), "empty set delete");
+}
+
+// 2. getOrInsert / getOrInsertComputed on a fresh (empty buffer) map must allocate a real
+//    buffer and insert, rather than writing into the shared sentinel at the stale index.
+for (var i = 0; i < 1e5; ++i) {
+    var key = {};
+    var map = makeWeakMap();
+    var inserted = map.getOrInsert(key, i);
+    assert(inserted === i, "getOrInsert returns inserted value");
+    assert(map.get(key) === i, "getOrInsert stored value");
+    assert(map.has(key), "getOrInsert key present");
+    // Second call must observe the existing entry (real-buffer exists path), not overwrite.
+    assert(map.getOrInsert(key, i + 1) === i, "getOrInsert keeps existing value");
+
+    var key2 = {};
+    var map2 = makeWeakMap();
+    var computed = map2.getOrInsertComputed(key2, (k) => i * 2);
+    assert(computed === i * 2, "getOrInsertComputed returns value");
+    assert(map2.get(key2) === i * 2, "getOrInsertComputed stored value");
+}
+
+// 3. A separate empty map sharing the same sentinel must remain empty after another map
+//    allocated its own real buffer (i.e. addBucket did not scribble on the shared buffer).
+var canary = {};
+for (var i = 0; i < 1e4; ++i) {
+    var emptyMap = makeWeakMap();
+    var usedMap = makeWeakMap();
+    usedMap.set(canary, 123);
+    assert(!emptyMap.has(canary), "sibling empty map stays empty after another map writes");
+    assert(emptyMap.get(canary) === undefined, "sibling empty map get misses");
+
+    var emptySet = makeWeakSet();
+    var usedSet = makeWeakSet();
+    usedSet.add(canary);
+    assert(!emptySet.has(canary), "sibling empty set stays empty");
+}
+
+// 4. Grow a map enough to force several rehashes (real-buffer reallocation + free), then
+//    verify every entry survives.
+function makeFilledMap(n) {
+    var map = new WeakMap();
+    var keys = [];
+    for (var j = 0; j < n; ++j) {
+        var k = { id: j };
+        keys.push(k);
+        map.set(k, j);
+    }
+    return [map, keys];
+}
+noInline(makeFilledMap);
+
+for (var round = 0; round < 100; ++round) {
+    var [map, keys] = makeFilledMap(256);
+    for (var j = 0; j < keys.length; ++j)
+        assert(map.get(keys[j]) === j, "filled map entry " + j);
+    // Delete half to exercise shrink/rehash.
+    for (var j = 0; j < keys.length; j += 2)
+        assert(map.delete(keys[j]), "delete entry " + j);
+    for (var j = 1; j < keys.length; j += 2)
+        assert(map.get(keys[j]) === j, "surviving entry " + j);
+}
+
+// 5. Allocate many empty (sentinel) maps and force GC. finalizeUnconditionally must not
+//    touch / free the shared empty buffer for these instances.
+var live = [];
+for (var i = 0; i < 1e4; ++i)
+    live.push(makeWeakMap(), makeWeakSet());
+if (typeof gc === "function")
+    gc();
+for (var i = 0; i < live.length; ++i) {
+    var obj = live[i];
+    assert(!obj.has(canary), "post-gc empty container has");
+}
+
+// 6. Subclasses (slow allocation path / new.target != callee) must also start empty.
+class SubWeakMap extends WeakMap {}
+function makeSub() {
+    return new SubWeakMap();
+}
+noInline(makeSub);
+for (var i = 0; i < 1e4; ++i) {
+    var m = makeSub();
+    assert(m.get(canary) === undefined, "subclass empty get");
+    m.set(canary, i);
+    assert(m.get(canary) === i, "subclass set/get");
+}
+
+// 7. Hand a fresh (still empty-buffer) map/set to read functions that were optimized against a
+//    populated one, so the DFG/FTL WeakMapGet fast path probes the shared empty buffer and misses.
+function readGet(map, key) {
+    return map.get(key);
+}
+noInline(readGet);
+
+function readHas(map, key) {
+    return map.has(key);
+}
+noInline(readHas);
+
+function readSetHas(set, key) {
+    return set.has(key);
+}
+noInline(readSetHas);
+
+var warmKey = {};
+var warmMap = new WeakMap();
+warmMap.set(warmKey, 1);
+var warmSet = new WeakSet();
+warmSet.add(warmKey);
+for (var i = 0; i < 1e5; ++i) {
+    assert(readGet(warmMap, warmKey) === 1, "warm get");
+    assert(readHas(warmMap, warmKey), "warm has");
+    assert(readSetHas(warmSet, warmKey), "warm set has");
+}
+for (var i = 0; i < 1e4; ++i) {
+    var emptyMap = makeWeakMap();
+    var emptySet = makeWeakSet();
+    assert(readGet(emptyMap, warmKey) === undefined, "optimized get on empty map");
+    assert(!readHas(emptyMap, warmKey), "optimized has on empty map");
+    assert(!readSetHas(emptySet, warmKey), "optimized has on empty set");
+}
+
+print("PASS");

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -201,6 +201,8 @@ namespace JSC::B3 {
     macro(WasmTable_length, Wasm::Table::offsetOfLength(), Mutability::Mutable) \
     macro(WeakMapImpl_capacity, WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfCapacity(), Mutability::Mutable) \
     macro(WeakMapImpl_buffer,  WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfBuffer(), Mutability::Mutable) \
+    macro(WeakMapImpl_keyCount, WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfKeyCount(), Mutability::Mutable) \
+    macro(WeakMapImpl_deleteCount, WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfDeleteCount(), Mutability::Mutable) \
     macro(WeakMapBucket_value, WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfValue(), Mutability::Mutable) \
     macro(WeakMapBucket_key, WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfKey(), Mutability::Mutable) \
     macro(WebAssemblyFunctionBase_boxedCallee, WebAssemblyFunctionBase::offsetOfBoxedCallee(), Mutability::Immutable) \

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -72,6 +72,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "JSRegExpStringIterator.h"
 #include "JSSetIterator.h"
 #include "JSStringIterator.h"
+#include "JSWeakMap.h"
+#include "JSWeakSet.h"
 #include "JSWebAssemblyInstance.h"
 #include "JSWrapForValidIterator.h"
 #include "JumpTable.h"
@@ -12057,23 +12059,53 @@ void SpeculativeJIT::compileNewSet(Node* node)
 
 void SpeculativeJIT::compileNewWeakMap(Node* node)
 {
-    // FIXME: Inline-allocate the cell like NewMap once WeakMapImpl supports a lazily-allocated buffer.
-    flushRegisters();
-    GPRFlushedCallResult result(this);
+    GPRTemporary result(this);
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
+
     GPRReg resultGPR = result.gpr();
+    GPRReg scratch1GPR = scratch1.gpr();
+    GPRReg scratch2GPR = scratch2.gpr();
+
+    JumpList slowCases;
+
     FrozenValue* structure = m_graph.freezeStrong(node->structure().get());
-    callOperation(operationNewWeakMap, resultGPR, TrustedImmPtr(&vm()), TrustedImmPtr(structure));
+    auto butterfly = TrustedImmPtr(nullptr);
+    emitAllocateJSObjectWithKnownSize<JSWeakMap>(resultGPR, TrustedImmPtr(structure), butterfly, scratch1GPR, scratch2GPR, slowCases, sizeof(JSWeakMap), SlowAllocationResult::UndefinedBehavior);
+    storePtr(TrustedImmPtr(JSWeakMap::emptyBuffer()), Address(resultGPR, JSWeakMap::offsetOfBuffer()));
+    store32(TrustedImm32(JSWeakMap::emptyCapacity), Address(resultGPR, JSWeakMap::offsetOfCapacity()));
+    store32(TrustedImm32(0), Address(resultGPR, JSWeakMap::offsetOfKeyCount()));
+    store32(TrustedImm32(0), Address(resultGPR, JSWeakMap::offsetOfDeleteCount()));
+    mutatorFence(vm());
+
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationNewWeakMap, resultGPR, TrustedImmPtr(&vm()), TrustedImmPtr(structure)));
+
     cellResult(resultGPR, node);
 }
 
 void SpeculativeJIT::compileNewWeakSet(Node* node)
 {
-    // FIXME: Inline-allocate the cell like NewSet once WeakMapImpl supports a lazily-allocated buffer.
-    flushRegisters();
-    GPRFlushedCallResult result(this);
+    GPRTemporary result(this);
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
+
     GPRReg resultGPR = result.gpr();
+    GPRReg scratch1GPR = scratch1.gpr();
+    GPRReg scratch2GPR = scratch2.gpr();
+
+    JumpList slowCases;
+
     FrozenValue* structure = m_graph.freezeStrong(node->structure().get());
-    callOperation(operationNewWeakSet, resultGPR, TrustedImmPtr(&vm()), TrustedImmPtr(structure));
+    auto butterfly = TrustedImmPtr(nullptr);
+    emitAllocateJSObjectWithKnownSize<JSWeakSet>(resultGPR, TrustedImmPtr(structure), butterfly, scratch1GPR, scratch2GPR, slowCases, sizeof(JSWeakSet), SlowAllocationResult::UndefinedBehavior);
+    storePtr(TrustedImmPtr(JSWeakSet::emptyBuffer()), Address(resultGPR, JSWeakSet::offsetOfBuffer()));
+    store32(TrustedImm32(JSWeakSet::emptyCapacity), Address(resultGPR, JSWeakSet::offsetOfCapacity()));
+    store32(TrustedImm32(0), Address(resultGPR, JSWeakSet::offsetOfKeyCount()));
+    store32(TrustedImm32(0), Address(resultGPR, JSWeakSet::offsetOfDeleteCount()));
+    mutatorFence(vm());
+
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationNewWeakSet, resultGPR, TrustedImmPtr(&vm()), TrustedImmPtr(structure)));
+
     cellResult(resultGPR, node);
 }
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -99,6 +99,7 @@
 #include "JSSetIterator.h"
 #include "JSStringIterator.h"
 #include "JSWeakMap.h"
+#include "JSWeakSet.h"
 #include "JSWebAssemblyInstance.h"
 #include "JSWrapForValidIterator.h"
 #include "LLIntThunks.h"
@@ -19539,14 +19540,50 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileNewWeakMap()
     {
-        // FIXME: Inline-allocate the cell like NewMap once WeakMapImpl supports a lazily-allocated buffer.
-        setJSValue(vmCall(pointerType(), operationNewWeakMap, m_vmValue, frozenPointer(m_graph.freezeStrong(m_node->structure().get()))));
+        LBasicBlock slowCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        LBasicBlock lastNext = m_out.insertNewBlocksBefore(slowCase);
+
+        LValue object = allocateObject<JSWeakMap>(m_node->structure(), m_out.intPtrZero, slowCase);
+        m_out.storePtr(m_out.constIntPtr(JSWeakMap::emptyBuffer()), object, m_heaps.WeakMapImpl_buffer);
+        m_out.store32(m_out.constInt32(JSWeakMap::emptyCapacity), object, m_heaps.WeakMapImpl_capacity);
+        m_out.store32(m_out.int32Zero, object, m_heaps.WeakMapImpl_keyCount);
+        m_out.store32(m_out.int32Zero, object, m_heaps.WeakMapImpl_deleteCount);
+        mutatorFence();
+        ValueFromBlock fastResult = m_out.anchor(object);
+        m_out.jump(continuation);
+
+        m_out.appendTo(slowCase, continuation);
+        ValueFromBlock slowResult = m_out.anchor(vmCall(pointerType(), operationNewWeakMap, m_vmValue, frozenPointer(m_graph.freezeStrong(m_node->structure().get()))));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setJSValue(m_out.phi(pointerType(), fastResult, slowResult));
     }
 
     void compileNewWeakSet()
     {
-        // FIXME: Inline-allocate the cell like NewSet once WeakMapImpl supports a lazily-allocated buffer.
-        setJSValue(vmCall(pointerType(), operationNewWeakSet, m_vmValue, frozenPointer(m_graph.freezeStrong(m_node->structure().get()))));
+        LBasicBlock slowCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        LBasicBlock lastNext = m_out.insertNewBlocksBefore(slowCase);
+
+        LValue object = allocateObject<JSWeakSet>(m_node->structure(), m_out.intPtrZero, slowCase);
+        m_out.storePtr(m_out.constIntPtr(JSWeakSet::emptyBuffer()), object, m_heaps.WeakMapImpl_buffer);
+        m_out.store32(m_out.constInt32(JSWeakSet::emptyCapacity), object, m_heaps.WeakMapImpl_capacity);
+        m_out.store32(m_out.int32Zero, object, m_heaps.WeakMapImpl_keyCount);
+        m_out.store32(m_out.int32Zero, object, m_heaps.WeakMapImpl_deleteCount);
+        mutatorFence();
+        ValueFromBlock fastResult = m_out.anchor(object);
+        m_out.jump(continuation);
+
+        m_out.appendTo(slowCase, continuation);
+        ValueFromBlock slowResult = m_out.anchor(vmCall(pointerType(), operationNewWeakSet, m_vmValue, frozenPointer(m_graph.freezeStrong(m_node->structure().get()))));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setJSValue(m_out.phi(pointerType(), fastResult, slowResult));
     }
 
     void compileSetFunctionName()

--- a/Source/JavaScriptCore/runtime/JSWeakMap.h
+++ b/Source/JavaScriptCore/runtime/JSWeakMap.h
@@ -36,6 +36,12 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    static size_t allocationSize(Checked<size_t> inlineCapacity)
+    {
+        ASSERT_UNUSED(inlineCapacity, !inlineCapacity);
+        return sizeof(JSWeakMap);
+    }
+
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     static JSWeakMap* create(VM& vm, Structure* structure)

--- a/Source/JavaScriptCore/runtime/JSWeakSet.h
+++ b/Source/JavaScriptCore/runtime/JSWeakSet.h
@@ -36,6 +36,12 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    static size_t allocationSize(Checked<size_t> inlineCapacity)
+    {
+        ASSERT_UNUSED(inlineCapacity, !inlineCapacity);
+        return sizeof(JSWeakSet);
+    }
+
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     static JSWeakSet* create(VM& vm, Structure* structure)

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.cpp
@@ -36,6 +36,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+const uint64_t emptyWeakMapBuffer[2] = { 0, 0 };
+
 template <typename WeakMapBucket>
 void WeakMapImpl<WeakMapBucket>::destroy(JSCell* cell)
 {

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.h
@@ -191,11 +191,19 @@ public:
         return buffer;
     }
 
+    static void destroy(WeakMapBuffer* buffer)
+    {
+        WTF::fastFree(buffer);
+    }
+
     ALWAYS_INLINE void reset(uint32_t capacity)
     {
         memset(this, 0, allocationSize(capacity));
     }
 };
+
+JS_EXPORT_PRIVATE extern const uint64_t emptyWeakMapBuffer[2];
+static_assert(sizeof(emptyWeakMapBuffer) == sizeof(WeakMapBucketDataKeyValue));
 
 template <typename WeakMapBucketType>
 class WeakMapImpl : public JSNonFinalObject {
@@ -214,11 +222,23 @@ public:
 
     static constexpr uint32_t initialCapacity = 4;
 
+    static constexpr uint32_t emptyCapacity = 1;
+
+    static WeakMapBufferType* emptyBuffer()
+    {
+        return std::bit_cast<WeakMapBufferType*>(const_cast<uint64_t*>(emptyWeakMapBuffer));
+    }
+
     WeakMapImpl(VM& vm, Structure* structure)
         : Base(vm, structure)
     {
         ASSERT_WITH_MESSAGE(WeakMapBucket<WeakMapBucketDataKey>::offsetOfKey() == WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfKey(), "We assume this to be true in the DFG and FTL JIT.");
-        makeAndSetNewBuffer(initialCapacity);
+    }
+
+    ~WeakMapImpl()
+    {
+        if (m_buffer != emptyBuffer())
+            WeakMapBufferType::destroy(m_buffer);
     }
 
     // WeakMap operations must not cause GC. We model operations in DFG based on this guarantee.
@@ -307,6 +327,16 @@ public:
         return OBJECT_OFFSETOF(WeakMapImpl<WeakMapBucketType>, m_capacity);
     }
 
+    static constexpr ptrdiff_t offsetOfKeyCount()
+    {
+        return OBJECT_OFFSETOF(WeakMapImpl<WeakMapBucketType>, m_keyCount);
+    }
+
+    static constexpr ptrdiff_t offsetOfDeleteCount()
+    {
+        return OBJECT_OFFSETOF(WeakMapImpl<WeakMapBucketType>, m_deleteCount);
+    }
+
     static constexpr bool isWeakMap()
     {
         return std::same_as<WeakMapBucketType, JSC::WeakMapBucket<WeakMapBucketDataKeyValue>>;
@@ -370,6 +400,7 @@ private:
 
     ALWAYS_INLINE void addInternal(VM& vm, JSCell* key, JSValue value, uint32_t hash)
     {
+        ASSERT(m_buffer != emptyBuffer());
         const uint32_t mask = m_capacity - 1;
         uint32_t index = hash & mask;
         WeakMapBucketType* buffer = this->buffer();
@@ -426,11 +457,13 @@ private:
         }
     }
 
+    // Overwrites m_buffer without freeing the previous one. Callers must have already taken
+    // ownership of the old buffer (rehash) or be replacing the shared empty buffer (add).
     void makeAndSetNewBuffer(uint32_t capacity)
     {
         ASSERT(!(capacity & (capacity - 1)));
 
-        m_buffer = WeakMapBufferType::create(capacity);
+        m_buffer = WeakMapBufferType::create(capacity).leakPtr();
         m_capacity = capacity;
         ASSERT(m_buffer);
         assertBufferIsEmpty();
@@ -447,8 +480,8 @@ private:
     template<typename Appender>
     void takeSnapshotInternal(unsigned limit, Appender);
 
-    MallocPtr<WeakMapBufferType> m_buffer;
-    uint32_t m_capacity { 0 };
+    WeakMapBufferType* m_buffer { emptyBuffer() };
+    uint32_t m_capacity { emptyCapacity };
     uint32_t m_keyCount { 0 };
     uint32_t m_deleteCount { 0 };
 };

--- a/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
@@ -70,6 +70,9 @@ ALWAYS_INLINE void WeakMapImpl<WeakMapBucket>::add(VM& vm, JSCell* key, JSValue 
     AssertNoGC assertNoGC;
     ASSERT_WITH_MESSAGE(jsWeakMapHash(key) == hash, "We expect hash value is what we expect.");
 
+    if (m_buffer == emptyBuffer()) [[unlikely]]
+        makeAndSetNewBuffer(initialCapacity);
+
     addInternal(vm, key, value, hash);
     if (shouldRehashAfterAdd())
         rehash();
@@ -78,6 +81,13 @@ ALWAYS_INLINE void WeakMapImpl<WeakMapBucket>::add(VM& vm, JSCell* key, JSValue 
 template <typename WeakMapBucket>
 ALWAYS_INLINE void WeakMapImpl<WeakMapBucket>::addBucket(VM& vm, JSCell* key, JSValue value, uint32_t hash, size_t index)
 {
+    if (m_buffer == emptyBuffer()) [[unlikely]] {
+        // index was computed against the shared empty buffer, so it is meaningless for a real
+        // buffer. Fall back to add(), which allocates and re-probes from scratch.
+        add(vm, key, value, hash);
+        return;
+    }
+
     UNUSED_PARAM(hash);
     ASSERT(jsWeakMapHash(key) == hash);
     ASSERT(!findBucket(key, hash));
@@ -125,7 +135,7 @@ void WeakMapImpl<WeakMapBucket>::rehash(RehashMode mode)
     // in auxiliary buffer.
 
     uint32_t oldCapacity = m_capacity;
-    MallocPtr<WeakMapBufferType> oldBuffer = WTF::move(m_buffer);
+    WeakMapBufferType* oldBuffer = m_buffer;
 
     uint32_t capacity = m_capacity;
     if (mode == RehashMode::RemoveBatching) {
@@ -154,6 +164,10 @@ void WeakMapImpl<WeakMapBucket>::rehash(RehashMode mode)
     m_deleteCount = 0;
 
     checkConsistency();
+
+    // rehash() only runs once a real buffer has been allocated, so the shared empty buffer is never freed here.
+    ASSERT(oldBuffer != emptyBuffer());
+    WeakMapBufferType::destroy(oldBuffer);
 }
 
 template<typename WeakMapBucket>


### PR DESCRIPTION
#### 8317f5c80ed481f795386bc0ad79a2295c183652
<pre>
[JSC] Inline-allocate cells for `NewWeakMap` and `NewWeakSet`
<a href="https://bugs.webkit.org/show_bug.cgi?id=315814">https://bugs.webkit.org/show_bug.cgi?id=315814</a>

Reviewed by Yusuke Suzuki.

NewWeakMap / NewWeakSet DFG nodes could not inline-allocate the cell because
WeakMapImpl eagerly allocates its hash buffer with fastMalloc in the constructor
(left as a FIXME when the nodes were added).

This patch makes the buffer lazily allocated. A freshly constructed WeakMap/WeakSet
now points to a shared, immortal, all-zero buffer (g_emptyWeakMapBuffer) with
capacity 1. Since that buffer is always empty, every read path (C++, DFG, FTL)
works on it unchanged: lookups always miss and shrink/rehash never trigger. The
first add() (or addBucket(), which falls back to add() when it sees the shared
buffer) swaps in a real heap-allocated buffer with the usual initial capacity.
m_buffer becomes a raw pointer so the shared buffer is never freed; rehash() and
the destructor free only real buffers.

With that in place, compileNewWeakMap / compileNewWeakSet in DFG and FTL now
inline-allocate the JSWeakMap / JSWeakSet cell like NewMap / NewSet, storing the
shared empty buffer, capacity, and zeroed counters, with the existing operations
as the slow path.

                                    TipOfTree                  Patched

weak-map-constructor-empty       43.9682+-2.5468     ^      8.7839+-0.0804        ^ definitely 5.0056x faster
weak-set-constructor-empty       42.6802+-0.9526     ^      8.8691+-0.1928        ^ definitely 4.8123x faster
weak-map-constructor              7.0352+-0.3864            6.6220+-0.3769          might be 1.0624x faster
weak-set-constructor              4.8727+-0.2691     ^      4.4130+-0.1081        ^ definitely 1.1042x faster
create-many-weak-map             23.4147+-0.3502           23.0340+-0.7137          might be 1.0165x faster
weak-map-key                     36.4065+-1.3320     ?     36.7283+-1.1744        ?
weak-set-key                     33.7195+-0.9247           33.6985+-0.4455

&lt;geometric&gt;                      21.0745+-0.3325     ^     13.0612+-0.1327        ^ definitely 1.6135x faster

* JSTests/stress/weak-map-weak-set-lazy-buffer.js: Added.
(assert):
(makeWeakMap):
(makeWeakSet):
(set for):
(makeFilledMap):
(SubWeakMap):
(makeSub):
(readHas):
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/JSWeakMap.h:
* Source/JavaScriptCore/runtime/JSWeakSet.h:
* Source/JavaScriptCore/runtime/WeakMapImpl.cpp:
* Source/JavaScriptCore/runtime/WeakMapImpl.h:
(JSC::WeakMapBuffer::destroy):
(JSC::WeakMapImpl::emptyBuffer):
(JSC::WeakMapImpl::WeakMapImpl):
(JSC::WeakMapImpl::~WeakMapImpl):
(JSC::WeakMapImpl::offsetOfKeyCount):
(JSC::WeakMapImpl::offsetOfDeleteCount):
(JSC::WeakMapImpl::addInternal):
(JSC::WeakMapImpl::makeAndSetNewBuffer):
* Source/JavaScriptCore/runtime/WeakMapImplInlines.h:
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::add):
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::addBucket):
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::rehash):

Canonical link: <a href="https://commits.webkit.org/314218@main">https://commits.webkit.org/314218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7afd8dd58696105647589c35d279dede2ff12dfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174497 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122710 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128575 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168414 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30884 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109100 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28562 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22572 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157612 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139825 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177021 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26348 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29929 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136900 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136836 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36887 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148141 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102077 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32106 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25008 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38212 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111286 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37609 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3088 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37753 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->