### PR TITLE
Type confusion in ReadableStream when cancel returns a fake Promise object

### DIFF
--- a/LayoutTests/streams/readable-stream-fake-promise-crash-expected.txt
+++ b/LayoutTests/streams/readable-stream-fake-promise-crash-expected.txt
@@ -1,0 +1,4 @@
+This tests overriding Promise object in cancel callback of ReadableStream.
+WebKit should not crash or hit any assertions under ASAN, and you should see PASS below.
+
+PASS

--- a/LayoutTests/streams/readable-stream-fake-promise-crash.html
+++ b/LayoutTests/streams/readable-stream-fake-promise-crash.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests overriding Promise object in cancel callback of ReadableStream.<br>
+WebKit should not crash or hit any assertions under ASAN, and you should see PASS below.</p>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function FakePromise(executor) {
+    executor(() => {}, () => {}); // satisfy resolve/reject callability checks
+    return 0; // construct() returns this object
+}
+
+const readableStream = new ReadableStream({
+    cancel(reason) {
+        // Fire m_promiseSpeciesWatchpointSet *here*, after all setup .@then calls are done
+        let didCall = false;
+        Object.defineProperty(Promise, Symbol.species, {
+            configurable: true,
+            get() {
+                if (!didCall) {
+                    didCall = true;
+                    return FakePromise;
+                }
+                return undefined; // fall back to %Promise% for every other .then
+            }
+        });
+        return new Promise(() => {}); // genuine pending JSPromise (passes through promiseResolve unchanged)
+    }
+});
+
+const writableStream = new WritableStream();
+const writer  = writableStream.getWriter();
+writer.close(); // sets @closeRequest => closeQueuedOrInFlight()==true, state still 'writable'
+writer.releaseLock(); // unlocks => destination.locked()==false
+
+readableStream.pipeTo(writableStream).catch(() => {}); // synchronous path to closingMustBePropagatedBackward -> jsCast -> performPromiseThen on 0
+
+document.write('PASS');
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -253,7 +253,7 @@ static RefPtr<DOMPromise> cancelReadableStream(JSDOMGlobalObject& globalObject, 
     if (!value)
         return nullptr;
 
-    auto* promise = downcast<JSC::JSPromise>(value);
+    auto* promise = dynamicDowncast<JSC::JSPromise>(value);
     if (!promise)
         return nullptr;
 
@@ -276,7 +276,8 @@ StreamPipeToState::~StreamPipeToState() = default;
 JSDOMGlobalObject* StreamPipeToState::globalObject()
 {
     RefPtr context = scriptExecutionContext();
-    return context ? downcast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
+
+    return context ? dynamicDowncast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
 }
 
 void StreamPipeToState::handleSignal()
@@ -411,7 +412,7 @@ void StreamPipeToState::errorsMustBePropagatedForward(JSDOMGlobalObject& globalO
                 auto value = internalWritableStream->abort(*globalObject, error.get());
                 if (!value)
                     return nullptr;
-                auto* promise = downcast<JSC::JSPromise>(value);
+                auto* promise = dynamicDowncast<JSC::JSPromise>(value);
                 if (!promise) {
                     auto [result, deferred] = createPromiseAndWrapper(*globalObject);
                     deferred->resolve();
@@ -559,7 +560,7 @@ void StreamPipeToState::closingMustBePropagatedBackward()
             };
 
             auto [result, deferred] = createPromiseAndWrapper(*globalObject);
-            auto* promise = downcast<JSC::JSPromise>(value);
+            auto* promise = dynamicDowncast<JSC::JSPromise>(value);
             if (!promise)
                 deferred->rejectWithCallback(WTF::move(getError2), RejectAsHandled::Yes);
             else {


### PR DESCRIPTION
#### 96ec73a1e57d67618055237272f866849103669c
<pre>
Type confusion in ReadableStream when cancel returns a fake Promise object
<a href="https://bugs.webkit.org/show_bug.cgi?id=312357">https://bugs.webkit.org/show_bug.cgi?id=312357</a>
<a href="https://rdar.apple.com/174652787">rdar://174652787</a>

Reviewed by Chris Dumez.

Use jsDynamicCast in place of jsCast to avoid type confusion.

Test: streams/readable-stream-fake-promise-crash.html

* LayoutTests/streams/readable-stream-fake-promise-crash-expected.txt: Added.
* LayoutTests/streams/readable-stream-fake-promise-crash.html: Added.
* Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp:
(WebCore::cancelReadableStream):
(WebCore::StreamPipeToState::globalObject):
(WebCore::StreamPipeToState::errorsMustBePropagatedForward):
(WebCore::StreamPipeToState::closingMustBePropagatedBackward):

Originally-landed-as: 305413.674@safari-7624-branch (86716cafbc99). <a href="https://rdar.apple.com/176058606">rdar://176058606</a>
Canonical link: <a href="https://commits.webkit.org/314690@main">https://commits.webkit.org/314690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c75233e88230b33e28226aba5b0ce56975292d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124094 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129730 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110256 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31107 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29808 "Passed tests") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178422 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31319 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138096 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33956 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138009 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149399 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103882 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25401 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33286 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26264 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39595 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112669 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38991 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4357 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->