### PR TITLE
ANGLE:

### DIFF
--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 				7BF5558A2C81F438002B101E /* PBXTargetDependency */,
 				7BF5558C2C81F438002B101E /* PBXTargetDependency */,
 				7BF554C32C81EF03002B101E /* PBXTargetDependency */,
+				AE0001000000000000000002 /* PBXTargetDependency */,
 			);
 			name = "Tools (ANGLE)";
 			productName = "Tools (ANGLE)";
@@ -1386,6 +1387,214 @@
 		FFD002AE2746E560002BE3BC /* egl_stubs_autogen.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD002A92746E55F002BE3BC /* egl_stubs_autogen.h */; };
 		FFD002AF2746E560002BE3BC /* egl_ext_stubs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFD002AA2746E55F002BE3BC /* egl_ext_stubs.cpp */; };
 		FFD002B02746E560002BE3BC /* entry_points_gles_3_1_autogen.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD002AB2746E55F002BE3BC /* entry_points_gles_3_1_autogen.h */; };
+		AE0000140000000000000000 /* ActiveTextureCacheTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4EA2DE59CFF00327F7F /* ActiveTextureCacheTest.cpp */; };
+		AE0000150000000000000000 /* AdvancedBlendTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4EE2DE59D8D00327F7F /* AdvancedBlendTest.cpp */; };
+		AE0000160000000000000000 /* angle_end2end_tests_main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BB971C32DE457E100455D13 /* angle_end2end_tests_main.cpp */; };
+		AE0000170000000000000000 /* angle_test_configs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4B12DE494CF00327F7F /* angle_test_configs.cpp */; };
+		AE0000180000000000000000 /* angle_test_instantiate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4B22DE494CF00327F7F /* angle_test_instantiate.cpp */; };
+		AE0000190000000000000000 /* angle_test_instantiate_apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4B32DE494CF00327F7F /* angle_test_instantiate_apple.mm */; };
+		AE00001A0000000000000000 /* angle_test_platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4B42DE494CF00327F7F /* angle_test_platform.cpp */; };
+		AE00001B0000000000000000 /* ANGLETest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4B52DE494CF00327F7F /* ANGLETest.cpp */; };
+		AE00001C0000000000000000 /* AtomicCounterBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4EF2DE59D8D00327F7F /* AtomicCounterBufferTest.cpp */; };
+		AE00001D0000000000000000 /* AttributeLayoutTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4F02DE59D8D00327F7F /* AttributeLayoutTest.cpp */; };
+		AE00001E0000000000000000 /* BaseInstanceOverflowTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BED4DFB2F98E33B00A240A7 /* BaseInstanceOverflowTest.cpp */; };
+		AE00001F0000000000000000 /* BindGeneratesResourceTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4F12DE59D8D00327F7F /* BindGeneratesResourceTest.cpp */; };
+		AE0000200000000000000000 /* BindUniformLocationTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4F22DE59D8D00327F7F /* BindUniformLocationTest.cpp */; };
+		AE0000210000000000000000 /* BlendFuncExtendedTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4F32DE59D8D00327F7F /* BlendFuncExtendedTest.cpp */; };
+		AE0000220000000000000000 /* BlendIntegerTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4F42DE59D8D00327F7F /* BlendIntegerTest.cpp */; };
+		AE0000230000000000000000 /* BlendMinMaxTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4F52DE59D8D00327F7F /* BlendMinMaxTest.cpp */; };
+		AE0000240000000000000000 /* BlendPackedTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4F62DE59D8D00327F7F /* BlendPackedTest.cpp */; };
+		AE0000250000000000000000 /* BlitFramebufferANGLETest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4F72DE59D8D00327F7F /* BlitFramebufferANGLETest.cpp */; };
+		AE0000260000000000000000 /* BlobCacheTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4F82DE59D8D00327F7F /* BlobCacheTest.cpp */; };
+		AE0000270000000000000000 /* BPTCCompressedTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4F92DE59D8D00327F7F /* BPTCCompressedTextureTest.cpp */; };
+		AE0000280000000000000000 /* BufferDataTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4FA2DE59D8D00327F7F /* BufferDataTest.cpp */; };
+		AE0000290000000000000000 /* BufferPoolTestMetal.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BED4DFC2F98E33B00A240A7 /* BufferPoolTestMetal.mm */; };
+		AE00002A0000000000000000 /* BuiltinVariableTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4FB2DE59D8D00327F7F /* BuiltinVariableTest.cpp */; };
+		AE00002B0000000000000000 /* ClearTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4AE2DE4903000327F7F /* ClearTest.cpp */; };
+		AE00002C0000000000000000 /* ClientArraysTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF50A2DE59DA000327F7F /* ClientArraysTest.cpp */; };
+		AE00002D0000000000000000 /* ClipControlTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF50B2DE59DA000327F7F /* ClipControlTest.cpp */; };
+		AE00002E0000000000000000 /* ClipDistanceTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF50C2DE59DA000327F7F /* ClipDistanceTest.cpp */; };
+		AE00002F0000000000000000 /* ColorMaskTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF50D2DE59DA000327F7F /* ColorMaskTest.cpp */; };
+		AE0000300000000000000000 /* CompressedTextureFormatsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF50E2DE59DA000327F7F /* CompressedTextureFormatsTest.cpp */; };
+		AE0000310000000000000000 /* ComputeShaderTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF50F2DE59DA000327F7F /* ComputeShaderTest.cpp */; };
+		AE0000320000000000000000 /* ContextLostTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5102DE59DA000327F7F /* ContextLostTest.cpp */; };
+		AE0000330000000000000000 /* ContextNoErrorTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5112DE59DA000327F7F /* ContextNoErrorTest.cpp */; };
+		AE0000340000000000000000 /* CopyCompressedTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5122DE59DA000327F7F /* CopyCompressedTextureTest.cpp */; };
+		AE0000350000000000000000 /* CopyTexImageTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5132DE59DA000327F7F /* CopyTexImageTest.cpp */; };
+		AE0000360000000000000000 /* CopyTexture3DTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5142DE59DA000327F7F /* CopyTexture3DTest.cpp */; };
+		AE0000370000000000000000 /* CopyTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5152DE59DA000327F7F /* CopyTextureTest.cpp */; };
+		AE0000380000000000000000 /* CubeMapTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5162DE59DA000327F7F /* CubeMapTextureTest.cpp */; };
+		AE0000390000000000000000 /* DebugMarkerTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5242DE59DB800327F7F /* DebugMarkerTest.cpp */; };
+		AE00003A0000000000000000 /* DebugTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5252DE59DB800327F7F /* DebugTest.cpp */; };
+		AE00003B0000000000000000 /* DepthStencilFormatsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5262DE59DB800327F7F /* DepthStencilFormatsTest.cpp */; };
+		AE00003C0000000000000000 /* DepthStencilTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5272DE59DB800327F7F /* DepthStencilTest.cpp */; };
+		AE00003D0000000000000000 /* DepthWriteTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5282DE59DB800327F7F /* DepthWriteTest.cpp */; };
+		AE00003E0000000000000000 /* DifferentStencilMasksTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5292DE59DB800327F7F /* DifferentStencilMasksTest.cpp */; };
+		AE00003F0000000000000000 /* DiscardFramebufferEXTTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF52A2DE59DB800327F7F /* DiscardFramebufferEXTTest.cpp */; };
+		AE0000400000000000000000 /* DrawBaseVertexBaseInstanceTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF52B2DE59DB800327F7F /* DrawBaseVertexBaseInstanceTest.cpp */; };
+		AE0000410000000000000000 /* DrawBaseVertexVariantsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF52C2DE59DB800327F7F /* DrawBaseVertexVariantsTest.cpp */; };
+		AE0000420000000000000000 /* DrawBuffersTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF52D2DE59DB800327F7F /* DrawBuffersTest.cpp */; };
+		AE0000430000000000000000 /* DrawElementsIndirectTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF52E2DE59DB800327F7F /* DrawElementsIndirectTest.cpp */; };
+		AE0000440000000000000000 /* DrawElementsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF52F2DE59DB800327F7F /* DrawElementsTest.cpp */; };
+		AE0000450000000000000000 /* DrawRangeElementsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5302DE59DB800327F7F /* DrawRangeElementsTest.cpp */; };
+		AE0000460000000000000000 /* DXT1CompressedTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5312DE59DB800327F7F /* DXT1CompressedTextureTest.cpp */; };
+		AE0000470000000000000000 /* DXTSRGBCompressedTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5322DE59DB800327F7F /* DXTSRGBCompressedTextureTest.cpp */; };
+		AE0000480000000000000000 /* EGLBackwardsCompatibleContextTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6212DE5A13800327F7F /* EGLBackwardsCompatibleContextTest.cpp */; };
+		AE0000490000000000000000 /* EGLBlobCacheTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6222DE5A13800327F7F /* EGLBlobCacheTest.cpp */; };
+		AE00004A0000000000000000 /* EGLBufferAgeTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6232DE5A13800327F7F /* EGLBufferAgeTest.cpp */; };
+		AE00004B0000000000000000 /* EGLChooseConfigTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6242DE5A13800327F7F /* EGLChooseConfigTest.cpp */; };
+		AE00004C0000000000000000 /* EGLContextASANTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6252DE5A13800327F7F /* EGLContextASANTest.cpp */; };
+		AE00004D0000000000000000 /* EGLContextCompatibilityTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6262DE5A13800327F7F /* EGLContextCompatibilityTest.cpp */; };
+		AE00004E0000000000000000 /* EGLContextSharingTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6272DE5A13800327F7F /* EGLContextSharingTest.cpp */; };
+		AE00004F0000000000000000 /* EGLCreateContextAttribsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6282DE5A13800327F7F /* EGLCreateContextAttribsTest.cpp */; };
+		AE0000500000000000000000 /* EGLDebugTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6292DE5A13800327F7F /* EGLDebugTest.cpp */; };
+		AE0000510000000000000000 /* EGLDisplaySelectionTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF62B2DE5A13800327F7F /* EGLDisplaySelectionTest.cpp */; };
+		AE0000520000000000000000 /* EGLDisplayTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF62C2DE5A13800327F7F /* EGLDisplayTest.cpp */; };
+		AE0000530000000000000000 /* EGLFeatureControlTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF62D2DE5A13800327F7F /* EGLFeatureControlTest.cpp */; };
+		AE0000540000000000000000 /* EGLIOSurfaceClientBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF62E2DE5A13800327F7F /* EGLIOSurfaceClientBufferTest.cpp */; };
+		AE0000550000000000000000 /* EGLLockSurface3Test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF62F2DE5A13800327F7F /* EGLLockSurface3Test.cpp */; };
+		AE0000560000000000000000 /* EGLMemoryUsageReportTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6302DE5A13800327F7F /* EGLMemoryUsageReportTest.cpp */; };
+		AE0000570000000000000000 /* EGLMultiContextTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6312DE5A13800327F7F /* EGLMultiContextTest.cpp */; };
+		AE0000580000000000000000 /* EGLNoConfigContextTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6322DE5A13800327F7F /* EGLNoConfigContextTest.cpp */; };
+		AE0000590000000000000000 /* EGLNoErrorTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6332DE5A13800327F7F /* EGLNoErrorTest.cpp */; };
+		AE00005A0000000000000000 /* EGLPrintEGLinfoTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6352DE5A13800327F7F /* EGLPrintEGLinfoTest.cpp */; };
+		AE00005B0000000000000000 /* EGLProgramCacheControlTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6362DE5A13800327F7F /* EGLProgramCacheControlTest.cpp */; };
+		AE00005C0000000000000000 /* EGLProtectedContentTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6372DE5A13800327F7F /* EGLProtectedContentTest.cpp */; };
+		AE00005D0000000000000000 /* EGLQueryContextTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6382DE5A13800327F7F /* EGLQueryContextTest.cpp */; };
+		AE00005E0000000000000000 /* EGLReadinessCheckTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6392DE5A13800327F7F /* EGLReadinessCheckTest.cpp */; };
+		AE00005F0000000000000000 /* EGLRecordableTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF63A2DE5A13800327F7F /* EGLRecordableTest.cpp */; };
+		AE0000600000000000000000 /* EGLRobustnessTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF63B2DE5A13800327F7F /* EGLRobustnessTest.cpp */; };
+		AE0000610000000000000000 /* EGLSurfacelessContextTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF63D2DE5A13800327F7F /* EGLSurfacelessContextTest.cpp */; };
+		AE0000620000000000000000 /* EGLSurfaceTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF63E2DE5A13800327F7F /* EGLSurfaceTest.cpp */; };
+		AE0000630000000000000000 /* EGLSyncTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6402DE5A13800327F7F /* EGLSyncTest.cpp */; };
+		AE0000640000000000000000 /* EGLSyncTestMetalSharedEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6412DE5A13800327F7F /* EGLSyncTestMetalSharedEvent.mm */; };
+		AE0000650000000000000000 /* EGLWaitUntilWorkScheduledTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6422DE5A13800327F7F /* EGLWaitUntilWorkScheduledTest.cpp */; };
+		AE0000660000000000000000 /* End2EndTestsSourcesPlatform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B820C762DE9956000DAC5E4 /* End2EndTestsSourcesPlatform.cpp */; };
+		AE0000670000000000000000 /* ErrorMessages.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5432DE59DCD00327F7F /* ErrorMessages.cpp */; };
+		AE0000680000000000000000 /* ETCTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5442DE59DCD00327F7F /* ETCTextureTest.cpp */; };
+		AE0000690000000000000000 /* ExternalBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5452DE59DCD00327F7F /* ExternalBufferTest.cpp */; };
+		AE00006A0000000000000000 /* ExternalWrapTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5462DE59DCD00327F7F /* ExternalWrapTest.cpp */; };
+		AE00006B0000000000000000 /* FenceSyncTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5472DE59DCD00327F7F /* FenceSyncTests.cpp */; };
+		AE00006C0000000000000000 /* FloatingPointSurfaceTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5482DE59DCD00327F7F /* FloatingPointSurfaceTest.cpp */; };
+		AE00006D0000000000000000 /* FormatPrintTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5492DE59DCD00327F7F /* FormatPrintTest.cpp */; };
+		AE00006E0000000000000000 /* FragDepthTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF54A2DE59DCD00327F7F /* FragDepthTest.cpp */; };
+		AE00006F0000000000000000 /* FramebufferFetchTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF54B2DE59DCD00327F7F /* FramebufferFetchTest.cpp */; };
+		AE0000700000000000000000 /* FramebufferMixedSamplesTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF54C2DE59DCD00327F7F /* FramebufferMixedSamplesTest.cpp */; };
+		AE0000710000000000000000 /* FramebufferRenderMipmapTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF54E2DE59DCD00327F7F /* FramebufferRenderMipmapTest.cpp */; };
+		AE0000720000000000000000 /* FramebufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF54F2DE59DCD00327F7F /* FramebufferTest.cpp */; };
+		AE0000730000000000000000 /* FrameCapture_mock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BB973A32DE48DEE00455D13 /* FrameCapture_mock.cpp */; };
+		AE0000740000000000000000 /* GeometryShaderTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5502DE59DCD00327F7F /* GeometryShaderTest.cpp */; };
+		AE0000750000000000000000 /* GetTexLevelParameterTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5522DE59DCD00327F7F /* GetTexLevelParameterTest.cpp */; };
+		AE0000760000000000000000 /* gl_enum_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF66D2DE5AA3500327F7F /* gl_enum_utils.cpp */; };
+		AE0000770000000000000000 /* gl_enum_utils_autogen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF66F2DE5AA3500327F7F /* gl_enum_utils_autogen.cpp */; };
+		AE0000780000000000000000 /* GLSLConstantFoldingTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BED4DFE2F98E33B00A240A7 /* GLSLConstantFoldingTest.cpp */; };
+		AE0000790000000000000000 /* GLSLOutputTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BED4DFF2F98E33B00A240A7 /* GLSLOutputTest.cpp */; };
+		AE00007A0000000000000000 /* GLSLTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5632DE59E0900327F7F /* GLSLTest.cpp */; };
+		AE00007B0000000000000000 /* GLSLUBTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B8EC83E2DF1BC9100105EB6 /* GLSLUBTest.cpp */; };
+		AE00007C0000000000000000 /* GLSLValidationTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BED4E002F98E33B00A240A7 /* GLSLValidationTest.cpp */; };
+		AE00007D0000000000000000 /* GPUTestConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4D72DE49CE200327F7F /* GPUTestConfig.cpp */; };
+		AE00007E0000000000000000 /* GPUTestExpectationsParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4DD2DE49CE200327F7F /* GPUTestExpectationsParser.cpp */; };
+		AE00007F0000000000000000 /* GPUTestExpectationsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4EC2DE59D5700327F7F /* GPUTestExpectationsTest.cpp */; };
+		AE0000800000000000000000 /* ImageTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5642DE59E0900327F7F /* ImageTest.cpp */; };
+		AE0000810000000000000000 /* ImageTestMetal.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7B8EC83F2DF1BC9100105EB6 /* ImageTestMetal.mm */; };
+		AE0000820000000000000000 /* IncompatibleTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5662DE59E0900327F7F /* IncompatibleTextureTest.cpp */; };
+		AE0000830000000000000000 /* IncompleteTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5672DE59E0900327F7F /* IncompleteTextureTest.cpp */; };
+		AE0000840000000000000000 /* IndexBufferOffsetTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5682DE59E0900327F7F /* IndexBufferOffsetTest.cpp */; };
+		AE0000850000000000000000 /* IndexedPointsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5692DE59E0900327F7F /* IndexedPointsTest.cpp */; };
+		AE0000860000000000000000 /* InstancingTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF56A2DE59E0900327F7F /* InstancingTest.cpp */; };
+		AE0000870000000000000000 /* KTXCompressedTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF56B2DE59E0900327F7F /* KTXCompressedTextureTest.cpp */; };
+		AE0000880000000000000000 /* libEGL_autogen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BB9723C2DE4827800455D13 /* libEGL_autogen.cpp */; };
+		AE0000890000000000000000 /* libGLESv2_autogen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BB972342DE480F000455D13 /* libGLESv2_autogen.cpp */; };
+		AE00008A0000000000000000 /* LineLoopTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF56C2DE59E0900327F7F /* LineLoopTest.cpp */; };
+		AE00008B0000000000000000 /* LinkAndRelinkTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF56D2DE59E0900327F7F /* LinkAndRelinkTest.cpp */; };
+		AE00008C0000000000000000 /* MatrixTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF56E2DE59E0900327F7F /* MatrixTest.cpp */; };
+		AE00008D0000000000000000 /* MaxTextureSizeTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF56F2DE59E0900327F7F /* MaxTextureSizeTest.cpp */; };
+		AE00008E0000000000000000 /* MemoryBarrierTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5702DE59E0900327F7F /* MemoryBarrierTest.cpp */; };
+		AE00008F0000000000000000 /* MemoryObjectTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5712DE59E0900327F7F /* MemoryObjectTest.cpp */; };
+		AE0000900000000000000000 /* MemorySizeTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5722DE59E0900327F7F /* MemorySizeTest.cpp */; };
+		AE0000910000000000000000 /* MipmapTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5732DE59E0900327F7F /* MipmapTest.cpp */; };
+		AE0000920000000000000000 /* MultiDrawTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5742DE59E0900327F7F /* MultiDrawTest.cpp */; };
+		AE0000930000000000000000 /* MultisampleCompatibilityTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5752DE59E0900327F7F /* MultisampleCompatibilityTest.cpp */; };
+		AE0000940000000000000000 /* MultisampledRenderToTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5762DE59E0900327F7F /* MultisampledRenderToTextureTest.cpp */; };
+		AE0000950000000000000000 /* MultisampleTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5772DE59E0900327F7F /* MultisampleTest.cpp */; };
+		AE0000960000000000000000 /* MultithreadingTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5782DE59E0900327F7F /* MultithreadingTest.cpp */; };
+		AE0000970000000000000000 /* MultiThreadSteps.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF66A2DE5A8F100327F7F /* MultiThreadSteps.cpp */; };
+		AE0000980000000000000000 /* ObjectAllocationTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF57A2DE59E0900327F7F /* ObjectAllocationTest.cpp */; };
+		AE0000990000000000000000 /* OcclusionQueriesTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF57B2DE59E0900327F7F /* OcclusionQueriesTest.cpp */; };
+		AE00009A0000000000000000 /* OSWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BB971EB2DE468FE00455D13 /* OSWindow.cpp */; };
+		AE00009B0000000000000000 /* PackUnpackTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF57C2DE59E0900327F7F /* PackUnpackTest.cpp */; };
+		AE00009C0000000000000000 /* ParallelShaderCompileTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF57D2DE59E0900327F7F /* ParallelShaderCompileTest.cpp */; };
+		AE00009D0000000000000000 /* PBOExtensionTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF57E2DE59E0900327F7F /* PBOExtensionTest.cpp */; };
+		AE00009E0000000000000000 /* PbufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF57F2DE59E0900327F7F /* PbufferTest.cpp */; };
+		AE00009F0000000000000000 /* PixelLocalStorageTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5802DE59E0900327F7F /* PixelLocalStorageTest.cpp */; };
+		AE0000A00000000000000000 /* PixmapTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5812DE59E0900327F7F /* PixmapTest.cpp */; };
+		AE0000A10000000000000000 /* PointSpritesTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5822DE59E0900327F7F /* PointSpritesTest.cpp */; };
+		AE0000A20000000000000000 /* PolygonModeTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5832DE59E0900327F7F /* PolygonModeTest.cpp */; };
+		AE0000A30000000000000000 /* PolygonOffsetClampTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5842DE59E0900327F7F /* PolygonOffsetClampTest.cpp */; };
+		AE0000A40000000000000000 /* ProgramInterfaceTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5862DE59E0900327F7F /* ProgramInterfaceTest.cpp */; };
+		AE0000A50000000000000000 /* ProgramParameterTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5872DE59E0900327F7F /* ProgramParameterTest.cpp */; };
+		AE0000A60000000000000000 /* ProgramPipelineTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5882DE59E0900327F7F /* ProgramPipelineTest.cpp */; };
+		AE0000A70000000000000000 /* ProvokingVertexTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5892DE59E0900327F7F /* ProvokingVertexTest.cpp */; };
+		AE0000A80000000000000000 /* PVRTCCompressedTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF58A2DE59E0900327F7F /* PVRTCCompressedTextureTest.cpp */; };
+		AE0000A90000000000000000 /* QueryObjectValidation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF58B2DE59E0900327F7F /* QueryObjectValidation.cpp */; };
+		AE0000AA0000000000000000 /* ReadOnlyFeedbackLoopTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF58C2DE59E0900327F7F /* ReadOnlyFeedbackLoopTest.cpp */; };
+		AE0000AB0000000000000000 /* ReadPixelsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF58D2DE59E0900327F7F /* ReadPixelsTest.cpp */; };
+		AE0000AC0000000000000000 /* RenderbufferMultisampleTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF58E2DE59E0900327F7F /* RenderbufferMultisampleTest.cpp */; };
+		AE0000AD0000000000000000 /* RenderDoc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4D32DE49C3B00327F7F /* RenderDoc.cpp */; };
+		AE0000AE0000000000000000 /* RendererTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF58F2DE59E0900327F7F /* RendererTest.cpp */; };
+		AE0000AF0000000000000000 /* RequestExtensionTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5902DE59E0900327F7F /* RequestExtensionTest.cpp */; };
+		AE0000B00000000000000000 /* RobustBufferAccessBehaviorTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5912DE59E0900327F7F /* RobustBufferAccessBehaviorTest.cpp */; };
+		AE0000B10000000000000000 /* RobustClientMemoryTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5922DE59E0900327F7F /* RobustClientMemoryTest.cpp */; };
+		AE0000B20000000000000000 /* RobustFragmentShaderOutputTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5932DE59E0900327F7F /* RobustFragmentShaderOutputTest.cpp */; };
+		AE0000B30000000000000000 /* RobustResourceInitTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5942DE59E0900327F7F /* RobustResourceInitTest.cpp */; };
+		AE0000B40000000000000000 /* S3TCTextureSizesTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5952DE59E0900327F7F /* S3TCTextureSizesTest.cpp */; };
+		AE0000B50000000000000000 /* SamplersTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5962DE59E0900327F7F /* SamplersTest.cpp */; };
+		AE0000B60000000000000000 /* SampleVariablesTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5972DE59E0900327F7F /* SampleVariablesTest.cpp */; };
+		AE0000B70000000000000000 /* SemaphoreTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5982DE59E0900327F7F /* SemaphoreTest.cpp */; };
+		AE0000B80000000000000000 /* serialize_mock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BB973A92DE48EB000455D13 /* serialize_mock.cpp */; };
+		AE0000B90000000000000000 /* ShaderAlgorithmTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5992DE59E0900327F7F /* ShaderAlgorithmTest.cpp */; };
+		AE0000BA0000000000000000 /* ShaderBinaryTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF59A2DE59E0900327F7F /* ShaderBinaryTest.cpp */; };
+		AE0000BB0000000000000000 /* ShaderInterpTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF59B2DE59E0900327F7F /* ShaderInterpTest.cpp */; };
+		AE0000BC0000000000000000 /* ShaderMultisampleInterpolation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF59C2DE59E0900327F7F /* ShaderMultisampleInterpolation.cpp */; };
+		AE0000BD0000000000000000 /* ShaderNonConstGlobalInitializerTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF59D2DE59E0900327F7F /* ShaderNonConstGlobalInitializerTest.cpp */; };
+		AE0000BE0000000000000000 /* ShaderOpTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF59E2DE59E0900327F7F /* ShaderOpTest.cpp */; };
+		AE0000BF0000000000000000 /* ShaderStorageBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF59F2DE59E0900327F7F /* ShaderStorageBufferTest.cpp */; };
+		AE0000C00000000000000000 /* ShadingRateQcomTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5A02DE59E0900327F7F /* ShadingRateQcomTest.cpp */; };
+		AE0000C10000000000000000 /* ShadowSamplerFunctionsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5A12DE59E0900327F7F /* ShadowSamplerFunctionsTest.cpp */; };
+		AE0000C20000000000000000 /* SimpleOperationTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5A22DE59E0900327F7F /* SimpleOperationTest.cpp */; };
+		AE0000C30000000000000000 /* SixteenBppTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5A32DE59E0900327F7F /* SixteenBppTextureTest.cpp */; };
+		AE0000C40000000000000000 /* SRGBFramebufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5A42DE59E0900327F7F /* SRGBFramebufferTest.cpp */; };
+		AE0000C50000000000000000 /* SRGBTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5A52DE59E0900327F7F /* SRGBTextureTest.cpp */; };
+		AE0000C60000000000000000 /* StateChangeTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5A62DE59E0900327F7F /* StateChangeTest.cpp */; };
+		AE0000C70000000000000000 /* SwizzleTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5A72DE59E0900327F7F /* SwizzleTest.cpp */; };
+		AE0000C80000000000000000 /* system_info_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6662DE5A7A200327F7F /* system_info_util.cpp */; };
+		AE0000C90000000000000000 /* TestSuite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B8C09082F7E843B007E37DE /* TestSuite.cpp */; };
+		AE0000CA0000000000000000 /* TextureExternalUpdateTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5A92DE59E0900327F7F /* TextureExternalUpdateTest.cpp */; };
+		AE0000CB0000000000000000 /* TextureFixedRateCompressionTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5AA2DE59E0900327F7F /* TextureFixedRateCompressionTest.cpp */; };
+		AE0000CC0000000000000000 /* TextureMultisampleTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5AB2DE59E0900327F7F /* TextureMultisampleTest.cpp */; };
+		AE0000CD0000000000000000 /* TextureRectangleTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5AC2DE59E0900327F7F /* TextureRectangleTest.cpp */; };
+		AE0000CE0000000000000000 /* TextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5AD2DE59E0900327F7F /* TextureTest.cpp */; };
+		AE0000CF0000000000000000 /* TextureUploadFormatTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5AE2DE59E0900327F7F /* TextureUploadFormatTest.cpp */; };
+		AE0000D00000000000000000 /* TiledRenderingTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5AF2DE59E0900327F7F /* TiledRenderingTest.cpp */; };
+		AE0000D10000000000000000 /* TimeoutDrawTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5B02DE59E0900327F7F /* TimeoutDrawTest.cpp */; };
+		AE0000D20000000000000000 /* TimerQueriesTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5B12DE59E0900327F7F /* TimerQueriesTest.cpp */; };
+		AE0000D30000000000000000 /* TransformFeedbackTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5B22DE59E0900327F7F /* TransformFeedbackTest.cpp */; };
+		AE0000D40000000000000000 /* UniformBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5B32DE59E0900327F7F /* UniformBufferTest.cpp */; };
+		AE0000D50000000000000000 /* UniformTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5B42DE59E0900327F7F /* UniformTest.cpp */; };
+		AE0000D60000000000000000 /* UnpackAlignmentTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5B52DE59E0900327F7F /* UnpackAlignmentTest.cpp */; };
+		AE0000D70000000000000000 /* UnpackRowLength.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5B62DE59E0900327F7F /* UnpackRowLength.cpp */; };
+		AE0000D80000000000000000 /* VertexAttributeTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5B72DE59E0900327F7F /* VertexAttributeTest.cpp */; };
+		AE0000D90000000000000000 /* ViewportTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF5B82DE59E0900327F7F /* ViewportTest.cpp */; };
+		AE0000DA0000000000000000 /* WebGLCompatibilityTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF60F2DE59E2300327F7F /* WebGLCompatibilityTest.cpp */; };
+		AE0000DB0000000000000000 /* WebGLCompressedTextureAvailabilityTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6102DE59E2300327F7F /* WebGLCompressedTextureAvailabilityTest.cpp */; };
+		AE0000DC0000000000000000 /* WebGLFramebufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6112DE59E2300327F7F /* WebGLFramebufferTest.cpp */; };
+		AE0000DD0000000000000000 /* WebGLReadOutsideFramebufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6122DE59E2300327F7F /* WebGLReadOutsideFramebufferTest.cpp */; };
+		AE0000DE0000000000000000 /* WEBGLVideoTextureTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF6132DE59E2300327F7F /* WEBGLVideoTextureTest.cpp */; };
+		AE0000DF0000000000000000 /* libANGLE.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BB972002DE47B8A00455D13 /* libANGLE.a */; };
+		AE0000E00000000000000000 /* libgtest.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BDE1EFA2DED923F007E43DC /* libgtest.a */; };
+		AE0000E10000000000000000 /* libutils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BFAF8232DE6EADC00327F7F /* libutils.a */; };
+		AE0000130000000000000000 /* ANGLEEnd2EndTestsAppLaunch.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AE0000050000000000000000 /* ANGLEEnd2EndTestsAppLaunch.storyboard */; };
+		AE0000F10000000000000000 /* angle_end2end_tests_expectations.txt in CopyFiles */ = {isa = PBXBuildFile; fileRef = AE0000F00000000000000000 /* angle_end2end_tests_expectations.txt */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -1544,6 +1753,27 @@
 			remoteGlobalIDString = FFDA50C4269F845100AE11E2;
 			remoteInfo = ANGLEMetalLib;
 		};
+		AE0000100000000000000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7BFAF76C2DE6EADC00327F7F;
+			remoteInfo = utils;
+		};
+		AE0000120000000000000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7BB971FF2DE47B8A00455D13;
+			remoteInfo = "ANGLE (static)";
+		};
+		AE0001000000000000000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AE00000A0000000000000000;
+			remoteInfo = ANGLEEnd2EndTestsApp;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -1609,6 +1839,17 @@
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 1;
+		};
+		AE0000F20000000000000000 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "src/tests";
+			dstSubfolderSpec = 7;
+			files = (
+				AE0000F10000000000000000 /* angle_end2end_tests_expectations.txt in CopyFiles */,
+			);
+			name = "Copy Test Expectations";
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
@@ -2762,6 +3003,13 @@
 		FFD002AB2746E55F002BE3BC /* entry_points_gles_3_1_autogen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = entry_points_gles_3_1_autogen.h; sourceTree = "<group>"; };
 		FFDA50D6269F9E5800AE11E2 /* create_mtl_internal_shaders.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = create_mtl_internal_shaders.py; sourceTree = "<group>"; };
 		FFE0D91526A0B4E80071ADAE /* AngleMetalLib.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AngleMetalLib.xcconfig; sourceTree = "<group>"; };
+		AE0000010000000000000000 /* ANGLEEnd2EndTestsApp.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ANGLEEnd2EndTestsApp.xcconfig; sourceTree = "<group>"; };
+		AE0000020000000000000000 /* ANGLEEnd2EndTestsApp-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "ANGLEEnd2EndTestsApp-iOS.entitlements"; sourceTree = "<group>"; };
+		AE0000030000000000000000 /* ANGLEEnd2EndTestsApp-iOS-simulator.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "ANGLEEnd2EndTestsApp-iOS-simulator.entitlements"; sourceTree = "<group>"; };
+		AE0000040000000000000000 /* ANGLEEnd2EndTestsAppInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = ANGLEEnd2EndTestsAppInfo.plist; path = WebKit/ANGLEEnd2EndTestsAppInfo.plist; sourceTree = "<group>"; };
+		AE0000050000000000000000 /* ANGLEEnd2EndTestsAppLaunch.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = ANGLEEnd2EndTestsAppLaunch.storyboard; path = WebKit/ANGLEEnd2EndTestsAppLaunch.storyboard; sourceTree = "<group>"; };
+		AE0000060000000000000000 /* ANGLEEnd2EndTestsApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ANGLEEnd2EndTestsApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE0000F00000000000000000 /* angle_end2end_tests_expectations.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = angle_end2end_tests_expectations.txt; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2852,6 +3100,16 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AE0000080000000000000000 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AE0000DF0000000000000000 /* libANGLE.a in Frameworks */,
+				AE0000E00000000000000000 /* libgtest.a in Frameworks */,
+				AE0000E10000000000000000 /* libutils.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3675,6 +3933,9 @@
 				31CDFDEE24917F8900486F27 /* ANGLE-dynamic.xcconfig */,
 				7BB972052DE47BDC00455D13 /* ANGLE-static.xcconfig */,
 				7BB971C82DE463A800455D13 /* ANGLEEnd2EndTests.xcconfig */,
+				AE0000030000000000000000 /* ANGLEEnd2EndTestsApp-iOS-simulator.entitlements */,
+				AE0000020000000000000000 /* ANGLEEnd2EndTestsApp-iOS.entitlements */,
+				AE0000010000000000000000 /* ANGLEEnd2EndTestsApp.xcconfig */,
 				FFE0D91526A0B4E80071ADAE /* AngleMetalLib.xcconfig */,
 				7B9829372E0EB05200F1E9FB /* ANGLETranslator.xcconfig */,
 				7BF554C62C81EFF9002B101E /* ANGLETranslatorFuzzer.xcconfig */,
@@ -3713,6 +3974,8 @@
 			isa = PBXGroup;
 			children = (
 				7B359DF52A7CF7AF0016DC59 /* angle_commit.h */,
+				AE0000040000000000000000 /* ANGLEEnd2EndTestsAppInfo.plist */,
+				AE0000050000000000000000 /* ANGLEEnd2EndTestsAppLaunch.storyboard */,
 				7B359DF62A7CF7AF0016DC59 /* ANGLEShaderProgramVersion.h */,
 				7B820C762DE9956000DAC5E4 /* End2EndTestsSourcesPlatform.cpp */,
 				7B037F9529E98CF200D23E74 /* SourcesPlatform-mm.mm */,
@@ -3849,6 +4112,7 @@
 				7BB973AB2DE48EE300455D13 /* gl_tests */,
 				7BFAF4D52DE49CBA00327F7F /* test_expectations */,
 				7BFAF4B02DE4947900327F7F /* test_utils */,
+				AE0000F00000000000000000 /* angle_end2end_tests_expectations.txt */,
 				7BB971C32DE457E100455D13 /* angle_end2end_tests_main.cpp */,
 				7BFAF92B2DE6F99B00327F7F /* angle_unittest_main.cpp */,
 				7BFAF92C2DE6F99B00327F7F /* angle_unittests_utils.h */,
@@ -4319,6 +4583,7 @@
 				7BFAF7692DE6E9D900327F7F /* ANGLEUnitTests */,
 				7BFAF8232DE6EADC00327F7F /* libutils.a */,
 				7B533A8F2E0A933D0069B90F /* ANGLETranslator */,
+				AE0000060000000000000000 /* ANGLEEnd2EndTestsApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -5174,6 +5439,28 @@
 			productName = ANGLEMetalLib;
 			productType = "com.apple.product-type.metal-library";
 		};
+		AE00000A0000000000000000 /* ANGLEEnd2EndTestsApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AE00000B0000000000000000 /* Build configuration list for PBXNativeTarget "ANGLEEnd2EndTestsApp" */;
+			buildPhases = (
+				AE0000070000000000000000 /* Sources */,
+				AE0000080000000000000000 /* Frameworks */,
+				AE0000090000000000000000 /* Resources */,
+				AE0000F20000000000000000 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AE00000F0000000000000000 /* PBXTargetDependency */,
+				AE0000110000000000000000 /* PBXTargetDependency */,
+			);
+			name = ANGLEEnd2EndTestsApp;
+			packageProductDependencies = (
+			);
+			productName = ANGLEEnd2EndTestsApp;
+			productReference = AE0000060000000000000000 /* ANGLEEnd2EndTestsApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -5244,6 +5531,7 @@
 				7BE4AA532DE4544900A16F7E /* ANGLEEnd2EndTests */,
 				7BFAF6882DE6E9D900327F7F /* ANGLEUnitTests */,
 				7B533A852E0A933D0069B90F /* ANGLETranslator */,
+				AE00000A0000000000000000 /* ANGLEEnd2EndTestsApp */,
 			);
 		};
 /* End PBXProject section */
@@ -5253,6 +5541,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AE0000090000000000000000 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AE0000130000000000000000 /* ANGLEEnd2EndTestsAppLaunch.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6349,6 +6645,216 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AE0000070000000000000000 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AE0000140000000000000000 /* ActiveTextureCacheTest.cpp in Sources */,
+				AE0000150000000000000000 /* AdvancedBlendTest.cpp in Sources */,
+				AE0000160000000000000000 /* angle_end2end_tests_main.cpp in Sources */,
+				AE0000170000000000000000 /* angle_test_configs.cpp in Sources */,
+				AE0000180000000000000000 /* angle_test_instantiate.cpp in Sources */,
+				AE0000190000000000000000 /* angle_test_instantiate_apple.mm in Sources */,
+				AE00001A0000000000000000 /* angle_test_platform.cpp in Sources */,
+				AE00001B0000000000000000 /* ANGLETest.cpp in Sources */,
+				AE00001C0000000000000000 /* AtomicCounterBufferTest.cpp in Sources */,
+				AE00001D0000000000000000 /* AttributeLayoutTest.cpp in Sources */,
+				AE00001E0000000000000000 /* BaseInstanceOverflowTest.cpp in Sources */,
+				AE00001F0000000000000000 /* BindGeneratesResourceTest.cpp in Sources */,
+				AE0000200000000000000000 /* BindUniformLocationTest.cpp in Sources */,
+				AE0000210000000000000000 /* BlendFuncExtendedTest.cpp in Sources */,
+				AE0000220000000000000000 /* BlendIntegerTest.cpp in Sources */,
+				AE0000230000000000000000 /* BlendMinMaxTest.cpp in Sources */,
+				AE0000240000000000000000 /* BlendPackedTest.cpp in Sources */,
+				AE0000250000000000000000 /* BlitFramebufferANGLETest.cpp in Sources */,
+				AE0000260000000000000000 /* BlobCacheTest.cpp in Sources */,
+				AE0000270000000000000000 /* BPTCCompressedTextureTest.cpp in Sources */,
+				AE0000280000000000000000 /* BufferDataTest.cpp in Sources */,
+				AE0000290000000000000000 /* BufferPoolTestMetal.mm in Sources */,
+				AE00002A0000000000000000 /* BuiltinVariableTest.cpp in Sources */,
+				AE00002B0000000000000000 /* ClearTest.cpp in Sources */,
+				AE00002C0000000000000000 /* ClientArraysTest.cpp in Sources */,
+				AE00002D0000000000000000 /* ClipControlTest.cpp in Sources */,
+				AE00002E0000000000000000 /* ClipDistanceTest.cpp in Sources */,
+				AE00002F0000000000000000 /* ColorMaskTest.cpp in Sources */,
+				AE0000300000000000000000 /* CompressedTextureFormatsTest.cpp in Sources */,
+				AE0000310000000000000000 /* ComputeShaderTest.cpp in Sources */,
+				AE0000320000000000000000 /* ContextLostTest.cpp in Sources */,
+				AE0000330000000000000000 /* ContextNoErrorTest.cpp in Sources */,
+				AE0000340000000000000000 /* CopyCompressedTextureTest.cpp in Sources */,
+				AE0000350000000000000000 /* CopyTexImageTest.cpp in Sources */,
+				AE0000360000000000000000 /* CopyTexture3DTest.cpp in Sources */,
+				AE0000370000000000000000 /* CopyTextureTest.cpp in Sources */,
+				AE0000380000000000000000 /* CubeMapTextureTest.cpp in Sources */,
+				AE0000390000000000000000 /* DebugMarkerTest.cpp in Sources */,
+				AE00003A0000000000000000 /* DebugTest.cpp in Sources */,
+				AE00003B0000000000000000 /* DepthStencilFormatsTest.cpp in Sources */,
+				AE00003C0000000000000000 /* DepthStencilTest.cpp in Sources */,
+				AE00003D0000000000000000 /* DepthWriteTest.cpp in Sources */,
+				AE00003E0000000000000000 /* DifferentStencilMasksTest.cpp in Sources */,
+				AE00003F0000000000000000 /* DiscardFramebufferEXTTest.cpp in Sources */,
+				AE0000400000000000000000 /* DrawBaseVertexBaseInstanceTest.cpp in Sources */,
+				AE0000410000000000000000 /* DrawBaseVertexVariantsTest.cpp in Sources */,
+				AE0000420000000000000000 /* DrawBuffersTest.cpp in Sources */,
+				AE0000430000000000000000 /* DrawElementsIndirectTest.cpp in Sources */,
+				AE0000440000000000000000 /* DrawElementsTest.cpp in Sources */,
+				AE0000450000000000000000 /* DrawRangeElementsTest.cpp in Sources */,
+				AE0000460000000000000000 /* DXT1CompressedTextureTest.cpp in Sources */,
+				AE0000470000000000000000 /* DXTSRGBCompressedTextureTest.cpp in Sources */,
+				AE0000480000000000000000 /* EGLBackwardsCompatibleContextTest.cpp in Sources */,
+				AE0000490000000000000000 /* EGLBlobCacheTest.cpp in Sources */,
+				AE00004A0000000000000000 /* EGLBufferAgeTest.cpp in Sources */,
+				AE00004B0000000000000000 /* EGLChooseConfigTest.cpp in Sources */,
+				AE00004C0000000000000000 /* EGLContextASANTest.cpp in Sources */,
+				AE00004D0000000000000000 /* EGLContextCompatibilityTest.cpp in Sources */,
+				AE00004E0000000000000000 /* EGLContextSharingTest.cpp in Sources */,
+				AE00004F0000000000000000 /* EGLCreateContextAttribsTest.cpp in Sources */,
+				AE0000500000000000000000 /* EGLDebugTest.cpp in Sources */,
+				AE0000510000000000000000 /* EGLDisplaySelectionTest.cpp in Sources */,
+				AE0000520000000000000000 /* EGLDisplayTest.cpp in Sources */,
+				AE0000530000000000000000 /* EGLFeatureControlTest.cpp in Sources */,
+				AE0000540000000000000000 /* EGLIOSurfaceClientBufferTest.cpp in Sources */,
+				AE0000550000000000000000 /* EGLLockSurface3Test.cpp in Sources */,
+				AE0000560000000000000000 /* EGLMemoryUsageReportTest.cpp in Sources */,
+				AE0000570000000000000000 /* EGLMultiContextTest.cpp in Sources */,
+				AE0000580000000000000000 /* EGLNoConfigContextTest.cpp in Sources */,
+				AE0000590000000000000000 /* EGLNoErrorTest.cpp in Sources */,
+				AE00005A0000000000000000 /* EGLPrintEGLinfoTest.cpp in Sources */,
+				AE00005B0000000000000000 /* EGLProgramCacheControlTest.cpp in Sources */,
+				AE00005C0000000000000000 /* EGLProtectedContentTest.cpp in Sources */,
+				AE00005D0000000000000000 /* EGLQueryContextTest.cpp in Sources */,
+				AE00005E0000000000000000 /* EGLReadinessCheckTest.cpp in Sources */,
+				AE00005F0000000000000000 /* EGLRecordableTest.cpp in Sources */,
+				AE0000600000000000000000 /* EGLRobustnessTest.cpp in Sources */,
+				AE0000610000000000000000 /* EGLSurfacelessContextTest.cpp in Sources */,
+				AE0000620000000000000000 /* EGLSurfaceTest.cpp in Sources */,
+				AE0000630000000000000000 /* EGLSyncTest.cpp in Sources */,
+				AE0000640000000000000000 /* EGLSyncTestMetalSharedEvent.mm in Sources */,
+				AE0000650000000000000000 /* EGLWaitUntilWorkScheduledTest.cpp in Sources */,
+				AE0000660000000000000000 /* End2EndTestsSourcesPlatform.cpp in Sources */,
+				AE0000670000000000000000 /* ErrorMessages.cpp in Sources */,
+				AE0000680000000000000000 /* ETCTextureTest.cpp in Sources */,
+				AE0000690000000000000000 /* ExternalBufferTest.cpp in Sources */,
+				AE00006A0000000000000000 /* ExternalWrapTest.cpp in Sources */,
+				AE00006B0000000000000000 /* FenceSyncTests.cpp in Sources */,
+				AE00006C0000000000000000 /* FloatingPointSurfaceTest.cpp in Sources */,
+				AE00006D0000000000000000 /* FormatPrintTest.cpp in Sources */,
+				AE00006E0000000000000000 /* FragDepthTest.cpp in Sources */,
+				AE00006F0000000000000000 /* FramebufferFetchTest.cpp in Sources */,
+				AE0000700000000000000000 /* FramebufferMixedSamplesTest.cpp in Sources */,
+				AE0000710000000000000000 /* FramebufferRenderMipmapTest.cpp in Sources */,
+				AE0000720000000000000000 /* FramebufferTest.cpp in Sources */,
+				AE0000730000000000000000 /* FrameCapture_mock.cpp in Sources */,
+				AE0000740000000000000000 /* GeometryShaderTest.cpp in Sources */,
+				AE0000750000000000000000 /* GetTexLevelParameterTest.cpp in Sources */,
+				AE0000760000000000000000 /* gl_enum_utils.cpp in Sources */,
+				AE0000770000000000000000 /* gl_enum_utils_autogen.cpp in Sources */,
+				AE0000780000000000000000 /* GLSLConstantFoldingTest.cpp in Sources */,
+				AE0000790000000000000000 /* GLSLOutputTest.cpp in Sources */,
+				AE00007A0000000000000000 /* GLSLTest.cpp in Sources */,
+				AE00007B0000000000000000 /* GLSLUBTest.cpp in Sources */,
+				AE00007C0000000000000000 /* GLSLValidationTest.cpp in Sources */,
+				AE00007D0000000000000000 /* GPUTestConfig.cpp in Sources */,
+				AE00007E0000000000000000 /* GPUTestExpectationsParser.cpp in Sources */,
+				AE00007F0000000000000000 /* GPUTestExpectationsTest.cpp in Sources */,
+				AE0000800000000000000000 /* ImageTest.cpp in Sources */,
+				AE0000810000000000000000 /* ImageTestMetal.mm in Sources */,
+				AE0000820000000000000000 /* IncompatibleTextureTest.cpp in Sources */,
+				AE0000830000000000000000 /* IncompleteTextureTest.cpp in Sources */,
+				AE0000840000000000000000 /* IndexBufferOffsetTest.cpp in Sources */,
+				AE0000850000000000000000 /* IndexedPointsTest.cpp in Sources */,
+				AE0000860000000000000000 /* InstancingTest.cpp in Sources */,
+				AE0000870000000000000000 /* KTXCompressedTextureTest.cpp in Sources */,
+				AE0000880000000000000000 /* libEGL_autogen.cpp in Sources */,
+				AE0000890000000000000000 /* libGLESv2_autogen.cpp in Sources */,
+				AE00008A0000000000000000 /* LineLoopTest.cpp in Sources */,
+				AE00008B0000000000000000 /* LinkAndRelinkTest.cpp in Sources */,
+				AE00008C0000000000000000 /* MatrixTest.cpp in Sources */,
+				AE00008D0000000000000000 /* MaxTextureSizeTest.cpp in Sources */,
+				AE00008E0000000000000000 /* MemoryBarrierTest.cpp in Sources */,
+				AE00008F0000000000000000 /* MemoryObjectTest.cpp in Sources */,
+				AE0000900000000000000000 /* MemorySizeTest.cpp in Sources */,
+				AE0000910000000000000000 /* MipmapTest.cpp in Sources */,
+				AE0000920000000000000000 /* MultiDrawTest.cpp in Sources */,
+				AE0000930000000000000000 /* MultisampleCompatibilityTest.cpp in Sources */,
+				AE0000940000000000000000 /* MultisampledRenderToTextureTest.cpp in Sources */,
+				AE0000950000000000000000 /* MultisampleTest.cpp in Sources */,
+				AE0000960000000000000000 /* MultithreadingTest.cpp in Sources */,
+				AE0000970000000000000000 /* MultiThreadSteps.cpp in Sources */,
+				AE0000980000000000000000 /* ObjectAllocationTest.cpp in Sources */,
+				AE0000990000000000000000 /* OcclusionQueriesTest.cpp in Sources */,
+				AE00009A0000000000000000 /* OSWindow.cpp in Sources */,
+				AE00009B0000000000000000 /* PackUnpackTest.cpp in Sources */,
+				AE00009C0000000000000000 /* ParallelShaderCompileTest.cpp in Sources */,
+				AE00009D0000000000000000 /* PBOExtensionTest.cpp in Sources */,
+				AE00009E0000000000000000 /* PbufferTest.cpp in Sources */,
+				AE00009F0000000000000000 /* PixelLocalStorageTest.cpp in Sources */,
+				AE0000A00000000000000000 /* PixmapTest.cpp in Sources */,
+				AE0000A10000000000000000 /* PointSpritesTest.cpp in Sources */,
+				AE0000A20000000000000000 /* PolygonModeTest.cpp in Sources */,
+				AE0000A30000000000000000 /* PolygonOffsetClampTest.cpp in Sources */,
+				AE0000A40000000000000000 /* ProgramInterfaceTest.cpp in Sources */,
+				AE0000A50000000000000000 /* ProgramParameterTest.cpp in Sources */,
+				AE0000A60000000000000000 /* ProgramPipelineTest.cpp in Sources */,
+				AE0000A70000000000000000 /* ProvokingVertexTest.cpp in Sources */,
+				AE0000A80000000000000000 /* PVRTCCompressedTextureTest.cpp in Sources */,
+				AE0000A90000000000000000 /* QueryObjectValidation.cpp in Sources */,
+				AE0000AA0000000000000000 /* ReadOnlyFeedbackLoopTest.cpp in Sources */,
+				AE0000AB0000000000000000 /* ReadPixelsTest.cpp in Sources */,
+				AE0000AC0000000000000000 /* RenderbufferMultisampleTest.cpp in Sources */,
+				AE0000AD0000000000000000 /* RenderDoc.cpp in Sources */,
+				AE0000AE0000000000000000 /* RendererTest.cpp in Sources */,
+				AE0000AF0000000000000000 /* RequestExtensionTest.cpp in Sources */,
+				AE0000B00000000000000000 /* RobustBufferAccessBehaviorTest.cpp in Sources */,
+				AE0000B10000000000000000 /* RobustClientMemoryTest.cpp in Sources */,
+				AE0000B20000000000000000 /* RobustFragmentShaderOutputTest.cpp in Sources */,
+				AE0000B30000000000000000 /* RobustResourceInitTest.cpp in Sources */,
+				AE0000B40000000000000000 /* S3TCTextureSizesTest.cpp in Sources */,
+				AE0000B50000000000000000 /* SamplersTest.cpp in Sources */,
+				AE0000B60000000000000000 /* SampleVariablesTest.cpp in Sources */,
+				AE0000B70000000000000000 /* SemaphoreTest.cpp in Sources */,
+				AE0000B80000000000000000 /* serialize_mock.cpp in Sources */,
+				AE0000B90000000000000000 /* ShaderAlgorithmTest.cpp in Sources */,
+				AE0000BA0000000000000000 /* ShaderBinaryTest.cpp in Sources */,
+				AE0000BB0000000000000000 /* ShaderInterpTest.cpp in Sources */,
+				AE0000BC0000000000000000 /* ShaderMultisampleInterpolation.cpp in Sources */,
+				AE0000BD0000000000000000 /* ShaderNonConstGlobalInitializerTest.cpp in Sources */,
+				AE0000BE0000000000000000 /* ShaderOpTest.cpp in Sources */,
+				AE0000BF0000000000000000 /* ShaderStorageBufferTest.cpp in Sources */,
+				AE0000C00000000000000000 /* ShadingRateQcomTest.cpp in Sources */,
+				AE0000C10000000000000000 /* ShadowSamplerFunctionsTest.cpp in Sources */,
+				AE0000C20000000000000000 /* SimpleOperationTest.cpp in Sources */,
+				AE0000C30000000000000000 /* SixteenBppTextureTest.cpp in Sources */,
+				AE0000C40000000000000000 /* SRGBFramebufferTest.cpp in Sources */,
+				AE0000C50000000000000000 /* SRGBTextureTest.cpp in Sources */,
+				AE0000C60000000000000000 /* StateChangeTest.cpp in Sources */,
+				AE0000C70000000000000000 /* SwizzleTest.cpp in Sources */,
+				AE0000C80000000000000000 /* system_info_util.cpp in Sources */,
+				AE0000C90000000000000000 /* TestSuite.cpp in Sources */,
+				AE0000CA0000000000000000 /* TextureExternalUpdateTest.cpp in Sources */,
+				AE0000CB0000000000000000 /* TextureFixedRateCompressionTest.cpp in Sources */,
+				AE0000CC0000000000000000 /* TextureMultisampleTest.cpp in Sources */,
+				AE0000CD0000000000000000 /* TextureRectangleTest.cpp in Sources */,
+				AE0000CE0000000000000000 /* TextureTest.cpp in Sources */,
+				AE0000CF0000000000000000 /* TextureUploadFormatTest.cpp in Sources */,
+				AE0000D00000000000000000 /* TiledRenderingTest.cpp in Sources */,
+				AE0000D10000000000000000 /* TimeoutDrawTest.cpp in Sources */,
+				AE0000D20000000000000000 /* TimerQueriesTest.cpp in Sources */,
+				AE0000D30000000000000000 /* TransformFeedbackTest.cpp in Sources */,
+				AE0000D40000000000000000 /* UniformBufferTest.cpp in Sources */,
+				AE0000D50000000000000000 /* UniformTest.cpp in Sources */,
+				AE0000D60000000000000000 /* UnpackAlignmentTest.cpp in Sources */,
+				AE0000D70000000000000000 /* UnpackRowLength.cpp in Sources */,
+				AE0000D80000000000000000 /* VertexAttributeTest.cpp in Sources */,
+				AE0000D90000000000000000 /* ViewportTest.cpp in Sources */,
+				AE0000DA0000000000000000 /* WebGLCompatibilityTest.cpp in Sources */,
+				AE0000DB0000000000000000 /* WebGLCompressedTextureAvailabilityTest.cpp in Sources */,
+				AE0000DC0000000000000000 /* WebGLFramebufferTest.cpp in Sources */,
+				AE0000DD0000000000000000 /* WebGLReadOutsideFramebufferTest.cpp in Sources */,
+				AE0000DE0000000000000000 /* WEBGLVideoTextureTest.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -6441,6 +6947,21 @@
 			isa = PBXTargetDependency;
 			target = FFDA50C4269F845100AE11E2 /* ANGLEMetalLib */;
 			targetProxy = FF194FF52744331A006A97A3 /* PBXContainerItemProxy */;
+		};
+		AE00000F0000000000000000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7BFAF76C2DE6EADC00327F7F /* utils */;
+			targetProxy = AE0000100000000000000000 /* PBXContainerItemProxy */;
+		};
+		AE0000110000000000000000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7BB971FF2DE47B8A00455D13 /* ANGLE (static) */;
+			targetProxy = AE0000120000000000000000 /* PBXContainerItemProxy */;
+		};
+		AE0001000000000000000002 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AE00000A0000000000000000 /* ANGLEEnd2EndTestsApp */;
+			targetProxy = AE0001000000000000000001 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -6780,6 +7301,27 @@
 			};
 			name = Production;
 		};
+		AE00000C0000000000000000 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AE0000010000000000000000 /* ANGLEEnd2EndTestsApp.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		AE00000D0000000000000000 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AE0000010000000000000000 /* ANGLEEnd2EndTestsApp.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		AE00000E0000000000000000 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AE0000010000000000000000 /* ANGLEEnd2EndTestsApp.xcconfig */;
+			buildSettings = {
+			};
+			name = Production;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -6939,6 +7481,16 @@
 				FFDA50C8269F845100AE11E2 /* Debug */,
 				FFDA50C9269F845100AE11E2 /* Release */,
 				FFDA50CA269F845100AE11E2 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		AE00000B0000000000000000 /* Build configuration list for PBXNativeTarget "ANGLEEnd2EndTestsApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AE00000C0000000000000000 /* Debug */,
+				AE00000D0000000000000000 /* Release */,
+				AE00000E0000000000000000 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;

--- a/Source/ThirdParty/ANGLE/Configurations/ANGLEEnd2EndTestsApp-iOS-simulator.entitlements
+++ b/Source/ThirdParty/ANGLE/Configurations/ANGLEEnd2EndTestsApp-iOS-simulator.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/ThirdParty/ANGLE/Configurations/ANGLEEnd2EndTestsApp-iOS.entitlements
+++ b/Source/ThirdParty/ANGLE/Configurations/ANGLEEnd2EndTestsApp-iOS.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/ThirdParty/ANGLE/Configurations/ANGLEEnd2EndTestsApp.xcconfig
+++ b/Source/ThirdParty/ANGLE/Configurations/ANGLEEnd2EndTestsApp.xcconfig
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "BaseTarget.xcconfig"
+
+PRODUCT_NAME = ANGLEEnd2EndTestsApp;
+PRODUCT_BUNDLE_IDENTIFIER = org.webkit.$(PRODUCT_NAME:rfc1034identifier);
+
+// Restrict to iOS-family platforms. Xcode will skip this target with the
+// message "target's SUPPORTED_PLATFORMS does not match the current platform"
+// when building for macosx or maccatalyst.
+SUPPORTED_PLATFORMS = iphoneos iphonesimulator appletvos appletvsimulator xros xrsimulator;
+SUPPORTS_MACCATALYST = NO;
+SKIP_INSTALL[sdk=macosx*] = YES;
+
+WRAPPER_EXTENSION = app;
+INFOPLIST_FILE = $(SRCROOT)/WebKit/ANGLEEnd2EndTestsAppInfo.plist;
+
+TARGETED_DEVICE_FAMILY = 1,2,3,4,7;
+
+// Same compile environment as ANGLEEnd2EndTests.xcconfig.
+ALTERNATE_HEADER_SEARCH_PATHS = $(ALTERNATE_HEADER_SEARCH_PATHS_$(SDK_VARIANT));
+ALTERNATE_HEADER_SEARCH_PATHS_iosmac = $(BUILT_PRODUCTS_DIR)$(WK_ALTERNATE_FRAMEWORKS_DIR)/usr/local/include
+
+HEADER_SEARCH_PATHS = $(ALTERNATE_HEADER_SEARCH_PATHS) ${BUILT_PRODUCTS_DIR}/usr/local/include $(ANGLE_HEADER_PATH_PREFIX)/src/tests/ $(inherited);
+GCC_PREPROCESSOR_DEFINITIONS = EGL_EGLEXT_PROTOTYPES=1 GL_GLES_PROTOTYPES=1 GL_GLEXT_PROTOTYPES=1 ANGLE_EGL_LIBRARY_NAME=\"\" ANGLE_GLESV2_LIBRARY_NAME=\"\" ANGLE_MESA_EGL_LIBRARY_NAME=\"mesa-libEGL\" ANGLE_MESA_GLESV2_LIBRARY_NAME=\"mesa-libGLESv2\" ANGLE_VULKAN_SECONDARIES_EGL_LIBRARY_NAME=\"vk-libEGL\" ANGLE_VULKAN_SECONDARIES_GLESV2_LIBRARY_NAME=\"vk-libGLESv2\" $(inherited);
+
+// Use ios_main (in util/ios/ios_main.mm, already linked via libutils.a) as the
+// binary entry point so UIKit is initialized before the gtest main runs.
+// Mirrors angle_root/util/ios/ios_main.mm wiring in upstream gni/angle.gni.
+ANGLE_OTHER_LDFLAGS = -framework QuartzCore -framework CoreGraphics -framework Foundation -framework IOSurface -framework Metal -framework UIKit -lz -Wl,-e,_ios_main;
+// Although SUPPORTED_PLATFORMS excludes macosx, xcodebuild still walks this
+// target as a dependency of the Tools (ANGLE) aggregate when building for
+// macOS.  Swap UIKit/iOS entry for the macOS framework set used by
+// libutils/libgtest, and force ARCHS to arm64e to match those libs.
+// Mirrors WebKitTestRunnerApp's no-op-on-macOS approach.
+ANGLE_OTHER_LDFLAGS[sdk=macosx*] = -framework AppKit -framework QuartzCore -framework CoreGraphics -framework Foundation -framework IOKit -framework IOSurface -framework Metal -lz;
+ARCHS[sdk=macosx*] = arm64e;
+
+// Disable the Xcode 16+ debug-dylib stub-executor pattern. The stub's entry is
+// fixed and ignores OTHER_LDFLAGS=-e, which would silently strand UIKit init.
+ENABLE_DEBUG_DYLIB = NO;
+
+CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*] = Configurations/ANGLEEnd2EndTestsApp-iOS-simulator.entitlements;
+CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]        = Configurations/ANGLEEnd2EndTestsApp-iOS.entitlements;
+CODE_SIGN_ENTITLEMENTS[sdk=appletv*]         = Configurations/ANGLEEnd2EndTestsApp-iOS.entitlements;
+CODE_SIGN_ENTITLEMENTS[sdk=xr*]              = Configurations/ANGLEEnd2EndTestsApp-iOS.entitlements;
+
+WARNING_CFLAGS = $(inherited) -Wno-global-constructors;
+GCC_WARN_64_TO_32_BIT_CONVERSION = NO;

--- a/Source/ThirdParty/ANGLE/WebKit/ANGLEEnd2EndTestsAppInfo.plist
+++ b/Source/ThirdParty/ANGLE/WebKit/ANGLEEnd2EndTestsAppInfo.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>ANGLEEnd2EndTestsAppLaunch</string>
+	<key>UIRequiresFullScreen</key>
+	<true/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Source/ThirdParty/ANGLE/WebKit/ANGLEEnd2EndTestsAppLaunch.storyboard
+++ b/Source/ThirdParty/ANGLE/WebKit/ANGLEEnd2EndTestsAppLaunch.storyboard
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/Source/ThirdParty/ANGLE/WebKit/run-angle-tests
+++ b/Source/ThirdParty/ANGLE/WebKit/run-angle-tests
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+"""Run ANGLE end-to-end tests locally on macOS, on an iOS simulator/device,
+or on a visionOS device.
+
+Forwards any unrecognized flags (e.g. --gtest_filter, --gtest_list_tests)
+straight to the test binary/app. With --lldb, runs under lldb (on local mac
+and simulator this auto-attaches; on device prints instructions). With
+--per-suite, runs each test suite separately to identify (and optionally
+isolate) crashing tests. Defaults to the Debug build directory; pass
+--release for Release.
+
+Examples:
+    run-angle-tests
+    run-angle-tests --release
+    run-angle-tests --gtest_filter='ClearTestES3.*'
+    run-angle-tests --simulator --gtest_list_tests
+    run-angle-tests --ios-device CE42FB0C-... --no-install
+    run-angle-tests --xros-device --gtest_filter='*Metal*'
+    run-angle-tests --lldb --gtest_filter='ClearTestES3.ClearMaxAttachments/ES3_Metal'
+    run-angle-tests --per-suite
+    run-angle-tests --ios-device --per-suite --suites-only
+"""
+
+import argparse
+import json
+import os
+import plistlib
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_TIMEOUT = 120
+
+
+def default_paths(config):
+    """Return mode → default path mapping for the given build config."""
+    return {
+        "mac":       f"WebKitBuild/{config}/ANGLEEnd2EndTests",
+        "simulator": f"WebKitBuild/{config}-iphonesimulator/ANGLEEnd2EndTestsApp.app",
+        "ios":       f"WebKitBuild/{config}-iphoneos/ANGLEEnd2EndTestsApp.app",
+        "xros":      f"WebKitBuild/{config}-xros/ANGLEEnd2EndTestsApp.app",
+    }
+
+
+def read_bundle_id(app_path):
+    with (app_path / "Info.plist").open("rb") as f:
+        return plistlib.load(f)["CFBundleIdentifier"]
+
+
+def is_crash(returncode):
+    # gtest exits 0 on pass, 1 on test failure; anything else (signals show as
+    # 128+sig or negative) means the process aborted.
+    if returncode is None:
+        return False
+    return returncode > 1 or returncode < 0
+
+
+# ---------------------------------------------------------------------------
+# Local macOS
+# ---------------------------------------------------------------------------
+
+class LocalRunner:
+    """Runs the test binary directly on the local machine."""
+
+    def __init__(self, executable):
+        self.executable = Path(executable)
+
+    def install(self):
+        pass  # no install step for local binaries
+
+    def launch(self, gtest_args):
+        return subprocess.call([str(self.executable), *gtest_args])
+
+    def run_capturing(self, gtest_args, timeout):
+        try:
+            result = subprocess.run(
+                [str(self.executable), *gtest_args],
+                capture_output=True, text=True, timeout=timeout,
+            )
+            return result.returncode, result.stdout
+        except subprocess.TimeoutExpired:
+            return None, ""
+
+    def format_command(self, filter_str):
+        return (f"{shlex.quote(str(self.executable))} "
+                f"--gtest_filter={shlex.quote(filter_str)}")
+
+    def launch_for_debug(self, gtest_args):
+        # Replace this process with lldb so the user gets the prompt directly.
+        os.execvp("lldb", ["lldb", "--", str(self.executable), *gtest_args])
+
+
+# ---------------------------------------------------------------------------
+# Simulator
+# ---------------------------------------------------------------------------
+
+class SimulatorRunner:
+    def __init__(self, app_path, device, bundle_id):
+        self.app_path = app_path
+        self.device = device
+        self.bundle_id = bundle_id
+
+    def install(self):
+        print(f"Installing on simulator {self.device} ...")
+        subprocess.run(
+            ["xcrun", "simctl", "install", self.device, str(self.app_path)],
+            check=True,
+        )
+
+    def launch(self, gtest_args):
+        cmd = [
+            "xcrun", "simctl", "launch",
+            "--console", "--terminate-running-process",
+            self.device, self.bundle_id, *gtest_args,
+        ]
+        return subprocess.call(cmd)
+
+    def run_capturing(self, gtest_args, timeout):
+        cmd = [
+            "xcrun", "simctl", "launch",
+            "--console", "--terminate-running-process",
+            self.device, self.bundle_id, *gtest_args,
+        ]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            return result.returncode, result.stdout
+        except subprocess.TimeoutExpired:
+            subprocess.run(
+                ["xcrun", "simctl", "terminate", self.device, self.bundle_id],
+                capture_output=True,
+            )
+            return None, ""
+
+    def format_command(self, filter_str):
+        return (
+            f"xcrun simctl launch --console --terminate-running-process "
+            f"{self.device} {self.bundle_id} "
+            f"--gtest_filter={shlex.quote(filter_str)}"
+        )
+
+    def launch_for_debug(self, gtest_args):
+        log_dir = Path(tempfile.mkdtemp(prefix="run-gtest-"))
+        stdout_log = log_dir / "stdout.log"
+        stderr_log = log_dir / "stderr.log"
+        cmd = [
+            "xcrun", "simctl", "launch",
+            "--wait-for-debugger", "--terminate-running-process",
+            f"--stdout={stdout_log}", f"--stderr={stderr_log}",
+            self.device, self.bundle_id, *gtest_args,
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        # simctl prints "org.webkit.ANGLEEnd2EndTestApp: 12345"
+        m = re.search(r"\b(\d+)\s*$", proc.stdout.strip())
+        if not m:
+            print(f"Could not parse PID from simctl output:\n{proc.stdout}",
+                  file=sys.stderr)
+            sys.exit(1)
+        pid = int(m.group(1))
+        print(f"App suspended at entry (waiting for debugger).")
+        print(f"  PID:    {pid}")
+        print(f"  stdout: {stdout_log}")
+        print(f"  stderr: {stderr_log}")
+        print(f"  (run `tail -f {stdout_log}` in another terminal to watch output)")
+        print(f"Attaching lldb ...")
+        # Replace this process with lldb so the user gets the prompt directly.
+        os.execvp("lldb", ["lldb", "-p", str(pid), "-o", "continue"])
+
+
+class DeviceRunner:
+    def __init__(self, app_path, device, bundle_id):
+        self.app_path = app_path
+        self.device = device  # may be None until resolved
+        self.bundle_id = bundle_id
+
+    @staticmethod
+    def _list_devices_json():
+        proc = subprocess.run(
+            ["xcrun", "devicectl", "list", "devices", "--json-output", "-"],
+            capture_output=True, text=True,
+        )
+        if proc.returncode != 0:
+            print(proc.stderr, file=sys.stderr)
+            sys.exit(proc.returncode)
+        return json.loads(proc.stdout)
+
+    @staticmethod
+    def _is_usable(d):
+        cp = d.get("connectionProperties", {})
+        return (cp.get("transportType") is not None
+                and cp.get("tunnelState") != "unavailable")
+
+    def resolve_device(self):
+        if self.device:
+            return
+        data = self._list_devices_json()
+        usable = [d for d in data.get("result", {}).get("devices", []) if self._is_usable(d)]
+        if not usable:
+            print("Error: no paired/reachable iOS device found.", file=sys.stderr)
+            sys.exit(1)
+        if len(usable) > 1:
+            print("Error: multiple usable devices found; pass --device <udid>:",
+                  file=sys.stderr)
+            for d in usable:
+                name = d.get("deviceProperties", {}).get("name", "?")
+                print(f"   {d['identifier']}  {name}", file=sys.stderr)
+            sys.exit(1)
+        self.device = usable[0]["identifier"]
+
+    def install(self):
+        self.resolve_device()
+        print(f"Installing on device {self.device} ...")
+        proc = subprocess.run(
+            ["xcrun", "devicectl", "device", "install", "app",
+             "--device", self.device, str(self.app_path)],
+            capture_output=True, text=True,
+        )
+        if proc.returncode != 0:
+            sys.stderr.write(proc.stderr)
+            blob = proc.stderr + proc.stdout
+            if "DeviceLocked" in blob or "device is locked" in blob.lower():
+                print("\nHint: unlock the device, then re-run.", file=sys.stderr)
+            sys.exit(proc.returncode)
+
+    def launch(self, gtest_args):
+        self.resolve_device()
+        cmd = [
+            "xcrun", "devicectl", "device", "process", "launch",
+            "--device", self.device,
+            "--console", "--terminate-existing",
+            self.bundle_id, *gtest_args,
+        ]
+        return subprocess.call(cmd)
+
+    def run_capturing(self, gtest_args, timeout):
+        self.resolve_device()
+        cmd = [
+            "xcrun", "devicectl", "device", "process", "launch",
+            "--device", self.device,
+            "--console", "--terminate-existing",
+            self.bundle_id, *gtest_args,
+        ]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            return result.returncode, result.stdout
+        except subprocess.TimeoutExpired:
+            # devicectl has no simple "terminate by bundle id"; the next launch's
+            # --terminate-existing will clean up any leftover instance.
+            return None, ""
+
+    def format_command(self, filter_str):
+        return (
+            f"xcrun devicectl device process launch --device {self.device} "
+            f"--console --terminate-existing {self.bundle_id} "
+            f"--gtest_filter={shlex.quote(filter_str)}"
+        )
+
+    def launch_for_debug(self, gtest_args):
+        self.resolve_device()
+        # --start-stopped suspends the app immediately after launch so a
+        # debugger can attach before any user code runs.
+        cmd = [
+            "xcrun", "devicectl", "device", "process", "launch",
+            "--device", self.device,
+            "--start-stopped", "--terminate-existing",
+            self.bundle_id, *gtest_args,
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        # devicectl prints something like "Launched application ... with process identifier 1234"
+        m = re.search(r"process identifier[:\s]+(\d+)", proc.stdout, re.IGNORECASE)
+        if not m:
+            print(f"Could not parse PID from devicectl output:\n{proc.stdout}",
+                  file=sys.stderr)
+            sys.exit(1)
+        pid = int(m.group(1))
+        print(f"App launched and suspended.")
+        print(f"  Device: {self.device}")
+        print(f"  PID:    {pid}")
+        print()
+        print("CLI lldb attach on a real device requires debugserver, which")
+        print("Xcode normally runs for you. Easiest path:")
+        print()
+        print(f"  1. Open Xcode → Debug → Attach to Process by PID or Name… → "
+              f"enter PID {pid}")
+        print(f"  2. Or: open the .app's Xcode project (ANGLE.xcodeproj), "
+              f"set ANGLEEnd2EndTestApp scheme, then Debug → Attach to Process")
+        print()
+        print("To resume the app without a debugger:")
+        print(f"  xcrun devicectl device process resume --device {self.device} "
+              f"--pid {pid}")
+        return 0
+
+
+def list_tests(runner, timeout, extra_args=()):
+    code, stdout = runner.run_capturing(
+        ["--gtest_list_tests", *extra_args], timeout=timeout
+    )
+    if code is None or code != 0:
+        print(f"Error: --gtest_list_tests exited {code}", file=sys.stderr)
+        sys.exit(1)
+    suites = {}
+    current_suite = None
+    for line in stdout.splitlines():
+        if not line.startswith(" ") and line.endswith("."):
+            current_suite = line.rstrip(".")
+            suites[current_suite] = []
+        elif line.startswith("  ") and current_suite is not None:
+            # Parameterized tests may have trailing "  # GetParam() = ..."
+            test_name = line.strip().split("  #")[0].strip()
+            if test_name:
+                suites[current_suite].append(test_name)
+    return suites
+
+
+def run_filter(runner, filter_str, timeout):
+    code, _ = runner.run_capturing(
+        [f"--gtest_filter={filter_str}", "--gtest_color=no"],
+        timeout,
+    )
+    return code
+
+
+def status_for(code):
+    if code is None:
+        return "TIMEOUT"
+    if is_crash(code):
+        return f"CRASH (exit {code})"
+    return f"ok (exit {code})"
+
+
+def run_per_suite(runner, timeout, suites_only, list_args=()):
+    print("Listing tests ...")
+    suites = list_tests(runner, timeout=max(timeout, 60), extra_args=list_args)
+    total_tests = sum(len(t) for t in suites.values())
+    print(f"Found {len(suites)} suites, {total_tests} total tests\n")
+
+    # Phase 1: run each suite, detect crashes. Sequential because only one app
+    # instance can run on a given simulator/device.
+    crashing_suites = {}
+    for i, (suite_name, tests) in enumerate(suites.items(), 1):
+        code = run_filter(runner, f"{suite_name}.*", timeout)
+        status = status_for(code)
+        if is_crash(code):
+            crashing_suites[suite_name] = tests
+        print(f"[{i}/{len(suites)}] {suite_name} ({len(tests)} tests) ... {status}")
+
+    if not crashing_suites:
+        print("\nNo crashing suites found.")
+        return 0
+
+    if suites_only:
+        print(f"\n{'='*60}")
+        print(f"CRASHING SUITES ({len(crashing_suites)})")
+        print(f"{'='*60}")
+        for suite_name, tests in crashing_suites.items():
+            print(f"  {suite_name}  ({len(tests)} tests)")
+        return 1
+
+    # Phase 2: isolate individual crashing tests in crashing suites.
+    print(f"\n{'='*60}")
+    print(f"Found {len(crashing_suites)} crashing suite(s) — isolating tests ...")
+    print(f"{'='*60}\n")
+
+    pairs = [(s, t) for s, ts in crashing_suites.items() for t in ts]
+    crashing_tests = {}  # {suite_name: [test, ...]}
+    for i, (suite_name, test) in enumerate(pairs, 1):
+        code = run_filter(runner, f"{suite_name}.{test}", timeout)
+        if code is None:
+            status = "TIMEOUT"
+        elif is_crash(code):
+            status = f"CRASH (exit {code})"
+            crashing_tests.setdefault(suite_name, []).append(test)
+        else:
+            status = "ok"
+        print(f"  [{i}/{len(pairs)}] {suite_name}.{test} ... {status}")
+
+    print(f"\n{'='*60}")
+    print("CRASHING TESTS")
+    print(f"{'='*60}")
+    if not crashing_tests:
+        print("  (none isolated — crash may be ordering-dependent)")
+    else:
+        for suite_name, tests in crashing_tests.items():
+            for t in tests:
+                print(f"  {suite_name}.{t}")
+
+    print(f"\n{'='*60}")
+    print("RUN SUITE SKIPPING CRASHING TESTS")
+    print(f"{'='*60}")
+    for suite_name, tests in crashing_tests.items():
+        skip = ":".join(f"-{suite_name}.{t}" for t in tests)
+        filter_expr = f"{suite_name}.*:{skip}"
+        print(f"\n# {suite_name}")
+        print(f"  {runner.format_command(filter_expr)}")
+
+    return 1
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--mac", action="store_true",
+        help="Run the test binary locally on macOS (default mode)."
+    )
+    mode.add_argument(
+        "--simulator", nargs="?", const="booted", default=None, metavar="SIM_ID",
+        help="Run on an iOS Simulator. Optional simulator id "
+             "(default when bare: 'booted')."
+    )
+    mode.add_argument(
+        "--ios-device", nargs="?", const="auto", default=None, metavar="UDID",
+        help="Run on a connected iOS device via xcrun devicectl. Optional "
+             "UDID (default when bare: auto-detect a single connected device)."
+    )
+    mode.add_argument(
+        "--xros-device", nargs="?", const="auto", default=None, metavar="UDID",
+        help="Run on a connected visionOS device via xcrun devicectl. "
+             "Optional UDID (default when bare: auto-detect a single "
+             "connected device)."
+    )
+    config_group = parser.add_mutually_exclusive_group()
+    config_group.add_argument(
+        "--debug", dest="config", action="store_const", const="Debug",
+        help="Use Debug build directory (default)."
+    )
+    config_group.add_argument(
+        "--release", dest="config", action="store_const", const="Release",
+        help="Use Release build directory."
+    )
+    parser.set_defaults(config="Debug")
+    parser.add_argument("--app", default=None,
+        help="Path to test binary or .app bundle. Defaults to "
+             "WebKitBuild/<Debug|Release>[-iphonesimulator|-iphoneos|-xros]/"
+             "ANGLEEnd2EndTests[App.app] depending on mode.")
+    parser.add_argument("--bundle-id", default=None,
+        help="Override bundle id (default: read from Info.plist)")
+    parser.add_argument("--no-install", action="store_true",
+        help="Skip the install step (re-launch already-installed app)")
+    parser.add_argument("--lldb", action="store_true",
+        help="Launch suspended and (on local mac / simulator) auto-attach lldb")
+    parser.add_argument("--per-suite", action="store_true",
+        help="Run each test suite separately to identify crashing suites, "
+             "then isolate individual crashing tests")
+    parser.add_argument("--suites-only", action="store_true",
+        help="With --per-suite: stop after the suite phase; skip per-test isolation")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT,
+        help=f"Per-suite/per-test timeout in seconds (default: {DEFAULT_TIMEOUT})")
+    args, gtest_args = parser.parse_known_args()
+
+    # Default to local mac mode if no mode flag was given.
+    if (not args.mac and args.simulator is None
+            and args.ios_device is None and args.xros_device is None):
+        args.mac = True
+
+    paths = default_paths(args.config)
+
+    if args.mac:
+        target_path = Path(args.app) if args.app else Path(paths["mac"])
+        if not target_path.is_file() or not os.access(target_path, os.X_OK):
+            print(f"Error: not an executable: {target_path}", file=sys.stderr)
+            sys.exit(1)
+        runner = LocalRunner(target_path)
+    else:
+        if args.xros_device is not None:
+            device_id = None if args.xros_device == "auto" else args.xros_device
+            default_app = paths["xros"]
+        elif args.ios_device is not None:
+            device_id = None if args.ios_device == "auto" else args.ios_device
+            default_app = paths["ios"]
+        else:
+            device_id = args.simulator  # always a real id ("booted" or user-supplied)
+            default_app = paths["simulator"]
+
+        app_path = Path(args.app) if args.app else Path(default_app)
+        if not app_path.is_dir():
+            print(f"Error: not a bundle: {app_path}", file=sys.stderr)
+            sys.exit(1)
+        bundle_id = args.bundle_id or read_bundle_id(app_path)
+
+        if args.ios_device is not None or args.xros_device is not None:
+            runner = DeviceRunner(app_path, device_id, bundle_id)
+        else:
+            runner = SimulatorRunner(app_path, device_id, bundle_id)
+
+    if args.suites_only and not args.per_suite:
+        parser.error("--suites-only requires --per-suite")
+    if args.per_suite and args.lldb:
+        parser.error("--per-suite is incompatible with --lldb")
+
+    if not args.no_install:
+        runner.install()
+
+    if args.per_suite:
+        sys.exit(run_per_suite(runner, args.timeout, args.suites_only,
+                               list_args=gtest_args))
+
+    if args.lldb:
+        # Replaces this process (mac / simulator path execs lldb).
+        runner.launch_for_debug(gtest_args)
+        return
+    sys.exit(runner.launch(gtest_args))
+
+
+if __name__ == "__main__":
+    main()

--- a/Source/ThirdParty/ANGLE/src/common/PoolAlloc_unittest.cpp
+++ b/Source/ThirdParty/ANGLE/src/common/PoolAlloc_unittest.cpp
@@ -119,6 +119,7 @@ TEST_F(PoolAllocatorTest, ResetRecyclesMemory)
 class PoolAllocatorGuardTest : public PoolAllocatorTest
 {};
 
+#ifdef GTEST_HAS_DEATH_TEST
 // Verify that alignment guard detects overflowing write.
 TEST_F(PoolAllocatorGuardTest, AlignmentGuardDetectsOverflowWrite)
 {
@@ -151,6 +152,8 @@ TEST_F(PoolAllocatorGuardTest, AllocationGuardsDetectsUnderflowWrite)
     };
     ASSERT_DEATH(testUnderflow(), "");
 }
+
+#endif
 
 #endif
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
@@ -1964,16 +1964,22 @@ mtl::RenderCommandEncoder *ContextMtl::getRenderPassCommandEncoder(const mtl::Re
     mDirtyBits.set();
 
     const mtl::ContextDevice &metalDevice = getMetalDevice();
-    if (mtl::DeviceHasMaximumRenderTargetSize(metalDevice))
+    const std::optional<NSUInteger> maxSize =
+        mtl::GetMaxRenderPassColorSizeBytes(getDisplay()->getFeatures(), metalDevice);
+    if (maxSize)
     {
-        NSUInteger maxSize = mtl::GetMaxRenderTargetSizeForDeviceInBytes(metalDevice);
         NSUInteger renderTargetSize =
             ComputeTotalSizeUsedForMTLRenderPassDescriptor(desc, this, metalDevice);
-        if (renderTargetSize > maxSize)
+        if (renderTargetSize > *maxSize)
         {
+            // Unreachable: FramebufferMtl::checkStatus rejects color-attachment
+            // configurations whose total byte size exceeds this device's
+            // budget, so the encoder-time check is defensive only.
+            UNREACHABLE();
             std::stringstream errorStream;
             errorStream << "This set of render targets requires " << renderTargetSize
-                        << " bytes of pixel storage. This device supports " << maxSize << " bytes.";
+                        << " bytes of pixel storage. This device supports " << *maxSize
+                        << " bytes.";
             handleError(GL_INVALID_OPERATION, errorStream.str().c_str(), __FILE__, ANGLE_FUNCTION,
                         __LINE__);
             return nullptr;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.h
@@ -155,7 +155,6 @@ class DisplayMtl : public DisplayImpl
     mtl::RenderUtils &getUtils() { return *mUtils; }
     mtl::StateCache &getStateCache() { return mStateCache; }
     mtl::LibraryCache &getLibraryCache() { return mLibraryCache; }
-    uint32_t getMaxColorTargetBits() { return mMaxColorTargetBits; }
     bool hasFragmentMemoryBarriers() const { return mHasFragmentMemoryBarriers; }
 
     id<MTLLibrary> getDefaultShadersLib();
@@ -219,7 +218,6 @@ class DisplayMtl : public DisplayImpl
     mutable gl::Caps mNativeCaps;
     mutable gl::Limitations mNativeLimitations;
     mutable ShPixelLocalStorageOptions mNativePLSOptions;
-    mutable uint32_t mMaxColorTargetBits = 0;
     mutable bool mHasFragmentMemoryBarriers;
 
     angle::FeaturesMtl mFeatures;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm
@@ -793,25 +793,6 @@ void DisplayMtl::ensureCapsInitialized() const
     mNativeCaps.maxViewportWidth     = mNativeCaps.max2DTextureSize;
     mNativeCaps.maxViewportHeight    = mNativeCaps.max2DTextureSize;
 
-    bool isCatalyst = TARGET_OS_MACCATALYST;
-
-    mMaxColorTargetBits = mtl::kMaxColorTargetBitsApple1To3;
-    if (supportsMacGPUFamily(1) || isCatalyst)
-    {
-        mMaxColorTargetBits = mtl::kMaxColorTargetBitsMacAndCatalyst;
-    }
-    else if (supportsAppleGPUFamily(4))
-    {
-        mMaxColorTargetBits = mtl::kMaxColorTargetBitsApple4Plus;
-    }
-
-    if (mFeatures.limitMaxColorTargetBitsForTesting.enabled)
-    {
-        // Set so we have enough for RGBA8 on every attachment
-        // but not enough for RGBA32UI.
-        mMaxColorTargetBits = mNativeCaps.maxColorAttachments * 32;
-    }
-
     // MSAA
     mNativeCaps.maxSamples             = mFormatTable.getMaxSamples();
     mNativeCaps.maxSampleMaskWords     = 1;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.h
@@ -197,8 +197,6 @@ class FramebufferMtl : public FramebufferImpl
                                      uint32_t dstBufferRowPitch,
                                      const mtl::BufferRef *dstBuffer) const;
 
-    bool totalBitsUsedIsLessThanOrEqualToMaxBitsSupported(const gl::Context *context) const;
-
     RenderTargetMtl *getColorReadRenderTargetNoCache(const gl::Context *context) const;
     angle::Result prepareForUse(const gl::Context *context) const;
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
@@ -658,30 +658,18 @@ angle::Result FramebufferMtl::blitWithDraw(const gl::Context *context,
     return angle::Result::Continue;
 }
 
-bool FramebufferMtl::totalBitsUsedIsLessThanOrEqualToMaxBitsSupported(
-    const gl::Context *context) const
-{
-    ContextMtl *contextMtl = mtl::GetImpl(context);
-
-    uint32_t bitsUsed = 0;
-    for (const gl::FramebufferAttachment &attachment : mState.getColorAttachments())
-    {
-        if (attachment.isAttached())
-        {
-            bitsUsed += attachment.getRedSize() + attachment.getGreenSize() +
-                        attachment.getBlueSize() + attachment.getAlphaSize();
-        }
-    }
-
-    return bitsUsed <= contextMtl->getDisplay()->getMaxColorTargetBits();
-}
-
 gl::FramebufferStatus FramebufferMtl::checkStatus(const gl::Context *context) const
 {
+    // Read attachments from mState rather than the cached mColorRenderTargets:
+    // returning true from shouldSyncStateBeforeCheckStatus() would force a full
+    // state sync, but Framebuffer::syncState's "before-check-status" path is
+    // only implemented for the GL backend.
+    ContextMtl *contextMtl             = mtl::GetImpl(context);
+    const angle::FeaturesMtl &features = contextMtl->getDisplay()->getFeatures();
+
     if (mState.hasSeparateDepthAndStencilAttachments())
     {
-        ContextMtl *contextMtl = mtl::GetImpl(context);
-        if (!contextMtl->getDisplay()->getFeatures().allowSeparateDepthStencilBuffers.enabled)
+        if (!features.allowSeparateDepthStencilBuffers.enabled)
         {
             return gl::FramebufferStatus::Incomplete(
                 GL_FRAMEBUFFER_UNSUPPORTED,
@@ -700,11 +688,36 @@ gl::FramebufferStatus FramebufferMtl::checkStatus(const gl::Context *context) co
         }
     }
 
-    if (!totalBitsUsedIsLessThanOrEqualToMaxBitsSupported(context))
+    const mtl::ContextDevice &device        = contextMtl->getMetalDevice();
+    const std::optional<NSUInteger> maxSize = mtl::GetMaxRenderPassColorSizeBytes(features, device);
+    if (maxSize)
     {
-        return gl::FramebufferStatus::Incomplete(
-            GL_FRAMEBUFFER_UNSUPPORTED,
-            gl::err::kFramebufferIncompleteColorBitsUsedExceedsMaxColorBitsSupported);
+        const auto &colorAttachments = mState.getColorAttachments();
+        mtl::RenderPassDesc desc;
+        for (size_t i = 0; i < colorAttachments.size(); ++i)
+        {
+            const gl::FramebufferAttachment &attachment = colorAttachments[i];
+            if (!attachment.isAttached())
+            {
+                continue;
+            }
+            RenderTargetMtl *rt = nullptr;
+            if (attachment.getRenderTarget(context, attachment.getRenderToTextureSamples(), &rt) ==
+                    angle::Result::Stop ||
+                !rt || !rt->getTexture())
+            {
+                return gl::FramebufferStatus::Incomplete(
+                    GL_FRAMEBUFFER_UNSUPPORTED, gl::err::kFramebufferIncompleteInternalError);
+            }
+            rt->toRenderPassAttachmentDesc(&desc.colorAttachments[i]);
+        }
+        if (mtl::ComputeTotalSizeUsedForMTLRenderPassDescriptor(desc, contextMtl, device) >
+            *maxSize)
+        {
+            return gl::FramebufferStatus::Incomplete(
+                GL_FRAMEBUFFER_UNSUPPORTED,
+                gl::err::kFramebufferIncompleteColorBitsUsedExceedsMaxColorBitsSupported);
+        }
     }
 
     return gl::FramebufferStatus::Complete();
@@ -921,7 +934,11 @@ angle::Result FramebufferMtl::ensureRenderPassStarted(const gl::Context *context
     // texture, level, slice must be the same.
     ASSERT(desc.equalIgnoreLoadStoreOptions(mRenderPassDesc));
 
-    encoder                     = contextMtl->getRenderPassCommandEncoder(desc);
+    encoder = contextMtl->getRenderPassCommandEncoder(desc);
+    if (!encoder)
+    {
+        return angle::Result::Stop;
+    }
     mStartedRenderEncoderSerial = encoder->getSerial();
 
     ANGLE_TRY(unresolveIfNeeded(context, encoder));

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/gen_mtl_format_table.py
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/gen_mtl_format_table.py
@@ -102,6 +102,14 @@ void FormatTable::initNativeFormatCapsAutogen(const DisplayMtl *display)
 {metal_format_caps}
     // clang-format on
 
+#if !(TARGET_OS_OSX || TARGET_OS_MACCATALYST)
+    const bool supportsiOS2 = SupportsAppleGPUFamily(display->getMetalDevice(), 2);
+    const bool supportsiOS4 = SupportsAppleGPUFamily(display->getMetalDevice(), 4);
+    for (auto &entry : mNativePixelFormatCapsTable)
+    {{
+        adjustFormatCapsForDevice(entry.first, supportsiOS2, supportsiOS4);
+    }}
+#endif
 }}
 
 }}  // namespace mtl

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_common.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_common.h
@@ -95,10 +95,6 @@ constexpr uint32_t kMaxRenderTargets = 8;
 // Metal Apple1 iOS devices only support 4 render targets
 constexpr uint32_t kMaxRenderTargetsOlderGPUFamilies = 4;
 
-constexpr uint32_t kMaxColorTargetBitsApple1To3      = 256;
-constexpr uint32_t kMaxColorTargetBitsApple4Plus     = 512;
-constexpr uint32_t kMaxColorTargetBitsMacAndCatalyst = std::numeric_limits<uint32_t>::max();
-
 constexpr uint32_t kMaxShaderUBOs = 16;
 constexpr uint32_t kMaxUBOSize    = 16384;
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_table_autogen.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_table_autogen.mm
@@ -5854,6 +5854,15 @@ void FormatTable::initNativeFormatCapsAutogen(const DisplayMtl *display)
 #endif // TARGET_OS_IPHONE && !TARGET_OS_MACCATALYST || mac 11.0+
 
     // clang-format on
+
+#if !(TARGET_OS_OSX || TARGET_OS_MACCATALYST)
+    const bool supportsiOS2 = SupportsAppleGPUFamily(display->getMetalDevice(), 2);
+    const bool supportsiOS4 = SupportsAppleGPUFamily(display->getMetalDevice(), 4);
+    for (auto &entry : mNativePixelFormatCapsTable)
+    {
+        adjustFormatCapsForDevice(entry.first, supportsiOS2, supportsiOS4);
+    }
+#endif
 }
 
 }  // namespace mtl

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.h
@@ -156,10 +156,7 @@ class FormatTable final : angle::NonCopyable
 
     void setFormatCaps(MTLPixelFormat formatId, const FormatCaps &caps);
 
-    void adjustFormatCapsForDevice(const mtl::ContextDevice &device,
-                                   MTLPixelFormat id,
-                                   bool supportsiOS2,
-                                   bool supportsiOS4);
+    void adjustFormatCapsForDevice(MTLPixelFormat id, bool supportsiOS2, bool supportsiOS4);
 
     std::array<Format, angle::kNumANGLEFormats> mPixelFormatTable;
     angle::HashMap<MTLPixelFormat, FormatCaps> mNativePixelFormatCapsTable;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.mm
@@ -277,10 +277,7 @@ void FormatTable::setFormatCaps(MTLPixelFormat formatId, const FormatCaps &caps)
     mNativePixelFormatCapsTable[formatId] = caps;
 }
 
-void FormatTable::adjustFormatCapsForDevice(const mtl::ContextDevice &device,
-                                            MTLPixelFormat id,
-                                            bool supportsiOS2,
-                                            bool supportsiOS4)
+void FormatTable::adjustFormatCapsForDevice(MTLPixelFormat id, bool supportsiOS2, bool supportsiOS4)
 {
 #if !(TARGET_OS_OSX || TARGET_OS_MACCATALYST)
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_pipeline_cache.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_pipeline_cache.mm
@@ -76,17 +76,22 @@ angle::Result ValidateRenderPipelineState(ContextMtl *context,
                     GL_INVALID_OPERATION);
     }
 
-    // Ensure the device can support the storage requirement for render targets.
-    if (DeviceHasMaximumRenderTargetSize(device))
+    const std::optional<NSUInteger> maxSize =
+        mtl::GetMaxRenderPassColorSizeBytes(context->getDisplay()->getFeatures(), device);
+    if (maxSize)
     {
-        NSUInteger maxSize = GetMaxRenderTargetSizeForDeviceInBytes(device);
         NSUInteger renderTargetSize =
             ComputeTotalSizeUsedForMTLRenderPipelineDescriptor(descriptor, context, device);
-        if (renderTargetSize > maxSize)
+        if (renderTargetSize > *maxSize)
         {
+            // Unreachable: FramebufferMtl::checkStatus rejects color-attachment
+            // configurations whose total byte size exceeds this device's
+            // budget, so the pipeline-time check is defensive only.
+            UNREACHABLE();
             std::stringstream errorStream;
             errorStream << "This set of render targets requires " << renderTargetSize
-                        << " bytes of pixel storage. This device supports " << maxSize << " bytes.";
+                        << " bytes of pixel storage. This device supports " << *maxSize
+                        << " bytes.";
             ANGLE_CHECK(context, false, errorStream.str().c_str(), GL_INVALID_OPERATION);
         }
     }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.h
@@ -13,6 +13,8 @@
 
 #import <Metal/Metal.h>
 
+#include <optional>
+
 #include "angle_gl.h"
 #include "common/MemoryBuffer.h"
 #include "common/PackedEnums.h"
@@ -188,6 +190,12 @@ NSUInteger ComputeTotalSizeUsedForMTLRenderPipelineDescriptor(
     const MTLRenderPipelineDescriptor *descriptor,
     const Context *context,
     const mtl::ContextDevice &device);
+
+// Returns the device's max render-pass color byte budget, or nullopt when the
+// device imposes no fixed limit (e.g. macOS).  Honors
+// FeaturesMtl::limitMaxColorTargetBitsForTesting.
+std::optional<NSUInteger> GetMaxRenderPassColorSizeBytes(const angle::FeaturesMtl &features,
+                                                         const mtl::ContextDevice &device);
 
 gl::Rectangle MTLRegionToGLRect(const MTLRegion &mtlRegion);
 gl::Box MTLRegionToGLBox(const MTLRegion &mtlRegion);

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm
@@ -1489,19 +1489,6 @@ NSUInteger ComputeTotalSizeUsedForMTLRenderPassDescriptor(const mtl::RenderPassD
         currentRenderTargetSize = getNextLocationForAttachment(descriptor.colorAttachments[i],
                                                                context, currentRenderTargetSize);
     }
-    if (descriptor.depthAttachment.texture == descriptor.stencilAttachment.texture)
-    {
-        currentRenderTargetSize = getNextLocationForAttachment(descriptor.depthAttachment, context,
-                                                               currentRenderTargetSize);
-    }
-    else
-    {
-        currentRenderTargetSize = getNextLocationForAttachment(descriptor.depthAttachment, context,
-                                                               currentRenderTargetSize);
-        currentRenderTargetSize = getNextLocationForAttachment(descriptor.stencilAttachment,
-                                                               context, currentRenderTargetSize);
-    }
-
     return currentRenderTargetSize;
 }
 
@@ -1522,34 +1509,21 @@ NSUInteger ComputeTotalSizeUsedForMTLRenderPipelineDescriptor(
                 getNextLocationForFormat(caps, isMsaa, currentRenderTargetSize);
         }
     }
-    if (descriptor.depthAttachmentPixelFormat == descriptor.stencilAttachmentPixelFormat)
-    {
-        if (descriptor.depthAttachmentPixelFormat != MTLPixelFormatInvalid)
-        {
-            const FormatCaps &caps =
-                context->getDisplay()->getNativeFormatCaps(descriptor.depthAttachmentPixelFormat);
-            currentRenderTargetSize =
-                getNextLocationForFormat(caps, isMsaa, currentRenderTargetSize);
-        }
-    }
-    else
-    {
-        if (descriptor.depthAttachmentPixelFormat != MTLPixelFormatInvalid)
-        {
-            const FormatCaps &caps =
-                context->getDisplay()->getNativeFormatCaps(descriptor.depthAttachmentPixelFormat);
-            currentRenderTargetSize =
-                getNextLocationForFormat(caps, isMsaa, currentRenderTargetSize);
-        }
-        if (descriptor.stencilAttachmentPixelFormat != MTLPixelFormatInvalid)
-        {
-            const FormatCaps &caps =
-                context->getDisplay()->getNativeFormatCaps(descriptor.stencilAttachmentPixelFormat);
-            currentRenderTargetSize =
-                getNextLocationForFormat(caps, isMsaa, currentRenderTargetSize);
-        }
-    }
     return currentRenderTargetSize;
+}
+
+std::optional<NSUInteger> GetMaxRenderPassColorSizeBytes(const angle::FeaturesMtl &features,
+                                                         const mtl::ContextDevice &device)
+{
+    if (features.limitMaxColorTargetBitsForTesting.enabled)
+    {
+        return 32;
+    }
+    if (mtl::DeviceHasMaximumRenderTargetSize(device))
+    {
+        return mtl::GetMaxRenderTargetSizeForDeviceInBytes(device);
+    }
+    return std::nullopt;
 }
 
 gl::Rectangle MTLRegionToGLRect(const MTLRegion &mtlRegion)

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawBuffersTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawBuffersTest.cpp
@@ -11,6 +11,10 @@
 #include "test_utils/ANGLETest.h"
 #include "test_utils/gl_raii.h"
 
+#include "common/gl_enum_utils.h"
+
+#include <limits>
+
 using namespace angle;
 
 class DrawBuffersTest : public ANGLETest<>
@@ -1785,8 +1789,1054 @@ TEST_P(ColorMaskForDrawBuffersTest, StateChangeAffectsBlendState)
     EXPECT_GL_NO_ERROR();
 }
 
+// Test parameters: <platform, color format, depth/stencil format (0 if none),
+// useTexture, sample count (0 = single-sampled)>.
+using DrawBuffersAnyFormatVariationsTestParams =
+    std::tuple<angle::PlatformParameters, GLenum, GLenum, bool, GLint>;
+
+std::string DrawBuffersAnyFormatVariationsTestPrint(
+    const ::testing::TestParamInfo<DrawBuffersAnyFormatVariationsTestParams> &paramsInfo)
+{
+    const DrawBuffersAnyFormatVariationsTestParams &params = paramsInfo.param;
+    std::ostringstream out;
+    out << std::get<0>(params) << "__"
+        << gl::GLenumToString(gl::GLESEnum::AllEnums, std::get<1>(params)) << "_"
+        << (std::get<2>(params) == 0
+                ? "NoDepthStencil"
+                : gl::GLenumToString(gl::GLESEnum::AllEnums, std::get<2>(params)))
+        << "_" << (std::get<3>(params) ? "Texture" : "Renderbuffer");
+    if (std::get<4>(params) > 0)
+    {
+        out << "_MSAA" << std::get<4>(params);
+    }
+    return out.str();
+}
+
+constexpr GLenum kDrawBuffersAnyFormatColorFormats[] = {
+    // Normalized / float-castable
+    GL_R8,
+    GL_RG8,
+    GL_RGB8,
+    GL_RGB565,
+    GL_RGB5_A1,
+    GL_RGBA4,
+    GL_RGB10_A2,
+    GL_RGBA8,
+    GL_SRGB8_ALPHA8,
+    // Signed / unsigned integer
+    GL_R8I,
+    GL_R8UI,
+    GL_R16I,
+    GL_R16UI,
+    GL_R32I,
+    GL_R32UI,
+    GL_RG8I,
+    GL_RG8UI,
+    GL_RG16I,
+    GL_RG16UI,
+    GL_RG32I,
+    GL_RG32UI,
+    GL_RGBA8I,
+    GL_RGBA8UI,
+    GL_RGBA16I,
+    GL_RGBA16UI,
+    GL_RGBA32I,
+    GL_RGBA32UI,
+    GL_RGB10_A2UI,
+    // Float, require EXT_color_buffer_half_float / EXT_color_buffer_float.
+    GL_R16F,
+    GL_RG16F,
+    GL_RGBA16F,
+    GL_R32F,
+    GL_RG32F,
+    GL_RGBA32F,
+    GL_R11F_G11F_B10F,
+    // Shared exponent, requires GL_QCOM_render_shared_exponent to render.
+    GL_RGB9_E5,
+    // Unsigned normalized 16-bit, requires GL_EXT_texture_norm16 to render.
+    GL_R16_EXT,
+    GL_RG16_EXT,
+    GL_RGBA16_EXT,
+    // Signed normalized 8-bit, requires GL_EXT_render_snorm to render.
+    GL_R8_SNORM,
+    GL_RG8_SNORM,
+    GL_RGBA8_SNORM,
+    // Signed normalized 16-bit, requires GL_EXT_render_snorm + GL_EXT_texture_norm16 to render.
+    GL_R16_SNORM_EXT,
+    GL_RG16_SNORM_EXT,
+    GL_RGBA16_SNORM_EXT,
+};
+
+constexpr GLenum kDrawBuffersAnyFormatDepthStencilFormats[] = {
+    0,  // No depth/stencil attachment
+    GL_DEPTH_COMPONENT16,
+    GL_DEPTH_COMPONENT24,
+    GL_DEPTH_COMPONENT32F,
+    GL_STENCIL_INDEX8,
+    GL_DEPTH24_STENCIL8,
+    GL_DEPTH32F_STENCIL8,
+};
+
+// Color formats that are eligible for multisample renderbuffers.  Excludes
+// signed/unsigned integer formats per ES 3.0 §4.4.2.1 (RenderbufferStorage-
+// Multisample with an integer internalformat generates INVALID_OPERATION),
+// and excludes formats that are texture-only as renderbuffers.  Float formats
+// require GL_EXT_color_buffer_float at runtime; the test skips when missing.
+constexpr GLenum kDrawBuffersAnyFormatMSAAColorFormats[] = {
+    GL_R8,
+    GL_RG8,
+    GL_RGB8,
+    GL_RGB565,
+    GL_RGB5_A1,
+    GL_RGBA4,
+    GL_RGB10_A2,
+    GL_RGBA8,
+    GL_SRGB8_ALPHA8,
+    // Half/float color.
+    GL_R16F,
+    GL_RG16F,
+    GL_RGBA16F,
+    GL_R32F,
+    GL_RG32F,
+    GL_RGBA32F,
+    GL_R11F_G11F_B10F,
+    // Shared exponent.
+    GL_RGB9_E5,
+    // Unsigned normalized 16-bit.
+    GL_R16_EXT,
+    GL_RG16_EXT,
+    GL_RGBA16_EXT,
+    // Signed normalized 8-bit.
+    GL_R8_SNORM,
+    GL_RG8_SNORM,
+    GL_RGBA8_SNORM,
+    // Signed normalized 16-bit.
+    GL_R16_SNORM_EXT,
+    GL_RG16_SNORM_EXT,
+    GL_RGBA16_SNORM_EXT,
+};
+
+// Largest sample count exercised by the MSAA instantiation of
+// DrawBuffersAnyFormatTestES3.  A separate sanity test verifies the
+// implementation does not advertise larger sample counts that would escape
+// coverage.
+constexpr GLint kDrawBuffersAnyFormatMaxTestedSampleCount = 4;
+
+struct DrawBuffersAnyFormatExpectationPerSampleResult
+{
+    GLint sampleCount;                  // 0 = single-sampled
+    GLint firstFailingDrawBufferCount;  // Count where FRAMEBUFFER_UNSUPPORTED starts.
+};
+
+struct DrawBuffersAnyFormatExpectation
+{
+    const char *deviceNameSubstring;
+    GLenum colorFormat;
+    DrawBuffersAnyFormatExpectationPerSampleResult sampleCounts[3];
+};
+
+// Per-known device results for framebuffer-completeness for the
+// (color format, sample count) keys listed.
+// If the device does not appear in the table at all, it is unknown
+// device. Any framebuffer status at any n is tolerated.
+// For known devices:
+// For this (color format, sampleCount), the FBO is expected to
+// become FRAMEBUFFER_UNSUPPORTED at firstFailingDrawBufferCount
+// and remain unsupported for larger counts.
+//
+// Sentinel values for firstFailingDrawBufferCount:
+//   0 -- FBO is expected FRAMEBUFFER_UNSUPPORTED at every n
+//   9 -- FBO is expected FRAMEBUFFER_COMPLETE at every n.  Any value
+//        larger than MAX_DRAW_BUFFERS works; iteration stops at
+//        MAX_DRAW_BUFFERS (8 on the platforms we target).
+constexpr DrawBuffersAnyFormatExpectation kDrawBuffersAnyFormatExpectedFramebufferIncomplete[] = {
+#if ANGLE_PLATFORM_IOS_FAMILY_SIMULATOR
+    // Simulator uses a 32-byte color tile budget but its emulated
+    // pixelBytes don't match a real Apple GPU.  Many "small" formats
+    // come out oversized.
+    {"Apple iOS simulator GPU", GL_R11F_G11F_B10F, {{0, 5}, {2, 5}, {4, 5}}},
+    {"Apple iOS simulator GPU", GL_RG32F, {{0, 5}, {2, 0}, {4, 0}}},
+    {"Apple iOS simulator GPU", GL_RG32I, {{0, 5}, {2, 0}, {4, 0}}},
+    {"Apple iOS simulator GPU", GL_RG32UI, {{0, 5}, {2, 0}, {4, 0}}},
+    {"Apple iOS simulator GPU", GL_RGB10_A2, {{0, 5}, {2, 5}, {4, 5}}},
+    {"Apple iOS simulator GPU", GL_RGB10_A2UI, {{0, 5}, {2, 0}, {4, 0}}},
+    {"Apple iOS simulator GPU", GL_RGB565, {{0, 5}, {2, 5}, {4, 5}}},
+    {"Apple iOS simulator GPU", GL_RGB5_A1, {{0, 5}, {2, 5}, {4, 5}}},
+    {"Apple iOS simulator GPU", GL_RGB8, {{0, 5}, {2, 5}, {4, 5}}},
+    {"Apple iOS simulator GPU", GL_RGBA16F, {{0, 5}, {2, 5}, {4, 5}}},
+    {"Apple iOS simulator GPU", GL_RGBA16I, {{0, 5}, {2, 0}, {4, 0}}},
+    {"Apple iOS simulator GPU", GL_RGBA16UI, {{0, 5}, {2, 0}, {4, 0}}},
+    {"Apple iOS simulator GPU", GL_RGBA32F, {{0, 3}, {2, 0}, {4, 0}}},
+    {"Apple iOS simulator GPU", GL_RGBA32I, {{0, 3}, {2, 0}, {4, 0}}},
+    {"Apple iOS simulator GPU", GL_RGBA32UI, {{0, 3}, {2, 0}, {4, 0}}},
+    {"Apple iOS simulator GPU", GL_RGBA4, {{0, 5}, {2, 5}, {4, 5}}},
+    {"Apple iOS simulator GPU", GL_RGBA8, {{0, 5}, {2, 5}, {4, 5}}},
+    {"Apple iOS simulator GPU", GL_RGBA8_SNORM, {{0, 5}, {2, 5}, {4, 5}}},
+    {"Apple iOS simulator GPU", GL_RGBA16_EXT, {{0, 5}, {2, 5}, {4, 5}}},
+    {"Apple iOS simulator GPU", GL_RGBA16_SNORM_EXT, {{0, 5}, {2, 5}, {4, 5}}},
+    {"Apple iOS simulator GPU", GL_SRGB8_ALPHA8, {{0, 5}, {2, 5}, {4, 5}}},
+#elif ANGLE_PLATFORM_IOS_FAMILY
+    // Real iOS Apple GPUs (Apple4+: 64-byte color tile budget).
+    {"Apple", GL_RGBA32F, {{0, 5}, {2, 5}, {4, 5}}},
+    {"Apple", GL_RGBA32I, {{0, 5}, {2, 0}, {4, 0}}},
+    {"Apple", GL_RGBA32UI, {{0, 5}, {2, 0}, {4, 0}}},
+#endif
+};
+
+class DrawBuffersAnyFormatTestES3 : public ANGLETest<DrawBuffersAnyFormatVariationsTestParams>
+{
+  protected:
+    DrawBuffersAnyFormatTestES3()
+    {
+        setWindowWidth(128);
+        setWindowHeight(128);
+        setConfigRedBits(8);
+        setConfigGreenBits(8);
+        setConfigBlueBits(8);
+        setConfigAlphaBits(8);
+        setConfigDepthBits(24);
+        setConfigStencilBits(8);
+    }
+
+    GLenum colorFormat() const { return std::get<1>(GetParam()); }
+    GLenum depthStencilFormat() const { return std::get<2>(GetParam()); }
+    bool useTexture() const { return std::get<3>(GetParam()); }
+    GLint samples() const { return std::get<4>(GetParam()); }
+
+    bool isSignedInt() const;
+    bool isUnsignedInt() const;
+    bool isFloatColorFormat() const;
+    bool isSnorm8ColorFormat() const;
+    bool isSnorm16ColorFormat() const;
+
+    static GLenum DepthStencilAttachmentFor(GLenum format);
+    // Number of color channels (1..4) of the format.
+    static int NumColorChannels(GLenum internalformat);
+
+    void setUpFramebufferAttachments(GLFramebuffer &fb, GLint numAttachments);
+
+    void clearColorAttachment(GLint i);
+    testing::AssertionResult verifyColorAttachment(GLint i);
+
+    // Issues per-attachment color clears via glClearBuffer{f,i,ui}v plus a
+    // single glClear for any depth/stencil attachment.
+    void clearAll(GLint numAttachments);
+
+    // Verifies each color attachment was cleared to its per-attachment value.
+    testing::AssertionResult verifyAttachments(GLint numAttachments);
+
+    bool deviceSupportsParameters() const;
+
+    testing::AssertionResult verifyKnownDeviceExpectedFramebufferStatus(GLenum status,
+                                                                        GLint numAttachments) const;
+};
+
+bool DrawBuffersAnyFormatTestES3::isSignedInt() const
+{
+    switch (colorFormat())
+    {
+        case GL_R8I:
+        case GL_R16I:
+        case GL_R32I:
+        case GL_RG8I:
+        case GL_RG16I:
+        case GL_RG32I:
+        case GL_RGBA8I:
+        case GL_RGBA16I:
+        case GL_RGBA32I:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool DrawBuffersAnyFormatTestES3::isUnsignedInt() const
+{
+    switch (colorFormat())
+    {
+        case GL_R8UI:
+        case GL_R16UI:
+        case GL_R32UI:
+        case GL_RG8UI:
+        case GL_RG16UI:
+        case GL_RG32UI:
+        case GL_RGBA8UI:
+        case GL_RGBA16UI:
+        case GL_RGBA32UI:
+        case GL_RGB10_A2UI:
+            return true;
+        default:
+            return false;
+    }
+}
+
+GLenum DrawBuffersAnyFormatTestES3::DepthStencilAttachmentFor(GLenum format)
+{
+    switch (format)
+    {
+        case GL_DEPTH_COMPONENT16:
+        case GL_DEPTH_COMPONENT24:
+        case GL_DEPTH_COMPONENT32F:
+            return GL_DEPTH_ATTACHMENT;
+        case GL_STENCIL_INDEX8:
+            return GL_STENCIL_ATTACHMENT;
+        case GL_DEPTH24_STENCIL8:
+        case GL_DEPTH32F_STENCIL8:
+            return GL_DEPTH_STENCIL_ATTACHMENT;
+        default:
+            return 0;
+    }
+}
+
+bool DrawBuffersAnyFormatTestES3::isFloatColorFormat() const
+{
+    switch (colorFormat())
+    {
+        case GL_R16F:
+        case GL_RG16F:
+        case GL_RGBA16F:
+        case GL_R32F:
+        case GL_RG32F:
+        case GL_RGBA32F:
+        case GL_R11F_G11F_B10F:
+        // GL_RGB9_E5 is a shared-exponent (float-ish) color buffer.  ES 3.0
+        // §4.3.2 only guarantees GL_RGBA + GL_UNSIGNED_BYTE for color buffers
+        // whose components are GL_UNSIGNED_NORMALIZED, so non-UNORM formats
+        // must use the GL_FLOAT readback path.
+        case GL_RGB9_E5:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool DrawBuffersAnyFormatTestES3::isSnorm8ColorFormat() const
+{
+    switch (colorFormat())
+    {
+        case GL_R8_SNORM:
+        case GL_RG8_SNORM:
+        case GL_RGBA8_SNORM:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool DrawBuffersAnyFormatTestES3::isSnorm16ColorFormat() const
+{
+    switch (colorFormat())
+    {
+        case GL_R16_SNORM_EXT:
+        case GL_RG16_SNORM_EXT:
+        case GL_RGBA16_SNORM_EXT:
+            return true;
+        default:
+            return false;
+    }
+}
+
+int DrawBuffersAnyFormatTestES3::NumColorChannels(GLenum internalformat)
+{
+    switch (internalformat)
+    {
+        case GL_R8:
+        case GL_R8I:
+        case GL_R8UI:
+        case GL_R16I:
+        case GL_R16UI:
+        case GL_R32I:
+        case GL_R32UI:
+        case GL_R16F:
+        case GL_R32F:
+        case GL_R16_EXT:
+        case GL_R8_SNORM:
+        case GL_R16_SNORM_EXT:
+            return 1;
+        case GL_RG8:
+        case GL_RG8I:
+        case GL_RG8UI:
+        case GL_RG16I:
+        case GL_RG16UI:
+        case GL_RG32I:
+        case GL_RG32UI:
+        case GL_RG16F:
+        case GL_RG32F:
+        case GL_RG16_EXT:
+        case GL_RG8_SNORM:
+        case GL_RG16_SNORM_EXT:
+            return 2;
+        case GL_RGB8:
+        case GL_RGB565:
+        case GL_R11F_G11F_B10F:
+        case GL_RGB9_E5:
+            return 3;
+        default:
+            return 4;
+    }
+}
+
+void DrawBuffersAnyFormatTestES3::setUpFramebufferAttachments(GLFramebuffer &fb,
+                                                              GLint numAttachments)
+{
+    constexpr GLsizei kSize = 16;
+    const GLenum cFormat    = colorFormat();
+    const GLenum dsFormat   = depthStencilFormat();
+    const GLenum dsAttach   = DepthStencilAttachmentFor(dsFormat);
+    const GLint msaa        = samples();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fb);
+
+    if (useTexture())
+    {
+        // Multisampled textures require ES 3.1 or an extension.  The MSAA
+        // suite uses renderbuffers only; this branch is for samples == 0.
+        ASSERT_EQ(msaa, 0);
+        std::vector<GLTexture> colorTexs(numAttachments);
+        for (GLint i = 0; i < numAttachments; ++i)
+        {
+            glBindTexture(GL_TEXTURE_2D, colorTexs[i]);
+            glTexStorage2D(GL_TEXTURE_2D, 1, cFormat, kSize, kSize);
+            ASSERT_GL_NO_ERROR() << i;
+            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, GL_TEXTURE_2D,
+                                   colorTexs[i], 0);
+            ASSERT_GL_NO_ERROR() << i;
+        }
+        GLTexture dsTex;
+        if (dsAttach != 0)
+        {
+            glBindTexture(GL_TEXTURE_2D, dsTex);
+            glTexStorage2D(GL_TEXTURE_2D, 1, dsFormat, kSize, kSize);
+            glFramebufferTexture2D(GL_FRAMEBUFFER, dsAttach, GL_TEXTURE_2D, dsTex, 0);
+        }
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    }
+    else
+    {
+        std::vector<GLRenderbuffer> colorRbs(numAttachments);
+        for (GLint i = 0; i < numAttachments; ++i)
+        {
+            glBindRenderbuffer(GL_RENDERBUFFER, colorRbs[i]);
+            if (msaa > 0)
+            {
+                glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa, cFormat, kSize, kSize);
+            }
+            else
+            {
+                glRenderbufferStorage(GL_RENDERBUFFER, cFormat, kSize, kSize);
+            }
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, GL_RENDERBUFFER,
+                                      colorRbs[i]);
+        }
+        GLRenderbuffer dsRb;
+        if (dsAttach != 0)
+        {
+            glBindRenderbuffer(GL_RENDERBUFFER, dsRb);
+            if (msaa > 0)
+            {
+                glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa, dsFormat, kSize, kSize);
+            }
+            else
+            {
+                glRenderbufferStorage(GL_RENDERBUFFER, dsFormat, kSize, kSize);
+            }
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, dsAttach, GL_RENDERBUFFER, dsRb);
+        }
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    }
+}
+
+void DrawBuffersAnyFormatTestES3::clearColorAttachment(GLint i)
+{
+    // Per-attachment R/G/B is the bit decomposition of (i+1); A is always
+    // "max".  Using only 0 / max (=255 / 1.0 / 1) values means the cleared
+    // values round-trip through any normalized format.
+    const bool R = ((i + 1) & 1) != 0;
+    const bool G = ((i + 1) & 2) != 0;
+    const bool B = ((i + 1) & 4) != 0;
+    if (isUnsignedInt())
+    {
+        const GLuint v[4] = {R ? 1u : 0u, G ? 1u : 0u, B ? 1u : 0u, 1u};
+        glClearBufferuiv(GL_COLOR, i, v);
+    }
+    else if (isSignedInt())
+    {
+        const GLint v[4] = {R ? 1 : 0, G ? 1 : 0, B ? 1 : 0, 1};
+        glClearBufferiv(GL_COLOR, i, v);
+    }
+    else
+    {
+        const GLfloat v[4] = {R ? 1.0f : 0.0f, G ? 1.0f : 0.0f, B ? 1.0f : 0.0f, 1.0f};
+        glClearBufferfv(GL_COLOR, i, v);
+    }
+}
+
+testing::AssertionResult DrawBuffersAnyFormatTestES3::verifyColorAttachment(GLint i)
+{
+    GLFramebuffer resolveFb;
+    GLRenderbuffer resolveRb;
+    GLint sourceFb = 0;
+
+    if (samples() > 0)
+    {
+        // ES 3.0 §4.3.3 forbids glReadPixels on a multisample renderbuffer.
+        // Resolve color attachment i into a single-sample temp FBO via
+        // glBlitFramebuffer, then read from the resolved FBO.  Width/height
+        // must match the source (and use the same internalformat) per the
+        // multisample-blit constraints.
+        constexpr GLsizei kSize = 16;
+        glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &sourceFb);
+
+        glBindRenderbuffer(GL_RENDERBUFFER, resolveRb);
+        glRenderbufferStorage(GL_RENDERBUFFER, colorFormat(), kSize, kSize);
+
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, resolveFb);
+        glFramebufferRenderbuffer(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER,
+                                  resolveRb);
+
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, sourceFb);
+        glReadBuffer(GL_COLOR_ATTACHMENT0 + i);
+        // NEAREST is required for multisample blits where SAMPLE_BUFFERS
+        // differs between read and draw.
+        glBlitFramebuffer(0, 0, kSize, kSize, 0, 0, kSize, kSize, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        // Restore DRAW so the test's outer code (subsequent clears/draws)
+        // continues targeting the source FBO.
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, sourceFb);
+        const GLenum blitErr = glGetError();
+        if (blitErr != GL_NO_ERROR)
+        {
+            glBindFramebuffer(GL_READ_FRAMEBUFFER, sourceFb);
+            return testing::AssertionFailure()
+                   << "MSAA blit-resolve attachment " << i << ": "
+                   << gl::GLenumToString(gl::GLESEnum::AllEnums, blitErr);
+        }
+
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, resolveFb);
+        glReadBuffer(GL_COLOR_ATTACHMENT0);
+    }
+    else
+    {
+        glReadBuffer(GL_COLOR_ATTACHMENT0 + i);
+    }
+
+    const int numC = NumColorChannels(colorFormat());
+
+    // Mask the expected components by the format's channel count.  Channels
+    // not present in the format read back as 0 (RGB) or "1" (alpha) per the
+    // ES 3.0 spec.
+    const bool R = numC >= 1 && ((i + 1) & 1) != 0;
+    const bool G = numC >= 2 && ((i + 1) & 2) != 0;
+    const bool B = numC >= 3 && ((i + 1) & 4) != 0;
+
+    testing::AssertionResult result = testing::AssertionSuccess();
+
+    if (isUnsignedInt())
+    {
+        GLuint pixel[4]          = {0u, 0u, 0u, 0u};
+        const GLuint expected[4] = {R ? 1u : 0u, G ? 1u : 0u, B ? 1u : 0u, 1u};
+        glReadPixels(0, 0, 1, 1, GL_RGBA_INTEGER, GL_UNSIGNED_INT, pixel);
+        if (std::memcmp(pixel, expected, sizeof(pixel)) != 0)
+        {
+            result = testing::AssertionFailure()
+                     << "color attachment " << i << ": got (" << pixel[0] << ", " << pixel[1]
+                     << ", " << pixel[2] << ", " << pixel[3] << "), expected (" << expected[0]
+                     << ", " << expected[1] << ", " << expected[2] << ", " << expected[3] << ")";
+        }
+    }
+    else if (isSignedInt())
+    {
+        GLint pixel[4]          = {0, 0, 0, 0};
+        const GLint expected[4] = {R ? 1 : 0, G ? 1 : 0, B ? 1 : 0, 1};
+        glReadPixels(0, 0, 1, 1, GL_RGBA_INTEGER, GL_INT, pixel);
+        if (std::memcmp(pixel, expected, sizeof(pixel)) != 0)
+        {
+            result = testing::AssertionFailure()
+                     << "color attachment " << i << ": got (" << pixel[0] << ", " << pixel[1]
+                     << ", " << pixel[2] << ", " << pixel[3] << "), expected (" << expected[0]
+                     << ", " << expected[1] << ", " << expected[2] << ", " << expected[3] << ")";
+        }
+    }
+    else if (isSnorm8ColorFormat())
+    {
+        // GL_EXT_render_snorm adds GL_RGBA + GL_BYTE to ReadPixels.  SNORM
+        // 1.0 maps to 127.
+        GLbyte pixel[4]          = {0, 0, 0, 0};
+        const GLbyte expected[4] = {static_cast<GLbyte>(R ? 127 : 0),
+                                    static_cast<GLbyte>(G ? 127 : 0),
+                                    static_cast<GLbyte>(B ? 127 : 0), 127};
+        glReadPixels(0, 0, 1, 1, GL_RGBA, GL_BYTE, pixel);
+        if (std::memcmp(pixel, expected, sizeof(pixel)) != 0)
+        {
+            result = testing::AssertionFailure()
+                     << "color attachment " << i << ": got (" << +pixel[0] << ", " << +pixel[1]
+                     << ", " << +pixel[2] << ", " << +pixel[3] << "), expected (" << +expected[0]
+                     << ", " << +expected[1] << ", " << +expected[2] << ", " << +expected[3] << ")";
+        }
+    }
+    else if (isSnorm16ColorFormat())
+    {
+        // GL_EXT_render_snorm adds GL_RGBA + GL_SHORT to ReadPixels.  SNORM
+        // 1.0 maps to 32767.
+        GLshort pixel[4]          = {0, 0, 0, 0};
+        const GLshort expected[4] = {static_cast<GLshort>(R ? 32767 : 0),
+                                     static_cast<GLshort>(G ? 32767 : 0),
+                                     static_cast<GLshort>(B ? 32767 : 0), 32767};
+        glReadPixels(0, 0, 1, 1, GL_RGBA, GL_SHORT, pixel);
+        if (std::memcmp(pixel, expected, sizeof(pixel)) != 0)
+        {
+            result = testing::AssertionFailure()
+                     << "color attachment " << i << ": got (" << pixel[0] << ", " << pixel[1]
+                     << ", " << pixel[2] << ", " << pixel[3] << "), expected (" << expected[0]
+                     << ", " << expected[1] << ", " << expected[2] << ", " << expected[3] << ")";
+        }
+    }
+    else if (isFloatColorFormat())
+    {
+        const GLColor32F expected(R ? 1.0f : 0.0f, G ? 1.0f : 0.0f, B ? 1.0f : 0.0f, 1.0f);
+        const GLColor32F actual = angle::ReadColor32F(0, 0);
+        if (actual != expected)
+        {
+            result = testing::AssertionFailure()
+                     << "color attachment " << i << ": got " << actual << ", expected " << expected;
+        }
+    }
+    else
+    {
+        const GLColor expected(static_cast<GLubyte>(R ? 255 : 0), static_cast<GLubyte>(G ? 255 : 0),
+                               static_cast<GLubyte>(B ? 255 : 0), 255);
+        const GLColor actual = angle::ReadColor(0, 0);
+        if (actual != expected)
+        {
+            result = testing::AssertionFailure()
+                     << "color attachment " << i << ": got " << actual << ", expected " << expected;
+        }
+    }
+
+    if (samples() > 0)
+    {
+        // Restore READ binding; resolveFb is about to go out of scope.
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, sourceFb);
+    }
+    return result;
+}
+
+void DrawBuffersAnyFormatTestES3::clearAll(GLint numAttachments)
+{
+    const GLenum dsAttach = DepthStencilAttachmentFor(depthStencilFormat());
+
+    for (GLint i = 0; i < numAttachments; ++i)
+    {
+        clearColorAttachment(i);
+    }
+
+    GLbitfield clearMask = 0;
+    if (dsAttach == GL_DEPTH_ATTACHMENT || dsAttach == GL_DEPTH_STENCIL_ATTACHMENT)
+    {
+        glClearDepthf(1.0f);
+        clearMask |= GL_DEPTH_BUFFER_BIT;
+    }
+    if (dsAttach == GL_STENCIL_ATTACHMENT || dsAttach == GL_DEPTH_STENCIL_ATTACHMENT)
+    {
+        glClearStencil(0x55);
+        clearMask |= GL_STENCIL_BUFFER_BIT;
+    }
+    if (clearMask != 0)
+    {
+        glClear(clearMask);
+    }
+}
+
+testing::AssertionResult DrawBuffersAnyFormatTestES3::verifyAttachments(GLint numAttachments)
+{
+    for (GLint i = 0; i < numAttachments; ++i)
+    {
+        testing::AssertionResult r = verifyColorAttachment(i);
+        if (!r)
+        {
+            return r;
+        }
+    }
+    return testing::AssertionSuccess();
+}
+
+bool DrawBuffersAnyFormatTestES3::deviceSupportsParameters() const
+{
+    switch (colorFormat())
+    {
+        case GL_R16F:
+        case GL_RG16F:
+        case GL_RGBA16F:
+            if (!EnsureGLExtensionEnabled("GL_EXT_color_buffer_half_float"))
+            {
+                return false;
+            }
+            break;
+        case GL_R32F:
+        case GL_RG32F:
+        case GL_RGBA32F:
+        case GL_R11F_G11F_B10F:
+            if (!EnsureGLExtensionEnabled("GL_EXT_color_buffer_float"))
+            {
+                return false;
+            }
+            break;
+        case GL_RGB9_E5:
+            // Texture-only in baseline ES 3.0; renderable on Apple Silicon via
+            // GL_QCOM_render_shared_exponent (WEBGL_render_shared_exponent).
+            if (!EnsureGLExtensionEnabled("GL_QCOM_render_shared_exponent"))
+            {
+                return false;
+            }
+            break;
+        case GL_R16_EXT:
+        case GL_RG16_EXT:
+        case GL_RGBA16_EXT:
+            // 16-bit unsigned normalized formats are gated behind
+            // GL_EXT_texture_norm16 (renderable on Metal).
+            if (!EnsureGLExtensionEnabled("GL_EXT_texture_norm16"))
+            {
+                return false;
+            }
+            break;
+        case GL_R8_SNORM:
+        case GL_RG8_SNORM:
+        case GL_RGBA8_SNORM:
+            // Signed normalized 8-bit formats are texture-only in baseline ES
+            // 3.0; rendering is gated behind GL_EXT_render_snorm.
+            if (!EnsureGLExtensionEnabled("GL_EXT_render_snorm"))
+            {
+                return false;
+            }
+            break;
+        case GL_R16_SNORM_EXT:
+        case GL_RG16_SNORM_EXT:
+        case GL_RGBA16_SNORM_EXT:
+            // Signed normalized 16-bit formats require both extensions.
+            if (!EnsureGLExtensionEnabled("GL_EXT_render_snorm") ||
+                !EnsureGLExtensionEnabled("GL_EXT_texture_norm16"))
+            {
+                return false;
+            }
+            break;
+        default:
+            break;
+    }
+
+    // Stencil-only attachments as textures require GL_OES_texture_stencil8.
+    // Renderbuffer GL_STENCIL_INDEX8 is required by ES 3.0 with no extension.
+    if (useTexture() && depthStencilFormat() == GL_STENCIL_INDEX8)
+    {
+        if (!EnsureGLExtensionEnabled("GL_OES_texture_stencil8"))
+        {
+            return false;
+        }
+    }
+
+    if (samples() > 0)
+    {
+        // ES 3.0 §4.4.2.1 / §6.1.15: signed/unsigned integer color formats
+        // cannot be multisampled.
+        if (isSignedInt() || isUnsignedInt())
+        {
+            return false;
+        }
+        // Per-format max sample count via §6.1.15 GetInternalformativ.
+        // Skip if the implementation does not support the requested count for
+        // either the color or depth/stencil format (otherwise
+        // RenderbufferStorageMultisample would itself raise INVALID_OPERATION).
+        GLint maxSamplesForColor = 0;
+        glGetInternalformativ(GL_RENDERBUFFER, colorFormat(), GL_SAMPLES, 1, &maxSamplesForColor);
+        if (samples() > maxSamplesForColor)
+        {
+            return false;
+        }
+        if (depthStencilFormat() != 0)
+        {
+            GLint maxSamplesForDS = 0;
+            glGetInternalformativ(GL_RENDERBUFFER, depthStencilFormat(), GL_SAMPLES, 1,
+                                  &maxSamplesForDS);
+            if (samples() > maxSamplesForDS)
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+testing::AssertionResult DrawBuffersAnyFormatTestES3::verifyKnownDeviceExpectedFramebufferStatus(
+    GLenum status,
+    GLint numAttachments) const
+{
+    // Known Devices have entry in the table.
+    // For given (format, samples, numAttachments, status), verify status:
+    //   * A matching entry covers the (format, samples, numAttachments)  ->
+    //     Expect status incomplete.
+    //   * status Complete   -> success (expectations default to success).
+    //   * status Incomplete -> failure (missing expectation).
+
+    const std::string deviceName(reinterpret_cast<const char *>(glGetString(GL_RENDERER)));
+    bool hasExpectation = false;
+    // If we have expectation, the default is that all framebuffers resolve to working.
+    GLint expectedFirstFailingBufferCount = std::numeric_limits<GLint>::max();
+    for (const DrawBuffersAnyFormatExpectation &e :
+         kDrawBuffersAnyFormatExpectedFramebufferIncomplete)
+    {
+        if (deviceName.find(e.deviceNameSubstring) == std::string::npos)
+        {
+            continue;
+        }
+        // NOTE: If device has any entry in the table, we expect the table fully
+        // define the status behavior.
+        hasExpectation = true;
+        if (e.colorFormat != colorFormat())
+        {
+            continue;
+        }
+        for (const DrawBuffersAnyFormatExpectationPerSampleResult &r : e.sampleCounts)
+        {
+            if (r.sampleCount == samples())
+            {
+                expectedFirstFailingBufferCount = r.firstFailingDrawBufferCount;
+                break;
+            }
+        }
+    }
+    if (hasExpectation)
+    {
+        GLenum expectedStatus = static_cast<GLenum>(numAttachments < expectedFirstFailingBufferCount
+                                                        ? GL_FRAMEBUFFER_COMPLETE
+                                                        : GL_FRAMEBUFFER_UNSUPPORTED);
+        if (status == expectedStatus)
+        {
+            return testing::AssertionSuccess();
+        }
+        return testing::AssertionFailure()
+               << "device: " << deviceName << " n=" << numAttachments << " samples=" << samples()
+               << " format=" << gl::GLenumToString(gl::GLESEnum::AllEnums, colorFormat())
+               << " expected status: " << gl::GLenumToString(gl::GLESEnum::AllEnums, expectedStatus)
+               << " got status: " << gl::GLenumToString(gl::GLESEnum::AllEnums, status);
+    }
+    // Device not in the table: any status is tolerated.  Toggle ((false)) ->
+    // ((true)) to log a candidate row to add to the expectations table.
+    if (status != GL_FRAMEBUFFER_COMPLETE && ((false)))
+    {
+        printf("DrawBuffersAnyFormat incomplete: {\"%s\", %s, {..., {%d, %d}, ...}},\n",
+               deviceName.c_str(), gl::GLenumToString(gl::GLESEnum::AllEnums, colorFormat()),
+               samples(), numAttachments);
+    }
+    return testing::AssertionSuccess();
+}
+
+// Fill FBO with maximum amount of attachments for a specific format.
+// Test clear codepath with the FBO.
+TEST_P(DrawBuffersAnyFormatTestES3, ClearIterativeAttachmentCount)
+{
+    ANGLE_SKIP_TEST_IF(!deviceSupportsParameters());
+
+    GLint maxDrawBuffers = 0;
+    glGetIntegerv(GL_MAX_DRAW_BUFFERS, &maxDrawBuffers);
+    ASSERT_GE(maxDrawBuffers, 4);
+
+    for (GLint n = maxDrawBuffers; n >= 1; --n)
+    {
+        SCOPED_TRACE(testing::Message() << "numAttachments=" << n);
+
+        GLFramebuffer fb;
+        setUpFramebufferAttachments(fb, n);
+        glBindFramebuffer(GL_FRAMEBUFFER, fb);
+        ASSERT_GL_NO_ERROR();
+
+        const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+        EXPECT_TRUE(verifyKnownDeviceExpectedFramebufferStatus(status, n));
+        if (status != GL_FRAMEBUFFER_COMPLETE)
+        {
+            continue;
+        }
+
+        std::vector<GLenum> drawBuffers(n);
+        for (GLint i = 0; i < n; ++i)
+        {
+            drawBuffers[i] = GL_COLOR_ATTACHMENT0 + i;
+        }
+        glDrawBuffers(n, drawBuffers.data());
+
+        clearAll(n);
+        EXPECT_GL_NO_ERROR();
+        EXPECT_TRUE(verifyAttachments(n));
+        break;
+    }
+}
+
+// Fill FBO with maximum amount of attachments for a specific format.
+// Test clear-after-draw codepath with the FBO.
+TEST_P(DrawBuffersAnyFormatTestES3, DrawThenClearIterativeAttachmentCount)
+{
+    ANGLE_SKIP_TEST_IF(!deviceSupportsParameters());
+
+    GLint maxDrawBuffers = 0;
+    glGetIntegerv(GL_MAX_DRAW_BUFFERS, &maxDrawBuffers);
+    ASSERT_GE(maxDrawBuffers, 4);
+
+    for (GLint n = maxDrawBuffers; n >= 1; --n)
+    {
+        SCOPED_TRACE(testing::Message() << "numAttachments=" << n);
+
+        GLFramebuffer fb;
+        setUpFramebufferAttachments(fb, n);
+        glBindFramebuffer(GL_FRAMEBUFFER, fb);
+        ASSERT_GL_NO_ERROR();
+
+        const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+        EXPECT_TRUE(verifyKnownDeviceExpectedFramebufferStatus(status, n));
+        if (status != GL_FRAMEBUFFER_COMPLETE)
+        {
+            continue;
+        }
+
+        std::vector<GLenum> drawBuffers(n);
+        for (GLint i = 0; i < n; ++i)
+        {
+            drawBuffers[i] = GL_COLOR_ATTACHMENT0 + i;
+        }
+        glDrawBuffers(n, drawBuffers.data());
+
+        const GLenum dsAttach = DepthStencilAttachmentFor(depthStencilFormat());
+        const bool hasDepth =
+            dsAttach == GL_DEPTH_ATTACHMENT || dsAttach == GL_DEPTH_STENCIL_ATTACHMENT;
+        const bool hasStencil =
+            dsAttach == GL_STENCIL_ATTACHMENT || dsAttach == GL_DEPTH_STENCIL_ATTACHMENT;
+        if (hasDepth)
+        {
+            glEnable(GL_DEPTH_TEST);
+            glDepthFunc(GL_ALWAYS);
+        }
+        else
+        {
+            glDisable(GL_DEPTH_TEST);
+        }
+        if (hasStencil)
+        {
+            glEnable(GL_STENCIL_TEST);
+            glStencilFunc(GL_ALWAYS, 0x3C, 0xFF);
+            glStencilOp(GL_REPLACE, GL_REPLACE, GL_REPLACE);
+            glStencilMask(0xFF);
+        }
+        else
+        {
+            glDisable(GL_STENCIL_TEST);
+        }
+
+        const char *outType = isUnsignedInt() ? "uvec4" : (isSignedInt() ? "ivec4" : "vec4");
+        const char *outValue =
+            isUnsignedInt() ? "uvec4(0u, 0u, 1u, 1u)"
+                            : (isSignedInt() ? "ivec4(0, 0, 1, 1)" : "vec4(0.0, 0.0, 1.0, 1.0)");
+
+        std::stringstream fs;
+        fs << "#version 300 es\nprecision highp float;\n";
+        for (GLint i = 0; i < n; ++i)
+        {
+            fs << "layout(location = " << i << ") out " << outType << " value" << i << ";\n";
+        }
+        fs << "void main(){\n";
+        for (GLint i = 0; i < n; ++i)
+        {
+            fs << "value" << i << " = " << outValue << ";\n";
+        }
+        fs << "}\n";
+
+        ANGLE_GL_PROGRAM(drawMRT, essl3_shaders::vs::Simple(), fs.str().c_str());
+        drawQuad(drawMRT, essl3_shaders::PositionAttrib(), 0.0f);
+
+        clearAll(n);
+        EXPECT_GL_NO_ERROR();
+        EXPECT_TRUE(verifyAttachments(n));
+        break;
+    }
+}
+
+// Setup a big framebuffer and if it returns incomplete, expect clear to
+// fail too.
+TEST_P(DrawBuffersAnyFormatTestES3, IncompleteClearIsInvalidFramebufferOperation)
+{
+    ANGLE_SKIP_TEST_IF(!deviceSupportsParameters());
+
+    GLint maxDrawBuffers = 0;
+    glGetIntegerv(GL_MAX_DRAW_BUFFERS, &maxDrawBuffers);
+    ASSERT_GE(maxDrawBuffers, 4);
+
+    for (GLint n = 1; n <= maxDrawBuffers; ++n)
+    {
+        SCOPED_TRACE(testing::Message() << "numAttachments=" << n);
+
+        GLFramebuffer fb;
+        setUpFramebufferAttachments(fb, n);
+        glBindFramebuffer(GL_FRAMEBUFFER, fb);
+        ASSERT_GL_NO_ERROR();
+
+        const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+        EXPECT_TRUE(verifyKnownDeviceExpectedFramebufferStatus(status, n));
+        if (status == GL_FRAMEBUFFER_COMPLETE)
+        {
+            continue;
+        }
+
+        glClear(GL_COLOR_BUFFER_BIT);
+        EXPECT_GL_ERROR(GL_INVALID_FRAMEBUFFER_OPERATION);
+        glClear(GL_STENCIL_BUFFER_BIT);
+        EXPECT_GL_ERROR(GL_INVALID_FRAMEBUFFER_OPERATION);
+    }
+}
+
+// Sanity test: detects implementations that advertise a per-format max
+// sample count exceeding what the MSAA instantiation of
+// DrawBuffersAnyFormatTestES3 actually exercises.  If this fires, raise
+// kDrawBuffersAnyFormatMaxTestedSampleCount and add the new value to the
+// MSAA instantiation's sample-count list.
+TEST_P(DrawBuffersTestES3, DrawBuffersAnyFormatMSAASampleLimitIsEnough)
+{
+    EnsureGLExtensionEnabled("GL_EXT_color_buffer_half_float");
+    EnsureGLExtensionEnabled("GL_EXT_color_buffer_float");
+    EnsureGLExtensionEnabled("GL_QCOM_render_shared_exponent");
+    EnsureGLExtensionEnabled("GL_EXT_texture_norm16");
+    EnsureGLExtensionEnabled("GL_EXT_render_snorm");
+
+    auto checkFormat = [&](GLenum fmt) {
+        GLint numCounts = 0;
+        glGetInternalformativ(GL_RENDERBUFFER, fmt, GL_NUM_SAMPLE_COUNTS, 1, &numCounts);
+        if (glGetError() != GL_NO_ERROR)
+        {
+            return;
+        }
+        if (numCounts == 0)
+        {
+            return;
+        }
+        GLint maxSamples = 0;
+        glGetInternalformativ(GL_RENDERBUFFER, fmt, GL_SAMPLES, 1, &maxSamples);
+        EXPECT_GL_NO_ERROR();
+        EXPECT_LE(maxSamples, kDrawBuffersAnyFormatMaxTestedSampleCount)
+            << "format: " << gl::GLenumToString(gl::GLESEnum::AllEnums, fmt);
+    };
+
+    for (GLenum fmt : kDrawBuffersAnyFormatMSAAColorFormats)
+    {
+        checkFormat(fmt);
+    }
+    for (GLenum fmt : kDrawBuffersAnyFormatDepthStencilFormats)
+    {
+        if (fmt == 0)
+        {
+            continue;  // sentinel for "no depth/stencil attachment"
+        }
+        checkFormat(fmt);
+    }
+}
+
 ANGLE_INSTANTIATE_TEST_ES2_AND_ES3_AND(DrawBuffersTest,
                                        ES2_METAL().enable(Feature::LimitMaxDrawBuffersForTesting),
+                                       ES3_METAL().enable(Feature::LimitMaxDrawBuffersForTesting),
                                        ES2_VULKAN()
                                            .disable(Feature::SupportsTransformFeedbackExtension)
                                            .disable(Feature::EmulateTransformFeedback));
@@ -1799,3 +2849,35 @@ ANGLE_INSTANTIATE_TEST_ES3(DrawBuffersTestES3);
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(ColorMaskForDrawBuffersTest);
 ANGLE_INSTANTIATE_TEST_ES3(ColorMaskForDrawBuffersTest);
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DrawBuffersAnyFormatTestES3);
+
+const angle::PlatformParameters kDrawBuffersAnyFormatPlatforms[] = {
+    ANGLE_ALL_TEST_PLATFORMS_ES3,
+    ES3_VULKAN().enable(Feature::ForceFallbackFormat),
+    ES3_VULKAN().enable(Feature::PreferDrawClearOverVkCmdClearAttachments),
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    NonMSAA,
+    DrawBuffersAnyFormatTestES3,
+    testing::Combine(
+        testing::ValuesIn(::angle::FilterTestParams(kDrawBuffersAnyFormatPlatforms,
+                                                    ArraySize(kDrawBuffersAnyFormatPlatforms))),
+        testing::ValuesIn(kDrawBuffersAnyFormatColorFormats),
+        testing::ValuesIn(kDrawBuffersAnyFormatDepthStencilFormats),
+        testing::Bool(),
+        testing::Values<GLint>(0)),
+    DrawBuffersAnyFormatVariationsTestPrint);
+
+INSTANTIATE_TEST_SUITE_P(
+    MSAA,
+    DrawBuffersAnyFormatTestES3,
+    testing::Combine(
+        testing::ValuesIn(::angle::FilterTestParams(kDrawBuffersAnyFormatPlatforms,
+                                                    ArraySize(kDrawBuffersAnyFormatPlatforms))),
+        testing::ValuesIn(kDrawBuffersAnyFormatMSAAColorFormats),
+        testing::ValuesIn(kDrawBuffersAnyFormatDepthStencilFormats),
+        testing::Values(false),  // renderbuffers only; ES 3.0 has no MSAA textures
+        testing::Values<GLint>(2, kDrawBuffersAnyFormatMaxTestedSampleCount)),
+    DrawBuffersAnyFormatVariationsTestPrint);

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/ImageTestMetal.mm
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/ImageTestMetal.mm
@@ -122,10 +122,14 @@ bool IsDepthOrStencil(MTLPixelFormat format)
         case MTLPixelFormatDepth16Unorm:
         case MTLPixelFormatDepth32Float:
         case MTLPixelFormatStencil8:
+#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
         case MTLPixelFormatDepth24Unorm_Stencil8:
+#endif
         case MTLPixelFormatDepth32Float_Stencil8:
         case MTLPixelFormatX32_Stencil8:
+#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
         case MTLPixelFormatX24_Stencil8:
+#endif
             return true;
 
         default:
@@ -346,8 +350,12 @@ class ImageTestMetal : public ANGLETest<>
 
     bool hasDepth24Stencil8PixelFormat()
     {
+    #if TARGET_OS_OSX || TARGET_OS_MACCATALYST
         id<MTLDevice> device = getMtlDevice();
         return device.depth24Stencil8PixelFormatSupported;
+    #else
+        return false;
+    #endif
     }
 
     bool hasImageNativeMetalTextureExt() const

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.cpp
@@ -1217,9 +1217,12 @@ TestSuite::TestSuite(int *argc, char **argv, std::function<void()> registerTests
 #if defined(ANGLE_ENABLE_METAL)
         // Metal does not support toggling per-context debug layers for tests.
         SetEnvironmentVar("MTL_DEBUG_LAYER", "1");
+        // Shader validation is not working for simulator.
+#if !TARGET_OS_SIMULATOR
         SetEnvironmentVar("MTL_SHADER_VALIDATION", "1");
         SetEnvironmentVar("MTL_SHADER_VALIDATION_ABORT_ON_FAULT", "1");
         SetEnvironmentVar("MTL_SHADER_VALIDATION_REPORT_TO_STDERR", "1");
+#endif
 #endif
     }
 


### PR DESCRIPTION
#### d474d7e454aad80e4080a403cca0faad2e2216dd
<pre>
ANGLE: Metal: Crash when clearing too many large pixels on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=315651">https://bugs.webkit.org/show_bug.cgi?id=315651</a>
<a href="https://rdar.apple.com/178037647">rdar://178037647</a>

Reviewed by NOBODY (OOPS!).

Fix bugs in handing render pass total pixel size limits:
 - Depth, stencil render attachments were part of the pixel size
   calculations, even though they should not be.
 - GL framebuffer completeness was incorrectly calculated based
   on the the color bitsizes of the attached attachments. The
   color bit sizes do not define the renderability, rather the
   underlying format.
 - If the framebuffer would be incorrectly validated as complete,
   draw could fail due to too big pixel size. In these cases
   a encoder nullptr dereference would occur.

OpenGL ES has following related limits:
 - MAX_COLOR_ATTACHMENTS -- how many attachments can be attached to FBO
 - MAX_DRAW_BUFFERS -- how many buffers can be rendered to
 - glDrawBuffers -- which buffers are being rendered to

Not all framebuffers are complete -- only those framebuffers are
complete that are renderable with all buffers
enabled.

Metal has following related limits:
 - Maximum number of color render targets per render
   pass descriptor
 - Maximum number of color bytes written per render pass

On macOS, there is no limit to number of bytes. On iOS, the limit is
32 or 64 bytes.

Thus framebuffers that do not fit into 32 or 64 bytes on respective
GPUs are not complete.

The change <a href="https://commits.webkit.org/311827@main">311827@main</a> would update pixel format sizes from zeros to the
actual sizes. The sizes were used to calculate whether a render pass is
usable. Before the <a href="https://commits.webkit.org/311827@main">311827@main</a>, the render pass size calculation was not
effective due to zero sizes and thus the tests completed. After, the
tests would crash on ClearTest.ClearMaxAttachments on simulator because
of the MAX_DRAW_BUFFERS (8) * sizeof RGBA8 + sizeof stencil/depth
exceeded the simulator max 32.

There would be existing bugs related to iOS format sizes not being
adjusted. Especially the simulator has unexpectedly large sizes
for some emulated formats. These were not exercised by the tests.

Fix by:
 - Remove accounting of depth, stencil to the render attachment pixel
   size. Only account the color attachments.
 - Fix the checking of the color attachment sizes for framebuffer
   completeness. Check based on the actual Metal pixel format.
 - Fix the nullptr deref when the draw fails due to too many bytes
   per pixel being drawn.
 - Adjust the sizes for iOS pixel formats.

Adds DrawBuffersAnyFormatTestES3 suite which iterates exhaustively all
pixel formats to render to and tests a test similar to
ClearTestES3.ClearMaxAttachmentsAfterDraw, ClearMaxAttachments.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm:
(rx::ContextMtl::getRenderPassCommandEncoder):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm:
(rx::DisplayMtl::ensureCapsInitialized const):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm:
(rx::FramebufferMtl::checkStatus const):
(rx::FramebufferMtl::ensureRenderPassStarted):
(rx::FramebufferMtl::totalBitsUsedIsLessThanOrEqualToMaxBitsSupported const): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/gen_mtl_format_table.py:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_common.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_table_autogen.mm:
(rx::mtl::FormatTable::initNativeFormatCapsAutogen):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.mm:
(rx::mtl::FormatTable::adjustFormatCapsForDevice):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_pipeline_cache.mm:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm:
(rx::mtl::ComputeTotalSizeUsedForMTLRenderPassDescriptor):
(rx::mtl::ComputeTotalSizeUsedForMTLRenderPipelineDescriptor):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawBuffersTest.cpp:
</pre>
----------------------------------------------------------------------
#### 8c5b6096a28bc75762e1d9f71a4a19b3a285ddec
<pre>
ANGLE: Support running ANGLEEnd2EndTests on iOS devices
<a href="https://bugs.webkit.org/show_bug.cgi?id=315654">https://bugs.webkit.org/show_bug.cgi?id=315654</a>
<a href="https://rdar.apple.com/178042675">rdar://178042675</a>

Reviewed by NOBODY (OOPS!).

Support running ANGLEEnd2EndTests on iOS, tvOS, watchOS, visionOS devices.
Add ANGLEEnd2EndTestsApp, since the test scaffolding opens windows.

Example script to run:
run-angle-tests --simulator  --gtest_filter=&quot;*Metal*&quot;
run-angle-tests --xros-device 00008142-001819621E20011C --per-suite
run-angle-tests --ios-device

* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:
* Source/ThirdParty/ANGLE/Configurations/ANGLEEnd2EndTestApp-iOS-simulator.entitlements: Added.
* Source/ThirdParty/ANGLE/Configurations/ANGLEEnd2EndTestApp-iOS.entitlements: Added.
* Source/ThirdParty/ANGLE/Configurations/ANGLEEnd2EndTestApp.xcconfig: Added.
* Source/ThirdParty/ANGLE/WebKit/ANGLEEnd2EndTestAppInfo.plist: Added.
* Source/ThirdParty/ANGLE/WebKit/ANGLEEnd2EndTestAppLaunch.storyboard: Added.
* Source/ThirdParty/ANGLE/WebKit/run-angle-tests: Added.
(read_bundle_id):
(is_crash):
(LocalRunner):
(LocalRunner.__init__):
(LocalRunner.install):
(LocalRunner.launch):
(LocalRunner.run_capturing):
(LocalRunner.format_command):
(LocalRunner.launch_for_debug):
(SimulatorRunner):
(SimulatorRunner.__init__):
(SimulatorRunner.install):
(SimulatorRunner.launch):
(SimulatorRunner.run_capturing):
(SimulatorRunner.format_command):
(SimulatorRunner.launch_for_debug):
(DeviceRunner):
(DeviceRunner.__init__):
(DeviceRunner._list_devices_json):
(DeviceRunner._is_usable):
(DeviceRunner.resolve_device):
(DeviceRunner.install):
(DeviceRunner.launch):
(DeviceRunner.run_capturing):
(DeviceRunner.format_command):
(DeviceRunner.launch_for_debug):
(list_tests):
(run_filter):
(status_for):
(run_per_suite):
(main):
* Source/ThirdParty/ANGLE/src/common/PoolAlloc_unittest.cpp:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/ImageTestMetal.mm:
(angle::IsDepthOrStencil):
(angle::ImageTestMetal::hasDepth24Stencil8PixelFormat):
* Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.cpp:
(angle::TestSuite::TestSuite):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d474d7e454aad80e4080a403cca0faad2e2216dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122507 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84f2feb1-c3a8-4eb6-9bb2-3838c657e9f3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128405 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90381 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7bd5c75c-bbcd-4eea-b192-c78ecc4f3479) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168209 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30720 "Found 6 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html webgl/1.0.x/conformance/extensions/webgl-draw-buffers-broadcast-return.html webgl/1.0.x/conformance/extensions/webgl-draw-buffers.html webgl/2.0.y/conformance2/extensions/oes-draw-buffers-indexed.html webgl/2.0.y/conformance2/rendering/draw-buffers.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108930 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8eb4444d-a81d-43cd-81b4-9547bf99437c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29767 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28389 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22047 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176815 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136726 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136665 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147960 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101825 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31946 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24827 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38009 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37406 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2905 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37652 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37550 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->