### PR TITLE
[JSC] Defer GC while using the direct eval CacheLookupKey

### DIFF
--- a/JSTests/stress/direct-eval-cache-rope.js
+++ b/JSTests/stress/direct-eval-cache-rope.js
@@ -1,0 +1,29 @@
+// @requireOptions("--slowPathAllocsBetweenGCs=10")
+
+function getRope(index) {
+    const a = "[" + index + ',[]'.repeat(0x100) + "]";
+    const b = "()";
+
+    [][a];
+
+    return a + b;
+}
+
+function main() {
+    for (let i = 0; i < 1000; i++) {
+        const s = getRope(i);
+        getRope(0);
+
+        gc();
+
+        try {
+            eval(s);
+
+        } catch {
+
+        }
+    }
+
+}
+
+main();

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -166,6 +166,12 @@ JSValue eval(CallFrame* callFrame, JSValue thisValue, JSScope* callerScopeChain,
     auto cacheKey = DirectEvalCodeCache::CacheLookupKey(programStr.data.impl(), bytecodeIndex);
     DirectEvalExecutable* eval = callerBaselineCodeBlock->directEvalCodeCache().get(cacheKey);
     if (!eval) {
+        // GC needs to be deferred as it's possible cacheKey holds one of programString's fibers'
+        // contents as a raw StringImpl*. Even though programString is on the stack, rope
+        // flattening could cause that fiber JSString to be unreachable by the GC, causing its
+        // content StringImpl to be deref'd if when the JSString is swept.
+        DeferGC deferGC(vm);
+
         auto programSource = programStr.data;
         if (SourceProfiler::g_profilerHook) [[unlikely]] {
             SourceTaintedOrigin sourceTaintedOrigin = computeNewSourceTaintedOriginFromStack(vm, callFrame);


### PR DESCRIPTION
#### 32f1bfb841291085addeca576816d73d8c3aed84
<pre>
[JSC] Defer GC while using the direct eval CacheLookupKey
<a href="https://bugs.webkit.org/show_bug.cgi?id=310146">https://bugs.webkit.org/show_bug.cgi?id=310146</a>
<a href="https://rdar.apple.com/172708456">rdar://172708456</a>

Reviewed by Yusuke Suzuki.

DirectEvalCodeCache::CacheLookupKey holds a raw StringImpl* for performance.
This StringImpl* can be the contents of a fiber of an on-stack rope JSString.
Though that JSString is live on the stack, it can be mutated in place due to
rope flattening, which means its fiber JSString, whose contents are referenced
in the key, can become unrooted and swept by the GC and consequently deref the
String whose raw pointer is in the key. This PR fixes by deferring GC during
while the lookup key is live on the stack.

Test: JSTests/stress/direct-eval-cache-rope.js

* JSTests/stress/direct-eval-cache-rope.js: Added.
(getRope):
(main):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::eval):

Originally-landed-as: 305413.520@rapid/safari-7624.2.5.110-branch (f84884541bfb). <a href="https://rdar.apple.com/176061437">rdar://176061437</a>
Canonical link: <a href="https://commits.webkit.org/314203@main">https://commits.webkit.org/314203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae6bd59f844ca9c014c38be3826015f24c882c4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/165320 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38811 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32391 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122577 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128467 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/168279 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30785 "Found 3 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html loader/navigation-policy/should-open-external-urls/subframe-navigated-programatically-by-main-frame.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/32391 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108992 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29833 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28449 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22438 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157479 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139728 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/32391 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176885 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26215 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29783 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32391 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136788 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136726 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36877 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39569 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/32391 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101913 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32003 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32391 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111153 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37476 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/32391 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->