### PR TITLE
FEMorphologySoftwareApplier is not thread safe

### DIFF
--- a/LayoutTests/svg/filters/feMorphology-radius-cases.svg
+++ b/LayoutTests/svg/filters/feMorphology-radius-cases.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="500">
+  <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-320" />
   <defs>
     <filter id="Erode-1">
       <feMorphology operator="erode" in="SourceGraphic" radius="-1" />

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -24,7 +24,6 @@ platform/PODInterval.h
 [ iOS ] platform/audio/ios/AudioSessionIOS.mm
 platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
 platform/graphics/filters/software/FELightingSoftwareApplier.h
-platform/graphics/filters/software/FEMorphologySoftwareApplier.h
 platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
 [ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
 [ iOS ] platform/ios/wak/WAKWindow.h

--- a/Source/WebCore/platform/graphics/PixelBuffer.h
+++ b/Source/WebCore/platform/graphics/PixelBuffer.h
@@ -29,7 +29,7 @@
 #include <WebCore/PixelBufferFormat.h>
 #include <optional>
 #include <span>
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 namespace WTF {
 class TextStream;
@@ -39,7 +39,7 @@ namespace WebCore {
 
 // Type for holding pixel buffers data.
 // For functions that source pixel buffers, see PixelBufferSourceView.
-class PixelBuffer : public RefCounted<PixelBuffer> {
+class PixelBuffer : public ThreadSafeRefCounted<PixelBuffer> {
     WTF_MAKE_NONCOPYABLE(PixelBuffer);
 public:
     static constexpr uint32_t bytesPerPixelComponent(PixelFormat);

--- a/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
@@ -4,7 +4,7 @@
  * Copyright (C) 2005 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
- * Copyright (C) Apple Inc. 2017-2022 All rights reserved.
+ * Copyright (C) Apple Inc. 2017-2026 All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -27,8 +27,8 @@
 
 #include "FEMorphology.h"
 #include "Filter.h"
+#include "FilterEffectSoftwareParallelApplier.h"
 #include "PixelBuffer.h"
-#include <wtf/ParallelJobs.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -44,12 +44,12 @@ inline ColorComponents<uint8_t, 4> FEMorphologySoftwareApplier::minOrMax(const C
     return perComponentMax(a, b);
 }
 
-inline ColorComponents<uint8_t, 4> FEMorphologySoftwareApplier::columnExtremum(const PixelBuffer& srcPixelBuffer, int x, int yStart, int yEnd, int width, MorphologyOperatorType type)
+inline ColorComponents<uint8_t, 4> FEMorphologySoftwareApplier::columnExtremum(const PixelBuffer& sourceBuffer, int x, int yStart, int yEnd, int width, MorphologyOperatorType type)
 {
-    auto extremum = makeColorComponentsfromPixelValue(PackedColor::RGBA { reinterpretCastSpanStartTo<const unsigned>(srcPixelBuffer.bytes().subspan(pixelArrayIndex(x, yStart, width))) });
+    auto extremum = makeColorComponentsfromPixelValue(PackedColor::RGBA { reinterpretCastSpanStartTo<const unsigned>(sourceBuffer.bytes().subspan(pixelArrayIndex(x, yStart, width))) });
 
     for (int y = yStart + 1; y < yEnd; ++y) {
-        auto pixel = makeColorComponentsfromPixelValue(PackedColor::RGBA { reinterpretCastSpanStartTo<const unsigned>(srcPixelBuffer.bytes().subspan(pixelArrayIndex(x, y, width))) });
+        auto pixel = makeColorComponentsfromPixelValue(PackedColor::RGBA { reinterpretCastSpanStartTo<const unsigned>(sourceBuffer.bytes().subspan(pixelArrayIndex(x, y, width))) });
         extremum = minOrMax(extremum, pixel, type);
     }
     return extremum;
@@ -64,93 +64,94 @@ inline ColorComponents<uint8_t, 4> FEMorphologySoftwareApplier::kernelExtremum(c
     return extremum;
 }
 
-void FEMorphologySoftwareApplier::applyPlatformGeneric(const PaintingData& paintingData, int startY, int endY)
+void FEMorphologySoftwareApplier::applyPlatformGeneric(PixelBuffer& sourceBuffer, PixelBuffer& destinationBuffer, const IntSize& sourceSize, const IntRect& destinationRect, MorphologyOperatorType type, const IntSize& radius)
 {
-    ASSERT(endY > startY);
+    const int radiusX = radius.width();
+    const int radiusY = radius.height();
+    const int startY = destinationRect.y();
+    const int endY = destinationRect.maxY();
+    const int sourceWidth = sourceSize.width();
+    const int sourceHeight = sourceSize.height();
 
-    const auto& srcPixelBuffer = *paintingData.srcPixelBuffer;
-    auto& dstPixelBuffer = *paintingData.dstPixelBuffer;
-
-    const int radiusX = paintingData.radiusX;
-    const int radiusY = paintingData.radiusY;
-    const int width = paintingData.width;
-    const int height = paintingData.height;
-
-    ASSERT(radiusX <= width || radiusY <= height);
-    ASSERT(startY >= 0 && endY <= height && startY < endY);
+    ASSERT(radiusX <= sourceWidth || radiusY <= sourceHeight);
+    ASSERT(destinationBuffer.size().width() <= sourceBuffer.size().width());
+    ASSERT(destinationBuffer.size().height() <= sourceBuffer.size().height());
 
     ColumnExtrema extrema;
     extrema.reserveInitialCapacity(2 * radiusX + 1);
 
     for (int y = startY; y < endY; ++y) {
         int yRadiusStart = std::max(0, y - radiusY);
-        int yRadiusEnd = std::min(height, y + radiusY + 1);
+        int yRadiusEnd = std::min(sourceHeight, y + radiusY + 1);
 
         extrema.shrink(0);
 
         // We start at the left edge, so compute extreme for the radiusX columns.
         for (int x = 0; x < radiusX; ++x)
-            extrema.append(columnExtremum(srcPixelBuffer, x, yRadiusStart, yRadiusEnd, width, paintingData.type));
+            extrema.append(columnExtremum(sourceBuffer, x, yRadiusStart, yRadiusEnd, sourceWidth, type));
 
         // Kernel is filled, get extrema of next column
-        for (int x = 0; x < width; ++x) {
-            if (x < width - radiusX)
-                extrema.append(columnExtremum(srcPixelBuffer, x + radiusX, yRadiusStart, yRadiusEnd, width, paintingData.type));
+        for (int x = 0; x < sourceWidth; ++x) {
+            if (x < sourceWidth - radiusX)
+                extrema.append(columnExtremum(sourceBuffer, x + radiusX, yRadiusStart, yRadiusEnd, sourceWidth, type));
 
             if (x > radiusX)
                 extrema.removeAt(0);
 
-            unsigned& destPixel = reinterpretCastSpanStartTo<unsigned>(dstPixelBuffer.bytes().subspan(pixelArrayIndex(x, y, width)));
-            destPixel = makePixelValueFromColorComponents(kernelExtremum(extrema, paintingData.type)).value;
+            unsigned& destPixel = reinterpretCastSpanStartTo<unsigned>(destinationBuffer.bytes().subspan(pixelArrayIndex(x, y - startY, sourceWidth)));
+            destPixel = makePixelValueFromColorComponents(kernelExtremum(extrema, type)).value;
         }
     }
 }
 
 void FEMorphologySoftwareApplier::applyPlatformWorker(ApplyParameters* params)
 {
-    applyPlatformGeneric(*params->paintingData, params->startY, params->endY);
+    RELEASE_ASSERT(params && params->sourceBuffer && params->destinationBuffer);
+    Ref sourceBuffer = *params->sourceBuffer;
+    Ref destinationBuffer = *params->destinationBuffer;
+    applyPlatformGeneric(sourceBuffer, destinationBuffer, params->sourceSize, params->destinationRect, params->type, params->radius);
 }
 
-void FEMorphologySoftwareApplier::applyPlatform(const PaintingData& paintingData)
+bool FEMorphologySoftwareApplier::applyPlatform(PixelBuffer& sourceBuffer, PixelBuffer& destinationBuffer, MorphologyOperatorType type, const IntSize& radius)
 {
     // Empirically, runtime is approximately linear over reasonable kernel sizes with a slope of about 0.65.
-    float kernelFactor = sqrt(paintingData.radiusX * paintingData.radiusY) * 0.65;
+    float kernelFactor = sqrt(radius.width() * radius.height()) * 0.65;
+    int kernelSizeY = 2 * radius.height();
+    int extraHeight = 3 * kernelSizeY * 0.5f;
 
     static const int minimalArea = (160 * 160); // Empirical data limit for parallel jobs
-    
-    unsigned maxNumThreads = paintingData.height / 8;
-    unsigned optimalThreadNumber = std::min<unsigned>((paintingData.width * paintingData.height * kernelFactor) / minimalArea, maxNumThreads);
+
+    IntSize paintSize = sourceBuffer.size();
+    IntRect paintRect = { { }, paintSize };
+    unsigned maxNumThreads = paintSize.height() / 8;
+    unsigned optimalThreadNumber = std::min<unsigned>((paintSize.unclampedArea() * kernelFactor) / (minimalArea + extraHeight * paintSize.width()), maxNumThreads);
+
     if (optimalThreadNumber > 1) {
-        ParallelJobs<ApplyParameters> parallelJobs(&applyPlatformWorker, optimalThreadNumber);
-        auto numOfThreads = parallelJobs.numberOfJobs();
-        if (numOfThreads > 1) {
-            // Split the job into "jobSize"-sized jobs but there a few jobs that need to be slightly larger since
-            // jobSize * jobs < total size. These extras are handled by the remainder "jobsWithExtra".
-            int jobSize = paintingData.height / numOfThreads;
-            int jobsWithExtra = paintingData.height % numOfThreads;
-            int currentY = 0;
-            for (int job = numOfThreads - 1; job >= 0; --job) {
-                ApplyParameters& param = parallelJobs.parameter(job);
-                param.startY = currentY;
-                currentY += job < jobsWithExtra ? jobSize + 1 : jobSize;
-                param.endY = currentY;
-                param.paintingData = &paintingData;
-            }
-            parallelJobs.execute();
-            return;
-        }
+        ApplyParameters params {
+            .sourceBuffer = sourceBuffer,
+            .destinationBuffer = destinationBuffer,
+            .sourceSize = paintSize,
+            .destinationRect = paintRect,
+            .type = type,
+            .radius = radius
+        };
+
+        if (applyPlatformParallel(&FEMorphologySoftwareApplier::applyPlatformWorker, optimalThreadNumber, params, extraHeight))
+            return true;
+
         // Fallback to single thread model
     }
 
-    applyPlatformGeneric(paintingData, 0, paintingData.height);
+    applyPlatformGeneric(sourceBuffer, destinationBuffer, paintSize, paintRect, type, radius);
+    return true;
 }
 
 bool FEMorphologySoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     auto& input = inputs[0].get();
 
-    auto destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
-    if (!destinationPixelBuffer)
+    auto destinationBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
+    if (!destinationBuffer)
         return false;
 
     auto isDegenerate = [](const IntSize& absoluteRadius) -> bool {
@@ -163,7 +164,7 @@ bool FEMorphologySoftwareApplier::apply(const Filter& filter, std::span<const Re
     auto absoluteRadius = flooredIntSize(filter.scaledByFilterScale(radius));
 
     if (isDegenerate(absoluteRadius)) {
-        input.copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
+        input.copyPixelBuffer(*destinationBuffer, effectDrawingRect);
         return true;
     }
 
@@ -171,25 +172,15 @@ bool FEMorphologySoftwareApplier::apply(const Filter& filter, std::span<const Re
     int radiusY = std::min(effectDrawingRect.height() - 1, absoluteRadius.height());
 
     if (isDegenerate({ radiusX, radiusY })) {
-        input.copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
+        input.copyPixelBuffer(*destinationBuffer, effectDrawingRect);
         return true;
     }
 
-    auto sourcePixelBuffer = input.getPixelBuffer(AlphaPremultiplication::Premultiplied, effectDrawingRect, m_effect->operatingColorSpace());
-    if (!sourcePixelBuffer)
+    RefPtr sourceBuffer = input.getPixelBuffer(AlphaPremultiplication::Premultiplied, effectDrawingRect, m_effect->operatingColorSpace());
+    if (!sourceBuffer)
         return false;
 
-    PaintingData paintingData;
-    paintingData.type = m_effect->morphologyOperator();
-    paintingData.srcPixelBuffer = &*sourcePixelBuffer;
-    paintingData.dstPixelBuffer = destinationPixelBuffer;
-    paintingData.width = effectDrawingRect.width();
-    paintingData.height = effectDrawingRect.height();
-    paintingData.radiusX = radiusX;
-    paintingData.radiusY = radiusY;
-
-    applyPlatform(paintingData);
-    return true;
+    return applyPlatform(*sourceBuffer, *destinationBuffer, m_effect->morphologyOperator(), { radiusX, radiusY });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2006, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005 Rob Buis <buis@kde.org>
  * Copyright (C) 2005 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2021-2022 Apple, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Apple, Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -46,20 +46,14 @@ private:
 
     using ColumnExtrema = Vector<ColorComponents<uint8_t, 4>, 16>;
 
-    struct PaintingData {
-        MorphologyOperatorType type;
-        int radiusX;
-        int radiusY;
-        const PixelBuffer* srcPixelBuffer;
-        PixelBuffer* dstPixelBuffer;
-        int width;
-        int height;
-    };
-
     struct ApplyParameters {
-        const PaintingData* paintingData;
-        int startY;
-        int endY;
+        RefPtr<PixelBuffer> sourceBuffer;
+        RefPtr<PixelBuffer> destinationBuffer;
+        IntSize sourceSize;
+        IntRect destinationRect;
+
+        MorphologyOperatorType type;
+        IntSize radius;
     };
 
     static inline int pixelArrayIndex(int x, int y, int width) { return (y * width + x) * 4; }
@@ -67,12 +61,12 @@ private:
 
     static inline ColorComponents<uint8_t, 4> makeColorComponentsfromPixelValue(PackedColor::RGBA pixel) { return asColorComponents(asSRGBA(pixel).resolved()); }
     static inline ColorComponents<uint8_t, 4> minOrMax(const ColorComponents<uint8_t, 4>& a, const ColorComponents<uint8_t, 4>& b, MorphologyOperatorType);
-    static inline ColorComponents<uint8_t, 4> columnExtremum(const PixelBuffer& srcPixelBuffer, int x, int yStart, int yEnd, int width, MorphologyOperatorType);
+    static inline ColorComponents<uint8_t, 4> columnExtremum(const PixelBuffer& sourceBuffer, int x, int yStart, int yEnd, int width, MorphologyOperatorType);
     static inline ColorComponents<uint8_t, 4> kernelExtremum(const ColumnExtrema& kernel, MorphologyOperatorType);
 
-    static void applyPlatformGeneric(const PaintingData&, int startY, int endY);
+    static void applyPlatformGeneric(PixelBuffer& sourceBuffer, PixelBuffer& destinationBuffer, const IntSize& sourceSize, const IntRect& destinationRect, MorphologyOperatorType, const IntSize& radius);
     static void applyPlatformWorker(ApplyParameters*);
-    static void applyPlatform(const PaintingData&);
+    static bool applyPlatform(PixelBuffer& sourceBuffer, PixelBuffer& destinationBuffer, MorphologyOperatorType, const IntSize& radius);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FilterEffectSoftwareParallelApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FilterEffectSoftwareParallelApplier.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ParallelJobs.h>
+
+namespace WebCore {
+
+template<typename ApplyParameters>
+inline bool applyPlatformParallel(typename ParallelJobs<ApplyParameters>::WorkerFunction func, int requestedJobNumber, const ApplyParameters& paintParameters, int extraHeight)
+{
+    if (requestedJobNumber <= 1)
+        return false;
+
+    ParallelJobs<ApplyParameters> parallelJobs(func, requestedJobNumber);
+    int jobs = parallelJobs.numberOfJobs();
+    if (jobs <= 1)
+        return false;
+
+    RefPtr sourceBuffer = paintParameters.sourceBuffer;
+    RefPtr destinationBuffer = paintParameters.destinationBuffer;
+    IntSize paintSize = destinationBuffer->size();
+
+    // Split the job into "blockHeight"-sized jobs but there a few jobs that need to be slightly larger since
+    // blockHeight * jobs < total size. These extras are handled by the remainder "jobsWithExtra".
+    const int blockHeight = paintSize.height() / jobs;
+    if (blockHeight <= extraHeight)
+        return false;
+
+    const int jobsWithExtra = paintSize.height() % jobs;
+    const int scanline = 4 * paintSize.width();
+
+    auto calculateAdjustedBlockHeight = [&](int job) -> int {
+        return job < jobsWithExtra ? blockHeight + 1 : blockHeight;
+    };
+
+    int currentY = 0;
+    for (int job = 0; job < jobs; ++job) {
+        ApplyParameters& params = parallelJobs.parameter(job);
+        int adjustedBlockHeight = calculateAdjustedBlockHeight(job);
+
+        IntRect sourceRect { 0, currentY, paintSize.width(), adjustedBlockHeight };
+        IntRect destinationRect { { }, sourceRect.size() };
+
+        if (job) {
+            sourceRect.shiftYEdgeBy(-extraHeight);
+            destinationRect.setY(extraHeight);
+        }
+
+        if (job < jobs - 1)
+            sourceRect.shiftMaxYEdgeBy(extraHeight);
+
+        params = paintParameters;
+        params.sourceSize = sourceRect.size();
+        params.destinationRect = destinationRect;
+
+        if (job) {
+            params.sourceBuffer = sourceBuffer->createScratchPixelBuffer(params.sourceSize);
+            memcpySpan(params.sourceBuffer->bytes(), sourceBuffer->bytes().subspan(sourceRect.y() * scanline, params.sourceBuffer->bytes().size()));
+            params.destinationBuffer = sourceBuffer->createScratchPixelBuffer(params.destinationRect.size());
+        }
+
+        currentY += adjustedBlockHeight;
+    }
+
+    parallelJobs.execute();
+
+    // Copy together the parts of the image.
+    currentY = 0;
+    for (int job = 1; job < jobs; ++job) {
+        ApplyParameters& params = parallelJobs.parameter(job);
+        int scratchHeight = calculateAdjustedBlockHeight(job);
+
+        currentY += scratchHeight;
+
+        unsigned destinationOffset = currentY * scanline;
+        unsigned scratchSize = scratchHeight * scanline;
+
+        // The final result of each job should be stored in ioBuffer.
+        ASSERT(params.destinationBuffer->bytes().size() >= scratchSize);
+        memcpySpan(destinationBuffer->bytes().subspan(destinationOffset), params.destinationBuffer->bytes().subspan(0, scratchSize));
+    }
+
+    return true;
+}
+
+} // namespace WebCore


### PR DESCRIPTION
#### f076e1adb5518485b51b627b28a57fb96f6cc4e3
<pre>
FEMorphologySoftwareApplier is not thread safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=308910">https://bugs.webkit.org/show_bug.cgi?id=308910</a>
<a href="https://rdar.apple.com/168776587">rdar://168776587</a>

Reviewed by Mike Wyrzykowski.

The software morphology applier relies on threading the calculations using
ParallelJobs. It splits the source image into vertical blocks and working on each
block separately. All the jobs access the same source and the destination
PixelBuffer. The problem is the PixelBuffer is not thread safe.

To fix this issue, FEMorphologySoftwareApplier will create a source and a
destination PixelBuffers for each job. Before executing the parallel jobs, it
copies bytes from its source PixelBuffer to the jobs source PixelBuffers. After
the calculation finishes, FEMorphologySoftwareApplier will collect the results
from the destination PixelBuffers of the jobs to its destination PixelBuffer.

* LayoutTests/svg/filters/feMorphology-radius-cases.svg:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/PixelBuffer.h:
* Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp:
(WebCore::FEMorphologySoftwareApplier::columnExtremum):
(WebCore::FEMorphologySoftwareApplier::applyPlatformGeneric):
(WebCore::FEMorphologySoftwareApplier::applyPlatformWorker):
(WebCore::FEMorphologySoftwareApplier::applyPlatform):
(WebCore::FEMorphologySoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.h:
* Source/WebCore/platform/graphics/filters/software/FilterEffectSoftwareParallelApplier.h: Added.
(WebCore::applyPlatformParallel):

Originally-landed-as: 305413.516@rapid/safari-7624.2.5.110-branch (e557102b0f77). <a href="https://rdar.apple.com/176061452">rdar://176061452</a>
Canonical link: <a href="https://commits.webkit.org/315239@main">https://commits.webkit.org/315239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4175bcad90b2569fbe7ab182b8798ef67dd7e038

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168006 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41503 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130713 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91865 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111230 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32161 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30869 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26004 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179901 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32653 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139138 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139018 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37542 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105543 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27336 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40767 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114019 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40164 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5436 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->