### PR TITLE
[JSC] JSLock m_hasOwnerThread has concurrency issue

### DIFF
--- a/Source/JavaScriptCore/runtime/JSLock.cpp
+++ b/Source/JavaScriptCore/runtime/JSLock.cpp
@@ -105,8 +105,7 @@ void JSLock::lock(intptr_t lockCount) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     }
 
     m_ownerThread = &Thread::currentSingleton();
-    WTF::storeStoreFence();
-    m_hasOwnerThread = true;
+    m_hasOwnerThread.store(true, std::memory_order_release);
     ASSERT(!m_lockCount);
     m_lockCount = lockCount;
 
@@ -291,7 +290,7 @@ void JSLock::unlock(intptr_t unlockCount) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     m_lockCount -= unlockCount;
 
     if (!m_lockCount) {
-        m_hasOwnerThread = false;
+        m_hasOwnerThread.store(false, std::memory_order_release);
         m_lock.unlock();
     }
 }

--- a/Source/JavaScriptCore/runtime/JSLock.h
+++ b/Source/JavaScriptCore/runtime/JSLock.h
@@ -87,7 +87,7 @@ public:
 
     std::optional<RefPtr<Thread>> ownerThread() const
     {
-        if (m_hasOwnerThread)
+        if (m_hasOwnerThread.load(std::memory_order_acquire))
             return m_ownerThread;
         return std::nullopt;
     }
@@ -97,12 +97,12 @@ public:
     // with thread suspension. Returns std::nullopt if there is no owner thread.
     std::optional<uint64_t> ownerThreadUID() const
     {
-        if (!m_hasOwnerThread)
+        if (!m_hasOwnerThread.load(std::memory_order_acquire))
             return std::nullopt;
         return m_ownerThread->uid();
     }
 
-    bool currentThreadIsHoldingLock() { return m_hasOwnerThread && m_ownerThread.get() == &Thread::currentSingleton(); }
+    bool currentThreadIsHoldingLock() { return m_hasOwnerThread.load(std::memory_order_acquire) && m_ownerThread.get() == &Thread::currentSingleton(); }
 
     void NODELETE willDestroyVM(VM*);
 
@@ -151,7 +151,7 @@ private:
     // m_hasOwnerThread) because currentThreadIsHoldingLock() may be called from a
     // different thread, and an optional is vulnerable to races.
     // See https://bugs.webkit.org/show_bug.cgi?id=169042#c6
-    bool m_hasOwnerThread { false };
+    std::atomic<bool> m_hasOwnerThread { false };
     bool m_shouldReleaseHeapAccess;
     RefPtr<Thread> m_ownerThread;
     intptr_t m_lockCount;


### PR DESCRIPTION
#### aed1fddc0be21a3eb4e94a231d794898b0360886
<pre>
[JSC] JSLock m_hasOwnerThread has concurrency issue
<a href="https://bugs.webkit.org/show_bug.cgi?id=311431">https://bugs.webkit.org/show_bug.cgi?id=311431</a>
<a href="https://rdar.apple.com/173797266">rdar://173797266</a>

Reviewed by Dan Hecht.

JSLock::lock is storing `true` flag to JSLock::m_hasOwnerThread after
store-store-barrier. However loading this is not having a brrier. This
is problemtic since JSLock is keeping two fields in sync: m_hasOwnerThread
and m_ownerThread. But ordering of stores to them and visibility of the
state of them must be strongly controlled, otherwise, random thread
accidentlly think that &quot;we are already taking a lock&quot; while it is not.
In particular, currentThreadIsHoldingLock has a bug that we are loading
these two fields without any barriers. So CPU can freely change the
visibility of the other thread&apos;s store to them. We may see a state that
m_hasOwnerThread is true, but m_ownerThread is not stored yet.

This patch fixes this issue by using release-acquire load/store for
m_hasOwnerThread. This ensures the load and store ordering before and
after this variable. So we can guarantee that m_ownerThread is not a
stale state.

* Source/JavaScriptCore/runtime/JSLock.cpp:
* Source/JavaScriptCore/runtime/JSLock.h:
(JSC::JSLock::ownerThread const):
(JSC::JSLock::ownerThreadUID const):
(JSC::JSLock::currentThreadIsHoldingLock):

Originally-landed-as: 305413.611@rapid/safari-7624.2.5.110-branch (729df7fb2917). <a href="https://rdar.apple.com/176061322">rdar://176061322</a>
Canonical link: <a href="https://commits.webkit.org/314150@main">https://commits.webkit.org/314150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/888a57453d3844939454af292f22d10bcd5744f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122472 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128381 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108906 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29741 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28361 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22012 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157374 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176780 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26110 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29663 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136702 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136641 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36848 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147934 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101773 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31919 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24801 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37974 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111047 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37371 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2879 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37617 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->