### PR TITLE
[JSC] ToBoolean/TypeOfIsUndefined/TypeOfIsFunction/TypeOf/CompareEq def value in DFGClobberize doesn't depend on node's origin.semantic

### DIFF
--- a/JSTests/stress/regress-173924142.js
+++ b/JSTests/stress/regress-173924142.js
@@ -1,0 +1,52 @@
+//@ runDefault("--useConcurrentJIT=false", "--jitPolicyScale=0.01")
+
+function assert(holds) {
+    if (!holds)
+        throw "Assertion failed";
+}
+
+const otherGlobal = createGlobalObject();
+otherGlobal.eval(`returnMultipleValues = function(foobar) {
+    return {
+        ToBoolean: Boolean(foobar),
+        TypeOfIsUndefined: typeof foobar === "undefined",
+        TypeOfIsFunction: typeof foobar === "function",
+        TypeOf: typeof foobar,
+        CompareEq: foobar == null,
+        LogicalNot: !foobar,
+    };
+}`);
+
+function returnMultipleValues(foobar) {
+    return [
+        {
+            ToBoolean: Boolean(foobar),
+            TypeOfIsUndefined: typeof foobar === "undefined",
+            TypeOfIsFunction: typeof foobar === "function",
+            TypeOf: typeof foobar,
+            CompareEq: foobar == null,
+            LogicalNot: !foobar,
+        },
+        otherGlobal.returnMultipleValues(foobar)
+    ]
+}
+noInline(returnMultipleValues)
+
+const masquerader = makeMasquerader()
+const otherGlobalMasquerader = otherGlobal.eval("makeMasquerader()")
+
+let masqueraderBefore = returnMultipleValues(masquerader);
+let otherGlobalMasqueraderBefore = returnMultipleValues(otherGlobalMasquerader);
+
+for (var i = 0; i < 10000; i++) {
+    returnMultipleValues(() => {})
+}
+
+let masqueraderAfter = returnMultipleValues(masquerader);
+let otherGlobalMasqueraderAfter = returnMultipleValues(otherGlobalMasquerader);
+
+for (const object of [masqueraderBefore, masqueraderAfter, otherGlobalMasqueraderBefore, otherGlobalMasqueraderAfter]) {
+    for (const property of Object.getOwnPropertyNames(object[0])) {
+        assert(object[0][property] !== object[1][property]);
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -249,7 +249,6 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case SameValue:
     case IsEmpty:
     case IsEmptyStorage:
-    case TypeOfIsUndefined:
     case IsUndefinedOrNull:
     case IsBoolean:
     case IsNumber:
@@ -257,8 +256,6 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case NumberIsInteger:
     case IsObject:
     case IsTypedArrayView:
-    case ToBoolean:
-    case LogicalNot:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case DoubleRep:
@@ -273,9 +270,17 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case ValueToInt32:
     case GetExecutable:
     case BottomValue:
-    case TypeOf:
     case SymbolToString:
         def(PureValue(node));
+        return;
+
+    // These nodes are realm-dependent when MasqueradesAsUndefined is involved.
+    // Including the globalObject in the PureValue ensures nodes from different realms are not folded by CSE.
+    case TypeOfIsUndefined:
+    case ToBoolean:
+    case LogicalNot:
+    case TypeOf:
+        def(PureValue(node, graph.globalObjectFor(node->origin.semantic)));
         return;
 
     // JSCallee for Eval can change the scope field.
@@ -691,12 +696,12 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
 
     case TypeOfIsObject:
         read(MiscFields);
-        def(HeapLocation(TypeOfIsObjectLoc, MiscFields, node->child1()), LazyNode(node));
+        def(HeapLocation(TypeOfIsObjectLoc, MiscFields, node->child1(), graph.globalObjectFor(node->origin.semantic)), LazyNode(node));
         return;
 
     case TypeOfIsFunction:
         read(MiscFields);
-        def(HeapLocation(TypeOfIsFunctionLoc, MiscFields, node->child1()), LazyNode(node));
+        def(HeapLocation(TypeOfIsFunctionLoc, MiscFields, node->child1(), graph.globalObjectFor(node->origin.semantic)), LazyNode(node));
         return;
         
     case IsCallable:
@@ -2382,6 +2387,13 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
 
         if (node->isBinaryUseKind(UntypedUse)) {
             clobberTop();
+            return;
+        }
+
+        // CompareEq is realm-dependent when MasqueradesAsUndefined is involved.
+        // Including the globalObject ensures nodes from different realms are not folded by CSE.
+        if (node->op() == CompareEq) {
+            def(PureValue(node, graph.globalObjectFor(node->origin.semantic)));
             return;
         }
 


### PR DESCRIPTION
#### c7fe05eb98f63f711766aa2822520c8557a1f404
<pre>
[JSC] ToBoolean/TypeOfIsUndefined/TypeOfIsFunction/TypeOf/CompareEq def value in DFGClobberize doesn&apos;t depend on node&apos;s origin.semantic
<a href="https://bugs.webkit.org/show_bug.cgi?id=311663">https://bugs.webkit.org/show_bug.cgi?id=311663</a>
<a href="https://rdar.apple.com/173924142">rdar://173924142</a>

Reviewed by Marcus Plutowski.

The semantics of operations like `typeof` are realm-dependent when the input has the
`MasqueradesAsUndefined` flag set. This patch prevents constant folding of these
expressions if they have different realms to preserve the semantics.

Added regress-173924142.js to ensure that the operations behave as expected even across realms.

* JSTests/stress/regress-173924142.js: Added.
(assert):
(otherGlobal.eval.returnMultipleValues):
(returnMultipleValues):
(i.returnMultipleValues):
(otherGlobalMasqueraderAfter.const.property.of.Object.getOwnPropertyNames):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):

Originally-landed-as: 305413.657@rapid/safari-7624.2.5.110-branch (882fc55c5e17). <a href="https://rdar.apple.com/176058724">rdar://176058724</a>
Canonical link: <a href="https://commits.webkit.org/315142@main">https://commits.webkit.org/315142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37b9214bdad200e242214f5c41c818b7a12daed2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41727 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35290 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125873 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130865 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33332 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111377 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26196 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160791 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142304 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180100 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29419 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32823 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30539 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139303 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41741 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139166 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37477 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42429 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105803 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34452 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27498 "Unexpected infrastructure issue, retrying build") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200850 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40933 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114189 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53955 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40330 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5594 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40581 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40475 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->