### PR TITLE
[JSC] Data race in WaiterListManager::unregister

### DIFF
--- a/LayoutTests/js/regress-311234-expected.txt
+++ b/LayoutTests/js/regress-311234-expected.txt
@@ -1,0 +1,5 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x8
+  RenderBlock {HTML} at (0,0) size 800x8
+    RenderBody {BODY} at (8,8) size 784x0

--- a/LayoutTests/js/regress-311234.html
+++ b/LayoutTests/js/regress-311234.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
+<script>
+if (testRunner) testRunner.waitUntilDone();
+
+function gc() { GCController.collect(); }
+
+const sab = new SharedArrayBuffer(4);
+
+const worker = new Worker(URL.createObjectURL(new Blob([`
+    onmessage = e => {
+        Atomics.waitAsync(new Int32Array(e.data), 0, 0);
+        postMessage("ready");
+    };
+`])));
+
+worker.onmessage = () => {
+    const f = document.createElement("iframe");
+    document.body.appendChild(f);
+    f.contentWindow.__sab__ = sab;
+    f.contentWindow.eval("Atomics.waitAsync(new Int32Array(__sab__), 0, 0)");
+    document.body.removeChild(f);
+    worker.terminate();
+    gc();
+    testRunner?.notifyDone();
+};
+
+worker.postMessage(sab);
+</script>

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
@@ -117,6 +117,10 @@ private:
     UncheckedKeyHashSet<Ref<TicketData>> m_pendingTickets;
 };
 
+// target() reads m_dependencies, which cancelAndClear() can free concurrently.
+// Safe only when: (1) holding m_taskLock, (2) inside a scheduleWorkSoon task lambda
+// (ticket already removed from m_pendingTickets), or (3) GC End phase is prevented from running.
+// Never call from a foreign VM's thread.
 inline JSObject* DeferredWorkTimer::TicketData::target()
 {
     ASSERT(!isCancelled() && isTargetObject());

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -63,6 +63,7 @@ Waiter::Waiter(VM* vm)
 
 Waiter::Waiter(JSPromise* promise)
     : m_vm(&promise->vm())
+    , m_globalObject(promise->realm())
     , m_ticket(m_vm->deferredWorkTimer->addPendingWork(DeferredWorkTimer::WorkType::AtSomePoint, *m_vm, promise, { }))
     , m_isAsync(true)
 {
@@ -331,16 +332,14 @@ void WaiterListManager::unregister(JSGlobalObject* globalObject)
         Ref<WaiterList> list = entry.value;
         Locker listLocker { list->lock };
         list->removeIf(listLocker, [&](Waiter* waiter) {
-            if (waiter->isAsync()) {
-                if (auto ticket = waiter->ticket(listLocker); ticket && !ticket->isCancelled() && ticket->target()->realm() == globalObject) {
-                    dataLogLnIf(WaiterListsManagerInternal::verbose,
-                        "<WaiterListManager> <Thread:", Thread::currentSingleton(),
-                        "> unregister JSGlobalObject is cancelling waiter=", *waiter,
-                        " in WaiterList for ptr ", RawPointer(entry.key));
+            if (waiter->isAsync() && waiter->globalObject() == globalObject) {
+                dataLogLnIf(WaiterListsManagerInternal::verbose,
+                    "<WaiterListManager> <Thread:", Thread::currentSingleton(),
+                    "> unregister JSGlobalObject is cancelling waiter=", *waiter,
+                    " in WaiterList for ptr ", RawPointer(entry.key));
 
-                    waiter->cancelAndClear(listLocker);
-                    return true;
-                }
+                waiter->cancelAndClear(listLocker);
+                return true;
             }
             return false;
         });
@@ -413,8 +412,8 @@ void Waiter::dump(PrintStream& out) const
 
     auto ticket = this->ticket(NoLockingNecessary);
     out.print(", ticket=", RawPointer(ticket.get()));
+    out.print(", globalObject=", RawPointer(m_globalObject));
     if (ticket && !ticket->isCancelled()) {
-        out.print(", m_ticket->globalObject=", RawPointer(ticket->target()->realm()));
         out.print(", m_ticket->target=", RawPointer(uncheckedDowncast<JSObject>(ticket->dependencies().last())));
         out.print(", m_ticket->scriptExecutionOwner=", RawPointer(ticket->scriptExecutionOwner()));
     }

--- a/Source/JavaScriptCore/runtime/WaiterListManager.h
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.h
@@ -54,6 +54,12 @@ public:
         return m_vm;
     }
 
+    JSGlobalObject* globalObject() const
+    {
+        ASSERT(m_isAsync);
+        return m_globalObject;
+    }
+
     Condition& condition()
     {
         ASSERT(!m_isAsync);
@@ -101,6 +107,11 @@ public:
 
 private:
     VM* m_vm { nullptr };
+    // Cached at construction to avoid a cross-VM race: unregister(JSGlobalObject*) runs on
+    // one VM's sweep thread; reading ticket->target()->realm() would race with another VM's
+    // GC End phase freeing m_dependencies via cancelAndClear(). Written before the Waiter
+    // is added to any list, so readers acquiring list->lock always see the completed write.
+    JSGlobalObject* m_globalObject { nullptr };
     ThreadSafeWeakPtr<DeferredWorkTimer::TicketData> m_ticket { nullptr };
     RefPtr<RunLoop::DispatchTimer> m_timer { nullptr };
     Condition m_condition;


### PR DESCRIPTION
#### 21ab50e40f062d97c1d1eb47f5d42e51bc201203
<pre>
[JSC] Data race in WaiterListManager::unregister
<a href="https://bugs.webkit.org/show_bug.cgi?id=311234">https://bugs.webkit.org/show_bug.cgi?id=311234</a>
<a href="https://rdar.apple.com/173161138">rdar://173161138</a>

Reviewed by Yijia Huang.

Stores a JSGlobalObject pointer in JSC::Waiter so that it doesn&apos;t
have to be fetched from the target.

Test: js/regress-311234.html

* LayoutTests/js/regress-311234-expected.txt: Added.
* LayoutTests/js/regress-311234.html: Added.
* Source/JavaScriptCore/runtime/DeferredWorkTimer.h:
* Source/JavaScriptCore/runtime/WaiterListManager.cpp:
(JSC::Waiter::Waiter):
(JSC::WaiterListManager::unregister):
(JSC::Waiter::dump const):
* Source/JavaScriptCore/runtime/WaiterListManager.h:

Originally-landed-as: 305413.625@rapid/safari-7624.2.5.110-branch (3b7488ef5bc6). <a href="https://rdar.apple.com/176059262">rdar://176059262</a>
Canonical link: <a href="https://commits.webkit.org/314376@main">https://commits.webkit.org/314376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/117730e6df0a2bc256ef02e0e201f7bda37edc98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174860 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123073 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128871 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90766 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148981 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30211 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28891 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22943 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157975 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177385 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26711 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30300 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137204 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137131 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36980 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148475 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102604 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32421 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25342 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38576 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111649 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37972 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3424 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38116 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->