### PR TITLE
[JSC] BBQJIT tail call shuffle should detect overlapping stack slots

### DIFF
--- a/JSTests/wasm/stress/tail-call-v128-ref-stack-overlap.js
+++ b/JSTests/wasm/stress/tail-call-v128-ref-stack-overlap.js
@@ -1,0 +1,64 @@
+//@ requireOptions("--useWasmSIMD=1", "--useWasmTailCalls=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// rdar://174490087
+
+let wat = `
+(module
+  (func $callee
+    (param i64 i64 i64 i64 i64 i64 i64 i64)          ;; 0-7   GPR
+    (param v128 v128 v128 v128 v128 v128 v128 v128)   ;; 8-15  FPR
+    (param i64)                                        ;; 16    first stack param
+    (param v128)                                       ;; 17    v128
+    (param externref)                                  ;; 18    externref overlapping v128
+    (param i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+           i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+           i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+           i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+           i64 i64 i64 i64 i64 i64)                   ;; 19-64 padding
+    (result externref)
+    local.get 18)
+
+  (func $caller (export "caller") (param $r externref) (result externref)
+    (local $z i64)
+    ;; GPR params 0-7
+    i64.const 0 i64.const 0 i64.const 0 i64.const 0
+    i64.const 0 i64.const 0 i64.const 0 i64.const 0
+    ;; FPR params 8-15
+    v128.const i64x2 0 0  v128.const i64x2 0 0
+    v128.const i64x2 0 0  v128.const i64x2 0 0
+    v128.const i64x2 0 0  v128.const i64x2 0 0
+    v128.const i64x2 0 0  v128.const i64x2 0 0
+    ;; param 16: i64
+    i64.const 0
+    ;; param 17: v128
+    v128.const i64x2 0x1111111111111111 0x2222222222222222
+    ;; param 18: the externref
+    local.get $r
+    ;; params 19-64: padding to force spills
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z
+    return_call $callee))
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, tail_call: true, exceptions: true })
+    const { caller } = instance.exports
+    const sentinel = { marker: 0x1337 }
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(caller(sentinel), sentinel)
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -284,6 +284,18 @@ bool Location::operator==(Location other) const
     }
 }
 
+bool Location::rangesOverlap(Location a, uint32_t aSize, Location b, uint32_t bSize)
+{
+    if (a.m_kind != b.m_kind)
+        return false;
+    if (a.isStack() || a.isStackArgument()) {
+        ASSERT(aSize);
+        ASSERT(bSize);
+        return WTF::nonEmptyRangesOverlap(a.m_offset, a.m_offset + static_cast<int32_t>(aSize), b.m_offset, b.m_offset + static_cast<int32_t>(bSize));
+    }
+    return a == b;
+}
+
 Location::Kind Location::kind() const
 {
     return Kind(m_kind);
@@ -5523,7 +5535,7 @@ void BBQJIT::emitShuffle(Vector<Value, N, OverflowHandler>& srcVector, Vector<Lo
 #if ASSERT_ENABLED
     for (size_t i = 0; i < dstVector.size(); ++i) {
         for (size_t j = i + 1; j < dstVector.size(); ++j)
-            ASSERT(dstVector[i] != dstVector[j]);
+            ASSERT(!Location::rangesOverlap(dstVector[i], srcVector[i].size(), dstVector[j], srcVector[j].size()));
     }
 
     // This algorithm assumes at most one cycle: https://xavierleroy.org/publi/parallel-move.pdf

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -127,6 +127,8 @@ public:
 
         static Location NODELETE fromArgumentLocation(ArgumentLocation argLocation, TypeKind type);
 
+        static bool rangesOverlap(Location a, uint32_t aSize, Location b, uint32_t bSize);
+
         bool NODELETE isNone() const;
 
         bool NODELETE isGPR() const;

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -517,11 +517,12 @@ void BBQJIT::emitShuffleMove(Vector<Value, N, OverflowHandler>& srcVector, Vecto
     if (srcLocation == dst)
         return; // Easily eliminate redundant moves here.
 
+    uint32_t dstSize = srcVector[index].size();
     statusVector[index] = ShuffleStatus::BeingMoved;
     for (unsigned i = 0; i < srcVector.size(); i ++) {
         // This check should handle constants too - constants always have location None, and no
         // dst should ever be a constant. But we assume that's asserted in the caller.
-        if (locationOf(srcVector[i]) == dst) {
+        if (Location::rangesOverlap(locationOf(srcVector[i]), srcVector[i].size(), dst, dstSize)) {
             switch (statusVector[i]) {
             case ShuffleStatus::ToMove:
                 emitShuffleMove(srcVector, dstVector, statusVector, i);


### PR DESCRIPTION
#### a6f42da10166a940ded9fdaa2018012470362516
<pre>
[JSC] BBQJIT tail call shuffle should detect overlapping stack slots
<a href="https://bugs.webkit.org/show_bug.cgi?id=312288">https://bugs.webkit.org/show_bug.cgi?id=312288</a>
<a href="https://rdar.apple.com/174490087">rdar://174490087</a>

Reviewed by Dan Hecht.

Because in a tail call the caller and the callee frames overlap, BBQJIT::emitTailCall()
uses emitShuffle() to orchestrate the copying of call arguments into their destination
locations in such a way that if a caller temp resides in the callee argument space and is
itself passed as an argument, it is not clobbered before it&apos;s been moved to its final
location.

The move hazard detection in emitShuffleMove() compares stack locations by offset only
(via Location::operator==). The core assumption here is that source and destination values
with different base addresses never overlap, so a write to a destination address A never
clobbers a source value at address B.

This assumption does not always hold. Caller temps (source values) are always 16-byte
aligned regardless of value type. Callee arguments (destination values) are packed
contiguously. If an i64 argument at address B is followed by a v128 argument, the v128
argument occupies the address range [B+8, B+24). This range overlaps two temp slots with
ranges [B, B+16) and [B+16, B+32). Because hazard detection currently only considers the
base address, this overlap will go unnoticed and the shuffle may write the v128 argument
before the values in the overlapping source slots have been moved.

This patch adds Location::overlaps() method which considers actual ranges for Stack and
StackArgument locations. The method replaces Location::operator==() for hazard detection.

The new method is also used in destination uniqueness assertion in emitShuffle.

Test: JSTests/wasm/stress/tail-call-v128-ref-stack-overlap.js

Originally-landed-as: 305413.670@safari-7624-branch (73c288dd8c72). <a href="https://rdar.apple.com/176058891">rdar://176058891</a>
Canonical link: <a href="https://commits.webkit.org/315129@main">https://commits.webkit.org/315129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d12ca51e3bb1ac6c36dc74ceb108132293b63be4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168138 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177466 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125839 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130833 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33308 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151108 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111345 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32294 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30995 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26162 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160757 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142279 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180066 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29385 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32789 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139270 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139133 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37474 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42395 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105755 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34423 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200816 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40899 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114155 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53944 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40296 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5570 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->