### PR TITLE
Crash when recreating option::checkmark

### DIFF
--- a/LayoutTests/fast/forms/select/base/option-checkmark-content-change-crash-expected.txt
+++ b/LayoutTests/fast/forms/select/base/option-checkmark-content-change-crash-expected.txt
@@ -1,0 +1,13 @@
+Changing the selected option while the picker is open must not crash when an author rule makes ::checkmark content depend on :checked.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS select.value is "Two"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+One
+Two
+

--- a/LayoutTests/fast/forms/select/base/option-checkmark-content-change-crash.html
+++ b/LayoutTests/fast/forms/select/base/option-checkmark-content-change-crash.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+select, ::picker(select) {
+    appearance: base-select;
+}
+
+select option:not(:checked)::checkmark {
+    content: ".";
+}
+</style>
+</head>
+<body>
+<select id="select">
+    <option>One</option>
+    <option>Two</option>
+</select>
+<script>
+description("Changing the selected option while the picker is open must not crash when an author rule makes ::checkmark content depend on :checked.");
+
+const select = document.getElementById("select");
+
+jsTestIsAsync = true;
+
+(async () => {
+    await UIHelper.activateElement(select);
+    await UIHelper.animationFrame();
+    select.value = "Two";
+    document.body.offsetHeight;
+    shouldBe('select.value', '"Two"');
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
@@ -137,6 +137,8 @@ void RenderTreeBuilder::FormControls::updatePseudoElement(PseudoElementType type
     }
 
     if (existingPseudoElement) {
+        if (beforeChild == existingPseudoElement)
+            beforeChild = existingPseudoElement->nextSibling();
         m_builder.destroy(*existingPseudoElement);
         existingPseudoElement = nullptr;
     }


### PR DESCRIPTION
#### 4f359a0df3734d9b3081fc937eb10563241c448f
<pre>
Crash when recreating option::checkmark
<a href="https://bugs.webkit.org/show_bug.cgi?id=315835">https://bugs.webkit.org/show_bug.cgi?id=315835</a>
<a href="https://rdar.apple.com/178153707">rdar://178153707</a>

Reviewed by Tim Nguyen.

RenderTreeBuilder::FormControls::updateAfterDescendants passes
renderer.firstChild() as beforeChild when calling updatePseudoElement for
&lt;option&gt; elements, so the ::checkmark is inserted as the first child. After
the first update the existing ::checkmark is the first child, so when its
content changes (e.g., via option:not(:checked)::checkmark { content: &quot;.&quot; })
updatePseudoElement destroys it and then re-attaches a fresh pseudo using the
now-dangling beforeChild, crashing in RenderTreeBuilder::Block::attach.

Advance beforeChild to the existing pseudo&apos;s nextSibling before destroying
it, so the replacement is attached in the same logical position.

Test: fast/forms/select/base/option-checkmark-content-change-crash.html
Canonical link: <a href="https://commits.webkit.org/314208@main">https://commits.webkit.org/314208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df9ccede49f70b97997a554adcb1620293fb8db5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122692 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7489b3c0-3d96-4f12-8b5c-9c760e995120) 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128558 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c2aa6b5-985f-4050-ae9e-42e681142dd2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168396 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/30867 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109083 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0308a532-76bd-435a-8703-f5ea3462910b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28544 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22554 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177003 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29911 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136882 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136818 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36880 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148120 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102058 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32088 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24987 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38194 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111268 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37591 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3067 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37735 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->