### PR TITLE
[AutoFill Debugging] Automatically scroll to reveal targeted elements when clicking

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-click-offscreen-element-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-click-offscreen-element-expected.txt
@@ -1,13 +1,15 @@
 PASS scrollTopBeforeClick is 0
 PASS clickButtonError is ""
 PASS buttonClicked is true
-PASS scrollTopAfterButtonClick is 0
+PASS scrollTopAfterButtonClick > 0 is true
+PASS buttonInViewportAfterClick is true
 PASS clickInputError is ""
-PASS scrollTopAfterInputClick is 0
+PASS scrollTopAfterInputClick > 0 is true
+PASS inputInViewportAfterClick is true
 PASS activeElementAfterInputClick is offscreenInput
 PASS successfullyParsed is true
 
 TEST COMPLETE
-This test verifies that clicking an offscreen element via text extraction focuses it without requiring scrolling.
+This test verifies that clicking an offscreen element via text extraction scrolls it into view and dispatches the click.
 
 Click Me

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-click-offscreen-element.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-click-offscreen-element.html
@@ -17,12 +17,17 @@
     </style>
 </head>
 <body>
-    <p>This test verifies that clicking an offscreen element via text extraction focuses it without requiring scrolling.</p>
+    <p>This test verifies that clicking an offscreen element via text extraction scrolls it into view and dispatches the click.</p>
     <div class="spacer"></div>
     <button id="offscreen-button" aria-label="Offscreen Button">Click Me</button>
     <input id="offscreen-input" type="text" aria-label="Offscreen Input" placeholder="Type here" />
     <script>
     jsTestIsAsync = true;
+
+    function isInViewport(element) {
+        const rect = element.getBoundingClientRect();
+        return rect.bottom >= 0 && rect.top <= window.innerHeight;
+    }
 
     addEventListener("load", async () => {
         offscreenButton = document.getElementById("offscreen-button");
@@ -48,6 +53,7 @@
         });
 
         scrollTopAfterButtonClick = document.scrollingElement.scrollTop;
+        buttonInViewportAfterClick = isInViewport(offscreenButton);
 
         clickInputError = await UIHelper.performTextExtractionInteraction("click", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Offscreen Input")
@@ -55,13 +61,16 @@
 
         scrollTopAfterInputClick = document.scrollingElement.scrollTop;
         activeElementAfterInputClick = document.activeElement;
+        inputInViewportAfterClick = isInViewport(offscreenInput);
 
         shouldBe("scrollTopBeforeClick", "0");
         shouldBeEqualToString("clickButtonError", "");
         shouldBeTrue("buttonClicked");
-        shouldBe("scrollTopAfterButtonClick", "0");
+        shouldBeTrue("scrollTopAfterButtonClick > 0");
+        shouldBeTrue("buttonInViewportAfterClick");
         shouldBeEqualToString("clickInputError", "");
-        shouldBe("scrollTopAfterInputClick", "0");
+        shouldBeTrue("scrollTopAfterInputClick > 0");
+        shouldBeTrue("inputInViewportAfterClick");
         shouldBe("activeElementAfterInputClick", "offscreenInput");
 
         finishJSTest();

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1875,7 +1875,9 @@ struct ResolvedMouseTarget {
     IntPoint centerInRootView;
 };
 
-static Expected<ResolvedMouseTarget, String> resolveMouseTarget(Node& targetNode, const String& searchText, ASCIILiteral boxShadowColor)
+enum class ScrollTargetIntoView : bool { No, Yes };
+
+static Expected<ResolvedMouseTarget, String> resolveMouseTarget(Node& targetNode, const String& searchText, ASCIILiteral boxShadowColor, ScrollTargetIntoView scrollTargetIntoView = ScrollTargetIntoView::No)
 {
     RefPtr element = dynamicDowncast<Element>(targetNode);
     if (!element)
@@ -1904,12 +1906,27 @@ static Expected<ResolvedMouseTarget, String> resolveMouseTarget(Node& targetNode
 
     addBoxShadowIfNeeded(targetNode, boxShadowColor);
 
-    std::optional<FloatRect> targetRectInRootView;
+    std::optional<SimpleRange> foundRange;
     if (!searchText.isEmpty()) {
-        auto foundRange = searchForClickTarget(*element, searchText);
+        foundRange = searchForClickTarget(*element, searchText);
         if (!foundRange)
             return makeUnexpected(searchTextNotFoundDescription(searchText));
+    }
 
+    if (scrollTargetIntoView == ScrollTargetIntoView::Yes) {
+        RefPtr scrollTarget = element;
+        if (foundRange) {
+            if (RefPtr ancestor = commonInclusiveAncestor<ComposedTree>(*foundRange)) {
+                if (RefPtr deeperElement = lineageOfType<Element>(*ancestor).first())
+                    scrollTarget = WTF::move(deeperElement);
+            }
+        }
+        scrollTarget->scrollIntoViewIfNeeded(false);
+        document->updateLayoutIgnorePendingStylesheets();
+    }
+
+    std::optional<FloatRect> targetRectInRootView;
+    if (foundRange) {
         if (auto absoluteQuads = RenderObject::absoluteTextQuads(*foundRange); !absoluteQuads.isEmpty())
             targetRectInRootView = view->contentsToRootView(absoluteQuads.first().boundingBox());
     }
@@ -1922,7 +1939,7 @@ static Expected<ResolvedMouseTarget, String> resolveMouseTarget(Node& targetNode
 
 static void dispatchSimulatedClick(Node& targetNode, const String& searchText, CompletionHandler<void(bool, String&&)>&& completion)
 {
-    auto resolved = resolveMouseTarget(targetNode, searchText, "#34c759"_s);
+    auto resolved = resolveMouseTarget(targetNode, searchText, "#34c759"_s, ScrollTargetIntoView::Yes);
     if (!resolved)
         return completion(false, WTF::move(resolved.error()));
 


### PR DESCRIPTION
#### f00e50519b92213b6f47760c0bd6c7eab2a6402c
<pre>
[AutoFill Debugging] Automatically scroll to reveal targeted elements when clicking
<a href="https://bugs.webkit.org/show_bug.cgi?id=315845">https://bugs.webkit.org/show_bug.cgi?id=315845</a>
<a href="https://rdar.apple.com/178246340">rdar://178246340</a>

Reviewed by Aditya Keerthi.

Automatically scroll to reveal offscreen elements when performing a click based on `uid` or search
text.

* LayoutTests/fast/text-extraction/debug-text-extraction-click-offscreen-element-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-click-offscreen-element.html:

Rebaseline a test, to verify that we&apos;ve scrolled after clicking.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::resolveMouseTarget):
(WebCore::TextExtraction::dispatchSimulatedClick):

Canonical link: <a href="https://commits.webkit.org/314161@main">https://commits.webkit.org/314161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/340234cc344e999ba95d579e1a52bdf8bfefb37c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174362 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122575 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9efded70-d9af-4da7-934d-724c51ca1a12) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38813 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128464 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f83c30bf-4080-4d73-847e-78a9b2222996) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108989 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3132e579-d9e9-4e0c-be39-4fbd01c6aa10) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28447 "Passed tests") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/22436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139725 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176883 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136798 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136724 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36856 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39567 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101911 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32000 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24886 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111151 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37474 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2964 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37720 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37618 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->