### PR TITLE
[IndexedDB] Use-After-Free caused by use of `-0.0` for HashMap Key

### DIFF
--- a/LayoutTests/storage/indexeddb/index-unique-negative-zero-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/index-unique-negative-zero-private-expected.txt
@@ -1,0 +1,31 @@
+Test that -0 and +0 are treated as equal keys in a unique index.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+db.createObjectStore('store')
+store.createIndex('index', 'v', {unique: true})
+onOpenSuccess():
+transaction = db.transaction(['store'], 'readwrite')
+transaction.objectStore('store').put({v: -0}, 'first')
+insertSecondRecord():
+transaction.objectStore('store').put({v: 0}, 'second')
+secondRecordFailed():
+PASS event.target.error.name is 'ConstraintError'
+event.preventDefault()
+testCount():
+transaction2 = db.transaction(['store'], 'readonly')
+transaction2.objectStore('store').count()
+countSuccess():
+PASS event.target.result is 1
+testCursor():
+transaction2.objectStore('store').index('index').openCursor()
+PASS cursorCount is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/index-unique-negative-zero-private.html
+++ b/LayoutTests/storage/indexeddb/index-unique-negative-zero-private.html
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/index-unique-negative-zero.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/resources/index-unique-negative-zero.js
+++ b/LayoutTests/storage/indexeddb/resources/index-unique-negative-zero.js
@@ -1,0 +1,84 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+    importScripts('shared.js');
+}
+
+description("Test that -0 and +0 are treated as equal keys in a unique index.");
+
+indexedDBTest(prepareDatabase, onOpenSuccess);
+function prepareDatabase()
+{
+    db = event.target.result;
+    event.target.transaction.onabort = unexpectedAbortCallback;
+
+    self.store = evalAndLog("db.createObjectStore('store')");
+    self.indexObject = evalAndLog("store.createIndex('index', 'v', {unique: true})");
+}
+
+function onOpenSuccess()
+{
+    debug("onOpenSuccess():");
+    self.transaction = evalAndLog("transaction = db.transaction(['store'], 'readwrite')");
+    transaction.onabort = function() {
+        debug("transaction.onabort:");
+        shouldBe("transaction.error.name", "'ConstraintError'");
+        testCount();
+    };
+
+    // Insert a record whose indexed value is -0.
+    request = evalAndLog("transaction.objectStore('store').put({v: -0}, 'first')");
+    request.onerror = unexpectedErrorCallback;
+    request.onsuccess = insertSecondRecord;
+}
+
+function insertSecondRecord()
+{
+    debug("insertSecondRecord():");
+
+    // Insert a record whose indexed value is +0. Because -0 and +0 are equal
+    // per the IndexedDB key comparison algorithm, this must violate the unique
+    // constraint.
+    request = evalAndLog("transaction.objectStore('store').put({v: 0}, 'second')");
+    request.onerror = secondRecordFailed;
+    request.onsuccess = unexpectedSuccessCallback;
+}
+
+function secondRecordFailed()
+{
+    debug("secondRecordFailed():");
+    shouldBe("event.target.error.name", "'ConstraintError'");
+    evalAndLog("event.preventDefault()");
+    testCount();
+}
+
+function testCount()
+{
+    debug("testCount():");
+    // Verify only one record exists.
+    self.transaction2 = evalAndLog("transaction2 = db.transaction(['store'], 'readonly')");
+    request = evalAndLog("transaction2.objectStore('store').count()");
+    request.onerror = unexpectedErrorCallback;
+    request.onsuccess = function() {
+        debug("countSuccess():");
+        shouldBe("event.target.result", "1");
+        testCursor();
+    };
+}
+
+function testCursor()
+{
+    debug("testCursor():");
+    // Open a cursor on the index and verify it yields exactly one entry.
+    self.cursorCount = 0;
+    request = evalAndLog("transaction2.objectStore('store').index('index').openCursor()");
+    request.onerror = unexpectedErrorCallback;
+    request.onsuccess = function() {
+        if (event.target.result) {
+            cursorCount++;
+            event.target.result.continue();
+        } else {
+            shouldBe("cursorCount", "1");
+            finishJSTest();
+        }
+    };
+}

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.h
@@ -152,10 +152,12 @@ inline void add(Hasher& hasher, const IDBKeyData& keyData)
     case IndexedDB::KeyType::Min:
         break;
     case IndexedDB::KeyType::Number:
-        add(hasher, keyData.number());
+        // Normalize negative 0.
+        add(hasher, keyData.number() + 0.0);
         break;
     case IndexedDB::KeyType::Date:
-        add(hasher, keyData.date());
+        // Normalize negative 0.
+        add(hasher, keyData.date() + 0.0);
         break;
     case IndexedDB::KeyType::String:
         add(hasher, keyData.string());

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
@@ -354,6 +354,8 @@ void MemoryIndex::transactionAborted(MemoryBackingStoreTransaction& transaction)
     if (m_writeTransaction != &transaction)
         return;
 
+    notifyCursorsOfAllRecordsChanged();
+
     auto transactionModifiedRecords = std::exchange(m_transactionModifiedRecords, { });
     for (auto& [key, valueKeys] : transactionModifiedRecords) {
         removeIndexRecord(key);

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -1664,5 +1664,13 @@ void UniqueIDBDatabase::handleLowMemoryWarning()
         backingStore->handleLowMemoryWarning();
 }
 
+bool UniqueIDBDatabase::isVersionChangeTransactionFinishingOrFinished(const IDBResourceIdentifier& transactionIdentifier) const
+{
+    if (!m_versionChangeTransaction || m_versionChangeTransaction->info().identifier() != transactionIdentifier)
+        return true;
+
+    return m_versionChangeTransaction->isFinishingOrFinished();
+}
+
 } // namespace IDBServer
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -127,6 +127,8 @@ public:
     WEBCORE_EXPORT bool hasDataInMemory() const;
     WEBCORE_EXPORT void handleLowMemoryWarning();
 
+    WEBCORE_EXPORT bool isVersionChangeTransactionFinishingOrFinished(const IDBResourceIdentifier& transactionIdentifier) const;
+
 private:
     void handleDatabaseOperations();
     void handleCurrentOperation();

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp
@@ -68,6 +68,11 @@ UniqueIDBDatabaseManager* UniqueIDBDatabaseConnection::manager()
     return m_manager.get();
 }
 
+CheckedPtr<UniqueIDBDatabase> UniqueIDBDatabaseConnection::checkedDatabase()
+{
+    return m_database.get();
+}
+
 bool UniqueIDBDatabaseConnection::hasNonFinishedTransactions() const
 {
     return !m_transactionMap.isEmpty();

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
@@ -53,6 +53,7 @@ public:
 
     const IDBResourceIdentifier& openRequestIdentifier() LIFETIME_BOUND { return m_openRequestIdentifier; }
     UniqueIDBDatabase* database() { return m_database.get(); }
+    WEBCORE_EXPORT CheckedPtr<UniqueIDBDatabase> checkedDatabase();
     UniqueIDBDatabaseManager* NODELETE manager();
     IDBConnectionToClient& connectionToClient() { return m_connectionToClient; }
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -91,7 +91,8 @@ IDBDatabaseInfo* UniqueIDBDatabaseTransaction::originalDatabaseInfo() const
 void UniqueIDBDatabaseTransaction::abort()
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::abort");
-    
+
+    setIsFinishingOrFinished();
     CheckedPtr database = this->database();
     if (!database)
         return;
@@ -111,6 +112,7 @@ void UniqueIDBDatabaseTransaction::abortWithoutCallback()
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::abortWithoutCallback");
 
+    setIsFinishingOrFinished();
     if (RefPtr databaseConnection = m_databaseConnection.get())
         databaseConnection->abortTransactionWithoutCallback(*this);
 }
@@ -147,6 +149,7 @@ void UniqueIDBDatabaseTransaction::commit(uint64_t handledRequestResultsCount)
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::commit");
 
+    setIsFinishingOrFinished();
     CheckedPtr database = this->database();
     if (!database)
         return;

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
@@ -103,8 +103,11 @@ public:
     bool generateIndexKeyForRecord(const IDBIndexInfo&, const std::optional<IDBKeyPath>&, const IDBKeyData&, const IDBValue&, std::optional<int64_t> recordID);
     WEBCORE_EXPORT void didGenerateIndexKeyForRecord(IDBResourceIdentifier createIndexRequestIdentifier, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t> recordID);
 
+    bool isFinishingOrFinished() const { return m_isFinishingOrFinished; }
+
 private:
     UniqueIDBDatabaseTransaction(UniqueIDBDatabaseConnection&, const IDBTransactionInfo&);
+    void setIsFinishingOrFinished() { m_isFinishingOrFinished = true; }
 
     WeakPtr<UniqueIDBDatabaseConnection> m_databaseConnection;
     IDBTransactionInfo m_transactionInfo;
@@ -118,6 +121,7 @@ private:
 
     uint64_t m_pendingGenerateIndexKeyRequests { 0 };
     IDBResourceIdentifier m_createIndexRequestIdentifier;
+    bool m_isFinishingOrFinished { false };
 };
 
 } // namespace IDBServer

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -2096,8 +2096,10 @@ void NetworkStorageManager::commitTransaction(IPC::Connection& connection, const
 
 void NetworkStorageManager::didFinishHandlingVersionChangeTransaction(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& transactionIdentifier)
 {
-    if (RefPtr databaseConnection = m_idbStorageRegistry->connection(databaseConnectionIdentifier, ipcConnection))
+    if (RefPtr databaseConnection = m_idbStorageRegistry->connection(databaseConnectionIdentifier, ipcConnection)) {
+        MESSAGE_CHECK(databaseConnection->checkedDatabase()->isVersionChangeTransactionFinishingOrFinished(transactionIdentifier), ipcConnection);
         databaseConnection->didFinishHandlingVersionChange(transactionIdentifier);
+    }
 }
 
 SUPPRESS_NODELETE RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> NetworkStorageManager::idbTransaction(const WebCore::IDBRequestData& requestData, IPC::Connection& connection)


### PR DESCRIPTION
#### 917854a9c245b87b333e23ed4b195505d574a333
<pre>
[IndexedDB] Use-After-Free caused by use of `-0.0` for HashMap Key
<a href="https://rdar.apple.com/172834266">rdar://172834266</a>

Reviewed by Brady Eidson.

IndexValueStore uses HashMap with key type IDBKeyData to store index records. For IDBKeyData, when its type is Number
or Date, the value passed to Hasher is a double. Since Hasher uses the raw bits to create the hash, -0.0 and +0.0
produce different hashes, meaning the HashMap can have two separate entries for IDBKeyData values of -0.0 and +0.0.
However, IDBKeyData::operator== returns true for -0.0 and +0.0 because it uses IEEE 754 comparison. This inconsistency
can corrupt the map: for example, an attempt to remove the entry for +0.0 can match and destroy the entry for -0.0
instead, leaving a cursor still referencing the freed entry (see the new test). To fix this, normalize -0.0 to +0.0
before passing to Hasher.

This patch also fixes two other issues. First, MemoryIndex::transactionAborted does not invalidate existing cursors when
a transaction is aborted, so a cursor may hold a reference to an index record that is destroyed during the rollback.
This patch fixes that by calling notifyCursorsOfAllRecordsChanged() before replaying the rollback.

Second, the network process does not validate the DidFinishHandlingVersionChangeTransaction message. An uncompromised
web content process will not send this message while the version change transaction is still in progress (i.e. before it
is committed or aborted). The network process should verify this before proceeding, as the handler resets internal state
such as UniqueIDBDatabase::m_versionChangeTransaction, which could lead to unexpected behavior.

Test: storage/indexeddb/index-unique-negative-zero-private.html

* LayoutTests/storage/indexeddb/index-unique-negative-zero-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/index-unique-negative-zero-private.html: Added.
* LayoutTests/storage/indexeddb/resources/index-unique-negative-zero.js: Added.
(prepareDatabase):
(onOpenSuccess.transaction.onabort):
(onOpenSuccess):
(insertSecondRecord):
(secondRecordFailed):
(testCount.request.onsuccess):
(testCount):
(testCursor.request.onsuccess):
(testCursor):
* Source/WebCore/Modules/indexeddb/IDBKeyData.h:
(WebCore::add):
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp:
(WebCore::IDBServer::MemoryIndex::transactionAborted):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::isVersionChangeTransactionFinishingOrFinished const):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::abort):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::abortWithoutCallback):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::commit):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::isFinishingOrFinished const):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::setIsFinishingOrFinished):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::didFinishHandlingVersionChangeTransaction):

Originally-landed-as: 305413.585@rapid/safari-7624.2.5.110-branch (95b97d3d6fc0). <a href="https://rdar.apple.com/176061219">rdar://176061219</a>
Canonical link: <a href="https://commits.webkit.org/314464@main">https://commits.webkit.org/314464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e3bfdcdb21b2c7c248ffa2a8107c94e69ffbee7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166143 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175190 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123398 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129134 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149281 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109660 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30485 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29178 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23331 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177723 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30625 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137481 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137409 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37031 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148775 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102993 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32693 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25642 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38901 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111975 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38298 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3728 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->