### PR TITLE
[WPE][QT6] expose run-file-chooser to QML via WPEView.

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
@@ -27,6 +27,7 @@
 #include "WPEViewQtQuick.h"
 
 #include <QQmlEngine>
+#include <QMetaMethod>
 #include <QQuickWindow>
 #include <QSGSimpleTextureNode>
 
@@ -139,6 +140,7 @@ void WPEQtView::createWebView()
     g_signal_connect_swapped(d->m_webView.get(), "notify::estimated-load-progress", G_CALLBACK(notifyLoadProgressCallback), this);
     g_signal_connect(d->m_webView.get(), "load-changed", G_CALLBACK(notifyLoadChangedCallback), this);
     g_signal_connect(d->m_webView.get(), "load-failed", G_CALLBACK(notifyLoadFailedCallback), this);
+    g_signal_connect(d->m_webView.get(), "run-file-chooser", G_CALLBACK(runFileChooserCallback), this);
 
     if (!d->m_url.isEmpty())
         webkit_web_view_load_uri(d->m_webView.get(), d->m_url.toString().toUtf8().constData());
@@ -203,6 +205,84 @@ void WPEQtView::notifyLoadFailedCallback(WebKitWebView*, WebKitLoadEvent, const 
 
     auto loadRequest = std::make_unique<WPEQtViewLoadRequest>(QUrl(QString(failingURI)), loadStatus, error->message);
     Q_EMIT view->loadingChanged(loadRequest.get());
+}
+
+/*!
+  \qmlsignal WPEView::fileChooserRequested(bool selectMultiple, list<string> mimeTypes)
+
+  This signal is emitted when the page requests a file chooser. For example, by clicking
+  an \c {<input type="file">} element. The user should be presented with a file chooser
+  as a result and call  \l selectFiles() with the chosen paths, or \l cancelFileChooser
+  if the user aborts the file chooser.
+
+  \a selectMultiple indicates more than one file maybe selected. \a mimeTypes contains
+*/
+gboolean WPEQtView::runFileChooserCallback(WebKitWebView*, WebKitFileChooserRequest* request, WPEQtView* view)
+{
+    if (!view->useCustomFileChooserHandling())
+        return FALSE;
+    view->setCurrentFileChooserRequest(request);
+
+    bool selectMultiple = webkit_file_chooser_request_get_select_multiple(request);
+
+    QStringList mimeTypes;
+    if (const gchar* const* types = webkit_file_chooser_request_get_mime_types(request)) {
+        for (const gchar* const* type = types; *type; ++type)
+            mimeTypes.append(QString::fromUtf8(*type));
+    }
+
+    Q_EMIT view->fileChooserRequested(selectMultiple, mimeTypes);
+    return TRUE;
+}
+
+/*!
+  \qmlmethod void WPEView::selectFiles(list<string> paths)
+
+  Completes a pending file-chooser request with the given \a paths. Passing an empty list
+  cancels the request.
+ */
+void WPEQtView::selectFiles(const QStringList& paths)
+{
+    Q_D(WPEQtView);
+    if (!d->m_currentFileChooserRequest) {
+        qWarning("WPEQtView::selectFiles() is called without a pending file chooser request.");
+        return;
+    }
+
+    if (paths.isEmpty()) {
+        webkit_file_chooser_request_cancel(d->m_currentFileChooserRequest.get());
+        d->m_currentFileChooserRequest = nullptr;
+        return;
+    }
+
+    QVector<QByteArray> utf8Paths;
+    utf8Paths.reserve(paths.size());
+    for (const QString& path : paths)
+        utf8Paths.append(path.toUtf8());
+
+    QVector<const gchar*> files;
+    files.reserve(utf8Paths.size() + 1);
+    for (const QByteArray& bytes : utf8Paths)
+        files.append(bytes.constData());
+    files.append(nullptr);
+
+    webkit_file_chooser_request_select_files(d->m_currentFileChooserRequest.get(), files.constData());
+    d->m_currentFileChooserRequest = nullptr;
+}
+
+/*!
+ \qmlmethod void WPEView::cancelFileChooser()
+
+ Cancels a pending file chooser request if any.
+ */
+void WPEQtView::cancelFileChooser()
+{
+    Q_D(WPEQtView);
+    if (!d->m_currentFileChooserRequest)
+        return;
+
+    webkit_file_chooser_request_cancel(d->m_currentFileChooserRequest.get());
+    d->m_currentFileChooserRequest = nullptr;
 }
 
 void WPEQtView::didUpdateScene()
@@ -662,6 +742,17 @@ void WPEQtView::setErrorOccured(bool errorOccured)
 {
     Q_D(WPEQtView);
     d->m_errorOccured = errorOccured;
+}
+
+void WPEQtView::setCurrentFileChooserRequest(WebKitFileChooserRequest* request)
+{
+    Q_D(WPEQtView);
+    d->m_currentFileChooserRequest = request;
+}
+
+bool WPEQtView::useCustomFileChooserHandling() const
+{
+    return isSignalConnected(QMetaMethod::fromSignal(&WPEQtView::fileChooserRequested));
 }
 
 #include "moc_WPEQtView.cpp"

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
@@ -76,6 +76,8 @@ public Q_SLOTS:
     void stop();
     void loadHtml(const QString& html, const QUrl& baseUrl = QUrl());
     void runJavaScript(const QString& script, const QJSValue& callback = QJSValue());
+    void selectFiles(const QStringList& paths);
+    void cancelFileChooser();
 
 Q_SIGNALS:
     void webViewCreated();
@@ -83,10 +85,12 @@ Q_SIGNALS:
     void titleChanged();
     void loadingChanged(WPEQtViewLoadRequest* loadRequest);
     void loadProgressChanged();
+    void fileChooserRequested(bool selectMultiple, const QStringList& mimeTypes);
 
 protected:
     bool errorOccured() const;
     void setErrorOccured(bool);
+    void setCurrentFileChooserRequest(WebKitFileChooserRequest*);
 
     bool event(QEvent*) override;
     void geometryChange(const QRectF&, const QRectF&) override;
@@ -123,6 +127,8 @@ private:
     static void notifyLoadProgressCallback(WPEQtView*);
     static void notifyLoadChangedCallback(WebKitWebView*, WebKitLoadEvent, WPEQtView*);
     static void notifyLoadFailedCallback(WebKitWebView*, WebKitLoadEvent, const gchar* failingURI, GError*, WPEQtView*);
+    static gboolean runFileChooserCallback(WebKitWebView*, WebKitFileChooserRequest*, WPEQtView*);
+    bool useCustomFileChooserHandling() const;
 
     Q_DECLARE_PRIVATE(WPEQtView)
     QScopedPointer<WPEQtViewPrivate> d_ptr;

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewPrivate.h
@@ -30,6 +30,7 @@ public:
     ~WPEQtViewPrivate() { }
 
     GRefPtr<WebKitWebView> m_webView;
+    GRefPtr<WebKitFileChooserRequest> m_currentFileChooserRequest;
     QUrl m_url;
     QString m_html;
     QUrl m_baseUrl;


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=315830

Reviewed by NOBODY (OOPS!).

Currently, WPEView does not have WebKit's run-file-chooser signal, so QML applications needs to implement it in CPP to react to <input type="file"> while a custom Qt file dialogue is shown.

The pending WeKitFileChooserRequest is stored in WPEQtViewPrivate as a GRefPtr. Also, the select-multiple and mime-types are passed directly as signal arguments.

* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp: (WPEQtView::createWebView): Connect 'run-file-chooser'. (WPEQtView::runFileChooserCallback): Store the request, extract select-multiple and -MIME-type info, emit fileChooserRequested, and return TRUE. (WPEQtView::selectFiles): Reply to a pending request by building a NULL terminated UTF-8 array.
(WPEQtView::cancelFileChooser): Cancel a pending request. (WPEQtView::setCurrentFileChooserRequest): Private setter.
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h: Add fileChooserRequested signal, selectFiles and cancelFileChooser slots, setCurrentFileChooserRequest helper and runFileChooserCallback.
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewPrivate.h: Add m_currentFileChooserRequest GRefPtr.

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d751b57b2df9e068fb3e9b2f650eeade00854664

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/55366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/198010 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/152340 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/63055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/61362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146649 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/101343 "An unexpected error occured in step: Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/167109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/127167 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/49122 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46936 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/159386 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46744 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/9121 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/54036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/200064 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/61236 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/156351 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61957 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/43229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155994 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/50297 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/134068 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/131741 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/60323 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21731 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59732 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->