### PR TITLE
[Grid] Resolve row-axis baseline alignment for orthogonal grid items per spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-alignment-style-changes-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-alignment-style-changes-003-expected.txt
@@ -1,16 +1,8 @@
 
 PASS .before 1
-FAIL .before 2 assert_equals:
-<div id="item2" data-expected-width="50" data-expected-height="50" data-offset-y="50" class=" before" data-offset-x="40"></div>
-offsetLeft expected 40 but got 10
-FAIL .before 3 assert_equals:
-<div id="item3" data-expected-width="30" data-expected-height="50" data-offset-y="100" class=" before" data-offset-x="40"></div>
-offsetLeft expected 40 but got 30
-FAIL .after 4 assert_equals:
-<div id="item1" data-expected-width="20" data-expected-height="50" data-offset-y="0" class=" before after" data-offset-x="70"></div>
-offsetLeft expected 70 but got 10
+PASS .before 2
+PASS .before 3
+PASS .after 4
 PASS .after 5
-FAIL .after 6 assert_equals:
-<div id="item3" data-expected-width="30" data-expected-height="50" data-offset-y="100" class=" before after" data-offset-x="70"></div>
-offsetLeft expected 70 but got 0
+PASS .after 6
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-alignment-style-changes-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-alignment-style-changes-004-expected.txt
@@ -1,16 +1,8 @@
 
-FAIL .before 1 assert_equals:
-<div id="item1" data-expected-width="20" data-expected-height="50" data-offset-y="0" class=" before" data-offset-x="70"></div>
-offsetLeft expected 70 but got 10
+PASS .before 1
 PASS .before 2
-FAIL .before 3 assert_equals:
-<div id="item3" data-expected-width="30" data-expected-height="50" data-offset-y="100" class=" before" data-offset-x="70"></div>
-offsetLeft expected 70 but got 0
+PASS .before 3
 PASS .after 4
-FAIL .after 5 assert_equals:
-<div id="item2" data-expected-width="50" data-expected-height="50" data-offset-y="50" class=" before after" data-offset-x="40" style="justify-self: baseline;"></div>
-offsetLeft expected 40 but got 10
-FAIL .after 6 assert_equals:
-<div id="item3" data-expected-width="30" data-expected-height="50" data-offset-y="100" class=" before after" data-offset-x="40"></div>
-offsetLeft expected 40 but got 30
+PASS .after 5
+PASS .after 6
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
@@ -11,9 +11,7 @@ line2
 line1
 line2
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-x="120">line1<br>line2</div>
-offsetLeft expected 120 but got 0
+PASS #target > div 1
 PASS #target > div 2
 PASS #target > div 3
 PASS #target > div 4

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-005-expected.txt
@@ -10,7 +10,7 @@ line2
 PASS #target > div 1
 FAIL #target > div 2 assert_equals:
 <div style="grid-row: 2; grid-column: span 3; justify-self: baseline;" data-offset-x="100">line1<br>line2</div>
-offsetLeft expected 100 but got 0
+offsetLeft expected 100 but got 110
 PASS #target > div 3
 FAIL #target > div 4 assert_equals:
 <div style="grid-row: 4; grid-column: span 3; justify-self: last baseline;" data-offset-x="10">line1<br>line2</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-001-expected.txt
@@ -11,13 +11,7 @@ VerticalRL grid and Horizontal item
 ÉÉ É ÉÉÉ É ÉÉ É
 É É ÉÉ
 
-FAIL .grid 1 assert_equals:
-<div class="grid width300 justifyItemsBaseline">
-  <div class="firstRowFirstColumn" data-offset-x="0" data-offset-y="0" data-expected-width="200" data-expected-height="100">ÉÉ É ÉÉÉ É ÉÉ É</div>
-  <div class="secondRowFirstColumn bigFont paddingRight verticalRL" data-offset-x="75" data-offset-y="100" data-expected-width="125" data-expected-height="200">É É ÉÉ</div>
-  <div class="autoRowSpanning2AutoColumn width25"></div>
-</div>
-offsetLeft expected 75 but got 0
+PASS .grid 1
 PASS .grid 2
 PASS .grid 3
 PASS .grid 4

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-002-expected.txt
@@ -8,13 +8,7 @@ VerticalRL grid and item with fixed width
 É É ÉÉ
 
 PASS .grid 1
-FAIL .grid 2 assert_equals:
-<div class="grid width300 justifyItemsBaseline">
-  <div class="firstRowFirstColumn fixedWidth" data-offset-x="0" data-offset-y="0" data-expected-width="125" data-expected-height="100"></div>
-  <div class="secondRowFirstColumn bigFont paddingRight verticalRL" data-offset-x="80" data-offset-y="100" data-expected-width="120" data-expected-height="200">É É ÉÉ</div>
-  <div class="autoRowSpanning2AutoColumn width25"></div>
-</div>
-offsetLeft expected 80 but got 0
+PASS .grid 2
 PASS .grid 3
 PASS .grid 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-003-expected.txt
@@ -8,13 +8,7 @@ VerticalRL grid and item with relative height
 É É ÉÉ
 
 PASS .grid 1
-FAIL .grid 2 assert_equals:
-<div class="grid width300 justifyItemsBaseline">
-  <div class="firstRowFirstColumn relativeWidth" data-offset-x="00" data-offset-y="0" data-expected-width="100" data-expected-height="100"></div>
-  <div class="secondRowFirstColumn bigFont paddingRight verticalRL" data-offset-x="80" data-offset-y="100" data-expected-width="120" data-expected-height="200">É É ÉÉ</div>
-  <div class="autoRowSpanning2AutoColumn width25"></div>
-</div>
-offsetLeft expected 80 but got 0
+PASS .grid 2
 PASS .grid 3
 PASS .grid 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009-expected.txt
@@ -6,38 +6,26 @@
 
 
 PASS .item 1
-FAIL .item 2 assert_equals:
-<div data-offset-x="237" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 237 but got 292
+PASS .item 2
 PASS .item 3
-FAIL .item 4 assert_equals:
-<div data-offset-x="57" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 57 but got 112
-FAIL .item 5 assert_equals:
-<div data-offset-x="475" class="item first">
-      <span></span><br><span></span>
-    </div>
-offsetLeft expected 475 but got 420
+PASS .item 4
+PASS .item 5
 PASS .item 6
 FAIL .item 7 assert_equals:
 <div data-offset-x="177" class="item small first"></div>
-offsetLeft expected 177 but got 60
+offsetLeft expected 177 but got 137
 FAIL .item 8 assert_equals:
 <div data-offset-x="102" class="item small last"></div>
 offsetLeft expected 102 but got 40
 FAIL .item 9 assert_equals:
 <div data-offset-x="357" class="item small first"></div>
-offsetLeft expected 357 but got 272
+offsetLeft expected 357 but got 325
 FAIL .item 10 assert_equals:
 <div data-offset-x="282" class="item small last"></div>
 offsetLeft expected 282 but got 252
 FAIL .item 11 assert_equals:
 <div data-offset-x="540" class="item small first"></div>
-offsetLeft expected 540 but got 460
+offsetLeft expected 540 but got 525
 FAIL .item 12 assert_equals:
 <div data-offset-x="465" class="item small last"></div>
 offsetLeft expected 465 but got 440

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -132,6 +132,7 @@ public:
     LayoutUnit maxContentSize() const { return m_maxContentSize; };
 
     LayoutUnit baselineOffsetForGridItem(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType) const;
+    bool isIntrinsicSizedGridArea(const RenderBox&, Style::GridTrackSizingDirection gridAreaDirection) const;
 
     // The estimated grid area should be use pre-layout versus the grid area, which should be used once
     // layout is complete.
@@ -238,7 +239,6 @@ private:
     bool canParticipateInBaselineAlignment(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType) const;
     bool participateInBaselineAlignment(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType) const;
 
-    bool isIntrinsicSizedGridArea(const RenderBox&, Style::GridTrackSizingDirection gridAreaDirection) const;
     void computeGridContainerIntrinsicSizes();
 
     // Helper methods for step 4. Stretch flexible tracks.

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2061,6 +2061,15 @@ GridAxisPosition RenderGrid::columnAxisPositionForGridItem(const RenderBox& grid
     return GridAxisPosition::GridAxisStart;
 }
 
+bool RenderGrid::inlineSizeDependsOnIntrinsicColumnTrackForGridItem(const RenderBox& gridItem) const
+{
+    // If the grid has a definite, non-fit-content inline size, its column tracks resolve without
+    // depending cyclically on grid items.
+    if (contentBoxLogicalWidth() && !sizesPreferredLogicalWidthToFitContent())
+        return false;
+    return m_trackSizingAlgorithm.isIntrinsicSizedGridArea(gridItem, Style::GridTrackSizingDirection::Columns);
+}
+
 GridAxisPosition RenderGrid::rowAxisPositionForGridItem(const RenderBox& gridItem) const
 {
     if (gridItem.isOutOfFlowPositioned() && !hasStaticPositionForGridItem(gridItem, Style::GridTrackSizingDirection::Columns))
@@ -2099,14 +2108,24 @@ GridAxisPosition RenderGrid::rowAxisPositionForGridItem(const RenderBox& gridIte
     case ItemPosition::Stretch:
         return GridAxisPosition::GridAxisStart;
     case ItemPosition::Baseline:
-        // FIXME: Handle non-inline matching orthogonal grid items properly.
-        if (GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem) && !WritingMode().isInlineMatchingAny(gridItem.writingMode()))
-            return GridAxisPosition::GridAxisStart;
+        if (GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem)) {
+            // https://drafts.csswg.org/css-grid-2/#row-align
+            // The grid's inline axis baseline is dependent on the grid item's size in that axis.
+            // For orthogonal items, the grid's inline axis is the grid item's block axis.
+            // If this size depends on the grid's column tracks due to intrinsic sizing,
+            // we should use the fallback alignment, GridAxisStart.
+            if (inlineSizeDependsOnIntrinsicColumnTrackForGridItem(gridItem))
+                return GridAxisPosition::GridAxisStart;
+            return writingMode().isInlineMatchingAny(gridItem.writingMode()) ? GridAxisPosition::GridAxisStart : GridAxisPosition::GridAxisEnd;
+        }
         return hasSameDirection ? GridAxisPosition::GridAxisStart : GridAxisPosition::GridAxisEnd;
     case ItemPosition::LastBaseline:
-        // FIXME: Handle non-inline matching orthogonal grid items properly.
-        if (GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem) && !WritingMode().isInlineMatchingAny(gridItem.writingMode()))
-            return GridAxisPosition::GridAxisStart;
+        if (GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem)) {
+            // Symmetric to ItemPosition::Baseline above; last-baseline falls back to GridAxisEnd.
+            if (inlineSizeDependsOnIntrinsicColumnTrackForGridItem(gridItem))
+                return GridAxisPosition::GridAxisEnd;
+            return writingMode().isInlineMatchingAny(gridItem.writingMode()) ? GridAxisPosition::GridAxisEnd : GridAxisPosition::GridAxisStart;
+        }
         return hasSameDirection ? GridAxisPosition::GridAxisEnd : GridAxisPosition::GridAxisStart;
     case ItemPosition::Legacy:
     case ItemPosition::Auto:

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -234,6 +234,7 @@ private:
 
     GridAxisPosition columnAxisPositionForGridItem(const RenderBox&) const;
     GridAxisPosition rowAxisPositionForGridItem(const RenderBox&) const;
+    bool inlineSizeDependsOnIntrinsicColumnTrackForGridItem(const RenderBox&) const;
     LayoutUnit columnAxisOffsetForGridItem(const RenderBox&) const;
     LayoutUnit rowAxisOffsetForGridItem(const RenderBox&) const;
     ContentAlignmentData computeContentPositionAndDistributionOffset(Style::GridTrackSizingDirection, const LayoutUnit& availableFreeSpace, unsigned numberOfGridTracks) const;


### PR DESCRIPTION
#### becea78a26e203dcbbe401c7dc94e38949b4d3b8
<pre>
[Grid] Resolve row-axis baseline alignment for orthogonal grid items per spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=315821">https://bugs.webkit.org/show_bug.cgi?id=315821</a>
&lt;<a href="https://rdar.apple.com/159973440">rdar://159973440</a>&gt;

Reviewed by NOBODY (OOPS!).

RenderGrid&apos;s inline axis baseline is dependent on the grid item&apos;s block size
if the grid item and RenderGrid are orthogonal. If this size depends on the
grid column&apos;s tracks due to intrinsic sizing, we should use fallback alignments:

baseline -&gt; GridAxisPosition::GridAxisStart
lastBaseline -&gt; GridAxisPosition::GridAxisEnd

This PR updates RenderGrid to correctly handle baseline alignment for
cyclically sized grid items by falling back to the fallback alignment.

<a href="https://www.w3.org/TR/css-grid-2/#row-align">https://www.w3.org/TR/css-grid-2/#row-align</a>

This PR fixes 15 subtests across 7 tests.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-alignment-style-changes-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-alignment-style-changes-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009-expected.txt:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::inlineSizeDependsOnIntrinsicColumnTrackForGridItem const):
(WebCore::RenderGrid::rowAxisPositionForGridItem const):
* Source/WebCore/rendering/RenderGrid.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/becea78a26e203dcbbe401c7dc94e38949b4d3b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166741 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40231 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33812 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175789 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123998 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d0e8a5f-93ae-4202-8c6b-e6700acd521b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168607 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40664 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40239 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/175789 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/123998 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8427eb2f-96e3-4cd3-9aab-07d2c6d8faea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169700 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/40664 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/33812 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/175789 "Hash becea78a for PR 65986 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f8ca3d7-5a56-403d-9c10-5bfacab71320) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/40664 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/40239 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24525 "Hash becea78a for PR 65986 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/40664 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/33812 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178323 "Hash becea78a for PR 65986 does not build (failure)") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31223 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/33812 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/178323 "Hash becea78a for PR 65986 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40301 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/40239 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/178323 "Hash becea78a for PR 65986 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40989 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/33812 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103786 "Hash becea78a for PR 65986 does not build (failure)") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/40989 "Failed to compile WebKit") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/33812 "Hash becea78a for PR 65986 does not build (failure)") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39500 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112574 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38896 "Hash becea78a for PR 65986 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/33812 "Hash becea78a for PR 65986 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39141 "Hash becea78a for PR 65986 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39039 "Hash becea78a for PR 65986 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->