### PR TITLE
[JSC] Move DataView null vector check in IC outside of register save/restore

### DIFF
--- a/JSTests/stress/dataview-bytelength-ic-stub-stack-desync.js
+++ b/JSTests/stress/dataview-bytelength-ic-stub-stack-desync.js
@@ -1,0 +1,44 @@
+let ab = new ArrayBuffer(64, { maxByteLength: 1024 });
+let dv = new DataView(ab);
+let decoy = { byteLength: 7 };
+let decoy2 = { byteLength: 7, x: 1 };
+let decoy3 = { byteLength: 7, y: 1 };
+
+let objs = [];
+for (let i = 0; i < 64; i++) objs.push({marker: 0x1337 + i});
+
+function hot(o, a, b) {
+    let p0=b[0], p1=b[1], p2=b[2], p3=b[3], p4=b[4], p5=b[5], p6=b[6], p7=b[7],
+        p8=b[8], p9=b[9], p10=b[10], p11=b[11], p12=b[12], p13=b[13], p14=b[14], p15=b[15],
+        p16=b[16], p17=b[17], p18=b[18], p19=b[19], p20=b[20], p21=b[21], p22=b[22], p23=b[23],
+        p24=b[24], p25=b[25], p26=b[26], p27=b[27], p28=b[28], p29=b[29], p30=b[30], p31=b[31];
+    let len;
+    try {
+        len = o.byteLength;
+    } catch (e) {
+        len = -1;
+    }
+    return [len, p0.marker, p1.marker, p2.marker, p3.marker, p4.marker, p5.marker, p6.marker, p7.marker,
+            p8.marker, p9.marker, p10.marker, p11.marker, p12.marker, p13.marker, p14.marker, p15.marker,
+            p16.marker, p17.marker, p18.marker, p19.marker, p20.marker, p21.marker, p22.marker, p23.marker,
+            p24.marker, p25.marker, p26.marker, p27.marker, p28.marker, p29.marker, p30.marker, p31.marker];
+}
+noInline(hot);
+
+let A = new Int32Array(64);
+for (let i = 0; i < 64; i++) A[i] = i + 1;
+
+for (let i = 0; i < 200000; i++) {
+    hot(decoy, A, objs);
+    hot(decoy2, A, objs);
+    hot(decoy3, A, objs);
+    hot(dv, A, objs);
+}
+
+for (let i = 0; i < 100; i++) {
+    hot(dv, A, objs);
+}
+
+ab.transfer();
+
+let r = hot(dv, A, objs);

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -4541,14 +4541,19 @@ void InlineCacheCompiler::emitIntrinsicGetter(IntrinsicGetterAccessCase& accessC
 
 #if USE(JSVALUE64)
         if (isResizableOrGrowableSharedTypedArrayIncludingDataView(accessCase.structure()->classInfoForCells())) {
+            // The null-vector guard above was emitted before the push, so route it
+            // directly to m_failAndIgnore to avoid the post-push restore path.
+            m_failAndIgnore.append(failAndIgnore);
+
             auto allocator = makeDefaultScratchAllocator(m_scratchGPR);
             GPRReg scratch2GPR = allocator.allocateScratchGPR();
 
             ScratchRegisterAllocator::PreservedState preservedState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
+            CCallHelpers::JumpList postPushFailAndIgnore;
             if (isDataView) {
                 auto [outOfBounds, doneCases] = jit.loadDataViewByteLength(baseGPR, valueGPR, m_scratchGPR, scratch2GPR, type);
-                failAndIgnore.append(outOfBounds);
+                postPushFailAndIgnore.append(outOfBounds);
                 doneCases.link(&jit);
             } else
                 jit.loadTypedArrayByteLength(baseGPR, valueGPR, m_scratchGPR, scratch2GPR, typedArrayType(accessCase.structure()->typeInfo().type()));
@@ -4560,12 +4565,12 @@ void InlineCacheCompiler::emitIntrinsicGetter(IntrinsicGetterAccessCase& accessC
             allocator.restoreReusedRegistersByPopping(jit, preservedState);
             succeed();
 
-            if (allocator.didReuseRegisters() && !failAndIgnore.empty()) {
-                failAndIgnore.link(&jit);
+            if (allocator.didReuseRegisters() && !postPushFailAndIgnore.empty()) {
+                postPushFailAndIgnore.link(&jit);
                 allocator.restoreReusedRegistersByPopping(jit, preservedState);
                 m_failAndIgnore.append(jit.jump());
             } else
-                m_failAndIgnore.append(failAndIgnore);
+                m_failAndIgnore.append(postPushFailAndIgnore);
             return;
         }
 #endif


### PR DESCRIPTION
#### 34669c802f5846a6c5e887eac932c18e9e8a156b
<pre>
[JSC] Move DataView null vector check in IC outside of register save/restore
<a href="https://bugs.webkit.org/show_bug.cgi?id=312218">https://bugs.webkit.org/show_bug.cgi?id=312218</a>
<a href="https://rdar.apple.com/174627873">rdar://174627873</a>

Reviewed by Marcus Plutowski.

In the DataView byteLength getter IC, there is a null vector check which
executes before a preserveReusedRegistersByPushing, but jumps to a point before
restoreReusedRegistersByPopping. In other words, causing a misbalanced push and
pop of register state.

This PR fixes by making the null vector check jump to after the popping of
saved registers.

Test: JSTests/stress/dataview-bytelength-ic-stub-stack-desync.js
* JSTests/stress/dataview-bytelength-ic-stub-stack-desync.js: Added.
(hot):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::emitIntrinsicGetter):

Originally-landed-as: 305413.668@safari-7624-branch (68274fa2f297). <a href="https://rdar.apple.com/176059143">rdar://176059143</a>
Canonical link: <a href="https://commits.webkit.org/314134@main">https://commits.webkit.org/314134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5443ad6276e3c05f11b11f49bc6c99fd64de9da1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174221 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122436 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128353 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108878 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29712 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28336 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21976 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157338 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176744 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26074 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29622 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27816 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136673 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136612 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36834 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147907 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101737 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31890 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24774 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37938 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111010 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37335 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2851 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37581 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37479 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->