### PR TITLE
Remove special case for sibling combinator invalidation

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1099,7 +1099,7 @@ ExceptionOr<void> KeyframeEffect::setKeyframes(JSGlobalObject& lexicalGlobalObje
 
         // Need a full style invalidation since the new keyframes may interact differently with the base style.
         if (auto target = targetStyleable())
-            target->element.invalidateStyleInternal();
+            target->element.invalidateStyle();
     }
 
     return processKeyframesResult;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6467,7 +6467,7 @@ void Document::invalidateEventListenerRegions()
     if (changed)
         scheduleFullStyleRebuild();
     else
-        protect(documentElement())->invalidateStyleInternal();
+        protect(documentElement())->invalidateStyle();
 }
 
 void Document::invalidateRenderingDependentRegions()

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2664,7 +2664,7 @@ void Element::partAttributeChanged(const AtomString& newValue)
     }
 
     if (needsStyleInvalidation() && isInShadowTree())
-        invalidateStyleInternal();
+        invalidateStyle();
 }
 
 URL Element::absoluteLinkURL() const
@@ -2721,47 +2721,19 @@ Style::UnadjustedStyle Element::resolveStyle(const Style::ResolutionContext& res
     return styleResolver().unadjustedStyleForElement(*this, resolutionContext);
 }
 
-void invalidateForSiblingCombinators(Element* sibling)
-{
-    for (RefPtr element = sibling; element; element = element->nextElementSibling()) {
-        if (element->styleIsAffectedByPreviousSibling())
-            element->invalidateStyleInternal();
-        if (element->descendantsAffectedByPreviousSibling()) {
-            for (RefPtr siblingChild = element->firstElementChild(); siblingChild; siblingChild = siblingChild->nextElementSibling())
-                siblingChild->invalidateStyleForSubtreeInternal();
-        }
-        if (!element->affectsNextSiblingElementStyle())
-            return;
-    }
-}
-
-static void invalidateSiblingsIfNeeded(Element& element)
-{
-    if (!element.affectsNextSiblingElementStyle())
-        return;
-    CheckedPtr parent = element.parentElement();
-    if (parent && parent->styleValidity() >= Style::Validity::SubtreeInvalid)
-        return;
-
-    invalidateForSiblingCombinators(element.nextElementSibling());
-}
-
 void Element::invalidateStyle()
 {
     Node::invalidateStyle(Style::Validity::ElementInvalid);
-    invalidateSiblingsIfNeeded(*this);
 }
 
 void Element::invalidateStyleAndLayerComposition()
 {
     Node::invalidateStyle(Style::Validity::ElementInvalid, Style::InvalidationMode::RecompositeLayer);
-    invalidateSiblingsIfNeeded(*this);
 }
 
 void Element::invalidateStyleForSubtree()
 {
     Node::invalidateStyle(Style::Validity::SubtreeInvalid);
-    invalidateSiblingsIfNeeded(*this);
 }
 
 void Element::invalidateStyleAndRenderersForSubtree()
@@ -2774,20 +2746,10 @@ void Element::invalidateRenderer()
     Node::invalidateStyle(Style::Validity::Valid, Style::InvalidationMode::RebuildRenderer);
 }
 
-void Element::invalidateStyleInternal()
-{
-    Node::invalidateStyle(Style::Validity::ElementInvalid);
-}
-
 void Element::invalidateStyleForAnimation()
 {
     ASSERT(!document().inStyleRecalc());
     Node::invalidateStyle(Style::Validity::AnimationInvalid);
-}
-
-void Element::invalidateStyleForSubtreeInternal()
-{
-    Node::invalidateStyle(Style::Validity::SubtreeInvalid);
 }
 
 void Element::invalidateForQueryContainerSizeChange()
@@ -2810,7 +2772,7 @@ void Element::invalidateForResumingQueryContainerResolution()
 
 void Element::invalidateForResumingAnchorPositionedElementResolution()
 {
-    invalidateStyleInternal();
+    invalidateStyle();
     markAncestorsForInvalidatedStyle();
 }
 
@@ -2827,7 +2789,7 @@ void Element::clearNeedsUpdateQueryContainerDependentStyle()
 void Element::invalidateEventListenerRegions()
 {
     // Event listener region is updated via style update.
-    invalidateStyleInternal();
+    invalidateStyle();
 }
 
 bool Element::hasDisplayContents() const
@@ -3362,7 +3324,7 @@ void Element::setInvokedPopover(RefPtr<Element>&& element)
     data.setInvokedPopover(WTF::move(element));
 
     // Invalidate so isPopoverInvoker style bit gets updated.
-    invalidateStyleInternal();
+    invalidateStyle();
 }
 
 void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
@@ -4668,9 +4630,9 @@ void Element::addToTopLayer()
     document->scheduleContentRelevancyUpdate(ContentRelevancy::IsInTopLayer);
 
     // Invalidate inert state
-    invalidateStyleInternal();
+    invalidateStyle();
     if (RefPtr documentElement = document->documentElement())
-        documentElement->invalidateStyleInternal();
+        documentElement->invalidateStyle();
 
     if (CheckedPtr renderer = this->renderer())
         renderer->establishesTopLayerDidChange();
@@ -4709,11 +4671,11 @@ void Element::removeFromTopLayer()
     document().scheduleContentRelevancyUpdate(ContentRelevancy::IsInTopLayer);
 
     // Invalidate inert state
-    invalidateStyleInternal();
+    invalidateStyle();
     if (RefPtr documentElement = document().documentElement())
-        documentElement->invalidateStyleInternal();
+        documentElement->invalidateStyle();
     if (RefPtr modalElement = document().activeModalDialog())
-        modalElement->invalidateStyleInternal();
+        modalElement->invalidateStyle();
 
     if (CheckedPtr renderer = this->renderer())
         renderer->establishesTopLayerDidChange();

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -844,9 +844,7 @@ public:
     void invalidateStyleAndRenderersForSubtree();
     void invalidateRenderer();
 
-    void invalidateStyleInternal();
     void invalidateStyleForAnimation();
-    void invalidateStyleForSubtreeInternal();
     void invalidateForQueryContainerSizeChange();
     void invalidateForAnchorRectChange();
     void invalidateForResumingQueryContainerResolution();
@@ -1118,7 +1116,6 @@ inline void Element::disconnectFromResizeObservers()
     disconnectFromResizeObserversSlow(*observerData);
 }
 
-void invalidateForSiblingCombinators(Element* sibling);
 inline bool isInTopLayerOrBackdrop(const RenderStyle&, const Element*);
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ContentRelevancy);

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -169,7 +169,7 @@ void ShadowRoot::childrenChanged(const ChildChange& childChange)
     case ChildChange::Type::ElementInserted:
     case ChildChange::Type::ElementAndTextInserted:
     case ChildChange::Type::ElementRemoved:
-        m_host->invalidateStyleForSubtreeInternal();
+        m_host->invalidateStyleForSubtree();
         break;
     case ChildChange::Type::TextInserted:
     case ChildChange::Type::TextRemoved:

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -113,7 +113,7 @@ void StyledElement::attributeChanged(const QualifiedName& name, const AtomString
             styleAttributeChanged(newValue, reason);
         else if (hasPresentationalHintsForAttribute(name)) {
             elementData()->setPresentationalHintStyleIsDirty(true);
-            invalidateStyleInternal();
+            invalidateStyle();
         }
     }
 }

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -785,7 +785,7 @@ void ViewTransition::activateViewTransition()
     }
 
     if (RefPtr documentElement = document()->documentElement())
-        documentElement->invalidateStyleInternal();
+        documentElement->invalidateStyle();
 
     m_phase = ViewTransitionPhase::Animating;
 
@@ -875,7 +875,7 @@ void ViewTransition::clearViewTransition()
     document->setActiveViewTransition(nullptr);
 
     if (RefPtr documentElement = document->documentElement())
-        documentElement->invalidateStyleInternal();
+        documentElement->invalidateStyle();
 }
 
 // https://drafts.csswg.org/css-view-transitions-1/#snapshot-containing-block
@@ -1015,7 +1015,7 @@ void ViewTransition::updatePseudoElementStylesWrite()
 
     if (changed) {
         if (RefPtr documentElement = document->documentElement())
-            documentElement->invalidateStyleInternal();
+            documentElement->invalidateStyle();
     }
 }
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -383,7 +383,7 @@ void HTMLElement::attributeChanged(const QualifiedName& name, const AtomString& 
             setTabIndexExplicitly(std::nullopt);
         return;
     case AttributeNames::inertAttr:
-        invalidateStyleInternal();
+        invalidateStyle();
         return;
     case AttributeNames::inputmodeAttr:
         if (Ref document = this->document(); this == document->focusedElement()) {

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -529,6 +529,14 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
         CSSSelector::PseudoClass::Optional,
         CSSSelector::PseudoClass::ReadWrite,
         CSSSelector::PseudoClass::ReadOnly,
+        CSSSelector::PseudoClass::Checked,
+        CSSSelector::PseudoClass::Indeterminate,
+        CSSSelector::PseudoClass::InRange,
+        CSSSelector::PseudoClass::OutOfRange,
+        CSSSelector::PseudoClass::Valid,
+        CSSSelector::PseudoClass::Invalid,
+        CSSSelector::PseudoClass::UserValid,
+        CSSSelector::PseudoClass::UserInvalid,
     }, Style::PseudoClassChangeInvalidation::AnyValue);
 
     removeFromRadioButtonGroup();
@@ -1086,7 +1094,7 @@ void HTMLInputElement::setChecked(bool isChecked, WasSetByJavaScript wasCheckedB
             cache->checkedStateChanged(*this);
     }
 
-    invalidateStyleInternal();
+    invalidateStyle();
 }
 
 void HTMLInputElement::setIndeterminate(bool newValue)
@@ -2262,7 +2270,7 @@ void HTMLInputElement::invalidateStyleOnFocusChangeIfNeeded()
         return;
     // Focus change may affect the result of shouldTruncateText().
     if (CheckedPtr style = renderStyle(); style && style->textOverflow() == TextOverflow::Ellipsis)
-        invalidateStyleForSubtreeInternal();
+        invalidateStyleForSubtree();
 }
 
 std::optional<unsigned> HTMLInputElement::selectionStartForBindings() const

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -197,7 +197,7 @@ void HTMLMeterElement::didChangeElementValue()
 
     if (RefPtr fillElement = m_fillElement) {
         fillElement->setInlineStyleProperty(CSSPropertyTransform, makeString("translate(-"_s, (1 - valueRatio()) * 100, "%, 0)"_s));
-        fillElement->invalidateStyleInternal();
+        fillElement->invalidateStyle();
     }
 }
 

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -140,7 +140,7 @@ void HTMLProgressElement::didChangeElementValue()
 
     if (RefPtr fillElement = m_fillElement) {
         fillElement->setInlineStyleProperty(CSSPropertyTransform, makeString("translate(-"_s, 100 - percentageValue, "%, 0)"_s));
-        fillElement->invalidateStyleInternal();
+        fillElement->invalidateStyle();
     }
 
     if (CheckedPtr renderer = renderProgress())

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -811,7 +811,7 @@ void InputType::setValue(const String& sanitizedValue, bool valueChanged, TextFi
     element->setValueInternal(sanitizedValue, eventBehavior);
 
     if (oldDirection.value_or(TextDirection::LTR) != computeTextDirectionIfDirIsAuto(*element).value_or(TextDirection::LTR))
-        element->invalidateStyleInternal();
+        element->invalidateStyle();
 
     switch (eventBehavior) {
     case DispatchChangeEvent:

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -396,7 +396,7 @@ void SearchInputType::setValue(const String& sanitizedValue, bool valueChanged, 
         return;
 
     if (RefPtr cancelButton = m_cancelButton)
-        cancelButton->invalidateStyleInternal();
+        cancelButton->invalidateStyle();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -286,6 +286,20 @@ void ChildChangeInvalidation::traverseAddedElements(Function&& function)
     }
 }
 
+static void invalidateForSiblingCombinators(Element* sibling)
+{
+    for (RefPtr element = sibling; element; element = element->nextElementSibling()) {
+        if (element->styleIsAffectedByPreviousSibling())
+            element->invalidateStyle();
+        if (element->descendantsAffectedByPreviousSibling()) {
+            for (RefPtr siblingChild = element->firstElementChild(); siblingChild; siblingChild = siblingChild->nextElementSibling())
+                siblingChild->invalidateStyleForSubtree();
+        }
+        if (!element->affectsNextSiblingElementStyle())
+            return;
+    }
+}
+
 static void invalidateForForwardPositionalRules(Element& parent, Element* elementAfterChange)
 {
     bool childrenAffected = parent.childrenAffectedByForwardPositionalRules();
@@ -296,10 +310,10 @@ static void invalidateForForwardPositionalRules(Element& parent, Element* elemen
 
     for (RefPtr sibling = elementAfterChange; sibling; sibling = sibling->nextElementSibling()) {
         if (childrenAffected)
-            sibling->invalidateStyleInternal();
+            sibling->invalidateStyle();
         if (descendantsAffected) {
             for (RefPtr siblingChild = sibling->firstElementChild(); siblingChild; siblingChild = siblingChild->nextElementSibling())
-                siblingChild->invalidateStyleForSubtreeInternal();
+                siblingChild->invalidateStyleForSubtree();
         }
     }
 }
@@ -314,10 +328,10 @@ static void invalidateForBackwardPositionalRules(Element& parent, Element* eleme
 
     for (RefPtr sibling = elementBeforeChange; sibling; sibling = sibling->previousElementSibling()) {
         if (childrenAffected)
-            sibling->invalidateStyleInternal();
+            sibling->invalidateStyle();
         if (descendantsAffected) {
             for (RefPtr siblingChild = sibling->firstElementChild(); siblingChild; siblingChild = siblingChild->nextElementSibling())
-                siblingChild->invalidateStyleForSubtreeInternal();
+                siblingChild->invalidateStyleForSubtree();
         }
     }
 }
@@ -326,14 +340,14 @@ static void invalidateForFirstChildState(Element& child, bool state)
 {
     auto* style = child.renderStyle();
     if (!style || style->firstChildState() == state)
-        child.invalidateStyleForSubtreeInternal();
+        child.invalidateStyleForSubtree();
 }
 
 static void invalidateForLastChildState(Element& child, bool state)
 {
     auto* style = child.renderStyle();
     if (!style || style->lastChildState() == state)
-        child.invalidateStyleForSubtreeInternal();
+        child.invalidateStyleForSubtree();
 }
 
 void ChildChangeInvalidation::invalidateAfterChange()

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -149,12 +149,12 @@ static void invalidateAssignedElements(HTMLSlotElement& slot)
             invalidateAssignedElements(*slotElement);
             continue;
         }
-        element->invalidateStyleInternal();
+        element->invalidateStyle();
         // Invalidate ::slotted nested pseudo-elements.
         if (RefPtr shadowRoot = element->userAgentShadowRoot()) {
             for (Ref descendant : descendantsOfType<Element>(*shadowRoot)) {
                 if (!descendant->userAgentPart().isEmpty())
-                    descendant->invalidateStyleInternal();
+                    descendant->invalidateStyle();
             }
         }
     }
@@ -179,7 +179,7 @@ Invalidator::CheckDescendants Invalidator::invalidateIfNeeded(Element& element, 
 
             auto matches = ruleCollector.matchesAnyAuthorRules();
             if (ruleSet.isNegation == IsNegation::No ? matches : !matches) {
-                element.invalidateStyleInternal();
+                element.invalidateStyle();
                 break;
             }
         }
@@ -263,7 +263,7 @@ void Invalidator::invalidateStyle(ShadowRoot& shadowRoot)
     ASSERT(!m_dirtiesAllStyle);
 
     if (m_ruleInformation.hasHostPseudoClassRules && shadowRoot.host())
-        shadowRoot.host()->invalidateStyleInternal();
+        shadowRoot.host()->invalidateStyle();
 
     for (Ref child : childrenOfType<Element>(shadowRoot)) {
         SelectorMatchingState selectorMatchingState;
@@ -576,7 +576,7 @@ void Invalidator::invalidateShadowParts(ShadowRoot& shadowRoot)
     for (Ref descendant : descendantsOfType<Element>(shadowRoot)) {
         // FIXME: We could only invalidate part names that actually show up in rules.
         if (!descendant->partNames().isEmpty())
-            descendant->invalidateStyleInternal();
+            descendant->invalidateStyle();
 
         RefPtr nestedShadowRoot = descendant->shadowRoot();
         if (nestedShadowRoot && !nestedShadowRoot->partMappings().isEmpty())
@@ -595,7 +595,7 @@ void Invalidator::invalidateUserAgentParts(ShadowRoot& shadowRoot)
             continue;
         for (auto& ruleSet : m_ruleSets) {
             if (ruleSet.ruleSet->userAgentPartRules(part))
-                descendant->invalidateStyleInternal();
+                descendant->invalidateStyle();
         }
     }
 }
@@ -618,7 +618,7 @@ void Invalidator::invalidateInShadowTreeIfNeeded(Element& element)
 
 #if ENABLE(VIDEO)
     if (m_ruleInformation.hasCuePseudoElementRules && element.isMediaElement())
-        element.invalidateStyleForSubtreeInternal();
+        element.invalidateStyleForSubtree();
 #endif
 
     // FIXME: More fine-grained invalidation for ::part()
@@ -657,7 +657,7 @@ void Invalidator::invalidateAllStyle(Scope& scope)
 {
     if (RefPtr shadowRoot = scope.shadowRoot()) {
         for (Ref shadowChild : childrenOfType<Element>(*shadowRoot))
-            shadowChild->invalidateStyleForSubtreeInternal();
+            shadowChild->invalidateStyleForSubtree();
         invalidateHostAndSlottedStyleIfNeeded(*shadowRoot);
         return;
     }
@@ -671,11 +671,11 @@ void Invalidator::invalidateHostAndSlottedStyleIfNeeded(ShadowRoot& shadowRoot)
     RefPtr resolver = shadowRoot.styleScope().resolverIfExists();
 
     if (!resolver || resolver->ruleSets().hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.hostPseudoClassRules().isEmpty(); }))
-        host->invalidateStyleInternal();
+        host->invalidateStyle();
 
     if (!resolver || resolver->ruleSets().hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.slottedPseudoElementRules().isEmpty(); })) {
         for (Ref shadowChild : childrenOfType<Element>(host.get()))
-            shadowChild->invalidateStyleInternal();
+            shadowChild->invalidateStyle();
     }
 }
 


### PR DESCRIPTION
#### 4e0cb515ac3173fdcf9c8ebbbd625c93f51a20c1
<pre>
Remove special case for sibling combinator invalidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=315828">https://bugs.webkit.org/show_bug.cgi?id=315828</a>
<a href="https://rdar.apple.com/178227281">rdar://178227281</a>

Reviewed by Alan Baradlay.

We have two versions of many style invalidation functions like
Element::invalidateStyle() and Element::invalidateStyleInternal(). The only
difference between the two is that the non-internal version calls
invalidateSiblingsIfNeeded() to do eager sibling invalidation.

After recent fixes our normal invalidation system (using FooChangeInvalidation
types) handles sibling combinators too in all cases so we can remove this
now-unnecessary path and also get rid of the special *Internal versions of
the functions.

invalidateForSiblingCombinators is only used by ChildChangeInvalidation now,
so move it next to the related invalidateForForwardPositionalRules helpers.

* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::invalidateSiblingsIfNeeded): Deleted.
(WebCore::invalidateForSiblingCombinators): Moved to ChildChangeInvalidation.cpp.
(WebCore::Element::invalidateStyle):
(WebCore::Element::invalidateStyleAndLayerComposition):
(WebCore::Element::invalidateStyleForSubtree):
(WebCore::Element::invalidateStyleInternal): Deleted.
(WebCore::Element::invalidateStyleForSubtreeInternal): Deleted.

* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::invalidateForSiblingCombinators):

Moved from Element.cpp.

* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType):

Cover all type-dependent pseudo-classes in the type-change invalidation,
not just the form-state ones. Without the eager sibling fallback, missing
pseudo-classes here are no longer silently caught.

* Source/WebCore/animation/KeyframeEffect.cpp:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/ShadowRoot.cpp:
* Source/WebCore/dom/StyledElement.cpp:
* Source/WebCore/dom/ViewTransition.cpp:
* Source/WebCore/html/HTMLElement.cpp:
* Source/WebCore/html/HTMLMeterElement.cpp:
* Source/WebCore/html/HTMLProgressElement.cpp:
* Source/WebCore/html/InputType.cpp:
* Source/WebCore/html/SearchInputType.cpp:
* Source/WebCore/style/StyleInvalidator.cpp:

Rename invalidateStyleInternal/invalidateStyleForSubtreeInternal call sites
to invalidateStyle/invalidateStyleForSubtree.

Canonical link: <a href="https://commits.webkit.org/314270@main">https://commits.webkit.org/314270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df0f9858a6578fc0b01066a0236a551c63047280

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122506 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc4ce651-1371-498e-837d-2f67908bf207) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128404 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90386 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10a37023-1a74-4cdc-8b98-41f8107c68fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108929 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f042997d-cc77-42a0-b7b8-09958f6005a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29766 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28387 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22046 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176814 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29700 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136725 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136664 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36910 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39498 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147959 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101824 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31944 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24826 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38008 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111081 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37405 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2904 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37651 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37549 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->