### PR TITLE
Cherry-pick(s) f045966f731c. rdar://176058798

### DIFF
--- a/LayoutTests/fast/events/blur-window-with-focus-in-shadow-tree-crash-expected.txt
+++ b/LayoutTests/fast/events/blur-window-with-focus-in-shadow-tree-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+PASS

--- a/LayoutTests/fast/events/blur-window-with-focus-in-shadow-tree-crash.html
+++ b/LayoutTests/fast/events/blur-window-with-focus-in-shadow-tree-crash.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test passes if it does not crash.</p>
+<div id="host"></div>
+<div id="result"></div>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+
+let shadowRoot = host.attachShadow({ mode: 'open' });
+let victim = document.createElement('div');
+victim.tabIndex = 0;
+victim.textContent = 'Focusable';
+shadowRoot.appendChild(victim);
+victim.focus();
+
+async function runTest() {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    document.addEventListener('blur', () => {
+        victim.remove();
+        victim = null;
+        GCController.collect();
+    }, true);
+
+    await UIHelper.setWindowIsKey(false);
+    await new Promise((resolve) => {
+        requestAnimationFrame(() => setTimeout(resolve, 0));
+    });
+
+    result.textContent = 'PASS';
+    testRunner.notifyDone();
+}
+
+if (!window.testRunner)
+    document.write('<p>This test requires testRunner.</p>');
+else
+    runTest();
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -418,26 +418,30 @@ static inline void dispatchEventsOnWindowAndFocusedElement(Document* document, b
             return;
     }
 
-    if (!focused && document->focusedElement()) {
-        if (document->focusedElement()->transferredFocusToPicker()) {
+    if (RefPtr focusedElement = document->focusedElement(); !focused && focusedElement) {
+        if (focusedElement->transferredFocusToPicker()) {
             // The webpage lost focus because the focused element transferred focus to
             // a non-web-content picker when it was activated. We don't want to post any
             // web-exposed events (e.g. blur) in these cases, so return.
-            document->focusedElement()->didSuppressBlurDueToPickerFocusTransfer();
+            focusedElement->didSuppressBlurDueToPickerFocusTransfer();
             return;
         }
 
+<<<<<<< HEAD
         if (RefPtr formControlElement = dynamicDowncast<HTMLFormControlElement>(*document->focusedElement())) {
             if (formControlElement->wasChangedSinceLastFormControlChangeEvent())
                 formControlElement->dispatchFormControlChangeEvent();
         }
 
         document->focusedElement()->dispatchBlurEvent(nullptr);
+=======
+        focusedElement->dispatchBlurEvent(nullptr);
+>>>>>>> f045966f731c (Use-after-free in Element::dispatchBlurEvent)
     }
 
     document->dispatchWindowEvent(Event::create(focused ? eventNames().focusEvent : eventNames().blurEvent, Event::CanBubble::No, Event::IsCancelable::No));
-    if (focused && document->focusedElement())
-        document->focusedElement()->dispatchFocusEvent(nullptr, { });
+    if (RefPtr focusedElement = document->focusedElement(); focused && focusedElement)
+        focusedElement->dispatchFocusEvent(nullptr, { });
 }
 
 static inline bool isFocusableElementOrScopeOwner(Element& element, const FocusEventData& focusEventData)


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176058798 to main. [f045966f731c] caused a merge conflict. 

```Use-after-free in Element::dispatchBlurEvent
https://bugs.webkit.org/show_bug.cgi?id=312365
rdar://174646151

Reviewed by Rupin Mittal, Chris Dumez, and Anne van Kesteren.

Deployed more smart pointers to fix the bug.

Test: fast/events/blur-window-with-focus-in-shadow-tree-crash.html

* LayoutTests/fast/events/blur-window-with-focus-in-shadow-tree-crash-expected.txt: Added.
* LayoutTests/fast/events/blur-window-with-focus-in-shadow-tree-crash.html: Added.
* Source/WebCore/page/FocusController.cpp:
(WebCore::dispatchEventsOnWindowAndFocusedElement):

Originally-landed-as: 305413.673@safari-7624-branch (f045966f731c). rdar://176058798

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58e96970567d335bdacf060ba089f1e017a69128

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165206 "2 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38697 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32275 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174249 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122463 "Hash 58e96970 for PR 65991 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167074 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39032 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38698 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/174249 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/122463 "Hash 58e96970 for PR 65991 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168165 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/39032 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/32275 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/174249 "Hash 58e96970 for PR 65991 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/39032 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/38698 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22003 "Hash 58e96970 for PR 65991 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/39032 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/32275 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176771 "Hash 58e96970 for PR 65991 does not build (failure)") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29653 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/32275 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/176771 "Hash 58e96970 for PR 65991 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38765 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/38698 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/176771 "Hash 58e96970 for PR 65991 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39455 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/32275 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101764 "Hash 58e96970 for PR 65991 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/39455 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/32275 "Hash 58e96970 for PR 65991 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37965 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111037 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37362 "Hash 58e96970 for PR 65991 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/32275 "Hash 58e96970 for PR 65991 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37608 "Hash 58e96970 for PR 65991 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37506 "Hash 58e96970 for PR 65991 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->