### PR TITLE
Ensure selectedcontent and textarea elements can be used with a namespace prefix

### DIFF
--- a/LayoutTests/fast/dom/Document-createElementNS-html-prefix-expected.txt
+++ b/LayoutTests/fast/dom/Document-createElementNS-html-prefix-expected.txt
@@ -1,0 +1,21 @@
+Tests that Document.createElementNS preserves a non-null prefix on known HTML elements.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS element.prefix is "foo"
+PASS element.localName is "textarea"
+PASS element.tagName is "FOO:TEXTAREA"
+PASS element.namespaceURI is "http://www.w3.org/1999/xhtml"
+PASS element.prefix is "foo"
+PASS element.localName is "article"
+PASS element.tagName is "FOO:ARTICLE"
+PASS element.namespaceURI is "http://www.w3.org/1999/xhtml"
+PASS element.prefix is "foo"
+PASS element.localName is "selectedcontent"
+PASS element.tagName is "FOO:SELECTEDCONTENT"
+PASS element.namespaceURI is "http://www.w3.org/1999/xhtml"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/Document-createElementNS-html-prefix.html
+++ b/LayoutTests/fast/dom/Document-createElementNS-html-prefix.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that Document.createElementNS preserves a non-null prefix on known HTML elements.");
+
+const xhtmlNS = "http://www.w3.org/1999/xhtml";
+
+var element = document.createElementNS(xhtmlNS, "foo:textarea");
+shouldBeEqualToString("element.prefix", "foo");
+shouldBeEqualToString("element.localName", "textarea");
+shouldBeEqualToString("element.tagName", "FOO:TEXTAREA");
+shouldBeEqualToString("element.namespaceURI", xhtmlNS);
+
+element = document.createElementNS(xhtmlNS, "foo:article");
+shouldBeEqualToString("element.prefix", "foo");
+shouldBeEqualToString("element.localName", "article");
+shouldBeEqualToString("element.tagName", "FOO:ARTICLE");
+shouldBeEqualToString("element.namespaceURI", xhtmlNS);
+
+element = document.createElementNS(xhtmlNS, "foo:selectedcontent");
+shouldBeEqualToString("element.prefix", "foo");
+shouldBeEqualToString("element.localName", "selectedcontent");
+shouldBeEqualToString("element.tagName", "FOO:SELECTEDCONTENT");
+shouldBeEqualToString("element.namespaceURI", xhtmlNS);
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLArticleElement.cpp
+++ b/Source/WebCore/html/HTMLArticleElement.cpp
@@ -43,7 +43,7 @@ Ref<HTMLArticleElement> HTMLArticleElement::create(const QualifiedName& tagName,
 HTMLArticleElement::HTMLArticleElement(const QualifiedName& tagName, Document& document)
     : HTMLElement(tagName, document)
 {
-    ASSERT(tagName == HTMLNames::articleTag);
+    ASSERT(hasTagName(HTMLNames::articleTag));
 }
 
 auto HTMLArticleElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> NeedsPostConnectionSteps

--- a/Source/WebCore/html/HTMLSelectedContentElement.cpp
+++ b/Source/WebCore/html/HTMLSelectedContentElement.cpp
@@ -40,15 +40,15 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLSelectedContentElement);
 
 using namespace HTMLNames;
 
-HTMLSelectedContentElement::HTMLSelectedContentElement(Document& document)
-    : HTMLElement(selectedcontentTag, document, { })
+HTMLSelectedContentElement::HTMLSelectedContentElement(const QualifiedName& tagName, Document& document)
+    : HTMLElement(tagName, document, { })
 {
     ASSERT(hasTagName(selectedcontentTag));
 }
 
-Ref<HTMLSelectedContentElement> HTMLSelectedContentElement::create(const QualifiedName&, Document& document)
+Ref<HTMLSelectedContentElement> HTMLSelectedContentElement::create(const QualifiedName& tagName, Document& document)
 {
-    return adoptRef(*new HTMLSelectedContentElement(document));
+    return adoptRef(*new HTMLSelectedContentElement(tagName, document));
 }
 
 auto HTMLSelectedContentElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> NeedsPostConnectionSteps

--- a/Source/WebCore/html/HTMLSelectedContentElement.h
+++ b/Source/WebCore/html/HTMLSelectedContentElement.h
@@ -40,7 +40,7 @@ public:
     bool isDisabled() { return m_isDisabled; }
 
 private:
-    explicit HTMLSelectedContentElement(Document&);
+    HTMLSelectedContentElement(const QualifiedName&, Document&);
 
     NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;
     void postConnectionSteps() final;

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -74,16 +74,16 @@ static inline unsigned NODELETE computeLengthForAPIValue(StringView text)
     return text.length() - crlfCount;
 }
 
-HTMLTextAreaElement::HTMLTextAreaElement(Document& document, HTMLFormElement* form)
-    : HTMLTextFormControlElement(textareaTag, document, form)
+HTMLTextAreaElement::HTMLTextAreaElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+    : HTMLTextFormControlElement(tagName, document, form)
 {
+    ASSERT(hasTagName(textareaTag));
     setFormControlValueMatchesRenderer(true);
 }
 
 Ref<HTMLTextAreaElement> HTMLTextAreaElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
 {
-    ASSERT_UNUSED(tagName, tagName == textareaTag);
-    auto textArea = adoptRef(*new HTMLTextAreaElement(document, form));
+    Ref textArea = adoptRef(*new HTMLTextAreaElement(tagName, document, form));
     textArea->ensureUserAgentShadowRoot();
     return textArea;
 }

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -61,7 +61,7 @@ public:
     bool dirAutoUsesValue() const final { return true; }
 
 private:
-    HTMLTextAreaElement(Document&, HTMLFormElement*);
+    HTMLTextAreaElement(const QualifiedName&, Document&, HTMLFormElement*);
 
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
 


### PR DESCRIPTION
#### 3bdc8f13fa091c7a0a06f89969806138d0e75cc3
<pre>
Ensure selectedcontent and textarea elements can be used with a namespace prefix
<a href="https://bugs.webkit.org/show_bug.cgi?id=315843">https://bugs.webkit.org/show_bug.cgi?id=315843</a>

Reviewed by Ryosuke Niwa.

Also fix an assert with the same underlying flaw in the article element.

Canonical link: <a href="https://commits.webkit.org/314166@main">https://commits.webkit.org/314166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd64e668e1d1889a9eb3169375adbc7e51fc0a22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174313 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122527 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f95da7d9-a38b-47f1-8686-cecb48c7cd0b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128424 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d43f63ce-4231-4779-ac11-ee69b9c91e6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168229 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30737 "Found 3 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108949 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95232cb5-32c3-4017-b754-275101b912fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29784 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28406 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22391 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176835 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29722 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136743 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136682 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36857 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147976 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101853 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24843 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38029 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111102 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37426 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2921 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37672 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37570 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->