### PR TITLE
Cherry-pick(s) 5d07bda85f02. rdar://176059252

### DIFF
--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -179,6 +179,8 @@ void removeDetachedChildrenInContainer(ContainerNode& container)
         node->setTreeScopeRecursively(Ref<Document> { container.document() });
         if (node->isInTreeScope())
             notifyChildNodeRemoved(container, *node);
+        else if (node->refCount() > 1)
+            node->updateShadowIncludingRootForSubtree();
         ASSERT_WITH_SECURITY_IMPLICATION(!node->isInTreeScope());
     }
 }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1502,6 +1502,15 @@ void Node::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemo
     }
 }
 
+void Node::updateShadowIncludingRootForSubtree()
+{
+    SUPPRESS_UNCOUNTED_LOCAL for (auto* current = this; current; current = NodeTraversal::next(*current, this)) {
+        current->updateShadowIncludingRoot();
+        SUPPRESS_UNCOUNTED_LOCAL if (auto* shadowRoot = current->shadowRoot())
+            shadowRoot->updateShadowIncludingRootForSubtree();
+    }
+}
+
 bool Node::isRootEditableElement() const
 {
     return hasEditableStyle() && isElementNode() && (!parentNode() || !parentNode()->hasEditableStyle()

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -508,6 +508,8 @@ public:
     // https://dom.spec.whatwg.org/#concept-node-move-ext
     virtual void movingSteps(bool, ContainerNode&) { };
 
+    void updateShadowIncludingRootForSubtree();
+
     virtual String description() const;
     virtual String debugDescription() const;
 


### PR DESCRIPTION
This is an automatic cherry-pick for rdar://176059252 to test against CI.
```
REGRESSION: Use-after-free in Node::m_shadowIncludingRoot via destructor cascade not propagating into shadow roots
https://bugs.webkit.org/show_bug.cgi?id=312712
rdar://175103172

Reviewed by Geoffrey Garen.

When a document is torn down via Document::removedLastRef through removeDetachedChildrenInContainer,
the <html> element is removed from the document. Since <html> is still in tree scope at this point,
notifyChildNodeRemoved is called, which walks the entire subtree - including shadow roots - and sets
m_shadowIncludingRoot to <html> for all descendants. This is correct at that moment.

Then <html> is freed when the loop's RefPtr releases it (children don't ref-count their parents -
m_parentNode is CheckedPtr). This triggers a destructor cascade: ~ContainerNode(<html>) via
removeDetachedChildrenInContainer(<html>) processes <body>, then ~ContainerNode(<body>) processes
the <video> element, and so on. Each step calls resetShadowIncludingRoot() on the direct child,
fixing that node's cache. However, since IsConnected and IsInShadowTree flags were cleared during
the initial notifyChildNodeRemoved walk, isInTreeScope() returns false, so notifyChildNodeRemoved
is skipped in this case. This means the shadow root and its descendants are never updated -
m_shadowIncludingRoot of these nodes still point to the now-freed <html>.

Nodes kept alive by mechanisms other than JS wrappers - such as HTMLMediaElement which survives as
an ActiveDOMObject - retain their shadow DOM with dangling m_shadowIncludingRoot pointers. When
these nodes are subsequently used (e.g., VTT cue display tree updates via an event loop task), the
stale pointer is dereferenced, causing an use-after-free.

This PR fixes this use-after-free bug by updating m_shadowIncludingRoot for removed subtrees when
the root's refCount is greater than 1 (i.e. there is an external reference to the node beyond the
RefPtr in removeDetachedChildrenInContainer).

No new tests since existing media tests such as media/track/webvtt-parser-does-not-leak.html would
hit debug assertions without this fix, and this bug requires a node to be kept alive by C++ code.

* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::removeDetachedChildrenInContainer):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::updateShadowIncludingRootForSubtree):
* Source/WebCore/dom/Node.h:

Originally-landed-as: 305413.700@safari-7624-branch (5d07bda85f02). rdar://176059252


```<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2b32f919ceccabf1e76953a7379434def2037b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165201 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38692 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32270 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174244 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122458 "Hash c2b32f91 for PR 65987 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167069 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39027 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38693 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/174244 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/122458 "Hash c2b32f91 for PR 65987 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168160 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/39027 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/32270 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/174244 "Hash c2b32f91 for PR 65987 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/39027 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/38693 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21998 "Hash c2b32f91 for PR 65987 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/39027 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/32270 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176766 "Hash c2b32f91 for PR 65987 does not build (failure)") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29648 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/32270 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/176766 "Hash c2b32f91 for PR 65987 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38760 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/38693 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/176766 "Hash c2b32f91 for PR 65987 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39450 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/32270 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101759 "Hash c2b32f91 for PR 65987 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/39450 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/32270 "Hash c2b32f91 for PR 65987 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37960 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111032 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37357 "Hash c2b32f91 for PR 65987 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/32270 "Hash c2b32f91 for PR 65987 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37603 "Hash c2b32f91 for PR 65987 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37501 "Hash c2b32f91 for PR 65987 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->