### PR TITLE
[EME] Protect MediaKeySession::sessionClosed from concurrent calls

### DIFF
--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close-expected.txt
@@ -1,0 +1,19 @@
+RUN(internals.initializeMockMediaSource())
+RUN(mock = internals.registerMockCDM())
+RUN(mock.supportedDataTypes = ["keyids"])
+RUN(capabilities.initDataTypes = ["keyids"])
+RUN(capabilities.videoCapabilities = [{ contentType: 'video/mock; codecs="mock"' }] )
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities]))
+Promise resolved OK
+RUN(promise = mediaKeySystemAccess.createMediaKeys())
+Promise resolved OK
+RUN(kids = JSON.stringify({ kids: [ "MTIzNDU=" ] }))
+RUN(mediaKeySession = mediaKeys.createSession("temporary"))
+RUN(promise = mediaKeySession.generateRequest("keyids", encoder.encode(kids)))
+Promise resolved OK
+Two concurrent close() calls should both resolve without crashing.
+RUN(promise = mediaKeySession.close())
+RUN(promise2 = mediaKeySession.close())
+Survived concurrent close() and the "closed" promise resolved exactly once.
+END OF TEST
+

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close.html
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src=../video-test.js></script>
+    <script type="text/javascript">
+    // Regression test: two concurrent close() calls on the same MediaKeySession must not resolve the
+    // "closed" promise twice. Each close() checks m_closed before queuing its work, but m_closed is only
+    // set when the queued task runs, so both calls queue a sessionClosed() task; resolving the "closed"
+    // promise a second time previously tripped an assertion in DOMPromiseProxy::resolve().
+    var mock;
+    var promise;
+    var promise2;
+    var mediaKeySystemAccess;
+    var mediaKeys;
+    var mediaKeySession;
+    var capabilities = {};
+    var kids;
+    var encoder = new TextEncoder();
+
+    function doTest()
+    {
+        if (!window.internals) {
+            failTest("Internals is required for this test.");
+            return;
+        }
+
+        run('internals.initializeMockMediaSource()');
+        run('mock = internals.registerMockCDM()');
+        run('mock.supportedDataTypes = ["keyids"]');
+        run('capabilities.initDataTypes = ["keyids"]');
+        run(`capabilities.videoCapabilities = [{ contentType: 'video/mock; codecs="mock"' }] `);
+        run('promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities])');
+        shouldResolve(promise).then(gotMediaKeySystemAccess, failTest);
+    }
+
+    function gotMediaKeySystemAccess(result) {
+        mediaKeySystemAccess = result;
+        run('promise = mediaKeySystemAccess.createMediaKeys()');
+        shouldResolve(promise).then(gotMediaKeys, failTest);
+    }
+
+    function gotMediaKeys(result) {
+        mediaKeys = result;
+        run('kids = JSON.stringify({ kids: [ "MTIzNDU=" ] })');
+        run('mediaKeySession = mediaKeys.createSession("temporary")');
+        run('promise = mediaKeySession.generateRequest("keyids", encoder.encode(kids))');
+        shouldResolve(promise).then(closeConcurrently, failTest);
+    }
+
+    function closeConcurrently() {
+        consoleWrite('Two concurrent close() calls should both resolve without crashing.');
+        run('promise = mediaKeySession.close()');
+        run('promise2 = mediaKeySession.close()');
+        // Wait on the raw promises (no per-promise logging) so completion order does not affect the output.
+        Promise.all([promise, promise2, mediaKeySession.closed]).then(finish, failTest);
+    }
+
+    function finish() {
+        consoleWrite('Survived concurrent close() and the "closed" promise resolved exactly once.');
+        mock.unregister();
+        endTest();
+    }
+    </script>
+</head>
+<body onload="doTest()">
+</body>
+</html>

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -815,6 +815,12 @@ void MediaKeySession::sessionClosed()
     // W3C Editor's Draft 09 November 2016
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    // close(), stop(), and a CDM-reported close during update() each queue a task that lands here. They guard on
+    // m_closed before enqueuing, but it is only set when the task runs, so more than one task can already be queued.
+    // Update m_closed here to ensure the promise is only resolved once, and avoid an assertion in DOMPromiseProxy.
+    if (std::exchange(m_closed, true))
+        return;
+
     // 1. Let session be the associated MediaKeySession object.
     // 2. If session's session type is "persistent-usage-record", execute the following steps in parallel:
     if (m_sessionType == MediaKeySessionType::PersistentUsageRecord) {
@@ -828,9 +834,6 @@ void MediaKeySession::sessionClosed()
 
     // 4. Run the Update Expiration algorithm on the session, providing NaN.
     updateExpiration(std::numeric_limits<double>::quiet_NaN());
-
-    // Let's consider the session closed before any promise on the 'closed' attribute is resolved.
-    m_closed = true;
 
     // 5. Let promise be the closed attribute of the session.
     // 6. Resolve promise.


### PR DESCRIPTION
#### eb9354ae86c5e349a0540457c53afc0831ed7dc0
<pre>
[EME] Protect MediaKeySession::sessionClosed from concurrent calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=315842">https://bugs.webkit.org/show_bug.cgi?id=315842</a>

Reviewed by Xabier Rodriguez-Calvar.

Add an additional m_closed check in MediaKeySession::sessionClosed to
account from multiple queued counts to close().

Test: media/encrypted-media/mock-MediaKeySession-concurrent-close.html

* LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close-expected.txt: Added.
* LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close.html: Added.
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::sessionClosed):

Canonical link: <a href="https://commits.webkit.org/314350@main">https://commits.webkit.org/314350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36168dff2584ceebec19624d550bdd525f511520

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174315 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128426 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90393 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29783 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28408 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22392 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139679 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176837 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29736 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136746 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136685 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36960 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147978 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101856 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24845 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38031 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111104 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37428 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2923 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->