### PR TITLE
[JSC] Track customSlotBase for CustomAccessorGetter/CustomAccessorSetter

### DIFF
--- a/JSTests/stress/regress-172736082.js
+++ b/JSTests/stress/regress-172736082.js
@@ -1,0 +1,41 @@
+//@ runDefault("--useDollarVM=1", "--useConcurrentJIT=false", "--jitPolicyScale=0.001")
+
+function main() {
+    function createPoly() {
+        function f() {}
+
+        const object = new f();
+        object.__proto__ = {};
+
+        return new f();
+    }
+
+    $vm.createCustomTestGetterSetter();
+
+    for (let i = 0; i < 50; i++) {
+        createPoly();
+    }
+
+    let obj = createPoly();
+    obj.__proto__ = $vm.createCustomTestGetterSetter();
+
+    function opt(x) {
+        return [x.customAccessor, Math.random(), Math.random(), Math.random(), Math.random(), Math.random()];
+    }
+
+    for (let i = 0; i < 1000; i++) {
+        opt(obj);
+    }
+
+    obj = null;
+    gc();
+
+    $vm.createCustomTestGetterSetter();
+
+    for (let i = 0; i < 10; i++) {
+        opt({});
+    }
+}
+
+main();
+

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -831,7 +831,9 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
         break;
     }
     case CustomValueGetter:
-    case CustomValueSetter: {
+    case CustomValueSetter:
+    case CustomAccessorGetter:
+    case CustomAccessorSetter: {
         auto& accessor = this->as<GetterSetterAccessCase>();
         if (accessor.customSlotBase())
             functor(accessor.customSlotBase());
@@ -856,8 +858,6 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
         if (as<InstanceOfAccessCase>().prototype())
             functor(as<InstanceOfAccessCase>().prototype());
         break;
-    case CustomAccessorGetter:
-    case CustomAccessorSetter:
     case Load:
     case LoadMegamorphic:
     case StoreMegamorphic:


### PR DESCRIPTION
#### 055680a255b7fd94a12dda66a6f494b5389a3c8c
<pre>
[JSC] Track customSlotBase for CustomAccessorGetter/CustomAccessorSetter
<a href="https://bugs.webkit.org/show_bug.cgi?id=310293">https://bugs.webkit.org/show_bug.cgi?id=310293</a>
<a href="https://rdar.apple.com/172736082">rdar://172736082</a>

Reviewed by Yusuke Suzuki.

This ensures that CustomAccessorGetter/CustomAccessorSetter will track customSlotBase.

Test: JSTests/stress/regress-172736082.js

* JSTests/stress/regress-172736082.js: Added.
(main.createPoly.f):
(main.createPoly):
(main.opt):
(main):
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::forEachDependentCell const): Track customSlotBase

Originally-landed-as: 305413.557@rapid/safari-7624.2.5.110-branch (9431ad8551c6). <a href="https://rdar.apple.com/176061688">rdar://176061688</a>
Canonical link: <a href="https://commits.webkit.org/315328@main">https://commits.webkit.org/315328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d55e39d2de5bd21f7af573f236a6d4a4591f4c41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122429 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128350 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90343 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108875 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29710 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28333 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21969 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157331 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139606 "Found 2 new API test failures: TestWebKitAPI.CopyHTML.SanitizationPreservesCharacterSetInSelectedText, TestWebKitAPI.HSTS.Preconnect (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176737 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26067 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136675 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136614 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37603 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39421 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24770 "Too many flaky failures: http/tests/media/hls/track-webvtt-multitracks.html, http/tests/misc/slow-preload-cancel.html, http/tests/navigation/redirect-preserves-fragment.html, http/tests/resourceLoadStatistics/ping-to-prevalent-resource.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/script-redirect-allowed2.html, http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image-UpgradeMixedContent.https.html, http/tests/site-isolation/iframe-dark-mode.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html, http/tests/webgpu/webgpu/web_platform/copyToTexture/image_file.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101730 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31889 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111003 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198994 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37931 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2847 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53422 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37328 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37574 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37472 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->