### PR TITLE
[WIP] Fallback to full-layout happens when more than 1 subtree layout is pending

### DIFF
--- a/LayoutTests/fast/css/css3-nth-child-bug-296807-expected.html
+++ b/LayoutTests/fast/css/css3-nth-child-bug-296807-expected.html
@@ -1,0 +1,42 @@
+<html>
+  <head>
+    <title>CSS selectors corner case (bug 296807)</title>
+    <link rel="author" title="Paweł Lampe" href="mailto:plampe@igalia.com">
+    <link rel="help" href="https://www.w3.org/TR/selectors-3/#nth-child-pseudo">
+    <link rel="help" href="https://www.w3.org/TR/selectors-4/#has-pseudo">
+    <style>
+      .container {
+          padding: 10px;
+          background: orange;
+      }
+      .container > div {
+          background: lightgray;
+      }
+      .container:has(:nth-child(1)) > div:nth-child(1) {
+          background: lightblue;
+      }
+      .container:has(:nth-child(2)) > div:nth-child(1) {
+          background: green;
+      }
+      .container:has(:nth-child(2)) > div:nth-child(2) {
+          background: lightblue;
+      }
+      .container:has(:nth-child(3)) > div:nth-child(1) {
+          background: red;
+      }
+      .container:has(:nth-child(3)) > div:nth-child(2) {
+          background: green;
+      }
+      .container:has(:nth-child(3)) > div:nth-child(3) {
+          background: lightblue;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div>Red</div>
+      <div>Green</div>
+      <div>Blue</div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/fast/css/css3-nth-child-bug-296807.html
+++ b/LayoutTests/fast/css/css3-nth-child-bug-296807.html
@@ -1,0 +1,50 @@
+<html>
+  <head>
+    <title>CSS selectors corner case (bug 296807)</title>
+    <link rel="author" title="Paweł Lampe" href="mailto:plampe@igalia.com">
+    <link rel="help" href="https://www.w3.org/TR/selectors-3/#nth-child-pseudo">
+    <link rel="help" href="https://www.w3.org/TR/selectors-4/#has-pseudo">
+    <style>
+      .container {
+          padding: 10px;
+          background: orange;
+      }
+      .container > div {
+          background: lightgray;
+      }
+      .container:has(:nth-child(1)) > div:nth-child(1) {
+          background: lightblue;
+      }
+      .container:has(:nth-child(2)) > div:nth-child(1) {
+          background: green;
+      }
+      .container:has(:nth-child(2)) > div:nth-child(2) {
+          background: lightblue;
+      }
+      .container:has(:nth-child(3)) > div:nth-child(1) {
+          background: red;
+      }
+      .container:has(:nth-child(3)) > div:nth-child(2) {
+          background: green;
+      }
+      .container:has(:nth-child(3)) > div:nth-child(3) {
+          background: lightblue;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div>Green</div>
+      <div>Blue</div>
+    </div>
+    <script>
+      requestAnimationFrame(() => {
+          const container = document.getElementsByClassName("container")[0];
+          let newElement = document.createElement("div");
+          newElement.innerText = 'Red';
+          const referenceElement = container.children[0];
+          container.insertBefore(newElement, referenceElement);
+      });
+    </script>
+  </body>
+</html>

--- a/LayoutTests/fast/css/scrollbar-gutter-overflow-change-expected.txt
+++ b/LayoutTests/fast/css/scrollbar-gutter-overflow-change-expected.txt
@@ -1,0 +1,2 @@
+PASS
+When scrollbar-gutter: stable is set, the content width remains the same even when overflow changes from auto to hidden, because the gutter area is preserved and not removed with the scrollbar

--- a/LayoutTests/fast/css/scrollbar-gutter-overflow-change.html
+++ b/LayoutTests/fast/css/scrollbar-gutter-overflow-change.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>scrollbar-gutter: content box width stability test</title>
+  <style>
+    #test {
+      overflow: auto;
+      scrollbar-gutter: stable;
+      width: 200px;
+      height: 100px;
+      border: 2px solid black;
+      background: lightblue;
+    }
+
+    .content {
+      width: 100%;
+      height: 200px;
+      background: orange;
+    }
+
+    #test::-webkit-scrollbar {
+      width: 20px;
+      background-color: #f0f0f0;
+    }
+
+    #test::-webkit-scrollbar-thumb {
+      background-color: #888;
+      border-radius: 4px;
+      border: 3px solid #f0f0f0;
+    }
+
+    #test::-webkit-scrollbar-thumb:hover {
+      background-color: #555;
+    }
+  </style>
+</head>
+<body>
+<pre id="result">FAIL: test did not run</pre>
+
+<div id="test">
+  <div class="content">When scrollbar-gutter: stable is set, the content width remains the same even when overflow changes from auto to hidden, because the gutter area is preserved and not removed with the scrollbar</div>
+</div>
+
+<script>
+  if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+  }
+
+  const content = document.querySelector('.content');
+  const container = document.getElementById('test');
+  const resultEl = document.getElementById('result');
+  let before;
+
+  function measureBefore() {
+    before = content.clientWidth;
+    container.style.overflow = 'hidden';
+    requestAnimationFrame(measureAfter);
+  }
+
+  function measureAfter() {
+    const after = content.clientWidth;
+
+    resultEl.textContent = (before === after) ? 'PASS' : 'FAIL';
+
+    if (window.testRunner)
+      testRunner.notifyDone();
+  }
+
+  window.addEventListener('load', () => {
+    requestAnimationFrame(measureBefore);
+  });
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-expected.html
+++ b/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    body {
+        font-size: 0px;
+    }
+    span {
+        display: inline-block;
+        background: silver;
+        width: 100px;
+        height: 100px;
+        margin: 20px;
+        font-size: 25px;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+    }
+    .first-line::first-line {
+        font-size: 35px;
+    }
+  </style>
+  <body>
+    <div>
+      <span>baar</span>
+      <span>baarbaar baarbaar</span>
+      <span>baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar</span>
+      <span>baar baar baar baar</span>
+      <span>baar</span>
+      <span>b &#x55e8;</span>
+      <span>baar&#9;baar&#9;baar&#9;baar</span>
+      <span>baar&#10;baar&#10;baar&#10;baar</span>
+    </div>
+    <div>
+      <span class="first-line">baar</span>
+      <span class="first-line">baarbaar baarbaar</span>
+      <span class="first-line">baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar</span>
+      <span class="first-line">baar baar baar baar</span>
+      <span class="first-line">baar</span>
+      <span class="first-line">b &#x55e8;</span>
+      <span class="first-line">baar&#9;baar&#9;baar&#9;baar</span>
+      <span class="first-line">baar&#10;baar&#10;baar&#10;baar</span>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-direction-rtl-expected.html
+++ b/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-direction-rtl-expected.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    body {
+        font-size: 0px;
+    }
+    span {
+        display: inline-block;
+        background: silver;
+        width: 100px;
+        height: 100px;
+        margin: 20px;
+        font-size: 25px;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+        direction: rtl;
+    }
+    .first-line::first-line {
+        font-size: 35px;
+    }
+  </style>
+  <body>
+    <div>
+      <span>baar</span>
+      <span>baarbaar baarbaar</span>
+      <span>baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar</span>
+      <span>baar baar baar baar</span>
+      <span>baar</span>
+      <span>b &#x55e8;</span>
+      <span>baar&#9;baar&#9;baar&#9;baar</span>
+      <span>baar&#10;baar&#10;baar&#10;baar</span>
+    </div>
+    <div>
+      <span class="first-line">baar</span>
+      <span class="first-line">baarbaar baarbaar</span>
+      <span class="first-line">baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar</span>
+      <span class="first-line">baar baar baar baar</span>
+      <span class="first-line">baar</span>
+      <span class="first-line">b &#x55e8;</span>
+      <span class="first-line">baar&#9;baar&#9;baar&#9;baar</span>
+      <span class="first-line">baar&#10;baar&#10;baar&#10;baar</span>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-direction-rtl.html
+++ b/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-direction-rtl.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    body {
+        font-size: 0px;
+    }
+    span {
+        display: inline-block;
+        background: silver;
+        width: 100px;
+        height: 100px;
+        margin: 20px;
+        font-size: 25px;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+        direction: rtl;
+    }
+    .first-line::first-line {
+        font-size: 35px;
+    }
+  </style>
+  <script>
+    const originalValues = [
+        "foo",
+        "foofoo foofoo",
+        "foofoofoo foofoofoo foofoofoo foofoofoo foofoofoo",
+        "foo",
+        "foo foo foo foo foo",
+        "foo",
+        "foo",
+        "foo",
+    ];
+    const newValues = [
+        "baar",
+        "baarbaar baarbaar",
+        "baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar",
+        "baar baar baar baar",
+        "baar",
+        "b \u55e8",
+        "baar\tbaar\tbaar\tbaar",
+        "baar\nbaar\nbaar\nbaar",
+    ];
+    function setupTest() {
+        {
+            let div = document.createElement("div");
+            originalValues.forEach((text) => {
+                let span = document.createElement("span");
+                span.appendChild(document.createTextNode(text));
+                div.appendChild(span);
+            });
+            document.body.appendChild(div);
+        }
+
+        {
+            let div = document.createElement("div");
+            originalValues.forEach((text) => {
+                let span = document.createElement("span");
+                span.className = "first-line";
+                span.appendChild(document.createTextNode(text));
+                div.appendChild(span);
+            });
+            document.body.appendChild(div);
+        }
+    }
+    function changeTextNodeData() {
+        let divs = document.getElementsByTagName("span");
+        for (let i = 0; i < divs.length; i++) {
+            divs[i].childNodes[0].data = newValues[i % newValues.length];
+        }
+    }
+    function runTest() {
+        setupTest();
+        document.body.offsetLeft; // Force layout.
+        changeTextNodeData();
+    }
+  </script>
+  <body onload="runTest();">
+  </body>
+</html>

--- a/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-text-align-right-expected.html
+++ b/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-text-align-right-expected.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    body {
+        font-size: 0px;
+    }
+    span {
+        display: inline-block;
+        background: silver;
+        width: 100px;
+        height: 100px;
+        margin: 20px;
+        font-size: 25px;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+        text-align: right;
+    }
+    .first-line::first-line {
+        font-size: 35px;
+    }
+  </style>
+  <body>
+    <div>
+      <span>baar</span>
+      <span>baarbaar baarbaar</span>
+      <span>baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar</span>
+      <span>baar baar baar baar</span>
+      <span>baar</span>
+      <span>b &#x55e8;</span>
+      <span>baar&#9;baar&#9;baar&#9;baar</span>
+      <span>baar&#10;baar&#10;baar&#10;baar</span>
+    </div>
+    <div>
+      <span class="first-line">baar</span>
+      <span class="first-line">baarbaar baarbaar</span>
+      <span class="first-line">baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar</span>
+      <span class="first-line">baar baar baar baar</span>
+      <span class="first-line">baar</span>
+      <span class="first-line">b &#x55e8;</span>
+      <span class="first-line">baar&#9;baar&#9;baar&#9;baar</span>
+      <span class="first-line">baar&#10;baar&#10;baar&#10;baar</span>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-text-align-right.html
+++ b/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-text-align-right.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    body {
+        font-size: 0px;
+    }
+    span {
+        display: inline-block;
+        background: silver;
+        width: 100px;
+        height: 100px;
+        margin: 20px;
+        font-size: 25px;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+        text-align: right;
+    }
+    .first-line::first-line {
+        font-size: 35px;
+    }
+  </style>
+  <script>
+    const originalValues = [
+        "foo",
+        "foofoo foofoo",
+        "foofoofoo foofoofoo foofoofoo foofoofoo foofoofoo",
+        "foo",
+        "foo foo foo foo foo",
+        "foo",
+        "foo",
+        "foo",
+    ];
+    const newValues = [
+        "baar",
+        "baarbaar baarbaar",
+        "baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar",
+        "baar baar baar baar",
+        "baar",
+        "b \u55e8",
+        "baar\tbaar\tbaar\tbaar",
+        "baar\nbaar\nbaar\nbaar",
+    ];
+    function setupTest() {
+        {
+            let div = document.createElement("div");
+            originalValues.forEach((text) => {
+                let span = document.createElement("span");
+                span.appendChild(document.createTextNode(text));
+                div.appendChild(span);
+            });
+            document.body.appendChild(div);
+        }
+
+        {
+            let div = document.createElement("div");
+            originalValues.forEach((text) => {
+                let span = document.createElement("span");
+                span.className = "first-line";
+                span.appendChild(document.createTextNode(text));
+                div.appendChild(span);
+            });
+            document.body.appendChild(div);
+        }
+    }
+    function changeTextNodeData() {
+        let divs = document.getElementsByTagName("span");
+        for (let i = 0; i < divs.length; i++) {
+            divs[i].childNodes[0].data = newValues[i % newValues.length];
+        }
+    }
+    function runTest() {
+        setupTest();
+        document.body.offsetLeft; // Force layout.
+        changeTextNodeData();
+    }
+  </script>
+  <body onload="runTest();">
+  </body>
+</html>

--- a/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container.html
+++ b/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    body {
+        font-size: 0px;
+    }
+    span {
+        display: inline-block;
+        background: silver;
+        width: 100px;
+        height: 100px;
+        margin: 20px;
+        font-size: 25px;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+    }
+    .first-line::first-line {
+        font-size: 35px;
+    }
+  </style>
+  <script>
+    const originalValues = [
+        "foo",
+        "foofoo foofoo",
+        "foofoofoo foofoofoo foofoofoo foofoofoo foofoofoo",
+        "foo",
+        "foo foo foo foo foo",
+        "foo",
+        "foo",
+        "foo",
+    ];
+    const newValues = [
+        "baar",
+        "baarbaar baarbaar",
+        "baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar",
+        "baar baar baar baar",
+        "baar",
+        "b \u55e8",
+        "baar\tbaar\tbaar\tbaar",
+        "baar\nbaar\nbaar\nbaar",
+    ];
+    function setupTest() {
+        {
+            let div = document.createElement("div");
+            originalValues.forEach((text) => {
+                let span = document.createElement("span");
+                span.appendChild(document.createTextNode(text));
+                div.appendChild(span);
+            });
+            document.body.appendChild(div);
+        }
+
+        {
+            let div = document.createElement("div");
+            originalValues.forEach((text) => {
+                let span = document.createElement("span");
+                span.className = "first-line";
+                span.appendChild(document.createTextNode(text));
+                div.appendChild(span);
+            });
+            document.body.appendChild(div);
+        }
+    }
+    function changeTextNodeData() {
+        let divs = document.getElementsByTagName("span");
+        for (let i = 0; i < divs.length; i++) {
+            divs[i].childNodes[0].data = newValues[i % newValues.length];
+        }
+    }
+    function runTest() {
+        setupTest();
+        document.body.offsetLeft; // Force layout.
+        changeTextNodeData();
+    }
+  </script>
+  <body onload="runTest();">
+  </body>
+</html>

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-arc.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-arc.html
@@ -21,9 +21,7 @@
           },
           () => {
               var damage = latestFrameDamage();
-              // We take a 1px margin into account as we cannot avoid it. It was added in:
-              // https://github.com/WebKit/WebKit/commit/0e8b2662b634fbd074709ee8ac30b3499c10e081
-              assertRectsEq(damage.rects, [[4, 4, 12, 12]]);
+              assertRectsEq(damage.rects, [[5, 5, 10, 10]]);
           },
       ], 0);
     </script>

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect-w-offset.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect-w-offset.html
@@ -27,7 +27,7 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertRectsEq(damage.rects, [[26, 26, 12, 12]]);
+              assertRectsEq(damage.rects, [[27, 27, 10, 10]]);
           },
       ], 0);
     </script>

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect.html
@@ -39,7 +39,7 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertRectsEq(damage.rects, [[0, 0, 11, 11], [19, 19, 12, 12]]);
+              assertRectsEq(damage.rects, [[0, 0, 10, 10], [20, 20, 10, 10]]);
           },
       ], 0);
     </script>

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-path.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-path.html
@@ -26,7 +26,7 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertRectsEq(damage.rects, [[9, 9, 32, 32]]);
+              assertRectsEq(damage.rects, [[10, 10, 30, 30]]);
           },
       ], 0);
     </script>

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-putImageData.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-putImageData.html
@@ -30,7 +30,7 @@
           },
           () => {
               var damage = latestFrameDamage();
-              assertRectsEq(damage.rects, [[9, 9, 7, 7]]);
+              assertRectsEq(damage.rects, [[10, 10, 5, 5]]);
           },
       ], 0);
     </script>

--- a/PerformanceTests/Containment/change-text-in-large-grid.html
+++ b/PerformanceTests/Containment/change-text-in-large-grid.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+        display: grid;
+        grid: repeat(100, 30px) / repeat(100, 60px);
+    }
+    span {
+        border: solid;
+        width: 60px;
+        height: 30px;
+        box-sizing: border-box;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+    }
+  </style>
+  <script src="../resources/runner.js"></script>
+  <script>
+    let textNodes = [];
+    function populateData() {
+        for (let i = 0; i < 100*100; i++) {
+            let span = document.createElement('span');
+            span.classList.add('cell');
+            let textNode = document.createTextNode('' + (100 * Math.random()).toFixed(2));
+            span.appendChild(textNode);
+            document.body.appendChild(span);
+            textNodes.push(textNode);
+        }
+    }
+    function forceLayout() {
+        document.body.offsetHeight;
+    }
+    function startTest() {
+        populateData();
+        forceLayout();
+        PerfTestRunner.measureRunsPerSecond({
+            description: "Measures performance of changing text nodes content.",
+            run: function() {
+                for (let i = 0; i < textNodes.length; i++) {
+                    textNodes[i].data = '' + (100 * Math.random()).toFixed(2);
+                }
+                document.body.offsetHeight;
+                forceLayout();
+            },
+        });
+    }
+  </script>
+</head>
+<body onload="startTest();">
+</body>
+</html>

--- a/PerformanceTests/Containment/multiple-changes-in-large-grid.html
+++ b/PerformanceTests/Containment/multiple-changes-in-large-grid.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="../resources/runner.js"></script>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+<style>
+  html, body { height: 100%; }
+
+  #gridContainer {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1px;
+  }
+
+  .gridItemContainStrict {
+      display: block;
+      width: 10px;
+      height: 10px;
+      background-color: #0F0;
+      contain: strict;
+      font-size: 6px;
+  }
+
+  .gridItemContainNone {
+      display: block;
+      width: 10px;
+      height: 10px;
+      background-color: #00F;
+      font-size: 6px;
+  }
+</style>
+
+</head>
+
+<body>
+    <pre id="log"></pre>
+
+    <div id="gridContainer">
+    </div>
+
+    <script>
+      var gridContainer = document.getElementById('gridContainer');
+
+      function makeid(length) {
+          let result = '';
+          const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+          const charactersLength = characters.length;
+          let counter = 0;
+          while (counter < length) {
+              result += characters.charAt(Math.floor(Math.random() * charactersLength));
+              counter += 1;
+          }
+          return result;
+      }
+
+      function createDivElement(className, htmlContent) {
+          let newElement = document.createElement('div');
+          newElement.className = className;
+          newElement.innerHTML = htmlContent;
+          return newElement;
+      }
+
+      function setup() {
+          gridContainer.appendChild(createDivElement("gridItemContainStrict", '<span class="text">qwertyui</span>'));
+          for (let i = 0; i < 5000; ++i) {
+              gridContainer.appendChild(createDivElement("gridItemContainNone", '<span>z</span>'));
+          }
+          gridContainer.appendChild(createDivElement("gridItemContainStrict", '<span class="text">asdfghjk</span>'));
+          for (let i = 0; i < 5000; ++i) {
+              gridContainer.appendChild(createDivElement("gridItemContainNone", '<span>z</span>'));
+          }
+          gridContainer.appendChild(createDivElement("gridItemContainStrict", '<span class="text">zxcvbnm,</span>'));
+      }
+
+      function test() {
+          for (element of document.getElementsByClassName("text")) {
+              element.innerText = makeid(8);
+          }
+          gridContainer.offsetHeight; // Force layout.
+      }
+
+      function done() {
+      }
+
+      setup();
+      PerfTestRunner.measureRunsPerSecond({
+          description: "Measures performance of getting offsetHeight of a large grid container.",
+          run: test,
+          done: done
+      });
+    </script>
+</body>
+
+</html>

--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.cpp
@@ -30,35 +30,4 @@ namespace JSC {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AssemblerData);
 
-#if ENABLE(ASSEMBLER)
-
-static ThreadSpecificAssemblerData* threadSpecificAssemblerDataPtr;
-
-ThreadSpecificAssemblerData& threadSpecificAssemblerData()
-{
-    static std::once_flag flag;
-    std::call_once(
-        flag,
-        [] () {
-            threadSpecificAssemblerDataPtr = new ThreadSpecificAssemblerData();
-        });
-    return *threadSpecificAssemblerDataPtr;
-}
-
-#if ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
-static ThreadSpecificAssemblerHashes* threadSpecificAssemblerHashesPtr;
-ThreadSpecificAssemblerHashes& threadSpecificAssemblerHashes()
-{
-    static std::once_flag flag;
-    std::call_once(
-        flag,
-        [] () {
-            threadSpecificAssemblerHashesPtr = new ThreadSpecificAssemblerHashes();
-        });
-    return *threadSpecificAssemblerHashesPtr;
-}
-#endif // ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
-
-#endif // ENABLE(ASSEMBLER)
-
 } // namespace JSC

--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.h
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.h
@@ -51,8 +51,6 @@ namespace JSC {
     class AssemblerDataImpl;
 
     using AssemblerData = AssemblerDataImpl<AssemblerDataType::Code>;
-    using ThreadSpecificAssemblerData = ThreadSpecific<AssemblerData, WTF::CanBeGCThread::True>;
-    JS_EXPORT_PRIVATE ThreadSpecificAssemblerData& threadSpecificAssemblerData();
 
 #if ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
     using AssemblerHashes = AssemblerDataImpl<AssemblerDataType::Hashes>;
@@ -123,12 +121,7 @@ namespace JSC {
             // from initialization
             poisonInlineBuffer();
 #endif
-            if constexpr (type == AssemblerDataType::Code)
-                takeBufferIfLarger(*threadSpecificAssemblerData());
-#if ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
-            if constexpr (type == AssemblerDataType::Hashes)
-                takeBufferIfLarger(*threadSpecificAssemblerHashes());
-#else
+#if !ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
             static_assert(type != AssemblerDataType::Hashes);
 #endif
         }
@@ -185,12 +178,7 @@ namespace JSC {
 
         ~AssemblerDataImpl()
         {
-            if constexpr (type == AssemblerDataType::Code)
-                threadSpecificAssemblerData()->takeBufferIfLarger(*this);
-#if ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
-            if constexpr (type == AssemblerDataType::Hashes)
-                threadSpecificAssemblerHashes()->takeBufferIfLarger(*this);
-#else
+#if !ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
             static_assert(type != AssemblerDataType::Hashes);
 #endif
             clear();

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -1158,7 +1158,7 @@ bool ExecutableAllocator::underMemoryPressure()
     FixedVMPoolExecutableAllocator* allocator = g_jscConfig.fixedVMPoolExecutableAllocator;
     if (!allocator)
         return Base::underMemoryPressure();
-    return allocator->bytesAllocated() > allocator->bytesReserved() / 2;
+    return allocator->bytesAllocated() > allocator->bytesReserved() * 9 / 10;
 }
 
 double ExecutableAllocator::memoryPressureMultiplier(size_t addedMemoryUsage)

--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -162,6 +162,10 @@ void JITWorklist::requestTemporaryStop()
 
 CompilationResult JITWorklist::enqueue(Ref<JITPlan> plan)
 {
+    if (ExecutableAllocator::singleton().underMemoryPressure()) [[unlikely]] {
+        dataLogLnIf(Options::verboseCompilationQueue(), "Plan deferred due to executable memory pressure ", plan->key());
+        return CompilationResult::CompilationInvalidated;
+    }
     if (!Options::useConcurrentJIT()) {
 #if USE(PROTECTED_JIT)
         // Must be constructed before we allocate anything using SequesteredArenaMalloc

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4586,13 +4586,16 @@ int jscmain(int argc, char** argv)
     if (!gigacageDisableRequested)
         Gigacage::forbidDisablingPrimitiveGigacage();
 
-#if PLATFORM(COCOA)
     auto& memoryPressureHandler = MemoryPressureHandler::singleton();
+#if PLATFORM(COCOA)
     {
         // FIXME: This is a false positive. rdar://160931336
         SUPPRESS_RETAINPTR_CTOR_ADOPT auto queue = adoptOSObject(dispatch_queue_create("jsc shell memory pressure handler", DISPATCH_QUEUE_SERIAL));
         memoryPressureHandler.setDispatchQueue(WTF::move(queue));
     }
+#else
+    memoryPressureHandler.setShouldUsePeriodicMemoryMonitor(true);
+#endif
     Box<Critical> memoryPressureCriticalState = Box<Critical>::create(Critical::No);
     Box<Synchronous> memoryPressureSynchronousState = Box<Synchronous>::create(Synchronous::No);
     memoryPressureHandler.setLowMemoryHandler([=] (Critical critical, Synchronous synchronous) {
@@ -4605,6 +4608,7 @@ int jscmain(int argc, char** argv)
     memoryPressureHandler.setShouldLogMemoryMemoryPressureEvents(false);
     memoryPressureHandler.install();
 
+#if PLATFORM(COCOA)
     auto onEachMicrotaskTick = [&] (VM& vm) {
         if (*memoryPressureCriticalState == Critical::No)
             return;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -96,7 +96,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, crashOnDisallowedVMEntry, ASSERT_ENABLED, Normal, "Forces a crash if we attempt to enter the VM when disallowed"_s) \
     v(Bool, crashIfCantAllocateJITMemory, false, Normal, nullptr) \
     v(Unsigned, structureHeapSizeInKB, 0, Normal, "Override for Structure Heap size (in KBs) if non-zero"_s) \
-    v(Unsigned, jitMemoryReservationSize, 0, Normal, "Set this number to change the executable allocation size in ExecutableAllocatorFixedVMPool. (In bytes.)"_s) \
+    v(Unsigned, jitMemoryReservationSize, 10 * MB, Normal, "Set this number to change the executable allocation size in ExecutableAllocatorFixedVMPool. (In bytes.)"_s) \
     v(Size, jitMemoryReservationAddress, 0, Restricted, "If non-zero, we will attempt to allocate JIT memory at the address provided and crash if we cannot.") \
     \
     v(Bool, forceCodeBlockLiveness, false, Normal, nullptr) \

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1695,7 +1695,7 @@ CanvasUsesAcceleratedDrawing:
       "PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR)": true
       default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
       default: false
 
@@ -2903,7 +2903,7 @@ ExposeSpeakersEnabled:
   condition: ENABLE(MEDIA_STREAM)
   defaultValue:
     WebKit:
-      "PLATFORM(COCOA)": true
+      "PLATFORM(COCOA) || USE(GSTREAMER)": true
       default: false
     WebCore:
       default: false
@@ -2917,7 +2917,7 @@ ExposeSpeakersWithoutMicrophoneEnabled:
   condition: ENABLE(MEDIA_STREAM)
   defaultValue:
     WebKit:
-      "PLATFORM(COCOA)": true
+      "PLATFORM(COCOA) || USE(GSTREAMER)": true
       default: false
     WebCore:
       default: false
@@ -3841,7 +3841,7 @@ ImageCaptureEnabled:
   condition: ENABLE(MEDIA_STREAM)
   defaultValue:
     WebKit:
-      "PLATFORM(COCOA)": true
+      "PLATFORM(COCOA) || USE(GSTREAMER)": true
       default: false
     WebCore:
       "PLATFORM(COCOA)": true
@@ -6513,12 +6513,12 @@ PropagateDamagingInformation:
    condition: ENABLE(DAMAGE_TRACKING)
    defaultValue:
      WebKitLegacy:
-       default: false
+       default: true
      WebKit:
        "PLATFORM(GTK)": true
-       default: false
+       default: true
      WebCore:
-       default: false
+       default: true
 
 PunchOutWhiteBackgroundsInDarkMode:
   type: bool
@@ -7894,8 +7894,10 @@ SpeakerSelectionRequiresUserGesture:
     WebKitLegacy:
       default: true
     WebKit:
+      "USE(GSTREAMER) && PLATFORM(WPE)": false
       default: true
     WebCore:
+      "USE(GSTREAMER) && PLATFORM(WPE)": false
       default: true
 
 SpeculationRulesPrefetchEnabled:
@@ -8738,11 +8740,11 @@ UseDamagingInformationForCompositing:
   condition: ENABLE(DAMAGE_TRACKING)
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 UseGPUProcessForCanvasRenderingEnabled:
   type: bool

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -163,6 +163,14 @@ static inline bool NODELETE isLastOfType(const Element& element, const Qualified
     return true;
 }
 
+static inline int countElementsBeforeSlow(const Element& element)
+{
+    int count = 0;
+    for (const Element* sibling = ElementTraversal::previousSibling(element); sibling; sibling = ElementTraversal::previousSibling(*sibling))
+        count++;
+    return count;
+}
+
 static inline int NODELETE countElementsBefore(const Element& element)
 {
     int count = 0;
@@ -174,6 +182,7 @@ static inline int NODELETE countElementsBefore(const Element& element)
         }
         count++;
     }
+    ASSERT(count == countElementsBeforeSlow(element));
     return count;
 }
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -709,6 +709,17 @@ void ContainerNode::insertBeforeCommon(Node& nextChild, Node& newChild)
     newChild.setParentNode(this);
     newChild.setPreviousSibling(previousSibling);
     newChild.setNextSibling(&nextChild);
+
+    // Invalidate childIndex-es of affected siblings.
+    CheckedPtr siblingWithAffectedIndex = &nextChild;
+    while (siblingWithAffectedIndex) {
+        if (CheckedPtr siblingElementWithAffectedIndex = dynamicDowncast<Element>(siblingWithAffectedIndex.get())) {
+            if (!siblingElementWithAffectedIndex->childIndex())
+                break;
+            siblingElementWithAffectedIndex->setChildIndex(0);
+        }
+        siblingWithAffectedIndex = siblingWithAffectedIndex->nextSibling();
+    }
 }
 
 void ContainerNode::appendChildCommon(Node& child)
@@ -897,6 +908,19 @@ void ContainerNode::removeBetween(Node* previousChild, Node* nextChild, Node& ol
     oldChild.setParentNode(nullptr);
 
     oldChild.setTreeScopeRecursively(document());
+
+    if (nextChild) {
+        // Invalidate childIndex-es of affected siblings.
+        CheckedPtr siblingWithAffectedIndex = nextChild;
+        while (siblingWithAffectedIndex) {
+            if (CheckedPtr siblingElementWithAffectedIndex = dynamicDowncast<Element>(siblingWithAffectedIndex.get())) {
+                if (!siblingElementWithAffectedIndex->childIndex())
+                    break;
+                siblingElementWithAffectedIndex->setChildIndex(0);
+            }
+            siblingWithAffectedIndex = siblingWithAffectedIndex->nextSibling();
+        }
+    }
 }
 
 void ContainerNode::parserRemoveChild(Node& oldChild)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3310,7 +3310,7 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
                 }
             }
 
-            if (currentRenderer == frameView->layoutContext().subtreeLayoutRoot())
+            if (frameView->layoutContext().hasSubtreeLayoutRoot(*currentRenderer))
                 break;
         }
     }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2409,15 +2409,15 @@ void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, Option
     else
 #endif
     {
-        // Inflate dirty rect to cover antialiasing on image buffers.
-        if (context->shouldAntialias())
-            dirtyRect.inflate(1);
 #if USE(COORDINATED_GRAPHICS)
         // In COORDINATED_GRAPHICS graphics layer is tiled and tiling logic handles dirty rects
         // internally and thus no unification of rects is needed here because that causes
         // unnecessary invalidation of tiles which are actually not dirty
         m_dirtyRect = dirtyRect;
 #else
+        // Inflate dirty rect to cover antialiasing on image buffers.
+        if (context->shouldAntialias())
+            dirtyRect.inflate(1);
         m_dirtyRect.unite(dirtyRect);
 #endif
         canvasBase().didDraw(m_dirtyRect, shouldApplyPostProcessing);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -676,6 +676,12 @@ void WebGLRenderingContextBase::destroyGraphicsContextGL()
     }
 }
 
+static inline FloatRect toLayerCoordinates(const FloatRect& rect, float canvasHeight)
+{
+    // WebGL canvas has Y inverted, so we need to invert it back to get layer coordinates.
+    return FloatRect { { rect.x(), canvasHeight - rect.maxY() }, rect.size() };
+}
+
 void WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver(WebGLRenderingContextBase::CallerType caller)
 {
     // Draw and clear ops with rasterizer discard enabled do not change the canvas.
@@ -691,7 +697,12 @@ void WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver(WebGLR
         m_readDrawingBuffer = nullptr;
         updateMemoryCost();
     }
-    markCanvasChanged();
+
+    Ref canvas = canvasBase();
+    if (m_damage) {
+        canvas->didDraw(toLayerCoordinates(*m_latestScissor, canvas->height()), ShouldApplyPostProcessingToDirtyRect::No);
+    } else
+        canvas->didDraw(FloatRect { { }, canvas->size() }, ShouldApplyPostProcessingToDirtyRect::No);
 }
 
 bool WebGLRenderingContextBase::clearIfComposited(WebGLRenderingContextBase::CallerType caller, GCGLbitfield mask)
@@ -903,6 +914,8 @@ void WebGLRenderingContextBase::didUpdateCanvasSizeProperties(bool)
 
     m_readDrawingBuffer = nullptr;
     m_readDisplayBuffer = nullptr;
+
+    m_damage = std::nullopt;
 
     m_defaultFramebuffer->reshape(newSize);
     updateMemoryCost();
@@ -1602,8 +1615,10 @@ void WebGLRenderingContextBase::disable(GCGLenum cap)
 {
     if (isContextLost() || !validateCapability("disable"_s, cap))
         return;
-    if (cap == GraphicsContextGL::SCISSOR_TEST)
+    if (cap == GraphicsContextGL::SCISSOR_TEST) {
         m_scissorEnabled = false;
+        m_damage = std::nullopt;
+    }
     if (cap == GraphicsContextGL::RASTERIZER_DISCARD)
         m_rasterizerDiscardEnabled = false;
     protect(graphicsContextGL())->disable(cap);
@@ -3118,6 +3133,9 @@ void WebGLRenderingContextBase::scissor(GCGLint x, GCGLint y, GCGLsizei width, G
     if (!validateSize("scissor"_s, width, height))
         return;
     graphicsContextGL()->scissor(x, y, width, height);
+    m_latestScissor = { x, y, width, height };
+    if (m_scissorEnabled && m_damage)
+        m_damage->add(*m_latestScissor);
 }
 
 void WebGLRenderingContextBase::shaderSource(WebGLShader& shader, const String& string)
@@ -5682,6 +5700,11 @@ void WebGLRenderingContextBase::prepareForDisplay()
         return;
 
     clearIfComposited(CallerTypeOther);
+    if (m_damage) {
+        m_context->setDamage(WTF::move(*m_damage));
+        m_damage = std::nullopt;
+    }
+    clearAccumulatedDirtyRect();
     graphicsContextGL()->prepareForDisplay();
     m_defaultFramebuffer->markAllUnpreservedBuffersDirty();
 
@@ -5723,6 +5746,15 @@ void WebGLRenderingContextBase::updateMemoryCost() const
         newMemoryCost += area * samplesPerPixel * bytesPerSample;
     }
     CanvasRenderingContext::updateMemoryCost(newMemoryCost);
+}
+
+void WebGLRenderingContextBase::clearAccumulatedDirtyRect()
+{
+    if (m_scissorEnabled && m_latestScissor) {
+        m_damage = std::make_optional<Damage>(clampedCanvasSize(), Damage::Mode::Rectangles, 5);
+        m_damage->add(*m_latestScissor);
+    } else
+        m_damage = std::nullopt;
 }
 
 WebCoreOpaqueRoot root(WebGLRenderingContextBase* context)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBGL)
 
+#include "Damage.h"
 #include "EventLoop.h"
 #include "GPUBasedCanvasRenderingContext.h"
 #include "GraphicsContextGL.h"
@@ -493,6 +494,9 @@ public:
 
     bool compositingResultsNeedUpdating() const final { return m_compositingResultsNeedUpdating; }
     void prepareForDisplay() final;
+
+    void clearAccumulatedDirtyRect() final;
+
 protected:
     WebGLRenderingContextBase(CanvasBase&, CanvasRenderingContext::Type, WebGLContextAttributes&&);
 
@@ -1058,6 +1062,8 @@ private:
 
     bool m_isSuspended { false };
     bool m_packReverseRowOrderSupported { false };
+    std::optional<IntRect> m_latestScissor;
+    std::optional<Damage> m_damage;
 };
 
 template<typename T>

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
@@ -145,6 +145,7 @@ struct Box {
     void setHasContent() { m_hasContent = true; }
     void setIsFullyTruncated() { m_isFullyTruncated = true; }
 
+    void setText(Text&&);
     Text& text() LIFETIME_BOUND { ASSERT(isTextOrSoftLineBreak()); return m_text; }
     const Text& text() const LIFETIME_BOUND { ASSERT(isTextOrSoftLineBreak()); return m_text; }
 
@@ -306,6 +307,11 @@ inline void Box::setRect(const FloatRect& rect, const FloatRect& inkOverflow)
 {
     m_unflippedVisualRect = rect;
     m_inkOverflow = inkOverflow;
+}
+
+inline void Box::setText(Text&& text)
+{
+    m_text = WTF::move(text);
 }
 
 inline void Box::removeFromGlyphDisplayListCache()

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -734,6 +734,19 @@ FloatRect LineLayout::applySVGTextFragments(SVGTextFragmentMap&& fragmentMap)
     return fullBoundaries;
 }
 
+bool LineLayout::preventsSkippingLayout() const
+{
+    // Line layout does not have enough information to tell if layout can be skipped but
+    // it has enough information to tell that it definitely cannot be skipped.
+
+    if (!m_inlineContent)
+        return true;
+
+    return m_inlineContent->displayContent().lines.size() != 1
+        || m_inlineContent->displayContent().boxes.size() != 2
+        || m_inlineContent->displayContent().boxes[0].isText() == m_inlineContent->displayContent().boxes[1].isText();
+}
+
 void LineLayout::preparePlacedFloats()
 {
     auto& placedFloats = m_blockFormattingState.placedFloats();
@@ -1481,6 +1494,23 @@ bool LineLayout::updateTextContent(const RenderText& textRenderer, std::optional
 
     int delta = inlineTextBox->content().length() - oldLength;
     return delta >= 0 ? invalidation.textInserted(inlineTextBox, offset) : invalidation.textWillBeRemoved(inlineTextBox, offset);
+}
+
+bool LineLayout::propagateInplaceTextContentChange(const RenderText& textRenderer)
+{
+    if (!m_inlineContent)
+        return false;
+
+    const CheckedPtr inlineTextBox = textRenderer.layoutBox();
+    auto box = std::find_if(m_inlineContent->displayContent().boxes.begin(), m_inlineContent->displayContent().boxes.end(), [&inlineTextBox](const auto& box) {
+        return &box.layoutBox() == inlineTextBox;
+    });
+    if (box == m_inlineContent->displayContent().boxes.end())
+        return false;
+    box->setText(InlineDisplay::Box::Text { 0, textRenderer.text().length(), textRenderer.text() });
+    box->removeFromGlyphDisplayListCache();
+
+    return true;
 }
 
 void LineLayout::releaseCaches(RenderView& view)

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -87,6 +87,7 @@ public:
     bool insertedIntoTree(const RenderElement& parent, RenderObject& child);
     bool removedFromTree(const RenderElement& parent, RenderObject& child);
     bool updateTextContent(const RenderText&, std::optional<size_t> offset, size_t oldLength);
+    bool propagateInplaceTextContentChange(const RenderText&);
     bool rootStyleWillChange(const RenderBlockFlow&, const RenderStyle& newStyle);
     bool styleWillChange(const RenderElement&, const RenderStyle& newStyle, Style::Difference);
     bool boxContentWillChange(const RenderBox&);
@@ -149,6 +150,8 @@ public:
     FloatRect applySVGTextFragments(SVGTextFragmentMap&&);
 
     bool NODELETE hasBlocks() const;
+
+    bool preventsSkippingLayout() const;
 
 private:
     void preparePlacedFloats();

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -539,12 +539,12 @@ void LocalFrameView::didRestoreFromBackForwardCache()
 void LocalFrameView::willDestroyRenderTree()
 {
     detachCustomScrollbars();
-    layoutContext().clearSubtreeLayoutRoot();
+    layoutContext().clearSubtreeLayoutRoots();
 }
 
 void LocalFrameView::didDestroyRenderTree()
 {
-    ASSERT(!layoutContext().subtreeLayoutRoot());
+    ASSERT(!layoutContext().isSubtreeLayout());
     ASSERT(m_widgetsInRenderTree.isEmpty());
 
     ASSERT(!m_embeddedObjectsToUpdate || m_embeddedObjectsToUpdate->isEmpty());
@@ -723,7 +723,7 @@ void LocalFrameView::calculateScrollbarModesForLayout(ScrollbarMode& hMode, Scro
         vMode = ScrollbarMode::AlwaysOff;
     }
     
-    if (layoutContext().subtreeLayoutRoot())
+    if (layoutContext().isSubtreeLayout())
         return;
 
     RefPtr document = m_frame->document();
@@ -4982,7 +4982,7 @@ void LocalFrameView::autoSizeIfEnabled()
         return;
 
     SetForScope changeInAutoSize(m_inAutoSize, true);
-    if (layoutContext().subtreeLayoutRoot())
+    if (layoutContext().isSubtreeLayout())
         layoutContext().convertSubtreeLayoutToFullLayout();
 
     switch (m_autoSizeMode) {
@@ -6166,7 +6166,7 @@ void LocalFrameView::enableAutoSizeMode(bool enable, const IntSize& viewSize, Au
 
 void LocalFrameView::forceLayout(bool allowSubtreeLayout)
 {
-    if (!allowSubtreeLayout && layoutContext().subtreeLayoutRoot())
+    if (!allowSubtreeLayout && layoutContext().isSubtreeLayout())
         layoutContext().convertSubtreeLayoutToFullLayout();
     layoutContext().layout();
 }

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -71,6 +71,7 @@ UpdateScrollInfoAfterLayoutTransaction::~UpdateScrollInfoAfterLayoutTransaction(
 
 #ifndef NDEBUG
 class RenderTreeNeedsLayoutChecker {
+    WTF_MAKE_FAST_ALLOCATED;
 public :
     RenderTreeNeedsLayoutChecker(const RenderView& renderView)
         : m_renderView(renderView)
@@ -169,7 +170,7 @@ void LocalFrameViewLayoutContext::layout(bool canDeferUpdateLayerPositions)
 
     Ref protectedView(view());
 
-    performLayout(canDeferUpdateLayerPositions);
+    performLayouts(canDeferUpdateLayerPositions);
 
     if (view().hasOneRef())
         return;
@@ -181,7 +182,7 @@ void LocalFrameViewLayoutContext::layout(bool canDeferUpdateLayerPositions)
         if (!needsLayout())
             break;
 
-        performLayout(canDeferUpdateLayerPositions);
+        performLayouts(canDeferUpdateLayerPositions);
 
         if (view().hasOneRef())
             return;
@@ -194,13 +195,35 @@ void LocalFrameViewLayoutContext::interleavedLayout()
 
     Ref protectedView(view());
 
-    performLayout(false);
+    performLayouts(false);
 
     Style::Scope::LayoutDependencyUpdateContext layoutDependencyUpdateContext;
     document()->styleScope().invalidateForLayoutDependencies(layoutDependencyUpdateContext);
 }
 
-void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPositions)
+void LocalFrameViewLayoutContext::performLayouts(bool canDeferUpdateLayerPositions)
+{
+#if PLATFORM(WPE) || PLATFORM(GTK)
+    WTFBeginSignpost(this, PerformSubtreesLayout, "subtrees: %u", m_subtreeLayoutRoots.size());
+#endif
+    if (isSubtreeLayout()) {
+        // When performing a subtree layout, we may need to perform layout for each subtree.
+        // The above might have been done in single pass, but calling performLayout() multiple times
+        // has some nice side-effects such as reporting "Layout" events in the inspector with specific subtree areas.
+        while (performLayout(canDeferUpdateLayerPositions, true) && !m_subtreeLayoutRoots.isEmpty()) { }
+#ifndef NDEBUG
+        // This function may be called recursively so let's do the checking when all the subtrees have been processed.
+        if (m_subtreeLayoutRoots.isEmpty())
+            RenderTreeNeedsLayoutChecker checker(*renderView());
+#endif
+    } else
+        performLayout(canDeferUpdateLayerPositions);
+#if PLATFORM(WPE) || PLATFORM(GTK)
+    WTFEndSignpost(this, PerformSubtreesLayout);
+#endif
+}
+
+bool LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPositions, bool unchecked)
 {
     Ref frame = this->frame();
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!document()->inRenderTreeUpdate());
@@ -212,13 +235,14 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         || document()->backForwardCacheState() == Document::AboutToEnterBackForwardCache);
     if (!canPerformLayout()) {
         LOG(Layout, "  is not allowed, bailing");
-        return;
+        return false;
     }
 
     LayoutFrameScope layoutFrameScope(*this);
     TraceScope tracingScope(PerformLayoutStart, PerformLayoutEnd);
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
     InspectorInstrumentation::willLayout(frame);
+    RenderElement* subtreeLayoutRoot;
     SingleThreadWeakPtr<RenderElement> layoutRoot;
     
     m_layoutTimer.stop();
@@ -229,7 +253,7 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " elapsed time before first layout: " << document()->timeSinceDocumentCreation());
 #endif
 #if PLATFORM(IOS_FAMILY)
-    if (protect(view())->updateFixedPositionLayoutRect() && subtreeLayoutRoot())
+    if (protect(view())->updateFixedPositionLayoutRect() && isSubtreeLayout())
         convertSubtreeLayoutToFullLayout();
 #endif
     {
@@ -244,16 +268,17 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         }
 
         if (view().hasOneRef())
-            return;
+            return false;
 
         protect(view())->autoSizeIfEnabled();
         if (!renderView())
-            return;
+            return false;
 
-        layoutRoot = subtreeLayoutRoot() ? subtreeLayoutRoot() : renderView();
+        subtreeLayoutRoot = isSubtreeLayout() ? *m_subtreeLayoutRoots.begin() : nullptr;
+        layoutRoot = subtreeLayoutRoot ?: renderView();
         m_needsFullRepaint = is<RenderView>(layoutRoot) && (m_firstLayout || renderView()->printing());
 
-        LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " layout " << m_layoutUpdateCount << " - subtree root " << subtreeLayoutRoot() << ", needsFullRepaint " << m_needsFullRepaint);
+        LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " layout " << m_layoutUpdateCount << " - subtree root " << subtreeLayoutRoot << ", needsFullRepaint " << m_needsFullRepaint);
 
         protect(view())->willDoLayout(layoutRoot);
         m_firstLayout = false;
@@ -264,10 +289,14 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         TraceScope tracingScope(RenderTreeLayoutStart, RenderTreeLayoutEnd);
         SetForScope layoutPhase(m_layoutPhase, LayoutPhase::InRenderTreeLayout);
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-        SubtreeLayoutStateMaintainer subtreeLayoutStateMaintainer(subtreeLayoutRoot());
+        SubtreeLayoutStateMaintainer subtreeLayoutStateMaintainer(subtreeLayoutRoot);
         RenderView::RepaintRegionAccumulator repaintRegionAccumulator(renderView());
 #ifndef NDEBUG
-        RenderTreeNeedsLayoutChecker checker(*renderView());
+        std::unique_ptr<RenderTreeNeedsLayoutChecker> checker;
+        if (!unchecked)
+            checker = WTF::makeUnique<RenderTreeNeedsLayoutChecker>(*renderView());
+#else
+        UNUSED_PARAM(unchecked);
 #endif
         layoutRoot->layout();
 #if ENABLE(TEXT_AUTOSIZING)
@@ -296,9 +325,11 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
             }
         }
 #endif
-        layoutRoot->absoluteQuads(layoutAreas);
+        for (auto* subtreeLayoutRoot : m_subtreeLayoutRoots)
+            subtreeLayoutRoot->absoluteQuads(layoutAreas);
 
-        clearSubtreeLayoutRoot();
+        if (subtreeLayoutRoot)
+            removeSubtreeLayoutRoot(*subtreeLayoutRoot);
         ASSERT(m_percentHeightIgnoreList.isEmptyIgnoringNullReferences());
 
 #if !LOG_DISABLED && ENABLE(TREE_DEBUGGING)
@@ -319,7 +350,7 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
             // FIXME: Firing media query callbacks synchronously on nested frames could produced a detached FrameView here by
             // navigating away from the current document (see webkit.org/b/173329).
             if (view().hasOneRef())
-                return;
+                return true;
         }
     }
     {
@@ -332,6 +363,7 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
     }
     InspectorInstrumentation::didLayout(frame, *layoutRoot, layoutAreas);
     DebugPageOverlays::didLayout(frame);
+    return true;
 }
 
 void LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks(bool canDeferUpdateLayerPositions)
@@ -472,7 +504,7 @@ bool LocalFrameViewLayoutContext::updateCompositingLayersAfterLayoutIfNeeded()
 void LocalFrameViewLayoutContext::reset()
 {
     m_layoutPhase = LayoutPhase::OutsideLayout;
-    clearSubtreeLayoutRoot();
+    clearSubtreeLayoutRoots();
     m_layoutSchedulingIsEnabled = true;
     m_layoutTimer.stop();
     m_firstLayout = true;
@@ -499,7 +531,7 @@ bool LocalFrameViewLayoutContext::needsLayoutInternal() const
     auto* renderView = this->renderView();
     return isLayoutPending()
         || (renderView && renderView->needsLayout())
-        || subtreeLayoutRoot()
+        || isSubtreeLayout()
         || (m_disableSetNeedsLayoutCount && m_setNeedsLayoutWasDeferred);
 }
 
@@ -538,7 +570,7 @@ void LocalFrameViewLayoutContext::scheduleLayout()
     if (!document)
         return;
 
-    if (subtreeLayoutRoot())
+    if (isSubtreeLayout())
         convertSubtreeLayoutToFullLayout();
 
     if (isLayoutPending())
@@ -583,48 +615,50 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
     ASSERT(!renderView->renderTreeBeingDestroyed());
     ASSERT(frame().view() == &view());
 
-    if (renderView->needsLayout() && !subtreeLayoutRoot()) {
+    if (renderView->needsLayout() && !isSubtreeLayout()) {
         layoutRoot.markContainingBlocksForLayout(renderView.ptr());
         return;
     }
 
     if (!isLayoutPending() && isLayoutSchedulingEnabled()) {
         ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
-        setSubtreeLayoutRoot(layoutRoot);
+        addSubtreeLayoutRoot(layoutRoot);
         InspectorInstrumentation::didInvalidateLayout(protect(frame()));
         m_layoutTimer.startOneShot(0_s);
         return;
     }
 
-    CheckedPtr subtreeLayoutRoot = this->subtreeLayoutRoot();
-    if (subtreeLayoutRoot == &layoutRoot)
+    if (hasSubtreeLayoutRoot(layoutRoot))
         return;
 
-    if (!subtreeLayoutRoot) {
+    if (!isSubtreeLayout()) {
         // We already have a pending (full) layout. Just mark the subtree for layout.
         layoutRoot.markContainingBlocksForLayout(renderView.ptr());
         InspectorInstrumentation::didInvalidateLayout(protect(frame()));
         return;
     }
 
-    if (subtreeLayoutRoot->isAncestorContainerOfRenderer(layoutRoot)) {
-        // Keep the current root.
-        layoutRoot.markContainingBlocksForLayout(subtreeLayoutRoot);
-        ASSERT(!subtreeLayoutRoot->container() || is<RenderView>(subtreeLayoutRoot->container()) || !subtreeLayoutRoot->container()->needsLayout());
-        return;
+    // Combine new subtree with existing ones to make sure we store only independent subtrees.
+    for (auto* subtreeLayoutRoot : m_subtreeLayoutRoots) {
+        if (subtreeLayoutRoot->isAncestorContainerOfRenderer(layoutRoot)) {
+            // New subtree is a subtree of existing subtree.
+            layoutRoot.markContainingBlocksForLayout(subtreeLayoutRoot);
+            ASSERT(!subtreeLayoutRoot->container() || is<RenderView>(subtreeLayoutRoot->container()) || !subtreeLayoutRoot->container()->needsLayout());
+            return;
+        }
+        if (layoutRoot.isAncestorContainerOfRenderer(*subtreeLayoutRoot)) {
+            // Existing subtree is a subtree of new subtree.
+            subtreeLayoutRoot->markContainingBlocksForLayout(&layoutRoot);
+            ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
+            InspectorInstrumentation::didInvalidateLayout(protect(frame()));
+            removeSubtreeLayoutRoot(*subtreeLayoutRoot);
+            addSubtreeLayoutRoot(layoutRoot);
+            return;
+        }
     }
 
-    if (layoutRoot.isAncestorContainerOfRenderer(*subtreeLayoutRoot)) {
-        // Re-root at newRelayoutRoot.
-        subtreeLayoutRoot->markContainingBlocksForLayout(&layoutRoot);
-        setSubtreeLayoutRoot(layoutRoot);
-        ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
-        InspectorInstrumentation::didInvalidateLayout(protect(frame()));
-        return;
-    }
-    // Two disjoint subtrees need layout. Mark both of them and issue a full layout instead.
-    convertSubtreeLayoutToFullLayout();
-    layoutRoot.markContainingBlocksForLayout(renderView.ptr());
+    // We already have a pending subtree layout. Just add new subtree to collection.
+    addSubtreeLayoutRoot(layoutRoot);
     InspectorInstrumentation::didInvalidateLayout(protect(frame()));
 }
 
@@ -637,21 +671,32 @@ void LocalFrameViewLayoutContext::layoutTimerFired()
     layout();
 }
 
-RenderElement* LocalFrameViewLayoutContext::subtreeLayoutRoot() const
+bool LocalFrameViewLayoutContext::hasSubtreeLayoutRoot(const RenderElement& subtreeLayoutRoot) const
 {
-    return m_subtreeLayoutRoot.get();
+    return m_subtreeLayoutRoots.contains(const_cast<RenderElement*>(&subtreeLayoutRoot));
+}
+
+void LocalFrameViewLayoutContext::clearSubtreeLayoutRoots()
+{
+    m_subtreeLayoutRoots.clear();
 }
 
 void LocalFrameViewLayoutContext::convertSubtreeLayoutToFullLayout()
 {
-    ASSERT(subtreeLayoutRoot());
-    subtreeLayoutRoot()->markContainingBlocksForLayout(renderView());
-    clearSubtreeLayoutRoot();
+    ASSERT(!m_subtreeLayoutRoots.isEmpty());
+    for (auto* subtreeLayoutRoot : m_subtreeLayoutRoots)
+        subtreeLayoutRoot->markContainingBlocksForLayout(renderView());
+    clearSubtreeLayoutRoots();
 }
 
-void LocalFrameViewLayoutContext::setSubtreeLayoutRoot(RenderElement& layoutRoot)
+void LocalFrameViewLayoutContext::addSubtreeLayoutRoot(RenderElement& subtreeLayoutRoot)
 {
-    m_subtreeLayoutRoot = layoutRoot;
+    m_subtreeLayoutRoots.add(&subtreeLayoutRoot);
+}
+
+void LocalFrameViewLayoutContext::removeSubtreeLayoutRoot(const RenderElement& subtreeLayoutRoot)
+{
+    m_subtreeLayoutRoots.remove(const_cast<RenderElement*>(&subtreeLayoutRoot));
 }
 
 bool LocalFrameViewLayoutContext::canPerformLayout() const
@@ -662,7 +707,7 @@ bool LocalFrameViewLayoutContext::canPerformLayout() const
     if (view().isPainting())
         return false;
 
-    if (!subtreeLayoutRoot() && !document()->renderView())
+    if (!isSubtreeLayout() && !document()->renderView())
         return false;
 
     return true;

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -103,6 +103,7 @@ public:
     LayoutPhase layoutPhase() const { return m_layoutPhase; }
     bool isLayoutNested() const { return m_layoutNestedState == LayoutNestedState::Nested; }
     bool isLayoutPending() const { return m_layoutTimer.isActive(); }
+    bool isSubtreeLayout() const { return !m_subtreeLayoutRoots.isEmpty(); }
     bool isInLayout() const { return layoutPhase() != LayoutPhase::OutsideLayout; }
     bool isInRenderTreeLayout() const { return layoutPhase() == LayoutPhase::InRenderTreeLayout; }
     bool inPaintableState() const { return layoutPhase() != LayoutPhase::InRenderTreeLayout && layoutPhase() != LayoutPhase::InViewSizeAdjust && (layoutPhase() != LayoutPhase::InPostLayout || inAsynchronousTasks()); }
@@ -119,8 +120,9 @@ public:
     std::optional<TextBoxTrim> textBoxTrim() const { return m_textBoxTrim; }
     void setTextBoxTrim(std::optional<TextBoxTrim> textBoxTrim) { m_textBoxTrim = textBoxTrim; }
 
-    RenderElement* NODELETE subtreeLayoutRoot() const;
-    void clearSubtreeLayoutRoot() { m_subtreeLayoutRoot.clear(); }
+    bool hasSubtreeLayoutRoot(const RenderElement&) const;
+    void removeSubtreeLayoutRoot(const RenderElement&);
+    void clearSubtreeLayoutRoots();
     void convertSubtreeLayoutToFullLayout();
 
     void reset();
@@ -202,7 +204,8 @@ private:
 
     bool NODELETE needsLayoutInternal() const;
 
-    void performLayout(bool canDeferUpdateLayerPositions);
+    void performLayouts(bool canDeferUpdateLayerPositions);
+    bool performLayout(bool canDeferUpdateLayerPositions, bool unchecked = false);
     bool NODELETE canPerformLayout() const;
     bool isLayoutSchedulingEnabled() const { return m_layoutSchedulingIsEnabled; }
 
@@ -213,7 +216,7 @@ private:
     void runOrScheduleAsynchronousTasks(bool canDeferUpdateLayerPositions);
     bool inAsynchronousTasks() const { return m_inAsynchronousTasks; }
 
-    void NODELETE setSubtreeLayoutRoot(RenderElement&);
+    void NODELETE addSubtreeLayoutRoot(RenderElement&);
 
 #if ENABLE(TEXT_AUTOSIZING)
     void applyTextSizingIfNeeded(RenderElement& layoutRoot);
@@ -257,7 +260,7 @@ private:
     SingleThreadWeakRef<LocalFrameView> m_frameView;
     Timer m_layoutTimer;
     Timer m_postLayoutTaskTimer;
-    SingleThreadWeakPtr<RenderElement> m_subtreeLayoutRoot;
+    HashSet<RenderElement*> m_subtreeLayoutRoots;
 
     bool m_layoutSchedulingIsEnabled { true };
     bool m_firstLayout { true };

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -92,6 +92,9 @@ Performance::Performance(ScriptExecutionContext* context, MonotonicTime timeOrig
 {
     ASSERT(m_timeOrigin);
     initializeEntryBufferMap();
+
+    if (getenv("ALLOW_HIGH_TIME_PRECISION"))
+        timePrecision = 1_us;
 }
 
 Performance::~Performance() = default;

--- a/Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.h
+++ b/Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.h
@@ -36,14 +36,16 @@ class GraphicsContext;
 
 namespace AdwaitaScrollbarPainter {
 
-static const unsigned scrollbarSize = 21;
-static const unsigned scrollbarBorderSize = 1;
-static const unsigned thumbBorderSize = 1;
+// Scrollbar style values adjusted per UX requirements.
+// https://github.com/philips-internal/synergy-project-external-partners/issues/441#issuecomment-3989163579
+static const unsigned scrollbarSize = 16;
+static const unsigned scrollbarBorderSize = 0;
+static const unsigned thumbBorderSize = 0;
 static const unsigned overlayThumbSize = 3;
 static const unsigned minimumThumbSize = 40;
-static const unsigned horizThumbMargin = 6;
+static const unsigned horizThumbMargin = 4;
 static const unsigned horizOverlayThumbMargin = 3;
-static const unsigned vertThumbMargin = 7;
+static const unsigned vertThumbMargin = 4;
 
 static constexpr auto scrollbarBackgroundColorLight = Color::white;
 static constexpr auto scrollbarBorderColorLight = Color::black.colorWithAlphaByte(38);

--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -293,6 +293,28 @@ public:
         return region;
     }
 
+    // Removes overlaps. May clip to grid.
+    Rects rectsForPainting() const
+    {
+        if (m_rects.rects.size() <= 1 || m_mode != Mode::Rectangles)
+            return rects();
+
+        Rects rects;
+        for (int row = 0; row < m_rects.gridCells.height(); ++row) {
+            for (int col = 0; col < m_rects.gridCells.width(); ++col) {
+                const IntRect cellRect = { { m_rect.x() + col * m_rects.cellSize.width(), m_rect.y() + row * m_rects.cellSize.height() }, m_rects.cellSize };
+                IntRect minimumBoundingRectangleContaingOverlaps;
+                for (const auto& rect : m_rects.rects) {
+                    if (!rect.isEmpty())
+                        minimumBoundingRectangleContaingOverlaps.unite(intersection(cellRect, rect));
+                }
+                if (!minimumBoundingRectangleContaingOverlaps.isEmpty())
+                    rects.append(minimumBoundingRectangleContaingOverlaps);
+            }
+        }
+        return rects;
+    }
+
     // May return overlapping rects.
     ALWAYS_INLINE Rects rects() const
     {

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1676,6 +1676,8 @@ public:
     WEBCORE_EXPORT virtual RefPtr<Image> videoFrameToImage(VideoFrame&);
 #endif
 
+    virtual void setDamage(Damage&&) { }
+
     IntSize getInternalFramebufferSize() const { return IntSize(m_currentWidth, m_currentHeight); }
 
     struct PixelStoreParameters final {

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -427,7 +427,8 @@ void GraphicsContextGLANGLE::validateAttributes()
     } else if (attrs.preserveDrawingBuffer) {
         // Needed for preserveDrawingBuffer:true support without antialiasing.
         bool supported = enableExtensionsImpl({ "GL_ANGLE_framebuffer_blit"_s });
-        ASSERT_UNUSED(supported, supported);
+        if (!supported)
+            m_useBlitFallback = true;
     }
 }
 
@@ -754,9 +755,18 @@ void GraphicsContextGLANGLE::prepareTexture()
         // Blit m_preserveDrawingBufferTexture into m_texture.
         ScopedGLCapability scopedScissor(GL_SCISSOR_TEST, GL_FALSE);
         ScopedGLCapability scopedDither(GL_DITHER, GL_FALSE);
-        GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER_ANGLE, m_preserveDrawingBufferFBO);
-        GL_BindFramebuffer(GL_READ_FRAMEBUFFER_ANGLE, m_fbo);
-        GL_BlitFramebufferANGLE(0, 0, m_currentWidth, m_currentHeight, 0, 0, m_currentWidth, m_currentHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        if (m_useBlitFallback) {
+            GL_BindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+            GLint texture2DBinding = 0;
+            GL_GetIntegerv(GL_TEXTURE_BINDING_2D, &texture2DBinding);
+            GL_BindTexture(GL_TEXTURE_2D, m_texture);
+            GL_CopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, m_currentWidth, m_currentHeight);
+            GL_BindTexture(GL_TEXTURE_2D, texture2DBinding);
+        } else {
+            GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER_ANGLE, m_preserveDrawingBufferFBO);
+            GL_BindFramebuffer(GL_READ_FRAMEBUFFER_ANGLE, m_fbo);
+            GL_BlitFramebufferANGLE(0, 0, m_currentWidth, m_currentHeight, 0, 0, m_currentWidth, m_currentHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        }
 
         if (m_isForWebGL2) {
             GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER, m_state.boundDrawFBO);

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -751,6 +751,17 @@ void GraphicsContextGLANGLE::prepareTexture()
         resolveMultisamplingIfNecessary();
 
     if (m_preserveDrawingBufferTexture) {
+        const IntRect fullRect{ 0, 0, m_currentWidth, m_currentHeight };
+        Damage::Rects rectsToCopy { };
+        if (m_damage && m_previousDamage) {
+            Damage& actualDamage = *m_previousDamage;
+            actualDamage.add(*m_damage);
+            rectsToCopy = actualDamage.rectsForPainting();
+        } else
+            rectsToCopy.append(fullRect);
+        m_previousDamage = WTF::move(m_damage);
+        m_damage = std::nullopt;
+
         prepareForDrawingBufferWrite();
         // Blit m_preserveDrawingBufferTexture into m_texture.
         ScopedGLCapability scopedScissor(GL_SCISSOR_TEST, GL_FALSE);
@@ -760,12 +771,14 @@ void GraphicsContextGLANGLE::prepareTexture()
             GLint texture2DBinding = 0;
             GL_GetIntegerv(GL_TEXTURE_BINDING_2D, &texture2DBinding);
             GL_BindTexture(GL_TEXTURE_2D, m_texture);
-            GL_CopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, m_currentWidth, m_currentHeight);
+            for (const auto& rectToCopy : rectsToCopy)
+                GL_CopyTexSubImage2D(GL_TEXTURE_2D, 0, rectToCopy.x(), rectToCopy.y(), rectToCopy.x(), rectToCopy.y(), rectToCopy.width(), rectToCopy.height());
             GL_BindTexture(GL_TEXTURE_2D, texture2DBinding);
         } else {
             GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER_ANGLE, m_preserveDrawingBufferFBO);
             GL_BindFramebuffer(GL_READ_FRAMEBUFFER_ANGLE, m_fbo);
-            GL_BlitFramebufferANGLE(0, 0, m_currentWidth, m_currentHeight, 0, 0, m_currentWidth, m_currentHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+            for (const auto& rectToCopy : rectsToCopy)
+                GL_BlitFramebufferANGLE(rectToCopy.x(), rectToCopy.y(), rectToCopy.x() + rectToCopy.width(), rectToCopy.y() + rectToCopy.height(), rectToCopy.x(), rectToCopy.y(), rectToCopy.x() + rectToCopy.width(), rectToCopy.y() + rectToCopy.height(), GL_COLOR_BUFFER_BIT, GL_NEAREST);
         }
 
         if (m_isForWebGL2) {
@@ -874,6 +887,11 @@ void GraphicsContextGLANGLE::reshape(int width, int height)
     }
 
     GL_Flush();
+}
+
+void GraphicsContextGLANGLE::setDamage(Damage&& damage)
+{
+    m_damage = WTF::move(damage);
 }
 
 void GraphicsContextGLANGLE::activeTexture(GCGLenum texture)

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -29,6 +29,7 @@
 #if ENABLE(WEBGL)
 
 #include <WebCore/ANGLEUtilities.h>
+#include <WebCore/Damage.h>
 #include <WebCore/GCGLSpan.h>
 #include <WebCore/GraphicsContextGL.h>
 #include <WebCore/GraphicsContextGLState.h>
@@ -344,6 +345,8 @@ public:
 
     RefPtr<NativeImage> copyNativeImageYFlipped(SurfaceBuffer) override;
 
+    void setDamage(Damage&&) final;
+
     // Returns the span of valid data read on success.
     bool getBufferSubDataWithStatus(GCGLenum target, GCGLintptr offset, std::span<uint8_t> data);
 
@@ -457,6 +460,8 @@ protected:
     IntSize m_maxInternalFramebufferSize;
 
     bool m_useBlitFallback { false };
+    std::optional<Damage> m_damage;
+    std::optional<Damage> m_previousDamage;
 };
 
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -455,6 +455,8 @@ protected:
     HashMap<uint32_t, void*, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_eglImages;
     HashMap<uint32_t, void*, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_eglSyncs;
     IntSize m_maxInternalFramebufferSize;
+
+    bool m_useBlitFallback { false };
 };
 
 

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -410,13 +410,13 @@ bool SkiaPaintingEngine::shouldUseLinearTileTextures()
 bool SkiaPaintingEngine::shouldUseVivanteSuperTiledTileTextures()
 {
     static std::once_flag onceFlag;
-    static bool shouldUseVivanteSuperTiledTextures = false;
+    static bool shouldUseVivanteSuperTiledTextures = true;
 
     std::call_once(onceFlag, [] {
         if (const char* envString = getenv("WEBKIT_SKIA_USE_VIVANTE_SUPER_TILED_TILE_TEXTURES")) {
             auto envStringView = StringView::fromLatin1(envString);
-            if (envStringView == "1"_s)
-                shouldUseVivanteSuperTiledTextures = true;
+            if (envStringView == "0"_s)
+                shouldUseVivanteSuperTiledTextures = false;
         }
     });
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
@@ -118,7 +118,8 @@ OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStorePro
         if (!tile.isDirty())
             continue;
 
-        tileDirtyRectUnion.unite(tile.dirtyRect);
+        for (const auto& each : tile.dirtyRects)
+            tileDirtyRectUnion.unite(each);
         ++dirtyTilesCount;
     }
 
@@ -138,22 +139,25 @@ OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStorePro
             if (!tile.isDirty())
                 continue;
 
-            WTFBeginSignpost(this, UpdateTile, "%u/%u, id: %d, rect: %ix%i+%i+%i, dirty: %ix%i+%i+%i", ++dirtyTileIndex, dirtyTilesCount, tile.id,
-                tile.rect.x(), tile.rect.y(), tile.rect.width(), tile.rect.height(), tile.dirtyRect.x(), tile.dirtyRect.y(), tile.dirtyRect.width(), tile.dirtyRect.height());
+        ++dirtyTileIndex;
+        for (auto& dirtyRect : tile.dirtyRects) {
+                WTFBeginSignpost(this, UpdateTile, "%u/%u, id: %d, rect: %ix%i+%i+%i, dirty: %ix%i+%i+%i", dirtyTileIndex, dirtyTilesCount, tile.id,
+                    tile.rect.x(), tile.rect.y(), tile.rect.width(), tile.rect.height(), dirtyRect.x(), dirtyRect.y(), dirtyRect.width(), dirtyRect.height());
 
 #if USE(SKIA)
-            auto buffer = recording ? layer.replay(recording, tile.dirtyRect) : layer.paint(tile.dirtyRect);
+                auto buffer = recording ? layer.replay(recording, dirtyRect) : layer.paint(dirtyRect);
 #else
-            auto buffer = layer.paint(tile.dirtyRect);
+                auto buffer = layer.paint(dirtyRect);
 #endif
 
-            IntRect updateRect(tile.dirtyRect);
-            updateRect.move(-tile.rect.x(), -tile.rect.y());
-            tilesToUpdate.append({ tile.id, tile.rect, WTF::move(updateRect), WTF::move(buffer) });
-            tile.markClean();
-            result.add(UpdateResult::BuffersChanged);
+                IntRect updateRect(dirtyRect);
+                updateRect.move(-tile.rect.x(), -tile.rect.y());
+                tilesToUpdate.append({ tile.id, tile.rect, WTF::move(updateRect), WTF::move(buffer) });
+                result.add(UpdateResult::BuffersChanged);
 
-            WTFEndSignpost(this, UpdateTile);
+                WTFEndSignpost(this, UpdateTile);
+        }
+            tile.markClean();
         }
 
 #if !HAVE(OS_SIGNPOST) && !USE(SYSPROF_CAPTURE)
@@ -333,9 +337,11 @@ void CoordinatedBackingStoreProxy::createOrDestroyTiles(const IntRect& unscaledV
         for (const auto& position : tilePositionsToCreate) {
             auto tile = Tile(generateTileID(), position, tileRectForPosition(position));
 #if ENABLE(DAMAGE_TRACKING)
-            IntRect unscaledDirtyRect = tile.dirtyRect;
-            unscaledDirtyRect.scale(1 / contentsScale);
-            damage.add(unscaledDirtyRect);
+            for (const auto& dirtyRect : tile.dirtyRects) {
+                IntRect unscaledDirtyRect = dirtyRect;
+                unscaledDirtyRect.scale(1 / contentsScale);
+                damage.add(unscaledDirtyRect);
+            }
 #else
             UNUSED_PARAM(damage);
 #endif

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -30,11 +30,15 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
+#include <sstream>
+
 namespace WebCore {
 class CoordinatedPlatformLayer;
 class CoordinatedTileBuffer;
 class Damage;
 class GraphicsLayer;
+
+static const uint32_t s_minimunUnionDirtyArea = 128 * 128;
 
 class CoordinatedBackingStoreProxy final : public ThreadSafeRefCounted<CoordinatedBackingStoreProxy> {
     WTF_MAKE_TZONE_ALLOCATED(CoordinatedBackingStoreProxy);
@@ -93,8 +97,19 @@ private:
             : id(id)
             , position(position)
             , rect(WTF::move(tileRect))
-            , dirtyRect(rect)
+            , dirtyRects({ rect })
+            , minimumDirtyAreaUnionRatio(0.7f)
         {
+            char* mimimumCoverageRatioString = getenv("TILE_DIRTY_AREA_UNION_COVERAGE_RATIO");
+            if (mimimumCoverageRatioString) {
+                float ratio;
+                std::stringstream ss;
+
+                ss << mimimumCoverageRatioString;
+                if (ss >> ratio) {
+                    minimumDirtyAreaUnionRatio = ratio;
+                }
+            }
         }
         Tile(const Tile&) = delete;
         Tile& operator=(const Tile&) = delete;
@@ -104,30 +119,67 @@ private:
         void resize(const IntSize& size)
         {
             rect.setSize(size);
-            dirtyRect = rect;
+            dirtyRects = { rect };
         }
 
         void addDirtyRect(const IntRect& dirty)
         {
             auto tileDirtyRect = intersection(dirty, rect);
             ASSERT(!tileDirtyRect.isEmpty());
-            dirtyRect.unite(tileDirtyRect);
+
+            // Do quick best effort to find dirty rect which is closest
+            // to incoming rect to avoid unification of huge areas
+
+            int uniteIndex = -1;
+            if (minimumDirtyAreaUnionRatio > 0) {
+                float highestCoverageAreaRatio = 0;
+                int highestCoverageAreaRatioIndex = -1;
+                for (size_t idx = 0; idx < dirtyRects.size(); ++idx) {
+                    float unitedArea = unionRect(tileDirtyRect, dirtyRects[idx]).area();
+                    if (unitedArea <= s_minimunUnionDirtyArea) {
+                        uniteIndex = idx;
+                        break;
+                    } else {
+                        float dirtyRectArea1 = tileDirtyRect.area();
+                        float dirtyRectArea2 = dirtyRects[idx].area();
+                        float interectionArea = intersection(tileDirtyRect, dirtyRects[idx]).area();
+                        float coverageAreaRatio = (dirtyRectArea1 + dirtyRectArea2 - interectionArea) / unitedArea;
+                        if (coverageAreaRatio >= highestCoverageAreaRatio) {
+                            highestCoverageAreaRatio = coverageAreaRatio;
+                            highestCoverageAreaRatioIndex = idx;
+                        }
+                    }
+                }
+
+                if (highestCoverageAreaRatio > minimumDirtyAreaUnionRatio) {
+                    uniteIndex = highestCoverageAreaRatioIndex;
+                }
+            } else if (dirtyRects.size() > 0) {
+                uniteIndex = 0;
+            }
+
+            if (uniteIndex != -1) {
+                dirtyRects[uniteIndex].unite(tileDirtyRect);
+            } else {
+                dirtyRects.append(tileDirtyRect);
+            }
         }
 
         bool isDirty() const
         {
-            return !dirtyRect.isEmpty();
+            return !dirtyRects.isEmpty();
         }
 
         void markClean()
         {
-            dirtyRect = { };
+            dirtyRects.clear();
         }
 
         uint32_t id { 0 };
         IntPoint position;
         IntRect rect;
-        IntRect dirtyRect;
+        Vector<IntRect> dirtyRects;
+        float minimumDirtyAreaUnionRatio;
     };
 
     CoordinatedBackingStoreProxy() = default;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1065,6 +1065,34 @@ int RenderBox::intrinsicScrollbarLogicalWidthIncludingGutter() const
     return 0;
 }
 
+// Determines whether to reserve space for the vertical scrollbar gutter.
+// This addresses a bug where toggling overflow from 'auto' to 'hidden' with
+// scrollbar-gutter: stable causes the scrollbar to be destroyed, making its width zero,
+// which would otherwise result in losing the reserved gutter space.
+// This behavior fixes that issue while adhering to the spec:
+// https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter#example_3
+bool RenderBox::shouldReserveVerticalScrollbarGutterSpace() const
+{
+    CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
+    if (style().scrollbarWidth() != Style::ScrollbarWidth::None
+        && style().scrollbarGutter().isStable()
+        && (scrollableArea && scrollableArea->verticalScrollbar() == nullptr && !verticalScrollbarWidth())
+        && hasNonVisibleOverflow() && layer() && !layer()->hasOverlayScrollbars())
+        return true;
+    return false;
+}
+
+// Returns the effective width of the vertical scrollbar gutter.
+// Called during content width calculation to subtract the gutter area if reserved.
+int RenderBox::effectiveScrollbarGutterWidth() const
+{
+    if (shouldReserveVerticalScrollbarGutterSpace()) {
+        CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
+        return scrollableArea ? scrollableArea->computeVerticalScrollbarGutterWidth() : 0;
+    }
+    return 0;
+}
+
 bool RenderBox::scrollLayer(ScrollDirection direction, ScrollGranularity granularity, unsigned stepCount, Element** stopElement)
 {
     CheckedPtr scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
@@ -5563,7 +5591,7 @@ void RenderBox::updateFloatPainterAfterSelfPaintingLayerChange()
     // Find the ancestor renderer that is supposed to paint this float now that it is not self painting anymore.
     auto floatingObjectForFloatPainting = [&]() -> FloatingObject* {
         auto& layoutContext = view().frameView().layoutContext();
-        if (!layoutContext.isInLayout() || layoutContext.subtreeLayoutRoot() != this)
+        if (!layoutContext.isInLayout() || !layoutContext.hasSubtreeLayoutRoot(*this))
             return nullptr;
 
         FloatingObject* floatPainter = nullptr;

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -439,6 +439,7 @@ public:
     WEBCORE_EXPORT virtual int verticalScrollbarWidth() const;
     WEBCORE_EXPORT virtual int horizontalScrollbarHeight() const;
     int intrinsicScrollbarLogicalWidthIncludingGutter() const;
+    WEBCORE_EXPORT int effectiveScrollbarGutterWidth() const;
     inline int scrollbarLogicalWidth() const;
     inline int scrollbarLogicalHeight() const;
     virtual bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1, Element** stopElement = nullptr, RenderBox* startBox = nullptr, const IntPoint& wheelEventAbsolutePoint = IntPoint());
@@ -635,6 +636,7 @@ public:
 
     bool includeVerticalScrollbarSize() const;
     bool includeHorizontalScrollbarSize() const;
+    bool shouldReserveVerticalScrollbarGutterSpace() const;
 
     void NODELETE invalidateAncestorBackgroundObscurationStatus();
 

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -52,7 +52,7 @@ inline LayoutUnit RenderBox::contentBoxLogicalWidth(LayoutUnit overridingBorderB
     return std::max(LayoutUnit(), overridingBorderBoxWidth - borderAndPaddingLogicalWidth() - scrollbarLogicalWidth - (style().scrollbarGutter().isStableBothEdges() ? scrollbarLogicalWidth : 0));
 }
 inline LayoutSize RenderBox::contentBoxSize() const { return { contentBoxWidth(), contentBoxHeight() }; }
-inline LayoutUnit RenderBox::contentBoxWidth() const { return std::max(0_lu, paddingBoxWidth() - paddingLeft() - paddingRight() - (style().scrollbarGutter().isStableBothEdges() ? verticalScrollbarWidth() : 0)); }
+inline LayoutUnit RenderBox::contentBoxWidth() const { return std::max(0_lu, paddingBoxWidth() - paddingLeft() - paddingRight() - (style().scrollbarGutter().isStableBothEdges() ? verticalScrollbarWidth() : 0) - effectiveScrollbarGutterWidth()); }
 inline std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerLogicalHeight() const { return writingMode().isHorizontal() ? explicitIntrinsicInnerHeight() : explicitIntrinsicInnerWidth(); }
 inline std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerLogicalWidth() const { return writingMode().isHorizontal() ? explicitIntrinsicInnerWidth() : explicitIntrinsicInnerHeight(); }
 inline bool RenderBox::hasHorizontalOverflow() const { return scrollWidth() != roundToInt(paddingBoxWidth()); }

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1272,7 +1272,7 @@ inline void RenderElement::clearSubtreeLayoutRootIfNeeded() const
     if (renderTreeBeingDestroyed())
         return;
 
-    if (view().frameView().layoutContext().subtreeLayoutRoot() != this)
+    if (!view().frameView().layoutContext().hasSubtreeLayoutRoot(*this))
         return;
 
     // Normally when a renderer is detached from the tree, the appropriate dirty bits get set
@@ -1282,7 +1282,7 @@ inline void RenderElement::clearSubtreeLayoutRootIfNeeded() const
     // This indicates a failure to layout the child, which is why
     // the layout root is still set to |this|. Make sure to clear it
     // since we are getting destroyed.
-    view().frameView().layoutContext().clearSubtreeLayoutRoot();
+    view().frameView().layoutContext().removeSubtreeLayoutRoot(*this);
 }
 
 void RenderElement::willBeDestroyed()

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2017,7 +2017,7 @@ bool RenderFlexibleBox::canUseFlexItemForPercentageResolution(const RenderBox& f
             return true;
         }
 
-        if (&flexItem == view().frameView().layoutContext().subtreeLayoutRoot())
+        if (view().frameView().layoutContext().hasSubtreeLayoutRoot(flexItem))
             return !mainAxisIsFlexItemInlineAxis(flexItem);
 
         // Outside of layout (i.e. when using relative percentage positioning), base the decision on style.

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1007,6 +1007,27 @@ int RenderLayerScrollableArea::verticalScrollbarWidth(OverlayScrollbarSizeReleva
     return vBar->width();
 }
 
+// Computes the width of the vertical scrollbar gutter.
+// If the current overflow state is 'hidden', the vertical scrollbar may not exist,
+// resulting in a width of 0. In that case, this function temporarily creates a vertical
+// scrollbar to measure its width and stores the result in m_gutterWidth.
+// As a fallback, if no measurement is available, returns the platform theme's
+// scrollbar thickness. Note: the fallback may not cover all cases, such as
+// certain custom scrollbars or platform-native variations.
+int RenderLayerScrollableArea::computeVerticalScrollbarGutterWidth()
+{
+    if (!m_gutterWidth) {
+        if (RefPtr<Scrollbar> tempVBar = createScrollbar(ScrollbarOrientation::Vertical)) {
+            m_gutterWidth = tempVBar->width();
+            if (!tempVBar->isCustomScrollbar())
+                willRemoveScrollbar(*tempVBar, ScrollbarOrientation::Vertical);
+            tempVBar->removeFromParent();
+            tempVBar = nullptr;
+        }
+    }
+    return (m_gutterWidth ? m_gutterWidth : ScrollbarTheme::theme().scrollbarThickness(scrollbarWidthStyle()));
+}
+
 int RenderLayerScrollableArea::horizontalScrollbarHeight(OverlayScrollbarSizeRelevancy relevancy, bool isHorizontalWritingMode) const
 {
     RefPtr hBar = m_hBar;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -137,6 +137,7 @@ public:
 
     int verticalScrollbarWidth(OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, bool isHorizontalWritingMode = true) const;
     int horizontalScrollbarHeight(OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, bool isHorizontalWritingMode = true) const;
+    int computeVerticalScrollbarGutterWidth();
 
     bool NODELETE hasOverflowControls() const;
     bool hitTestOverflowControls(HitTestResult&, const IntPoint& localPoint);
@@ -322,6 +323,10 @@ private:
     // The width/height of our scrolled area.
     int m_scrollWidth { 0 };
     int m_scrollHeight { 0 };
+
+    // Reserve gutter space to prevent layout shift with 'scrollbar-gutter: stable'.
+    // Space must be preserved regardless of scrollbar visibility or overflow state.
+    int m_gutterWidth { 0 };
 
     RenderLayer& m_layer;
     ScrollPosition m_scrollPosition;

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1895,7 +1895,40 @@ static void invalidateLineLayoutPathOnContentChangeIfNeeded(RenderText& renderer
         container->invalidateLineLayout(RenderBlockFlow::InvalidationReason::ContentChange);
 }
 
-void RenderText::setTextInternal(const String& text, bool force)
+static void updateLineLayoutPathOnInplaceContentChangeIfNeeded(RenderText& renderer, std::optional<size_t> offset, size_t oldLength)
+{
+    auto* container = LayoutIntegration::LineLayout::blockContainer(renderer);
+    if (!container)
+        return;
+
+    auto* inlineLayout = container->inlineLayout();
+    if (!inlineLayout)
+        return;
+
+    if (!inlineLayout->updateTextContent(renderer, offset, oldLength) || !inlineLayout->propagateInplaceTextContentChange(renderer))
+        container->invalidateLineLayout(RenderBlockFlow::InvalidationReason::ContentChange);
+}
+
+bool RenderText::canSkipLayout(const String& newText) const
+{
+    // Under certain circumstances it's possible to skip layout despite text node change.
+    // In such case it's just enough to propagate text change internally and trigger repaint.
+
+    if (auto* container = dynamicDowncast<RenderBlockFlow>(parent())) {
+        return container->style().usedContain().containsAll({ Style::ContainValue::Size, Style::ContainValue::Layout, Style::ContainValue::Style, Style::ContainValue::Paint })
+            && container->style().whiteSpaceCollapse() == WhiteSpaceCollapse::Preserve
+            && container->style().textWrapMode() == TextWrapMode::NoWrap
+            && container->style().writingMode().isBidiLTR()
+            && (container->style().textAlign() == Style::TextAlign::Start || container->style().textAlign() == Style::TextAlign::Left)
+            && container->inlineLayout()
+            && !container->inlineLayout()->preventsSkippingLayout()
+            && !newText.contains('\n');
+    }
+
+    return false;
+}
+
+void RenderText::setTextInternal(const String& text, bool force, bool skipLayout)
 {
     ASSERT(!text.isNull());
 
@@ -1908,7 +1941,14 @@ void RenderText::setTextInternal(const String& text, bool force)
         m_originalTextDiffersFromRendered = false;
     }
 
-    updateRenderedText(text);
+    setRenderedText(text);
+
+    if (skipLayout)
+        parent()->repaint();
+    else
+        setNeedsLayoutAndInvalidateContentLogicalWidths();
+
+    m_knownToHaveNoOverflowAndNoFallbackFonts = false;
 
     if (AXObjectCache* cache = document().existingAXObjectCache())
         cache->deferTextChangedIfNeeded(textNode());
@@ -1936,9 +1976,14 @@ void RenderText::updateRenderedText()
 void RenderText::setText(const String& newContent, bool force)
 {
     auto isDifferent = newContent != text();
-    setTextInternal(newContent, force);
-    if (isDifferent || force)
-        invalidateLineLayoutPathOnContentChangeIfNeeded(*this, { }, { });
+    const auto skipLayout = canSkipLayout(newContent);
+    setTextInternal(newContent, force, skipLayout);
+    if (isDifferent || force) {
+        if (skipLayout)
+            updateLineLayoutPathOnInplaceContentChangeIfNeeded(*this, { }, { });
+        else
+            invalidateLineLayoutPathOnContentChangeIfNeeded(*this, { }, { });
+    }
 }
 
 void RenderText::setTextWithOffset(const String& newText, unsigned offset)
@@ -1947,8 +1992,12 @@ void RenderText::setTextWithOffset(const String& newText, unsigned offset)
         return;
 
     size_t oldLength = text().length();
-    setTextInternal(newText, false);
-    invalidateLineLayoutPathOnContentChangeIfNeeded(*this, offset, oldLength);
+    const auto skipLayout = canSkipLayout(newText);
+    setTextInternal(newText, false, skipLayout);
+    if (skipLayout)
+        updateLineLayoutPathOnInplaceContentChangeIfNeeded(*this, offset, oldLength);
+    else
+        invalidateLineLayoutPathOnContentChangeIfNeeded(*this, offset, oldLength);
 }
 
 String RenderText::textWithoutConvertingBackslashToYenSymbol() const

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -198,7 +198,7 @@ protected:
     virtual void setRenderedText(const String&);
     virtual char32_t previousCharacter() const;
 
-    virtual void setTextInternal(const String&, bool force);
+    virtual void setTextInternal(const String&, bool force, bool skipLayout = false);
 
 private:
     void updateRenderedText();
@@ -234,6 +234,8 @@ private:
     float maxWordFragmentWidth(const RenderStyle&, const FontCascade&, StringView word, unsigned minimumPrefixLength, unsigned minimumSuffixLength, bool currentCharacterIsSpace, unsigned characterIndex, float xPos, float entireWordWidth, WordTrailingSpace&, SingleThreadWeakHashSet<const Font>& fallbackFonts, GlyphOverflow&);
     float widthFromCacheConsideringPossibleTrailingSpace(const RenderStyle&, const FontCascade&, unsigned startIndex, unsigned wordLen, float xPos, bool currentCharacterIsSpace, WordTrailingSpace&, SingleThreadWeakHashSet<const Font>& fallbackFonts, GlyphOverflow&) const;
     void initiateFontLoadingByAccessingGlyphDataAndComputeCanUseSimplifiedTextMeasuring(const String&);
+
+    bool canSkipLayout(const String&) const;
 
 #if ENABLE(TEXT_AUTOSIZING)
     // FIXME: This should probably be part of the text sizing structures in Document instead. That would save some memory.

--- a/Source/WebCore/rendering/RenderTextFragment.cpp
+++ b/Source/WebCore/rendering/RenderTextFragment.cpp
@@ -79,7 +79,7 @@ bool RenderTextFragment::canBeSelectionLeaf() const
     return anonymousInlineWrapper && anonymousInlineWrapper->firstLetterRemainingText();
 }
 
-void RenderTextFragment::setTextInternal(const String& newText, bool force)
+void RenderTextFragment::setTextInternal(const String& newText, bool force, bool)
 {
     RenderText::setTextInternal(newText, force);
 

--- a/Source/WebCore/rendering/RenderTextFragment.h
+++ b/Source/WebCore/rendering/RenderTextFragment.h
@@ -58,7 +58,7 @@ public:
     void setAltText(const String& altText) { m_altText = altText; }
     
 private:
-    void setTextInternal(const String&, bool force) override;
+    void setTextInternal(const String&, bool force, bool) override;
     void setTextWithOffset(const String&, unsigned offset) override;
     Node* nodeForHitTest() const override;
     char32_t previousCharacter() const override;

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -98,7 +98,7 @@ String RenderSVGInlineText::originalText() const
     return textNode().data();
 }
 
-void RenderSVGInlineText::setTextInternal(const String& newText, bool force)
+void RenderSVGInlineText::setTextInternal(const String& newText, bool force, bool)
 {
     RenderText::setTextInternal(newText, force);
     m_legacyLineBoxes.dirtyForTextChange(*this);

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -76,7 +76,7 @@ private:
     PositionWithAffinity positionForPoint(const LayoutPoint&, HitTestSource, const RenderFragmentContainer*) override;
     IntRect linesBoundingBox() const override;
 
-    void setTextInternal(const String&, bool force) final;
+    void setTextInternal(const String&, bool force, bool) final;
 
     float m_scalingFactor;
     FontCascade m_scaledFont;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -90,6 +90,32 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 namespace WebKit {
 using namespace WebCore;
 
+#define STRINGIFY(...) #__VA_ARGS__
+
+static const char* vertexFullscreenQuadShader =
+    STRINGIFY(
+        precision highp float;
+
+        attribute vec2 position;
+
+        void main()
+        {
+            gl_Position = vec4(position, 0.0, 1.0);
+        }
+    );
+
+static const char* fragmentFullscreenQuadShader =
+    STRINGIFY(
+        precision highp float;
+
+        void main()
+        {
+            gl_FragColor = vec4(0.0,0.0,0.0,0.0);
+        }
+    );
+
+bool AcceleratedSurface::m_force_shader_clear;
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedSurface);
 
 Ref<AcceleratedSurface> AcceleratedSurface::create(WebPage& webPage, Function<void()>&& frameCompleteHandler, RenderingPurpose renderingPurpose, bool useSkia)
@@ -990,6 +1016,22 @@ void AcceleratedSurface::willDestroyGLContext()
     m_pendingFrameNotifyTargets.clear();
     m_target = nullptr;
     m_swapChain.reset();
+    if (m_force_shader_clear) {
+        glDeleteVertexArrays(1, &m_vao);
+        glDeleteBuffers(1, &m_vbo);
+        glDetachShader(m_clearProgram, m_vertexShader);
+        glDeleteShader(m_vertexShader);
+        glDetachShader(m_clearProgram, m_fragmentShader);
+        glDeleteShader(m_fragmentShader);
+        glDeleteProgram(m_clearProgram);
+    }
+}
+
+void AcceleratedSurface::checkClearShader()
+{
+    const char* var = getenv("WEBKIT_FORCE_SHADER_CLEAR_COMPOSITING");
+
+    m_force_shader_clear = var && var == "1"_s;
 }
 
 uint64_t AcceleratedSurface::window()
@@ -1037,8 +1079,38 @@ void AcceleratedSurface::willRenderFrame(const IntSize& size)
         glViewport(0, 0, size.width(), size.height());
 }
 
+void AcceleratedSurface::doClear(float r, float g, float b, float a)
+{
+    if (m_force_shader_clear) {
+        glDisable(GL_DEPTH_TEST);
+        glDisable(GL_BLEND);
+        glBlendFunc(GL_ONE, GL_ZERO);
+        glUseProgram(m_clearProgram);
+        glUniform4f(m_clearColorUniformLocation, r, g, b, a);
+        glBindVertexArray(m_vao);
+        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+        glBindVertexArray(0);
+        glUseProgram(0);
+    } else {
+        glClearColor(r, g, b, a);
+        glClear(GL_COLOR_BUFFER_BIT);
+    }
+
+}
+
 void AcceleratedSurface::clear(const OptionSet<WebCore::CompositionReason>& reasons)
 {
+    static bool stop_glClear = false;
+    static std::once_flag glClear_flag;
+    std::call_once(glClear_flag, []{
+        const char* var = getenv("WEBKIT_STOP_CLEAR_COMPOSITING");
+
+        stop_glClear = var && var == "1"_s;
+    });
+
+    if (stop_glClear)
+        return;
+
     std::optional<Color> backgroundColor;
     {
         Locker locker { m_backgroundColorLock };
@@ -1056,19 +1128,60 @@ void AcceleratedSurface::clear(const OptionSet<WebCore::CompositionReason>& reas
     }
 
     if (backgroundColor && !backgroundColor->isOpaque()) {
-        glClearColor(0, 0, 0, 0);
-        glClear(GL_COLOR_BUFFER_BIT);
+        doClear(0, 0, 0, 0);
         return;
     }
 
     if (reasons.contains(CompositionReason::AsyncScrolling)) {
         if (backgroundColor) {
             auto [r, g, b, a] = backgroundColor->toResolvedColorComponentsInColorSpace(WebCore::ColorSpace::SRGB);
-            glClearColor(r, g, b, a);
+            doClear(r, g, b, a);
         } else
-            glClearColor(1, 1, 1, 1);
-        glClear(GL_COLOR_BUFFER_BIT);
+            doClear(1, 1, 1, 1);
     }
+}
+
+void AcceleratedSurface::didCreateGLContext()
+{
+    static std::once_flag shader_clear_flag;
+    std::call_once(shader_clear_flag, checkClearShader);
+
+    if (m_force_shader_clear) {
+        m_vertexShader = glCreateShader(GL_VERTEX_SHADER);
+        glShaderSource(m_vertexShader, 1, &vertexFullscreenQuadShader, NULL);
+        glCompileShader(m_vertexShader);
+
+        m_fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
+        glShaderSource(m_fragmentShader, 1, &fragmentFullscreenQuadShader, NULL);
+        glCompileShader(m_fragmentShader);
+
+        m_clearProgram = glCreateProgram();
+        glAttachShader(m_clearProgram, m_vertexShader);
+        glAttachShader(m_clearProgram, m_fragmentShader);
+        glLinkProgram(m_clearProgram);
+
+        m_clearColorUniformLocation = glGetUniformLocation(m_clearProgram, "u_clearColor");
+
+        float quad[] =
+        {
+            -1.0f,  1.0f,
+            -1.0f, -1.0f,
+            1.0f,  1.0f,
+            1.0f, -1.0f
+        };
+
+        glGenVertexArrays(1, &m_vao);
+        glBindVertexArray(m_vao);
+        glGenBuffers(1, &m_vbo);
+        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+        glBufferData(GL_ARRAY_BUFFER, sizeof(quad), quad, GL_STATIC_DRAW);
+
+        GLint posAttrib = glGetAttribLocation(m_clearProgram, "position");
+        glVertexAttribPointer(posAttrib, 2, GL_FLOAT, GL_FALSE, 0, 0);
+        glEnableVertexAttribArray(posAttrib);
+
+        glBindVertexArray(0);
+     }
 }
 
 void AcceleratedSurface::didRenderFrame()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -126,9 +126,11 @@ public:
     SkCanvas* canvas();
 
     void willDestroyGLContext();
+    void didCreateGLContext();
     void willRenderFrame(const WebCore::IntSize&);
     void didRenderFrame();
     void sendFrame();
+    void doClear(float, float, float, float);
     void clear(const OptionSet<WebCore::CompositionReason>&);
 
 #if ENABLE(DAMAGE_TRACKING)
@@ -401,6 +403,8 @@ private:
 #endif
     };
 
+    static void checkClearShader();
+
     const WeakRef<WebPage> m_webPage;
     Function<void()> m_frameCompleteHandler;
     bool m_useSkia { false };
@@ -421,6 +425,14 @@ private:
     std::optional<WebCore::Damage> m_frameDamage;
     unsigned m_frameDamageRectangleThreshold { 4 };
 #endif
+
+    guint m_clearProgram;
+    guint m_clearColorUniformLocation;
+    guint m_vertexShader;
+    guint m_fragmentShader;
+    guint m_vao;
+    guint m_vbo;
+    static bool m_force_shader_clear;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -130,6 +130,7 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
             m_textureMapper = TextureMapper::create();
             if (!nativeSurfaceHandle)
                 m_flipY = !m_flipY;
+            m_surface->didCreateGLContext();
         }
     });
 }

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -209,8 +209,10 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 
     const char* enableCPURendering = getenv("WEBKIT_SKIA_ENABLE_CPU_RENDERING");
     IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
-    if (enableCPURendering && strcmp(enableCPURendering, "0"))
+    if (!enableCPURendering || strcmp(enableCPURendering, "0"))
         ProcessCapabilities::setCanUseAcceleratedBuffers(false);
+    else
+        ProcessCapabilities::setCanUseAcceleratedBuffers(true);
     IGNORE_CLANG_WARNINGS_END
 
 #if ENABLE(MEDIA_STREAM)

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -601,6 +601,71 @@ TEST(Damage, Unite)
     EXPECT_EQ(damage.rectsForTesting().size(), 1);
 }
 
+TEST(Damage, RectsForPainting)
+{
+    // The function should return the original rect when theres only a single one.
+    Damage damage(IntSize { 512, 512 });
+    damage.add(IntRect { 250, 250, 12, 12 });
+    ASSERT_EQ(damage.rectsForPainting().size(), 1);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(250, 250, 12, 12));
+
+    // The function should remove overlaps.
+    damage = Damage(IntSize { 512, 512 });
+    damage.add(IntRect { 0, 0, 100, 100 });
+    damage.add(IntRect { 50, 50, 100, 100 });
+    ASSERT_EQ(damage.rectsForPainting().size(), 1);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 150, 150));
+
+    // The function should clip the rects.
+    damage = Damage(IntSize { 512, 512 });
+    damage.add(IntRect { -2, -2, 10, 10 });
+    damage.add(IntRect { 504, 504, 10, 10 });
+    ASSERT_EQ(damage.rectsForPainting().size(), 2);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 8, 8));
+    EXPECT_EQ(damage.rectsForPainting()[1], IntRect(504, 504, 8, 8));
+
+    // The function should preserve the layout of cells when unification is enabled.
+    damage = Damage(IntSize { 512, 512 });
+    damage.add(IntRect { 0, 0, 10, 10 });
+    damage.add(IntRect { 10, 10, 10, 10 });
+    damage.add(IntRect { 0, 256, 10, 10 });
+    damage.add(IntRect { 256, 0, 10, 10 });
+    damage.add(IntRect { 256, 256, 10, 10 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+
+    // The function should preserve the layout of cells when unification is enabled
+    // and the grid does not start at { 0, 0 }.
+    damage = Damage(IntRect { 256, 256, 512, 512 });
+    damage.add(IntRect { 256, 256, 10, 10 });
+    damage.add(IntRect { 256+10, 256+10, 10, 10 });
+    damage.add(IntRect { 256, 256+256, 10, 10 });
+    damage.add(IntRect { 256+256, 256, 10, 10 });
+    damage.add(IntRect { 256+256, 256+256, 10, 10 });
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+
+    // The function should split a rect spanning multiple cells.
+    damage = Damage(IntSize { 512, 512 });
+    damage.add(IntRect { 250, 250, 12, 12 });
+    damage.add(IntRect { 249, 249, 1, 1 });
+    ASSERT_EQ(damage.rectsForPainting().size(), 4);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(249, 249, 7, 7));
+    EXPECT_EQ(damage.rectsForPainting()[1], IntRect(256, 250, 6, 6));
+    EXPECT_EQ(damage.rectsForPainting()[2], IntRect(250, 256, 6, 6));
+    EXPECT_EQ(damage.rectsForPainting()[3], IntRect(256, 256, 6, 6));
+
+    // The function should just return original rects when mode != Mode::Rectangles.
+    damage = Damage(IntRect { 1024, 512, 512, 512 }, Damage::Mode::BoundingBox);
+    damage.add(IntRect { 1278, 678, 9, 341 });
+    damage.add(IntRect { 1285, 678, 5, 341 });
+    damage.add(IntRect { 1279, 678, 9, 341 });
+    damage.add(IntRect { 1286, 678, 5, 341 });
+    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+    damage = Damage(IntRect { 1024, 512, 512, 512 }, Damage::Mode::Full);
+    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+}
+
 TEST(Damage, MaxRectangles)
 {
     Damage damage(IntSize { 512, 512 }, Damage::Mode::Rectangles, 2);


### PR DESCRIPTION
#### c43b1d5cc0c1e835dac0a0becc6da1f232751a2b
<pre>
[WIP] Fallback to full-layout happens when more than 1 subtree layout is pending
<a href="https://bugs.webkit.org/show_bug.cgi?id=275394">https://bugs.webkit.org/show_bug.cgi?id=275394</a>

Reviewed by NOBODY.

This PR merges together the PRs associated to the following bugs:
  - <a href="https://bugs.webkit.org/show_bug.cgi?id=275394">https://bugs.webkit.org/show_bug.cgi?id=275394</a>
  - <a href="https://bugs.webkit.org/show_bug.cgi?id=287952">https://bugs.webkit.org/show_bug.cgi?id=287952</a>
  - <a href="https://bugs.webkit.org/show_bug.cgi?id=290529">https://bugs.webkit.org/show_bug.cgi?id=290529</a>
  - <a href="https://bugs.webkit.org/show_bug.cgi?id=295113">https://bugs.webkit.org/show_bug.cgi?id=295113</a>
  - <a href="https://bugs.webkit.org/show_bug.cgi?id=296475">https://bugs.webkit.org/show_bug.cgi?id=296475</a>
  - <a href="https://bugs.webkit.org/show_bug.cgi?id=296807">https://bugs.webkit.org/show_bug.cgi?id=296807</a>

The goal is to check whether all these PRs combined cause regressions
in Layout tests.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e006979c414f4452694353eab7672c3b2c2b8c4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165291 "21 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38782 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32360 "Hash e006979c for PR 66009 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174334 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122548 "Hash e006979c for PR 66009 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167159 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39117 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38783 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128446 "Found 12 new test failures: compositing/canvas/accelerated-canvas-compositing-size-limit.html compositing/canvas/accelerated-canvas-compositing.html compositing/layer-creation/compositing-policy.html fast/animation/css-animation-resuming-when-visible-with-style-change.html fast/canvas/canvas-ellipse-connecting-line.html fast/canvas/canvas-will-read-frequently.html fast/canvas/image-buffer-backend-variants.html fast/canvas/offscreen-clipped.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation.html imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-nested-in-iframe.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/122548 "Hash e006979c for PR 66009 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168250 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/39117 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/32360 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108971 "Found 1 new API test failure: WPE/TestWebKitSettings:/webkit/WebKitSettings/webkit-settings (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/39117 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/38783 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22409 "Hash e006979c for PR 66009 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157450 "Found 39 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/dfg-osr-entry-hoisted-clobbered-structure-check.js.layout-no-llint, jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks.yaml/slowMicrobenchmarks/quicksort-wasm-load.js.default, modules.yaml/modules/module-jit-reachability.js.no-llint-modules, mozilla-tests.yaml/js1_5/Regress/regress-159334.js.mozilla-baseline, stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint, wasm.yaml/wasm/references/multitable.js.default-wasm, wasm.yaml/wasm/references/multitable.js.wasm-aggressive-inline, wasm.yaml/wasm/references/multitable.js.wasm-bbq, wasm.yaml/wasm/references/multitable.js.wasm-bbq-no-consts ... (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/39117 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/32360 "Hash e006979c for PR 66009 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176856 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26186 "Found 53 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/dfg-double-vote-fuzz.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/dfg-double-vote-fuzz.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/dfg-double-vote-fuzz.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/dfg-double-vote-fuzz.js.layout-no-llint, jsc-layout-tests.yaml/js/script-tests/dfg-float32array.js.layout-no-llint, jsc-layout-tests.yaml/js/script-tests/dfg-float64array.js.layout-no-llint, jsc-layout-tests.yaml/js/script-tests/dfg-int16array.js.layout-no-llint, jsc-layout-tests.yaml/js/script-tests/dfg-int32array-overflow-values.js.layout-no-llint, jsc-layout-tests.yaml/js/script-tests/dfg-int32array.js.layout-no-llint, jsc-layout-tests.yaml/js/script-tests/dfg-int8array.js.layout-no-llint ... (failure)") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29754 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/32360 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136766 "Found 170 new test failures: compositing/canvas/accelerated-canvas-compositing-size-limit.html compositing/canvas/accelerated-canvas-compositing.html compositing/clipping/cached-cliprect-with-compositing-boundary.html compositing/layer-creation/compositing-policy.html compositing/overlap-blending/reflection-opacity-huge.html css3/background/background-repeat-space-padding.html css3/filters/backdrop/backdrop-filter-with-border-radius-and-reflection-add.html css3/filters/backdrop/backdrop-filter-with-border-radius-and-reflection.html fast/animation/css-animation-resuming-when-visible-with-style-change.html fast/canvas/canvas-ellipse-connecting-line.html ... (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38850 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/38783 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136705 "Found 1 new API test failure: WebKitGTK/TestWebKitSettings:/webkit/WebKitSettings/webkit-settings (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39540 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/32360 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101879 "Hash e006979c for PR 66009 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/39540 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/32360 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198968 "Failed to checkout and rebase branch from PR 66009") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38050 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111123 "Failed to build and analyze WebKit") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/198968 "Failed to checkout and rebase branch from PR 66009") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37447 "Hash e006979c for PR 66009 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/32360 "Hash e006979c for PR 66009 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37693 "Hash e006979c for PR 66009 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37591 "Hash e006979c for PR 66009 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->