### PR TITLE
Cherry-pick 3e213e67f6ad. https://bugs.webkit.org/show_bug.cgi?id=306831

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7676,6 +7676,7 @@ webkit.org/b/282024 fast/text/text-box-edge-with-margin-padding-border-simple.ht
 # -- Anchor Positioning -- #
 
 # general failures
+
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-008.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-012.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/transform-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid-expected.txt
@@ -2355,4 +2355,6 @@ PASS e.style['top'] = "calc((anchor(--foo top) + anchor(--bar bottom)) / 2)" sho
 PASS e.style['top'] = "calc(0.5 * (anchor(--foo top) + anchor(--bar bottom)))" should set the property value
 PASS e.style['top'] = "anchor(--foo top, calc(0.5 * anchor(--bar bottom)))" should set the property value
 PASS e.style['top'] = "min(100px, 10%, anchor(--foo top), anchor(--bar bottom))" should set the property value
+PASS e.style['top'] = "anchor(--foo left, 0)" should set the property value
+PASS e.style['top'] = "calc(anchor(--foo left, 0))" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid.html
@@ -75,4 +75,8 @@ test_valid_value('top', 'calc((anchor(--foo top) + anchor(--bar bottom)) / 2)', 
 test_valid_value('top', 'calc(0.5 * (anchor(--foo top) + anchor(--bar bottom)))');
 test_valid_value('top', 'anchor(--foo top, calc(0.5 * anchor(--bar bottom)))');
 test_valid_value('top', 'min(100px, 10%, anchor(--foo top), anchor(--bar bottom))');
+
+// Should accept unitless zero
+test_valid_value('top', "anchor(--foo left, 0)", "anchor(--foo left, 0px)");
+test_valid_value('top', "calc(anchor(--foo left, 0))", "anchor(--foo left, 0px)");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid-expected.txt
@@ -4299,4 +4299,6 @@ PASS e.style['margin-left'] = "calc((anchor-size(--foo width) + anchor-size(--ba
 PASS e.style['margin-left'] = "calc(0.5 * (anchor-size(--foo width) + anchor-size(--bar height)))" should set the property value
 PASS e.style['margin-left'] = "anchor-size(--foo width, calc(0.5 * anchor-size(--bar height)))" should set the property value
 PASS e.style['margin-left'] = "min(100px, 10%, anchor-size(--foo width), anchor-size(--bar height))" should set the property value
+PASS e.style['width'] = "anchor-size(--foo width, 0)" should set the property value
+PASS e.style['width'] = "calc(anchor-size(--foo width, 0))" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid.html
@@ -105,4 +105,8 @@ for (const prop of ['width', 'max-width', 'margin-left']) {
   test_valid_value(prop, 'anchor-size(--foo width, calc(0.5 * anchor-size(--bar height)))');
   test_valid_value(prop, 'min(100px, 10%, anchor-size(--foo width), anchor-size(--bar height))');
 }
+
+// Should accept unitless zero
+test_valid_value('width', "anchor-size(--foo width, 0)", "anchor-size(--foo width, 0px)");
+test_valid_value('width', "calc(anchor-size(--foo width, 0))", "anchor-size(--foo width, 0px)");
 </script>

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -996,6 +996,40 @@ static std::optional<TypedChild> consumeValueWithoutSimplifyingCalc(CSSParserTok
     return typedValue;
 }
 
+// Parse the fallback value specified in anchor() and anchor-size() as a <length> or
+// <length-percentage>. Additionally, unitless zero is allowed and gets treated as 0px.
+static std::optional<TypedChild> consumeAnchorFallback(CSSParserTokenRange& tokens, int depth, ParserState& state)
+{
+    auto typedFallback = consumeValueWithoutSimplifyingCalc(tokens, depth, state);
+    if (!typedFallback)
+        return { };
+
+    auto category = typedFallback->type.calculationCategory();
+    if (!category)
+        return { };
+
+    switch (*category) {
+    case CSS::Category::Length:
+    case CSS::Category::LengthPercentage:
+        return typedFallback;
+
+    case CSS::Category::Number: {
+        if (state.parserOptions.propertyOptions.unitlessZeroLength != UnitlessZeroQuirk::Allow)
+            return { };
+
+        // Allow unitless 0.
+        auto value = std::get<Number>(typedFallback->child.value);
+        if (value.value)
+            return { };
+
+        return TypedChild { makeNumeric(0, CSSUnitType::CSS_PX), Type::makeLength() };
+    }
+
+    default:
+        return { };
+    }
+}
+
 static std::optional<TypedChild> consumeAnchor(CSSParserTokenRange& tokens, int depth, ParserState& state)
 {
     // <anchor()> = anchor( <anchor-element>? && <anchor-side>, <length-percentage>? )
@@ -1047,17 +1081,15 @@ static std::optional<TypedChild> consumeAnchor(CSSParserTokenRange& tokens, int 
     std::optional<Child> fallback;
 
     if (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(tokens)) {
-        auto typedFallback = consumeValueWithoutSimplifyingCalc(tokens, depth, state);
-        if (!typedFallback)
+        auto maybeFallback = consumeAnchorFallback(tokens, depth, state);
+        if (!maybeFallback)
             return { };
 
-        auto category = typedFallback->type.calculationCategory();
-        if (!category)
-            return { };
-        if (*category != CSS::Category::Length && *category != CSS::Category::LengthPercentage)
-            return { };
+        fallback = WTF::move(maybeFallback->child);
 
-        fallback = WTF::move(typedFallback->child);
+        auto category = maybeFallback->type.calculationCategory();
+        ASSERT(category && (category == CSS::Category::Length || category == CSS::Category::LengthPercentage));
+
         type.percentHint = Type::determinePercentHint(*category);
     }
 
@@ -1122,7 +1154,7 @@ static std::optional<TypedChild> consumeAnchorSize(CSSParserTokenRange& tokens, 
         // if a comma follows...
         if (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(tokens)) {
             // it must be followed by the fallback value.
-            fallback = consumeValueWithoutSimplifyingCalc(tokens, depth, state);
+            fallback = consumeAnchorFallback(tokens, depth, state);
             if (!fallback)
                 return { };
         }
@@ -1130,21 +1162,15 @@ static std::optional<TypedChild> consumeAnchorSize(CSSParserTokenRange& tokens, 
     } else {
         // if <anchor-element> and <anchor-size> is not present
         // then an optional fallback value follows
-        fallback = consumeValueWithoutSimplifyingCalc(tokens, depth, state);
+        fallback = consumeAnchorFallback(tokens, depth, state);
     }
 
+    // Return type of this function. It's a <length> if it can be resolved, otherwise the
+    // <length-percentage> fallback is resolved, which could be a percentage.
     auto type = Type::makeLength();
-
-    // anchor-size() resolves to a <length> if it can be resolved, otherwise the fallback
-    // value is resolved, which is of type <length-percentage>. Therefore the overall type
-    // of anchor-size() is <length> or <length-percentage>, depending on the type of the
-    // fallback value.
     if (fallback) {
         auto category = fallback->type.calculationCategory();
-        if (!category)
-            return { };
-        if (*category != CSS::Category::Length && *category != CSS::Category::LengthPercentage)
-            return { };
+        ASSERT(category && (category == CSS::Category::Length || category == CSS::Category::LengthPercentage));
 
         type.percentHint = Type::determinePercentHint(*category);
     }


### PR DESCRIPTION
#### 571059e95e35d4c83c51c0c9dddad089a1de30cf
<pre>
Cherry-pick 3e213e67f6ad. <a href="https://bugs.webkit.org/show_bug.cgi?id=306831">https://bugs.webkit.org/show_bug.cgi?id=306831</a>

    [css-anchor-position-1] anchor()/anchor-size() fallback value should support unitless zero
    <a href="https://rdar.apple.com/169500991">rdar://169500991</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=306831">https://bugs.webkit.org/show_bug.cgi?id=306831</a>

    Reviewed by Antti Koivisto.

    This patch allows using unitless zero (&quot;0&quot;) as fallback value for
    anchor() and anchor-size(), which gets treated as 0px.

    Tests: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid.html
           imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-invalid.html
           imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid.html
           imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-invalid.html

    * LayoutTests/TestExpectations:
    * LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid-expected.txt:
    * LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-parse-valid.html:
    * LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid-expected.txt:
    * LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid.html:
    * Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
    (WebCore::CSSCalc::consumeAnchorFallback):
    (WebCore::CSSCalc::consumeAnchor):
    (WebCore::CSSCalc::consumeAnchorSize):

    Canonical link: <a href="https://commits.webkit.org/310108@main">https://commits.webkit.org/310108@main</a>

    Identifier: 305413.589@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.690@webkitglib/2.52">https://commits.webkit.org/305877.690@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48877888869d6a5a7bfe9e1ce36641c5ca50af73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165328 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38819 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32399 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174372 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122585 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167196 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39156 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38823 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128475 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122585 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168287 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39156 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/32399 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109000 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39156 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38823 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22446 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39156 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/32399 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176893 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29793 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32399 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136799 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38887 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/38823 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136735 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/39577 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/32399 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101921 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25156 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/39577 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32399 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/38087 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/111161 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/37484 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/32399 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37730 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/37628 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->