### PR TITLE
Cherry-pick(s) 90e48031ed4d. rdar://176059102

### DIFF
--- a/LayoutTests/streams/pipeTo-removed-iframe-crash-expected.txt
+++ b/LayoutTests/streams/pipeTo-removed-iframe-crash-expected.txt
@@ -1,0 +1,4 @@
+Tests that pipeTo does not crash when the document frame is detached during error propagation.
+WebKit should not crash, and you should see PASS below.
+
+PASS

--- a/LayoutTests/streams/pipeTo-removed-iframe-crash.html
+++ b/LayoutTests/streams/pipeTo-removed-iframe-crash.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Tests that pipeTo does not crash when the document frame is detached during error propagation.<br>
+WebKit should not crash, and you should see PASS below.</p>
+<div id="result"></div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// The crash: StreamPipeToState::globalObject() calls
+// jsDynamicCast<JSDOMGlobalObject*>(context->globalObject()), but
+// ScriptExecutionContext::globalObject() can return null when the document
+// has no frame (e.g. after its iframe is removed). jsDynamicCast does not
+// null-check its argument, so passing null crashes with a read from 0x0.
+//
+// To reproduce, pipeTo must be called in the iframe's JS context so that
+// StreamPipeToState is associated with the iframe's ScriptExecutionContext.
+// Erroring the source stream queues a microtask. If the iframe is removed
+// before that microtask runs, context->globalObject() returns null when the
+// error-propagation callback fires.
+
+const iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+
+// Run pipeTo inside the iframe's context (CallWith=CurrentGlobalObject means
+// the StreamPipeToState gets the iframe's ScriptExecutionContext).
+iframe.contentWindow.eval(`
+    var readable = new ReadableStream({ start(c) { window._controller = c; } });
+    var writable = new WritableStream();
+    readable.pipeTo(writable).catch(() => {});
+    window._controller.error("test error");
+`);
+
+// Detach the iframe's document from its frame before the error-propagation
+// microtask runs. After this, ScriptExecutionContext::globalObject() returns
+// null for the iframe's context (document->frame() is null).
+iframe.remove();
+
+// Let microtasks and the event loop run. Without the fix, the error-propagation
+// microtask crashes in StreamPipeToState::globalObject().
+setTimeout(() => {
+    document.getElementById('result').textContent = 'PASS';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, 0);
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -276,7 +276,16 @@ StreamPipeToState::~StreamPipeToState() = default;
 JSDOMGlobalObject* StreamPipeToState::globalObject()
 {
     RefPtr context = scriptExecutionContext();
+<<<<<<< HEAD
     return context ? downcast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
+=======
+    if (!context)
+        return nullptr;
+    auto* jsGlobalObject = context->globalObject();
+    if (!jsGlobalObject)
+        return nullptr;
+    return JSC::jsDynamicCast<JSDOMGlobalObject*>(jsGlobalObject);
+>>>>>>> 90e48031ed4d (REGRESSION(305413.674@safari-7624-branch): Crash in StreamPipeToState::globalObject)
 }
 
 void StreamPipeToState::handleSignal()

--- a/Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp
@@ -163,8 +163,15 @@ void InternalReadableStreamDefaultReader::onClosedPromiseRejection(Function<void
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
+<<<<<<< HEAD
     domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto result) {
         if (isFulfilled || !globalObject)
+=======
+    domPromise->whenSettled([domPromise, callback = WTF::move(callback)] {
+        if (domPromise->activeDOMObjectAreStopped())
+            return;
+        if (domPromise->status() != DOMPromise::Status::Rejected || !domPromise->globalObject())
+>>>>>>> 90e48031ed4d (REGRESSION(305413.674@safari-7624-branch): Crash in StreamPipeToState::globalObject)
             return;
         callback(*globalObject, result);
     });
@@ -193,8 +200,15 @@ void InternalReadableStreamDefaultReader::onClosedPromiseResolution(Function<voi
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
+<<<<<<< HEAD
     domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto*, bool isFulfilled, auto) {
         if (isFulfilled)
+=======
+    domPromise->whenSettled([domPromise, callback = WTF::move(callback)] {
+        if (domPromise->activeDOMObjectAreStopped())
+            return;
+        if (domPromise->status() == DOMPromise::Status::Fulfilled)
+>>>>>>> 90e48031ed4d (REGRESSION(305413.674@safari-7624-branch): Crash in StreamPipeToState::globalObject)
             callback();
     });
 }

--- a/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
@@ -155,8 +155,15 @@ void InternalWritableStreamWriter::onClosedPromiseRejection(Function<void(JSDOMG
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
+<<<<<<< HEAD
     domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto result) mutable {
         if (isFulfilled || !globalObject)
+=======
+    domPromise->whenSettled([domPromise, callback = WTF::move(callback)]() mutable {
+        if (domPromise->activeDOMObjectAreStopped())
+            return;
+        if (domPromise->status() != DOMPromise::Status::Rejected || !domPromise->globalObject())
+>>>>>>> 90e48031ed4d (REGRESSION(305413.674@safari-7624-branch): Crash in StreamPipeToState::globalObject)
             return;
         callback(*globalObject, result);
     });
@@ -183,8 +190,15 @@ void InternalWritableStreamWriter::onClosedPromiseResolution(Function<void()>&& 
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
+<<<<<<< HEAD
     domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto*, bool isFulfilled, auto) mutable {
         if (!isFulfilled)
+=======
+    domPromise->whenSettled([domPromise, callback = WTF::move(callback)]() mutable {
+        if (domPromise->activeDOMObjectAreStopped())
+            return;
+        if (domPromise->status() != DOMPromise::Status::Fulfilled)
+>>>>>>> 90e48031ed4d (REGRESSION(305413.674@safari-7624-branch): Crash in StreamPipeToState::globalObject)
             return;
         callback();
     });
@@ -232,8 +246,15 @@ void InternalWritableStreamWriter::whenReady(Function<void (bool)>&& callback)
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
+<<<<<<< HEAD
     domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto*, bool isFulfilled, auto) mutable {
         callback(isFulfilled);
+=======
+    domPromise->whenSettled([domPromise, callback = WTF::move(callback)]() mutable {
+        if (domPromise->activeDOMObjectAreStopped())
+            return;
+        callback(domPromise->status() == DOMPromise::Status::Fulfilled);
+>>>>>>> 90e48031ed4d (REGRESSION(305413.674@safari-7624-branch): Crash in StreamPipeToState::globalObject)
     });
 }
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176059102 to main. [90e48031ed4d] caused a merge conflict. 

```REGRESSION(305413.674@safari-7624-branch): Crash in StreamPipeToState::globalObject
https://bugs.webkit.org/show_bug.cgi?id=312938
rdar://175084445

Reviewed by Chris Dumez.

The crash was caused by StreamPipeToState::globalObject calling jsDynamicCast<JSDOMGlobalObject*>
on context->globalObject() without a nullptr check. Fixed the crash by adding a nullptr check.

The newly written test revealed a related bug that we were calling DOMPromise::status even when
active DOM objects had been stopped. Added a bunch of early returns to functions in
InternalReadableStreamDefaultReader and InternalWritableStreamWriter to avoid debug assertions
in these cases, one of which is hit by the new test.

Test: streams/pipeTo-removed-iframe-crash.html

* LayoutTests/streams/pipeTo-removed-iframe-crash-expected.txt: Added.
* LayoutTests/streams/pipeTo-removed-iframe-crash.html: Added.
* Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp:
(WebCore::StreamPipeToState::globalObject):
* Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp:
(WebCore::InternalReadableStreamDefaultReader::onClosedPromiseRejection):
(WebCore::InternalReadableStreamDefaultReader::onClosedPromiseResolution):
* Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp:
(WebCore::InternalWritableStreamWriter::onClosedPromiseRejection):
(WebCore::InternalWritableStreamWriter::onClosedPromiseResolution):
(WebCore::InternalWritableStreamWriter::whenReady):

Originally-landed-as: 305413.711@safari-7624-branch (90e48031ed4d). rdar://176059102

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5641b276d4e8de742d8a3f2304fbe6760ed503d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165166 "6 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38657 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32234 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174208 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122423 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167034 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38991 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38658 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/174208 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122423 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/168125 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38991 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/32234 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174208 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38991 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38658 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/21963 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38991 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/32234 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176731 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29608 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32234 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/176731 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/38658 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176731 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/39415 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/32234 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101724 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/39415 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32234 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37925 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110997 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/37322 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/32234 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37568 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/37466 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->