### PR TITLE
Fix baseline write barrier handling in OpDelBy{Id,Val}

### DIFF
--- a/JSTests/stress/baseline-op-del-by-id-write-barrier.js
+++ b/JSTests/stress/baseline-op-del-by-id-write-barrier.js
@@ -1,0 +1,29 @@
+//@ requireOptions("--verifyHeap=1", "--useConcurrentJIT=0")
+
+function main() {
+    globalThis.dummy = {
+        x: 1
+    };
+
+    globalThis.dummy.y = 2;
+
+    for (let i = 0; i < 10; i++) {
+        const target = {x: 1};
+        fullGC();
+
+        let opt = new Function('o', 'o = delete o.x;');
+
+        for (let j = 0; j < 10; j++) {
+            opt({
+                x: 1
+            });
+        }
+
+        opt(target);
+        opt = null;
+
+        edenGC();
+    }
+}
+
+main();

--- a/JSTests/stress/baseline-op-del-by-val-write-barrier.js
+++ b/JSTests/stress/baseline-op-del-by-val-write-barrier.js
@@ -1,0 +1,24 @@
+//@ requireOptions("--verifyHeap=1", "--useConcurrentJIT=0")
+
+function main() {
+    globalThis.dummy = {x: 1};
+    globalThis.dummy.y = 2;
+
+    for (let i = 0; i < 100; i++) {
+        const target = {x: 1};
+        fullGC();
+
+        let opt = new Function('o', 'o = delete o["x"];');
+
+        for (let j = 0; j < 10; j++) {
+            opt({x: 1});
+        }
+
+        opt(target);
+        opt = null;
+
+        edenGC();
+    }
+}
+
+main();

--- a/Source/JavaScriptCore/jit/BaselineJITRegisters.h
+++ b/Source/JavaScriptCore/jit/BaselineJITRegisters.h
@@ -316,8 +316,9 @@ namespace DelById {
     static constexpr GPRReg scratch1GPR { scratchRegisters[0] };
     static constexpr GPRReg scratch2GPR { scratchRegisters[1] };
     static constexpr GPRReg scratch3GPR { scratchRegisters[2] };
+    static constexpr JSValueRegs scratchJSR { JSValueRegs::withTwoAvailableRegs(scratch1GPR, scratch2GPR) };
 
-    static_assert(noOverlap(baseJSR, propertyCacheGPR, scratch1GPR, scratch2GPR, scratch3GPR, GPRInfo::handlerGPR), "Required for call to slow operation");
+    static_assert(noOverlap(baseJSR, propertyCacheGPR, scratchJSR, scratch3GPR, GPRInfo::handlerGPR), "Required for call to slow operation");
     static_assert(noOverlap(resultJSR.payloadGPR(), propertyCacheGPR));
 }
 
@@ -332,7 +333,9 @@ namespace DelByVal {
     static constexpr GPRReg scratch1GPR { scratchRegisters[0] };
     static constexpr GPRReg scratch2GPR { scratchRegisters[1] };
     static constexpr GPRReg scratch3GPR { scratchRegisters[2] };
-    static_assert(noOverlap(baseJSR, propertyJSR, propertyCacheGPR, scratch1GPR, scratch2GPR, scratch3GPR, GPRInfo::handlerGPR), "Required for call to slow operation");
+    static constexpr JSValueRegs scratchJSR { JSValueRegs::withTwoAvailableRegs(scratch1GPR, scratch2GPR) };
+
+    static_assert(noOverlap(baseJSR, propertyJSR, propertyCacheGPR, scratchJSR, scratch3GPR, GPRInfo::handlerGPR), "Required for call to slow operation");
     static_assert(noOverlap(resultJSR.payloadGPR(), propertyCacheGPR));
 }
 

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -309,6 +309,7 @@ namespace JSC {
 #endif
         // value register in write barrier is used before any scratch registers
         // so may safely be the same as either of the scratch registers.
+        void emitWriteBarrier(JSValueRegs owner, WriteBarrierMode);
         void emitWriteBarrier(VirtualRegister owner, WriteBarrierMode);
         void emitWriteBarrier(VirtualRegister owner, VirtualRegister value, WriteBarrierMode);
         void emitWriteBarrier(JSCell* owner);

--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -426,6 +426,7 @@ void JIT::emit_op_del_by_id(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::DelById::baseJSR;
     using BaselineJITRegisters::DelById::resultJSR;
     using BaselineJITRegisters::DelById::propertyCacheGPR;
+    using BaselineJITRegisters::DelById::scratchJSR;
 
     emitGetVirtualRegister(base, baseJSR);
 
@@ -444,6 +445,7 @@ void JIT::emit_op_del_by_id(const JSInstruction* currentInstruction)
     m_delByIds.append(gen);
 
     setFastPathResumePoint();
+    emitGetVirtualRegister(base, scratchJSR); // IC may clobber baseJSR so reload from virtual register
     boxBoolean(resultJSR.payloadGPR(), resultJSR);
     emitPutVirtualRegister(dst, resultJSR);
 
@@ -451,7 +453,7 @@ void JIT::emit_op_del_by_id(const JSInstruction* currentInstruction)
     // We should emit write-barrier at the end of sequence since write-barrier clobbers registers.
     // FIXME: Use UnconditionalWriteBarrier in Baseline effectively to reduce code size.
     // https://bugs.webkit.org/show_bug.cgi?id=209395
-    emitWriteBarrier(base, ShouldFilterBase);
+    emitWriteBarrier(scratchJSR, ShouldFilterBase);
 }
 
 void JIT::emitSlow_op_del_by_id(const JSInstruction*, Vector<SlowCaseEntry>::iterator& iter)
@@ -474,6 +476,7 @@ void JIT::emit_op_del_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::DelByVal::propertyJSR;
     using BaselineJITRegisters::DelByVal::resultJSR;
     using BaselineJITRegisters::DelByVal::propertyCacheGPR;
+    using BaselineJITRegisters::DelByVal::scratchJSR;
 
     emitGetVirtualRegister(base, baseJSR);
     emitGetVirtualRegister(property, propertyJSR);
@@ -494,6 +497,7 @@ void JIT::emit_op_del_by_val(const JSInstruction* currentInstruction)
     m_delByVals.append(gen);
 
     setFastPathResumePoint();
+    emitGetVirtualRegister(base, scratchJSR); // IC may clobber baseJSR so reload from virtual register
     boxBoolean(resultJSR.payloadGPR(), resultJSR);
     emitPutVirtualRegister(dst, resultJSR);
 
@@ -501,7 +505,7 @@ void JIT::emit_op_del_by_val(const JSInstruction* currentInstruction)
     // IC can write new Structure without write-barrier if a base is cell.
     // FIXME: Use UnconditionalWriteBarrier in Baseline effectively to reduce code size.
     // https://bugs.webkit.org/show_bug.cgi?id=209395
-    emitWriteBarrier(base, ShouldFilterBase);
+    emitWriteBarrier(scratchJSR, ShouldFilterBase);
 }
 
 void JIT::emitSlow_op_del_by_val(const JSInstruction*, Vector<SlowCaseEntry>::iterator& iter)
@@ -2310,6 +2314,26 @@ void JIT::emitWriteBarrier(VirtualRegister owner, VirtualRegister value, WriteBa
         ownerNotCell.link(this);
     if (mode == ShouldFilterValue || mode == ShouldFilterBaseAndValue)
         valueNotCell.link(this);
+}
+
+void JIT::emitWriteBarrier(JSValueRegs ownerJSR, WriteBarrierMode mode)
+{
+    ASSERT(mode == UnconditionalWriteBarrier || mode == ShouldFilterBase);
+
+    constexpr GPRReg tempGPR = regT0;
+
+    ASSERT(noOverlap(tempGPR, ownerJSR));
+
+    Jump ownerNotCell;
+    if (mode == ShouldFilterBase)
+        ownerNotCell = branchIfNotCell(ownerJSR);
+
+    Jump ownerIsRememberedOrInEden = barrierBranch(vm(), ownerJSR.payloadGPR(), tempGPR);
+    callOperationNoExceptionCheck(operationWriteBarrierSlowPath, TrustedImmPtr(&vm()), ownerJSR.payloadGPR());
+    ownerIsRememberedOrInEden.link(this);
+
+    if (mode == ShouldFilterBase)
+        ownerNotCell.link(this);
 }
 
 void JIT::emitWriteBarrier(VirtualRegister owner, WriteBarrierMode mode)


### PR DESCRIPTION
#### 1cdc540e6ebee5192b5b5d4fc0202b8bfd37eece
<pre>
Fix baseline write barrier handling in OpDelBy{Id,Val}
<a href="https://bugs.webkit.org/show_bug.cgi?id=310139">https://bugs.webkit.org/show_bug.cgi?id=310139</a>
<a href="https://rdar.apple.com/172299872">rdar://172299872</a>

Reviewed by Yusuke Suzuki.

In the baseline implementation of OpDelById, code like `o = delete o.x` can
overwrite the pointer to object o with a boolean value before the write
barrier, meaning the barrier is wrongly invoked on the boolean instead of
the original object. Same problem with OpDelByVal, which can be
replicated with `o = delete o[&quot;x&quot;]`.

Tests: JSTests/stress/baseline-op-del-by-id-write-barrier.js
       JSTests/stress/baseline-op-del-by-val-write-barrier.js

* JSTests/stress/baseline-op-del-by-id-write-barrier.js: Added.
(main):
* JSTests/stress/baseline-op-del-by-val-write-barrier.js: Added.
(main):
* Source/JavaScriptCore/jit/BaselineJITRegisters.h:
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::emit_op_del_by_id):
(JSC::JIT::emit_op_del_by_val):
(JSC::JIT::emitWriteBarrier):

Originally-landed-as: 305413.540@rapid/safari-7624.2.5.110-branch (7c715b4eeda1). <a href="https://rdar.apple.com/176061249">rdar://176061249</a>
Canonical link: <a href="https://commits.webkit.org/314381@main">https://commits.webkit.org/314381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd6f29a379fa3d7c00b701a6eabee819426fe8cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123007 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128811 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90721 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109335 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30150 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28828 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22877 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157909 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177319 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26645 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30234 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137145 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137073 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36982 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148404 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102526 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32360 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25271 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38510 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111583 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37906 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3353 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38152 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->