### PR TITLE
[grid layout] Don't call viewportContentsChanged() from scroll updates during render tree layout

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-update-during-grid-layout-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-update-during-grid-layout-crash-expected.txt
@@ -1,0 +1,2 @@
+
+Test passes if it does not crash.

--- a/LayoutTests/fast/scrolling/scroll-update-during-grid-layout-crash.html
+++ b/LayoutTests/fast/scrolling/scroll-update-during-grid-layout-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<div style="display: grid; position: relative;">
+  <div style="overflow: scroll; writing-mode: vertical-rl; width: 10px;">
+    <div style="transform: scale(2)"></div>
+  </div>
+  <iframe style="grid-column-start: 1; padding-left: 0%; position: absolute;"></iframe>
+</div>
+<p>Test passes if it does not crash.</p>

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -439,7 +439,9 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
     if (scrollsOverflow())
         view.frameView().didChangeScrollOffset();
 
-    view.frameView().viewportContentsChanged();
+    if (!view.frameView().layoutContext().isInRenderTreeLayout())
+        view.frameView().viewportContentsChanged();
+
     protect(frame->editor())->renderLayerDidScroll(m_layer);
 }
 


### PR DESCRIPTION
#### bf80e3eedd686c0fe2ecce39b3143e6279a89103
<pre>
[grid layout] Don&apos;t call viewportContentsChanged() from scroll updates during render tree layout
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=309595">https://bugs.webkit.org/show_bug.cgi?id=309595</a>&gt;
&lt;<a href="https://rdar.apple.com/170531390">rdar://170531390</a>&gt;

Reviewed by Simon Fraser.

RenderLayerScrollableArea::scrollTo() calls LocalFrameView::viewportContentsChanged() which computes visibility
rects by querying renderer geometry via applyRecursivelyWithVisibleRect.
When scrollTo() is invoked during render tree layout (e.g. via
updateScrollInfoAfterLayout during grid pre-layout), containing blocks
may not have completed layout yet. This causes an assertion failure in
gridAreaRangeForOutOfFlow when trying to resolve percentage padding on
an absolutely positioned iframe against a grid area that hasn&apos;t been
populated yet.

Guard the viewportContentsChanged() call with isInRenderTreeLayout().
This is safe because performPostLayoutTasks() already calls
viewportContentsChanged() unconditionally after every layout completes.

* LayoutTests/fast/scrolling/scroll-update-during-grid-layout-crash-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-update-during-grid-layout-crash.html: Added.
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollTo):

Originally-landed-as: 305413.639@rapid/safari-7624.2.5.110-branch (b6e4815bf940). <a href="https://rdar.apple.com/176059267">rdar://176059267</a>
Canonical link: <a href="https://commits.webkit.org/314622@main">https://commits.webkit.org/314622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/051d7ae160bc13a78dbb067c3cdc7474a7629880

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175074 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123282 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39943 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39521 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129035 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90899 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109561 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30380 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29070 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23214 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140349 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177607 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30509 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137379 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39586 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137306 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37140 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148657 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102866 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32594 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25524 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38785 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111859 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38182 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3610 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38427 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->