### PR TITLE
AX: Reduce per-call allocations and recomputation in the accessibility isIgnored() hot path

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1010,19 +1010,16 @@ void AXObjectCache::onLaidOutInlineContent(const RenderBlockFlow& renderBlock)
     setDirtyStitchGroups(renderBlock);
 }
 
-AccessibilityObject* AXObjectCache::getOrCreate(Widget& widget)
+AccessibilityObject* AXObjectCache::getOrCreateSlow(Widget& widget)
 {
-    if (RefPtr object = get(widget))
-        return object.unsafeGet();
+    // `get` for this Widget should've been attempted before calling this method.
+    AX_ASSERT(!get(widget));
 
     RefPtr<AccessibilityObject> newObject;
     if (auto* scrollView = dynamicDowncast<ScrollView>(widget))
         newObject = AccessibilityScrollView::create(AXID::generate(), *scrollView, *this);
     else if (auto* scrollbar = dynamicDowncast<Scrollbar>(widget))
         newObject = AccessibilityScrollbar::create(AXID::generate(), *scrollbar, *this);
-
-    // Will crash later if we have two objects for the same widget.
-    AX_ASSERT(!get(widget));
 
     // Ensure we weren't given an unsupported widget type.
     AX_ASSERT(newObject);

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -386,6 +386,7 @@ private:
     void attachWrapper(AccessibilityObject&);
 
     AccessibilityObject* getOrCreateSlow(Node&, IsPartOfRelation);
+    AccessibilityObject* getOrCreateSlow(Widget&);
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     RefPtr<AccessibilityScrollView> scrollViewForFrame(LocalFrame&);

--- a/Source/WebCore/accessibility/AXObjectCacheInlines.h
+++ b/Source/WebCore/accessibility/AXObjectCacheInlines.h
@@ -83,6 +83,13 @@ inline AccessibilityObject* AXObjectCache::getOrCreate(Element& element, IsPartO
     return getOrCreateSlow(element, isPartOfRelation);
 }
 
+inline AccessibilityObject* AXObjectCache::getOrCreate(Widget& widget)
+{
+    if (auto* object = get(widget))
+        return object;
+    return getOrCreateSlow(widget);
+}
+
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
 inline void AXObjectCache::scheduleObjectRegionsUpdate(bool scheduleImmediately)

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -179,26 +179,31 @@ bool hasRole(Element& element, StringView role)
     if (roleValue.isEmpty())
         return false;
 
-    return SpaceSplitString::spaceSplitStringContainsValue(roleValue, role, SpaceSplitString::ShouldFoldCase::Yes);
+    // Lowercase the role value ourselves (allocation-free when it's already lowercase, the common case for
+    // ARIA roles) and match without folding, so spaceSplitStringContainsValue doesn't allocate a lowercased copy.
+    return SpaceSplitString::spaceSplitStringContainsValue(roleValue.convertToASCIILowercase(), role, SpaceSplitString::ShouldFoldCase::No);
 }
 
-bool hasAnyRole(Element& element, Vector<StringView>&& roles)
+bool hasAnyRole(Element& element, std::initializer_list<StringView> roles)
 {
     auto roleValue = element.attributeWithDefaultARIA(roleAttr);
     if (roleValue.isEmpty())
         return false;
 
+    // Lowercase the role value once (allocation-free when it's already lowercase, the common case for ARIA
+    // roles) and match each candidate without folding, rather than lowercasing it once per candidate role.
+    AtomString lowercasedRoleValue = roleValue.convertToASCIILowercase();
     for (const auto& role : roles) {
         AX_ASSERT(!role.isEmpty());
-        if (SpaceSplitString::spaceSplitStringContainsValue(roleValue, role, SpaceSplitString::ShouldFoldCase::Yes))
+        if (SpaceSplitString::spaceSplitStringContainsValue(lowercasedRoleValue, role, SpaceSplitString::ShouldFoldCase::No))
             return true;
     }
     return false;
 }
 
-bool hasAnyRole(Element* element, Vector<StringView>&& roles)
+bool hasAnyRole(Element* element, std::initializer_list<StringView> roles)
 {
-    return element ? hasAnyRole(*element, WTF::move(roles)) : false;
+    return element ? hasAnyRole(*element, roles) : false;
 }
 
 bool hasTableRole(Element& element)

--- a/Source/WebCore/accessibility/AXUtilities.h
+++ b/Source/WebCore/accessibility/AXUtilities.h
@@ -44,8 +44,8 @@ class RenderObject;
 class StyleProperties;
 
 bool hasRole(Element&, StringView role);
-bool hasAnyRole(Element&, Vector<StringView>&& roles);
-bool hasAnyRole(Element*, Vector<StringView>&& roles);
+bool hasAnyRole(Element&, std::initializer_list<StringView> roles);
+bool hasAnyRole(Element*, std::initializer_list<StringView> roles);
 bool hasCellARIARole(Element&);
 bool hasPresentationRole(Element&);
 bool hasTableRole(Element&);

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -68,23 +68,36 @@ AccessibilityScrollView::~AccessibilityScrollView()
 
 bool AccessibilityScrollView::isRoot() const
 {
+    if (m_isRoot)
+        return *m_isRoot;
+
     RefPtr frameView = dynamicDowncast<FrameView>(m_scrollView.get());
+    if (!frameView) {
+        // m_scrollView may be transiently unavailable (e.g. during teardown), so don't memoize a result
+        // we couldn't determine. Once we have a valid frame view, root-ness is invariant for our lifetime.
+        return false;
+    }
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    // A remote frame is not a root.
-    if (frameView && frameView->isRemoteFrameView())
-        return false;
+    if (frameView->isRemoteFrameView()) {
+        // A remote frame is not a root.
+        m_isRoot = false;
+        return *m_isRoot;
+    }
 
-    // Interpret this as "is this the root of the local frame"
+    // Interpret this as "is this the root of the local frame".
     WeakPtr cache = axObjectCache();
     if (!cache)
         return false;
 
-    return document() == cache->document();
+    // AXObjectCache::m_document is const, so we can safely cache m_isRoot here.
+    m_isRoot = document() == cache->document();
 #else
-    // Interpret this as "is this the root of the whole page"
-    return frameView && frameView->frame().isMainFrame();
-#endif
+    // Interpret this as "is this the root of the whole page".
+    // A frame's main-frame-ness never changes.
+    m_isRoot = frameView->frame().isMainFrame();
+#endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    return *m_isRoot;
 }
 
 String AccessibilityScrollView::ownerDebugDescription() const

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -124,6 +124,8 @@ private:
     void removeChildScrollbar(AccessibilityObject*);
 
     bool m_childrenDirty;
+    // Memoized result of isRoot(), which is invariant for this object's lifetime (see isRoot()).
+    mutable std::optional<bool> m_isRoot;
     SingleThreadWeakPtr<ScrollView> m_scrollView;
     WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_frameOwnerElement;
     RefPtr<AccessibilityObject> m_horizontalScrollbar;


### PR DESCRIPTION
#### c7a6997ebbb97fe9be83987597e69c3d25324fba
<pre>
AX: Reduce per-call allocations and recomputation in the accessibility isIgnored() hot path
<a href="https://bugs.webkit.org/show_bug.cgi?id=315867">https://bugs.webkit.org/show_bug.cgi?id=315867</a>
<a href="https://rdar.apple.com/178267741">rdar://178267741</a>

Reviewed by Dominic Mazzoni.

This patch features a few optimizations based on a sample taken from a
page that exercised isIgnored() a lot:

- ARIA role checks (AXListHelpers::isAccessibilityList, AXTableHelpers::
  isTableCellElement -&gt; hasCellARIARole) allocated a lowercased copy of the role
  attribute on every comparison, via SpaceSplitString::spaceSplitStringContainsValue()
  with ShouldFoldCase::Yes -- and hasAnyRole() did so once per candidate role, so a
  single isTableCellElement() check could allocate four times. hasAnyRole() also
  heap-allocated a Vector for its candidate list on every call.

- AccessibilityScrollView::isRoot() recomputed a downcast plus a virtual document()
  comparison on every call, even though the answer is invariant for the object&apos;s
  lifetime. It is called from many hot paths (computeIsIgnored, parentObject,
  isARIAHidden, isWithinHiddenWebArea, elementRect, ...).

- AXObjectCache::getOrCreate(Widget&amp;) was out-of-line, so even cache hits (the common
  case from parentObject()/containingWebArea()) paid a cross-function call before
  reaching the already-inline get().

This patch addresses each with no change in observable behavior:

- hasRole()/hasAnyRole() now lowercase the role value once via
  AtomString::convertToASCIILowercase() -- which returns *this without allocating
  when the string is already lowercase, the common case for ARIA roles -- and match
  with ShouldFoldCase::No. This is equivalent to the previous ShouldFoldCase::Yes
  path (which folded the haystack internally) since all callers pass lowercase
  values. hasAnyRole() takes a std::initializer_list&lt;StringView&gt; instead of a Vector,
  removing the per-call backing-store allocation. SpaceSplitString is left untouched.

- AccessibilityScrollView::isRoot() is memoized in a std::optional&lt;bool&gt;. The value
  is invariant for the object&apos;s lifetime: AXObjectCache::m_document is const, there is
  one cache per document under ACCESSIBILITY_LOCAL_FRAME (computeIsIgnored relies on
  this), and isMainFrame() is fixed for a given frame otherwise. The cache-is-null
  teardown case is intentionally not memoized.

- AXObjectCache::getOrCreate(Widget&amp;) is now an inline fast path (get() +
  getOrCreateSlow(Widget&amp;)), matching the existing getOrCreate(Node&amp;)/(Element&amp;)
  pattern in AXObjectCacheInlines.h.

These yield a 0.79% improvement on our Speedometer 3.1 score.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::getOrCreateSlow):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXObjectCacheInlines.h:
(WebCore::AXObjectCache::getOrCreate):
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::hasRole):
(WebCore::hasAnyRole):
* Source/WebCore/accessibility/AXUtilities.h:
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::isRoot const):
* Source/WebCore/accessibility/AccessibilityScrollView.h:

Canonical link: <a href="https://commits.webkit.org/314234@main">https://commits.webkit.org/314234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0208cb2f2a00e1c4dcb23c404faa8909e9ec845e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174466 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122679 "Built successfully") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128550 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90478 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168383 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30960 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109075 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29997 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28537 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22541 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176990 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29895 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136875 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38983 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136811 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36895 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148115 "Passed tests") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32082 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24982 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38181 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111255 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37578 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3062 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37824 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37722 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->