### PR TITLE
REGRESSION(313563@main): Scroll perf regression was caused by the snapshot optimization

### DIFF
--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -113,9 +113,13 @@ static bool isValidSampleLocation(Document& document, const IntPoint& location)
     return true;
 }
 
-static RefPtr<PixelBuffer> takeRowSnapshot(Document& document, IntPoint&& topRight)
+static std::optional<Lab<float>> sampleColor(Document& document, IntPoint&& location)
 {
     // FIXME: <https://webkit.org/b/225167> (Sampled Page Top Color: hook into painting logic instead of taking snapshots)
+
+    if (!isValidSampleLocation(document, location))
+        return std::nullopt;
+
     // FIXME: <https://webkit.org/b/225942> (Sampled Page Top Color: support sampling non-RGB values like P3)
 
     static constexpr OptionSet snapshotFlags {
@@ -125,31 +129,21 @@ static RefPtr<PixelBuffer> takeRowSnapshot(Document& document, IntPoint&& topRig
     };
 
     auto colorSpace = DestinationColorSpace::SRGB();
-    auto rect = IntRect { { 0, topRight.y() }, { topRight.x() + 1, 1 } };
 
     ASSERT(document.view());
-    auto snapshot = snapshotFrameRect(protect(document.view()->frame()), rect, { snapshotFlags, PixelFormat::BGRA8, colorSpace });
+    auto snapshot = snapshotFrameRect(protect(document.view()->frame()), IntRect(location, IntSize(1, 1)), { snapshotFlags, PixelFormat::BGRA8, colorSpace });
     if (!snapshot)
-        return nullptr;
+        return std::nullopt;
 
     auto pixelBuffer = snapshot->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, colorSpace }, { { }, snapshot->truncatedLogicalSize() });
     if (!pixelBuffer)
-        return nullptr;
-
-    if (pixelBuffer->bytes().size() < rect.area() * 4)
-        return nullptr;
-
-    return pixelBuffer;
-}
-
-static std::optional<Lab<float>> sampleColor(Document& document, const PixelBuffer& rowPixelBuffer, const IntPoint& location)
-{
-    if (!isValidSampleLocation(document, location))
         return std::nullopt;
 
-    auto pixels = rowPixelBuffer.bytes();
-    auto pixel = pixels.subspan(location.x() * 4, 4);
-    return convertColor<Lab<float>>(SRGBA<uint8_t> { pixel[2], pixel[1], pixel[0], pixel[3] });
+    if (pixelBuffer->bytes().size() < 4)
+        return std::nullopt;
+
+    auto snapshotData = pixelBuffer->bytes();
+    return convertColor<Lab<float>>(SRGBA<uint8_t> { snapshotData[2], snapshotData[1], snapshotData[0], snapshotData[3] });
 }
 
 static double colorDifference(const Lab<float>& lhs, const Lab<float>& rhs)
@@ -204,7 +198,8 @@ std::optional<Color> PageColorSampler::sampleTop(Page& page)
     if (!frameView->isVisuallyNonEmpty() || !frameView->hasContentfulDescendants() || !ContentfulPaintChecker::qualifiesForContentfulPaint(*frameView))
         return std::nullopt;
 
-    auto frameWidth = frameView->contentsWidth();
+    // Decrease the width by one pixel so that the last sample is within bounds and not off-by-one.
+    auto frameWidth = frameView->contentsWidth() - 1;
 
     static constexpr auto numSamples = 5;
     size_t nonMatchingColorIndex = numSamples;
@@ -221,13 +216,8 @@ std::optional<Color> PageColorSampler::sampleTop(Page& page)
         return false;
     };
 
-    RefPtr topPagePixelBuffer = takeRowSnapshot(*mainDocument, IntPoint(frameWidth - 1, 0));
-    if (!topPagePixelBuffer)
-        return Color();
-
     for (size_t i = 0; i < numSamples; ++i) {
-        auto column = (i == numSamples - 1) ? frameWidth - 1 : frameWidth * i / (numSamples - 1);
-        auto sample = sampleColor(*mainDocument, *topPagePixelBuffer, IntPoint(column, 0));
+        auto sample = sampleColor(*mainDocument, IntPoint(frameWidth * i / (numSamples - 1), 0));
         if (!sample) {
             if (shouldStopAfterFindingNonMatchingColor(i))
                 return Color();
@@ -272,21 +262,17 @@ std::optional<Color> PageColorSampler::sampleTop(Page& page)
     }
 
     // Decrease the height by one pixel so that the last sample is within bounds and not off-by-one.
-    int minY = static_cast<int>(page.settings().sampledPageTopColorMinHeight() - 1);
-    if (minY > 0) {
-        RefPtr minYPixelBuffer = takeRowSnapshot(*mainDocument, IntPoint(frameWidth - 1, minY));
-        if (!minYPixelBuffer)
-            return Color();
-
+    auto minHeight = page.settings().sampledPageTopColorMinHeight() - 1;
+    if (minHeight > 0) {
         if (nonMatchingColorIndex) {
-            if (auto leftMiddleSample = sampleColor(*mainDocument, *minYPixelBuffer, IntPoint(0, minY))) {
+            if (auto leftMiddleSample = sampleColor(*mainDocument, IntPoint(0, minHeight))) {
                 if (colorDifference(*leftMiddleSample, samples[0]) > maxDifference)
                     return Color();
             }
         }
 
         if (nonMatchingColorIndex != numSamples - 1) {
-            if (auto rightMiddleSample = sampleColor(*mainDocument, *minYPixelBuffer, IntPoint(frameWidth - 1, minY))) {
+            if (auto rightMiddleSample = sampleColor(*mainDocument, IntPoint(frameWidth, minHeight))) {
                 if (colorDifference(*rightMiddleSample, samples[numSamples - 1]) > maxDifference)
                     return Color();
             }


### PR DESCRIPTION
#### 82d39ddef02e8f109c4406fe9e813b0c2dc5b0d4
<pre>
REGRESSION(313563@main): Scroll perf regression was caused by the snapshot optimization
<a href="https://bugs.webkit.org/show_bug.cgi?id=315854">https://bugs.webkit.org/show_bug.cgi?id=315854</a>
<a href="https://rdar.apple.com/177955379">rdar://177955379</a>

Unreviewed, partially reverting 313563@main.

This part can safely reverted from 313563@main. This revert will not affect the
fix of bug 315118. Bug 315118 was fixed by clamping the blur filter stdDeviation
for the snapshotting. The part, which will be reverted, was considered an extra
optimization for the PageColorSampler.

* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::sampleColor):
(WebCore::PageColorSampler::sampleTop):
(WebCore::takeRowSnapshot): Deleted.

Canonical link: <a href="https://commits.webkit.org/314152@main">https://commits.webkit.org/314152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57d0e198d688ac8a021b15b54e117963c7e9a96b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174351 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68689d6f-2d4d-450d-bedc-4804b725c482) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38802 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/128456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9242d790-7f33-4406-9bdd-43f2a3cae14f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30769 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/148515 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108981 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ff464bf-d799-4368-a6a9-9ce927eb9db6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/22425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139712 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176872 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136776 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38866 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32576 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136715 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36849 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148009 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101900 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31991 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24876 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38066 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111140 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37463 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2954 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37709 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37607 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->