### PR TITLE
FontPlatformSerializedAttributes::toCFDictionary should skip null key/value pairs in paletteColors and variations

### DIFF
--- a/LayoutTests/ipc/cache-font-null-palette-colors-crash-expected.txt
+++ b/LayoutTests/ipc/cache-font-null-palette-colors-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/cache-font-null-palette-colors-crash.html
+++ b/LayoutTests/ipc/cache-font-null-palette-colors-crash.html
@@ -1,0 +1,67 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+<script src="../resources/ipc.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    if (!window.IPC)
+        return window.testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const renderingBackendIdentifier = randomIPCID();
+    const connection = CoreIPC.newStreamConnection();
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, { renderingBackendIdentifier, connectionHandle: connection });
+    const remoteBackend = connection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+    const didInitializeReply = connection.connection.waitForMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1);
+    connection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+
+    const number = { optionalValue: { get: { alias: { variantType: "char", variant: 1 } } } };
+    try {
+        remoteBackend.CacheFont({
+            data: { renderingResourceIdentifier: {}, origin: 0, isInterstitial: 0, visibility: 0, isTextOrientationFallback: 0 },
+            platformData: {
+                m_size: 12, m_orientation: 0, m_widthVariant: 0, m_textRenderingMode: 0,
+                m_syntheticBold: false, m_syntheticOblique: false,
+                serializableAttributes: { optionalValue: {
+                    fontName: "Helvetica", descriptorLanguage: "", descriptorTextStyle: "",
+                    matrix: {}, ignoreLegibilityWeight: {}, baselineAdjust: {}, fallbackOption: {},
+                    fixedAdvance: {}, orientation: {}, palette: {}, size: {}, sizeCategory: {},
+                    track: {}, unscaledTracking: {},
+                    paletteColors: { optionalValue: [
+                        [{}, {}],
+                        [number, {}],
+                    ] },
+                    variations: { optionalValue: [
+                        [{}, {}],
+                        [{}, number],
+                        [number, {}],
+                    ] },
+                    opticalSize: {}, traits: {}, featureSettings: {}, additionalNumber: {}
+                } },
+                m_options: 0, m_url: {}, m_psName: {}
+            },
+            renderingResourceIdentifier: {}
+        });
+    } catch { }
+
+    // Verify the GPU is still alive by doing a round-trip. If it crashed processing CacheFont,
+    // it will not respond to FinalizeRenderingUpdate and the wait will time out.
+    try {
+        connection.connection.sendMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackend_FinalizeRenderingUpdate.name, [{ type: 'uint64_t', value: 1 }]);
+        const reply = connection.connection.waitForMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidFinalizeRenderingUpdate.name, 2);
+        if (!reply)
+            document.querySelector('p').textContent = 'FAIL: GPU process crashed.';
+    } catch {
+        document.querySelector('p').textContent = 'FAIL: GPU process crashed.';
+    }
+
+    connection.connection.invalidate();
+    window.testRunner?.notifyDone();
+})();
+</script>

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -419,8 +419,10 @@ std::optional<FontPlatformSerializedAttributes> FontPlatformSerializedAttributes
 #define PAIR_VECTOR_TO_DICTIONARY(key, vector) \
     if (vector) { \
         RetainPtr<CFMutableDictionaryRef> newResult = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks)); \
-        for (auto& item : *vector) \
-            CFDictionaryAddValue(newResult.get(), item.first.get(), item.second.get()); \
+        for (auto& item : *vector) { \
+            if (item.first && item.second) \
+                CFDictionaryAddValue(newResult.get(), item.first.get(), item.second.get()); \
+        } \
         CFDictionaryAddValue(result.get(), key, newResult.get()); \
     }
 


### PR DESCRIPTION
#### e57f9072af0d65bc0f80777f1ba672b06eb16e43
<pre>
FontPlatformSerializedAttributes::toCFDictionary should skip null key/value pairs in paletteColors and variations
<a href="https://bugs.webkit.org/show_bug.cgi?id=315820">https://bugs.webkit.org/show_bug.cgi?id=315820</a>
<a href="https://rdar.apple.com/177612731">rdar://177612731</a>

Reviewed by Vitor Roriz.

FontPlatformSerializedAttributes deserializes font attributes from IPC and converts them to a CFDictionaryRef via toCFDictionary(). The
paletteColors and variations fields are vectors of key/value pairs where both key (RetainPtr&lt;CFNumberRef&gt;) and value (RetainPtr&lt;CGColorRef&gt; or
RetainPtr&lt;CFNumberRef&gt;) are encoded as optionals in IPC — a false prefix yields a null RetainPtr. The PAIR_VECTOR_TO_DICTIONARY macro did not check
for null before calling CFDictionaryAddValue, so a crafted CacheFont IPC message with null keys or values would pass NULL to CoreFoundation,
triggering an NSInvalidArgumentException that propagates uncaught and crashes the GPU process.

Fix: skip any pair where either the key or value is null.

Add an IPC layout test that sends CacheFont with null palette color entries and then uses a FinalizeRenderingUpdate round-trip to verify the GPU
process is still alive. Without the fix the round-trip times out (GPU crashed); with the fix it completes successfully.

Test: ipc/cache-font-null-palette-colors-crash.html

* LayoutTests/ipc/cache-font-null-palette-colors-crash-expected.txt: Added.
* LayoutTests/ipc/cache-font-null-palette-colors-crash.html: Added.
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:

Canonical link: <a href="https://commits.webkit.org/314182@main">https://commits.webkit.org/314182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/158d951920df668dde48549cf19370de9b970d85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122444 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/537a1053-4b32-440f-bf44-00a936371666) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38679 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128361 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 7 flakes 3 failures; Uploaded test results; 1 flakes; Passed layout tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/145ce26e-fb49-4b25-ba68-8a06188d6426) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108886 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52de2ae7-f108-42a5-86c0-d12a7bc740e7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29723 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28343 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21984 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26120 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176752 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29637 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136681 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38746 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32480 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-display/display-contents-svg-elements.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136620 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147916 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101745 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25155 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31898 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24783 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37946 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111018 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37343 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2861 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37589 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37487 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->