### PR TITLE
Use-after-free in HTMLDialogElement::close

### DIFF
--- a/LayoutTests/fast/html/dialog-close-from-button-crash-expected.txt
+++ b/LayoutTests/fast/html/dialog-close-from-button-crash-expected.txt
@@ -1,0 +1,4 @@
+This tests removing the value attribute of a button as it tries to close the dialog element.
+WebKit should not crash or hit any assertions under ASAN.
+
+PASS

--- a/LayoutTests/fast/html/dialog-close-from-button-crash.html
+++ b/LayoutTests/fast/html/dialog-close-from-button-crash.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests removing the value attribute of a button as it tries to close the dialog element.<br>
+WebKit should not crash or hit any assertions under ASAN.</p>
+<dialog id=dialog open>
+    <button command=close commandfor=dialog>Close</button>
+</dialog>
+<script>
+window?.testRunner?.dumpAsText();
+window?.GCController?.collect();
+const button = document.querySelector('button');
+button.setAttribute('value', 'PA' + 'SS');
+document.querySelector('dialog').addEventListener('beforetoggle', (event) => {
+    button.removeAttribute('value');
+});
+button.click();
+document.write(dialog.returnValue);
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -305,11 +305,13 @@ bool HTMLDialogElement::handleCommandInternal(HTMLButtonElement& invoker, const 
 
     if (isOpen()) {
         if (command == CommandType::Close) {
-            close(invoker.value().string(), &invoker);
+            String value = invoker.value().string();
+            close(value, &invoker);
             return true;
         }
         if (command == CommandType::RequestClose) {
-            requestClose(invoker.value().string(), &invoker);
+            String value = invoker.value().string();
+            requestClose(value, &invoker);
             return true;
         }
     } else {


### PR DESCRIPTION
#### 70753442a3d86ab5085352b3f3a8072c6733c7f3
<pre>
Use-after-free in HTMLDialogElement::close
<a href="https://bugs.webkit.org/show_bug.cgi?id=312180">https://bugs.webkit.org/show_bug.cgi?id=312180</a>
<a href="https://rdar.apple.com/174525336">rdar://174525336</a>

Reviewed by Geoffrey Garen.

Fix the bug in HTMLDialogElement::handleCommandInternal by storing the String value
of the invoker in a local variable.

Test: fast/html/dialog-close-from-button-crash.html

* LayoutTests/fast/html/dialog-close-from-button-crash-expected.txt: Added.
* LayoutTests/fast/html/dialog-close-from-button-crash.html: Added.
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::handleCommandInternal):

Originally-landed-as: 305413.656@rapid/safari-7624.2.5.110-branch (d986891db87d). <a href="https://rdar.apple.com/176058778">rdar://176058778</a>
Canonical link: <a href="https://commits.webkit.org/315325@main">https://commits.webkit.org/315325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/088a90dc3d10947c92ac00e6b27cb8818102cdbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174229 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122443 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128360 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90350 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108885 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29720 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28342 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21983 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176751 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29630 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32479 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-display/display-contents-svg-elements.html imported/w3c/web-platform-tests/fullscreen/model/move-to-fullscreen-iframe.html media/media-source/media-source-real-scrub-then-play.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136679 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136618 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37600 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39435 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24779 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101744 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31899 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111017 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37945 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2856 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37342 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->