### PR TITLE
ASSERTION FAILED: it != m_querySelectorAllResults.end() - clearQuerySelectorAllResults() leaves stale per-node HasValidQuerySelectorAllResults bit

### DIFF
--- a/LayoutTests/fast/dom/query-selector-all-cache-memory-pressure-crash-expected.txt
+++ b/LayoutTests/fast/dom/query-selector-all-cache-memory-pressure-crash-expected.txt
@@ -1,0 +1,10 @@
+Clearing the querySelectorAll result cache under memory pressure must also clear each node's HasValidQuerySelectorAllResults flag. Otherwise a still-alive node keeps claiming it has cached results while the document's map no longer has an entry for it, and a later class-attribute change asserts.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash changing a class after the cache was cleared under memory pressure.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/query-selector-all-cache-memory-pressure-crash.html
+++ b/LayoutTests/fast/dom/query-selector-all-cache-memory-pressure-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="cached"><span class="foo"></span></div>
+<div id="other"><span class="bar"></span></div>
+<script>
+description("Clearing the querySelectorAll result cache under memory pressure must also clear each node's " +
+    "HasValidQuerySelectorAllResults flag. Otherwise a still-alive node keeps claiming it has cached results " +
+    "while the document's map no longer has an entry for it, and a later class-attribute change asserts.");
+
+if (!window.internals)
+    testFailed("This test requires window.internals.");
+else {
+    var cached = document.getElementById("cached");
+    var other = document.getElementById("other");
+
+    // 1. Populate the cache for #cached: this sets #cached's HasValidQuerySelectorAllResults flag AND adds a
+    //    map entry keyed by #cached (".foo" is a class selector, which is cacheable).
+    cached.querySelectorAll(".foo");
+
+    // 2. Run WebCore::releaseMemory synchronously, which clears the document's querySelectorAll result map.
+    //    (We call releaseMemoryNow() directly rather than beginSimulatedMemoryPressure(): WebKitTestRunner sets
+    //    WEBKIT_DISABLE_MEMORY_PRESSURE_MONITOR=1, which suppresses the WebProcess low-memory handler, so
+    //    simulated pressure flips isUnderMemoryPressure() but never invokes releaseMemory / clearQuerySelectorAllResults.)
+    internals.releaseMemoryNow();
+
+    // 3. Repopulate the map through a different node so it is non-empty. This defeats the "empty map" early-out
+    //    in the invalidation path, forcing it to actually look #cached up.
+    other.querySelectorAll(".bar");
+
+    // 4. Mutate #cached's class. Before the fix, #cached still reported a valid cache, so invalidation looked up
+    //    an entry that the memory-pressure clear had removed and hit the assertion.
+    cached.className = "changed";
+
+    testPassed("Did not crash changing a class after the cache was cleared under memory pressure.");
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1335,6 +1335,11 @@ void Document::invalidateQuerySelectorAllResultsForClassAttributeChange(Node& st
 
 void Document::clearQuerySelectorAllResults()
 {
+    // The map holds only weak references, so its keyed nodes outlive this clear. Reset their per-node flag too, or a
+    // surviving node keeps claiming valid cached results after its entry is gone, asserting in the invalidation path
+    // (invalidateQuerySelectorAllResultsForClassAttributeChange) when it looks up an entry the clear already removed.
+    for (auto entry : m_querySelectorAllResults)
+        entry.key.setHasValidQuerySelectorAllResults(false);
     m_querySelectorAllResults.clear();
 }
 


### PR DESCRIPTION
#### 4f393fd202e3aae8e78552bb3dd8473b10fa7113
<pre>
ASSERTION FAILED: it != m_querySelectorAllResults.end() - clearQuerySelectorAllResults() leaves stale per-node HasValidQuerySelectorAllResults bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=315844">https://bugs.webkit.org/show_bug.cgi?id=315844</a>

Reviewed by Ryosuke Niwa.

When clearing the querySelectorAll cached results, ensure that the node
references have their HasValidQuerySelectorAllResults bit cleared as
well, to avoid an assertion in
invalidateQuerySelectorAllResultsForClassAttributeChange.

Test: fast/dom/query-selector-all-cache-memory-pressure-crash.html

* LayoutTests/fast/dom/query-selector-all-cache-memory-pressure-crash-expected.txt: Added.
* LayoutTests/fast/dom/query-selector-all-cache-memory-pressure-crash.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::clearQuerySelectorAllResults):

Canonical link: <a href="https://commits.webkit.org/314347@main">https://commits.webkit.org/314347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf2f14069f8a044f4f5089357b7c2f22c2f178f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174322 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167147 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128433 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90397 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148491 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108958 "Passed tests") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29793 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28417 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22397 "Hash cf2f1406 for PR 66022 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176844 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26174 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136753 "Passed tests") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136692 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36958 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147985 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101863 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31973 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24852 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38038 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111111 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37435 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2930 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37681 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->