### PR TITLE
[JSC] DFG `NewTypedArrayWithSize` should zero-fill the storage 8 bytes at a time

### DIFF
--- a/JSTests/microbenchmarks/typed-array-allocate-float64-variable-length.js
+++ b/JSTests/microbenchmarks/typed-array-allocate-float64-variable-length.js
@@ -1,0 +1,12 @@
+function allocate(length) {
+    return new Float64Array(length);
+}
+noInline(allocate);
+
+let sum = 0;
+for (let i = 0; i < 50000; ++i) {
+    let array = allocate(1000);
+    sum += array[0] + array[999];
+}
+if (sum !== 0)
+    throw new Error("bad: " + sum);

--- a/JSTests/microbenchmarks/typed-array-allocate-int32-constant-512.js
+++ b/JSTests/microbenchmarks/typed-array-allocate-int32-constant-512.js
@@ -1,0 +1,12 @@
+function allocate() {
+    return new Int32Array(512);
+}
+noInline(allocate);
+
+let sum = 0;
+for (let i = 0; i < 100000; ++i) {
+    let array = allocate();
+    sum += array[0] + array[511];
+}
+if (sum !== 0)
+    throw new Error("bad: " + sum);

--- a/JSTests/microbenchmarks/typed-array-allocate-uint8-variable-length.js
+++ b/JSTests/microbenchmarks/typed-array-allocate-uint8-variable-length.js
@@ -1,0 +1,12 @@
+function allocate(length) {
+    return new Uint8Array(length);
+}
+noInline(allocate);
+
+let sum = 0;
+for (let i = 0; i < 200000; ++i) {
+    let array = allocate(1000);
+    sum += array[0] + array[999];
+}
+if (sum !== 0)
+    throw new Error("bad: " + sum);

--- a/JSTests/stress/dfg-new-typed-array-with-size-zero-fill.js
+++ b/JSTests/stress/dfg-new-typed-array-with-size-zero-fill.js
@@ -1,0 +1,39 @@
+function makeUint8(length) { return new Uint8Array(length); }
+noInline(makeUint8);
+function makeInt16(length) { return new Int16Array(length); }
+noInline(makeInt16);
+function makeInt32(length) { return new Int32Array(length); }
+noInline(makeInt32);
+function makeFloat32(length) { return new Float32Array(length); }
+noInline(makeFloat32);
+function makeFloat64(length) { return new Float64Array(length); }
+noInline(makeFloat64);
+function makeBigInt64(length) { return new BigInt64Array(length); }
+noInline(makeBigInt64);
+function makeConstantSizes() { return [new Float64Array(16), new Float64Array(17), new Uint8Array(128), new Uint8Array(129), new Int32Array(512), new Float64Array(1000)]; }
+noInline(makeConstantSizes);
+
+function check(array, length, zero) {
+    if (array.length !== length)
+        throw new Error("bad length " + array.length + ", expected " + length);
+    for (let i = 0; i < length; ++i) {
+        if (array[i] !== zero)
+            throw new Error("non-zero element " + array[i] + " at index " + i + " of length " + length);
+    }
+}
+
+const lengths = [0, 1, 2, 3, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 255, 256, 257, 511, 512, 513, 999, 1000, 1001];
+const constantLengths = [16, 17, 128, 129, 512, 1000];
+
+for (let i = 0; i < testLoopCount; ++i) {
+    let length = lengths[i % lengths.length];
+    check(makeUint8(length), length, 0);
+    check(makeInt16(length), length, 0);
+    check(makeInt32(length), length, 0);
+    check(makeFloat32(length), length, 0);
+    check(makeFloat64(length), length, 0);
+    check(makeBigInt64(length), length, 0n);
+    let constants = makeConstantSizes();
+    for (let j = 0; j < constants.length; ++j)
+        check(constants[j], constantLengths[j], 0);
+}

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -2406,6 +2406,11 @@ public:
         store64(dataTempRegister, address);
     }
 
+    void store64(TrustedImm32 imm, BaseIndex address)
+    {
+        store64(TrustedImm64(imm.m_value), address);
+    }
+
     void store64(TrustedImm64 imm, BaseIndex address)
     {
         if (!imm.m_value) {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -12213,8 +12213,22 @@ void SpeculativeJIT::emitNewTypedArrayWithSizeInRegister(Node* node, TypedArrayT
     constexpr unsigned zeroFillUnrollWordLimit = 16;
     if (constantByteSize && *constantByteSize / sizeof(UCPURegister) <= zeroFillUnrollWordLimit)
         emitFillStorageWithJSEmpty(storageGPR, 0, *constantByteSize / sizeof(UCPURegister), scratchGPR);
-    else
-#endif
+    else {
+        Jump done = branchTest32(Zero, sizeGPR);
+        move(sizeGPR, scratchGPR);
+        if (elementSize(typedArrayType) != 8) {
+            if (elementSize(typedArrayType) > 1)
+                lshift32(TrustedImm32(logElementSize(typedArrayType)), scratchGPR);
+            add32(TrustedImm32(7), scratchGPR);
+            urshift32(TrustedImm32(3), scratchGPR);
+        }
+        Label loop = label();
+        sub32(TrustedImm32(1), scratchGPR);
+        store64(TrustedImm32(0), BaseIndex(storageGPR, scratchGPR, TimesEight));
+        branchTest32(NonZero, scratchGPR).linkTo(loop, this);
+        done.link(this);
+    }
+#else
     {
         Jump done = branchTest32(Zero, sizeGPR);
         move(sizeGPR, scratchGPR);
@@ -12236,6 +12250,7 @@ void SpeculativeJIT::emitNewTypedArrayWithSizeInRegister(Node* node, TypedArrayT
         branchTest32(NonZero, scratchGPR).linkTo(loop, this);
         done.link(this);
     }
+#endif
 
     auto butterfly = TrustedImmPtr(nullptr);
     switch (typedArrayType) {


### PR DESCRIPTION
#### dcc2aea406e0e9a99e44813a9f15e536f0fe8806
<pre>
[JSC] DFG `NewTypedArrayWithSize` should zero-fill the storage 8 bytes at a time
<a href="https://bugs.webkit.org/show_bug.cgi?id=315818">https://bugs.webkit.org/show_bug.cgi?id=315818</a>

Reviewed by Yusuke Suzuki.

The DFG fast path for NewTypedArrayWithSize zero-fills the storage with a
store32 loop unless the size is a small constant, while the FTL already
fills one 64-bit word per iteration via splatWords. Since the storage size
is rounded up to a multiple of 8 bytes, the DFG can do the same: compute
the number of 8-byte words and fill with store64, halving the loop
iterations on 64-bit targets. 32-bit targets keep the store32 loop.

Microbenchmark results with JSC_useFTLJIT=false:

                                                  TipOfTree                  Patched

typed-array-allocate-float64-variable-length
                                               21.8137+-0.3112     ^     16.5516+-0.2430        ^ definitely 1.3179x faster
typed-array-allocate-uint8-variable-length
                                               18.1906+-0.4245     ^     12.2229+-0.2481        ^ definitely 1.4882x faster
typed-array-allocate-int32-constant-512        18.0384+-0.2828     ^     13.4179+-0.2017        ^ definitely 1.3444x faster

&lt;geometric&gt;                                    19.2619+-0.1634     ^     13.9444+-0.1445        ^ definitely 1.3813x faster

* JSTests/microbenchmarks/typed-array-allocate-float64-variable-length.js: Added.
(allocate):
* JSTests/microbenchmarks/typed-array-allocate-int32-constant-512.js: Added.
(allocate):
* JSTests/microbenchmarks/typed-array-allocate-uint8-variable-length.js: Added.
(allocate):
* JSTests/stress/dfg-new-typed-array-with-size-zero-fill.js: Added.
(makeUint8):
(makeInt16):
(makeInt32):
(makeFloat32):
(makeFloat64):
(makeBigInt64):
(makeConstantSizes):
(check):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/314262@main">https://commits.webkit.org/314262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee73310c87f87b85ac4154135fb84e7168f66854

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122862 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128701 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168566 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109225 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28700 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22727 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157764 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139959 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177173 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26500 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30085 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137025 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136959 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36905 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148278 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102334 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32242 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25145 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38365 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111438 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37761 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3226 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38007 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->