### PR TITLE
[JSC] DFG object allocation sinking shouldn't insert a check when given a PutByVal node

### DIFF
--- a/JSTests/stress/regress-168411205.js
+++ b/JSTests/stress/regress-168411205.js
@@ -1,0 +1,14 @@
+//@ runDefault("--useConcurrentJIT=0", "--validateGraphAtEachPhase=1", "--validateGraph=true")
+
+function f() {
+  const a = new Array(3);
+  a[0] = 0;
+  for (let i = 1; i < 3; ++i) {
+    a[i] = a[0];
+  }
+}
+noInline(f);
+
+for (let i = 0; i < testLoopCount; ++i) {
+  f();
+}

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -2315,14 +2315,6 @@ escapeChildren:
 
                         doLower = true;
 
-                        if (node->op() == PutByVal) {
-                            // We must insert the check before the PutHint inserted below. This is because that both PutHint and PutByVal
-                            // clobber the exit state. Since they have consistent exit state clobberization assumption, an ExitOK wouldn't be
-                            // inserted below which breaks the validation.
-                            Edge value = m_graph.varArgChild(node, 2);
-                            m_insertionSet.insertNode(nodeIndex + 1, SpecNone, Check, node->origin, Edge(value.node(), value.useKind()));
-                        }
-
                         dataLogLnIf(Options::verboseObjectAllocationSinking(), "Creating hint with value ", nodeValue, " before ", node);
                         m_insertionSet.insert(
                             nodeIndex + 1,
@@ -2334,9 +2326,6 @@ escapeChildren:
                     });
 
 
-                // After inserting a PutHint, the next node cannot exit. If the current node does clobber the exit state, then we are fine since
-                // the exit state clobberization are consistent after the insertion. Otherwise, the assumption was broken and an ExitOK is required
-                // to ensure a valid exit state.
                 if (!nextCanExit && desiredNextExitOK) {
                     // We indicate that the exit state is fine now. We need to do this because we
                     // emitted hints that appear to invalidate the exit state.

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -1021,10 +1021,6 @@ private:
                     VALIDATE((node), node->entrypointIndex() < m_graph.m_numberOfEntrypoints);
                     break;
 
-                case GetButterfly:
-                    VALIDATE((node), !node->child1()->isPhantomAllocation());
-                    break;
-
                 default:
                     m_graph.doToChildren(
                         node,


### PR DESCRIPTION
#### cdfa73fdc391180a7fe3b00eb01dd1d2b410956a
<pre>
[JSC] DFG object allocation sinking shouldn&apos;t insert a check when given a PutByVal node
<a href="https://bugs.webkit.org/show_bug.cgi?id=305732">https://bugs.webkit.org/show_bug.cgi?id=305732</a>
<a href="https://rdar.apple.com/168411205">rdar://168411205</a>

Reviewed by Yijia Huang.

The if statement that this change removes was originally added as a fix
for an old, now-replaced array allocation sinking method. Now, it runs
the risk of invalidating the DFG graph. Because it doesn&apos;t otherwise
serve any purpose now, it should just be removed.

Test: JSTests/stress/regress-168411205.js

* JSTests/stress/regress-168411205.js: Added.
(f):
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp: Remove special case for PutByVal
* Source/JavaScriptCore/dfg/DFGValidate.cpp:

Originally-landed-as: 305413.542@rapid/safari-7624.2.5.110-branch (5fbe988916b7). <a href="https://rdar.apple.com/176061619">rdar://176061619</a>
Canonical link: <a href="https://commits.webkit.org/314144@main">https://commits.webkit.org/314144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ddfc7de0c0d680c885c99759f08f2b48c9b0dd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174205 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122420 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128345 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108870 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29704 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28330 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21960 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157322 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176728 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26058 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29632 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136665 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136606 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36843 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147900 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101721 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31887 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24767 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37922 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110994 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37319 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2844 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37565 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->