### PR TITLE
Use-After-Free in `BaseDateAndTimeInputType::didChangeValueFromControl`

### DIFF
--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event-expected.txt
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event-expected.txt
@@ -1,0 +1,11 @@
+Test that changing the input type during an input event does not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.type is "text"
+PASS Did not crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input id="input" type="date">
+
+<script>
+
+jsTestIsAsync = true;
+
+description("Test that changing the input type during an input event does not crash.");
+
+input.addEventListener("input", () => {
+    input.type = "text";
+});
+
+addEventListener("load", async () => {
+    input.focus();                                         // [mm]/dd/yyyy
+    UIHelper.keyDown("9");                                 // -> [09]/dd/yyyy
+    UIHelper.keyDown("rightArrow");                        // -> 09/[dd]/yyyy
+    UIHelper.keyDown("2");                                 // -> 09/[02]/yyyy
+    UIHelper.keyDown("rightArrow");                        // -> 09/02/[yyyy]
+    UIHelper.keyDown("2");                                 // -> 09/02/[0002]
+    UIHelper.keyDown("0");                                 // -> 09/02/[0020]
+    UIHelper.keyDown("1");                                 // -> 09/02/[0201]
+    UIHelper.keyDown("2");                                 // -> 09/02/[2012] -> input event fires -> type changes to text
+
+    shouldBeEqualToString("input.type", "text");
+
+    testPassed("Did not crash.");
+    finishJSTest();
+});
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -650,9 +650,10 @@ void BaseDateAndTimeInputType::didEndChooser()
 
 bool BaseDateAndTimeInputType::setupDateTimeChooserParameters(DateTimeChooserParameters& parameters)
 {
-    ASSERT(element());
+    RefPtr element = this->element();
+    if (!element)
+        return false;
 
-    Ref element = *this->element();
     Ref document = element->document();
 
     if (!document->view())

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -55,6 +55,9 @@ public:
     bool typeMismatch() const final;
     bool hasBadInput() const final;
 
+    void ref() const final { InputType::ref(); }
+    void deref() const final { InputType::deref(); }
+
 protected:
     enum class DateTimeFormatValidationResults : uint8_t {
         HasYear = 1 << 0,

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -236,9 +236,10 @@ size_t DateTimeEditElement::fieldIndexOf(const DateTimeFieldElement& fieldToFind
 void DateTimeEditElement::defaultEventHandler(Event& event)
 {
     if (RefPtr keyboardEvent = dynamicDowncast<KeyboardEvent>(event)) {
-        if (keyboardEvent->keyIdentifier() == "U+0020"_s && m_editControlOwner) {
+        RefPtr editControlOwner = m_editControlOwner;
+        if (editControlOwner && keyboardEvent->keyIdentifier() == "U+0020"_s) {
             // Forward space keypresses to the owner to activate the date picker.
-            m_editControlOwner->didReceiveSpaceKeyFromControl();
+            editControlOwner->didReceiveSpaceKeyFromControl();
             // We want to mark the event as handled to avoid scrolling the page.
             event.setDefaultHandled();
             return;
@@ -314,7 +315,8 @@ void DateTimeEditElement::layout(const LayoutParameters& layoutParameters)
 
 void DateTimeEditElement::didBlurFromField(Event& event)
 {
-    if (!m_editControlOwner)
+    RefPtr editControlOwner = m_editControlOwner;
+    if (!editControlOwner)
         return;
 
     if (RefPtr newFocusedElement = event.relatedTarget()) {
@@ -326,13 +328,13 @@ void DateTimeEditElement::didBlurFromField(Event& event)
             return;
     }
 
-    m_editControlOwner->didBlurFromControl();
+    editControlOwner->didBlurFromControl();
 }
 
 void DateTimeEditElement::fieldValueChanged()
 {
-    if (m_editControlOwner)
-        m_editControlOwner->didChangeValueFromControl();
+    if (RefPtr editControlOwner = m_editControlOwner)
+        editControlOwner->didChangeValueFromControl();
 }
 
 bool DateTimeEditElement::focusOnNextFocusableField(size_t startIndex)
@@ -382,12 +384,16 @@ bool DateTimeEditElement::focusOnPreviousField(const DateTimeFieldElement& field
 
 bool DateTimeEditElement::isFieldOwnerDisabled() const
 {
-    return m_editControlOwner && m_editControlOwner->isEditControlOwnerDisabled();
+    if (RefPtr editControlOwner = m_editControlOwner)
+        return editControlOwner->isEditControlOwnerDisabled();
+    return false;
 }
 
 bool DateTimeEditElement::isFieldOwnerReadOnly() const
 {
-    return m_editControlOwner && m_editControlOwner->isEditControlOwnerReadOnly();
+    if (RefPtr editControlOwner = m_editControlOwner)
+        return editControlOwner->isEditControlOwnerReadOnly();
+    return false;
 }
 
 bool DateTimeEditElement::isFieldOwnerHorizontal() const
@@ -399,18 +405,22 @@ bool DateTimeEditElement::isFieldOwnerHorizontal() const
 
 bool DateTimeEditElement::didFieldOwnerTransferFocusToPicker()
 {
-    return m_editControlOwner && m_editControlOwner->didEditControlOwnerTransferFocusToPicker();
+    if (RefPtr editControlOwner = m_editControlOwner)
+        return editControlOwner->didEditControlOwnerTransferFocusToPicker();
+    return false;
 }
 
 void DateTimeEditElement::didSuppressBlurDueToPickerFocusTransfer()
 {
-    if (m_editControlOwner)
-        m_editControlOwner->didSuppressBlurDueToPickerFocusTransfer();
+    if (RefPtr editControlOwner = m_editControlOwner)
+        editControlOwner->didSuppressBlurDueToPickerFocusTransfer();
 }
 
 AtomString DateTimeEditElement::localeIdentifier() const
 {
-    return m_editControlOwner ? m_editControlOwner->localeIdentifier() : nullAtom();
+    if (RefPtr editControlOwner = m_editControlOwner)
+        return editControlOwner->localeIdentifier();
+    return nullAtom();
 }
 
 const GregorianDateTime& DateTimeEditElement::placeholderDate() const
@@ -439,12 +449,16 @@ void DateTimeEditElement::setEmptyValue(const LayoutParameters& layoutParameters
 
 String DateTimeEditElement::value() const
 {
-    return m_editControlOwner ? m_editControlOwner->formatDateTimeFieldsState(valueAsDateTimeFieldsState()) : emptyString();
+    if (RefPtr editControlOwner = m_editControlOwner)
+        return editControlOwner->formatDateTimeFieldsState(valueAsDateTimeFieldsState());
+    return emptyString();
 }
 
 String DateTimeEditElement::placeholderValue() const
 {
-    return m_editControlOwner ? m_editControlOwner->formatDateTimeFieldsState(valueAsDateTimeFieldsState(DateTimePlaceholderIfNoValue::Yes)) : emptyString();
+    if (RefPtr editControlOwner = m_editControlOwner)
+        return editControlOwner->formatDateTimeFieldsState(valueAsDateTimeFieldsState(DateTimePlaceholderIfNoValue::Yes));
+    return emptyString();
 }
 
 DateTimeFieldsState DateTimeEditElement::valueAsDateTimeFieldsState(DateTimePlaceholderIfNoValue placeholderIfNoValue) const

--- a/Source/WebCore/html/shadow/DateTimeEditElement.h
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.h
@@ -28,24 +28,14 @@
 
 #include "DateComponents.h"
 #include "DateTimeFieldElement.h"
-
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CheckedRef.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class DateTimeEditElementEditControlOwner;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::DateTimeEditElementEditControlOwner> : std::true_type { };
-}
 
 namespace WebCore {
 
 class Locale;
 
-class DateTimeEditElementEditControlOwner : public CanMakeWeakPtr<DateTimeEditElementEditControlOwner> {
+class DateTimeEditElementEditControlOwner : public AbstractRefCountedAndCanMakeWeakPtr<DateTimeEditElementEditControlOwner> {
 public:
     virtual ~DateTimeEditElementEditControlOwner();
     virtual void didBlurFromControl() = 0;


### PR DESCRIPTION
#### 869d5c55313783da5714584b7db649435dbb16b0
<pre>
Use-After-Free in `BaseDateAndTimeInputType::didChangeValueFromControl`
<a href="https://bugs.webkit.org/show_bug.cgi?id=310544">https://bugs.webkit.org/show_bug.cgi?id=310544</a>
<a href="https://rdar.apple.com/173012873">rdar://173012873</a>

Reviewed by Abrar Rahman Protyasha and Lily Spiniolas.

`BaseDateAndTimeInputType::didChangeValueFromControl()` dispatches `input`
events without protecting itself. An event handler can change the input&apos;s type
(e.g., from `date` to `text`), which replaces `HTMLInputElement::m_inputType`
and destroys the `BaseDateAndTimeInputType` instance. After the event handler
returns, the function continues executing `setupDateTimeChooserParameters()`
and `showDateTimeChooser()` on the freed object, resulting in a use-after-free.

Fix by holding a `RefPtr` to the input type on the stack prior to calling
`didChangeValueFromControl()`.

Test: fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event.html

* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event-expected.txt: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-change-type-on-input-event.html: Added.
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::setupDateTimeChooserParameters):

Fix `setupDateTimeChooserParameters` to null-check element() instead of
of asserting, since the element may be gone after the type change.

* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/shadow/DateTimeEditElement.cpp:
(WebCore::DateTimeEditElement::defaultEventHandler):
(WebCore::DateTimeEditElement::didBlurFromField):
(WebCore::DateTimeEditElement::fieldValueChanged):
(WebCore::DateTimeEditElement::isFieldOwnerDisabled const):
(WebCore::DateTimeEditElement::isFieldOwnerReadOnly const):
(WebCore::DateTimeEditElement::didFieldOwnerTransferFocusToPicker):
(WebCore::DateTimeEditElement::didSuppressBlurDueToPickerFocusTransfer):
(WebCore::DateTimeEditElement::localeIdentifier const):
(WebCore::DateTimeEditElement::value const):
(WebCore::DateTimeEditElement::placeholderValue const):
* Source/WebCore/html/shadow/DateTimeEditElement.h:

Change the base class of `DateTimeEditElementEditControlOwner` from
`CanMakeWeakPtr&lt;DateTimeEditElementEditControlOwner&gt;` to
`AbstractRefCountedAndCanMakeWeakPtr&lt;DateTimeEditElementEditControlOwner&gt;`,
so that the object may be ref-counted.

Remove the `IsDeprecatedWeakRefSmartPointerException` exception, since
`DateTimeEditElementEditControlOwner` needs to be ref-counted to avoid
use-after-free.

Originally-landed-as: 305413.565@rapid/safari-7624.2.5.110-branch (f49e83162fdd). <a href="https://rdar.apple.com/176061451">rdar://176061451</a>
Canonical link: <a href="https://commits.webkit.org/314162@main">https://commits.webkit.org/314162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f1e8a5796c31417ca19bc360aa14888e1b7d3ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174380 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c0b22c7-4edc-478e-b73c-32ff3a8e1d20) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38831 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/128484 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bd98158-4567-4525-aa27-d73f0432fb2c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109009 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ed2a710-c8a0-4d20-a79a-bbeb6d96eaf6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/22454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139735 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176901 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27944 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/136805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136741 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36853 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101929 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32018 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24902 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38095 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111169 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37492 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2980 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37738 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37636 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->