### PR TITLE
[Wasm] Fix JS Table.grow with a default value

### DIFF
--- a/JSTests/stress/wasm-funcref-table-grow-gc-marking-gap.js
+++ b/JSTests/stress/wasm-funcref-table-grow-gc-marking-gap.js
@@ -1,0 +1,58 @@
+// Regression test: Wasm::Table::grow on a funcref table with a non-null
+// default left slots in an inconsistent state where m_value held a live
+// WebAssemblyFunction wrapper but m_function.rtt was null. Because
+// Function::isEmpty() == !m_function.rtt and visitAggregateImpl skipped
+// visiting m_value on "empty" slots, the wrapper went unmarked, GC freed
+// it, and table.get returned a dangling pointer.
+
+if (!this.WebAssembly)
+    quit(0);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " (expected " + expected + ")");
+}
+
+// (module (func $f (export "f") (result i32) (i32.const <constant>)))
+// Each slot gets its own module/instance/function so identity is unambiguous.
+function makeModule(constant) {
+    const leb = [];
+    let v = constant;
+    while (true) {
+        const b = v & 0x7f;
+        v >>>= 7;
+        if (v === 0 && (b & 0x40) === 0) {
+            leb.push(b);
+            break;
+        }
+        leb.push(b | 0x80);
+    }
+    const bodyLen = 3 + leb.length;
+    const codeLen = 2 + bodyLen;
+    return new WebAssembly.Module(new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+        0x03, 0x02, 0x01, 0x00,
+        0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+        0x0a, codeLen, 0x01, bodyLen, 0x00, 0x41, ...leb, 0x0b,
+    ]));
+}
+
+const N = 1000;
+const table = new WebAssembly.Table({ element: "funcref", initial: 0 });
+
+// Each slot's only strong reference is the m_value WriteBarrier on the slot
+// itself; the `fn` local goes dead between iterations.
+for (let i = 0; i < N; ++i) {
+    const fn = new WebAssembly.Instance(makeModule(i)).exports.f;
+    table.grow(1, fn);
+}
+
+fullGC();
+
+for (let i = 0; i < N; ++i) {
+    const stale = table.get(i);
+    if (typeof stale !== "function")
+        throw new Error("table.get(" + i + ") was not a function: " + stale);
+    shouldBe(stale(), i);
+}

--- a/JSTests/wasm/stress/grow-funcref-table-with-default.js
+++ b/JSTests/wasm/stress/grow-funcref-table-with-default.js
@@ -1,0 +1,92 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// JS-API WebAssembly.Table.prototype.grow with a non-null funcref default
+// goes through Wasm::Table::grow with a real fill value. That path used to
+// populate only m_value while leaving m_function default-constructed
+// (Bug A: call_indirect would dereference null rtt; Bug B: isEmpty()
+// reading m_function.rtt was true, so visitAggregate skipped marking the
+// wrapper held in m_value).
+//
+// Wasm-side `(table.grow ...)` lowers to tableGrow + tableSet which
+// populate the slot correctly, so this test must use the JS API to
+// reach the buggy path.
+
+let mainWat = `
+(module
+    (type $sig (func (param i32) (result i32)))
+    (table $t (export "t") 1 funcref)
+    (elem (i32.const 0) $base)
+    (func $base (param i32) (result i32) (i32.add (local.get 0) (i32.const 100)))
+    (func (export "callIndirect") (param i32 i32) (result i32)
+        (call_indirect (type $sig) (local.get 1) (local.get 0)))
+)
+`
+
+let helperWat = `
+(module
+    (func (export "f") (param i32) (result i32) (i32.add (local.get 0) (i32.const 7)))
+)
+`
+
+async function testCallIndirectAfterGrow() {
+    const main = (await instantiate(mainWat, {}, {})).exports
+    const fn = (await instantiate(helperWat, {}, {})).exports.f
+
+    const oldSize = main.t.grow(4, fn)
+    assert.eq(oldSize, 1)
+    assert.eq(main.t.length, 5)
+
+    for (let i = 1; i < 5; ++i)
+        assert.eq(main.callIndirect(i, 10), 17)
+
+    assert.eq(main.callIndirect(0, 10), 110)
+}
+
+async function testGCPreservesWrapperAfterGrow() {
+    const main = (await instantiate(mainWat, {}, {})).exports
+
+    // Many grows, each with an ephemeral wrapper from a fresh instance.
+    // After the loop, the only path to each wrapper is the slot's m_value;
+    // with the marking gap, fullGC reclaims them and table.get / call return
+    // dangling cells.
+    const N = 200;
+    for (let i = 0; i < N; ++i) {
+        const fn = (await instantiate(helperWat, {}, {})).exports.f
+        main.t.grow(1, fn)
+    }
+
+    fullGC()
+
+    for (let i = 1; i <= N; ++i) {
+        const f = main.t.get(i)
+        assert.eq(typeof f, "function")
+        assert.eq(f(5), 12)
+        assert.eq(main.callIndirect(i, 5), 12)
+    }
+}
+
+async function testNullDefault() {
+    const main = (await instantiate(mainWat, {}, {})).exports
+
+    const oldSize = main.t.grow(3, null)
+    assert.eq(oldSize, 1)
+    assert.eq(main.t.get(1), null)
+    assert.eq(main.t.get(2), null)
+
+    let threw = false
+    try {
+        main.callIndirect(2, 0)
+    } catch (e) {
+        threw = e instanceof WebAssembly.RuntimeError
+    }
+    assert.eq(threw, true)
+}
+
+async function test() {
+    await testCallIndirectAfterGrow()
+    await testGCPreservesWrapperAfterGrow()
+    await testNullDefault()
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -160,13 +160,18 @@ std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
         break;
     }
     case TableElementType::Funcref: {
-        bool success = checkedGrow(static_cast<FuncRefTable*>(this)->m_importableFunctions, [&](auto& slot) {
-            slot.m_value.set(vm, m_owner, defaultValue);
+        auto* funcTable = static_cast<FuncRefTable*>(this);
+        auto* defaultFunction = dynamicDowncast<WebAssemblyFunctionBase>(defaultValue);
+        ASSERT(defaultFunction || defaultValue.isNull());
+        bool success = checkedGrow(funcTable->m_importableFunctions, [&](auto& slot) {
+            ASSERT(slot.m_value.isNull());
+            if (defaultFunction)
+                slot.setFunction(vm, m_owner, defaultFunction);
         });
         if (!success) [[unlikely]]
             return std::nullopt;
         setLength(newLength);
-        for (auto& instance : static_cast<FuncRefTable*>(this)->m_instances) {
+        for (auto& instance : funcTable->m_instances) {
             if (auto* strongReference = instance.get())
                 strongReference->updateCachedTable0();
         }
@@ -228,8 +233,6 @@ void Table::visitAggregateImpl(Visitor& visitor)
         auto* table = static_cast<FuncRefTable*>(this);
         for (unsigned i = 0; i < m_length; ++i) {
             auto& slot = table->m_importableFunctions.get()[i];
-            if (slot.isEmpty())
-                continue;
             visitor.append(slot.m_value);
             visitor.append(slot.m_function.targetInstance);
             visitor.append(slot.m_function.importFunction);
@@ -307,8 +310,13 @@ void FuncRefTable::setFunction(uint32_t index, WebAssemblyFunctionBase* function
     ASSERT(index < length());
     ASSERT_WITH_SECURITY_IMPLICATION(isSubtype(function->type(), wasmType()));
     auto& slot = m_importableFunctions.get()[index];
-    slot.m_function = function->importableFunction();
-    slot.m_value.set(function->instance()->vm(), m_owner, function);
+    slot.setFunction(function->instance()->vm(), m_owner, function);
+}
+
+void FuncRefTable::Function::setFunction(VM& vm, JSCell* owner, WebAssemblyFunctionBase* function)
+{
+    m_function = function->importableFunction();
+    m_value.set(vm, owner, function);
 }
 
 void FuncRefTable::setLazy(uint32_t index, JSWebAssemblyInstance* targetInstance, FunctionSpaceIndex functionIndex)

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -139,12 +139,14 @@ public:
     JS_EXPORT_PRIVATE ~FuncRefTable();
 
     struct Function {
-        WasmOrJSImportableFunction m_function;
-        WriteBarrier<Unknown> m_value { NullWriteBarrierTag };
-        void* m_padding { nullptr };
+        void setFunction(VM&, JSCell* owner, WebAssemblyFunctionBase*);
         bool isEmpty() const { return !m_function.rtt; }
         static constexpr ptrdiff_t offsetOfFunction() { return OBJECT_OFFSETOF(Function, m_function); }
         static constexpr ptrdiff_t offsetOfValue() { return OBJECT_OFFSETOF(Function, m_value); }
+
+        WasmOrJSImportableFunction m_function;
+        WriteBarrier<Unknown> m_value { NullWriteBarrierTag };
+        void* m_padding { nullptr };
     };
 
     void setFunction(uint32_t, WebAssemblyFunctionBase*);


### PR DESCRIPTION
#### 36a3e59badd181416ef6d3ad629d9f93ba5added
<pre>
[Wasm] Fix JS Table.grow with a default value
<a href="https://bugs.webkit.org/show_bug.cgi?id=315856">https://bugs.webkit.org/show_bug.cgi?id=315856</a>
<a href="https://rdar.apple.com/177654868">rdar://177654868</a>

Reviewed by Yusuke Suzuki.

The JS-API WebAssembly.Table.prototype.grow(delta, fillValue) routes through
Wasm::Table::grow with a non-null defaultValue. For a funcref table that path
only wrote slot.m_value with the supplied JSValue and never populated
slot.m_function, so call_indirect into a grown slot dereferenced a null rtt and
trapped with &quot;signature does not match&quot; instead of dispatching to the fill
function. Worse, after 313985@main introduced the m_function-based
Function::isEmpty() predicate, visitAggregateImpl skipped visiting m_value on
funcref slots where !m_function.rtt; slots populated only by Table::grow read as
empty, so the GC reclaimed the live wrapper and table.get returned a dangling
cell. The Wasm-side (table.grow ...) path is unaffected because it always passes
jsNull to Table::grow and then populates both halves of each slot via tableSet.

Centralize &quot;set both halves of a funcref slot with a write barrier&quot; into a new
FuncRefTable::Function::setFunction and call it from both FuncRefTable::setFunction
and Table::grow&apos;s funcref case. Also drop the visitAggregateImpl isEmpty()
short-circuit so a slot with a live m_value but a null m_function is still kept
alive by the GC as an extra precaution.

Tests: JSTests/stress/wasm-funcref-table-grow-gc-marking-gap.js
       JSTests/wasm/stress/grow-funcref-table-with-default.js

Canonical link: <a href="https://commits.webkit.org/314219@main">https://commits.webkit.org/314219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8ada365a4a598026347a6b8f60766334e459a0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122693 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04ae3b5c-e508-417c-9998-7cb91bae3c3c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128559 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8edd6434-e8be-4efb-a7cb-cc96acfafc33) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168397 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30870 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109084 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b44ca2e6-5121-45ba-b914-38f4d67195d2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28545 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22555 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157595 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177004 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26331 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29912 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136884 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136820 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148121 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102060 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25177 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32090 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24988 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38195 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111269 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37592 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3068 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37838 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37736 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->