### PR TITLE
[WPE][Qt6] Add download-started and related signal to WPEView.

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
@@ -27,10 +27,33 @@
 #include "WPEViewQtQuick.h"
 
 #include <QQmlEngine>
+#include <QMetaMethod>
 #include <QQuickWindow>
 #include <QSGSimpleTextureNode>
 
 #include <wtf/glib/GUniquePtr.h>
+
+namespace {
+bool hasDownload(const QList<GRefPtr<WebKitDownload>>& downloads, WebKitDownload* download)
+{
+    for (const auto& dl : downloads) {
+        if (dl.get() == download)
+            return true;
+    }
+    return false;
+}
+
+bool removeDownload(QList<GRefPtr<WebKitDownload>>& downloads, WebKitDownload* download)
+{
+    for (qsizetype i = 0; i < downloads.size(); ++i) {
+        if (downloads[i].get() == download) {
+            downloads.removeAt(i);
+            return true;
+        }
+    }
+    return false;
+}
+}
 
 /*!
   \qmltype WPEView
@@ -62,6 +85,15 @@ WPEQtView::~WPEQtView()
 
     if (d->m_webView)
         g_signal_handlers_disconnect_by_data(d->m_webView.get(), this);
+
+    if (d->m_currentDownload)
+        g_signal_handlers_disconnect_by_data(d->m_currentDownload.get(), this);
+    for (const auto& download : d->m_pendingDownloads)
+        g_signal_handlers_disconnect_by_data(download.get(), this);
+    for (const auto& download : d->m_activeDownloads)
+        g_signal_handlers_disconnect_by_data(download.get(), this);
+    if (auto* session = webkit_web_view_get_network_session(d->m_webView.get()))
+        g_signal_handlers_disconnect_by_data(session, this);
 }
 
 bool WPEQtView::event(QEvent* ev)
@@ -139,6 +171,8 @@ void WPEQtView::createWebView()
     g_signal_connect_swapped(d->m_webView.get(), "notify::estimated-load-progress", G_CALLBACK(notifyLoadProgressCallback), this);
     g_signal_connect(d->m_webView.get(), "load-changed", G_CALLBACK(notifyLoadChangedCallback), this);
     g_signal_connect(d->m_webView.get(), "load-failed", G_CALLBACK(notifyLoadFailedCallback), this);
+    if (auto* session = webkit_web_view_get_network_session(d->m_webView.get()))
+        g_signal_connect(session, "download-started", G_CALLBACK(downloadStartedCallback), this);
 
     if (!d->m_url.isEmpty())
         webkit_web_view_load_uri(d->m_webView.get(), d->m_url.toString().toUtf8().constData());
@@ -203,6 +237,127 @@ void WPEQtView::notifyLoadFailedCallback(WebKitWebView*, WebKitLoadEvent, const 
 
     auto loadRequest = std::make_unique<WPEQtViewLoadRequest>(QUrl(QString(failingURI)), loadStatus, error->message);
     Q_EMIT view->loadingChanged(loadRequest.get());
+}
+
+void WPEQtView::downloadStartedCallback(WebKitNetworkSession*, WebKitDownload* download, WPEQtView* view)
+{
+    view->setCurrentDownload(download);
+}
+
+void WPEQtView::downloadFinishedCallback(WebKitDownload* download, WPEQtView* view)
+{
+    view->handleDownloadFinished(download);
+}
+
+void WPEQtView::downloadFailedCallback(WebKitDownload* download, GError* error, WPEQtView* view)
+{
+    view->handleDownloadFailed(download, error);
+}
+
+void WPEQtView::handleDownloadFinished(WebKitDownload* download)
+{
+    Q_D(WPEQtView);
+    Q_EMIT downloadFinished(getFileNameFromDownload(download));
+
+    g_signal_handlers_disconnect_by_data(download, this);
+    if (d->m_currentDownload.get() == download) {
+        d->m_currentDownload = nullptr;
+        activateNextPendingDownload();
+    } else
+        removeDownload(d->m_pendingDownloads, download);
+    removeDownload(d->m_activeDownloads, download);
+}
+
+void WPEQtView::handleDownloadFailed(WebKitDownload* download, GError* error)
+{
+    Q_D(WPEQtView);
+    const QString filename = getFileNameFromDownload(download);
+    QString errorMsg = "";
+    if (error && error->message)
+        errorMsg = QString::fromUtf8(error->message);
+    else
+        errorMsg = QStringLiteral("Unknown error.");
+    Q_EMIT downloadFailed(filename, errorMsg);
+
+    g_signal_handlers_disconnect_by_data(download, this);
+    if (d->m_currentDownload.get() == download) {
+        d->m_currentDownload = nullptr;
+        activateNextPendingDownload();
+    } else
+        removeDownload(d->m_pendingDownloads, download);
+    removeDownload(d->m_activeDownloads, download);
+}
+
+gboolean WPEQtView::downloadDecideDestinationCallback(WebKitDownload*, gchar*, WPEQtView*)
+{
+    // Returning TRUE is necessary to indicate webkit that the webkit_download_set_destination
+    // will be called later.
+    return TRUE;
+}
+
+QString WPEQtView::getFileNameFromDownload(WebKitDownload* download)
+{
+    static const QString defaultFilename = "download";
+    if (!download)
+        return defaultFilename;
+
+    auto* uriRequest = webkit_download_get_request(download);
+    if (!uriRequest)
+        return defaultFilename;
+
+    const gchar* uri = webkit_uri_request_get_uri(uriRequest);
+    if (!uri)
+        return defaultFilename;
+
+    const QString suggestedFilename = QUrl(QString::fromUtf8(uri)).fileName();
+    if (suggestedFilename.isEmpty())
+        return defaultFilename;
+    return suggestedFilename;
+}
+
+void WPEQtView::setDownloadPath(const QString& path)
+{
+    Q_D(WPEQtView);
+    if (!d->m_currentDownload) {
+        qWarning("WPEQtView::setDownloadPath called without a pending download request");
+        return;
+    }
+
+    if (path.isEmpty()) {
+        webkit_download_cancel(d->m_currentDownload.get());
+        d->m_currentDownload = nullptr;
+        activateNextPendingDownload();
+        return;
+    }
+
+    const QByteArray pathByte = path.toUtf8();
+    if (!g_path_is_absolute(pathByte.constData())) {
+        qWarning("WPEQtView::setDownloadPath requires an absolute path");
+        webkit_download_cancel(d->m_currentDownload.get());
+        d->m_currentDownload = nullptr;
+        activateNextPendingDownload();
+        return;
+    }
+
+    webkit_download_set_destination(d->m_currentDownload.get(), pathByte.constData());
+    d->m_currentDownload = nullptr;
+    activateNextPendingDownload();
+}
+
+/*!
+  \qmlmethod void WPEQtView::cancelPendingDownload()
+
+  Cancels a pending download request, if any.
+*/
+void WPEQtView::cancelPendingDownload()
+{
+    Q_D(WPEQtView);
+    if (!d->m_currentDownload)
+        return;
+
+    webkit_download_cancel(d->m_currentDownload.get());
+    d->m_currentDownload = nullptr;
+    activateNextPendingDownload();
 }
 
 void WPEQtView::didUpdateScene()
@@ -662,6 +817,54 @@ void WPEQtView::setErrorOccured(bool errorOccured)
 {
     Q_D(WPEQtView);
     d->m_errorOccured = errorOccured;
+}
+
+void WPEQtView::setCurrentDownload(WebKitDownload* download)
+{
+    Q_D(WPEQtView);
+    if (!download)
+        return;
+
+    if (d->m_currentDownload.get() == download)
+        return;
+
+    if (hasDownload(d->m_pendingDownloads, download))
+        return;
+
+    if (!hasDownload(d->m_activeDownloads, download))
+        d->m_activeDownloads.append(GRefPtr<WebKitDownload>(download));
+
+
+    g_signal_connect(download, "finished", G_CALLBACK(downloadFinishedCallback), this);
+    g_signal_connect(download, "failed", G_CALLBACK(downloadFailedCallback), this);
+
+    if (!useCustomDownloadHandling())
+        return;
+
+    g_signal_connect(download, "decide-destination", G_CALLBACK(downloadDecideDestinationCallback), this);
+    if (!d->m_currentDownload) {
+        d->m_currentDownload = download;
+        Q_EMIT downloadStarted(getFileNameFromDownload(download));
+    } else
+        d->m_pendingDownloads.append(GRefPtr<WebKitDownload>(download));
+}
+
+bool WPEQtView::useCustomDownloadHandling() const
+{
+    return isSignalConnected(QMetaMethod::fromSignal(&WPEQtView::downloadStarted));
+}
+
+void WPEQtView::activateNextPendingDownload()
+{
+    Q_D(WPEQtView);
+    if (d->m_currentDownload)
+        return;
+    if (d->m_pendingDownloads.isEmpty())
+        return;
+
+    d->m_currentDownload = d->m_pendingDownloads.takeFirst();
+    if (d->m_currentDownload)
+        Q_EMIT downloadStarted(getFileNameFromDownload(d->m_currentDownload.get()));
 }
 
 #include "moc_WPEQtView.cpp"

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
@@ -76,6 +76,8 @@ public Q_SLOTS:
     void stop();
     void loadHtml(const QString& html, const QUrl& baseUrl = QUrl());
     void runJavaScript(const QString& script, const QJSValue& callback = QJSValue());
+    void setDownloadPath(const QString&);
+    void cancelPendingDownload();
 
 Q_SIGNALS:
     void webViewCreated();
@@ -83,10 +85,15 @@ Q_SIGNALS:
     void titleChanged();
     void loadingChanged(WPEQtViewLoadRequest* loadRequest);
     void loadProgressChanged();
+    void downloadStarted(const QString& suggestedFilename);
+    void downloadFinished(const QString& filename);
+    void downloadFailed(const QString& filename, const QString& error);
 
 protected:
     bool errorOccured() const;
     void setErrorOccured(bool);
+
+    void setCurrentDownload(WebKitDownload*);
 
     bool event(QEvent*) override;
     void geometryChange(const QRectF&, const QRectF&) override;
@@ -123,6 +130,15 @@ private:
     static void notifyLoadProgressCallback(WPEQtView*);
     static void notifyLoadChangedCallback(WebKitWebView*, WebKitLoadEvent, WPEQtView*);
     static void notifyLoadFailedCallback(WebKitWebView*, WebKitLoadEvent, const gchar* failingURI, GError*, WPEQtView*);
+    static void downloadStartedCallback(WebKitNetworkSession*, WebKitDownload*, WPEQtView*);
+    static void downloadFinishedCallback(WebKitDownload*, WPEQtView*);
+    static void downloadFailedCallback(WebKitDownload*, GError*, WPEQtView*);
+    void handleDownloadFinished(WebKitDownload*);
+    void handleDownloadFailed(WebKitDownload*, GError*);
+    bool useCustomDownloadHandling() const;
+    static gboolean downloadDecideDestinationCallback(WebKitDownload*, gchar*, WPEQtView*);
+    void activateNextPendingDownload();
+    QString getFileNameFromDownload(WebKitDownload*);
 
     Q_DECLARE_PRIVATE(WPEQtView)
     QScopedPointer<WPEQtViewPrivate> d_ptr;

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewPrivate.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <QList>
 #include <QSize>
 #include <QUrl>
 #include <wpe/webkit.h>
@@ -30,6 +31,10 @@ public:
     ~WPEQtViewPrivate() { }
 
     GRefPtr<WebKitWebView> m_webView;
+    GRefPtr<WebKitDownload> m_currentDownload;
+    QList<GRefPtr<WebKitDownload>> m_pendingDownloads;
+    QList<GRefPtr<WebKitDownload>> m_activeDownloads;
+
     QUrl m_url;
     QString m_html;
     QUrl m_baseUrl;


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=315851.

Reviewed by NOBODY (OOPS!).

Expose WebKit download-started and related signal to QML, so that
applications can provide a custom file dialogue without patching in Qt's
C++ code to handle `<a href="simple.txt" download>` kind of elements.

Note that if there is no custom destination decision handling the
WebKit's default behaviour is assured through useCustomDownloadHandling
method.

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87fb542aa2a7d5e52c52b431a146f19da809cf5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/55367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/198011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/152341 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/63056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/61363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146652 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/101344 "An unexpected error occured in step: Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190778 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/167111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/127170 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/49125 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46933 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/159389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46746 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/9122 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/54037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/200065 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/61237 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/156353 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61958 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/43231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155996 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/50293 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/134069 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/131743 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/60324 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21733 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59733 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->