### PR TITLE
Cherry-pick(s) 500da5401d26. rdar://176062075

### DIFF
--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -188,10 +188,18 @@ GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, Ref<GPUComposit
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
+<<<<<<< HEAD
 
         Ref screen = PlatformScreen::singleton();
         if (auto* screenData = screen->screenData(displayID))
             protectedThis->updateScreenHeadroom(screenData->currentEDRHeadroom, screenData->suppressEDR);
+=======
+        if (auto* screenData = WebCore::screenData(displayID)) {
+            protectedThis->m_screenEDRHeadroom = screenData->currentEDRHeadroom;
+            protectedThis->m_screenSuppressEDR = screenData->suppressEDR;
+            protectedThis->updateHeadroomFromScreenProperties();
+        }
+>>>>>>> 500da5401d26 (Concurrent HashMap access leads to MTE crashes)
     }))
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
 {
@@ -269,6 +277,7 @@ void GPUCanvasContextCocoa::updateScreenHeadroomFromScreenPropertiesIfNeeded()
     if (!m_layerContentsDisplayDelegate->hasExtendedRange())
         return;
 
+<<<<<<< HEAD
     float maxEDRHeadroom = 1.f;
     bool suppressEDR = false;
 
@@ -291,6 +300,35 @@ void GPUCanvasContextCocoa::updateScreenHeadroomFromScreenPropertiesIfNeeded()
         semaphore.wait();
     }
 
+=======
+    if (m_screenPropertiesChangedObserver && (m_currentEDRHeadroom >= 1.f || m_screenEDRHeadroom >= 1.f)) {
+        if (m_currentEDRHeadroom < 1.f)
+            updateHeadroomFromScreenProperties();
+        return;
+    }
+
+    float maxEDRHeadroom = 1.f;
+    bool suppressEDR = false;
+
+    auto gatherScreenProperties = [&] {
+        for (const auto& screenData : WebCore::getScreenProperties().screenDataMap.values()) {
+            maxEDRHeadroom = std::max(maxEDRHeadroom, screenData.currentEDRHeadroom);
+            suppressEDR |= screenData.suppressEDR;
+        }
+    };
+
+    if (isMainThread())
+        gatherScreenProperties();
+    else {
+        BinarySemaphore semaphore;
+        callOnMainThread([&gatherScreenProperties, &semaphore] {
+            gatherScreenProperties();
+            semaphore.signal();
+        });
+        semaphore.wait();
+    }
+
+>>>>>>> 500da5401d26 (Concurrent HashMap access leads to MTE crashes)
     updateScreenHeadroom(maxEDRHeadroom, suppressEDR);
 }
 

--- a/Source/WebCore/platform/PlatformScreen.cpp
+++ b/Source/WebCore/platform/PlatformScreen.cpp
@@ -36,8 +36,15 @@ namespace WebCore {
 
 static Lock& platformScreenLock()
 {
+<<<<<<< HEAD
     static Lock lock;
     return lock;
+=======
+    ASSERT(isMainThread());
+
+    static NeverDestroyed<ScreenProperties> screenProperties;
+    return screenProperties;
+>>>>>>> 500da5401d26 (Concurrent HashMap access leads to MTE crashes)
 }
 
 Ref<PlatformScreen>& PlatformScreen::instance() WTF_REQUIRES_LOCK(platformScreenLock())


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176062075 to main. The following sources [962438e00d35,cf20d123b3b1,08911bd034c3] will still need to be cherry-picked once the conflict is resolved.

```Concurrent HashMap access leads to MTE crashes
https://bugs.webkit.org/show_bug.cgi?id=308476
rdar://163967950

Reviewed by Gerald Squelart.

Calling WebCore::getScreenProperties from a worker thread and iterating
over the HashMap is unsafe, since the main thread might be simultaneously
mutating it.

Correct this by only calling WebCore::getScreenProperties on the main thread.

* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::updateHeadroomFromScreenProperties):
(WebCore::GPUCanvasContextCocoa::updateScreenHeadroomFromScreenPropertiesIfNeeded):
(WebCore::GPUCanvasContextCocoa::setDynamicRangeLimit):
(WebCore::GPUCanvasContextCocoa::surfaceBufferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::updateScreenHeadroomFromScreenProperties): Deleted.
* Source/WebCore/platform/PlatformScreen.cpp:
(WebCore::getScreenProperties):

Originally-landed-as: 305413.414@rapid/safari-7624.2.5.110-branch (500da5401d26). rdar://176062075

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de68de3756c3a6ee9a376cf301107ead41315656

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165155 "4 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38646 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32223 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174197 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167023 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38980 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38647 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/174197 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/168114 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38980 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/32223 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174197 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38980 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38647 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/21952 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38980 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/32223 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176720 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32223 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/176720 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38714 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/38647 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176720 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/39404 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/32223 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101713 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/39404 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32223 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37914 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/37311 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/32223 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37557 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/37455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->