### PR TITLE
[Build perf] Stabilize measure-build-time subtest order

### DIFF
--- a/Tools/Scripts/measure-build-time
+++ b/Tools/Scripts/measure-build-time
@@ -491,19 +491,20 @@ def main():
     args = get_args()
 
     # Read each test's `depends` lists to compute a topological order to run
-    # all the tests. Does NOT perform cycle detection.
+    # all the tests. Ties are broken by AVAILABLE_TESTS order, so the plan is
+    # deterministic. Does NOT perform cycle detection.
     plan: list[type[Task]] = []
-    roots = {T for T in AVAILABLE_TESTS if not T.depends}
+    roots = [T for T in AVAILABLE_TESTS if not T.depends]
     edges = {T: set(T.depends) for T in AVAILABLE_TESTS}
 
     while roots:
-        T = roots.pop()
+        T = roots.pop(0)
         plan.append(T)
         for T2 in AVAILABLE_TESTS:
             if T in edges[T2]:
                 edges[T2].remove(T)
                 if not edges[T2]:
-                    roots.add(T2)
+                    roots.append(T2)
 
     tests: dict[str, TestResult] = {}
     for T in plan:


### PR DESCRIPTION
#### 39d081f6b07865c53c85cd4e031219b743d10f57
<pre>
[Build perf] Stabilize measure-build-time subtest order
<a href="https://bugs.webkit.org/show_bug.cgi?id=315817">https://bugs.webkit.org/show_bug.cgi?id=315817</a>
<a href="https://rdar.apple.com/178206263">rdar://178206263</a>

Reviewed by Geoffrey Garen and Richard Robinson.

Use a list instead of a set when computing the dependency order for
running tests. This ensures that tests run in the same order, which may
help reduce some spikiness we see in the build time perf charts.

* Tools/Scripts/measure-build-time:
(main):

Canonical link: <a href="https://commits.webkit.org/314176@main">https://commits.webkit.org/314176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/646e96e03d0caed88d49b83a3aaa359212acd421

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174199 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122414 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22053faa-a565-461f-bc81-bdd3d7a7c537) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128339 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90338 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed1e05cc-c52a-47d2-997e-460018972b73) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108864 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6df57f56-398e-4c26-b512-21e2837d4b10) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29701 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28325 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21954 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176722 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136661 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38716 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32462 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-display/display-contents-svg-elements.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136602 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147895 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101715 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25150 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31880 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24762 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37916 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37313 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2839 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37559 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37457 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->