### PR TITLE
[JSC] Take slow path in LiteralParser if original structure changes

### DIFF
--- a/JSTests/stress/literal-parser-proto-setter.js
+++ b/JSTests/stress/literal-parser-proto-setter.js
@@ -1,0 +1,17 @@
+let fired = false;
+Object.prototype.__defineSetter__("__proto__", function(v) {
+    if (fired) return;
+    fired = true;
+    Object.prototype.__defineSetter__(0, function(){});
+});
+
+let ks = '"0":null,"1":2,"5":3';
+
+eval("({"+ks+",a:1})");
+eval("({"+ks+",a:1})");
+
+let o = eval("({"+ks+",a:{__proto__:0}})");
+
+if (o[1] !== 2) {
+    throw new Error("incorrect eval result");
+}

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -121,7 +121,7 @@ public:
     static Identifier fromString(VM&, const AtomString&);
     static Identifier fromString(VM&, SymbolImpl*);
 
-    static Identifier fromUid(VM&, UniquedStringImpl* uid);
+    static Identifier NODELETE fromUid(VM&, UniquedStringImpl* uid);
     static Identifier fromUid(const PrivateName&);
     static Identifier fromUid(SymbolImpl&);
 

--- a/Source/JavaScriptCore/runtime/IdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/IdentifierInlines.h
@@ -121,7 +121,7 @@ inline Identifier Identifier::createLatin1(VM& vm, std::span<const char16_t> str
     return Identifier(vm, add8(vm, string));
 }
 
-inline Identifier Identifier::fromUid(VM& vm, UniquedStringImpl* uid)
+SUPPRESS_NODELETE inline Identifier Identifier::fromUid(VM& vm, UniquedStringImpl* uid)
 {
     if (!uid || !uid->isSymbol())
         return Identifier(vm, uid);

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -1429,9 +1429,9 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
                 PropertyOffset offset;
             };
 
-            auto* structure = object->structure();
+            auto* originalStructure = object->structure();
             auto property = [&, &vm = vm] ALWAYS_INLINE_LAMBDA -> Variant<ExistingProperty, Identifier> {
-                if (Structure* transition = structure->trySingleTransition()) {
+                if (Structure* transition = originalStructure->trySingleTransition()) {
                     // This check avoids hash lookup and refcount churn in the common case of a matching single transition.
                     SUPPRESS_UNCOUNTED_ARG if (transition->transitionKind() == TransitionKind::PropertyAddition
                         && !transition->transitionPropertyAttributes()
@@ -1441,11 +1441,11 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
                         else if (transition->transitionPropertyName() != vm.propertyNames->underscoreProto && m_visitedUnderscoreProto.isEmpty())
                             return ExistingProperty { transition, transition->transitionOffset() };
                     }
-                } else if (!structure->isDictionary()) {
+                } else if (!originalStructure->isDictionary()) {
                     // This check avoids refcount churn in the common case of a cached Identifier.
                     if (SUPPRESS_UNCOUNTED_LOCAL AtomStringImpl* ident = existingIdentifier(vm, m_lexer.currentToken())) {
                         PropertyOffset offset = 0;
-                        Structure* newStructure = Structure::addPropertyTransitionToExistingStructure(structure, ident, 0, offset);
+                        Structure* newStructure = Structure::addPropertyTransitionToExistingStructure(originalStructure, ident, 0, offset);
                         if (newStructure) [[likely]] {
                             if constexpr (parserMode == StrictJSON)
                                 return ExistingProperty { newStructure, offset };
@@ -1474,6 +1474,12 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
             if (!value) [[unlikely]]
                 return { };
 
+            // After parseRecursively, user code may have run (e.g. due to a __proto__ setter in a
+            // nested object), which may have changed the structure of the object. This invalidates
+            // any cached transition, so reset it to Identifier to take the slow path.
+            if (object->structure() != originalStructure && std::holds_alternative<ExistingProperty>(property)) [[unlikely]]
+                property = Identifier::fromUid(vm, std::get<ExistingProperty>(property).structure->transitionPropertyName());
+
             // When creating JSON object in this fast path, we know the following.
             //   1. The object is definitely JSFinalObject.
             //   2. The object rarely has duplicate properties.
@@ -1483,10 +1489,10 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
                 auto& [newStructure, offset] = std::get<ExistingProperty>(property);
 
                 Butterfly* newButterfly = object->butterfly();
-                if (structure->outOfLineCapacity() != newStructure->outOfLineCapacity()) {
-                    ASSERT(newStructure != structure);
-                    newButterfly = object->allocateMoreOutOfLineStorage(vm, structure->outOfLineCapacity(), newStructure->outOfLineCapacity());
-                    object->nukeStructureAndSetButterfly(vm, structure->id(), newButterfly);
+                if (originalStructure->outOfLineCapacity() != newStructure->outOfLineCapacity()) {
+                    ASSERT(newStructure != originalStructure);
+                    newButterfly = object->allocateMoreOutOfLineStorage(vm, originalStructure->outOfLineCapacity(), newStructure->outOfLineCapacity());
+                    object->nukeStructureAndSetButterfly(vm, originalStructure->id(), newButterfly);
                 }
 
                 validateOffset(offset);


### PR DESCRIPTION
#### aa5589433c390617ad88c26ba56299dec2087bbf
<pre>
[JSC] Take slow path in LiteralParser if original structure changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=310231">https://bugs.webkit.org/show_bug.cgi?id=310231</a>
<a href="https://rdar.apple.com/172857687">rdar://172857687</a>

Reviewed by Keith Miller.

LiteralParser has a fast path for caching transitions if we&apos;re parsing a
literal with an existing transition. This is done before the object literal is
actually parsed. During actual parsing, user code may run due to setters for
__proto__, which may invalidate the original object&apos;s structure and thus its
cached transition. Currently we don&apos;t account for the structure changing. This
PR fixes it by taking the slow path if the structure changes.

Test: JSTests/stress/literal-parser-proto-setter.js

* JSTests/stress/literal-parser-proto-setter.js: Added.
* Source/JavaScriptCore/runtime/Identifier.h:
* Source/JavaScriptCore/runtime/IdentifierInlines.h:
(JSC::Identifier::fromUid):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::requires):

Originally-landed-as: 305413.524@rapid/safari-7624.2.5.110-branch (15b9c504262f). <a href="https://rdar.apple.com/176061347">rdar://176061347</a>
Canonical link: <a href="https://commits.webkit.org/315327@main">https://commits.webkit.org/315327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b891225610f2308ccf45824f4d9e667633639f0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177896 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126274 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131221 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92296 "1 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111732 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32664 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31367 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26591 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/161185 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180495 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29813 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33218 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35531 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139662 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42135 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139520 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37599 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42823 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27866 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106488 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34802 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114583 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201244 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41327 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5949 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54043 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40724 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40975 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->