### PR TITLE
passive:false wheel event listener and overscroll-behavior: contain prevent scrolling

### DIFF
--- a/LayoutTests/fast/scrolling/mac/overscroll-behavior-with-wheel-listener-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/overscroll-behavior-with-wheel-listener-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Main frame with overscroll-behavior: contain and a non-passive wheel listener should scroll
+

--- a/LayoutTests/fast/scrolling/mac/overscroll-behavior-with-wheel-listener-iframe-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/overscroll-behavior-with-wheel-listener-iframe-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Subframe with overscroll-behavior: contain and a non-passive wheel listener should scroll without propagating to the main frame
+

--- a/LayoutTests/fast/scrolling/mac/overscroll-behavior-with-wheel-listener-iframe.html
+++ b/LayoutTests/fast/scrolling/mac/overscroll-behavior-with-wheel-listener-iframe.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/overscroll-behavior-support.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<link rel="help" href="https://drafts.csswg.org/css-overscroll-behavior">
+<style>
+    body {
+        height: 5000px;
+    }
+    iframe {
+        width: 300px;
+        height: 300px;
+        border: none;
+    }
+</style>
+<iframe id="frame" srcdoc="
+    <style>
+        :root { overscroll-behavior: contain; }
+        body { height: 5000px; }
+    </style>
+    <script>
+        window.addEventListener('wheel', () => {}, { passive: false });
+    </script>
+"></iframe>
+<script>
+    const frame = document.getElementById('frame');
+    frame.addEventListener('load', () => {
+        promise_test(async () => {
+            window.scrollTo(0, 0);
+            frame.contentWindow.scrollTo(0, 0);
+            const rect = frame.getBoundingClientRect();
+            const x = rect.left + rect.width / 2;
+            const y = rect.top + rect.height / 2;
+            const delta = getDeltas("down");
+            await mouseWheelScrollAndWait(x, y, delta.X, delta.Y, delta.X, delta.Y);
+            assert_greater_than(frame.contentWindow.scrollY, 0, 'Subframe should have scrolled');
+            assert_equals(window.scrollY, 0, 'Main frame should not have scrolled');
+        }, 'Subframe with overscroll-behavior: contain and a non-passive wheel listener should scroll without propagating to the main frame');
+    });
+</script>

--- a/LayoutTests/fast/scrolling/mac/overscroll-behavior-with-wheel-listener.html
+++ b/LayoutTests/fast/scrolling/mac/overscroll-behavior-with-wheel-listener.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/overscroll-behavior-support.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<link rel="help" href="https://drafts.csswg.org/css-overscroll-behavior">
+<style>
+    :root {
+        overscroll-behavior: contain;
+    }
+    body {
+        height: 5000px;
+    }
+</style>
+<script>
+    window.addEventListener('wheel', () => {}, { passive: false });
+
+    promise_test(async () => {
+        window.scrollTo(0, 0);
+        const delta = getDeltas("down");
+        await mouseWheelScrollAndWait(50, 50, delta.X, delta.Y, delta.X, delta.Y);
+        assert_greater_than(window.scrollY, 0, 'Page should have scrolled');
+    }, 'Main frame with overscroll-behavior: contain and a non-passive wheel listener should scroll');
+</script>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3649,16 +3649,16 @@ HandleUserInputEventResult EventHandler::handleWheelEventInternal(const Platform
         allowScrolling = m_frame->page()->scrollLatchingController().latchingAllowsScrollingInFrame(m_frame.get(), scrollableArea);
 #endif
     auto adjustedWheelEvent = event;
-    auto filteredDelta = adjustedWheelEvent.delta();
-    filteredDelta = view->deltaForPropagation(filteredDelta);
-    if (view->shouldBlockScrollPropagation(filteredDelta))
-        return true;
-
     if (allowScrolling) {
         // FIXME: processWheelEventForScrolling() is only called for FrameView scrolling, not overflow scrolling, which is confusing.
-        adjustedWheelEvent = adjustedWheelEvent.copyWithDeltaAndVelocity(filteredDelta, adjustedWheelEvent.scrollingVelocity());
         handledEvent = processWheelEventForScrolling(adjustedWheelEvent, scrollableArea, handling);
         processWheelEventForScrollSnap(adjustedWheelEvent, scrollableArea);
+    }
+
+    if (!handledEvent) {
+        auto filteredDelta = view->deltaForPropagation(adjustedWheelEvent.delta());
+        if (view->shouldBlockScrollPropagation(filteredDelta))
+            return true;
     }
 
     return handledEvent;


### PR DESCRIPTION
#### 25e43d9150adb51f5d52a9af7b59216cc5bf7ae2
<pre>
passive:false wheel event listener and overscroll-behavior: contain prevent scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=281300">https://bugs.webkit.org/show_bug.cgi?id=281300</a>
<a href="https://rdar.apple.com/137757208">rdar://137757208</a>

Reviewed by Abrar Rahman Protyasha.

In the synchronous wheel event handling code path which goes via
`EventHandler::handleWheelEventInternal()`, the `shouldBlockScrollPropagation()`
check that handles `overscroll-behavior: contain` came before the default event
handling, so broke scrolling entirely on a scroller with a non-passive event handler
and `overscroll-behavior: contain`.

Fix by moving the `shouldBlockScrollPropagation()` check to after the default
event handling. We no longer need the `event.copyWithDeltaAndVelocity()` because
there&apos;s no `filteredDelta` to apply.

Tests: fast/scrolling/mac/overscroll-behavior-with-wheel-listener-iframe.html
       fast/scrolling/mac/overscroll-behavior-with-wheel-listener.html

* LayoutTests/fast/scrolling/mac/overscroll-behavior-with-wheel-listener-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/overscroll-behavior-with-wheel-listener-iframe-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/overscroll-behavior-with-wheel-listener-iframe.html: Added.
* LayoutTests/fast/scrolling/mac/overscroll-behavior-with-wheel-listener.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleWheelEventInternal):

Canonical link: <a href="https://commits.webkit.org/314170@main">https://commits.webkit.org/314170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0a7e924e79c82bd3b8cc516d393ace3e01861bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174226 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122440 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128357 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108882 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29716 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28337 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21980 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176748 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29627 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136677 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136616 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36859 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147913 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101741 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31895 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24780 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111014 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37339 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2857 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37585 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37483 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->