### PR TITLE
[WPE][WebXR] Use an Android User-Agent when visiting ikea.com

### DIFF
--- a/Source/WebCore/platform/glib/UserAgentGLib.cpp
+++ b/Source/WebCore/platform/glib/UserAgentGLib.cpp
@@ -83,6 +83,8 @@ static String buildUserAgentString(const UserAgentQuirks& quirks)
 
     if (quirks.contains(UserAgentQuirks::NeedsMacintoshPlatform))
         uaString.append(UserAgentQuirks::stringForQuirk(UserAgentQuirks::NeedsMacintoshPlatform));
+    else if (quirks.contains(UserAgentQuirks::NeedsAndroidPlatform))
+        uaString.append(UserAgentQuirks::stringForQuirk(UserAgentQuirks::NeedsAndroidPlatform));
     else {
         uaString.append(platformForUAString(), "; "_s);
 #if defined(USER_AGENT_BRANDING)

--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -157,6 +157,17 @@ static bool urlRequiresMacintoshPlatform(const String& domain, const String& bas
     return false;
 }
 
+static bool urlRequiresAndroidPlatform([[maybe_unused]] const String& baseDomain)
+{
+#if ENABLE(WEBXR) && PLATFORM(WPE)
+    // When WebXR is available the model viewer support provides a better UX.
+    if (baseDomain == "ikea.com"_s)
+        return true;
+#endif
+
+    return false;
+}
+
 static bool urlRequiresUnbrandedUserAgent(const String& domain)
 {
     // Google uses an ugly fallback login page if application branding is
@@ -192,6 +203,8 @@ UserAgentQuirks UserAgentQuirks::quirksForURL(const URL& url)
 
     if (urlRequiresMacintoshPlatform(domain, baseDomain))
         quirks.add(UserAgentQuirks::NeedsMacintoshPlatform);
+    else if (urlRequiresAndroidPlatform(baseDomain))
+        quirks.add(UserAgentQuirks::NeedsAndroidPlatform);
 
     if (urlRequiresUnbrandedUserAgent(domain))
         quirks.add(UserAgentQuirks::NeedsUnbrandedUserAgent);
@@ -208,6 +221,8 @@ String UserAgentQuirks::stringForQuirk(UserAgentQuirk quirk)
         return "; rv:300.0) Gecko/20100101 Firefox/300.0"_s;
     case NeedsMacintoshPlatform:
         return "Macintosh; Intel Mac OS X 10_15"_s;
+    case NeedsAndroidPlatform:
+        return "Linux; Android 12.0.0"_s;
     case NeedsUnbrandedUserAgent:
     case NumUserAgentQuirks:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/glib/UserAgentQuirks.h
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.h
@@ -36,6 +36,7 @@ public:
         NeedsChromeBrowser,
         NeedsFirefoxBrowser,
         NeedsMacintoshPlatform,
+        NeedsAndroidPlatform,
         NeedsUnbrandedUserAgent,
 
         NumUserAgentQuirks

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
@@ -61,9 +61,24 @@ static void assertUserAgentForURLHasMacPlatformQuirk(const char* url)
     EXPECT_TRUE(uaString.contains("Macintosh"_s));
     EXPECT_TRUE(uaString.contains("Mac OS X"_s));
     EXPECT_FALSE(uaString.contains("Linux"_s));
+    EXPECT_FALSE(uaString.contains("Android"_s));
     EXPECT_FALSE(uaString.contains("Chrome"_s));
     EXPECT_FALSE(uaString.contains("FreeBSD"_s));
 }
+
+#if ENABLE(WEBXR) && PLATFORM(WPE)
+static void assertUserAgentForURLHasAndroidQuirk(const char* url)
+{
+    String uaString = standardUserAgentForURL(URL(String::fromLatin1(url)));
+
+    EXPECT_FALSE(uaString.contains("Macintosh"_s));
+    EXPECT_FALSE(uaString.contains("Mac OS X"_s));
+    EXPECT_TRUE(uaString.contains("Linux"_s));
+    EXPECT_TRUE(uaString.contains("Android"_s));
+    EXPECT_FALSE(uaString.contains("Chrome"_s));
+    EXPECT_FALSE(uaString.contains("FreeBSD"_s));
+}
+#endif
 
 // Some Google domains require an unbranded user agent, which is a little
 // awkward to test for. We want to check that standardUserAgentForURL is
@@ -104,6 +119,10 @@ TEST(UserAgentTest, Quirks)
 #if ENABLE(THUNDER)
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.netflix.com/");
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.disneyplus.com/");
+#endif
+
+#if ENABLE(WEBXR) && PLATFORM(WPE)
+    assertUserAgentForURLHasAndroidQuirk("https://www.ikea.com/");
 #endif
 
     assertUserAgentForURLHasMacPlatformQuirk("http://www.yahoo.com/");


### PR DESCRIPTION
#### 843b726247e0df51f6052c743f859c3cdfdccb8e
<pre>
[WPE][WebXR] Use an Android User-Agent when visiting ikea.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=315839">https://bugs.webkit.org/show_bug.cgi?id=315839</a>

Reviewed by Adrian Perez de Castro.

When WebXR is available the model viewer support provides a better UX.

* Source/WebCore/platform/glib/UserAgentGLib.cpp:
(WebCore::buildUserAgentString):
* Source/WebCore/platform/glib/UserAgentQuirks.cpp:
(WebCore::urlRequiresAndroidPlatform):
(WebCore::UserAgentQuirks::quirksForURL):
(WebCore::UserAgentQuirks::stringForQuirk):
* Source/WebCore/platform/glib/UserAgentQuirks.h:

Canonical link: <a href="https://commits.webkit.org/314216@main">https://commits.webkit.org/314216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1c8f80b3061f7b6048de98d2367d757acd09e06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128436 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90399 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29794 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28415 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22398 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176845 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29737 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136755 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136694 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36886 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147986 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101864 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31974 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24853 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38039 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111112 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37436 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2931 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->