### PR TITLE
Cherry-pick(s) 33be61fed07c. rdar://176058579

### DIFF
--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -107,11 +107,13 @@ void TrackBase::setSourceBuffer(SourceBuffer* buffer)
 void TrackBase::setTrackList(TrackListBase& trackList)
 {
     m_trackList = trackList;
+    m_opaqueRoot = WebCoreOpaqueRoot { &trackList };
 }
 
 void TrackBase::clearTrackList()
 {
     m_trackList = nullptr;
+    m_opaqueRoot = WebCoreOpaqueRoot { this };
 }
 
 TrackListBase* TrackBase::trackList() const
@@ -119,6 +121,7 @@ TrackListBase* TrackBase::trackList() const
     return m_trackList.get();
 }
 
+<<<<<<< HEAD
 WebCoreOpaqueRoot TrackBase::opaqueRoot() const
 {
     // Runs on GC thread.
@@ -127,6 +130,8 @@ WebCoreOpaqueRoot TrackBase::opaqueRoot() const
     return WebCoreOpaqueRoot { const_cast<TrackBase*>(this) };
 }
 
+=======
+>>>>>>> 33be61fed07c (Data race in TrackBase::opaqueRoot during GC leading to use-after-free)
 // See: https://tools.ietf.org/html/bcp47#section-2.1
 static bool NODELETE isValidBCP47LanguageTag(const String& languageTag)
 {

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/ContextDestructionObserver.h>
 #include <WebCore/WebCoreOpaqueRoot.h>
+#include <atomic>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -79,8 +80,13 @@ public:
 
     void setTrackList(TrackListBase&);
     void clearTrackList();
+<<<<<<< HEAD
     TrackListBase* NODELETE trackList() const;
     WebCoreOpaqueRoot NODELETE opaqueRoot() const;
+=======
+    TrackListBase* trackList() const;
+    WebCoreOpaqueRoot opaqueRoot() const { return m_opaqueRoot; }
+>>>>>>> 33be61fed07c (Data race in TrackBase::opaqueRoot during GC leading to use-after-free)
 
     virtual bool enabled() const = 0;
 
@@ -122,6 +128,7 @@ private:
     uint64_t m_logIdentifier { 0 };
 #endif
     WeakPtr<TrackListBase, WeakPtrImplWithEventTargetData> m_trackList;
+    std::atomic<WebCoreOpaqueRoot> m_opaqueRoot { WebCoreOpaqueRoot { this } };
     size_t m_clientRegistrationId;
 };
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176058579 to main. [33be61fed07c] caused a merge conflict. 

```Data race in TrackBase::opaqueRoot during GC leading to use-after-free
https://bugs.webkit.org/show_bug.cgi?id=311800
rdar://173766033

Reviewed by Jer Noble.

Store the opaque root value separately from m_trackList to avoid data race during GC.

No new tests since there is no reliable way to test this data race.

* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::TrackBase::setTrackList):
(WebCore::TrackBase::clearTrackList):
(WebCore::TrackBase::opaqueRoot): Deleted.
* Source/WebCore/html/track/TrackBase.h:
(WebCore::TrackBase::opaqueRoot const):

Originally-landed-as: 305413.636@rapid/safari-7624.2.5.110-branch (33be61fed07c). rdar://176058579

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c96b453b7bf22e05d749c69de74c0650bd4fbf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165202 "2 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38693 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32271 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174245 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122459 "Hash 3c96b453 for PR 65988 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167070 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39028 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38694 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/174245 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/122459 "Hash 3c96b453 for PR 65988 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168161 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/39028 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/32271 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/174245 "Hash 3c96b453 for PR 65988 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/39028 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/38694 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21999 "Hash 3c96b453 for PR 65988 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/39028 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/32271 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176767 "Hash 3c96b453 for PR 65988 does not build (failure)") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29649 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/32271 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/176767 "Hash 3c96b453 for PR 65988 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38761 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/38694 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/176767 "Hash 3c96b453 for PR 65988 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39451 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/32271 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101760 "Hash 3c96b453 for PR 65988 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/39451 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/32271 "Hash 3c96b453 for PR 65988 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37961 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111033 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37358 "Hash 3c96b453 for PR 65988 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/32271 "Hash 3c96b453 for PR 65988 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37604 "Hash 3c96b453 for PR 65988 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37502 "Hash 3c96b453 for PR 65988 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->