### PR TITLE
[JSC] Check initial object structure in tryEnsureAbsence in DFG

### DIFF
--- a/JSTests/stress/dfg-ensure-absence-own-then-property.js
+++ b/JSTests/stress/dfg-ensure-absence-own-then-property.js
@@ -1,0 +1,88 @@
+function createObject1() {
+    const tmp = {
+        toJSON: 1,
+        a: 1,
+    };
+
+    Object.create(tmp);
+
+    return tmp;
+}
+
+function createObject2() {
+    const tmp = {
+        b: 1,
+        toJSON: {}
+    };
+
+    Object.create(tmp);
+
+    return tmp;
+}
+
+function opt(container1, object2, array, thenable, flags) {
+    const promise = new Promise(() => {});
+
+    container1.x;
+    thenable.x;
+
+    const object1 = Object.getPrototypeOf(container1);
+
+    let tmp = object1;
+    object1.a;
+
+    if (flags & 1) {
+        tmp = object2;
+        tmp.b;
+
+        0[0];
+    }
+
+    +tmp.toJSON;
+    +tmp.toJSON;
+
+    array[0];
+    Promise.resolve(+tmp.toJSON === 1 ? thenable : promise);
+
+    array[0] = 2.3023e-320;
+}
+
+function main() {
+    noDFG(main);
+
+    const object1 = createObject1();
+    const object2 = createObject2();
+
+    createObject1().z = 1;
+
+    const container1 = Object.create(object1);
+
+    const thenable = {
+        x: 1
+    };
+
+    const array = {
+        0: 1.1
+    };
+
+    let trigger = false;
+
+    thenable.__defineGetter__('then', () => {
+        if (trigger) {
+            array[0] = {};
+        }
+    });
+
+    JSON.stringify(container1);
+
+    for (let i = 0; i < 200; i++) {
+        opt(container1, object2, array, thenable, i);
+    }
+
+    trigger = true;
+    opt(container1, object2, array, thenable, 0);
+
+    array[0].x;
+}
+
+main();

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1555,6 +1555,26 @@ ObjectPropertyConditionSet Graph::tryEnsureAbsence(JSGlobalObject* globalObject,
     if (!headStructure)
         return ObjectPropertyConditionSet::invalid();
 
+    auto isAbsenceCacheable = [&](Structure* structure) {
+        if (structure->typeInfo().overridesGetOwnPropertySlot())
+            return false;
+        if (!structure->propertyAccessesAreCacheable())
+            return false;
+        if (!structure->propertyAccessesAreCacheableForAbsence())
+            return false;
+        unsigned attributes;
+        if (isValidOffset(structure->getConcurrently(identifier.uid(), attributes)))
+            return false;
+        if (structure->hasPolyProto())
+            return false;
+        return true;
+    };
+
+    // generateConditionsForPropertyMissConcurrently only walks the prototype chain, so validate
+    // headStructure first.
+    if (!isAbsenceCacheable(headStructure))
+        return ObjectPropertyConditionSet::invalid();
+
     auto result = generateConditionsForPropertyMissConcurrently(globalObject->vm(), globalObject, headStructure, identifier.uid());
     if (!result.isValid())
         return result;
@@ -1564,22 +1584,7 @@ ObjectPropertyConditionSet Graph::tryEnsureAbsence(JSGlobalObject* globalObject,
         if (!object)
             return ObjectPropertyConditionSet::invalid();
 
-        auto* structure = object->structure();
-        if (structure->typeInfo().overridesGetOwnPropertySlot())
-            return ObjectPropertyConditionSet::invalid();
-
-        if (!structure->propertyAccessesAreCacheable())
-            return ObjectPropertyConditionSet::invalid();
-
-        if (!structure->propertyAccessesAreCacheableForAbsence())
-            return ObjectPropertyConditionSet::invalid();
-
-        unsigned attributes;
-        PropertyOffset offset = structure->getConcurrently(identifier.uid(), attributes);
-        if (isValidOffset(offset))
-            return ObjectPropertyConditionSet::invalid();
-
-        if (structure->hasPolyProto())
+        if (!isAbsenceCacheable(object->structure()))
             return ObjectPropertyConditionSet::invalid();
     }
     return result;


### PR DESCRIPTION
#### 78c04ea7a1bc88f883951d5b5a1ad75dd4676e4e
<pre>
[JSC] Check initial object structure in tryEnsureAbsence in DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=310578">https://bugs.webkit.org/show_bug.cgi?id=310578</a>
<a href="https://rdar.apple.com/173052986">rdar://173052986</a>

Reviewed by Yijia Huang.

In DFG, tryEnsureAbsence currently does not check the structure of the object
on which it&apos;s trying to generate the conditions that a property remains absent.
It only checks the structures of the objects on the prototype chain. This is
incorrect in the case where object itself contains the property we&apos;re trying to
ensure absence of.

Test: JSTests/stress/dfg-ensure-absence-own-then-property.js
* JSTests/stress/dfg-ensure-absence-own-then-property.js: Added.
(createObject1):
(createObject2):
(opt):
(main):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::tryEnsureAbsence):

Originally-landed-as: 305413.567@rapid/safari-7624.2.5.110-branch (eaf1fed3279c). <a href="https://rdar.apple.com/176061662">rdar://176061662</a>
Canonical link: <a href="https://commits.webkit.org/314147@main">https://commits.webkit.org/314147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/118dd848243d39dccdd960e9a4aacdaeaa90c779

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174241 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122455 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128366 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108891 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29725 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28348 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21995 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157357 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139621 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176763 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26093 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29654 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27826 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136687 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32486 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136627 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36844 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147917 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101756 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31903 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24784 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111029 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37354 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2862 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->