### PR TITLE
[JSC] `Array.prototype.join` skips prototype element added during element toString

### DIFF
--- a/JSTests/stress/array-join-tostring-adds-indexed-prototype-property.js
+++ b/JSTests/stress/array-join-tostring-adds-indexed-prototype-property.js
@@ -1,0 +1,76 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected ' + expected);
+}
+
+// An element's toString adds an indexed property to Array.prototype. Holes visited
+// after that point must forward to the prototype instead of being treated as empty.
+{
+    let calls = 0;
+    const obj = {
+        toString() {
+            calls++;
+            Array.prototype[2] = "P";
+            return "X";
+        }
+    };
+    const arr = [, obj, , ];
+    arr.length = 3;
+    shouldBe(arr.join(","), ",X,P");
+    shouldBe(calls, 1);
+    delete Array.prototype[2];
+}
+
+// Multiple holes after the mutation point.
+{
+    const obj = {
+        toString() {
+            Array.prototype[1] = "P1";
+            Array.prototype[2] = "P2";
+            return "X";
+        }
+    };
+    const arr = [obj, , , ];
+    arr.length = 3;
+    shouldBe(arr.join(","), "X,P1,P2");
+    delete Array.prototype[1];
+    delete Array.prototype[2];
+}
+
+// The added prototype property is an accessor; it must be invoked exactly once.
+{
+    let getterCalls = 0;
+    const obj = {
+        toString() {
+            Object.defineProperty(Array.prototype, 1, {
+                get() {
+                    getterCalls++;
+                    return "G";
+                },
+                configurable: true
+            });
+            return "X";
+        }
+    };
+    const arr = [obj, , ];
+    arr.length = 2;
+    shouldBe(arr.join(","), "X,G");
+    shouldBe(getterCalls, 1);
+    delete Array.prototype[1];
+}
+
+// Holes visited before the mutation must still read as empty.
+{
+    const obj = {
+        toString() {
+            Array.prototype[0] = "P0";
+            Array.prototype[2] = "P2";
+            return "X";
+        }
+    };
+    const arr = [, obj, , ];
+    arr.length = 3;
+    shouldBe(arr.join(","), ",X,P2");
+    delete Array.prototype[0];
+    delete Array.prototype[2];
+}

--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -350,6 +350,7 @@ ALWAYS_INLINE JSString* fastArrayJoin(JSGlobalObject* globalObject, JSObject* th
                 RETURN_IF_EXCEPTION(scope, { });
                 if (!withoutSideEffect) {
                     genericCase = true;
+                    holesKnownToBeOK = false;
                     if (thisObject->butterfly() == &butterfly && originalLength == butterfly.publicLength()) [[likely]]
                         continue;
                     ++i;


### PR DESCRIPTION
#### f181acea44641a3c7ebfc1181b0deaf049466d62
<pre>
[JSC] `Array.prototype.join` skips prototype element added during element toString
<a href="https://bugs.webkit.org/show_bug.cgi?id=315653">https://bugs.webkit.org/show_bug.cgi?id=315653</a>

Reviewed by Yusuke Suzuki.

fastArrayJoin caches whether holes can be treated as empty strings in
holesKnownToBeOK so that it only checks holesMustForwardToPrototype once.
However, in the contiguous case, JSStringJoiner::append can run arbitrary
user code (e.g. an element&apos;s toString), which may add indexed properties
to the prototype chain. Since holesKnownToBeOK was not invalidated, holes
visited after such a side effect were still appended as empty strings
instead of forwarding to the prototype.

This is a regression from 296180@main, which started calling
JSStringJoiner::append in the contiguous fast path and continuing the
loop when the butterfly and length are unchanged. Before that, the fast
path bailed out to the general case via appendWithoutSideEffects before
running any user code, so holesKnownToBeOK could never become stale.

This change resets holesKnownToBeOK whenever append reports that it may
have executed user code, so the next hole re-checks
holesMustForwardToPrototype and falls back to the general case if needed.

Test: JSTests/stress/array-join-tostring-adds-indexed-prototype-property.js

* JSTests/stress/array-join-tostring-adds-indexed-prototype-property.js: Added.
(shouldBe):
(throw.new.Error):
(const.obj.toString):
* Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h:
(JSC::fastArrayJoin):

Canonical link: <a href="https://commits.webkit.org/314210@main">https://commits.webkit.org/314210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3f6e3b0f50cd7532be0a4ccc561a0ef82d380e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174269 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122483 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128384 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90368 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108909 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29746 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28367 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22023 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157385 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139642 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176791 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26121 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29674 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27848 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136705 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136644 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36883 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147939 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101787 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31923 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24806 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37985 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111058 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37382 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2884 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->