### PR TITLE
[JSC] Array rematerialization should know how to have a bad time

### DIFF
--- a/JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time.js
+++ b/JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time.js
@@ -1,0 +1,35 @@
+//@ runDefault("--jitPolicyScale=0.1")
+
+let trigger = false;
+
+function cb() {
+    if (trigger) {
+        Object.defineProperty(Array.prototype, 0, {
+            get() { return 42; }, configurable: true
+        });
+    }
+}
+noInline(cb);
+
+function collect() { gc(); }
+noInline(collect);
+
+function opt() {
+    let a = new Array(5);
+    a[0] = 1.1;
+    a[1] = 2.2;
+    a[2] = 3.3;
+    a[3] = 4.4;
+    a[4] = 5.5;
+    cb();
+    collect();
+    return a[0] + a[1] + a[2] + a[3] + a[4];
+}
+noInline(opt);
+
+for (let i = 0; i < 1000; i++)
+    opt();
+
+trigger = true;
+opt();
+gc();

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -112,10 +112,17 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
             // empty JSValue is not an Int32. Contiguous is also handled here for the debug ASSERT
             // in putDirectIndex that null-derefs on the empty JSValue. Write directly into the
             // butterfly to preserve the indexing type.
+            //
+            // If the VM had a bad time between FTL compilation and this OSR exit, the Array was
+            // switched to SlowPutArrayStorage in operationMaterializeObjectInOSR. A hole (empty
+            // JSValue) must then be cleared in the ArrayStorage vector rather than the contiguous
+            // butterfly to match the rematerialized layout.
             if (hasDouble(array->indexingType()) && value.isNumber() && std::isnan(value.asNumber())) [[unlikely]]
                 array->butterfly()->contiguousDouble().atUnsafe(index) = PNaN;
             else if ((hasInt32(array->indexingType()) || hasContiguous(array->indexingType())) && !value) [[unlikely]]
                 array->butterfly()->contiguous().atUnsafe(index).setStartingValue(JSValue());
+            else if (hasAnyArrayStorage(array->indexingType()) && !value) [[unlikely]]
+                array->butterfly()->arrayStorage()->m_vector[index].clear();
             else
                 array->putDirectIndex(globalObject, index, value);
 
@@ -308,7 +315,13 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
     }
 
     case PhantomNewArrayWithButterfly: {
-        Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(materialization->indexingType());
+        // Rematerialized butterflies are always non-ArrayStorage. However, isHavingABadTime could
+        // have become true between the FTL compilation and the rematerialization, which would have
+        // switched arrayStructureForIndexingTypeDuringAllocation to SlowPutArrayStorage for all
+        // indexing types. To avoid a layout mismatch, the original Array structure is used to
+        // rematerialize the Array initially. If we're having a bad time, the layout is switched to
+        // SlowPutArrayStorage below.
+        Structure* structure = globalObject->originalArrayStructureForIndexingType(materialization->indexingType());
 
         Butterfly* butterfly = nullptr;
         for (unsigned i = 0; i < materialization->properties().size(); ++i) {
@@ -347,6 +360,14 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
                 butterfly->contiguousDouble().atUnsafe(index) = static_cast<double>(sentinel);
             else
                 butterfly->contiguous().atUnsafe(index).setStartingValue(jsNumber(sentinel));
+        }
+
+        if (globalObject->isHavingABadTime()) [[unlikely]] {
+#if ASSERT_ENABLED
+            Structure* originalStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(materialization->indexingType());
+            ASSERT(!originalStructure || hasSlowPutArrayStorage(originalStructure->indexingType()));
+#endif
+            result->switchToSlowPutArrayStorage(vm);
         }
 
         return result;


### PR DESCRIPTION
#### eba64ef44de395091d66bdfdf1c2b1f0f4983c56
<pre>
[JSC] Array rematerialization should know how to have a bad time
<a href="https://bugs.webkit.org/show_bug.cgi?id=311883">https://bugs.webkit.org/show_bug.cgi?id=311883</a>
<a href="https://rdar.apple.com/174420676">rdar://174420676</a>

Reviewed by Keith Miller.

Sunk Arrays that are rematerialized with a butterfly are always rematerialized
with a contiguous butterfly. If, in the meantime, the VM had a bad time and
moved all Array structures to SlowPutArrayStorage, rematerialization can end up
treating remterialized Arrays, which are now ArrayStorage, as if they had
contiguous butterflies.

This PR fixes that by always rematerializing with the contiguous butterfly, but
switching to SlowPutArrayStorage after the fact if the VM is having a bad time.

Test: JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time.js

* JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time.js: Added.
(cb):
(collect):
(opt):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Originally-landed-as: 305413.641@rapid/safari-7624.2.5.110-branch (899331a21899). <a href="https://rdar.apple.com/176058667">rdar://176058667</a>
Canonical link: <a href="https://commits.webkit.org/314202@main">https://commits.webkit.org/314202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7653536f87539adf99fba4423a592a82952d3c83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122569 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128462 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108987 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29825 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28444 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22430 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157471 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139720 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176877 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26207 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29785 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136781 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136720 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36878 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148063 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101905 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31995 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24930 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38071 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111145 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37468 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3009 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->