### PR TITLE
Add bounds checks to platformImportSpki and platformImportPkcs8

### DIFF
--- a/LayoutTests/crypto/subtle/ec-import-pkcs8-empty-key-data-expected.txt
+++ b/LayoutTests/crypto/subtle/ec-import-pkcs8-empty-key-data-expected.txt
@@ -1,0 +1,10 @@
+Test importing a PKCS8 ECDSA key where index equals keyData.size()
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.importKey("pkcs8", emptyKeyDataPkcs8, {name: "ECDSA", namedCurve: "P-256"}, extractable, ["sign"]) rejected promise.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/ec-import-pkcs8-empty-key-data.html
+++ b/LayoutTests/crypto/subtle/ec-import-pkcs8-empty-key-data.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a PKCS8 ECDSA key where index equals keyData.size()");
+
+// This test verifies that importing a malformed PKCS8 key where the computed
+// index exactly equals the buffer size is rejected gracefully.
+// After stripping the header, there would be zero bytes left for the public key.
+//
+// Key structure (72 bytes):
+// - Offset 0-66: Valid PKCS8 EC header with OIDs and 32-byte private key
+// - Offset 67: 0xa1 (TaggedType1)
+// - Offset 68: 0x00 (length byte)
+// - Offset 69: 0x03 (BIT STRING)
+// - Offset 70: 0x00 (length byte, bytesUsedToEncodedLength returns 1)
+// - Offset 71: 0x00 (InitialOctet placeholder, consumed by +1)
+//
+// At offset 70: bytesUsedToEncodedLength(0x00) = 1
+// index = 70 + 1 + 1 = 72
+// index == keyData.size(), zero bytes remain for public key data
+
+var extractable = true;
+
+// 72 bytes: valid PKCS8 EC structure, but no public key data remains after parsing
+var emptyKeyDataPkcs8 = hexStringToUint8Array("3000020100300006072a8648ce3d020106082a8648ce3d0301070400300002010104000000000000000000000000000000000000000000000000000000000000000000a100030000");
+
+// Should reject with DataError, not crash
+shouldReject('crypto.subtle.importKey("pkcs8", emptyKeyDataPkcs8, {name: "ECDSA", namedCurve: "P-256"}, extractable, ["sign"])');
+
+</script>
+
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/ec-import-pkcs8-invalid-length-expected.txt
+++ b/LayoutTests/crypto/subtle/ec-import-pkcs8-invalid-length-expected.txt
@@ -1,0 +1,10 @@
+Test importing a PKCS8 ECDSA key with invalid length byte causing buffer overread
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.importKey("pkcs8", invalidLengthPkcs8Key, {name: "ECDSA", namedCurve: "P-256"}, extractable, ["sign"]) rejected promise.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/ec-import-pkcs8-invalid-length.html
+++ b/LayoutTests/crypto/subtle/ec-import-pkcs8-invalid-length.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a PKCS8 ECDSA key with invalid length byte causing buffer overread");
+
+// This test verifies that importing a malformed PKCS8 key where the final
+// length byte has a large value (0xFF) is rejected gracefully.
+// Without proper bounds checking, subvector(index) would access memory
+// far beyond the buffer.
+//
+// Key structure (71 bytes):
+// - Offset 0: 0x30 (SequenceMark - outer)
+// - Offset 1: 0x00 (length byte)
+// - Offset 2-4: 02 01 00 (Version)
+// - Offset 5: 0x30 (SequenceMark - AlgorithmIdentifier)
+// - Offset 6: 0x00 (length byte)
+// - Offset 7-15: IdEcPublicKey OID (06 07 2a 86 48 ce 3d 02 01)
+// - Offset 16-25: Secp256r1 OID (06 08 2a 86 48 ce 3d 03 01 07)
+// - Offset 26: 0x04 (OCTET STRING)
+// - Offset 27: 0x00 (length byte)
+// - Offset 28: 0x30 (SEQUENCE - ECPrivateKey)
+// - Offset 29: 0x00 (length byte)
+// - Offset 30-32: 02 01 01 (PrivateKeyVersion)
+// - Offset 33: 0x04 (OCTET STRING)
+// - Offset 34: 0x00 (length byte)
+// - Offset 35-66: 32 zero bytes (private key data)
+// - Offset 67: 0xa1 (TaggedType1)
+// - Offset 68: 0x00 (length byte)
+// - Offset 69: 0x03 (BIT STRING)
+// - Offset 70: 0xFF (length byte, bytesUsedToEncodedLength returns 128)
+//
+// At offset 70: bytesUsedToEncodedLength(0xFF) = 128
+// index = 70 + 128 + 1 = 199
+// keyData.subvector(199) on 71-byte buffer -> OOB access without bounds check
+
+var extractable = true;
+
+// 71 bytes: valid PKCS8 EC structure with IdEcPublicKey + Secp256r1 OIDs, then 0xFF length byte
+var invalidLengthPkcs8Key = hexStringToUint8Array("3000020100300006072a8648ce3d020106082a8648ce3d0301070400300002010104000000000000000000000000000000000000000000000000000000000000000000a10003ff");
+
+// Should reject with DataError, not crash or read beyond buffer
+shouldReject('crypto.subtle.importKey("pkcs8", invalidLengthPkcs8Key, {name: "ECDSA", namedCurve: "P-256"}, extractable, ["sign"])');
+
+</script>
+
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/ec-import-pkcs8-truncated-key-expected.txt
+++ b/LayoutTests/crypto/subtle/ec-import-pkcs8-truncated-key-expected.txt
@@ -1,0 +1,10 @@
+Test importing a truncated PKCS8 ECDSA key that triggers bounds check failure
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.importKey("pkcs8", truncatedPkcs8Key, {name: "ECDSA", namedCurve: "P-256"}, extractable, ["sign"]) rejected promise.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/ec-import-pkcs8-truncated-key.html
+++ b/LayoutTests/crypto/subtle/ec-import-pkcs8-truncated-key.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a truncated PKCS8 ECDSA key that triggers bounds check failure");
+
+// This test verifies that importing a malformed PKCS8 key with a truncated
+// ASN.1 structure is rejected gracefully rather than crashing.
+//
+// The malformed key is crafted so that:
+// 1. All intermediate size checks pass
+// 2. But the final computed index exceeds the buffer size
+// 3. Without the fix, keyData.subvector(index) crashes
+//
+// Key structure (71 bytes):
+// - Offset 0-66: Valid PKCS8 EC header with OIDs and 32-byte private key
+// - Offset 67: 0xa1 (TaggedType1)
+// - Offset 68: 0x00 (length byte)
+// - Offset 69: 0x03 (BIT STRING)
+// - Offset 70: 0x82 (length byte, bytesUsedToEncodedLength returns 3)
+//
+// At offset 70: bytesUsedToEncodedLength(0x82) = 3
+// index = 70 + 3 + 1 = 74
+// keyData.subvector(74) on 71-byte buffer -> OOB access (before fix)
+
+var extractable = true;
+
+// 71 bytes: valid PKCS8 EC structure with 0x82 length byte causing index overflow
+var truncatedPkcs8Key = hexStringToUint8Array("3000020100300006072a8648ce3d020106082a8648ce3d0301070400300002010104000000000000000000000000000000000000000000000000000000000000000000a1000382");
+
+// Should reject with DataError, not crash
+shouldReject('crypto.subtle.importKey("pkcs8", truncatedPkcs8Key, {name: "ECDSA", namedCurve: "P-256"}, extractable, ["sign"])');
+
+</script>
+
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/ec-import-spki-empty-key-data-expected.txt
+++ b/LayoutTests/crypto/subtle/ec-import-spki-empty-key-data-expected.txt
@@ -1,0 +1,10 @@
+Test importing a SPKI ECDSA key where index equals keyData.size()
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.importKey("spki", emptyKeyDataSpki, {name: "ECDSA", namedCurve: "P-256"}, extractable, ["verify"]) rejected promise.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/ec-import-spki-empty-key-data.html
+++ b/LayoutTests/crypto/subtle/ec-import-spki-empty-key-data.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a SPKI ECDSA key where index equals keyData.size()");
+
+// This test verifies that importing a malformed SPKI key where the computed
+// index exactly equals the buffer size is rejected gracefully.
+// After stripping the header, there would be zero bytes left for the key data.
+//
+// Key structure (26 bytes):
+// - Offset 0-22: Valid SPKI header with IdEcPublicKey + Secp256r1 OIDs
+// - Offset 23: 0x03 (BIT STRING mark)
+// - Offset 24: 0x00 (length byte, bytesUsedToEncodedLength returns 1)
+// - Offset 25: 0x00 (InitialOctet placeholder, consumed by +1)
+//
+// index computation:
+// After parsing header: index = 24
+// bytesUsedToEncodedLength(0x00) = 1
+// index = 24 + 1 + 1 = 26
+// index == keyData.size(), zero bytes remain for key data
+
+var extractable = true;
+
+// 26 bytes: valid SPKI header, but no key data remains after parsing
+var emptyKeyDataSpki = hexStringToUint8Array("3000300006072a8648ce3d020106082a8648ce3d030107030000");
+
+// Should reject with DataError, not crash
+shouldReject('crypto.subtle.importKey("spki", emptyKeyDataSpki, {name: "ECDSA", namedCurve: "P-256"}, extractable, ["verify"])');
+
+</script>
+
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/ec-import-spki-invalid-length-expected.txt
+++ b/LayoutTests/crypto/subtle/ec-import-spki-invalid-length-expected.txt
@@ -1,0 +1,10 @@
+Test importing a SPKI ECDSA key with invalid length byte causing buffer overread
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.importKey("spki", invalidLengthSpkiKey, {name: "ECDSA", namedCurve: "P-256"}, extractable, ["verify"]) rejected promise.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/ec-import-spki-invalid-length.html
+++ b/LayoutTests/crypto/subtle/ec-import-spki-invalid-length.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a SPKI ECDSA key with invalid length byte causing buffer overread");
+
+// This test verifies that importing a malformed SPKI key where the final
+// length byte has a large value (0xFF) is rejected gracefully.
+// Without proper bounds checking, this would cause an unsigned underflow
+// in the (keyData.size() - index) computation.
+//
+// Key structure (25 bytes):
+// - Offset 0: 0x30 (SequenceMark - outer)
+// - Offset 1: 0x00 (length byte, bytesUsedToEncodedLength returns 1)
+// - Offset 2: 0x30 (SequenceMark - inner AlgorithmIdentifier)
+// - Offset 3: 0x00 (length byte, bytesUsedToEncodedLength returns 1)
+// - Offset 4-12: IdEcPublicKey OID (06 07 2a 86 48 ce 3d 02 01)
+// - Offset 13-22: Secp256r1 OID (06 08 2a 86 48 ce 3d 03 01 07)
+// - Offset 23: 0x03 (BIT STRING mark, skipped by +1)
+// - Offset 24: 0xFF (length byte, bytesUsedToEncodedLength returns 128)
+//
+// index computation:
+// 1. index = 1
+// 2. Check: 25 >= 2 (pass)
+// 3. index = 1 + 1 + 1 = 3 (Read length, inner SEQUENCE)
+// 4. Check: 25 >= 4 (pass)
+// 5. index = 3 + 1 = 4 (Read length)
+// 6. Check: 25 >= 4 + 9 = 13 (pass), verify IdEcPublicKey
+// 7. index = 4 + 9 = 13
+// 8. Check: 25 >= 13 + 10 = 23 (pass), verify Secp256r1
+// 9. index = 13 + 10 + 1 = 24 (Read OID + BIT STRING)
+// 10. Check: 25 >= 24 + 1 = 25 (pass)
+// 11. bytesUsedToEncodedLength(0xFF) = 128
+//     index = 24 + 128 + 1 = 153
+// 12. keyData.size() - index = 25 - 153 -> unsigned underflow without bounds check
+
+var extractable = true;
+
+// 25 bytes: valid SPKI header with IdEcPublicKey + Secp256r1 OIDs, then 0xFF length byte
+var invalidLengthSpkiKey = hexStringToUint8Array("3000300006072a8648ce3d020106082a8648ce3d03010703ff");
+
+// Should reject with DataError, not crash or read beyond buffer
+shouldReject('crypto.subtle.importKey("spki", invalidLengthSpkiKey, {name: "ECDSA", namedCurve: "P-256"}, extractable, ["verify"])');
+
+</script>
+
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/ec-import-spki-truncated-key-expected.txt
+++ b/LayoutTests/crypto/subtle/ec-import-spki-truncated-key-expected.txt
@@ -1,0 +1,10 @@
+Test importing a truncated SPKI ECDSA key that triggers bounds check failure
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.importKey("spki", truncatedSpkiKey, {name: "ECDSA", namedCurve: "P-256"}, extractable, ["verify"]) rejected promise.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/ec-import-spki-truncated-key.html
+++ b/LayoutTests/crypto/subtle/ec-import-spki-truncated-key.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a truncated SPKI ECDSA key that triggers bounds check failure");
+
+// This test verifies that importing a malformed SPKI key with a truncated
+// ASN.1 structure is rejected gracefully rather than crashing.
+//
+// The malformed key is crafted so that:
+// 1. All intermediate size checks pass
+// 2. But the final computed index exceeds the buffer size
+// 3. Without the fix, keyData.size() - index underflows
+//
+// Key structure (25 bytes):
+// - Offset 0-22: Valid SPKI header with IdEcPublicKey + Secp256r1 OIDs
+// - Offset 23: 0x03 (BIT STRING mark)
+// - Offset 24: 0x82 (length byte, bytesUsedToEncodedLength returns 3)
+//
+// index computation:
+// After parsing header: index = 24
+// bytesUsedToEncodedLength(0x82) = 3
+// index = 24 + 3 + 1 = 28
+// keyData.size() - index = 25 - 28 -> unsigned underflow (before fix)
+
+var extractable = true;
+
+// 25 bytes: valid SPKI header with 0x82 length byte causing index overflow
+var truncatedSpkiKey = hexStringToUint8Array("3000300006072a8648ce3d020106082a8648ce3d0301070382");
+
+// Should reject with DataError, not crash
+shouldReject('crypto.subtle.importKey("spki", truncatedSpkiKey, {name: "ECDSA", namedCurve: "P-256"}, extractable, ["verify"])');
+
+</script>
+
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/rsa-import-pkcs8-empty-key-data-expected.txt
+++ b/LayoutTests/crypto/subtle/rsa-import-pkcs8-empty-key-data-expected.txt
@@ -3,7 +3,7 @@ Test importing a PKCS8 RSA-OAEP key where headerSize equals keyData.size()
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS crypto.subtle.importKey("pkcs8", emptyKeyDataPkcs8, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["decrypt"]) rejected promise  with DataError: Data provided to an operation does not meet requirements.
+PASS crypto.subtle.importKey("pkcs8", emptyKeyDataPkcs8, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["decrypt"]) rejected promise.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/crypto/subtle/rsa-import-pkcs8-empty-key-data.html
+++ b/LayoutTests/crypto/subtle/rsa-import-pkcs8-empty-key-data.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="../resources/common.js"></script>
 </head>
 <body>
@@ -40,6 +40,5 @@ shouldReject('crypto.subtle.importKey("pkcs8", emptyKeyDataPkcs8, {name: "RSA-OA
 
 </script>
 
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/crypto/subtle/rsa-import-pkcs8-invalid-length-expected.txt
+++ b/LayoutTests/crypto/subtle/rsa-import-pkcs8-invalid-length-expected.txt
@@ -3,7 +3,7 @@ Test importing a PKCS8 RSA-OAEP key with invalid length byte causing buffer over
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS crypto.subtle.importKey("pkcs8", invalidLengthPkcs8Key, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["decrypt"]) rejected promise  with DataError: Data provided to an operation does not meet requirements.
+PASS crypto.subtle.importKey("pkcs8", invalidLengthPkcs8Key, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["decrypt"]) rejected promise.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/crypto/subtle/rsa-import-pkcs8-invalid-length.html
+++ b/LayoutTests/crypto/subtle/rsa-import-pkcs8-invalid-length.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="../resources/common.js"></script>
 </head>
 <body>
@@ -41,6 +41,5 @@ shouldReject('crypto.subtle.importKey("pkcs8", invalidLengthPkcs8Key, {name: "RS
 
 </script>
 
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/crypto/subtle/rsa-import-pkcs8-truncated-key-expected.txt
+++ b/LayoutTests/crypto/subtle/rsa-import-pkcs8-truncated-key-expected.txt
@@ -3,7 +3,7 @@ Test importing a truncated PKCS8 RSA-OAEP key that triggers bounds check failure
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS crypto.subtle.importKey("pkcs8", truncatedPkcs8Key, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["decrypt"]) rejected promise  with DataError: Data provided to an operation does not meet requirements.
+PASS crypto.subtle.importKey("pkcs8", truncatedPkcs8Key, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["decrypt"]) rejected promise.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/crypto/subtle/rsa-import-pkcs8-truncated-key.html
+++ b/LayoutTests/crypto/subtle/rsa-import-pkcs8-truncated-key.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="../resources/common.js"></script>
 </head>
 <body>
@@ -43,6 +43,5 @@ shouldReject('crypto.subtle.importKey("pkcs8", truncatedPkcs8Key, {name: "RSA-OA
 
 </script>
 
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/crypto/subtle/rsa-import-spki-empty-key-data-expected.txt
+++ b/LayoutTests/crypto/subtle/rsa-import-spki-empty-key-data-expected.txt
@@ -3,7 +3,7 @@ Test importing a SPKI RSA-OAEP key where headerSize equals keyData.size()
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS crypto.subtle.importKey("spki", emptyKeyDataSpki, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["encrypt"]) rejected promise  with DataError: Data provided to an operation does not meet requirements.
+PASS crypto.subtle.importKey("spki", emptyKeyDataSpki, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["encrypt"]) rejected promise.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/crypto/subtle/rsa-import-spki-empty-key-data.html
+++ b/LayoutTests/crypto/subtle/rsa-import-spki-empty-key-data.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="../resources/common.js"></script>
 </head>
 <body>
@@ -40,6 +40,5 @@ shouldReject('crypto.subtle.importKey("spki", emptyKeyDataSpki, {name: "RSA-OAEP
 
 </script>
 
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/crypto/subtle/rsa-import-spki-invalid-length-expected.txt
+++ b/LayoutTests/crypto/subtle/rsa-import-spki-invalid-length-expected.txt
@@ -3,7 +3,7 @@ Test importing a SPKI RSA-OAEP key with invalid length byte causing buffer overr
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS crypto.subtle.importKey("spki", invalidLengthSpkiKey, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["encrypt"]) rejected promise  with DataError: Data provided to an operation does not meet requirements.
+PASS crypto.subtle.importKey("spki", invalidLengthSpkiKey, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["encrypt"]) rejected promise.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/crypto/subtle/rsa-import-spki-invalid-length.html
+++ b/LayoutTests/crypto/subtle/rsa-import-spki-invalid-length.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="../resources/common.js"></script>
 </head>
 <body>
@@ -41,6 +41,5 @@ shouldReject('crypto.subtle.importKey("spki", invalidLengthSpkiKey, {name: "RSA-
 
 </script>
 
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/crypto/subtle/rsa-import-spki-truncated-key-expected.txt
+++ b/LayoutTests/crypto/subtle/rsa-import-spki-truncated-key-expected.txt
@@ -3,7 +3,7 @@ Test importing a truncated SPKI RSA-OAEP key that triggers bounds check failure
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS crypto.subtle.importKey("spki", truncatedSpkiKey, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["encrypt"]) rejected promise  with DataError: Data provided to an operation does not meet requirements.
+PASS crypto.subtle.importKey("spki", truncatedSpkiKey, {name: "RSA-OAEP", hash: "sha-256"}, extractable, ["encrypt"]) rejected promise.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/crypto/subtle/rsa-import-spki-truncated-key.html
+++ b/LayoutTests/crypto/subtle/rsa-import-spki-truncated-key.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="../resources/common.js"></script>
 </head>
 <body>
@@ -43,6 +43,5 @@ shouldReject('crypto.subtle.importKey("spki", truncatedSpkiKey, {name: "RSA-OAEP
 
 </script>
 
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyECCocoa.cpp
@@ -236,6 +236,8 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier id
     if (keyData.size() < index + 1)
         return nullptr;
     index += bytesUsedToEncodedLength(keyData[index]) + 1; // Read length
+    if (keyData.size() < index)
+        return nullptr;
     if (doesUncompressedPointMatchNamedCurve(curve, keyData.size() - index))
         return platformImportRaw(identifier, curve, Vector<uint8_t>(keyData.subspan(index, keyData.size() - index)), extractable, usages);
 
@@ -333,6 +335,8 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier i
     if (keyData.size() < index + 1)
         return nullptr;
     index += bytesUsedToEncodedLength(keyData[index]) + 1; // Read length, InitialOctet
+    if (keyData.size() < index)
+        return nullptr;
 
     // KeyBinary = uncompressed point + private key
     auto keyBinary = keyData.subvector(index);


### PR DESCRIPTION
#### d3de21e23bc8d8443a47227ed0027e7c92b566db
<pre>
Add bounds checks to platformImportSpki and platformImportPkcs8
<a href="https://rdar.apple.com/173548767">rdar://173548767</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311703">https://bugs.webkit.org/show_bug.cgi?id=311703</a>

Reviewed by Abrar Rahman Protyasha.

`bytesUsedToEncodedLength()` can return up to 128 for a 0xFF length byte,
which pushes the parsing index past the buffer end. Without a bounds check,
`platformImportSpki` underflows on `keyData.size() - index` and
`platformImportPkcs8` calls `subvector()` out of bounds — both crash the
WebContent process. This is the same bug fixed for RSA in 308706@main.

Tests: crypto/subtle/ec-import-pkcs8-empty-key-data.html
       crypto/subtle/ec-import-pkcs8-invalid-length.html
       crypto/subtle/ec-import-pkcs8-truncated-key.html
       crypto/subtle/ec-import-spki-empty-key-data.html
       crypto/subtle/ec-import-spki-invalid-length.html
       crypto/subtle/ec-import-spki-truncated-key.html

* LayoutTests/crypto/subtle/ec-import-pkcs8-empty-key-data-expected.txt: Added.
* LayoutTests/crypto/subtle/ec-import-pkcs8-empty-key-data.html: Added.
* LayoutTests/crypto/subtle/ec-import-pkcs8-invalid-length-expected.txt: Added.
* LayoutTests/crypto/subtle/ec-import-pkcs8-invalid-length.html: Added.
* LayoutTests/crypto/subtle/ec-import-pkcs8-truncated-key-expected.txt: Added.
* LayoutTests/crypto/subtle/ec-import-pkcs8-truncated-key.html: Added.
* LayoutTests/crypto/subtle/ec-import-spki-empty-key-data-expected.txt: Added.
* LayoutTests/crypto/subtle/ec-import-spki-empty-key-data.html: Added.
* LayoutTests/crypto/subtle/ec-import-spki-invalid-length-expected.txt: Added.
* LayoutTests/crypto/subtle/ec-import-spki-invalid-length.html: Added.
* LayoutTests/crypto/subtle/ec-import-spki-truncated-key-expected.txt: Added.
* LayoutTests/crypto/subtle/ec-import-spki-truncated-key.html: Added.
* LayoutTests/crypto/subtle/rsa-import-pkcs8-empty-key-data-expected.txt:
* LayoutTests/crypto/subtle/rsa-import-pkcs8-empty-key-data.html:
* LayoutTests/crypto/subtle/rsa-import-pkcs8-invalid-length-expected.txt:
* LayoutTests/crypto/subtle/rsa-import-pkcs8-invalid-length.html:
* LayoutTests/crypto/subtle/rsa-import-pkcs8-truncated-key-expected.txt:
* LayoutTests/crypto/subtle/rsa-import-pkcs8-truncated-key.html:
* LayoutTests/crypto/subtle/rsa-import-spki-empty-key-data-expected.txt:
* LayoutTests/crypto/subtle/rsa-import-spki-empty-key-data.html:
* LayoutTests/crypto/subtle/rsa-import-spki-invalid-length-expected.txt:
* LayoutTests/crypto/subtle/rsa-import-spki-invalid-length.html:
* LayoutTests/crypto/subtle/rsa-import-spki-truncated-key-expected.txt:
* LayoutTests/crypto/subtle/rsa-import-spki-truncated-key.html:
* Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformImportPkcs8):

Originally-landed-as: 305413.644@rapid/safari-7624.2.5.110-branch (ba8a6514960f). <a href="https://rdar.apple.com/176059138">rdar://176059138</a>
Canonical link: <a href="https://commits.webkit.org/314145@main">https://commits.webkit.org/314145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67e8bc65df0090341d1dc14840342b65b7590829

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174204 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128343 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108868 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29707 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28328 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21959 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176727 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29603 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136664 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136605 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36842 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101720 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31886 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24766 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37921 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110993 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37318 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2843 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->