### PR TITLE
[PCM] Support proxying PCM requests on iOS

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -111,11 +111,11 @@ NetworkStorageSession* NetworkSession::networkStorageSession() const
 static Ref<PCM::ManagerInterface> managerOrProxy(NetworkSession& networkSession, NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)
 {
 #if PLATFORM(COCOA)
-    ApplicationBundleIdentifierOrAuditToken applicationBundleIdentifier = parameters.sourceApplicationBundleIdentifier;
+    ApplicationBundleIdentifiersOrAuditToken applicationBundleIdentifier = std::make_pair(parameters.sourceApplicationBundleIdentifier, parameters.sourceApplicationSecondaryIdentifier);
     if (auto data = networkProcess.sourceApplicationAuditData(); data && parameters.sourceApplicationBundleIdentifier.isEmpty())
         applicationBundleIdentifier = makeVector(data.get());
 #else
-    ApplicationBundleIdentifierOrAuditToken applicationBundleIdentifier = String();
+    ApplicationBundleIdentifiersOrAuditToken applicationBundleIdentifier = std::make_pair(String(), String());
 #endif
 
     if (!parameters.pcmMachServiceName.isEmpty() && !networkSession.sessionID().isEphemeral())

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
@@ -58,12 +58,12 @@ constexpr Seconds debugModeSecondsUntilSend { 10_s };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PrivateClickMeasurementManager);
 
-Ref<PrivateClickMeasurementManager> PrivateClickMeasurementManager::create(UniqueRef<PCM::Client>&& client, const String& storageDirectory, const ApplicationBundleIdentifierOrAuditToken& applicationBundleIdentifier)
+Ref<PrivateClickMeasurementManager> PrivateClickMeasurementManager::create(UniqueRef<PCM::Client>&& client, const String& storageDirectory, const ApplicationBundleIdentifiersOrAuditToken& applicationBundleIdentifier)
 {
     return adoptRef(*new PrivateClickMeasurementManager(WTF::move(client), storageDirectory, applicationBundleIdentifier));
 }
 
-PrivateClickMeasurementManager::PrivateClickMeasurementManager(UniqueRef<PCM::Client>&& client, const String& storageDirectory, const ApplicationBundleIdentifierOrAuditToken& applicationBundleIdentifier)
+PrivateClickMeasurementManager::PrivateClickMeasurementManager(UniqueRef<PCM::Client>&& client, const String& storageDirectory, const ApplicationBundleIdentifiersOrAuditToken& applicationBundleIdentifier)
     : m_firePendingAttributionRequestsTimer(RunLoop::mainSingleton(), "PrivateClickMeasurementManager::FirePendingAttributionRequestsTimer"_s, this, &PrivateClickMeasurementManager::firePendingAttributionRequests)
     , m_storageDirectory(storageDirectory)
     , m_applicationBundleIdentifier(applicationBundleIdentifier)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
@@ -39,12 +39,12 @@
 
 namespace WebKit {
 
-using ApplicationBundleIdentifierOrAuditToken = Variant<String, Vector<uint8_t>>;
+using ApplicationBundleIdentifiersOrAuditToken = Variant<std::pair<String, String>, Vector<uint8_t>>;
 
 class PrivateClickMeasurementManager : public PCM::ManagerInterface, public CanMakeWeakPtr<PrivateClickMeasurementManager> {
     WTF_MAKE_TZONE_ALLOCATED(PrivateClickMeasurementManager);
 public:
-    static Ref<PrivateClickMeasurementManager> create(UniqueRef<PCM::Client>&&, const String& storageDirectory, const ApplicationBundleIdentifierOrAuditToken&);
+    static Ref<PrivateClickMeasurementManager> create(UniqueRef<PCM::Client>&&, const String& storageDirectory, const ApplicationBundleIdentifiersOrAuditToken&);
 
     ~PrivateClickMeasurementManager();
 
@@ -74,7 +74,7 @@ public:
     void fetchRegistrableDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&&);
 
 private:
-    PrivateClickMeasurementManager(UniqueRef<PCM::Client>&&, const String& storageDirectory, const ApplicationBundleIdentifierOrAuditToken&);
+    PrivateClickMeasurementManager(UniqueRef<PCM::Client>&&, const String& storageDirectory, const ApplicationBundleIdentifiersOrAuditToken&);
 
     PCM::Store& store();
     const PCM::Store& store() const;
@@ -103,7 +103,7 @@ private:
     std::optional<ApplicationBundleIdentifier> m_privateClickMeasurementAppBundleIDForTesting;
     mutable RefPtr<PCM::Store> m_store;
     String m_storageDirectory;
-    const ApplicationBundleIdentifierOrAuditToken m_applicationBundleIdentifier;
+    const ApplicationBundleIdentifiersOrAuditToken m_applicationBundleIdentifier;
     const UniqueRef<PCM::Client> m_client;
 
     struct AttributionReportTestConfig {

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
@@ -198,10 +198,10 @@ static RefPtr<PrivateClickMeasurementManager>& NODELETE managerPointer()
     return manager.get();
 }
 
-void initializePCMStorageInDirectory(const String& storageDirectory, const String& applicationBundleIdentifier)
+void initializePCMStorageInDirectory(const String& storageDirectory, const String& applicationBundleIdentifier, const String& secondaryApplicationBundleIdentifier)
 {
     ASSERT(!managerPointer());
-    managerPointer() = PrivateClickMeasurementManager::create(makeUniqueRef<PCM::DaemonClient>(), storageDirectory, applicationBundleIdentifier);
+    managerPointer() = PrivateClickMeasurementManager::create(makeUniqueRef<PCM::DaemonClient>(), storageDirectory, std::make_pair(applicationBundleIdentifier, secondaryApplicationBundleIdentifier));
 }
 
 static PrivateClickMeasurementManager& NODELETE daemonManagerSingleton()

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h
@@ -114,7 +114,7 @@ void decodeMessageAndSendToManager(const Daemon::Connection&, MessageType, std::
 void doDailyActivityInManager();
 bool NODELETE messageTypeSendsReply(MessageType);
 
-void initializePCMStorageInDirectory(const String& storageDirectory, const String& applicationBundleIdentifier);
+void initializePCMStorageInDirectory(const String& storageDirectory, const String& applicationBundleIdentifier, const String& secondaryApplicationBundleIdentifier);
 
 } // namespace PCM
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.cpp
@@ -37,7 +37,7 @@ namespace WebKit::PCM {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkLoader);
 
-void NetworkLoader::start(URL&&, RefPtr<JSON::Object>&&, WebCore::PrivateClickMeasurement::PcmDataCarried, const ApplicationBundleIdentifierOrAuditToken&, Callback&& completionHandler)
+void NetworkLoader::start(URL&&, RefPtr<JSON::Object>&&, WebCore::PrivateClickMeasurement::PcmDataCarried, const ApplicationBundleIdentifiersOrAuditToken&, Callback&& completionHandler)
 {
     notImplemented();
     completionHandler({ }, { });

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.h
@@ -38,13 +38,13 @@ class ResourceResponse;
 
 namespace WebKit::PCM {
 
-using ApplicationBundleIdentifierOrAuditToken = Variant<String, Vector<uint8_t>>;
+using ApplicationBundleIdentifiersOrAuditToken = Variant<std::pair<String, String>, Vector<uint8_t>>;
 
 class NetworkLoader {
     WTF_MAKE_TZONE_ALLOCATED(NetworkLoader);
 public:
     using Callback = CompletionHandler<void(const String&, const RefPtr<JSON::Object>&)>;
-    static void start(URL&&, RefPtr<JSON::Object>&&, WebCore::PrivateClickMeasurement::PcmDataCarried, const ApplicationBundleIdentifierOrAuditToken&, Callback&&);
+    static void start(URL&&, RefPtr<JSON::Object>&&, WebCore::PrivateClickMeasurement::PcmDataCarried, const ApplicationBundleIdentifiersOrAuditToken&, Callback&&);
     static void allowTLSCertificateChainForLocalPCMTesting(const WebCore::CertificateInfo&);
 };
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
@@ -87,7 +87,7 @@ static HashMap<LoadTaskIdentifier, RetainPtr<NSURLSessionDataTask>>& NODELETE ta
     return map.get();
 }
 
-static NSURLSession *statelessSessionWithoutRedirectsSingleton(const ApplicationBundleIdentifierOrAuditToken& applicationBundleIdentifier)
+static NSURLSession *statelessSessionWithoutRedirectsSingleton(const ApplicationBundleIdentifiersOrAuditToken& applicationBundleIdentifier)
 {
     static NeverDestroyed<RetainPtr<WKNetworkSessionDelegateAllowingOnlyNonRedirectedJSON>> delegate = adoptNS([WKNetworkSessionDelegateAllowingOnlyNonRedirectedJSON new]);
     static NeverDestroyed<RetainPtr<NSURLSession>> session = [&] {
@@ -100,8 +100,9 @@ static NSURLSession *statelessSessionWithoutRedirectsSingleton(const Application
         configuration.get()._shouldSkipPreferredClientCertificateLookup = YES;
 
         WTF::switchOn(applicationBundleIdentifier,
-            [&] (const String& bundleIdentifier) {
-                configuration.get()._sourceApplicationBundleIdentifier = bundleIdentifier.createNSString().get();
+            [&] (const std::pair<String, String>& bundleIdentifiers) {
+                configuration.get()._sourceApplicationBundleIdentifier = bundleIdentifiers.first.createNSString().get();
+                configuration.get()._sourceApplicationSecondaryIdentifier = bundleIdentifiers.second.createNSString().get();
             }, [&] (const Vector<uint8_t>& auditToken) {
                 configuration.get()._sourceApplicationAuditTokenData = [NSData dataWithBytes:auditToken.span().data() length:auditToken.size()];
             }
@@ -117,7 +118,7 @@ void NetworkLoader::allowTLSCertificateChainForLocalPCMTesting(const WebCore::Ce
     allowedLocalTestServerTrust() = certificateInfo.trust();
 }
 
-void NetworkLoader::start(URL&& url, RefPtr<JSON::Object>&& jsonPayload, WebCore::PrivateClickMeasurement::PcmDataCarried pcmDataCarried, const ApplicationBundleIdentifierOrAuditToken& applicationBundleIdentifier, Callback&& callback)
+void NetworkLoader::start(URL&& url, RefPtr<JSON::Object>&& jsonPayload, WebCore::PrivateClickMeasurement::PcmDataCarried pcmDataCarried, const ApplicationBundleIdentifiersOrAuditToken& applicationBundleIdentifier, Callback&& callback)
 {
     // Prevent contacting non-local servers when a test certificate chain is used for 127.0.0.1.
     // FIXME: Use a proxy server to have tests cover the reports sent to the destination, too.
@@ -125,12 +126,12 @@ void NetworkLoader::start(URL&& url, RefPtr<JSON::Object>&& jsonPayload, WebCore
         return callback({ }, { });
 
     auto request = adoptNS([[NSMutableURLRequest alloc] initWithURL:url.createNSURL().get()]);
-    [request _setPrivacyProxyFailClosed:YES];
     [request setValue:WebCore::HTTPHeaderValues::maxAge0().createNSString().get() forHTTPHeaderField:@"Cache-Control"];
     [request setValue:WebCore::standardUserAgentWithApplicationName({ }).createNSString().get() forHTTPHeaderField:@"User-Agent"];
     RetainPtr crossSiteMainDocument = [NSURLComponents componentsWithURL:request.get().URL resolvingAgainstBaseURL:NO];
     crossSiteMainDocument.get().host = [NSString stringWithFormat:@"not-%@", crossSiteMainDocument.get().host];
     [request setMainDocumentURL:crossSiteMainDocument.get().URL];
+    [request setAttribution:NSURLRequestAttributionUser];
 
     if (jsonPayload) {
         request.get().HTTPMethod = @"POST";

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -103,6 +103,7 @@ void setPCMDataCarriedOnRequest(WebCore::PrivateClickMeasurement::PcmDataCarried
         return;
 
     request._needsNetworkTrackingPrevention = YES;
+    request._privacyProxyFailClosed = YES;
 #else
     UNUSED_PARAM(pcmDataCarried);
     UNUSED_PARAM(request);

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.adattributiond.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.adattributiond.sb.in
@@ -46,6 +46,8 @@
 (define (system-network)
     (allow file-read*
         (literal "/Library/Preferences/com.apple.networkd.plist")
+        (literal "/Library/Preferences/com.apple.networkextension.uuidcache.plist")
+        (literal "/private/var/preferences/com.apple.networkextension.uuidcache.plist")
         (literal "/private/var/db/nsurlstoraged/dafsaData.bin"))
     (deny mach-lookup (with telemetry)
         (global-name "com.apple.SystemConfiguration.PPPController")

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -596,6 +596,10 @@ function ios_family_process_model_entitlements()
 function ios_family_process_adattributiond_entitlements()
 {
     plistbuddy Add :com.apple.private.sandbox.profile string com.apple.WebKit.adattributiond
+    plistbuddy Add :com.apple.private.network.socket-delegate bool YES
+    plistbuddy Add :com.apple.security.network.client bool YES
+    plistbuddy Add :com.apple.private.networkserviceproxy bool YES
+    plistbuddy Add :com.apple.security.exception.mach-lookup.global-name:0 string com.apple.networkserviceproxy
 }
 
 function ios_family_process_webpushd_entitlements()

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
@@ -132,6 +132,7 @@ int PCMDaemonMain(int argc, const char** argv)
 #else
     constexpr auto safariApplicationBundleIdentifier { "com.apple.safari"_s };
 #endif
+    constexpr auto webKitSecondaryIdentifier { "com.apple.webkit.adattributiond"_s };
 
     auto arguments = unsafeMakeSpan(argv, argc);
     if (arguments.size() < 5 || !equalSpans(unsafeSpan(arguments[1]), "--machServiceName"_span) || !equalSpans(unsafeSpan(arguments[3]), "--storageLocation"_span)) {
@@ -152,7 +153,7 @@ int PCMDaemonMain(int argc, const char** argv)
         if (startActivity)
             registerScheduledActivityHandler();
         WTF::initializeMainThread();
-        PCM::initializePCMStorageInDirectory(FileSystem::stringFromFileSystemRepresentation(storageLocation), safariApplicationBundleIdentifier);
+        PCM::initializePCMStorageInDirectory(FileSystem::stringFromFileSystemRepresentation(storageLocation), safariApplicationBundleIdentifier, webKitSecondaryIdentifier);
     }
     CFRunLoopRun();
     return 0;


### PR DESCRIPTION
#### f8277ab0a96dc1a24aec6c65284506377a3a64a8
<pre>
[PCM] Support proxying PCM requests on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=308999">https://bugs.webkit.org/show_bug.cgi?id=308999</a>
<a href="https://rdar.apple.com/168773036">rdar://168773036</a>

Reviewed by Charlie Wolfe.

This change adds a new &quot;secondary&quot; identifier that we use when creating a
URLSession in adattributiond. The identifier is defined in
PCMDaemonEntryPoint.mm and it is passed as a new parameter when we construct
the PrivateClickMeasurementManager.

This PR also adds a couple more entitlements that are required. And it slightly
relaxes the sandbox for accessing a process-uuid cache. I also moved the
FailClosed flag so that we only apply it when we aren&apos;t in debug mode.

No new tests, tested manually.

* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::managerOrProxy):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp:
(WebKit::PrivateClickMeasurementManager::create):
(WebKit::PrivateClickMeasurementManager::PrivateClickMeasurementManager):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp:
(WebKit::PCM::initializePCMStorageInDirectory):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.cpp:
(WebKit::PCM::NetworkLoader::start):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm:
(WebKit::PCM::statelessSessionWithoutRedirectsSingleton):
(WebKit::PCM::NetworkLoader::start):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::setPCMDataCarriedOnRequest):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.adattributiond.sb.in:
* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
(WebKit::PCMDaemonMain):

Originally-landed-as: 305413.651@rapid/safari-7624.2.5.110-branch (5d220089dab7). <a href="https://rdar.apple.com/176059110">rdar://176059110</a>
Canonical link: <a href="https://commits.webkit.org/314666@main">https://commits.webkit.org/314666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4283657d48a9bd20a6bb6efdb575c007c4ea4ea2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175856 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40306 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/129704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169767 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110230 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/166131 "Found 2 webkitpy test failures: webkitscmpy.test.land_unittest.TestLand.test_svn, webkitscmpy.test.land_unittest.TestLandBitBucket.test_no_reviewer") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178394 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29284 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40368 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137984 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37166 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41056 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149375 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103854 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33261 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39567 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112641 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38963 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4332 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39208 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39106 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->