### PR TITLE
WebGL: GenerateMipmap after out of base level -max level texupload uses the wrong type

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/angleutils.h
+++ b/Source/ThirdParty/ANGLE/src/common/angleutils.h
@@ -427,6 +427,13 @@ inline bool IsLittleEndian()
     UNREACHABLE();                    \
     ANGLE_CHECK(context, false, "Unreachable code.", GL_INVALID_OPERATION)
 
+#define ANGLE_CHECK_ASSERT(context, result) \
+    do { \
+        bool resultValue = (result); \
+        ASSERT(resultValue); \
+        ANGLE_CHECK(context, resultValue, gl::err::kInternalError, GL_INVALID_OPERATION); \
+    } while (false)
+
 #if defined(ANGLE_WITH_LSAN)
 #    define ANGLE_SCOPED_DISABLE_LSAN() __lsan::ScopedDisabler lsanDisabler
 #else

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.h
@@ -183,7 +183,7 @@ class TextureMtl : public TextureImpl
                                     GLenum format);
 
   private:
-    void deallocateNativeStorage(bool keepImages, bool keepSamplerStateAndFormat = false);
+    void deallocateNativeStorage(bool keepImages);
     angle::Result createNativeStorage(const gl::Context *context,
                                       gl::TextureType type,
                                       GLuint mips,
@@ -192,8 +192,6 @@ class TextureMtl : public TextureImpl
                                       const mtl::Format &format);
     angle::Result onBaseMaxLevelsChanged(const gl::Context *context);
     angle::Result ensureSamplerStateCreated(const gl::Context *context);
-    // Ensure image at given index is created:
-    angle::Result ensureImageCreated(const gl::Context *context, const gl::ImageIndex &index);
     // Ensure all image views at all faces/levels are retained.
     void retainImageDefinitions();
     mtl::TextureRef createImageViewFromTextureStorage(GLuint cubeFaceOrZero, GLuint glLevel);

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm
@@ -841,7 +841,7 @@ void TextureMtl::onDestroy(const gl::Context *context)
     mBoundSurface = nullptr;
 }
 
-void TextureMtl::deallocateNativeStorage(bool keepImages, bool keepSamplerStateAndFormat)
+void TextureMtl::deallocateNativeStorage(bool keepImages)
 {
 
     if (!keepImages)
@@ -858,6 +858,7 @@ void TextureMtl::deallocateNativeStorage(bool keepImages, bool keepSamplerStateA
     mNativeTextureStorage       = nullptr;
     mViewFromBaseToMaxLevel     = nullptr;
     mSwizzleStencilSamplingView = nullptr;
+    mMetalSamplerState = nil;
 
     // Clear render target cache for each texture's image. We don't erase them because they
     // might still be referenced by a framebuffer.
@@ -880,11 +881,6 @@ void TextureMtl::deallocateNativeStorage(bool keepImages, bool keepSamplerStateA
     for (mtl::TextureRef &view : mLevelViewsWithinBaseMax)
     {
         view.reset();
-    }
-
-    if (!keepSamplerStateAndFormat)
-    {
-        mMetalSamplerState = nil;
     }
 }
 
@@ -928,9 +924,9 @@ angle::Result TextureMtl::ensureNativeStorageCreated(const gl::Context *context,
     ANGLE_CHECK(contextMtl, desc.format.valid(), gl::err::kInternalError, GL_INVALID_OPERATION);
     angle::FormatID angleFormatId =
         angle::Format::InternalFormatToID(desc.format.info->sizedInternalFormat);
-    mtl::Format format = contextMtl->getPixelFormat(angleFormatId);
+    const mtl::Format &mtlFormat = contextMtl->getPixelFormat(angleFormatId);
 
-    ANGLE_TRY(createNativeStorage(context, mState.getType(), mips, 0, desc.size, format));
+    ANGLE_TRY(createNativeStorage(context, mState.getType(), mips, 0, desc.size, mtlFormat));
 
     // Transfer data from defined images to actual texture object
     int numCubeFaces = static_cast<int>(mNativeTextureStorage->cubeFaces());
@@ -1179,30 +1175,11 @@ angle::Result TextureMtl::onBaseMaxLevelsChanged(const gl::Context *context)
     // Note: We release the native texture storage but keep old image definitions. So that when the
     // storage is recreated, its levels can be recreated with data from the old image definitions
     // respectively.
-    deallocateNativeStorage(/*keepImages=*/true, /*keepSamplerStateAndFormat=*/true);
+    deallocateNativeStorage(/*keepImages=*/true);
 
     // Tell context to rebind textures
     contextMtl->invalidateCurrentTextures();
 
-    return angle::Result::Continue;
-}
-
-angle::Result TextureMtl::ensureImageCreated(const gl::Context *context,
-                                             const gl::ImageIndex &index)
-{
-    mtl::TextureRef &image = getImage(index);
-    if (!image)
-    {
-        ContextMtl *contextMtl = mtl::GetImpl(context);
-
-        // Image at this level hasn't been defined yet. We need to define it:
-        const gl::ImageDesc &desc = mState.getImageDesc(index);
-        angle::FormatID angleFormatId =
-            angle::Format::InternalFormatToID(desc.format.info->sizedInternalFormat);
-        mtl::Format format = contextMtl->getPixelFormat(angleFormatId);
-
-        ANGLE_TRY(redefineImage(context, index, format, desc.size));
-    }
     return angle::Result::Continue;
 }
 
@@ -1340,38 +1317,27 @@ angle::Result TextureMtl::getRenderTarget(ContextMtl *context,
             ? gl::RenderToTextureImageIndex::Default
             : static_cast<gl::RenderToTextureImageIndex>(PackSampleCount(implicitSamples));
 
-    ImageDefinitionMtl &imageDef = getImageDefinition(imageIndex);
-    mtl::Format format           = context->getPixelFormat(imageDef.formatID);
-
-    GLuint layer         = GetImageLayerIndexFrom(imageIndex);
     RenderTargetMtl &rtt = mRenderTargets[imageIndex][renderToTextureIndex];
     if (!rtt.getTexture())
     {
-        // Lazy initialization of render target:
-        if (imageDef.image)
-        {
-            if (imageIndex.getType() == gl::TextureType::CubeMap)
-            {
-                // Cube map is special, the image is already the view of its layer
-                rtt.set(imageDef.image, mtl::kZeroNativeMipLevel, 0, format);
-            }
-            else
-            {
-                rtt.set(imageDef.image, mtl::kZeroNativeMipLevel, layer, format);
-            }
-        }
+        auto &imageDef = getImageDefinition(imageIndex);
+        ANGLE_CHECK_ASSERT(context, imageDef.image && imageDef.image->valid());
+        // Cube map is special, the image is already the view of its layer.
+        GLuint layer = imageIndex.getType() == gl::TextureType::CubeMap ? 0 : GetImageLayerIndexFrom(imageIndex);
+        const mtl::Format &mtlFormat = context->getPixelFormat(imageDef.formatID);
+        rtt.set(imageDef.image, mtl::kZeroNativeMipLevel, layer, mtlFormat);
     }
 
     if (implicitSamples > 1 && !rtt.getImplicitMSTexture())
     {
         // This format must supports implicit resolve
-        ANGLE_CHECK(context, format.getCaps().resolve, gl::err::kInternalError, GL_INVALID_VALUE);
+        ANGLE_CHECK_ASSERT(context, rtt.getFormat().getCaps().resolve);
         mtl::TextureRef &msTexture = mImplicitMSTextures[imageIndex][renderToTextureIndex];
         if (!msTexture)
         {
             const gl::ImageDesc &desc = mState.getImageDesc(imageIndex);
             ANGLE_TRY(mtl::Texture::MakeMemoryLess2DMSTexture(
-                context, format, desc.size.width, desc.size.height, implicitSamples, &msTexture));
+                context, rtt.getFormat(), desc.size.width, desc.size.height, implicitSamples, &msTexture));
         }
         rtt.setImplicitMSTexture(msTexture);
     }
@@ -1701,8 +1667,7 @@ angle::Result TextureMtl::generateMipmapCPU(const gl::Context *context)
     ContextMtl *contextMtl           = mtl::GetImpl(context);
     const angle::Format &angleFormat = mViewFromBaseToMaxLevel->getFormat().actualAngleFormat();
     // This format must have mip generation function.
-    ANGLE_CHECK(contextMtl, angleFormat.mipGenerationFunction, gl::err::kInternalError,
-                GL_INVALID_OPERATION);
+    ANGLE_CHECK_ASSERT(contextMtl, angleFormat.mipGenerationFunction);
 
     for (uint32_t slice = 0; slice < mSlices; ++slice)
     {
@@ -2106,7 +2071,6 @@ angle::Result TextureMtl::setStorageImpl(const gl::Context *context,
 
     // Tell context to rebind textures
     contextMtl->invalidateCurrentTextures();
-
     ANGLE_TRY(createNativeStorage(context, type, mips, samples, size, mtlFormat));
     ANGLE_TRY(createViewFromBaseToMaxLevel());
 
@@ -2166,9 +2130,8 @@ angle::Result TextureMtl::setSubImageImpl(const gl::Context *context,
 
     ContextMtl *contextMtl = mtl::GetImpl(context);
 
-    ANGLE_TRY(ensureImageCreated(context, index));
     ImageDefinitionMtl &imageDef = getImageDefinition(index);
-
+    ANGLE_CHECK_ASSERT(contextMtl, imageDef.image && imageDef.image->valid());
     GLuint sourceRowPitch   = 0;
     GLuint sourceDepthPitch = 0;
     GLuint sourceSkipBytes  = 0;
@@ -2363,9 +2326,8 @@ angle::Result TextureMtl::convertAndSetPerSliceSubImage(const gl::Context *conte
                                                         const uint8_t *pixels,
                                                         const ImageDefinitionMtl &imageDef)
 {
-    ASSERT(imageDef.image && imageDef.image->valid());
-
     ContextMtl *contextMtl = mtl::GetImpl(context);
+    ANGLE_CHECK_ASSERT(contextMtl, imageDef.image && imageDef.image->valid());
     mtl::Format imageFormat = contextMtl->getPixelFormat(imageDef.formatID);
 
     if (unpackBuffer)
@@ -2610,9 +2572,9 @@ angle::Result TextureMtl::initializeContents(const gl::Context *context,
     }
 
     ASSERT(index.getLayerCount() == 1 && !index.isLayered());
-    ANGLE_TRY(ensureImageCreated(context, index));
     ContextMtl *contextMtl       = mtl::GetImpl(context);
     ImageDefinitionMtl &imageDef = getImageDefinition(index);
+    ANGLE_CHECK_ASSERT(contextMtl, imageDef.image && imageDef.image->valid());
     const mtl::TextureRef &image = imageDef.image;
     const mtl::Format &format    = contextMtl->getPixelFormat(imageDef.formatID);
     // For Texture's image definition, we always use zero mip level.
@@ -2654,13 +2616,11 @@ angle::Result TextureMtl::copySubImageImpl(const gl::Context *context,
     const gl::Offset modifiedDestOffset(destOffset.x + clippedSourceArea.x - sourceArea.x,
                                         destOffset.y + clippedSourceArea.y - sourceArea.y, 0);
 
-    ANGLE_TRY(ensureImageCreated(context, index));
-
     ContextMtl *contextMtl = mtl::GetImpl(context);
-    mtl::Format format     = contextMtl->getPixelFormat(
-        angle::Format::InternalFormatToID(internalFormat.sizedInternalFormat));
-
-    if (!format.getCaps().isRenderable())
+    auto &imageDef = getImageDefinition(index);
+    ANGLE_CHECK_ASSERT(contextMtl, imageDef.image && imageDef.image->valid());
+    mtl::Format mtlFormat = contextMtl->getPixelFormat(imageDef.formatID);
+    if (!mtlFormat.getCaps().isRenderable())
     {
         return copySubImageCPU(context, index, modifiedDestOffset, clippedSourceArea,
                                internalFormat, source, colorReadRT);
@@ -2716,14 +2676,11 @@ angle::Result TextureMtl::copySubImageCPU(const gl::Context *context,
                                           const FramebufferMtl *source,
                                           const RenderTargetMtl *colorReadRT)
 {
-    mtl::TextureRef &image = getImage(index);
-    ASSERT(image && image->valid());
-
     ContextMtl *contextMtl = mtl::GetImpl(context);
+    auto &imageDef = getImageDefinition(index);
+    ANGLE_CHECK_ASSERT(contextMtl, imageDef.image && imageDef.image->valid());
 
-    mtl::Format format = contextMtl->getPixelFormat(
-        angle::Format::InternalFormatToID(internalFormat.sizedInternalFormat));
-    const angle::Format &dstFormat = angle::Format::Get(format.actualFormatId);
+    const angle::Format &dstFormat = angle::Format::Get(imageDef.formatID);
     const int dstRowPitch          = dstFormat.pixelBytes * clippedSourceArea.width;
     angle::MemoryBuffer conversionRow;
     ANGLE_CHECK_GL_ALLOC(contextMtl, conversionRow.resize(dstRowPitch));
@@ -2770,7 +2727,7 @@ angle::Result TextureMtl::copySubImageCPU(const gl::Context *context,
         // Upload to texture
         ANGLE_TRY(UploadTextureContents(context, dstFormat, mtlDstRowArea, mtl::kZeroNativeMipLevel,
                                         dstSlice, conversionRow.data(), dstRowPitch, 0,
-                                        kAvoidStagingBuffers, image));
+                                        kAvoidStagingBuffers, imageDef.image));
     }
 
     return angle::Result::Continue;
@@ -2795,18 +2752,15 @@ angle::Result TextureMtl::copySubTextureImpl(const gl::Context *context,
     ContextMtl *contextMtl = mtl::GetImpl(context);
     TextureMtl *sourceMtl  = mtl::GetImpl(source);
 
-    ANGLE_TRY(ensureImageCreated(context, index));
-
-    ANGLE_TRY(sourceMtl->ensureImageCreated(context, sourceIndex));
-
-    const ImageDefinitionMtl &srcImageDef  = sourceMtl->getImageDefinition(sourceIndex);
-    const mtl::TextureRef &sourceImage     = srcImageDef.image;
-    const mtl::Format &sourceFormat        = contextMtl->getPixelFormat(srcImageDef.formatID);
+    const ImageDefinitionMtl &imageDef = getImageDefinition(sourceIndex);
+    ANGLE_CHECK_ASSERT(contextMtl, imageDef.image && imageDef.image->valid());
+    const ImageDefinitionMtl &sourceImageDef = sourceMtl->getImageDefinition(sourceIndex);
+    ANGLE_CHECK_ASSERT(contextMtl, sourceImageDef.image && sourceImageDef.image->valid());
+    const mtl::Format &mtlFormat           = contextMtl->getPixelFormat(imageDef.formatID);
+    const mtl::TextureRef &sourceImage     = sourceImageDef.image;
+    const mtl::Format &sourceFormat        = contextMtl->getPixelFormat(sourceImageDef.formatID);
     const angle::Format &sourceAngleFormat = sourceFormat.actualAngleFormat();
-
-    mtl::Format format = contextMtl->getPixelFormat(
-        angle::Format::InternalFormatToID(internalFormat.sizedInternalFormat));
-    if (!format.getCaps().isRenderable())
+    if (!mtlFormat.getCaps().isRenderable())
     {
         return copySubTextureCPU(context, index, destOffset, internalFormat,
                                  mtl::kZeroNativeMipLevel, sourceBox, sourceAngleFormat,
@@ -2831,10 +2785,9 @@ angle::Result TextureMtl::copySubTextureWithDraw(const gl::Context *context,
                                                  const mtl::TextureRef &sourceTexture)
 {
     ContextMtl *contextMtl = mtl::GetImpl(context);
-    DisplayMtl *displayMtl = contextMtl->getDisplay();
-
-    mtl::TextureRef image = getImage(index);
-    ASSERT(image && image->valid());
+    auto &imageDef = getImageDefinition(index);
+    ANGLE_CHECK_ASSERT(contextMtl, imageDef.image && imageDef.image->valid());
+    mtl::TextureRef image = imageDef.image;
 
     if (internalFormat.colorEncoding == GL_SRGB)
     {
@@ -2849,7 +2802,7 @@ angle::Result TextureMtl::copySubTextureWithDraw(const gl::Context *context,
     blitParams.dstRect =
         gl::Rectangle(destOffset.x, destOffset.y, sourceBox.width, sourceBox.height);
     blitParams.dstScissorRect = blitParams.dstRect;
-
+    const angle::Format &dstAngleFormat = angle::Format::Get(imageDef.formatID);
     blitParams.enabledBuffers.set(0);
 
     blitParams.src      = sourceTexture;
@@ -2864,10 +2817,9 @@ angle::Result TextureMtl::copySubTextureWithDraw(const gl::Context *context,
     blitParams.unpackUnmultiplyAlpha  = unpackUnmultiplyAlpha;
     blitParams.transformLinearToSrgb  = sourceAngleFormat.isSRGB;
 
-    mtl::Format format = contextMtl->getPixelFormat(
-        angle::Format::InternalFormatToID(internalFormat.sizedInternalFormat));
+    DisplayMtl *displayMtl = contextMtl->getDisplay();
     return displayMtl->getUtils().copyTextureWithDraw(context, cmdEncoder, sourceAngleFormat,
-                                                      format.actualAngleFormat(), blitParams);
+                                                      dstAngleFormat, blitParams);
 }
 
 angle::Result TextureMtl::copySubTextureCPU(const gl::Context *context,
@@ -2882,14 +2834,11 @@ angle::Result TextureMtl::copySubTextureCPU(const gl::Context *context,
                                             bool unpackUnmultiplyAlpha,
                                             const mtl::TextureRef &sourceTexture)
 {
-    mtl::TextureRef &image = getImage(index);
-    ASSERT(image && image->valid());
-
     ContextMtl *contextMtl = mtl::GetImpl(context);
+    auto &imageDef = getImageDefinition(index);
+    ANGLE_CHECK_ASSERT(contextMtl, imageDef.image && imageDef.image->valid());
 
-    mtl::Format format = contextMtl->getPixelFormat(
-        angle::Format::InternalFormatToID(internalFormat.sizedInternalFormat));
-    const angle::Format &dstAngleFormat = format.actualAngleFormat();
+    const angle::Format &dstAngleFormat = angle::Format::Get(imageDef.formatID);
     const int srcRowPitch               = sourceAngleFormat.pixelBytes * sourceBox.width;
     const int srcImageSize              = srcRowPitch * sourceBox.height;
     const int convRowPitch              = dstAngleFormat.pixelBytes * sourceBox.width;
@@ -2917,7 +2866,7 @@ angle::Result TextureMtl::copySubTextureCPU(const gl::Context *context,
 
     // Upload to texture
     ANGLE_TRY(UploadTextureContents(context, dstAngleFormat, mtlDstArea, mtl::kZeroNativeMipLevel,
-                                    0, conversionDst.data(), convRowPitch, 0, false, image));
+                                    0, conversionDst.data(), convRowPitch, 0, false, imageDef.image));
 
     return angle::Result::Continue;
 }

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/CopyTexImageTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/CopyTexImageTest.cpp
@@ -1455,6 +1455,41 @@ TEST_P(CopyTexImageTestES3, CopyTexSubImageToNonZeroBase)
                   kTexSize, 1.0);
 }
 
+// Test that copying into a image after unrelated image has been defined with another format works.
+TEST_P(CopyTexImageTestES3, CopyTexSubImageAfterIncompatibleDefinition)
+{
+    constexpr GLsizei kTexSize = 4;
+    std::vector<GLColor> green(kTexSize * kTexSize, GLColor::green);
+
+    GLTexture srcColor;
+    glBindTexture(GL_TEXTURE_2D, srcColor);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, kTexSize, kTexSize, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 green.data());
+    ASSERT_GL_NO_ERROR();
+
+    GLFramebuffer fbo;
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, srcColor, 0);
+    ASSERT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
+
+    std::vector<GLColor> red(kTexSize * kTexSize, GLColor::red);
+    GLTexture dstColor;
+    glBindTexture(GL_TEXTURE_2D, dstColor);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, kTexSize, kTexSize, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 red.data());
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glGenerateMipmap(GL_TEXTURE_2D); // Sync state.
+    glTexImage2D(GL_TEXTURE_2D, 7, GL_DEPTH_COMPONENT32F, 1, 1, 0, GL_DEPTH_COMPONENT, GL_FLOAT, nullptr); // Trigger the bug.
+    ASSERT_GL_NO_ERROR();
+
+    glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, kTexSize, kTexSize);
+    ASSERT_GL_NO_ERROR();
+
+    constexpr std::array<GLubyte, 4> kExpected = {0, 255, 0, 255};
+    verifyResults(dstColor, kExpected.data(), kTexSize, 0, 0, kTexSize, kTexSize, 1.0);
+}
+
 // Initialize the 3D texture we will copy the subImage data into
 void CopyTexImageTestES3::initialize3DTexture(GLTexture &texture,
                                               const GLsizei imageWidth,

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/MipmapTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/MipmapTest.cpp
@@ -2223,6 +2223,31 @@ TEST_P(MipmapTestES3, GenerateMipmapWithRedefineLevelAndTexture)
     EXPECT_PIXEL_COLOR_EQ(getWindowWidth() / 2, getWindowHeight() / 2, GLColor::black);
 }
 
+// Test that generating mipmaps after defining an incompatible image out of base-max range
+// does not cause problems. At the time of writing with Metal backend, defining images
+// after one state sync would cause problems upon subsequent GenerateMipmaps().
+TEST_P(MipmapTestES3, GenerateMipmapWithOutOfRangeLevelDefinition)
+{
+    GLTexture texture;
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+    std::vector<GLColor> data(2 * 2, GLColor::green);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA4, 2, 2, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 data.data());
+    glGenerateMipmap(GL_TEXTURE_2D); // Sync state.
+    glTexImage2D(GL_TEXTURE_2D, 10, GL_DEPTH_COMPONENT32F, 1, 1, 0, GL_DEPTH_COMPONENT, GL_FLOAT,
+                 nullptr); // Trigger the bug.
+    EXPECT_GL_NO_ERROR();
+    glGenerateMipmap(GL_TEXTURE_2D); // At the time, this would fail.
+    EXPECT_GL_NO_ERROR();
+
+    clearAndDrawQuad(m2DProgram, getWindowWidth(), getWindowHeight());
+    EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(getWindowWidth() / 2, getWindowHeight() / 2, GLColor::green);
+}
+
 // Test that manually generating mipmaps using draw calls is functional
 TEST_P(MipmapTestES31, GenerateMipmapWithDraw)
 {
@@ -2738,6 +2763,7 @@ TEST_P(MipmapTest, GeneratedMipmapsInvalidatedAfterSizeChange)
     EXPECT_GL_NO_ERROR();
     EXPECT_PIXEL_COLOR_EQ(64, 64, GLColor::green);
 }
+
 
 // Use this to select which configurations (e.g. which renderer, which GLES major version) these
 // tests should be run against.

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/TextureTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/TextureTest.cpp
@@ -2376,7 +2376,37 @@ TEST_P(Texture2DTest, DefineMultipleLevelsWithoutMipmapping)
     EXPECT_PIXEL_COLOR_EQ(0, 0, kMipColors[0][0]);
 }
 
-// Test drawing with two texture types, regression test for an old bug in validation.
+// Test that glTexSubImage2D works after defining a incompatible image out of base-max range.
+TEST_P(Texture2DTestES3, TexSubImageWithOutOfRangeLevelDefinition)
+{
+    setUpProgram();
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, mTexture2D);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+    std::vector<GLColor> data(2 * 2, GLColor::red);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA4, 2, 2, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 data.data());
+    EXPECT_GL_NO_ERROR();
+    glGenerateMipmap(GL_TEXTURE_2D); // Sync state.
+    glTexImage2D(GL_TEXTURE_2D, 10, GL_DEPTH_COMPONENT32F, 1, 1, 0, GL_DEPTH_COMPONENT, GL_FLOAT,
+                 nullptr);
+    EXPECT_GL_NO_ERROR();
+
+    std::vector<GLColor> updateData(2 * 2, GLColor::green);
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 2, 2, GL_RGBA, GL_UNSIGNED_BYTE,
+                    updateData.data()); // Trigger the bug.
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE,
+                    updateData.data()); // Clean up the mipmap so test verification works.
+    EXPECT_GL_NO_ERROR();
+
+    drawQuad(mProgram, "position", 0.0f);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(getWindowWidth() / 2, getWindowHeight() / 2, GLColor::green);
+}
+
+// Test drawing with two texture types, to trigger an ANGLE bug in validation
 TEST_P(TextureCubeTest, CubeMapBug)
 {
     glActiveTexture(GL_TEXTURE0);


### PR DESCRIPTION
#### c9fd4a1a1e6a337b6f4b75c1e660e2cab54e1470
<pre>
WebGL: GenerateMipmap after out of base level -max level texupload uses the wrong type
<a href="https://bugs.webkit.org/show_bug.cgi?id=309414">https://bugs.webkit.org/show_bug.cgi?id=309414</a>
<a href="https://rdar.apple.com/171630355">rdar://171630355</a>

Reviewed by Dan Glastonbury.

TextureMtl::mFormat was updated on each TexImage2D. However, this
variable represents the format of mNativeTextureStorage, the base-max
mipmap range of a mipmap complete texture. Updating out-of-range
mipmaps does not invalidate the mipmap chain, and thus not
mNativeTextureStorage. Many functions further used mFormat then to
configure the use or update of mNativeTextureStorage, with incorrect
mFormat.

Fix by not updating mFormat when an image is defined. This happens
in glTexImage*(), glCopyImage*(), glCopyTexture*(), eglBindTexImage(),
eglReleaseTexImage().

Fix updating mFormat only when mNativeTextureStorage is updated,
based on the mipmap chain format, i.e base mipmap format. This happens
in glGenerateMipmap() and state synchronization for rendering to texture
and draw sampling from the texture.

Fix by using the existing image definition for functions that already
expect the image to exist. If the image does not exist, fail with
a internal runtime error. This happens for glTexSubImage*,
glCopySubTexture*() glCopySubImage*().

* Source/ThirdParty/ANGLE/src/common/angleutils.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm:
(rx::TextureMtl::deallocateNativeStorage):
Remove keepSamplerStateAndFormat
Only used when the base or max mipmap level changes. This might
change the texture format, so the sampler and format will change.
Also, mFormat is only defined when mNativeTextureStorage exists, and
this function discards it.
Sampler is always discarded, because base-max change might change
the format, and sample depends on the format.

(rx::TextureMtl::ensureNativeStorageCreated):
(rx::TextureMtl::onBaseMaxLevelsChanged):
(rx::TextureMtl::getRenderTarget):

Framebuffer attachment update on render-to-texture via FBO
- Expect image to be defined, as otherwise frontend should not let
  the call through.
- Use the format of the defined image, not the format of the mipmap
  chain. The RT image might not be within the mipmap chain.

(rx::TextureMtl::generateMipmapCPU):
(rx::TextureMtl::setStorageImpl):
(rx::TextureMtl::setSubImageImpl):
(rx::TextureMtl::convertAndSetPerSliceSubImage):
(rx::TextureMtl::initializeContents):
(rx::TextureMtl::copySubImageImpl):
(rx::TextureMtl::copySubImageCPU):
(rx::TextureMtl::copySubTextureImpl):
(rx::TextureMtl::copySubTextureWithDraw):
(rx::TextureMtl::copySubTextureCPU):
(rx::TextureMtl::ensureImageCreated): Deleted.
Remove the function. It was always called from functions that
should already have image on that level. If we didn&apos;t have image on
the particular level, we would not be able to create one since we
would not know which format to create.

* Source/ThirdParty/ANGLE/src/tests/gl_tests/CopyTexImageTest.cpp:
(angle::TEST_P):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/MipmapTest.cpp:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/TextureTest.cpp:

Originally-landed-as: 305413.455@rapid/safari-7624.2.5.110-branch (92ab1d63ba59). <a href="https://rdar.apple.com/176061493">rdar://176061493</a>
Canonical link: <a href="https://commits.webkit.org/315237@main">https://commits.webkit.org/315237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15ff9b7e4e92cca8f1c4ab4d7e65078297100217

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125783 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130786 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91924 "5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111303 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32246 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30954 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179985 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139216 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41659 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139091 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37541 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42347 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105682 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27414 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40851 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40248 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5513 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->