### PR TITLE
[JSC] JSOrderedHashTable is overly allocating DataTable

### DIFF
--- a/JSTests/stress/iterator-helpers-fast-path-drain-and-reentrancy.js
+++ b/JSTests/stress/iterator-helpers-fast-path-drain-and-reentrancy.js
@@ -1,0 +1,183 @@
+// Regression tests for the Iterator.prototype.toArray / forEach / etc. fast path
+// in forEachInIteratorProtocol, and Array.from(map.keys() / .values()) fast path
+// in tryCreateArrayFromMapIterator. Requirements:
+//   1. Seed iteration from the iterator's stored storage (not the map's current),
+//      so transit() can shift entry indices across rehashes/clears.
+//   2. Leave the iterator drained when iteration completes.
+//   3. The fast path and the user-visible callback share the iterator's cursor:
+//      a reentrant iter.next() inside the callback must advance the iterator,
+//      consuming the next element so the helper does not see it again.
+//      Closing the iterator inside the callback (iter.return-equivalent) must
+//      stop the helper.
+
+function shouldEq(actual, expected, msg) {
+    const a = JSON.stringify(actual);
+    const e = JSON.stringify(expected);
+    if (a !== e)
+        throw new Error("FAIL " + msg + ": got " + a + ", expected " + e);
+}
+
+// --- Iterator.prototype.toArray on Map/Set iterators ---
+
+// Partial-consume returns the remaining elements.
+{
+    const s = new Set([1, 2, 3]);
+    const it = s.values();
+    it.next();
+    shouldEq(it.toArray(), [2, 3], "set toArray after partial consume");
+}
+
+// Iterator must be drained after toArray.
+{
+    const s = new Set([1, 2, 3]);
+    const it = s.values();
+    it.toArray();
+    shouldEq(it.next(), { value: undefined, done: true }, "set: next() after toArray must be done");
+}
+{
+    const s = new Set([1, 2, 3]);
+    const it = s.values();
+    it.next();
+    it.toArray();
+    shouldEq(it.next(), { value: undefined, done: true }, "set: next() after partial+toArray must be done");
+}
+{
+    const m = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+    const it = m.entries();
+    it.toArray();
+    shouldEq(it.next(), { value: undefined, done: true }, "map: next() after toArray must be done");
+}
+
+// Rehash with deletions during partial consume.
+{
+    const s = new Set();
+    s.add("a"); s.add("b"); s.add("c"); s.add("d");
+    const it = s.values();
+    it.next(); it.next();
+    s.delete("a"); s.delete("b");
+    s.add("e");
+    shouldEq(it.toArray(), ["c", "d", "e"], "set toArray after rehash with deletions");
+}
+
+// Drained iterator across clear().
+{
+    const s = new Set();
+    for (let i = 0; i < 1000; i++) s.add(i);
+    const it = s.values();
+    while (!it.next().done) {}
+    s.clear();
+    shouldEq(it.toArray(), [], "set toArray after drain+clear");
+}
+
+// --- Reentrancy: callback advances the iterator, helper picks up after it ---
+
+// Set: callback calls iter.next() once per element, "stealing" alternate entries.
+// Helper should see the rest. Total elements distributed between helper & callback
+// must equal the iterator contents in spec order.
+{
+    const s = new Set([10, 20, 30, 40, 50]);
+    const it = s.values();
+    const helperSaw = [];
+    const userTook = [];
+    it.forEach(v => {
+        helperSaw.push(v);
+        const n = it.next();
+        if (!n.done)
+            userTook.push(n.value);
+    });
+    shouldEq(helperSaw, [10, 30, 50], "set forEach: helper sees alternate elements when callback steals one each step");
+    shouldEq(userTook, [20, 40], "set forEach: callback's iter.next() takes interleaved elements");
+    shouldEq(it.next(), { value: undefined, done: true }, "set: drained after forEach");
+}
+
+// Map: same shape.
+{
+    const m = new Map([[1, "a"], [2, "b"], [3, "c"], [4, "d"], [5, "e"]]);
+    const it = m.values();
+    const helperSaw = [];
+    const userTook = [];
+    it.forEach(v => {
+        helperSaw.push(v);
+        const n = it.next();
+        if (!n.done)
+            userTook.push(n.value);
+    });
+    shouldEq(helperSaw, ["a", "c", "e"], "map forEach: helper sees alternate elements");
+    shouldEq(userTook, ["b", "d"], "map forEach: callback gets the rest");
+    shouldEq(it.next(), { value: undefined, done: true }, "map: drained after forEach");
+}
+
+// Callback drains the iterator entirely via repeated iter.next() — helper must
+// then see no more elements.
+{
+    const s = new Set([1, 2, 3, 4, 5]);
+    const it = s.values();
+    const helperSaw = [];
+    const userTook = [];
+    it.forEach(v => {
+        helperSaw.push(v);
+        if (v === 1) {
+            while (true) {
+                const n = it.next();
+                if (n.done) break;
+                userTook.push(n.value);
+            }
+        }
+    });
+    shouldEq(helperSaw, [1], "set forEach: helper stops after callback drains rest");
+    shouldEq(userTook, [2, 3, 4, 5], "set forEach: callback drained the rest");
+    shouldEq(it.next(), { value: undefined, done: true }, "set: drained");
+}
+
+// --- Array.from(map.keys()) / Array.from(map.values()) ---
+
+// Partial-consume returns remaining elements.
+{
+    const m = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+    const it = m.keys();
+    it.next();
+    shouldEq(Array.from(it), [2, 3], "Array.from(map.keys()) after partial consume");
+}
+
+// Iterator drained after Array.from.
+{
+    const m = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+    const it = m.keys();
+    Array.from(it);
+    shouldEq(it.next(), { value: undefined, done: true }, "map: next() after Array.from must be done");
+}
+{
+    const m = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+    const it = m.values();
+    it.next();
+    Array.from(it);
+    shouldEq(it.next(), { value: undefined, done: true }, "map: next() after partial+Array.from must be done");
+}
+
+// Fresh iterator on a map with deletions — fast path skips empties.
+{
+    const m = new Map([[1, "a"], [2, "b"], [3, "c"], [4, "d"]]);
+    m.delete(2);
+    m.delete(3);
+    shouldEq(Array.from(m.keys()), [1, 4], "Array.from(map.keys()) fresh, with deletions");
+}
+
+// Partial consume across a rehash with deletions.
+{
+    const m = new Map();
+    m.set("a", 1); m.set("b", 2); m.set("c", 3); m.set("d", 4);
+    const it = m.keys();
+    it.next(); it.next();
+    m.delete("a"); m.delete("b");
+    m.set("e", 5);
+    shouldEq(Array.from(it), ["c", "d", "e"], "Array.from(map.keys()) after rehash with deletions");
+}
+
+// Repeat under JIT tiers.
+for (let i = 0; i < 1000; i++) {
+    const m = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+    const it = m.keys();
+    it.next();
+    shouldEq(Array.from(it), [2, 3], "Array.from(map.keys()) loop");
+    shouldEq(it.next(), { value: undefined, done: true }, "iterator drained loop");
+}

--- a/JSTests/stress/map-iterator-fully-packed-table.js
+++ b/JSTests/stress/map-iterator-fully-packed-table.js
@@ -1,0 +1,104 @@
+// Regression test for the JIT-inlined MapIteratorNext / SetIteratorNext path
+// and the C++ helper transitAndNext.
+//
+// JSOrderedHashTable's DataTable is sized to its load-factor cap (DataCapacity)
+// rather than the bucket count, so a Map/Set populated to exactly DataCapacity
+// has no spare zero-initialized slot inside the DataTable past the last entry.
+// The iterator (both the JIT-inlined fast path and the C++ helper) terminates
+// when it loads an empty JSValue from the slot one past the last alive entry;
+// without a trailing IterationSentinel slot, that load would run off the end
+// of the storage and read whatever happens to be in adjacent memory, which can
+// either yield bogus extra entries, loop forever on a stray deleted-marker, or
+// crash. ASan reliably catches the OOB read; in normal release builds the bug
+// surfaces only when adjacent memory happens to hold a non-zero value, so this
+// test exercises the path but is not a deterministic detector on its own.
+//
+// The sizes packed below are exactly DataCapacity at the small-capacity
+// regime, where DataCapacity = capacity / 2.  If the dataCapacity formula in
+// JSOrderedHashTableHelper ever changes, regenerate these values.
+//   capacity 8   -> DataCapacity 4
+//   capacity 32  -> DataCapacity 16
+//   capacity 128 -> DataCapacity 64
+
+function assert(b, msg) {
+    if (!b)
+        throw new Error("FAIL: " + msg);
+}
+noInline(assert);
+
+const fullSizes = [4, 16, 64];
+
+function buildMap(n) {
+    const m = new Map();
+    for (let i = 0; i < n; ++i)
+        m.set(i, i * 2);
+    return m;
+}
+
+function buildSet(n) {
+    const s = new Set();
+    for (let i = 0; i < n; ++i)
+        s.add(i);
+    return s;
+}
+
+function drainMap(m) {
+    const it = m[Symbol.iterator]();
+    let count = 0;
+    let sumK = 0;
+    let sumV = 0;
+    while (true) {
+        const { value, done } = it.next();
+        if (done) {
+            assert(value === undefined, "done iterator value");
+            break;
+        }
+        sumK += value[0];
+        sumV += value[1];
+        ++count;
+    }
+    // One additional next() after done must keep returning done with no error.
+    const after = it.next();
+    assert(after.done === true, "post-done iterator");
+    return [count, sumK, sumV];
+}
+noInline(drainMap);
+
+function drainSet(s) {
+    const it = s[Symbol.iterator]();
+    let count = 0;
+    let sum = 0;
+    while (true) {
+        const { value, done } = it.next();
+        if (done) {
+            assert(value === undefined, "done iterator value");
+            break;
+        }
+        sum += value;
+        ++count;
+    }
+    const after = it.next();
+    assert(after.done === true, "post-done iterator");
+    return [count, sum];
+}
+noInline(drainSet);
+
+for (const n of fullSizes) {
+    const map = buildMap(n);
+    const set = buildSet(n);
+
+    const expectedSumK = (n * (n - 1)) / 2;
+    const expectedSumV = expectedSumK * 2;
+    const expectedSetSum = expectedSumK;
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        const [c, sk, sv] = drainMap(map);
+        assert(c === n, "map count " + n);
+        assert(sk === expectedSumK, "map sumK " + n);
+        assert(sv === expectedSumV, "map sumV " + n);
+
+        const [sc, ss] = drainSet(set);
+        assert(sc === n, "set count " + n);
+        assert(ss === expectedSetSum, "set sum " + n);
+    }
+}

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
@@ -455,32 +455,35 @@ static JSArray* tryCreateArrayFromMapIterator(JSGlobalObject* globalObject, JSMa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (!mapIterator->entry())
+    JSMap* map = mapIterator->iteratedObject();
+    if (!map) [[unlikely]]
         return nullptr;
 
-    JSMap* map = mapIterator->iteratedObject();
     IterationKind kind = mapIterator->kind();
     ASSERT(kind == IterationKind::Keys || kind == IterationKind::Values);
-    unsigned length = map->size();
 
-    if (!length)
-        RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
-
-    JSCell* storageCell = map->storageOrSentinel(vm);
+    JSCell* storageCell = mapIterator->tryGetStorage();
     if (storageCell == vm.orderedHashTableSentinel())
         RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
+    if (!storageCell) {
+        storageCell = map->storageOrSentinel(vm);
+        if (storageCell == vm.orderedHashTableSentinel())
+            RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
+    }
 
+    JSMap::Helper::Entry startEntry = mapIterator->entry();
     auto* storage = uncheckedDowncast<JSMap::Storage>(storageCell);
 
     IndexingType indexingType = IsArray;
-    JSMap::Helper::Entry entry = 0;
+    JSMap::Helper::Entry entry = startEntry;
+    unsigned length = 0;
 
     while (true) {
-        storageCell = JSMap::Helper::nextAndUpdateIterationEntry(vm, *storage, entry);
-        if (storageCell == vm.orderedHashTableSentinel())
+        JSCell* nextCell = JSMap::Helper::nextAndUpdateIterationEntry(vm, *storage, entry);
+        if (nextCell == vm.orderedHashTableSentinel())
             break;
 
-        auto* currentStorage = uncheckedDowncast<JSMap::Storage>(storageCell);
+        auto* currentStorage = uncheckedDowncast<JSMap::Storage>(nextCell);
         entry = JSMap::Helper::iterationEntry(*currentStorage) + 1;
 
         JSValue entryValue;
@@ -490,8 +493,12 @@ static JSArray* tryCreateArrayFromMapIterator(JSGlobalObject* globalObject, JSMa
             entryValue = JSMap::Helper::getIterationEntryValue(*currentStorage);
 
         indexingType = leastUpperBoundOfIndexingTypeAndValue(indexingType, entryValue);
+        ++length;
         storage = currentStorage;
     }
+
+    if (!length)
+        RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
 
     Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(indexingType);
     IndexingType resultIndexingType = resultStructure->indexingType();
@@ -512,21 +519,20 @@ static JSArray* tryCreateArrayFromMapIterator(JSGlobalObject* globalObject, JSMa
     resultButterfly->setVectorLength(vectorLength);
     resultButterfly->setPublicLength(length);
 
-    storageCell = map->storageOrSentinel(vm);
-    if (storageCell == vm.orderedHashTableSentinel()) [[unlikely]]
-        return nullptr;
+    storageCell = mapIterator->tryGetStorage();
+    if (!storageCell)
+        storageCell = map->storageOrSentinel(vm);
     storage = uncheckedDowncast<JSMap::Storage>(storageCell);
-
-    entry = 0;
+    entry = startEntry;
     size_t i = 0;
 
     if (hasDouble(resultIndexingType)) {
         while (true) {
-            storageCell = JSMap::Helper::nextAndUpdateIterationEntry(vm, *storage, entry);
-            if (storageCell == vm.orderedHashTableSentinel())
+            JSCell* nextCell = JSMap::Helper::nextAndUpdateIterationEntry(vm, *storage, entry);
+            if (nextCell == vm.orderedHashTableSentinel())
                 break;
 
-            auto* currentStorage = uncheckedDowncast<JSMap::Storage>(storageCell);
+            auto* currentStorage = uncheckedDowncast<JSMap::Storage>(nextCell);
             entry = JSMap::Helper::iterationEntry(*currentStorage) + 1;
 
             JSValue value;
@@ -542,11 +548,11 @@ static JSArray* tryCreateArrayFromMapIterator(JSGlobalObject* globalObject, JSMa
         }
     } else if (hasInt32(resultIndexingType) || hasContiguous(resultIndexingType)) {
         while (true) {
-            storageCell = JSMap::Helper::nextAndUpdateIterationEntry(vm, *storage, entry);
-            if (storageCell == vm.orderedHashTableSentinel())
+            JSCell* nextCell = JSMap::Helper::nextAndUpdateIterationEntry(vm, *storage, entry);
+            if (nextCell == vm.orderedHashTableSentinel())
                 break;
 
-            auto* currentStorage = uncheckedDowncast<JSMap::Storage>(storageCell);
+            auto* currentStorage = uncheckedDowncast<JSMap::Storage>(nextCell);
             entry = JSMap::Helper::iterationEntry(*currentStorage) + 1;
 
             JSValue value;
@@ -563,6 +569,9 @@ static JSArray* tryCreateArrayFromMapIterator(JSGlobalObject* globalObject, JSMa
         RELEASE_ASSERT_NOT_REACHED();
 
     Butterfly::clearRange(resultIndexingType, resultButterfly, length, vectorLength);
+
+    mapIterator->close(vm);
+
     return JSArray::createWithButterfly(vm, nullptr, resultStructure, resultButterfly);
 }
 

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -324,24 +324,23 @@ void forEachInIteratorProtocol(JSGlobalObject* globalObject, JSValue iterable, N
 
     if (auto* mapIterator = dynamicDowncast<JSMapIterator>(iterable)) {
         if (mapIteratorProtocolIsFastAndNonObservable(vm, mapIterator)) {
-            if (JSMap* iteratedMap = mapIterator->iteratedObject()) {
-                JSCell* storageCell = iteratedMap->storageOrSentinel(vm);
-                if (storageCell != vm.orderedHashTableSentinel()) {
-                    JSMap::Helper::Entry startEntry = mapIterator->entry();
-                    IterationKind iterationKind = mapIterator->kind();
-                    forEachInMapStorage(vm, globalObject, storageCell, startEntry, iterationKind, callback);
+            if (mapIterator->iteratedObject()) {
+                JSValue value;
+                while (mapIterator->next(globalObject, value)) {
+                    RETURN_IF_EXCEPTION(scope, void());
+                    callback(vm, globalObject, value);
                     RETURN_IF_EXCEPTION(scope, void());
                 }
+                RETURN_IF_EXCEPTION(scope, void());
                 return;
             }
         }
     } else if (auto* setIterator = dynamicDowncast<JSSetIterator>(iterable)) {
         if (setIteratorProtocolIsFastAndNonObservable(vm, setIterator)) {
-            if (JSSet* iteratedSet = setIterator->iteratedObject()) {
-                JSCell* storageCell = iteratedSet->storageOrSentinel(vm);
-                if (storageCell != vm.orderedHashTableSentinel()) {
-                    JSSet::Helper::Entry startEntry = setIterator->entry();
-                    forEachInSetStorage(vm, globalObject, storageCell, startEntry, callback);
+            if (setIterator->iteratedObject()) {
+                JSValue value;
+                while (setIterator->next(globalObject, value)) {
+                    callback(vm, globalObject, value);
                     RETURN_IF_EXCEPTION(scope, void());
                 }
                 return;

--- a/Source/JavaScriptCore/runtime/JSMapIterator.h
+++ b/Source/JavaScriptCore/runtime/JSMapIterator.h
@@ -186,6 +186,11 @@ public:
     void setStorage(VM& vm, JSCell* storage) { internalField(Field::Storage).set(vm, this, storage); }
     void setEntry(VM& vm, JSMap::Helper::Entry entry) { internalField(Field::Entry).set(vm, this, JSMap::Helper::toJSValue(entry)); }
 
+    void close(VM& vm)
+    {
+        markClosed(vm.orderedHashTableSentinel());
+    }
+
 private:
     JSMapIterator(VM& vm, Structure* structure)
         : Base(vm, structure)

--- a/Source/JavaScriptCore/runtime/JSOrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/JSOrderedHashTableHelper.h
@@ -53,14 +53,15 @@ class JSOrderedHashTable;
 
 // ################ NonObsolete Table ################
 //
-//                      Count                                    Value(s)                           ValueType                  WriteBarrier
-//               -------------------------------------------------------------------------------------------------------------------------------------
-// TableStart ->           1          | AliveEntryCount                                            | TableSize                | NO
-//                         1          | DeletedEntryCount                                          | TableSize                | NO
-//                         1          | Capacity                                                   | TableSize                | NO
-//                         1          | IterationEntry                                             | Entry                    | NO
-//                    BucketCount     | HashTable:  { <BucketIndex, ChainStartKeyIndex>, ... }     | <TableIndex, TableIndex> | NO
-//  TableEnd  -> Capacity * EntrySize | DataTable:  { <Entry_0, Data_0>, <Entry_1, Data_1>, ... }  | <TableIndex, JSValue>    | Yes (Key or Value)
+//                          Count                                      Value(s)                           ValueType                  WriteBarrier
+//               -----------------------------------------------------------------------------------------------------------------------------------------
+// TableStart ->             1            | AliveEntryCount                                            | TableSize                | NO
+//                           1            | DeletedEntryCount                                          | TableSize                | NO
+//                           1            | Capacity                                                   | TableSize                | NO
+//                           1            | IterationEntry                                             | Entry                    | NO
+//                       BucketCount      | HashTable:  { <BucketIndex, ChainStartKeyIndex>, ... }     | <TableIndex, TableIndex> | NO
+//                      DataTableSize     | DataTable:  { <Entry_0, Data_0>, <Entry_1, Data_1>, ... }  | <TableIndex, JSValue>    | Yes (Key or Value)
+//  TableEnd  ->   IterationSentinelSlots | IterationSentinel                                          | JSValue                  | NO
 //
 // ################ Obsolete Table from Rehash ################
 //
@@ -178,9 +179,22 @@ public:
     ALWAYS_INLINE static constexpr TableIndex bucketIndex(TableSize capacity, uint32_t hash) { return bucketIndex(hashTableStartIndex(), bucketCount(capacity), hash); }
 
     /* -------------------------------- Data table -------------------------------- */
-    ALWAYS_INLINE static constexpr TableSize dataTableSize(TableSize capacity) { return capacity * EntrySize; }
+    // The DataTable is packed and only holds up to dataCapacity entries before a rehash is forced.
+    // dataCapacity matches the rehash threshold in expandIfNeeded: 50% of capacity for small tables,
+    // 75% for large. Sizing the DataTable this way avoids the dead tail that would otherwise sit
+    // between the rehash threshold and the end of the buffer.
+    ALWAYS_INLINE static constexpr TableSize dataCapacity(TableSize capacity)
+    {
+        if (capacity < LargeCapacity)
+            return capacity / 2;
+        return (capacity / 4) * 3;
+    }
+    ALWAYS_INLINE static constexpr TableSize dataTableSize(TableSize capacity) { return dataCapacity(capacity) * EntrySize; }
 
     ALWAYS_INLINE static constexpr TableIndex dataTableStartIndex(TableSize capacity) { return hashTableStartIndex() + bucketCount(capacity); }
+    // Index of the last DataTable slot proper. The allocated storage extends one further
+    // slot — the IterationSentinel — so use tableSize() / tableSizeSlow() when reasoning
+    // about total length, not dataTableEndIndex().
     ALWAYS_INLINE static constexpr TableIndex dataTableEndIndex(TableSize capacity) { return dataTableStartIndex(capacity) + dataTableSize(capacity) - 1; }
     ALWAYS_INLINE static constexpr TableIndex entryDataStartIndex(TableIndex dataTableStartIndex, Entry entry) { return dataTableStartIndex + entry * EntrySize; }
 
@@ -195,15 +209,20 @@ public:
     }
 
     /* -------------------------------- JSOrderedHashTable -------------------------------- */
+    // One trailing zero-initialized JSValue is allocated past the DataTable so the iterator
+    // can safely read one slot past the last entry when the table is fully packed.
+    static constexpr TableSize iterationSentinelSlots = 1;
+
     ALWAYS_INLINE static constexpr TableSize tableSize(TableSize capacity)
     {
         TableSize result = 4 /* AliveEntryCount, DeletedEntryCount, Capacity, and IterationEntry */
-            + capacity /* BucketCount */
-            + capacity * EntrySize; /* DataTableSize */
+            + bucketCount(capacity) /* BucketCount */
+            + dataTableSize(capacity) /* DataTableSize */
+            + iterationSentinelSlots;
         ASSERT(result == tableSizeSlow(capacity));
         return result;
     }
-    ALWAYS_INLINE static constexpr TableSize tableSizeSlow(TableSize capacity) { return dataTableEndIndex(capacity) + 1; }
+    ALWAYS_INLINE static constexpr TableSize tableSizeSlow(TableSize capacity) { return dataTableEndIndex(capacity) + 1 + iterationSentinelSlots; }
 
     /* -------------------------------- Obsolete table -------------------------------- */
     ALWAYS_INLINE static constexpr bool isObsolete(Storage& storage) { return !!nextTable(storage); }
@@ -397,18 +416,13 @@ public:
         TableSize deletedEntryCount = Helper::deletedEntryCount(base);
         TableSize usedCapacity = Helper::aliveEntryCount(base) + deletedEntryCount;
 
-        bool isSmallCapacity = capacity < LargeCapacity;
-        if (isSmallCapacity) {
-            if (usedCapacity < (capacity / 2))
-                return nullptr;
-        } else {
-            if (usedCapacity < ((capacity / 4) * 3))
-                return nullptr;
-        }
+        if (usedCapacity < dataCapacity(capacity))
+            return nullptr;
 
+        bool isSmallCapacity = capacity < LargeCapacity;
         TableSize expansionFactor = isSmallCapacity ? 4 : 2;
         TableSize newCapacity = Checked<TableSize>(capacity) * expansionFactor;
-        if (deletedEntryCount >= (capacity  / 2)) {
+        if (deletedEntryCount >= (capacity / 2)) {
             // No need to expand. Just clear the deleted entries.
             // FIXME: Can we do this in place?
             newCapacity = capacity;
@@ -594,8 +608,7 @@ public:
         ASSERT(!isObsolete(candidate));
         TableSize capacity = Helper::capacity(candidate);
         TableIndex entryKeyIndex = entryDataStartIndex(dataTableStartIndex(capacity), from);
-        if (from >= capacity) [[unlikely]]
-            return { };
+        ASSERT_UNUSED(capacity, from <= dataCapacity(capacity));
         for (Entry entry = from;; ++entry, entryKeyIndex += EntrySize) {
             JSValue key = get(candidate, entryKeyIndex);
             if (!key)

--- a/Source/JavaScriptCore/runtime/JSSetIterator.h
+++ b/Source/JavaScriptCore/runtime/JSSetIterator.h
@@ -161,6 +161,11 @@ public:
     void setStorage(VM& vm, JSCell* storage) { internalField(Field::Storage).set(vm, this, storage); }
     void setEntry(VM& vm, JSSet::Helper::Entry entry) { internalField(Field::Entry).set(vm, this, JSSet::Helper::toJSValue(entry)); }
 
+    void close(VM& vm)
+    {
+        markClosed(vm.orderedHashTableSentinel());
+    }
+
 private:
     JSSetIterator(VM& vm, Structure* structure)
         : Base(vm, structure)


### PR DESCRIPTION
#### f72ea56abf5c63e3eef3ed11dcd052fe94d133bc
<pre>
[JSC] JSOrderedHashTable is overly allocating DataTable
<a href="https://bugs.webkit.org/show_bug.cgi?id=315829">https://bugs.webkit.org/show_bug.cgi?id=315829</a>
<a href="https://rdar.apple.com/178227340">rdar://178227340</a>

Reviewed by Yijia Huang.

CloseTable (JSOrderedHashTable) has HashTable and DataTable. HashTable
manages indice, and DataTable is a vector of actual key-values so that
we can maintain insertion order in that vector side. This means that
DataTable size does not need to be the same to HashTable: load-factor is
typically 50% or 75%. So actually held key-values are only up to 75% of
size of HashTable.

This patch computes this and reduces the allocation of DataTable. But we
add one slot IterationSentinel at the end and keeping it empty. So
iterator can stop by detecting empty value. Previously overly allocated
DataTable was guaranteeing this empty sentinel. But now we may use full
of DataTable vector, thus we need this sentinel explicitly.

Also, we found several issues.

1. forEachInIteratorProtocol is introduced in 299358@main. While we are
   getting entry index from MapIterator / SetIterator, we are obtaining
   storage from iterated Map / Set, not MapIterator / SetIterator&apos;s current
   cursor.
2. forEachInIteratorProtocol is not draining an iterator, which is
   incorrect as for-of should drain it.
3. (1) and (2) exist in tryCreateArrayFromMapIterator as well.

Test: JSTests/stress/map-iterator-fully-packed-table.js

* JSTests/stress/iterator-helpers-fast-path-drain-and-reentrancy.js: Added.
(shouldEq):
(throw.new.Error):
(i.shouldEq.it.next):
* JSTests/stress/map-iterator-fully-packed-table.js: Added.
(assert):
(buildMap):
(buildSet):
(drainMap):
(drainSet):
* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
(JSC::tryCreateArrayFromMapIterator):
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInIteratorProtocol):
* Source/JavaScriptCore/runtime/JSMapIterator.h:
* Source/JavaScriptCore/runtime/JSOrderedHashTableHelper.h:
(JSC::JSOrderedHashTableHelper::dataCapacity):
(JSC::JSOrderedHashTableHelper::dataTableSize):
(JSC::JSOrderedHashTableHelper::tableSize):
(JSC::JSOrderedHashTableHelper::tableSizeSlow):
(JSC::JSOrderedHashTableHelper::expandIfNeeded):
(JSC::JSOrderedHashTableHelper::transitAndNext):
* Source/JavaScriptCore/runtime/JSSetIterator.h:

Canonical link: <a href="https://commits.webkit.org/314169@main">https://commits.webkit.org/314169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/877eb09d3c3c2155432255a9225f0bdaff71d910

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174394 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122607 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4b10ae7-cda7-4550-8d81-13478aaef23d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128497 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e27036ef-471a-48c8-87ea-7684a4ad5cc1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109022 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1efba8db-0198-4cbc-b5eb-69335b463704) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/164670 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22468 "Hash 877eb09d for PR 66004 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157509 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176916 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26245 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29817 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136820 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/164754 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38910 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136756 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148044 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101943 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25149 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24911 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38109 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111183 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37506 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2989 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37753 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37650 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->