### PR TITLE
[EME] Crash pruning a back/forward-cached page that owns an open MediaKeySession

### DIFF
--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS: pruning a back/forward-cached MediaKeySession page does not crash.

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash.html
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash.html
@@ -1,0 +1,87 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+// Regression test: pruning a back/forward-cached page that still owns an open MediaKeySession must not crash.
+//
+// When the page enters the BackForwardCache its active DOM objects are suspended and its event-loop task group is
+// suspended. If the cached page is then pruned (rather than restored), Document teardown stops the active DOM
+// objects: markAsReadyToStop() runs first and -- because the group was suspended -- transitions it straight to
+// Stopped, while activeDOMObjectsAreSuspended() stays true. MediaKeySession::stop() then closes the CDM session;
+// the Thunder/Mock backends invoke the close callback synchronously, so before the fix sessionClosed() resolved
+// the "closed" promise synchronously here, tripping DeferredPromise's suspended-context assertion.
+//
+// This page opens a MediaKeySession and navigates to a helper so this document enters the BackForwardCache (the
+// proven page-cache navigation idiom -- a separate document, not a same-URL query change). The helper then prunes
+// the cache, which destroys this still-cached document. The result is reported by the helper, since this page is
+// gone by then.
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const encoder = new TextEncoder();
+
+async function setUpOpenSession() {
+    // Mirror the working mock-EME setup (mock-MediaKeySession-close.html): enable the mock media engine first or
+    // "video/mock" is unsupported and requestMediaKeySystemAccess rejects.
+    internals.initializeMockMediaSource();
+    // Pin the factory on window: CDMFactory's registry holds only a WeakRef, MockCDM holds only a WeakPtr,
+    // so the JS wrapper is the only strong reference. A local would let GC collect it across the awaits below,
+    // unregistering the factory mid-flight -- the failure presents as NotSupportedError or NotAllowedError
+    // depending on which await GC interleaves with.
+    window.__mock = internals.registerMockCDM();
+    window.__mock.supportedDataTypes = ["keyids"];
+
+    const access = await navigator.requestMediaKeySystemAccess("org.webkit.mock", [{
+        initDataTypes: ["keyids"],
+        videoCapabilities: [{ contentType: 'video/mock; codecs="mock"' }],
+    }]);
+    const mediaKeys = await access.createMediaKeys();
+    const session = mediaKeys.createSession("temporary");
+
+    // Keep both alive on the window so the session survives un-closed into the BackForwardCache; that is what makes
+    // MediaKeySession::stop() run against a suspended-then-stopped context when the cached page is pruned.
+    window.__mediaKeys = mediaKeys;
+    window.__session = session;
+
+    await session.generateRequest("keyids", encoder.encode(JSON.stringify({ kids: ["MTIzNDU="] })));
+
+    // Touch the "closed" attribute so a DeferredPromise is registered on its DOMPromiseProxy (real EME apps do
+    // `session.closed.then(...)`). Without an attached deferred promise, resolving the closed promise during
+    // teardown is a no-op that never reaches DeferredPromise::callFunction -- so the assertion would not fire and
+    // the test would pass even on the buggy build.
+    window.__closed = session.closed;
+}
+
+window.addEventListener("load", () => {
+    if (!window.internals || !window.testRunner) {
+        document.body.textContent = "FAIL: this test requires window.internals and window.testRunner.";
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+
+    setUpOpenSession().then(() => {
+        // Navigate outside the load/promise continuation so it produces a history entry.
+        setTimeout(() => { window.location.href = "resources/mock-MediaKeySession-backforwardcache-prune-helper.html"; }, 0);
+    }, e => {
+        document.body.textContent = "FAIL: could not set up MediaKeySession: " + e;
+        testRunner.notifyDone();
+    });
+});
+</script>
+</head>
+<body>
+<!-- Substantial visible content so the main frame is "visually non-empty"; canCachePage refuses a visually-empty
+     main frame, which would stop the page entering the cache at all. -->
+<div style="width: 400px; height: 400px;">
+This page opens an EME MediaKeySession and then navigates to a helper so that this document enters the back/forward
+cache. The helper prunes the cache, destroying this still-cached document while its MediaKeySession is open, which
+is the teardown path the fix is about. This paragraph exists so the page is visually non-empty and therefore
+eligible for the back/forward cache in the first place.
+</div>
+</body>
+</html>

--- a/LayoutTests/media/encrypted-media/resources/mock-MediaKeySession-backforwardcache-prune-helper.html
+++ b/LayoutTests/media/encrypted-media/resources/mock-MediaKeySession-backforwardcache-prune-helper.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+// Helper for mock-MediaKeySession-backforwardcache-prune-crash.html. The previous page (with an open
+// MediaKeySession) is now in the BackForwardCache. Prune it -- which synchronously destroys the cached page and
+// tears down its still-open session -- and report the result here, since the pruned page is gone.
+//
+// This is a crash test: the success condition is "tearing down a back/forward-cached MediaKeySession page does not
+// crash". That holds whether the page was actually pruned or never entered the cache at all, so both outcomes
+// report the same PASS. Reporting PASS on non-entry keeps the test from flaking when the environment denies
+// caching: BackForwardCache::canCache() refuses entry while the process is under memory pressure (e.g. the WK2
+// Stress bot). A regression still aborts the process when the prune path is exercised, independent of this text.
+const PASS_MESSAGE = "PASS: pruning a back/forward-cached MediaKeySession page does not crash.";
+
+function finish(message) {
+    document.body.textContent = message;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+function prune(retries = 0) {
+    // The previous page enters the cache as part of this navigation's commit; give it a few ticks if needed so we
+    // exercise the real prune path whenever caching is allowed.
+    if (internals.backForwardCacheSize() < 1) {
+        if (retries < 50) {
+            setTimeout(() => prune(retries + 1), 10);
+            return;
+        }
+        // Page never entered the cache (e.g. denied under memory pressure): nothing to prune, no crash.
+        finish(PASS_MESSAGE);
+        return;
+    }
+
+    // Synchronously destroys the cached page -> Document teardown -> MediaKeySession::stop(). Before the fix this
+    // crashed here; now it must return cleanly.
+    internals.clearBackForwardCache();
+    finish(PASS_MESSAGE);
+}
+
+window.addEventListener("load", () => {
+    if (!window.internals || !window.testRunner) {
+        finish("FAIL: this test requires window.internals and window.testRunner.");
+        return;
+    }
+    prune();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -880,8 +880,14 @@ void MediaKeySession::stop()
         if (!protectedThis)
             return;
 
-        ALWAYS_LOG_WITH_THIS(protectedThis, logIdentifier, "::lambda, closed");
-        protectedThis->sessionClosed();
+        // closeSession() may invoke this callback synchronously (e.g. the Thunder backend), and stop() runs during
+        // document teardown while the event loop has already been marked ready-to-stop. Resolving the closed promise
+        // synchronously here would violate DeferredPromise's suspended-context invariant. Defer to the event loop,
+        // mirroring close(); the task is cleanly dropped if the event loop is already stopped.
+        queueTaskKeepingObjectAlive(*protectedThis, TaskSource::Networking, [logIdentifier](auto& session) {
+            ALWAYS_LOG_WITH_THIS(&session, logIdentifier, "::task, closed");
+            session.sessionClosed();
+        });
     });
 }
 


### PR DESCRIPTION
#### b09929827ab58775bb1e23c60c0ebcafce31c341
<pre>
[EME] Crash pruning a back/forward-cached page that owns an open MediaKeySession
<a href="https://bugs.webkit.org/show_bug.cgi?id=315849">https://bugs.webkit.org/show_bug.cgi?id=315849</a>

Reviewed by Xabier Rodriguez-Calvar.

Invoking session.sessionClosed during document teardown can trigger an
assertion in a deferred promise (JSDOMPromiseDeferred --
!activeDOMObjectsAreSuspended() ||
scriptExecutionContext()-&gt;eventLoop().isSuspended()).

By queueing it, we can ensure the task is dropped if the event loop is
stopped.

Test: media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash.html

* LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash-expected.txt: Added.
* LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash.html: Added.
* LayoutTests/media/encrypted-media/resources/mock-MediaKeySession-backforwardcache-prune-helper.html: Added.
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::stop):

Canonical link: <a href="https://commits.webkit.org/314352@main">https://commits.webkit.org/314352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebfe3e0479b2b2cadbafc1afcd0418abc60af851

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122964 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128775 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90697 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109299 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30156 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28791 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22832 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177275 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30191 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28285 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137105 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137034 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36961 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148375 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102472 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32324 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25242 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38467 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111540 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37863 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3323 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->