### PR TITLE
Cherry-pick(s) 4fcd36e3a363. rdar://176058666

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -303,7 +303,12 @@ Ref<WebProcessProxy> WebProcessProxy::create(WebProcessPool& processPool, Websit
 
 Ref<WebProcessProxy> WebProcessProxy::createForRemoteWorkers(RemoteWorkerType workerType, WebProcessPool& processPool, Site&& site, WebsiteDataStore& websiteDataStore, CrossOriginMode crossOriginMode, LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity)
 {
+<<<<<<< HEAD
     Ref proxy = adoptRef(*new WebProcessProxy(processPool, &websiteDataStore, IsPrewarmed::No, crossOriginMode, lockdownMode, enhancedSecurity));
+=======
+    Ref proxy = adoptRef(*new WebProcessProxy(processPool, &websiteDataStore, IsPrewarmed::No, CrossOriginMode::Shared, lockdownMode, enhancedSecurity));
+    proxy->m_committedSites.add(site);
+>>>>>>> 4fcd36e3a363 (REGRESSION(305413.548@safari-7624-branch): Crash in WebProcessProxy::hasCommittedClientOrigin)
     proxy->m_site = WTF::move(site);
     proxy->enableRemoteWorkers(workerType, processPool.userContentControllerForRemoteWorkers());
     proxy->connect();
@@ -955,6 +960,34 @@ void WebProcessProxy::removeWebPage(WebPageProxy& webPage, EndsUsingDataStore en
     maybeShutDown();
 }
 
+<<<<<<< HEAD
+=======
+void WebProcessProxy::addPagePendingClose(WebPageProxyIdentifier pageID)
+{
+    m_pagesPendingClose.add(pageID);
+}
+
+void WebProcessProxy::removePagePendingClose(WebPageProxyIdentifier pageID)
+{
+    m_pagesPendingClose.remove(pageID);
+}
+
+bool WebProcessProxy::hasCommittedClientOrigin(const WebCore::ClientOrigin& clientOrigin) const
+{
+    if (isRunningWorkers()) {
+        if (!m_site)
+            return m_committedSites.contains(Site { clientOrigin.topOrigin }) && m_committedSites.contains(Site { clientOrigin.clientOrigin });
+        return Site { clientOrigin.topOrigin } == *m_site && Site { clientOrigin.clientOrigin } == *m_site;
+    }
+    return m_committedClientOrigins.contains(clientOrigin);
+}
+
+void WebProcessProxy::didCommitLoadClientOrigin(WebCore::ClientOrigin&& clientOrigin)
+{
+    m_committedClientOrigins.add(WTF::move(clientOrigin));
+}
+
+>>>>>>> 4fcd36e3a363 (REGRESSION(305413.548@safari-7624-branch): Crash in WebProcessProxy::hasCommittedClientOrigin)
 void WebProcessProxy::addVisitedLinkStoreUser(VisitedLinkStore& visitedLinkStore, WebPageProxyIdentifier pageID)
 {
     auto& users = m_visitedLinkStoresWithUsers.ensure(visitedLinkStore, [] {
@@ -2302,6 +2335,7 @@ void WebProcessProxy::didStartProvisionalLoadForMainFrame(const URL& url)
         ASSERT((m_site && *m_site == site) || m_site.error() == SiteState::SharedProcess);
     else {
         // Associate the process with this site.
+        m_committedSites.add(site);
         m_site = WTF::move(site);
     }
 }
@@ -2314,7 +2348,12 @@ void WebProcessProxy::didStartUsingProcessForSiteIsolation(const std::optional<W
         m_sharedProcessMainFrameSite = mainFrameSite;
         return;
     }
+<<<<<<< HEAD
     ASSERT(m_site ? (m_site.value().isEmpty() || m_site.value() == *site || !m_hasCommittedAnyProvisionalLoads) : (m_site.error() == SiteState::NotYetSpecified || m_site.error() == SiteState::MultipleSites));
+=======
+    ASSERT(m_site ? (m_site.value().isEmpty() || m_site.value() == *site) : (m_site.error() == SiteState::NotYetSpecified || m_site.error() == SiteState::MultipleSites));
+    m_committedSites.add(*site);
+>>>>>>> 4fcd36e3a363 (REGRESSION(305413.548@safari-7624-branch): Crash in WebProcessProxy::hasCommittedClientOrigin)
     m_site = *site;
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -830,7 +830,12 @@ private:
 
     HashMap<String, uint64_t> m_pageURLRetainCountMap;
 
+<<<<<<< HEAD
     Expected<WebCore::Site, SiteState> m_site { std::unexpected<SiteState> { SiteState::NotYetSpecified } };
+=======
+    Expected<WebCore::Site, SiteState> m_site { Unexpected<SiteState> { SiteState::NotYetSpecified } };
+    HashSet<WebCore::Site> m_committedSites;
+>>>>>>> 4fcd36e3a363 (REGRESSION(305413.548@safari-7624-branch): Crash in WebProcessProxy::hasCommittedClientOrigin)
     std::optional<WebCore::Site> m_sharedProcessMainFrameSite;
     HashSet<WebCore::RegistrableDomain> m_sharedProcessDomains;
     std::pair<LoadedWebArchive, HashSet<WebCore::RegistrableDomain>> m_allowedFirstPartiesForCookies { LoadedWebArchive::No, { } };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm
@@ -34,8 +34,20 @@
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKFeature.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
+#import <wtf/text/MakeString.h>
 
 namespace TestWebKitAPI {
+
+static void enableWebLocksAPI(WKWebViewConfiguration *configuration)
+{
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            return;
+        }
+    }
+}
 
 enum class ShouldUseSameProcess : bool { No, Yes };
 
@@ -45,6 +57,7 @@ static void runSnapshotAcrossPagesTest(ShouldUseSameProcess shouldUseSameProcess
         { "/"_s, { "foo"_s } }
     });
 
+<<<<<<< HEAD:Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm
     RetainPtr configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
@@ -52,6 +65,10 @@ static void runSnapshotAcrossPagesTest(ShouldUseSameProcess shouldUseSameProcess
             break;
         }
     }
+=======
+    auto configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableWebLocksAPI(configuration1.get());
+>>>>>>> 4fcd36e3a363 (REGRESSION(305413.548@safari-7624-branch): Crash in WebProcessProxy::hasCommittedClientOrigin):Tools/TestWebKitAPI/Tests/WebKitCocoa/WebLocks.mm
 
     RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
     [webView1 synchronouslyLoadRequest:server.request()];
@@ -71,12 +88,7 @@ static void runSnapshotAcrossPagesTest(ShouldUseSameProcess shouldUseSameProcess
 
     RetainPtr configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration2.get().processPool = [configuration1 processPool];
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
-            [[configuration2 preferences] _setEnabled:YES forFeature:feature];
-            break;
-        }
-    }
+    enableWebLocksAPI(configuration2.get());
     if (shouldUseSameProcess == ShouldUseSameProcess::Yes) {
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         configuration2.get()._relatedWebView = webView1.get();
@@ -141,6 +153,7 @@ static void runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess shouldUseSam
         { "/"_s, { "foo"_s } }
     });
 
+<<<<<<< HEAD:Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm
     RetainPtr configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
@@ -148,6 +161,10 @@ static void runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess shouldUseSam
             break;
         }
     }
+=======
+    auto configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableWebLocksAPI(configuration1.get());
+>>>>>>> 4fcd36e3a363 (REGRESSION(305413.548@safari-7624-branch): Crash in WebProcessProxy::hasCommittedClientOrigin):Tools/TestWebKitAPI/Tests/WebKitCocoa/WebLocks.mm
 
     RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
     [webView1 synchronouslyLoadRequest:server.request()];
@@ -167,12 +184,7 @@ static void runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess shouldUseSam
 
     RetainPtr configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration2.get().processPool = [configuration1 processPool];
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
-            [[configuration2 preferences] _setEnabled:YES forFeature:feature];
-            break;
-        }
-    }
+    enableWebLocksAPI(configuration2.get());
     if (shouldUseSameProcess == ShouldUseSameProcess::Yes) {
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         configuration2.get()._relatedWebView = webView1.get();
@@ -242,6 +254,45 @@ TEST(WebLocks, LockRequestWaitingOnAnotherPageInOtherProcess)
 TEST(WebLocks, LockRequestWaitingOnAnotherPageInSameProcess)
 {
     runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess::Yes);
+}
+
+TEST(WebLocks, ServiceWorkerLockRequestAfterCrossSiteNavigationInSameProcess)
+{
+    TestWebKitAPI::HTTPServer server1({ }, TestWebKitAPI::HTTPServer::Protocol::Http);
+    TestWebKitAPI::HTTPServer server2({ }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto swScript = "self.addEventListener('message', event => { event.waitUntil(new Promise(() => {})); event.source.postMessage('processing'); function loop() { navigator.locks.request('sw-lock', () => {}).then(loop); } loop(); });"_s;
+    auto page2HTML = "<script>webkit.messageHandlers.testHandler.postMessage('LOADED');</script>"_s;
+    auto page1HTML = makeString(
+        "<script>"
+        "navigator.serviceWorker.register('/sw.js').then(() => navigator.serviceWorker.ready).then(reg => {"
+        "    navigator.serviceWorker.onmessage = () => { window.location = 'http://localhost:"_s, server2.port(), "/'; };"
+        "    reg.active.postMessage('start');"
+        "});"
+        "</script>"_s);
+
+    server1.addResponse("/sw.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, swScript });
+    server1.addResponse("/"_s, { page1HTML });
+    server2.addResponse("/"_s, { page2HTML });
+
+    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    processPoolConfiguration.get().processSwapsOnNavigation = NO;
+    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get().processPool = processPool.get();
+    enableWebLocksAPI(configuration.get());
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    __block bool done = false;
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        EXPECT_WK_STREQ(message, @"LOADED");
+        done = true;
+    }];
+
+    [webView synchronouslyLoadRequest:server1.request()];
+    TestWebKitAPI::Util::run(&done);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176058666 to main. [4fcd36e3a363] caused a merge conflict. 

```REGRESSION(305413.548@safari-7624-branch): Crash in WebProcessProxy::hasCommittedClientOrigin
https://bugs.webkit.org/show_bug.cgi?id=312335
rdar://174679141

Reviewed by Chris Dumez.

WebProcessProxy::hasCommittedClientOrigin has a code path for processes running workers (isRunningWorkers())
that dereferences m_site as in *m_site. m_site is a WTF::Expected<WebCore::Site, SiteState> — when it holds
the error value SiteState::MultipleSites, operator*() accesses the non-existent value member, throwing
std::bad_variant_access. This propagates uncaught to the Objective-C run loop boundary, triggering std::terminate().

The three conditions that must hold simultaneously for this crash to occur:
  1. isRunningWorkers() is true — a service worker is running inside a web content process (not a dedicated worker
     process), so m_serviceWorkerInformation is set.
  2. m_site holds MultipleSites — a cross-site navigation occurred in that same web content process (no process swap),
     so didStartProvisionalLoadForMainFrame set m_site = makeUnexpected(SiteState::MultipleSites).
  3. A RequestLock IPC from the service worker arrives after condition 2 — the service worker's termination is
     deferred (terminateRemoteWorkerContextConnectionWhenPossible instead of the old disableRemoteWorkers), so
     isRunningWorkers() remains true during a window where the worker can still send IPCs.

Fixed the bug by adding a HashSet<WebCore::Site> m_committedSites to WebProcessProxy, populated whenever m_site is
assigned a valid Site (in createForRemoteWorkers, didStartProvisionalLoadForMainFrame, and
didStartUsingProcessForSiteIsolation). In hasCommittedClientOrigin, when isRunningWorkers() is true but m_site does
not holds a value (it's MultipleSites), the check falls back to m_committedSites instead of dereferencing m_site
in an error state. This correctly validates the worker's origin against the sites the process has legitimately
committed — rather than crashing or incorrectly rejecting a legitimate lock request and killing the web process.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WebLocks.mm

* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::createForRemoteWorkers):
(WebKit::WebProcessProxy::hasCommittedClientOrigin const):
(WebKit::WebProcessProxy::didStartProvisionalLoadForMainFrame):
(WebKit::WebProcessProxy::didStartUsingProcessForSiteIsolation):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebLocks.mm:
(TestWebKitAPI::enableWebLocksAPI):
(TestWebKitAPI::runSnapshotAcrossPagesTest):
(TestWebKitAPI::runLockRequestWaitingOnAnotherPage):
(TestWebKitAPI::TEST(WebLocks, ServiceWorkerLockRequestAfterCrossSiteNavigationInSameProcess)):

Originally-landed-as: 305413.672@safari-7624-branch (4fcd36e3a363). rdar://176058666

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2217988faef46d6c04a6adaba3bd4ffc2ad3be2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165207 "16 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38698 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174250 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122464 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167075 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39033 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38699 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/174250 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122464 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/168166 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39033 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/32276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174250 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39033 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38699 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/22004 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39033 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/32276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29655 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/176772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38766 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/38699 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/39456 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/32276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101765 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/39456 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37966 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/111038 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/37363 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/32276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37609 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/37507 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->