### PR TITLE
[GTK][WPE] Skia Compositor: avoid SkCanvas::clipPath when possible

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -445,6 +445,25 @@ bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& damage
     return hasRunningAnimations;
 }
 
+void SkiaCompositingLayer::clipRect(SkCanvas& canvas, const FloatRoundedRect& rect, const TransformationMatrix& transform)
+{
+    if (transform.isIdentity()) {
+        if (rect.isRounded())
+            canvas.clipRRect(SkRRect(rect), true);
+        else
+            canvas.clipRect(SkRect(rect.rect()));
+        return;
+    }
+
+    auto matrix = SkM44(transform).asM33();
+    if (rect.isRounded())
+        canvas.clipPath(SkPath::RRect(SkRRect(rect)).makeTransform(matrix), true);
+    else if (matrix.rectStaysRect())
+        canvas.clipRect(matrix.mapRect(SkRect(rect.rect())));
+    else
+        canvas.clipPath(SkPath::Rect(SkRect(rect.rect())).makeTransform(matrix));
+}
+
 void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
 {
 #if ENABLE(DAMAGE_TRACKING)
@@ -496,12 +515,8 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
     } else if (m_contentsBuffer || m_imageBackingStore) {
         bool shouldClipContents = m_contentsClippingRect.isRounded() || !m_contentsClippingRect.rect().contains(m_contentsRect);
         SkAutoCanvasRestore autoRestore(&canvas, shouldClipContents);
-        if (shouldClipContents) {
-            if (m_contentsClippingRect.isRounded())
-                canvas.clipRRect(SkRRect(m_contentsClippingRect), true);
-            else
-                canvas.clipRect(SkRect(m_contentsClippingRect.rect()));
-        }
+        if (shouldClipContents)
+            clipRect(canvas, m_contentsClippingRect);
 
         sk_sp<SkImage> image;
 
@@ -635,21 +650,12 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
     bool shouldClip = (m_masksToBounds || m_contentsRectClipsDescendants) && !m_preserves3D;
     SkAutoCanvasRestore autoRestore(&canvas, shouldClip);
     if (shouldClip) {
+        FloatRoundedRect rect = m_contentsRectClipsDescendants ? m_contentsClippingRect : FloatRoundedRect(effectiveLayerRect());
         TransformationMatrix clipTransform(context.accumulatedReplicaTransform);
         clipTransform.multiply(m_transforms.combined);
-        if (m_contentsRectClipsDescendants) {
-            SkPathBuilder builder;
-            if (m_contentsClippingRect.isRounded())
-                builder.addRRect(SkRRect(m_contentsClippingRect));
-            else
-                builder.addRect(SkRect(m_contentsClippingRect.rect()));
-            canvas.clipPath(builder.detach().makeTransform(SkM44(clipTransform).asM33()), true);
-        } else {
+        if (!m_contentsRectClipsDescendants)
             clipTransform.translate(m_boundsOrigin.x(), m_boundsOrigin.y());
-            SkPathBuilder builder;
-            builder.addRect(SkRect(effectiveLayerRect()));
-            canvas.clipPath(builder.detach().makeTransform(SkM44(clipTransform).asM33()));
-        }
+        clipRect(canvas, rect, clipTransform);
     }
 
     for (auto& child : m_children)
@@ -753,11 +759,9 @@ void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintC
 void SkiaCompositingLayer::paintBackdrop(SkCanvas& canvas, PaintContext& context)
 {
     SkAutoCanvasRestore autoRestore(&canvas, true);
-    SkPathBuilder builder;
-    builder.addRRect(SkRRect(m_backdrop.clipRect));
     TransformationMatrix clipTransform(context.accumulatedReplicaTransform);
     clipTransform.multiply(m_transforms.combined);
-    canvas.clipPath(builder.detach().makeTransform(SkM44(clipTransform).asM33()), true);
+    clipRect(canvas, m_backdrop.clipRect, clipTransform);
 
     // Paint the backdrop root's subtree into a fresh surface (spec step 1),
     // apply the backdrop filter (step 2), and composite via SrcOver so the

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -173,6 +173,8 @@ private:
     sk_sp<SkImage> maskImage();
     void collect3DRenderingContextLayers(Vector<Ref<SkiaCompositingLayer>>&);
 
+    void clipRect(SkCanvas&, const FloatRoundedRect&, const TransformationMatrix& = { });
+
     enum class IncludesReplica : bool { No, Yes };
     void computeOverlapRegions(ComputeOverlapRegionData&, const TransformationMatrix& accumulatedReplicaTransform, IncludesReplica = IncludesReplica::Yes);
 


### PR DESCRIPTION
#### c2d31e897eb83ad3ad41ff5e43ca908390cae480
<pre>
[GTK][WPE] Skia Compositor: avoid SkCanvas::clipPath when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=315841">https://bugs.webkit.org/show_bug.cgi?id=315841</a>

Reviewed by Nikolas Zimmermann.

When clipping not rounded rects, SkCanvas::clipRect is more efficient.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::clipRect):
(WebCore::SkiaCompositingLayer::paintSelf):
(WebCore::SkiaCompositingLayer::paintSelfAndChildren):
(WebCore::SkiaCompositingLayer::paintBackdrop):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:

Canonical link: <a href="https://commits.webkit.org/314286@main">https://commits.webkit.org/314286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9599a00adb9f4c783258a532bee7dfecda397bbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122940 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128754 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168644 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109278 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28768 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22808 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140023 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177251 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137082 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137012 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148351 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102436 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25216 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25218 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111516 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37839 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3299 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->