### PR TITLE
Introduce --site-isolation-enabled-by-default to run-webkit-tests to simulate SI-on-by-default

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
@@ -46,6 +46,12 @@ _log = logging.getLogger(__name__)
 
 _render_tree_dump_pattern = re.compile(r"^layer at \(\d+,\d+\) size \d+x\d+\n")
 
+# A testharness.js subtest result line, e.g. "PASS some subtest name".
+_testharness_result_line_pattern = re.compile(r"^(PASS|FAIL|TIMEOUT|NOTRUN|PRECONDITION_FAILED) ")
+
+# Only imported WPT tests get order-insensitive comparison (see _compare_text).
+_imported_wpt_dir = "imported/w3c/web-platform-tests/"
+
 
 def run_single_test(port, options, results_directory, worker_name, driver, test_input, stop_when_done):
     runner = SingleTestRunner(port, options, results_directory, worker_name, driver, test_input, stop_when_done)
@@ -386,15 +392,38 @@ class SingleTestRunner(object):
         failures = []
         if self._options.ignore_render_tree_dump_results and actual_text and _render_tree_dump_pattern.match(actual_text):
             return failures
-        if (expected_text and actual_text and
-            # Assuming expected_text is already normalized.
-            self._port.do_text_results_differ(expected_text, self._get_normalized_output_text(actual_text))):
+        normalized_actual_text = self._get_normalized_output_text(actual_text) if actual_text else actual_text
+        if (expected_text and actual_text and self._port.do_text_results_differ(expected_text, normalized_actual_text)):
+            # WPT treats testharness subtests as an unordered set matched by
+            # name, but site isolation can change their completion order. Sort
+            # the result lines and re-compare before reporting a mismatch.
+            if (self._is_site_isolation_enabled_by_default_mode() and self._is_wpt_test() and self._normalize_testharness_result_order(expected_text) == self._normalize_testharness_result_order(normalized_actual_text)):
+                _log.warning('%s: passed via order-insensitive testharness comparison' % self._test_name)
+                return failures
             failures.append(test_failures.FailureTextMismatch())
         elif actual_text and not expected_text:
             failures.append(test_failures.FailureMissingResult())
         elif not actual_text and expected_text:
             failures.append(test_failures.FailureNoOutput())
         return failures
+
+    def _is_site_isolation_enabled_by_default_mode(self):
+        return bool(self._options.site_isolation_enabled_by_default)
+
+    def _is_wpt_test(self):
+        return self._test_name.startswith(_imported_wpt_dir)
+
+    def _normalize_testharness_result_order(self, text):
+        """Returns text with testharness subtest result lines sorted in place
+        (all other lines untouched), so outputs with the same results in a
+        different order compare equal."""
+        lines = text.split('\n')
+        indices = [i for i, line in enumerate(lines) if _testharness_result_line_pattern.match(line)]
+        if len(indices) < 2:
+            return text
+        for index, line in zip(indices, sorted(lines[i] for i in indices)):
+            lines[index] = line
+        return '\n'.join(lines)
 
     def _compare_audio(self, expected_audio, actual_audio):
         failures = []

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -372,6 +372,9 @@ def parse_args(args):
             "--site-isolation", action="store_true", default=False,
             help=("Run each test with and without site isolation enabled and compare the results. Uses site-isolation test expectations")),
         optparse.make_option(
+            "--site-isolation-enabled-by-default", action="store_true", default=False,
+            help=("Run all tests with site isolation enabled by default (simulating SiteIsolationEnabled=true as the default preference). Individual tests can still opt out with SiteIsolationEnabled=false. Compares against expected.txt, preferring mac-site-isolation/ios-site-isolation baselines.")),
+        optparse.make_option(
             "--load-in-cross-origin-iframe", action="store_true", default=False,
             help=("Run each test in a cross origin iframe.")),
         optparse.make_option(
@@ -509,6 +512,22 @@ def _set_up_derived_options(port, options):
         if options.result_report_flavor:
             raise RuntimeError('--site-isolation implicitly sets the result flavor, this should not be overridden')
         options.result_report_flavor = 'site-isolation'
+
+    if port.port_name == "mac" and options.site_isolation_enabled_by_default:
+        host = Host()
+        host.initialize_scm()
+        options.additional_expectations.insert(0, port.host.filesystem.join(host.scm().checkout_root, 'LayoutTests/platform/mac-site-isolation/TestExpectations'))
+        if not options.additional_platform_directory:
+            options.additional_platform_directory = []
+        options.additional_platform_directory.insert(0, port.host.filesystem.join(host.scm().checkout_root, 'LayoutTests/platform/mac-site-isolation'))
+
+    if port.port_name.startswith(('ios', 'iphone', 'ipad')) and options.site_isolation_enabled_by_default:
+        host = Host()
+        host.initialize_scm()
+        options.additional_expectations.insert(0, port.host.filesystem.join(host.scm().checkout_root, 'LayoutTests/platform/ios-site-isolation/TestExpectations'))
+        if not options.additional_platform_directory:
+            options.additional_platform_directory = []
+        options.additional_platform_directory.insert(0, port.host.filesystem.join(host.scm().checkout_root, 'LayoutTests/platform/ios-site-isolation'))
 
     if options.additional_platform_directory:
         additional_platform_directories = []

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -600,6 +600,9 @@ class Driver(object):
         if not self._port.get_option('enable_all_experimental_features'):
             cmd.append('--no-enable-all-experimental-features')
 
+        if self._port.get_option('site_isolation_enabled_by_default'):
+            cmd.append('--site-isolation-enabled-by-default')
+
         for feature in self._port.experimental_feature():
             cmd.append('--experimental-feature')
             cmd.append(feature)

--- a/Tools/WebKitTestRunner/Options.cpp
+++ b/Tools/WebKitTestRunner/Options.cpp
@@ -190,6 +190,12 @@ static bool handleOptionLockdownMode(Options& options, const char*, const char*)
     return true;
 }
 
+static bool handleOptionSiteIsolationEnabledByDefault(Options& options, const char*, const char*)
+{
+    options.siteIsolationEnabledByDefault = true;
+    return true;
+}
+
 #if PLATFORM(WPE)
 static bool handleOptionWPELegacyAPI(Options& options, const char*, const char*)
 {
@@ -236,6 +242,7 @@ OptionsHandler::OptionsHandler(Options& o)
     optionList.append(Option("--webcore-logging", "Enable WebCore log channels", handleOptionWebCoreLogging, true));
     optionList.append(Option("--webkit-logging", "Enable WebKit log channels", handleOptionWebKitLogging, true));
     optionList.append(Option("--lockdown-mode", "Enable Lockdown Mode", handleOptionLockdownMode));
+    optionList.append(Option("--site-isolation-enabled-by-default", "Enable site isolation by default for all tests; individual tests can still disable it with SiteIsolationEnabled=false", handleOptionSiteIsolationEnabledByDefault));
 #if PLATFORM(WPE)
     optionList.append(Option("--wpe-legacy-api", "Use the WPE legacy API (libwpe)", handleOptionWPELegacyAPI));
 #endif

--- a/Tools/WebKitTestRunner/Options.h
+++ b/Tools/WebKitTestRunner/Options.h
@@ -51,6 +51,7 @@ struct Options {
     bool allowAnyHTTPSCertificateForAllowedHosts { false };
     bool enableAllExperimentalFeatures { true };
     bool lockdownModeEnabled { false };
+    bool siteIsolationEnabledByDefault { false };
 #if PLATFORM(WPE)
     bool useWPELegacyAPI { false };
 #endif

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -924,6 +924,8 @@ void TestController::initialize(int argc, const char* argv[])
     m_allowAnyHTTPSCertificateForAllowedHosts = options.allowAnyHTTPSCertificateForAllowedHosts;
     m_enableAllExperimentalFeatures = options.enableAllExperimentalFeatures;
     m_globalFeatures = std::move(options.features);
+    if (options.siteIsolationEnabledByDefault)
+        m_globalFeatures.boolWebPreferenceFeatures.insert_or_assign("SiteIsolationEnabled", true);
 #if ENABLE(WPE_PLATFORM)
     m_useWPELegacyAPI = options.useWPELegacyAPI;
 #endif


### PR DESCRIPTION
#### 7dc7c1f5a8abc337fb5cc365f03161e2c536480e
<pre>
Introduce --site-isolation-enabled-by-default to run-webkit-tests to simulate SI-on-by-default
<a href="https://bugs.webkit.org/show_bug.cgi?id=315857">https://bugs.webkit.org/show_bug.cgi?id=315857</a>
<a href="https://rdar.apple.com/178255472">rdar://178255472</a>

Reviewed by Per Arne Vollan.

Adds a `--site-isolation-enabled-by-default` flag that runs every test with SiteIsolationEnabled=true as the default
preference, simulating the environment we&apos;d get if site isolation were turned on by default in
UnifiedWebPreferences.yaml. This lets a bot surface problems ahead of that change.

The flag is different from `--site-isolation` because it runs tests with Site Isolation on and compares the result
against the -expected.txt file, while `--site-isolation` compares the results with SI off and on.

The flag is different from `--additional-header=SiteIsolationEnabled=true` because it injects SiteIsolationEnabled=true
into the test runner&apos;s global features, so an individual test can still opt out with a SiteIsolationEnabled=false
header, while `--additional-header` would override the test&apos;s own header and force SI on even for tests that ask to
disable it (e.g. the test wants to verify a non-SI behavior). Another difference is expected-result lookup prefers the
mac-site-isolation / ios-site-isolation platform baselines, falling back to the generic expected files. This would be
useful if there is intended behavior change under Site Isolation (e.g. console log may not include full url for remote
frame under SI).

For imported WPT tests, there is a known issue that subtest results in test output might be out-of-order under SI.
Specifically, all subtests are still PASS, but the order of the result is different compared to when SI is off. This is
because when frames are hosted in different processes, the ordering of events and operations could change, and it can
impact when a subtest is created. WPT treats testharness subtest results as an unordered set matched by name (see
tools/wptrunner/.../manifestexpected.py get_subtest), so the test still passes under SI; but WebKit test infra treats
subtest results as an ordered list (must match the order in -expected.txt), so the test is mistakenly reported as FAIL.
To fix this issue, this patch adds a fallback in the result comparison under `--site-isolation-enabled-by-default` for
WPT tests: when exact comparison between test output and the -expected.txt file fails, the script sorts the subtest
result lines in the outputs and compares them again (performing an order-insensitive comparison).

* Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py:
(SingleTestRunner._compare_text):
(SingleTestRunner._is_site_isolation_enabled_by_default_mode):
(SingleTestRunner):
(SingleTestRunner._is_wpt_test):
(SingleTestRunner._normalize_testharness_result_order):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args):
(_set_up_derived_options):
* Tools/Scripts/webkitpy/port/driver.py:
(Driver.cmd_line):
* Tools/WebKitTestRunner/Options.cpp:
(WTR::handleOptionSiteIsolationEnabledByDefault):
(WTR::OptionsHandler::OptionsHandler):
* Tools/WebKitTestRunner/Options.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::initialize):

Canonical link: <a href="https://commits.webkit.org/314431@main">https://commits.webkit.org/314431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e64cd02f7484e5e46ccb057f6b7697ab4cd29482

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123277 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e4d91ed-4456-4ce2-8483-ca8d467fc4d2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129033 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d06d00eb-079c-4e2d-abb0-2bef2e36848b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109559 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcf7799c-7fd5-49e1-a1c8-b7e65c02d5db) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/165340 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30378 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29065 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23209 "Hash e64cd02f for PR 66037 does not build (failure)") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177602 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30504 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137377 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137304 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37005 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148656 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102860 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32588 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25523 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38780 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38177 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3609 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38422 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38320 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->