### PR TITLE
[CMake] Unified-source hygiene fixes for larger bundles

### DIFF
--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -939,13 +939,12 @@ writeH("OpcodeGenerated") {
     outp.puts "#include \"CCallHelpers.h\""
     outp.puts "#include \"wtf/PrintStream.h\""
     outp.puts "namespace WTF {"
-    outp.puts "using namespace JSC::B3::Air;"
-    outp.puts "void printInternal(PrintStream& out, Opcode opcode)"
+    outp.puts "void printInternal(PrintStream& out, JSC::B3::Air::Opcode opcode)"
     outp.puts "{"
     outp.puts "    switch (opcode) {"
     $opcodes.keys.each {
         | opcode |
-        outp.puts "    case Opcode::#{opcode}:"
+        outp.puts "    case JSC::B3::Air::Opcode::#{opcode}:"
         outp.puts "        out.print(\"#{opcode}\");"
         outp.puts "        return;"
     }

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -535,7 +535,7 @@ void printInternal(PrintStream& out, SwitchKind kind)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void printInternal(PrintStream& out, Node* node)
+void printInternal(PrintStream& out, JSC::DFG::Node* node)
 {
     if (!node) {
         out.print("-");

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -37,7 +37,7 @@ static bool NODELETE verboseCapabilities()
     return verboseCompilationEnabled() || Options::verboseFTLFailure();
 }
 
-inline CapabilityLevel canCompile(Node* node)
+inline CapabilityLevel canCompile(DFG::Node* node)
 {
     // NOTE: If we ever have phantom arguments, we can compile them but we cannot
     // OSR enter.
@@ -59,7 +59,7 @@ inline CapabilityLevel canCompile(Node* node)
     case ExtractFromTuple:
     case SetArgumentDefinitely:
     case SetArgumentMaybe:
-    case Return:
+    case DFG::Return:
     case ArithBitNot:
     case ArithBitAnd:
     case ArithBitOr:
@@ -132,10 +132,10 @@ inline CapabilityLevel canCompile(Node* node)
     case ArithNegate:
     case ArithUnary:
     case UInt32ToNumber:
-    case Jump:
+    case DFG::Jump:
     case ForceOSRExit:
-    case Phi:
-    case Upsilon:
+    case DFG::Phi:
+    case DFG::Upsilon:
     case ExtractOSREntryLocal:
     case ExtractCatchLocal:
     case ClearCatchLocals:
@@ -215,14 +215,14 @@ inline CapabilityLevel canCompile(Node* node)
     case VarargsLength:
     case LoadVarargs:
     case ValueToInt32:
-    case Branch:
+    case DFG::Branch:
     case ToBoolean:
     case LogicalNot:
     case AssertInBounds:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case ConstantStoragePointer:
-    case Check:
+    case DFG::Check:
     case CheckVarargs:
     case CheckArray:
     case CheckArrayOrEmpty:
@@ -340,9 +340,9 @@ inline CapabilityLevel canCompile(Node* node)
     case InstanceOfMegamorphic:
     case InstanceOfCustom:
     case DoubleRep:
-    case ValueRep:
+    case DFG::ValueRep:
     case Int52Rep:
-    case PurifyNaN:
+    case DFG::PurifyNaN:
     case DoubleConstant:
     case Int52Constant:
     case BooleanToNumber:
@@ -383,8 +383,8 @@ inline CapabilityLevel canCompile(Node* node)
     case GetMyArgumentByVal:
     case GetMyArgumentByValOutOfBounds:
     case ForwardVarargs:
-    case EntrySwitch:
-    case Switch:
+    case DFG::EntrySwitch:
+    case DFG::Switch:
     case TypeOf:
     case PutById:
     case PutByIdDirect:
@@ -532,7 +532,7 @@ inline CapabilityLevel canCompile(Node* node)
         // These are OK.
         break;
 
-    case Identity:
+    case DFG::Identity:
         // No backend handles this because it will be optimized out. But we may check
         // for capabilities before optimization. It would be a deep error to remove this
         // case because it would prevent us from catching bugs where the FTL backend
@@ -568,7 +568,7 @@ CapabilityLevel canCompile(Graph& graph)
     CapabilityLevel result = CanCompileAndOSREnter;
     
     for (BlockIndex blockIndex = graph.numBlocks(); blockIndex--;) {
-        BasicBlock* block = graph.block(blockIndex);
+        DFG::BasicBlock* block = graph.block(blockIndex);
         if (!block)
             continue;
         
@@ -577,8 +577,8 @@ CapabilityLevel canCompile(Graph& graph)
             continue;
         
         for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
-            Node* node = block->at(nodeIndex);
-            
+            DFG::Node* node = block->at(nodeIndex);
+
             for (unsigned childIndex = graph.numChildren(node); childIndex--;) {
                 Edge edge = graph.child(node, childIndex);
                 if (!edge)

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -356,7 +356,7 @@ void compile(State& state, Safepoint::Result& safepointResult)
 
         DumpContext dumpContext;
         StringPrintStream out;
-        Node* lastNode = nullptr;
+        DFG::Node* lastNode = nullptr;
         for (size_t blockIndex = 0; blockIndex < graph.numBlocks(); ++blockIndex) {
             DFG::BasicBlock* block = graph.block(blockIndex);
             if (!block)
@@ -367,7 +367,7 @@ void compile(State& state, Safepoint::Result& safepointResult)
             out.reset();
 
             for (size_t nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
-                Node* node = block->at(nodeIndex);
+                DFG::Node* node = block->at(nodeIndex);
 
                 Profiler::OriginStack stack;
 
@@ -398,7 +398,7 @@ void compile(State& state, Safepoint::Result& safepointResult)
         compilation->addDescription(Profiler::OriginStack(), out.toCString());
         out.reset();
 
-        state.dumpDisassembly(out, *state.b3CodeLinkBuffer, scopedLambda<void(Node*)>([&] (Node*) {
+        state.dumpDisassembly(out, *state.b3CodeLinkBuffer, scopedLambda<void(DFG::Node*)>([&] (DFG::Node*) {
             compilation->addDescription({ }, out.toCString());
             out.reset();
         }));

--- a/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.cpp
+++ b/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.cpp
@@ -34,7 +34,7 @@ namespace JSC { namespace FTL {
 
 using namespace JSC::DFG;
 
-ExitTimeObjectMaterialization::ExitTimeObjectMaterialization(Node* node, CodeOrigin codeOrigin)
+ExitTimeObjectMaterialization::ExitTimeObjectMaterialization(DFG::Node* node, CodeOrigin codeOrigin)
     : m_type(node->op())
     , m_indexingType(node->hasIndexingType() ? node->indexingType() : NoIndexingShape)
     , m_origin(codeOrigin)

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -93,16 +93,16 @@ void State::dumpDisassembly(PrintStream& out, LinkBuffer& linkBuffer, const Scop
         out.print("Generated ", graph.m_plan.mode(), " code for ", CodeBlockWithJITType(graph.m_codeBlock, JITType::FTLJIT), ", instructions size = ", graph.m_codeBlock->instructionsSize(), ":\n");
 
         B3::Value* currentB3Value = nullptr;
-        Node* currentDFGNode = nullptr;
+        DFG::Node* currentDFGNode = nullptr;
 
         UncheckedKeyHashSet<B3::Value*> printedValues;
-        UncheckedKeyHashSet<Node*> printedNodes;
+        UncheckedKeyHashSet<DFG::Node*> printedNodes;
         const char* dfgPrefix = "DFG " "    ";
         const char* b3Prefix  = "b3  " "          ";
         const char* airPrefix = "Air " "              ";
         const char* asmPrefix = "asm " "                ";
 
-        auto printDFGNode = [&] (Node* node) {
+        auto printDFGNode = [&] (DFG::Node* node) {
             if (currentDFGNode == node)
                 return;
 
@@ -112,8 +112,8 @@ void State::dumpDisassembly(PrintStream& out, LinkBuffer& linkBuffer, const Scop
 
             perDFGNodeCallback(node);
 
-            UncheckedKeyHashSet<Node*> localPrintedNodes;
-            WTF::Function<void(Node*)> printNodeRecursive = [&] (Node* node) {
+            UncheckedKeyHashSet<DFG::Node*> localPrintedNodes;
+            WTF::Function<void(DFG::Node*)> printNodeRecursive = [&] (DFG::Node* node) {
                 if (printedNodes.contains(node) || localPrintedNodes.contains(node))
                     return;
 

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.h
@@ -453,6 +453,9 @@ private:
     uint32_t m_deleteCount { 0 };
 };
 
+template<> void WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::takeSnapshot(MarkedArgumentBuffer&, unsigned);
+template<> void WeakMapImpl<WeakMapBucket<WeakMapBucketDataKeyValue>>::takeSnapshot(MarkedArgumentBuffer&, unsigned);
+
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/cocoa/SoftLinking.h
+++ b/Source/WTF/wtf/cocoa/SoftLinking.h
@@ -43,7 +43,7 @@
 #pragma mark - Soft-link macros for use within a single source file
 
 #define SOFT_LINK_LIBRARY(lib) \
-    static void* lib##Library() \
+    static void* lib##Library(bool = false) \
     { \
         static void* dylib = ^{ \
             void *result = dlopen("/usr/lib/" #lib ".dylib", RTLD_NOW); \
@@ -54,7 +54,7 @@
     }
 
 #define SOFT_LINK_SYSTEM_LIBRARY(lib) \
-    static void* lib##Library() \
+    static void* lib##Library(bool = false) \
     { \
         static void* dylib = ^{ \
             void *result = dlopen("/usr/lib/system/" #lib ".dylib", RTLD_NOW); \
@@ -65,7 +65,7 @@
     }
 
 #define SOFT_LINK_LIBRARY_OPTIONAL(lib) \
-static void* lib##Library() \
+static void* lib##Library(bool = false) \
 { \
     static void* dylib = ^{ \
         void *result = dlopen("/usr/lib/" #lib ".dylib", RTLD_NOW); \
@@ -75,7 +75,7 @@ static void* lib##Library() \
 }
 
 #define SOFT_LINK_LIBRARY_WITH_PATH(lib, path) \
-    static void* lib##Library() \
+    static void* lib##Library(bool = false) \
     { \
         static void* dylib = ^{ \
             void *result = dlopen(path #lib ".dylib", RTLD_NOW); \
@@ -86,7 +86,7 @@ static void* lib##Library() \
     }
 
 #define SOFT_LINK_FRAMEWORK(framework) \
-    static void* framework##Library() \
+    static void* framework##Library(bool = false) \
     { \
         static void* frameworkLibrary = ^{ \
             void* result = dlopen("/System/Library/Frameworks/" #framework ".framework/" #framework, RTLD_NOW); \
@@ -97,7 +97,7 @@ static void* lib##Library() \
     }
 
 #define SOFT_LINK_PRIVATE_FRAMEWORK(framework) \
-    static void* framework##Library() \
+    static void* framework##Library(bool = false) \
     { \
         static void* frameworkLibrary = ^{ \
             void* result = dlopen("/System/Library/PrivateFrameworks/" #framework ".framework/" #framework, RTLD_NOW); \
@@ -108,21 +108,21 @@ static void* lib##Library() \
     }
 
 #define SOFT_LINK_FRAMEWORK_OPTIONAL(framework) \
-    static void* framework##Library() \
+    static void* framework##Library(bool = false) \
     { \
         static void* frameworkLibrary = dlopen("/System/Library/Frameworks/" #framework ".framework/" #framework, RTLD_NOW); \
         return frameworkLibrary; \
     }
 
 #define SOFT_LINK_PRIVATE_FRAMEWORK_OPTIONAL(framework) \
-    static void* framework##Library() \
+    static void* framework##Library(bool = false) \
     { \
         static void* frameworkLibrary = dlopen("/System/Library/PrivateFrameworks/" #framework ".framework/" #framework, RTLD_NOW); \
         return frameworkLibrary; \
     }
 
 #define SOFT_LINK_FRAMEWORK_IN_UMBRELLA(umbrella, framework) \
-    static void* framework##Library() \
+    static void* framework##Library(bool = false) \
     { \
         static void* frameworkLibrary = ^{ \
             void* result = dlopen("/System/Library/Frameworks/" #umbrella ".framework/Frameworks/" #framework ".framework/" #framework, RTLD_NOW); \
@@ -133,7 +133,7 @@ static void* lib##Library() \
     }
 
 #define SOFT_LINK_FRAMEWORK_IN_UMBRELLA_OPTIONAL(umbrella, framework) \
-    static void* framework##Library() \
+    static void* framework##Library(bool = false) \
     { \
         static void* frameworkLibrary = dlopen("/System/Library/Frameworks/" #umbrella ".framework/Frameworks/" #framework ".framework/" #framework, RTLD_NOW); \
         return frameworkLibrary; \
@@ -141,7 +141,7 @@ static void* lib##Library() \
 
 #define SOFT_LINK_FRAMEWORK_IN_UMBRELLA_FOR_SOURCE_WITH_EXPORT(functionNamespace, umbrella, framework, export) \
     namespace functionNamespace { \
-    export void* framework##Library(bool isOptional = false); \
+    export void* framework##Library(bool isOptional); \
     void* framework##Library(bool isOptional) \
     { \
         static void* frameworkLibrary; \
@@ -156,7 +156,7 @@ static void* lib##Library() \
     }
 
 #define SOFT_LINK_PRIVATE_FRAMEWORK_IN_UMBRELLA_OPTIONAL(umbrella, framework) \
-    static void* framework##Library() \
+    static void* framework##Library(bool = false) \
     { \
         static void* frameworkLibrary = dlopen("/System/Library/PrivateFrameworks/" #umbrella ".framework/Frameworks/" #framework ".framework/" #framework, RTLD_NOW); \
         return frameworkLibrary; \
@@ -172,7 +172,7 @@ static void* lib##Library() \
     static resultType init##functionName parameterDeclarations \
     { \
         _STORE_IN_DLSYM_SECTION static char const auditedName[] = #functionName; \
-        softLink##functionName = (resultType (*) parameterDeclarations) dlsym(framework##Library(), auditedName); \
+        softLink##functionName = (resultType (*) parameterDeclarations) dlsym(framework##Library(false), auditedName); \
         RELEASE_ASSERT_WITH_MESSAGE(softLink##functionName, "%s", dlerror()); \
         return softLink##functionName parameterNames; \
     } \
@@ -198,7 +198,7 @@ static void* lib##Library() \
     { \
         ASSERT(!softLink##functionName); \
         _STORE_IN_DLSYM_SECTION static char const auditedName[] = #functionName; \
-        softLink##functionName = (resultType (*) parameterDeclarations) dlsym(framework##Library(), auditedName); \
+        softLink##functionName = (resultType (*) parameterDeclarations) dlsym(framework##Library(false), auditedName); \
         return !!softLink##functionName; \
     } \
     \
@@ -230,23 +230,23 @@ static void* lib##Library() \
     static functionName##PtrType functionName##Ptr() \
     { \
         _STORE_IN_DLSYM_SECTION static char const auditedName[] = #functionName; \
-        static functionName##PtrType ptr = reinterpret_cast<functionName##PtrType>(dlsym(framework##Library(), auditedName)); \
+        static functionName##PtrType ptr = reinterpret_cast<functionName##PtrType>(dlsym(framework##Library(false), auditedName)); \
         return ptr; \
     }
 
 #define SOFT_LINK_CLASS(framework, className) \
     @class className; \
-    static Class init##className(); \
-    static Class (*get##className##ClassSingleton)() = init##className; \
-    struct Class##className##Wrapper { SUPPRESS_UNCOUNTED_MEMBER Class classObject; }; \
+    static ::Class init##className(); \
+    static ::Class (*get##className##ClassSingleton)() = init##className; \
+    struct Class##className##Wrapper { SUPPRESS_UNCOUNTED_MEMBER ::Class classObject; }; \
     static Class##className##Wrapper class##className; \
     \
-    static Class className##Function() \
+    static ::Class className##Function() \
     { \
         return class##className.classObject; \
     } \
     \
-    static Class init##className() \
+    static ::Class init##className() \
     { \
         framework##Library(); \
         _STORE_IN_GETCLASS_SECTION static char const auditedClassName[] = #className; \
@@ -266,17 +266,17 @@ static void* lib##Library() \
 
 #define SOFT_LINK_CLASS_OPTIONAL(framework, className) \
     @class className; \
-    static Class init##className(); \
-    static Class (*get##className##ClassSingleton)() = init##className; \
-    struct class##className##Wrapper { SUPPRESS_UNCOUNTED_MEMBER Class classObject; }; \
+    static ::Class init##className(); \
+    static ::Class (*get##className##ClassSingleton)() = init##className; \
+    struct class##className##Wrapper { SUPPRESS_UNCOUNTED_MEMBER ::Class classObject; }; \
     static class##className##Wrapper class##className; \
     \
-    static Class className##Function() \
+    static ::Class className##Function() \
     { \
         return class##className.classObject; \
     } \
     \
-    static Class init##className() \
+    static ::Class init##className() \
     { \
         framework##Library(); \
         _STORE_IN_GETCLASS_SECTION static char const auditedClassName[] = #className; \
@@ -306,7 +306,7 @@ static void* lib##Library() \
     static type init##name() \
     { \
         _STORE_IN_DLSYM_SECTION static char const auditedName[] = #name; \
-        void** pointer = static_cast<void**>(dlsym(framework##Library(), auditedName)); \
+        void** pointer = static_cast<void**>(dlsym(framework##Library(false), auditedName)); \
         RELEASE_ASSERT_WITH_MESSAGE(pointer, "%s", dlerror()); \
         pointer##name = static_cast<type>(*pointer); \
         get##name = name##Function; \
@@ -326,7 +326,7 @@ static void* lib##Library() \
     static type init##name() \
     { \
         _STORE_IN_DLSYM_SECTION static char const auditedName[] = #name; \
-        void** pointer = static_cast<void**>(dlsym(framework##Library(), auditedName)); \
+        void** pointer = static_cast<void**>(dlsym(framework##Library(false), auditedName)); \
         if (pointer) \
             pointer##name = static_cast<type>(*pointer); \
         get##name = name##Function; \
@@ -347,7 +347,7 @@ static void* lib##Library() \
     static type init##name() \
     { \
         _STORE_IN_DLSYM_SECTION static char const auditedName[] = #name; \
-        void* constant = dlsym(framework##Library(), auditedName); \
+        void* constant = dlsym(framework##Library(false), auditedName); \
         RELEASE_ASSERT_WITH_MESSAGE(constant, "%s", dlerror()); \
         constant##name.constant = *static_cast<type const *>(constant); \
         get##name##Singleton = name##Function; \
@@ -375,7 +375,7 @@ static void* lib##Library() \
     { \
         ASSERT(!get##name##Singleton); \
         _STORE_IN_DLSYM_SECTION static char const auditedName[] = #name; \
-        void* constant = dlsym(framework##Library(), auditedName); \
+        void* constant = dlsym(framework##Library(false), auditedName); \
         if (!constant) \
             return false; \
         constant##name.constant = *static_cast<type const *>(constant); \
@@ -399,7 +399,7 @@ static void* lib##Library() \
 
 #define SOFT_LINK_LIBRARY_FOR_SOURCE(functionNamespace, lib) \
     namespace functionNamespace { \
-    extern void* lib##Library(bool isOptional = false); \
+    extern void* lib##Library(bool isOptional); \
     void* lib##Library(bool isOptional) \
     { \
         static void* library; \
@@ -424,7 +424,7 @@ static void* lib##Library() \
 
 #define SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_FLAGS_AND_EXPORT(functionNamespace, framework, flags, export) \
     namespace functionNamespace { \
-    export void* framework##Library(bool isOptional = false); \
+    export void* framework##Library(bool isOptional); \
     void* framework##Library(bool isOptional) \
     { \
         static void* frameworkLibrary; \
@@ -449,7 +449,7 @@ static void* lib##Library() \
 
 #define SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(functionNamespace, framework, export) \
     namespace functionNamespace { \
-    export void* framework##Library(bool isOptional = false); \
+    export void* framework##Library(bool isOptional); \
     void* framework##Library(bool isOptional) \
     { \
         static void* frameworkLibrary; \
@@ -469,7 +469,7 @@ static void* lib##Library() \
 #define SOFT_LINK_CLASS_FOR_HEADER(functionNamespace, className) \
     @class className; \
     namespace functionNamespace { \
-    extern Class (*get##className##ClassSingleton)(); \
+    extern ::Class (*get##className##ClassSingleton)(); \
     className *alloc##className##Instance() NS_RETURNS_RETAINED; \
     inline className *alloc##className##Instance() NS_RETURNS_RETAINED \
     { \
@@ -480,23 +480,23 @@ static void* lib##Library() \
 #define SOFT_LINK_CLASS_FOR_HEADER_WITH_AVAILABILITY(functionNamespace, className, availability) \
     @class className; \
     namespace functionNamespace { \
-    extern Class (*get##className##ClassSingleton)(); \
+    extern ::Class (*get##className##ClassSingleton)(); \
     NS_RETURNS_RETAINED className *alloc##className##Instance() availability; \
     }
 
 #define SOFT_LINK_CLASS_FOR_SOURCE_INTERNAL(functionNamespace, framework, className, export, isOptional, availability) \
     @class className; \
     namespace functionNamespace { \
-    static Class init##className(); \
-    export Class (*get##className##ClassSingleton)() = init##className; \
-    SUPPRESS_UNRETAINED_LOCAL static Class class##className; \
+    static ::Class init##className(); \
+    export ::Class (*get##className##ClassSingleton)() = init##className; \
+    SUPPRESS_UNRETAINED_LOCAL static ::Class class##className; \
     \
-    static Class className##Function() \
+    static ::Class className##Function() \
     { \
         return class##className; \
     } \
     \
-    static Class init##className() \
+    static ::Class init##className() \
     { \
         static dispatch_once_t once; \
         dispatch_once(&once, ^{ \
@@ -554,7 +554,7 @@ static void* lib##Library() \
         static dispatch_once_t once; \
         dispatch_once(&once, ^{ \
             _STORE_IN_DLSYM_SECTION static char const auditedName[] = #variableName; \
-            void* constant = dlsym(framework##Library(), auditedName); \
+            void* constant = dlsym(framework##Library(false), auditedName); \
             RELEASE_ASSERT_WITH_MESSAGE(constant, "%s", dlerror()); \
             constant##framework##variableName = *static_cast<variableType const *>(constant); \
         }); \
@@ -563,7 +563,21 @@ static void* lib##Library() \
     }
 
 #define SOFT_LINK_CONSTANT_FOR_SOURCE(functionNamespace, framework, variableName, variableType) \
-    SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(functionNamespace, framework, variableName, variableType, )
+    namespace functionNamespace { \
+    variableType get_##framework##_##variableName##Singleton(); \
+    variableType get_##framework##_##variableName##Singleton() \
+    { \
+        SUPPRESS_UNRETAINED_LOCAL static variableType constant##framework##variableName; \
+        static dispatch_once_t once; \
+        dispatch_once(&once, ^{ \
+            _STORE_IN_DLSYM_SECTION static char const auditedName[] = #variableName; \
+            void* constant = dlsym(framework##Library(false), auditedName); \
+            RELEASE_ASSERT_WITH_MESSAGE(constant, "%s", dlerror()); \
+            constant##framework##variableName = *static_cast<variableType const *>(constant); \
+        }); \
+        return constant##framework##variableName; \
+    } \
+    }
 
 #define SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(functionNamespace, framework, variableName, variableType) \
     namespace functionNamespace { \
@@ -580,7 +594,7 @@ static void* lib##Library() \
     bool init_##framework##_##variableName() \
     { \
         _STORE_IN_DLSYM_SECTION static char const auditedName[] = #variableName; \
-        void* constant = dlsym(framework##Library(), auditedName); \
+        void* constant = dlsym(framework##Library(false), auditedName); \
         if (!constant) \
             return false; \
         constant##framework##variableName.constant = *static_cast<variableType const *>(constant); \
@@ -600,7 +614,31 @@ static void* lib##Library() \
     }
 
 #define SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(functionNamespace, framework, variableName, variableType) \
-    SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(functionNamespace, framework, variableName, variableType, )
+    namespace functionNamespace { \
+    struct Constant##framework##variableName##Wrapper { SUPPRESS_UNRETAINED_LOCAL variableType constant; }; \
+    static Constant##framework##variableName##Wrapper constant##framework##variableName; \
+    bool init_##framework##_##variableName(); \
+    bool init_##framework##_##variableName() \
+    { \
+        _STORE_IN_DLSYM_SECTION static char const auditedName[] = #variableName; \
+        void* constant = dlsym(framework##Library(false), auditedName); \
+        if (!constant) \
+            return false; \
+        constant##framework##variableName.constant = *static_cast<variableType const *>(constant); \
+        return true; \
+    } \
+    bool canLoad_##framework##_##variableName(); \
+    bool canLoad_##framework##_##variableName() \
+    { \
+        static bool loaded = init_##framework##_##variableName(); \
+        return loaded; \
+    } \
+    variableType get_##framework##_##variableName##Singleton(); \
+    variableType get_##framework##_##variableName##Singleton() \
+    { \
+        return constant##framework##variableName.constant; \
+    } \
+    }
 
 #define SOFT_LINK_FUNCTION_FOR_HEADER_INTERNAL(functionNamespace, framework, functionName, resultType, parameterDeclarations, parameterNames, functionAttributes) \
     WTF_EXTERN_C_BEGIN \
@@ -632,7 +670,7 @@ static void* lib##Library() \
         static dispatch_once_t once; \
         dispatch_once(&once, ^{ \
             _STORE_IN_DLSYM_SECTION static char const auditedName[] = #functionName; \
-            softLink##framework##functionName = (resultType (*) parameterDeclarations) dlsym(framework##Library(), auditedName); \
+            softLink##framework##functionName = (resultType (*) parameterDeclarations) dlsym(framework##Library(false), auditedName); \
             RELEASE_ASSERT_WITH_MESSAGE(softLink##framework##functionName, "%s", dlerror()); \
         }); \
         return softLink##framework##functionName parameterNames; \
@@ -640,7 +678,20 @@ static void* lib##Library() \
     }
 
 #define SOFT_LINK_FUNCTION_FOR_SOURCE(functionNamespace, framework, functionName, resultType, parameterDeclarations, parameterNames) \
-    SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(functionNamespace, framework, functionName, resultType, parameterDeclarations, parameterNames, )
+    namespace functionNamespace { \
+    static resultType init##framework##functionName parameterDeclarations; \
+    resultType(*softLink##framework##functionName) parameterDeclarations = init##framework##functionName; \
+    static resultType init##framework##functionName parameterDeclarations \
+    { \
+        static dispatch_once_t once; \
+        dispatch_once(&once, ^{ \
+            _STORE_IN_DLSYM_SECTION static char const auditedName[] = #functionName; \
+            softLink##framework##functionName = (resultType (*) parameterDeclarations) dlsym(framework##Library(false), auditedName); \
+            RELEASE_ASSERT_WITH_MESSAGE(softLink##framework##functionName, "%s", dlerror()); \
+        }); \
+        return softLink##framework##functionName parameterNames; \
+    } \
+    }
 
 #define SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER_INTERNAL(functionNamespace, framework, functionName, resultType, parameterDeclarations, parameterNames, functionAttributes) \
     WTF_EXTERN_C_BEGIN \
@@ -670,7 +721,7 @@ static void* lib##Library() \
     { \
         ASSERT(!softLink##framework##functionName); \
         _STORE_IN_DLSYM_SECTION static char const auditedName[] = #functionName; \
-        softLink##framework##functionName = (resultType (*) parameterDeclarations) dlsym(framework##Library(), auditedName); \
+        softLink##framework##functionName = (resultType (*) parameterDeclarations) dlsym(framework##Library(false), auditedName); \
         return !!softLink##framework##functionName; \
     } \
     \
@@ -690,7 +741,31 @@ static void* lib##Library() \
     }
 
 #define SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(functionNamespace, framework, functionName, resultType, parameterDeclarations, parameterNames) \
-    SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(functionNamespace, framework, functionName, resultType, parameterDeclarations, parameterNames, )
+    namespace functionNamespace { \
+    resultType (*softLink##framework##functionName) parameterDeclarations = 0; \
+    bool init_##framework##_##functionName(); \
+    bool init_##framework##_##functionName() \
+    { \
+        ASSERT(!softLink##framework##functionName); \
+        _STORE_IN_DLSYM_SECTION static char const auditedName[] = #functionName; \
+        softLink##framework##functionName = (resultType (*) parameterDeclarations) dlsym(framework##Library(false), auditedName); \
+        return !!softLink##framework##functionName; \
+    } \
+    \
+    bool canLoad_##framework##_##functionName(); \
+    bool canLoad_##framework##_##functionName() \
+    { \
+        static bool loaded = init_##framework##_##functionName(); \
+        return loaded; \
+    } \
+    \
+    resultType softLink_##framework##_##functionName parameterDeclarations; \
+    resultType softLink_##framework##_##functionName parameterDeclarations \
+    { \
+        ASSERT(softLink##framework##functionName); \
+        return softLink##framework##functionName parameterNames; \
+    } \
+    }
 
 #define SOFT_LINK_POINTER_FOR_HEADER(functionNamespace, framework, variableName, variableType) \
     namespace functionNamespace { \
@@ -713,7 +788,7 @@ static void* lib##Library() \
         static dispatch_once_t once; \
         dispatch_once(&once, ^{ \
             _STORE_IN_DLSYM_SECTION static char const auditedName[] = #variableName; \
-            void** pointer = static_cast<void**>(dlsym(framework##Library(), auditedName)); \
+            void** pointer = static_cast<void**>(dlsym(framework##Library(false), auditedName)); \
             RELEASE_ASSERT_WITH_MESSAGE(pointer, "%s", dlerror()); \
             SUPPRESS_UNRETAINED_LOCAL pointer##framework##variableName = static_cast<variableType>(*pointer); \
             get_##framework##_##variableName = pointer##framework##variableName##Function; \
@@ -742,7 +817,7 @@ static void* lib##Library() \
         static dispatch_once_t once; \
         dispatch_once(&once, ^{ \
             _STORE_IN_DLSYM_SECTION static char const auditedName[] = #variableName; \
-            void* variable = dlsym(framework##Library(), auditedName); \
+            void* variable = dlsym(framework##Library(false), auditedName); \
             RELEASE_ASSERT_WITH_MESSAGE(variable, "%s", dlerror()); \
             variable##framework##variableName = static_cast<variableType *>(variable); \
         }); \

--- a/Source/WebCore/PAL/pal/spi/mac/NSWindowSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSWindowSPI.h
@@ -46,6 +46,7 @@ DECLARE_SYSTEM_HEADER
 - (id)_oldFirstResponderBeforeBecoming;
 - (id)_newFirstResponderAfterResigning;
 - (void)_setCursorForMouseLocation:(NSPoint)point;
+- (void)_enableScreenUpdatesIfNeeded;
 - (void)exitFullScreenMode:(id)sender;
 - (void)enterFullScreenMode:(id)sender;
 

--- a/Source/WebCore/bindings/js/JSDOMPromise.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromise.cpp
@@ -38,9 +38,9 @@
 #include <JavaScriptCore/SourceCode.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 
-using namespace JSC;
-
 namespace WebCore {
+
+using namespace JSC;
 
 auto DOMPromise::whenSettledWithResult(Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&& callback) -> IsCallbackRegistered
 {

--- a/Source/WebCore/bindings/js/ScriptControllerMac.mm
+++ b/Source/WebCore/bindings/js/ScriptControllerMac.mm
@@ -48,8 +48,6 @@
 - (RefPtr<JSC::Bindings::Instance>)createPluginBindingsInstance:(Ref<JSC::Bindings::RootObject>&&)rootObject;
 @end
 
-using namespace JSC::Bindings;
-
 namespace WebCore {
 
 RefPtr<JSC::Bindings::Instance> ScriptController::createScriptInstanceForWidget(Widget* widget)

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp
@@ -102,7 +102,6 @@ void CryptoAlgorithmECDSA::generateKey(const CryptoAlgorithmParameters& paramete
 
 void CryptoAlgorithmECDSA::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
 {
-    using namespace CryptoAlgorithmECDSAInternal;
     const auto& ecParameters = downcast<CryptoAlgorithmEcKeyParams>(parameters);
 
     RefPtr<CryptoKeyEC> result;
@@ -120,12 +119,12 @@ void CryptoAlgorithmECDSA::importKey(CryptoKeyFormat format, KeyData&& data, con
         }
 
         bool isMatched = false;
-        if (key.crv == P256)
-            isMatched = key.alg.isNull() || key.alg == ALG256;
-        if (key.crv == P384)
-            isMatched = key.alg.isNull() || key.alg == ALG384;
-        if (key.crv == P521)
-            isMatched = key.alg.isNull() || key.alg == ALG512;
+        if (key.crv == CryptoAlgorithmECDSAInternal::P256)
+            isMatched = key.alg.isNull() || key.alg == CryptoAlgorithmECDSAInternal::ALG256;
+        if (key.crv == CryptoAlgorithmECDSAInternal::P384)
+            isMatched = key.alg.isNull() || key.alg == CryptoAlgorithmECDSAInternal::ALG384;
+        if (key.crv == CryptoAlgorithmECDSAInternal::P521)
+            isMatched = key.alg.isNull() || key.alg == CryptoAlgorithmECDSAInternal::ALG512;
         if (!isMatched) {
             exceptionCallback(ExceptionCode::DataError);
             return;

--- a/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapCocoa.mm
+++ b/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapCocoa.mm
@@ -253,9 +253,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     auto dictionary = @{
         versionKey: [NSNumber numberWithUnsignedInteger:currentSerializationVersion],
-        wrappedKEKKey: toNSData(wrappedKEK).autorelease(),
-        encryptedKeyKey: toNSData(encryptedKey).autorelease(),
-        tagKey: toNSData(std::span { tag }.first(tagLength)).get()
+        wrappedKEKKey: WTF::toNSData(wrappedKEK).autorelease(),
+        encryptedKeyKey: WTF::toNSData(encryptedKey).autorelease(),
+        tagKey: WTF::toNSData(std::span { tag }.first(tagLength)).get()
     };
 
     NSData* serialization = [NSPropertyListSerialization dataWithPropertyList:dictionary format:NSPropertyListBinaryFormat_v1_0 options:0 error:nullptr];

--- a/Source/WebCore/editing/cocoa/WebArchiveResourceFromNSAttributedString.mm
+++ b/Source/WebCore/editing/cocoa/WebArchiveResourceFromNSAttributedString.mm
@@ -29,8 +29,6 @@
 #import "ArchiveResource.h"
 #import "MIMETypeRegistry.h"
 
-using namespace WebCore;
-
 @implementation WebArchiveResourceFromNSAttributedString
 
 - (instancetype)initWithData:(NSData *)data URL:(NSURL *)URL MIMEType:(NSString *)MIMEType textEncodingName:(NSString *)textEncodingName frameName:(NSString *)frameName
@@ -46,12 +44,12 @@ using namespace WebCore;
     RetainPtr updatedMIMEType = MIMEType;
     if ([MIMEType isEqualToString:@"application/octet-stream"]) {
         // FIXME: This is a workaround for <rdar://problem/36074429>, and can be removed once that is fixed.
-        auto mimeTypeFromURL = MIMETypeRegistry::mimeTypeForExtension(String(URL.pathExtension));
+        auto mimeTypeFromURL = WebCore::MIMETypeRegistry::mimeTypeForExtension(String(URL.pathExtension));
         if (!mimeTypeFromURL.isEmpty())
             updatedMIMEType = mimeTypeFromURL.createNSString();
     }
 
-    resource = ArchiveResource::create(SharedBuffer::create(adoptNS([data copy]).get()), URL, updatedMIMEType.get(), textEncodingName, frameName, { });
+    resource = WebCore::ArchiveResource::create(WebCore::SharedBuffer::create(adoptNS([data copy]).get()), URL, updatedMIMEType.get(), textEncodingName, frameName, { });
     if (!resource) {
         [self release];
         return nil;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -120,8 +120,6 @@ class VideoTrackList;
 class VideoTrackPrivate;
 class WebKitMediaKeys;
 
-struct MachSendRightAnnotated;
-
 enum class AudioSessionCategory : uint8_t;
 enum class AudioSessionMode : uint8_t;
 enum class DynamicRangeMode : uint8_t;

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -3620,4 +3620,6 @@ void WebGL2RenderingContext::updateBuffersToAutoClear(ClearBufferCaller caller, 
 
 } // namespace WebCore
 
+#undef ENABLE_IF_REQUESTED
+
 #endif // ENABLE(WEBGL)

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -373,4 +373,6 @@ WebCoreOpaqueRoot root(const WebGLExtension<WebGLRenderingContext>* extension)
 
 } // namespace WebCore
 
+#undef ENABLE_IF_REQUESTED
+
 #endif // ENABLE(WEBGL)

--- a/Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm
+++ b/Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm
@@ -54,7 +54,7 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateUnlinkableToken
         auto serverPublicKeyData = base64URLDecode(serverPublicKeyBase64URL);
         if (!serverPublicKeyData)
             return makeString("Could not decode the "_s, contextForLogMessage, "'s public key data."_s);
-        RetainPtr serverPublicKey = toNSData(serverPublicKeyData->span());
+        RetainPtr serverPublicKey = WTF::toNSData(serverPublicKeyData->span());
 
         NSError* nsError = 0;
         unlinkableToken.blinder = adoptNS([PAL::allocRSABSSATokenBlinderInstance() initWithPublicKey:serverPublicKey.get() error:&nsError]);
@@ -110,7 +110,7 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateSecretToken(con
         auto serverResponseData = base64URLDecode(serverResponseBase64URL);
         if (!serverResponseData)
             return makeString("Could not decode "_s, contextForLogMessage, " response data."_s);
-        RetainPtr serverResponse = toNSData(serverResponseData->span());
+        RetainPtr serverResponse = WTF::toNSData(serverResponseData->span());
 
         NSError* nsError = 0;
         unlinkableToken.readyToken = [unlinkableToken.waitingToken activateTokenWithServerResponse:serverResponse.get() error:&nsError];

--- a/Source/WebCore/loader/mac/LoaderNSURLExtras.mm
+++ b/Source/WebCore/loader/mac/LoaderNSURLExtras.mm
@@ -37,11 +37,9 @@
 #import <wtf/Vector.h>
 #import <wtf/text/WTFString.h>
 
-using namespace WebCore;
-
 NSString *suggestedFilenameWithMIMEType(NSURL *url, const String& mimeType)
 {
-    return suggestedFilenameWithMIMEType(url, mimeType, copyImageUnknownFileLabel());
+    return suggestedFilenameWithMIMEType(url, mimeType, WebCore::copyImageUnknownFileLabel());
 }
 
 NSString *suggestedFilenameWithMIMEType(NSURL *url, const String& mimeType, const String& defaultValue)
@@ -79,11 +77,11 @@ NSString *suggestedFilenameWithMIMEType(NSURL *url, const String& mimeType, cons
     // I don't think we need to worry about this for the image case
     // If the type is known, check the extension and correct it if necessary.
     if (mimeType != "application/octet-stream"_s && mimeType != "text/plain"_s) {
-        Vector<String> extensions = MIMETypeRegistry::extensionsForMIMEType(mimeType);
+        Vector<String> extensions = WebCore::MIMETypeRegistry::extensionsForMIMEType(mimeType);
 
         if (extensions.isEmpty() || !extensions.contains(String(extension.get()))) {
             // The extension doesn't match the MIME type. Correct this.
-            RetainPtr correctExtension = MIMETypeRegistry::preferredExtensionForMIMEType(mimeType).createNSString();
+            RetainPtr correctExtension = WebCore::MIMETypeRegistry::preferredExtensionForMIMEType(mimeType).createNSString();
             if ([correctExtension length] != 0) {
                 // Append the correct extension.
                 filename = [filename stringByAppendingPathExtension:correctExtension.get()];

--- a/Source/WebCore/mathml/MathMLAnnotationElement.cpp
+++ b/Source/WebCore/mathml/MathMLAnnotationElement.cpp
@@ -50,7 +50,7 @@ using namespace MathMLNames;
 MathMLAnnotationElement::MathMLAnnotationElement(const QualifiedName& tagName, Document& document)
     : MathMLPresentationElement(tagName, document)
 {
-    ASSERT(hasTagName(annotationTag) || hasTagName(annotation_xmlTag));
+    ASSERT(hasTagName(annotationTag) || hasTagName(MathMLNames::annotation_xmlTag));
 }
 
 Ref<MathMLAnnotationElement> MathMLAnnotationElement::create(const QualifiedName& tagName, Document& document)
@@ -63,7 +63,7 @@ RenderPtr<RenderElement> MathMLAnnotationElement::createElementRenderer(RenderSt
     if (document().settings().coreMathMLEnabled() || hasTagName(MathMLNames::annotationTag))
         return MathMLElement::createElementRenderer(WTF::move(style), insertionPosition);
 
-    ASSERT(hasTagName(annotation_xmlTag));
+    ASSERT(hasTagName(MathMLNames::annotation_xmlTag));
     return createRenderer<RenderMathMLBlock>(RenderObject::Type::MathMLBlock, *this, WTF::move(style));
 }
 
@@ -76,7 +76,7 @@ bool MathMLAnnotationElement::childShouldCreateRenderer(const Node& child) const
     if (hasTagName(MathMLNames::annotationTag))
         return child.isTextNode();
 
-    ASSERT(hasTagName(annotation_xmlTag));
+    ASSERT(hasTagName(MathMLNames::annotation_xmlTag));
     return StyledElement::childShouldCreateRenderer(child);
 }
 

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -80,7 +80,7 @@ unsigned MathMLElement::rowSpan() const
 {
     if (!hasTagName(mtdTag))
         return 1u;
-    auto& rowSpanValue = attributeWithoutSynchronization(rowspanAttr);
+    auto& rowSpanValue = attributeWithoutSynchronization(MathMLNames::rowspanAttr);
     return std::max(1u, std::min(limitToOnlyHTMLNonNegative(rowSpanValue, 1u), HTMLTableCellElement::maxRowspan));
 }
 
@@ -304,7 +304,7 @@ void MathMLElement::defaultEventHandler(Event& event)
             return;
         }
         if (MouseEvent::canTriggerActivationBehavior(event)) {
-            const auto& href = attributeWithoutSynchronization(hrefAttr);
+            const auto& href = attributeWithoutSynchronization(MathMLNames::hrefAttr);
             event.setDefaultHandled();
             if (RefPtr frame = document().frame())
                 frame->loader().changeLocation(document().encodingParseURL(href), selfTargetFrameName(), &event, ReferrerPolicy::EmptyString, document().shouldOpenExternalURLsPolicyToPropagate());
@@ -351,7 +351,7 @@ bool MathMLElement::isURLAttribute(const Attribute& attribute) const
     if (!allowsHref())
         return false;
     // FIXME: Should this be attribute.name().matches(hrefAttr) to also enforce the namespace?
-    return hrefAttr->hasLocalName(attribute.name().localName()) || StyledElement::isURLAttribute(attribute);
+    return MathMLNames::hrefAttr->hasLocalName(attribute.name().localName()) || StyledElement::isURLAttribute(attribute);
 }
 
 bool MathMLElement::allowsHref() const

--- a/Source/WebCore/mathml/MathMLOperatorElement.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorElement.cpp
@@ -119,7 +119,7 @@ Property MathMLOperatorElement::computeDictionaryProperty()
     Property dictionaryProperty;
 
     // We first determine the form attribute and use the default spacing and properties.
-    const auto& value = attributeWithoutSynchronization(formAttr);
+    const auto& value = attributeWithoutSynchronization(MathMLNames::formAttr);
     bool explicitForm = true;
     if (value == "prefix"_s)
         dictionaryProperty.form = Form::Prefix;

--- a/Source/WebCore/page/scrolling/ScrollLatchingController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollLatchingController.cpp
@@ -196,7 +196,7 @@ void ScrollLatchingController::removeLatchingStateForFrame(const LocalFrame& fra
         clear();
 }
 
-static bool NODELETE deltaIsPredominantlyVertical(FloatSize delta)
+static bool NODELETE scrollDeltaIsPredominantlyVertical(FloatSize delta)
 {
     return std::abs(delta.height()) > std::abs(delta.width());
 }
@@ -216,7 +216,7 @@ bool ScrollLatchingController::shouldLatchToScrollableArea(const LocalFrame& fra
     if (scrollDelta.isZero())
         return false;
 
-    if (!deltaIsPredominantlyVertical(scrollDelta) && scrollDelta.width()) {
+    if (!scrollDeltaIsPredominantlyVertical(scrollDelta) && scrollDelta.width()) {
         if (!scrollableArea->horizontalScrollbar())
             return false;
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeLatchingController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeLatchingController.cpp
@@ -37,7 +37,7 @@
 namespace WebCore {
 
 // See also ScrollLatchingController.cpp
-static const Seconds resetLatchedStateTimeout { 100_ms };
+static const Seconds scrollingTreeResetLatchedStateTimeout { 100_ms };
 
 ScrollingTreeLatchingController::ScrollingTreeLatchingController() = default;
 
@@ -146,7 +146,7 @@ void ScrollingTreeLatchingController::clearLatchedNode()
 bool ScrollingTreeLatchingController::latchedNodeHasRecentInteraction() const
 {
     auto secondsSinceLastInteraction = MonotonicTime::now() - m_lastLatchedNodeInterationTime;
-    return secondsSinceLastInteraction < resetLatchedStateTimeout;
+    return secondsSinceLastInteraction < scrollingTreeResetLatchedStateTimeout;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -47,7 +47,7 @@
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/text/TextStream.h>
 
-using namespace WebCore;
+namespace WebCore {
 
 Ref<ScrollingTreeMac> ScrollingTreeMac::create(AsyncScrollingCoordinator& scrollingCoordinator)
 {
@@ -257,5 +257,7 @@ void ScrollingTreeMac::registerForPlatformRenderingUpdateCallback()
         PlatformCALayerContentsDelayedReleaser::singleton().scrollingThreadCommitDidEnd();
     } forPhase:kCATransactionPhasePostCommit];
 }
+
+} // namespace WebCore
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -35,6 +35,7 @@
 #include "FloatPoint.h"
 #include "KeyboardScrollingAnimator.h"
 #include "LayoutSize.h"
+#include "Logging.h"
 #include "PlatformWheelEvent.h"
 #include "ScrollExtents.h"
 #include "ScrollableArea.h"

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h
@@ -91,7 +91,7 @@ protected:
 
 inline size_t AudioSampleBufferList::audioBufferListSizeForStream(const CAAudioStreamDescription& description)
 {
-    return offsetof(AudioBufferList, mBuffers) + (sizeof(AudioBuffer) * std::max<uint32_t>(1, description.numberOfChannelStreams()));
+    return offsetof(AudioBufferList, mBuffers) + (sizeof(::AudioBuffer) * std::max<uint32_t>(1, description.numberOfChannelStreams()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
@@ -84,7 +84,7 @@ static void StoreABL(Vector<std::span<Byte>>& channels, size_t destOffset, const
 {
     ASSERT(list->mNumberBuffers == channels.size());
     auto buffers = span(*list);
-    const AudioBuffer* src = list->mBuffers;
+    const ::AudioBuffer* src = list->mBuffers;
     for (auto& channel : channels) {
         if (srcOffset > buffers[0].mDataByteSize)
             continue;

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
@@ -176,7 +176,7 @@ void WebAudioBufferList::reset()
     memcpySpan(span(*m_list), span(*m_canonicalList));
 }
 
-IteratorRange<AudioBuffer*> WebAudioBufferList::buffers() const
+IteratorRange<::AudioBuffer*> WebAudioBufferList::buffers() const
 {
     auto buffers = span(*m_list);
     return WTF::makeIteratorRange(std::to_address(buffers.begin()), std::to_address(buffers.end()));
@@ -187,7 +187,7 @@ uint32_t WebAudioBufferList::bufferCount() const
     return m_list->mNumberBuffers;
 }
 
-AudioBuffer* WebAudioBufferList::buffer(uint32_t index) const
+::AudioBuffer* WebAudioBufferList::buffer(uint32_t index) const
 {
     auto buffers = span(*m_list);
     ASSERT(index < buffers.size());

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
@@ -60,7 +60,7 @@ public:
 
     uint32_t NODELETE bufferCount() const;
     uint32_t channelCount() const { return m_channelCount; }
-    AudioBuffer* NODELETE buffer(uint32_t index) const;
+    ::AudioBuffer* NODELETE buffer(uint32_t index) const;
 
     template <typename T = uint8_t>
     std::span<T> bufferAsSpan(uint32_t index) const
@@ -72,7 +72,7 @@ public:
         return { };
     }
 
-    IteratorRange<AudioBuffer*> NODELETE buffers() const;
+    IteratorRange<::AudioBuffer*> NODELETE buffers() const;
 
     WEBCORE_EXPORT static bool isSupportedDescription(const CAAudioStreamDescription&, size_t sampleCount);
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -212,7 +212,7 @@ void CDMSessionAVContentKeySession::releaseKeys()
         if (storagePath.isEmpty())
             return;
 
-        RetainPtr certificateData = toNSData(m_certificate->span());
+        RetainPtr certificateData = WTF::toNSData(m_certificate->span());
         NSArray* expiredSessions = [PAL::getAVContentKeySessionClassSingleton() pendingExpiredSessionReportsWithAppIdentifier:certificateData.get() storageDirectoryAtURL:[NSURL fileURLWithPath:storagePath.createNSString().get()]];
         for (NSData* expiredSessionData in expiredSessions) {
             static const NSString *PlaybackSessionIdKey = @"PlaybackSessionID";
@@ -260,7 +260,7 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
             return false;
         }
 
-        RetainPtr certificateData = toNSData(m_certificate->span());
+        RetainPtr certificateData = WTF::toNSData(m_certificate->span());
 
         if ([PAL::getAVContentKeySessionClassSingleton() respondsToSelector:@selector(removePendingExpiredSessionReports:withAppIdentifier:storageDirectoryAtURL:)])
             [PAL::getAVContentKeySessionClassSingleton() removePendingExpiredSessionReports:@[m_expiredSession.get()] withAppIdentifier:certificateData.get() storageDirectoryAtURL:[NSURL fileURLWithPath:storagePath.createNSString().get()]];
@@ -297,7 +297,7 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
 
     if (!hasContentKeyRequest()) {
         RetainPtr<NSData> nsInitData = m_initData ? m_initData->createNSData() : nil;
-        RetainPtr nsIdentifier = m_identifier ? toNSData(m_identifier->span()) : nil;
+        RetainPtr nsIdentifier = m_identifier ? WTF::toNSData(m_identifier->span()) : nil;
         if ([contentKeySession() respondsToSelector:@selector(processContentKeyRequestWithIdentifier:initializationData:options:)])
             [contentKeySession() processContentKeyRequestWithIdentifier:nsIdentifier.get() initializationData:nsInitData.get() options:nil];
         else
@@ -309,7 +309,7 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
 
     if (shouldGenerateKeyRequest) {
         ASSERT(contentKeyRequest);
-        RetainPtr certificateData = toNSData(m_certificate->span());
+        RetainPtr certificateData = WTF::toNSData(m_certificate->span());
 
         RetainPtr options = CDMInstanceSessionFairPlayStreamingAVFObjC::optionsForKeyRequestWithHashSalt(Ref { *m_client }->mediaKeysHashSalt());
 
@@ -326,7 +326,7 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
         systemCode = 0;
         RetainPtr<id> nsIdentifier;
         if (m_identifier)
-            nsIdentifier = toNSData(m_identifier->span());
+            nsIdentifier = WTF::toNSData(m_identifier->span());
         else
             nsIdentifier = contentKeyRequest.get().identifier;
 
@@ -355,7 +355,7 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
     ALWAYS_LOG(LOGIDENTIFIER, "processing key response");
     errorCode = MediaPlayer::NoError;
     systemCode = 0;
-    RetainPtr keyData = toNSData(key->span());
+    RetainPtr keyData = WTF::toNSData(key->span());
     
     if ([contentKeyRequest respondsToSelector:@selector(processContentKeyResponse:)] && [PAL::getAVContentKeyResponseClassSingleton() respondsToSelector:@selector(contentKeyResponseWithFairPlayStreamingKeyResponseData:)])
         [contentKeyRequest processContentKeyResponse:[PAL::getAVContentKeyResponseClassSingleton() contentKeyResponseWithFairPlayStreamingKeyResponseData:keyData.get()]];
@@ -409,7 +409,7 @@ void CDMSessionAVContentKeySession::removeRenderer(AudioVideoRenderer& renderer)
 RefPtr<Uint8Array> CDMSessionAVContentKeySession::generateKeyReleaseMessage(unsigned short& errorCode, uint32_t& systemCode)
 {
     ASSERT(m_mode == KeyRelease);
-    RetainPtr certificateData = toNSData(m_certificate->span());
+    RetainPtr certificateData = WTF::toNSData(m_certificate->span());
 
     String storagePath = this->storagePath();
     if (storagePath.isEmpty() || ![PAL::getAVContentKeySessionClassSingleton() respondsToSelector:@selector(pendingExpiredSessionReportsWithAppIdentifier:storageDirectoryAtURL:)]) {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
@@ -93,7 +93,7 @@ RefPtr<Uint8Array> CDMSessionAVFoundationObjC::generateKeyRequest(const String& 
         return nullptr;
     }
 
-    RetainPtr certificateData = toNSData(certificate->span());
+    RetainPtr certificateData = WTF::toNSData(certificate->span());
     RetainPtr assetString = keyID.createNSString();
     RetainPtr<NSData> assetID = [assetString dataUsingEncoding:NSUTF8StringEncoding];
     NSError* nsError = nullptr;
@@ -123,7 +123,7 @@ void CDMSessionAVFoundationObjC::releaseKeys()
 
 bool CDMSessionAVFoundationObjC::update(Uint8Array* key, RefPtr<Uint8Array>& nextMessage, unsigned short& errorCode, uint32_t& systemCode)
 {
-    RetainPtr keyData = toNSData(key->span());
+    RetainPtr keyData = WTF::toNSData(key->span());
     [retainPtr([m_request dataRequest]) respondWithData:keyData.get()];
     [m_request finishLoading];
     errorCode = MediaPlayer::NoError;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -454,7 +454,7 @@ static void drawPatternCallback(void* info, CGContextRef context)
     CGContextDrawImage(context, rect, image);
 }
 
-static void patternReleaseCallback(void* info)
+static void drawPatternReleaseCallback(void* info)
 {
     callOnMainThread([image = adoptCF(static_cast<CGImageRef>(info))] { });
 }
@@ -505,7 +505,7 @@ void GraphicsContextCG::drawPattern(const NativeImage& nativeImage, const FloatR
         // we should tile all but the last, and stretch the last image to fit.
         CGContextDrawTiledImage(context, FloatRect(adjustedX, adjustedY, scaledTileWidth, scaledTileHeight), subImage.get());
     } else {
-        static const CGPatternCallbacks patternCallbacks = { 0, drawPatternCallback, patternReleaseCallback };
+        static const CGPatternCallbacks patternCallbacks = { 0, drawPatternCallback, drawPatternReleaseCallback };
         CGAffineTransform matrix = CGAffineTransformMake(narrowPrecisionToCGFloat(patternTransform.a()), 0, 0, narrowPrecisionToCGFloat(patternTransform.d()), adjustedX, adjustedY);
         matrix = CGAffineTransformConcat(matrix, CGContextGetCTM(context));
         // The top of a partially-decoded image is drawn at the bottom of the tile. Map it to the top.

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -42,15 +42,16 @@
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
+#if !defined(WebCore_AVKitLibrary_SoftLinked)
+#define WebCore_AVKitLibrary_SoftLinked
 SOFTLINK_AVKIT_FRAMEWORK()
+#endif
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPlayerController)
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVTimeRange)
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVValueTiming)
 
 OBJC_CLASS AVAssetTrack;
 OBJC_CLASS AVMetadataItem;
-
-using namespace WebCore;
 
 static void * WebAVPlayerControllerSeekableTimeRangesObserverContext = &WebAVPlayerControllerSeekableTimeRangesObserverContext;
 static void * WebAVPlayerControllerHasLiveStreamingContentObserverContext = &WebAVPlayerControllerHasLiveStreamingContentObserverContext;
@@ -891,7 +892,7 @@ Class webAVPlayerControllerClassSingleton()
     }
 
     if (WebAVPlayerControllerIsPlayingOnSecondScreenObserverContext == context) {
-        if (CheckedPtr<PlaybackSessionModel> delegate = self.delegate)
+        if (CheckedPtr<WebCore::PlaybackSessionModel> delegate = self.delegate)
             delegate->setPlayingOnSecondScreen(_playingOnSecondScreen);
         return;
     }

--- a/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
+++ b/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
@@ -39,7 +39,10 @@
 
 IGNORE_WARNINGS_BEGIN("nullability-completeness")
 
+#if !defined(WebCore_AVKitLibrary_SoftLinked)
+#define WebCore_AVKitLibrary_SoftLinked
 SOFTLINK_AVKIT_FRAMEWORK()
+#endif
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVTouchBarMediaSelectionOption)
 
 using WebCore::MediaSelectionOption;

--- a/Source/WebCore/platform/mediacapabilities/PlatformMediaEngineConfigurationFactory.cpp
+++ b/Source/WebCore/platform/mediacapabilities/PlatformMediaEngineConfigurationFactory.cpp
@@ -54,10 +54,10 @@ static bool& NODELETE mockEnabled()
     return enabled;
 }
 
-using FactoryVector = Vector<PlatformMediaEngineConfigurationFactory::MediaEngineFactory>;
-static FactoryVector defaultFactories()
+using MediaEngineFactoryVector = Vector<PlatformMediaEngineConfigurationFactory::MediaEngineFactory>;
+static MediaEngineFactoryVector defaultFactories()
 {
-    FactoryVector factories;
+    MediaEngineFactoryVector factories;
 #if PLATFORM(COCOA)
     factories.append({ &createMediaPlayerDecodingConfigurationCocoa, nullptr });
 #endif
@@ -67,7 +67,7 @@ static FactoryVector defaultFactories()
     return factories;
 }
 
-static FactoryVector& factories()
+static MediaEngineFactoryVector& factories()
 {
     static NeverDestroyed factories = defaultFactories();
     return factories;

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h
@@ -90,7 +90,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     mutable RefPtr<const Logger> m_logger;
-    uint64_t m_logIdentifier { 0 };
+    [[maybe_unused]] uint64_t m_logIdentifier { 0 };
 #endif
 };
 

--- a/Source/WebCore/platform/network/cocoa/AuthenticationCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/AuthenticationCocoa.mm
@@ -33,7 +33,9 @@
 #import <Foundation/NSURLProtectionSpace.h>
 #import <wtf/WeakPtr.h>
 
-using namespace WebCore;
+using WebCore::AuthenticationClient;
+using WebCore::Credential;
+using WebCore::core;
 
 @interface WebCoreAuthenticationClientAsChallengeSender : NSObject <NSURLAuthenticationChallengeSender> {
     WeakPtr<AuthenticationClient> m_client;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -85,6 +85,10 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/unicode/CharacterNames.h>
 
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderBlockFlow);

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -57,11 +57,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderGrid);
 
-enum class TrackSizeRestriction : uint8_t {
-    AllowInfinity,
-    ForbidInfinity,
-};
-
 RenderGrid::RenderGrid(Element& element, RenderStyle&& style)
     : RenderBlock(Type::Grid, element, WTF::move(style), { })
     , m_grid(*this)

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -1002,21 +1002,21 @@ static CornerRadii NODELETE trimRadii(const CornerRadii& radii, TrimSide trimSid
     }
 }
 
-enum class SnapDirection : uint8_t {
+enum class TextBoxSnapDirection : uint8_t {
     Left,
     Right,
     Both,
 };
 
-static FloatRect snapRectToDevicePixelsInDirection(const FloatRect& rect, float deviceScaleFactor, SnapDirection snapDirection)
+static FloatRect snapRectToDevicePixelsInDirection(const FloatRect& rect, float deviceScaleFactor, TextBoxSnapDirection snapDirection)
 {
     const auto layoutRect = LayoutRect { rect };
     switch (snapDirection) {
-    case SnapDirection::Left:
+    case TextBoxSnapDirection::Left:
         return snapRectToDevicePixelsWithWritingDirection(layoutRect, deviceScaleFactor, true);
-    case SnapDirection::Right:
+    case TextBoxSnapDirection::Right:
         return snapRectToDevicePixelsWithWritingDirection(layoutRect, deviceScaleFactor, false);
-    case SnapDirection::Both:
+    case TextBoxSnapDirection::Both:
         auto snappedRectLeft = snapRectToDevicePixelsWithWritingDirection(layoutRect, deviceScaleFactor, true);
         return snapRectToDevicePixelsWithWritingDirection(LayoutRect { snappedRectLeft }, deviceScaleFactor, false);
     }
@@ -1110,13 +1110,13 @@ void TextBoxPainter::fillCompositionUnderline(float start, float width, const Co
     if (fragmentLocation.containsAll({ TextBoxFragmentLocationWithinLayoutBox::First, TextBoxFragmentLocationWithinLayoutBox::Last }))
         context.fillRoundedRect(FloatRoundedRect { rect, radii }, underlineColor);
     else if (fragmentLocation == TextBoxFragmentLocationWithinLayoutBox::First)
-        context.fillRoundedRect(FloatRoundedRect { snapRectToDevicePixelsInDirection(rect, deviceScaleFactor, SnapDirection::Right), trimRadii(radii, TrimSide::Right) }, underlineColor);
+        context.fillRoundedRect(FloatRoundedRect { snapRectToDevicePixelsInDirection(rect, deviceScaleFactor, TextBoxSnapDirection::Right), trimRadii(radii, TrimSide::Right) }, underlineColor);
     else if (fragmentLocation == TextBoxFragmentLocationWithinLayoutBox::Last)
-        context.fillRoundedRect(FloatRoundedRect { snapRectToDevicePixelsInDirection(rect, deviceScaleFactor, SnapDirection::Left), trimRadii(radii, TrimSide::Left) }, underlineColor);
+        context.fillRoundedRect(FloatRoundedRect { snapRectToDevicePixelsInDirection(rect, deviceScaleFactor, TextBoxSnapDirection::Left), trimRadii(radii, TrimSide::Left) }, underlineColor);
     else {
         ASSERT(fragmentLocation.isEmpty());
         // This text fragment is right in the middle of the box content.
-        context.fillRect(snapRectToDevicePixelsInDirection(rect, deviceScaleFactor, SnapDirection::Both), underlineColor);
+        context.fillRect(snapRectToDevicePixelsInDirection(rect, deviceScaleFactor, TextBoxSnapDirection::Both), underlineColor);
     }
 #else
     UNUSED_PARAM(radii);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -188,20 +188,20 @@ static void getElementCTM(SVGElement* element, AffineTransform& transform)
 
 // FloatRect::intersects does not consider horizontal or vertical lines (because of isEmpty()).
 // So special-case handling of such lines.
-static bool NODELETE intersectsAllowingEmpty(const FloatRect& r, const FloatRect& other)
+static bool NODELETE legacyIntersectsAllowingEmpty(const FloatRect& r, const FloatRect& other)
 {
     if (r.isEmpty() && other.isEmpty())
         return false;
     if (r.isEmpty() && !other.isEmpty())
         return (other.contains(r.x(), r.y()) && !other.contains(r.maxX(), r.maxY())) || (!other.contains(r.x(), r.y()) && other.contains(r.maxX(), r.maxY()));
     if (other.isEmpty() && !r.isEmpty())
-        return intersectsAllowingEmpty(other, r);
+        return legacyIntersectsAllowingEmpty(other, r);
     return r.intersects(other);
 }
 
 // One of the element types that can cause graphics to be drawn onto the target canvas. Specifically: circle, ellipse,
 // image, line, path, polygon, polyline, rect, text and use.
-static bool NODELETE isGraphicsElement(const RenderElement& renderer)
+static bool NODELETE legacyIsGraphicsElement(const RenderElement& renderer)
 {
     return renderer.isLegacyRenderSVGShape() || renderer.isRenderSVGText() || renderer.isLegacyRenderSVGImage() || renderer.element()->hasTagName(SVGNames::useTag);
 }
@@ -217,7 +217,7 @@ bool LegacyRenderSVGModelObject::checkIntersection(RenderElement* renderer, cons
 {
     if (!renderer || renderer->usedPointerEvents() == PointerEvents::None)
         return false;
-    if (!isGraphicsElement(*renderer))
+    if (!legacyIsGraphicsElement(*renderer))
         return false;
     AffineTransform ctm;
     RefPtr svgElement = downcast<SVGElement>(renderer->element());
@@ -225,14 +225,14 @@ bool LegacyRenderSVGModelObject::checkIntersection(RenderElement* renderer, cons
     ASSERT(svgElement->renderer());
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
-    return intersectsAllowingEmpty(rect, ctm.mapRect(protect(svgElement->renderer())->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
+    return legacyIntersectsAllowingEmpty(rect, ctm.mapRect(protect(svgElement->renderer())->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
 }
 
 bool LegacyRenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRect& rect)
 {
     if (!renderer || renderer->usedPointerEvents() == PointerEvents::None)
         return false;
-    if (!isGraphicsElement(*renderer))
+    if (!legacyIsGraphicsElement(*renderer))
         return false;
     AffineTransform ctm;
     RefPtr svgElement = downcast<SVGElement>(renderer->element());

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -103,7 +103,7 @@ FloatRect LegacyRenderSVGPath::adjustStrokeBoundingBoxForMarkersAndZeroLengthLin
     return strokeBoundingBox;
 }
 
-static void useStrokeStyleToFill(GraphicsContext& context)
+static void legacyUseStrokeStyleToFill(GraphicsContext& context)
 {
     if (RefPtr gradient = context.strokeGradient())
         context.setFillGradient(*gradient, context.strokeGradientSpaceTransform());
@@ -196,7 +196,7 @@ void LegacyRenderSVGPath::strokeZeroLengthSubpaths(GraphicsContext& context) con
         nonScalingTransform = nonScalingStrokeTransform();
 
     GraphicsContextStateSaver stateSaver(context, true);
-    useStrokeStyleToFill(context);
+    legacyUseStrokeStyleToFill(context);
     for (size_t i = 0; i < m_zeroLengthLinecapLocations.size(); ++i) {
         auto usePath = zeroLengthLinecapPath(m_zeroLengthLinecapLocations[i]);
         if (hasNonScalingStroke())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
@@ -215,7 +215,7 @@ void LegacyRenderSVGResourcePattern::postApplyResource(RenderElement&, GraphicsC
     context->restore();
 }
 
-static inline FloatRect calculatePatternBoundaries(const PatternAttributes& attributes,
+static inline FloatRect legacyCalculatePatternBoundaries(const PatternAttributes& attributes,
                                                    const FloatRect& objectBoundingBox,
                                                    const SVGPatternElement& patternElement)
 {
@@ -229,7 +229,7 @@ bool LegacyRenderSVGResourcePattern::buildTileImageTransform(RenderElement& rend
                                                        AffineTransform& tileImageTransform) const
 {
     FloatRect objectBoundingBox = renderer.objectBoundingBox();
-    patternBoundaries = calculatePatternBoundaries(attributes, objectBoundingBox, patternElement); 
+    patternBoundaries = legacyCalculatePatternBoundaries(attributes, objectBoundingBox, patternElement);
     if (patternBoundaries.width() <= 0 || patternBoundaries.height() <= 0)
         return false;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -57,8 +57,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyRenderSVGRoot);
 
-const int defaultWidth = 300;
-const int defaultHeight = 150;
+const int legacySVGRootDefaultWidth = 300;
+const int legacySVGRootDefaultHeight = 150;
 
 LegacyRenderSVGRoot::LegacyRenderSVGRoot(SVGSVGElement& element, RenderStyle&& style)
     : RenderReplaced(Type::LegacySVGRoot, element, WTF::move(style), ReplacedFlag::UsesBoundaryCaching)
@@ -66,9 +66,9 @@ LegacyRenderSVGRoot::LegacyRenderSVGRoot(SVGSVGElement& element, RenderStyle&& s
     ASSERT(isLegacyRenderSVGRoot());
     LayoutSize intrinsicSize(computeIntrinsicSize());
     if (!svgSVGElement().hasIntrinsicWidth())
-        intrinsicSize.setWidth(defaultWidth);
+        intrinsicSize.setWidth(legacySVGRootDefaultWidth);
     if (!svgSVGElement().hasIntrinsicHeight())
-        intrinsicSize.setHeight(defaultHeight);
+        intrinsicSize.setHeight(legacySVGRootDefaultHeight);
     setIntrinsicSize(intrinsicSize);
 }
 
@@ -162,7 +162,7 @@ LayoutUnit LegacyRenderSVGRoot::computeReplacedLogicalWidth(ShouldComputePreferr
         if (!element->hasIntrinsicWidth()) {
             FloatSize viewBoxSize = element->currentViewBoxRect().size();
             if (!viewBoxSize.isEmpty()) {
-                float height = element->hasIntrinsicHeight() ? element->intrinsicHeight() : defaultHeight;
+                float height = element->hasIntrinsicHeight() ? element->intrinsicHeight() : legacySVGRootDefaultHeight;
                 double ratio = viewBoxSize.width() / viewBoxSize.height();
                 return computeReplacedLogicalWidthRespectingMinMaxWidth(LayoutUnit(height * ratio), shouldComputePreferred);
             }
@@ -190,7 +190,7 @@ LayoutUnit LegacyRenderSVGRoot::computeReplacedLogicalHeight(std::optional<Layou
         if (!element->hasIntrinsicHeight()) {
             FloatSize viewBoxSize = element->currentViewBoxRect().size();
             if (!viewBoxSize.isEmpty()) {
-                float width = element->hasIntrinsicWidth() ? element->intrinsicWidth() : defaultWidth;
+                float width = element->hasIntrinsicWidth() ? element->intrinsicWidth() : legacySVGRootDefaultWidth;
                 double ratio = viewBoxSize.height() / viewBoxSize.width();
                 return computeReplacedLogicalHeightRespectingMinMaxHeight(LayoutUnit(width * ratio));
             }

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -72,7 +72,7 @@ SharedWorker* SharedWorker::fromIdentifier(SharedWorkerObjectIdentifier identifi
     return allSharedWorkers().get(identifier);
 }
 
-static inline SharedWorkerObjectConnection* mainThreadConnection()
+static inline SharedWorkerObjectConnection* sharedWorkerMainThreadConnection()
 {
     return SharedWorkerProvider::singleton().sharedWorkerConnection();
 }
@@ -83,7 +83,7 @@ ExceptionOr<Ref<SharedWorker>> SharedWorker::create(Document& document, Variant<
     if (compliantScriptURLString.hasException())
         return compliantScriptURLString.releaseException();
 
-    if (!mainThreadConnection())
+    if (!sharedWorkerMainThreadConnection())
         return Exception { ExceptionCode::NotSupportedError, "Shared workers are not supported"_s };
 
     if (!document.hasBrowsingContext())
@@ -121,7 +121,7 @@ ExceptionOr<Ref<SharedWorker>> SharedWorker::create(Document& document, Variant<
         return sharedWorker;
     }
 
-    mainThreadConnection()->requestSharedWorker(key, sharedWorker->identifier(), WTF::move(transferredPort), options);
+    sharedWorkerMainThreadConnection()->requestSharedWorker(key, sharedWorker->identifier(), WTF::move(transferredPort), options);
     return sharedWorker;
 }
 
@@ -176,13 +176,13 @@ void SharedWorker::stop()
 {
     SHARED_WORKER_RELEASE_LOG("stop:");
     m_isActive = false;
-    mainThreadConnection()->sharedWorkerObjectIsGoingAway(m_key, identifier());
+    sharedWorkerMainThreadConnection()->sharedWorkerObjectIsGoingAway(m_key, identifier());
 }
 
 void SharedWorker::suspend(ReasonForSuspension reason)
 {
     if (reason == ReasonForSuspension::BackForwardCache) {
-        mainThreadConnection()->suspendForBackForwardCache(m_key, identifier());
+        sharedWorkerMainThreadConnection()->suspendForBackForwardCache(m_key, identifier());
         m_isSuspendedForBackForwardCache = true;
     }
 }
@@ -190,7 +190,7 @@ void SharedWorker::suspend(ReasonForSuspension reason)
 void SharedWorker::resume()
 {
     if (m_isSuspendedForBackForwardCache) {
-        mainThreadConnection()->resumeForBackForwardCache(m_key, identifier());
+        sharedWorkerMainThreadConnection()->resumeForBackForwardCache(m_key, identifier());
         m_isSuspendedForBackForwardCache = false;
     }
 }

--- a/Source/WebCore/workers/shared/SharedWorkerProvider.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerProvider.cpp
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-static SharedWorkerProvider* sharedProvider;
+static SharedWorkerProvider* sharedWorkerSharedProvider;
 
 // For WebKitLegacy.
 class DummySharedWorkerProvider final : public SharedWorkerProvider {
@@ -38,15 +38,15 @@ public:
 
 SharedWorkerProvider& SharedWorkerProvider::singleton()
 {
-    if (!sharedProvider)
-        sharedProvider = new DummySharedWorkerProvider;
-    return *sharedProvider;
+    if (!sharedWorkerSharedProvider)
+        sharedWorkerSharedProvider = new DummySharedWorkerProvider;
+    return *sharedWorkerSharedProvider;
 }
 
 void SharedWorkerProvider::setSharedProvider(SharedWorkerProvider& newProvider)
 {
-    RELEASE_ASSERT(!sharedProvider);
-    sharedProvider = &newProvider;
+    RELEASE_ASSERT(!sharedWorkerSharedProvider);
+    sharedWorkerSharedProvider = &newProvider;
 }
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -83,9 +83,9 @@
 #include <WebCore/ScreenCaptureKitCaptureSource.h>
 #endif
 
-using namespace WebCore;
-
 namespace WebKit {
+
+using namespace WebCore;
 
 // We wouldn't want the GPUProcess to repeatedly exit then relaunch when under memory pressure. In particular, we need to make sure the
 // WebProcess has a change to schedule work after the GPUProcess get launched. For this reason, we make sure that the GPUProcess never

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -43,9 +43,9 @@
 
 #define MESSAGE_CHECK(assertion, message) MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, m_renderingBackend->streamConnection(), message)
 
-using namespace WebCore;
-
 namespace WebKit {
+
+using namespace WebCore;
 
 Ref<RemoteImageBuffer> RemoteImageBuffer::create(Ref<WebCore::ImageBuffer>&& imageBuffer, WebCore::RenderingResourceIdentifier identifier, RemoteGraphicsContextIdentifier contextIdentifier, RemoteRenderingBackend& renderingBackend)
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -99,6 +99,6 @@ void RemoteCompositorIntegration::updateContentsHeadroom(float headroom)
 
 } // namespace WebKit
 
-#undef MESSAGE_CHECK
+#undef MESSAGE_CHECK_COMPLETION
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -823,4 +823,7 @@ WTFLogChannel& RemoteAudioVideoRendererProxyManager::logChannel() const
 
 } // namespace WebKit
 
+#undef MESSAGE_CHECK
+#undef MESSAGE_CHECK_COMPLETION
+
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1965,6 +1965,7 @@ void NetworkConnectionToWebProcess::takeInvalidMessageStringForTesting(Completio
 } // namespace WebKit
 
 #undef CONNECTION_RELEASE_LOG
+#undef CONNECTION_RELEASE_LOG_ERROR
 #undef MESSAGE_CHECK_COMPLETION
 #undef MESSAGE_CHECK
 #undef MESSAGE_CHECK_WITH_RETURN_VALUE

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -54,6 +54,7 @@
 #import <WebCore/NotImplemented.h>
 #import <WebCore/ResourceError.h>
 #import <WebCore/ResourceRequest.h>
+#import <WebCore/ResourceRequestCFNet.h>
 #import <WebCore/ResourceResponse.h>
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/ThreadableWebSocketChannel.h>
@@ -105,6 +106,7 @@ void WebKit::NetworkSessionCocoa::removeNetworkWebsiteData(std::optional<WallTim
 #include <Network/NSURLSession+Network.h>
 #endif
 SOFT_LINK_LIBRARY_OPTIONAL(libnetwork)
+#define WebKit_libnetworkLibrary_SoftLinked
 SOFT_LINK_OPTIONAL(libnetwork, nw_context_add_proxy, void, __cdecl, (nw_context_t, nw_proxy_config_t))
 SOFT_LINK_OPTIONAL(libnetwork, nw_context_clear_proxies, void, __cdecl, (nw_context_t))
 SOFT_LINK_OPTIONAL(libnetwork, nw_proxy_config_create_with_agent_data, nw_proxy_config_t, __cdecl, (const uint8_t*, size_t, const uuid_t))

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -41,7 +41,7 @@ namespace WebKit {
 
 static constexpr auto cachesListFileName = "cacheslist"_s;
 static constexpr auto sizeFileName = "estimatedsize"_s;
-static constexpr auto originFileName = "origin"_s;
+static constexpr auto cachesOriginFileName = "origin"_s;
 static constexpr auto originSaltFileName = "salt"_s;
 
 static uint64_t nextUpdateNumber()
@@ -187,7 +187,7 @@ HashSet<WebCore::ClientOrigin> CacheStorageManager::originsOfCacheStorageData(co
 {
     HashSet<WebCore::ClientOrigin> result;
     for (auto& originName : FileSystem::listDirectory(rootDirectory)) {
-        auto originFile = FileSystem::pathByAppendingComponents(rootDirectory, std::initializer_list<StringView>({ originName, originFileName }));
+        auto originFile = FileSystem::pathByAppendingComponents(rootDirectory, std::initializer_list<StringView>({ originName, cachesOriginFileName }));
         if (auto origin = WebCore::StorageUtilities::readOriginFromFile(originFile))
             result.add(*origin);
     }
@@ -251,7 +251,7 @@ CacheStorageManager::CacheStorageManager(const String& path, CacheStorageRegistr
     if (m_path.isEmpty() || !origin)
         return;
 
-    auto originFile = FileSystem::pathByAppendingComponent(m_path, originFileName);
+    auto originFile = FileSystem::pathByAppendingComponent(m_path, cachesOriginFileName);
     WebCore::StorageUtilities::writeOriginToFile(originFile, *origin);
 }
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp
@@ -30,6 +30,7 @@
 
 #include "Logging.h"
 #include "NetworkRTCMonitor.h"
+#include "NetworkRTCProvider.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/WorkQueue.h>
 

--- a/Source/WebKit/Platform/cocoa/CocoaImage.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaImage.mm
@@ -29,6 +29,7 @@
 #import <ImageIO/ImageIO.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebCore/UTIRegistry.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
@@ -34,11 +34,15 @@
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebCore/AttributedString.h>
 #import <WebCore/TextRecognitionResult.h>
-#import <pal/cocoa/VisionKitCoreSoftLink.h>
-#import <pal/cocoa/VisionSoftLink.h>
 #import <pal/spi/cocoa/FeatureFlagsSPI.h>
+#import <wtf/BlockPtr.h>
 #import <wtf/RobinHoodHashSet.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/cf/TypeCastsCF.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
+
+#import <pal/cocoa/VisionKitCoreSoftLink.h>
+#import <pal/cocoa/VisionSoftLink.h>
 
 #define CRLayoutDirectionTopToBottom 3
 

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "LayerHostingContextManager.h"
 
+#include <WebCore/FloatRect.h>
+#include <WebCore/IntRect.h>
 #include <wtf/MachSendRightAnnotated.h>
 
 namespace WebKit {

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -60,7 +60,9 @@
 #endif
 
 #if HAVE(SYSTEM_SUPPORT_FOR_ADVANCED_PRIVACY_PROTECTIONS)
+#if !defined(WebKit_libnetworkLibrary_SoftLinked)
 SOFT_LINK_LIBRARY_OPTIONAL(libnetwork)
+#endif
 SOFT_LINK_OPTIONAL(libnetwork, nw_context_set_tracker_lookup_callback, void, __cdecl, (nw_context_t, nw_context_tracker_lookup_callback_t))
 #endif
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1560,6 +1560,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebKit::MessageBatchIdentifier': ['"NetworkConnectionToWebProcess.h"'],
         'WebKit::NetworkActivityTracker::CompletionCode': ['"NetworkActivityTracker.h"'],
         'WebKit::PageGroupIdentifier': ['"IdentifierTypes.h"'],
+        'WebKit::PDFPluginDisplayMode': ['"PDFDisplayMode.h"'],
         'WebKit::RealmIdentifier': ['"IdentifierTypes.h"'],
         'WebKit::PaymentSetupConfiguration': ['"PaymentSetupConfigurationWebKit.h"'],
         'WebKit::PaymentSetupFeatures': ['"ApplePayPaymentSetupFeaturesWebKit.h"'],

--- a/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
+++ b/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
@@ -67,7 +67,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
 
     RetainPtr<PKPaymentRequest> paymentRequest;
 #if HAVE(PASSKIT_DISBURSEMENTS)
-    std::optional<ApplePayDisbursementRequest> webDisbursementRequest = request.disbursementRequest();
+    std::optional<WebCore::ApplePayDisbursementRequest> webDisbursementRequest = request.disbursementRequest();
     if (webDisbursementRequest) {
         auto disbursementRequest = platformDisbursementRequest(request, originatingURL, webDisbursementRequest->requiredRecipientContactFields);
         paymentRequest = RetainPtr<PKPaymentRequest>((PKPaymentRequest *)disbursementRequest.get());

--- a/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
@@ -30,8 +30,6 @@
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/AlignedStorage.h>
 
-using namespace WebKit;
-
 @implementation WKNSDictionary {
     AlignedStorage<API::Dictionary> _dictionary;
 }
@@ -76,7 +74,7 @@ using namespace WebKit;
 
 - (NSEnumerator *)keyEnumerator
 {
-    return [wrapper(protect(*_dictionary)->keys()) objectEnumerator];
+    return [WebKit::wrapper(protect(*_dictionary)->keys()) objectEnumerator];
 }
 
 #pragma mark NSCopying protocol implementation

--- a/Source/WebKit/Shared/Cocoa/WKNSNumber.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSNumber.mm
@@ -28,8 +28,6 @@
 
 #import <wtf/AlignedStorage.h>
 
-using namespace WebKit;
-
 @implementation WKNSNumber {
     union {
         AlignedStorage<API::Boolean> _boolean;

--- a/Source/WebKit/Shared/Cocoa/WKNSString.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSString.mm
@@ -30,8 +30,6 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
-using namespace WebKit;
-
 @implementation WKNSString
 
 - (NSObject *)_web_createTarget

--- a/Source/WebKit/Shared/IPCTesterReceiver.cpp
+++ b/Source/WebKit/Shared/IPCTesterReceiver.cpp
@@ -28,6 +28,8 @@
 
 #if ENABLE(IPC_TESTING_API) && !ENABLE(IPC_TESTING_SWIFT)
 
+#include <wtf/CompletionHandler.h>
+
 namespace WebKit {
 
 Ref<IPCTesterReceiver> IPCTesterReceiver::create()

--- a/Source/WebKit/Shared/PDFDisplayMode.h
+++ b/Source/WebKit/Shared/PDFDisplayMode.h
@@ -29,18 +29,18 @@
 
 namespace WebKit {
 
-enum class PDFDisplayMode : uint8_t {
+enum class PDFPluginDisplayMode : uint8_t {
     SinglePageDiscrete,
     SinglePageContinuous,
     TwoUpDiscrete,
     TwoUpContinuous,
 };
 
-constexpr bool isSinglePagePDFDisplayMode(PDFDisplayMode mode) { return mode == PDFDisplayMode::SinglePageDiscrete || mode == PDFDisplayMode::SinglePageContinuous; }
-constexpr bool isTwoUpPDFDisplayMode(PDFDisplayMode mode) { return mode == PDFDisplayMode::TwoUpDiscrete || mode == PDFDisplayMode::TwoUpContinuous; }
+constexpr bool isSinglePagePDFDisplayMode(PDFPluginDisplayMode mode) { return mode == PDFPluginDisplayMode::SinglePageDiscrete || mode == PDFPluginDisplayMode::SinglePageContinuous; }
+constexpr bool isTwoUpPDFDisplayMode(PDFPluginDisplayMode mode) { return mode == PDFPluginDisplayMode::TwoUpDiscrete || mode == PDFPluginDisplayMode::TwoUpContinuous; }
 
-constexpr bool isScrollingPDFDisplayMode(PDFDisplayMode mode) { return mode == PDFDisplayMode::SinglePageContinuous || mode == PDFDisplayMode::TwoUpContinuous; }
-constexpr bool isDiscretePDFDisplayMode(PDFDisplayMode mode) { return mode == PDFDisplayMode::SinglePageDiscrete || mode == PDFDisplayMode::TwoUpDiscrete; }
+constexpr bool isScrollingPDFDisplayMode(PDFPluginDisplayMode mode) { return mode == PDFPluginDisplayMode::SinglePageContinuous || mode == PDFPluginDisplayMode::TwoUpContinuous; }
+constexpr bool isDiscretePDFDisplayMode(PDFPluginDisplayMode mode) { return mode == PDFPluginDisplayMode::SinglePageDiscrete || mode == PDFPluginDisplayMode::TwoUpDiscrete; }
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/PDFDisplayMode.serialization.in
+++ b/Source/WebKit/Shared/PDFDisplayMode.serialization.in
@@ -24,7 +24,7 @@ header: "PDFDisplayMode.h"
 
 #if ENABLE(UNIFIED_PDF)
 
-enum class WebKit::PDFDisplayMode : uint8_t {
+enum class WebKit::PDFPluginDisplayMode : uint8_t {
     SinglePageDiscrete,
     SinglePageContinuous,
     TwoUpDiscrete,

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -191,7 +191,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionContext, WebExtensionContext
     return Ref { *_webExtensionContext }->overrideNewTabPageURL().createNSURL().autorelease();
 }
 
-static inline WallTime toImpl(NSDate *date)
+static inline WallTime toExpirationTime(NSDate *date)
 {
     NSCParameterAssert(!date || [date isKindOfClass:NSDate.class]);
     return date ? WebKit::toImpl(date) : WebKit::toImpl(NSDate.distantFuture);
@@ -225,7 +225,7 @@ static inline WebKit::WebExtensionContext::PermissionsMap toImpl(NSDictionary<WK
     [permissions enumerateKeysAndObjectsUsingBlock:^(WKWebExtensionPermission permission, NSDate *date, BOOL *) {
         NSCParameterAssert([permission isKindOfClass:NSString.class]);
         NSCParameterAssert([date isKindOfClass:NSDate.class]);
-        result.set(permission, toImpl(date));
+        result.set(permission, toExpirationTime(date));
     }];
 
     return result;
@@ -239,7 +239,7 @@ static inline WebKit::WebExtensionContext::PermissionMatchPatternsMap toImpl(NSD
     [permissionMatchPatterns enumerateKeysAndObjectsUsingBlock:^(WKWebExtensionMatchPattern *origin, NSDate *date, BOOL *) {
         NSCParameterAssert([origin isKindOfClass:WKWebExtensionMatchPattern.class]);
         NSCParameterAssert([date isKindOfClass:NSDate.class]);
-        result.set(origin._webExtensionMatchPattern, toImpl(date));
+        result.set(origin._webExtensionMatchPattern, toExpirationTime(date));
     }];
 
     return result;
@@ -450,7 +450,7 @@ static inline WebKit::WebExtensionContext::PermissionState NODELETE toImpl(WKWeb
     NSParameterAssert(status == WKWebExtensionContextPermissionStatusDeniedExplicitly || status == WKWebExtensionContextPermissionStatusUnknown || status == WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert([permission isKindOfClass:NSString.class]);
 
-    Ref { *_webExtensionContext }->setPermissionState(toImpl(status), permission, toImpl(expirationDate));
+    Ref { *_webExtensionContext }->setPermissionState(toImpl(status), permission, toExpirationTime(expirationDate));
 }
 
 - (WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url
@@ -481,7 +481,7 @@ static inline WebKit::WebExtensionContext::PermissionState NODELETE toImpl(WKWeb
     NSParameterAssert(status == WKWebExtensionContextPermissionStatusDeniedExplicitly || status == WKWebExtensionContextPermissionStatusUnknown || status == WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert([url isKindOfClass:NSURL.class]);
 
-    Ref { *_webExtensionContext }->setPermissionState(toImpl(status), url, toImpl(expirationDate));
+    Ref { *_webExtensionContext }->setPermissionState(toImpl(status), url, toExpirationTime(expirationDate));
 }
 
 - (WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(WKWebExtensionMatchPattern *)pattern
@@ -512,7 +512,7 @@ static inline WebKit::WebExtensionContext::PermissionState NODELETE toImpl(WKWeb
     NSParameterAssert(status == WKWebExtensionContextPermissionStatusDeniedExplicitly || status == WKWebExtensionContextPermissionStatusUnknown || status == WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert([pattern isKindOfClass:WKWebExtensionMatchPattern.class]);
 
-    Ref { *_webExtensionContext }->setPermissionState(toImpl(status), protect(*pattern->_webExtensionMatchPattern), toImpl(expirationDate));
+    Ref { *_webExtensionContext }->setPermissionState(toImpl(status), protect(*pattern->_webExtensionMatchPattern), toExpirationTime(expirationDate));
 }
 
 - (BOOL)hasAccessToAllURLs

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -43,6 +43,8 @@
 #import <wtf/cocoa/Entitlements.h>
 #endif
 
+#import <wtf/cocoa/VectorCocoa.h>
+
 namespace WebKit {
 
 #if PLATFORM(IOS_FAMILY)
@@ -390,7 +392,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy NODELETE toWKWebsiteDevi
 
 - (NSArray<_WKCustomHeaderFields *> *)_customHeaderFields
 {
-    return createNSArray(_websitePolicies->customHeaderFields(), [] (auto& field) {
+    return WTF::createNSArray(_websitePolicies->customHeaderFields(), [] (auto& field) {
         return wrapper(API::CustomHeaderFields::create(field));
     }).autorelease();
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -683,7 +683,7 @@ enum class MediaPlaybackState : uint8_t;
 enum class NavigatingToAppBoundDomain : bool;
 enum class NegotiatedLegacyTLS : bool;
 #if ENABLE(UNIFIED_PDF)
-enum class PDFDisplayMode : uint8_t;
+enum class PDFPluginDisplayMode : uint8_t;
 #endif
 enum class PasteboardAccessIntent : bool;
 enum class ProcessSwapRequestedByClient : bool;
@@ -2518,10 +2518,10 @@ public:
 #endif
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(UNIFIED_PDF)
-    PDFDisplayMode pdfDisplayMode() const;
-    void setPDFDisplayMode(PDFDisplayMode);
+    PDFPluginDisplayMode pdfDisplayMode() const;
+    void setPDFDisplayMode(PDFPluginDisplayMode);
 
-    void requestPDFDisplayMode(PDFDisplayMode);
+    void requestPDFDisplayMode(PDFPluginDisplayMode);
 #endif
 
     Seconds mediaCaptureReportingDelay() const { return m_mediaCaptureReportingDelay; }

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -595,7 +595,7 @@ messages -> WebPageProxy {
 #endif
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(UNIFIED_PDF)
-    SetPDFDisplayMode(enum:uint8_t WebKit::PDFDisplayMode mode)
+    SetPDFDisplayMode(enum:uint8_t WebKit::PDFPluginDisplayMode mode)
 #endif
 
     ConfigureLoggingChannel(String channelName, enum:uint8_t WTFLogChannelState state, enum:uint8_t WTFLogLevel level)

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -403,7 +403,7 @@ public:
     EnhancedSecurityTracking enhancedSecurityTracker;
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(UNIFIED_PDF)
-    PDFDisplayMode pdfDisplayMode { PDFDisplayMode::SinglePageContinuous };
+    PDFPluginDisplayMode pdfDisplayMode { PDFPluginDisplayMode::SinglePageContinuous };
 #endif
 
 #if HAVE(NSVIEW_CORNER_CONFIGURATION)

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -1106,7 +1106,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular)
         return;
 
-    page->requestPDFDisplayMode(WebKit::PDFDisplayMode::SinglePageContinuous);
+    page->requestPDFDisplayMode(WebKit::PDFPluginDisplayMode::SinglePageContinuous);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -15543,7 +15543,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             if (isSinglePage == isSinglePageAction)
                 return;
 
-            page->requestPDFDisplayMode(isSinglePageAction ? WebKit::PDFDisplayMode::SinglePageContinuous : WebKit::PDFDisplayMode::TwoUpContinuous);
+            page->requestPDFDisplayMode(isSinglePageAction ? WebKit::PDFPluginDisplayMode::SinglePageContinuous : WebKit::PDFPluginDisplayMode::TwoUpContinuous);
         };
 
         RetainPtr singlePageAction = [UIAction actionWithTitle:WebCore::contextMenuItemPDFSinglePage().createNSString().get() image:nil identifier:WKPDFActionSinglePageIdentifier handler:actionHandler];

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1860,17 +1860,17 @@ void WebPageProxy::updatePDFPageNumberIndicatorCurrentPage(PDFPluginIdentifier i
 
 #if ENABLE(UNIFIED_PDF)
 
-PDFDisplayMode WebPageProxy::pdfDisplayMode() const
+PDFPluginDisplayMode WebPageProxy::pdfDisplayMode() const
 {
     return internals().pdfDisplayMode;
 }
 
-void WebPageProxy::setPDFDisplayMode(PDFDisplayMode mode)
+void WebPageProxy::setPDFDisplayMode(PDFPluginDisplayMode mode)
 {
     internals().pdfDisplayMode = mode;
 }
 
-void WebPageProxy::requestPDFDisplayMode(PDFDisplayMode mode)
+void WebPageProxy::requestPDFDisplayMode(PDFPluginDisplayMode mode)
 {
     if (!hasRunningProcess())
         return;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -49,7 +49,6 @@
 
 namespace WebKit {
 
-using namespace PAL;
 using namespace WebCore;
 
 class MediaPlayerRemoteFactory final : public MediaPlayerFactory {

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -38,11 +38,11 @@
 namespace WebKit {
 using namespace WebCore;
 
-using WorldMap = HashMap<SingleThreadWeakRef<const DOMWrapperWorld>, WeakRef<InjectedBundleScriptWorld>>;
+using DOMWrapperWorldMap = HashMap<SingleThreadWeakRef<const DOMWrapperWorld>, WeakRef<InjectedBundleScriptWorld>>;
 
-static WorldMap& NODELETE allWorlds()
+static DOMWrapperWorldMap& NODELETE allWorlds()
 {
-    static NeverDestroyed<WorldMap> map;
+    static NeverDestroyed<DOMWrapperWorldMap> map;
     return map;
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -91,7 +91,7 @@ class WebMouseEvent;
 class WebWheelEvent;
 enum class SelectionEndpoint : bool;
 enum class SelectionWasFlipped : bool;
-enum class PDFDisplayMode : uint8_t;
+enum class PDFPluginDisplayMode : uint8_t;
 struct DocumentEditingContextRequest;
 struct DocumentEditingContext;
 struct EditorState;
@@ -156,7 +156,7 @@ public:
     virtual void setPageScaleFactor(double, std::optional<WebCore::IntPoint> origin) = 0;
     virtual void mainFramePageScaleFactorDidChange() { }
 
-    virtual void setDisplayModeAndUpdateLayout(PDFDisplayMode) { }
+    virtual void setDisplayModeAndUpdateLayout(PDFPluginDisplayMode) { }
 
     virtual double minScaleFactor() const { return 0.25; }
     virtual double maxScaleFactor() const { return 5; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -35,6 +35,7 @@
 #import "MessageSenderInlines.h"
 #import "PDFIncrementalLoader.h"
 #import "PDFKitSPI.h"
+#import "PDFPluginAnnotation.h"
 #import "PDFScriptEvaluation.h"
 #import "PluginView.h"
 #import "WKAccessibilityPDFDocumentObject.h"

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
@@ -30,6 +30,7 @@
 
 #import "PDFAnnotationTypeHelpers.h"
 #import "PDFKitSPI.h"
+#import "PDFPluginBase.h"
 #import <WebCore/CSSPrimitiveValue.h>
 #import <WebCore/CSSPropertyNames.h>
 #import <WebCore/ColorCocoa.h>

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
@@ -59,8 +59,8 @@ public:
 
 
 private:
-    bool supportsDisplayMode(PDFDisplayMode) const override;
-    void willChangeDisplayMode(PDFDisplayMode) override;
+    bool supportsDisplayMode(PDFPluginDisplayMode) const override;
+    void willChangeDisplayMode(PDFPluginDisplayMode) override;
 
     void teardown() override;
 
@@ -216,7 +216,7 @@ private:
     Vector<RowData> m_rows;
 
     WeakHashMap<WebCore::GraphicsLayer, unsigned> m_layerToRowIndexMap;
-    std::optional<PDFDisplayMode> m_displayModeAtLastLayerSetup;
+    std::optional<PDFPluginDisplayMode> m_displayModeAtLastLayerSetup;
 
     unsigned m_visibleRowIndex { 0 };
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -97,12 +97,12 @@ void PDFDiscretePresentationController::teardown()
     m_rows.clear();
 }
 
-bool PDFDiscretePresentationController::supportsDisplayMode(PDFDisplayMode mode) const
+bool PDFDiscretePresentationController::supportsDisplayMode(PDFPluginDisplayMode mode) const
 {
     return isDiscretePDFDisplayMode(mode);
 }
 
-void PDFDiscretePresentationController::willChangeDisplayMode(PDFDisplayMode newMode)
+void PDFDiscretePresentationController::willChangeDisplayMode(PDFPluginDisplayMode newMode)
 {
     ASSERT(supportsDisplayMode(newMode));
     m_visibleRowIndex = 0;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -108,8 +108,8 @@ public:
     WebCore::FloatSize NODELETE contentsSize() const;
     WebCore::FloatSize NODELETE scaledContentsSize() const;
 
-    void setDisplayMode(PDFDisplayMode displayMode) { m_displayMode = displayMode; }
-    PDFDisplayMode displayMode() const { return m_displayMode; }
+    void setDisplayMode(PDFPluginDisplayMode displayMode) { m_displayMode = displayMode; }
+    PDFPluginDisplayMode displayMode() const { return m_displayMode; }
 
     void setShouldLeftAlignTrailingTwoUpPage(bool value) { m_shouldLeftAlignTrailingTwoUpPage = value; }
     bool shouldLeftAlignTrailingTwoUpPage() const { return m_shouldLeftAlignTrailingTwoUpPage; }
@@ -148,7 +148,7 @@ private:
     Vector<PageGeometry> m_pageGeometry;
     WebCore::FloatRect m_documentBounds;
     float m_scale { 1 };
-    PDFDisplayMode m_displayMode { PDFDisplayMode::SinglePageContinuous };
+    PDFPluginDisplayMode m_displayMode { PDFPluginDisplayMode::SinglePageContinuous };
     bool m_shouldLeftAlignTrailingTwoUpPage { false };
 };
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -94,8 +94,8 @@ PDFDocumentLayout::PageIndex PDFDocumentLayout::nearestPageIndexForDocumentPoint
     ASSERT(pageCount);
 
     switch (displayMode()) {
-    case PDFDisplayMode::SinglePageDiscrete:
-    case PDFDisplayMode::TwoUpDiscrete: {
+    case PDFPluginDisplayMode::SinglePageDiscrete:
+    case PDFPluginDisplayMode::TwoUpDiscrete: {
         using PairedPagesLayoutBounds = std::pair<FloatRect, std::optional<FloatRect>>;
 
         auto layoutBoundsForRow = [this](PDFLayoutRow row) -> PairedPagesLayoutBounds {
@@ -162,7 +162,7 @@ PDFDocumentLayout::PageIndex PDFDocumentLayout::nearestPageIndexForDocumentPoint
         return visibleRow->pages[0];
     }
 
-    case PDFDisplayMode::TwoUpContinuous: {
+    case PDFPluginDisplayMode::TwoUpContinuous: {
         using PairedPagesLayoutBounds = std::pair<FloatRect, std::optional<FloatRect>>;
 
         auto layoutBoundsForPairedPages = [this](PageIndex pageIndex) -> PairedPagesLayoutBounds {
@@ -238,7 +238,7 @@ PDFDocumentLayout::PageIndex PDFDocumentLayout::nearestPageIndexForDocumentPoint
         return lastPageIndex;
     }
 
-    case PDFDisplayMode::SinglePageContinuous: {
+    case PDFPluginDisplayMode::SinglePageContinuous: {
         for (PDFDocumentLayout::PageIndex index = 0; index < pageCount; ++index) {
             auto pageBounds = layoutBoundsForPageAtIndex(index);
 
@@ -263,8 +263,8 @@ auto PDFDocumentLayout::pageIndexAndPagePointForDocumentYOffset(float documentYO
     };
 
     switch (displayMode()) {
-    case PDFDisplayMode::TwoUpDiscrete:
-    case PDFDisplayMode::TwoUpContinuous:
+    case PDFPluginDisplayMode::TwoUpDiscrete:
+    case PDFPluginDisplayMode::TwoUpContinuous:
         for (PageIndex index = 0; index < pageCount; ++index) {
             if (index == pageCount - 1)
                 return resultWithPageHorizontalCenterPoint(index, documentYOffset);
@@ -297,8 +297,8 @@ auto PDFDocumentLayout::pageIndexAndPagePointForDocumentYOffset(float documentYO
             return resultWithPageHorizontalCenterPoint(*targetPageIndex, documentYOffset);
         }
         break;
-    case PDFDisplayMode::SinglePageDiscrete:
-    case PDFDisplayMode::SinglePageContinuous: {
+    case PDFPluginDisplayMode::SinglePageDiscrete:
+    case PDFPluginDisplayMode::SinglePageContinuous: {
         for (PageIndex index = 0; index < pageCount; ++index) {
             auto pageBounds = layoutBoundsForPageAtIndex(index);
             if (documentYOffset <= pageBounds.maxY() || index == pageCount - 1)
@@ -385,13 +385,13 @@ void PDFDocumentLayout::layoutPages(FloatSize availableSize, FloatSize maxRowSiz
 {
     // We always lay out in a continuous mode. We handle non-continuous mode via scroll snap.
     switch (m_displayMode) {
-    case PDFDisplayMode::SinglePageDiscrete:
-    case PDFDisplayMode::TwoUpDiscrete:
+    case PDFPluginDisplayMode::SinglePageDiscrete:
+    case PDFPluginDisplayMode::TwoUpDiscrete:
         layoutDiscreteRows(availableSize, maxRowSize, CenterRowVertically::Yes);
         break;
 
-    case PDFDisplayMode::SinglePageContinuous:
-    case PDFDisplayMode::TwoUpContinuous:
+    case PDFPluginDisplayMode::SinglePageContinuous:
+    case PDFPluginDisplayMode::TwoUpContinuous:
         layoutContinuousRows(availableSize, maxRowSize, CenterRowVertically::No);
         break;
     }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -59,7 +59,7 @@ class PDFPresentationController : public ThreadSafeRefCountedAndCanMakeThreadSaf
     WTF_MAKE_NONCOPYABLE(PDFPresentationController);
     WTF_MAKE_TZONE_ALLOCATED(PDFPresentationController);
 public:
-    static RefPtr<PDFPresentationController> createForMode(PDFDisplayMode, UnifiedPDFPlugin&);
+    static RefPtr<PDFPresentationController> createForMode(PDFPluginDisplayMode, UnifiedPDFPlugin&);
 
     PDFPresentationController(UnifiedPDFPlugin&);
     virtual ~PDFPresentationController();
@@ -69,8 +69,8 @@ public:
     // Subclasses must call the base class teardown().
     virtual void teardown();
 
-    virtual bool supportsDisplayMode(PDFDisplayMode) const = 0;
-    virtual void willChangeDisplayMode(PDFDisplayMode newMode) = 0;
+    virtual bool supportsDisplayMode(PDFPluginDisplayMode) const = 0;
+    virtual void willChangeDisplayMode(PDFPluginDisplayMode newMode) = 0;
 
     // Package up the data needed to paint a set of pages for the given clip, for use by UnifiedPDFPlugin::paintPDFContent and async rendering.
     virtual PDFPageCoverage pageCoverageForContentsRect(const WebCore::FloatRect&, std::optional<PDFLayoutRow>) const = 0;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -47,7 +47,7 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFPresentationController);
 
-RefPtr<PDFPresentationController> PDFPresentationController::createForMode(PDFDisplayMode mode, UnifiedPDFPlugin& plugin)
+RefPtr<PDFPresentationController> PDFPresentationController::createForMode(PDFPluginDisplayMode mode, UnifiedPDFPlugin& plugin)
 {
     if (isScrollingPDFDisplayMode(mode))
         return adoptRef(*new PDFScrollingPresentationController { plugin });

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
@@ -46,8 +46,8 @@ public:
 
 
 private:
-    bool supportsDisplayMode(PDFDisplayMode) const override;
-    void willChangeDisplayMode(PDFDisplayMode) override { }
+    bool supportsDisplayMode(PDFPluginDisplayMode) const override;
+    void willChangeDisplayMode(PDFPluginDisplayMode) override { }
 
     void teardown() override;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -62,7 +62,7 @@ void PDFScrollingPresentationController::teardown()
 #endif
 }
 
-bool PDFScrollingPresentationController::supportsDisplayMode(PDFDisplayMode mode) const
+bool PDFScrollingPresentationController::supportsDisplayMode(PDFPluginDisplayMode mode) const
 {
     return isScrollingPDFDisplayMode(mode);
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -351,8 +351,8 @@ private:
     [[maybe_unused]] bool performCopyEditingOperation() const;
     void performCopyLinkOperation(const WebCore::IntPoint& contextMenuEventRootViewPoint) const;
 
-    void setDisplayMode(PDFDisplayMode);
-    void setDisplayModeAndUpdateLayout(PDFDisplayMode) final;
+    void setDisplayMode(PDFPluginDisplayMode);
+    void setDisplayModeAndUpdateLayout(PDFPluginDisplayMode) final;
 
     // Context Menu
 #if ENABLE(CONTEXT_MENUS)
@@ -389,8 +389,8 @@ private:
     static ContextMenuItemTag toContextMenuItemTag(int tagValue);
     void performContextMenuAction(ContextMenuItemTag, const WebCore::IntPoint& contextMenuEventRootViewPoint);
 
-    ContextMenuItemTag NODELETE contextMenuItemTagFromDisplayMode(const PDFDisplayMode&) const;
-    PDFDisplayMode NODELETE displayModeFromContextMenuItemTag(const ContextMenuItemTag&) const;
+    ContextMenuItemTag NODELETE contextMenuItemTagFromDisplayMode(const PDFPluginDisplayMode&) const;
+    PDFPluginDisplayMode NODELETE displayModeFromContextMenuItemTag(const ContextMenuItemTag&) const;
 #endif
 
     // Autoscroll

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -197,7 +197,7 @@ UnifiedPDFPlugin::UnifiedPDFPlugin(HTMLPlugInElement& element)
     annotationContainer->appendChild(annotationStyleElement);
     installAnnotationContainer();
 
-    setDisplayMode(PDFDisplayMode::SinglePageContinuous);
+    setDisplayMode(PDFPluginDisplayMode::SinglePageContinuous);
 
     lazyInitialize(m_accessibilityDocumentObject, adoptNS([[WKAccessibilityPDFDocumentObject alloc] initWithPDFDocument:m_pdfDocument andElement:&element]));
     [m_accessibilityDocumentObject setPDFPlugin:this];
@@ -1818,12 +1818,12 @@ WebCore::OverscrollBehavior UnifiedPDFPlugin::overscrollBehavior() const
 
 bool UnifiedPDFPlugin::isInDiscreteDisplayMode() const
 {
-    return m_documentLayout.displayMode() == PDFDisplayMode::SinglePageDiscrete || m_documentLayout.displayMode() == PDFDisplayMode::TwoUpDiscrete;
+    return m_documentLayout.displayMode() == PDFPluginDisplayMode::SinglePageDiscrete || m_documentLayout.displayMode() == PDFPluginDisplayMode::TwoUpDiscrete;
 }
 
 bool UnifiedPDFPlugin::isShowingTwoPages() const
 {
-    return m_documentLayout.displayMode() == PDFDisplayMode::TwoUpContinuous || m_documentLayout.displayMode() == PDFDisplayMode::TwoUpDiscrete;
+    return m_documentLayout.displayMode() == PDFPluginDisplayMode::TwoUpContinuous || m_documentLayout.displayMode() == PDFPluginDisplayMode::TwoUpDiscrete;
 }
 
 FloatRect UnifiedPDFPlugin::pageBoundsInContentsSpace(PDFDocumentLayout::PageIndex index) const
@@ -2423,26 +2423,26 @@ void UnifiedPDFPlugin::revealFragmentIfNeeded()
 #pragma mark Context Menu
 
 #if ENABLE(CONTEXT_MENUS)
-UnifiedPDFPlugin::ContextMenuItemTag UnifiedPDFPlugin::contextMenuItemTagFromDisplayMode(const PDFDisplayMode& displayMode) const
+UnifiedPDFPlugin::ContextMenuItemTag UnifiedPDFPlugin::contextMenuItemTagFromDisplayMode(const PDFPluginDisplayMode& displayMode) const
 {
     switch (displayMode) {
-    case PDFDisplayMode::SinglePageDiscrete: return ContextMenuItemTag::SinglePage;
-    case PDFDisplayMode::SinglePageContinuous: return ContextMenuItemTag::SinglePageContinuous;
-    case PDFDisplayMode::TwoUpDiscrete: return ContextMenuItemTag::TwoPages;
-    case PDFDisplayMode::TwoUpContinuous: return ContextMenuItemTag::TwoPagesContinuous;
+    case PDFPluginDisplayMode::SinglePageDiscrete: return ContextMenuItemTag::SinglePage;
+    case PDFPluginDisplayMode::SinglePageContinuous: return ContextMenuItemTag::SinglePageContinuous;
+    case PDFPluginDisplayMode::TwoUpDiscrete: return ContextMenuItemTag::TwoPages;
+    case PDFPluginDisplayMode::TwoUpContinuous: return ContextMenuItemTag::TwoPagesContinuous;
     }
 }
 
-PDFDisplayMode UnifiedPDFPlugin::displayModeFromContextMenuItemTag(const ContextMenuItemTag& tag) const
+PDFPluginDisplayMode UnifiedPDFPlugin::displayModeFromContextMenuItemTag(const ContextMenuItemTag& tag) const
 {
     switch (tag) {
-    case ContextMenuItemTag::SinglePage: return PDFDisplayMode::SinglePageDiscrete;
-    case ContextMenuItemTag::SinglePageContinuous: return PDFDisplayMode::SinglePageContinuous;
-    case ContextMenuItemTag::TwoPages: return PDFDisplayMode::TwoUpDiscrete;
-    case ContextMenuItemTag::TwoPagesContinuous: return PDFDisplayMode::TwoUpContinuous;
+    case ContextMenuItemTag::SinglePage: return PDFPluginDisplayMode::SinglePageDiscrete;
+    case ContextMenuItemTag::SinglePageContinuous: return PDFPluginDisplayMode::SinglePageContinuous;
+    case ContextMenuItemTag::TwoPages: return PDFPluginDisplayMode::TwoUpDiscrete;
+    case ContextMenuItemTag::TwoPagesContinuous: return PDFPluginDisplayMode::TwoUpContinuous;
     default:
         ASSERT_NOT_REACHED();
-        return PDFDisplayMode::SinglePageContinuous;
+        return PDFPluginDisplayMode::SinglePageContinuous;
     }
 }
 
@@ -4357,23 +4357,23 @@ void UnifiedPDFPlugin::setPDFDisplayModeForTesting(const String& mode)
 {
     setDisplayModeAndUpdateLayout([mode] {
         if (mode == "SinglePageDiscrete"_s)
-            return PDFDisplayMode::SinglePageDiscrete;
+            return PDFPluginDisplayMode::SinglePageDiscrete;
 
         if (mode == "SinglePageContinuous"_s)
-            return PDFDisplayMode::SinglePageContinuous;
+            return PDFPluginDisplayMode::SinglePageContinuous;
 
         if (mode == "TwoUpDiscrete"_s)
-            return PDFDisplayMode::TwoUpDiscrete;
+            return PDFPluginDisplayMode::TwoUpDiscrete;
 
         if (mode == "TwoUpContinuous"_s)
-            return PDFDisplayMode::TwoUpContinuous;
+            return PDFPluginDisplayMode::TwoUpContinuous;
 
         ASSERT_NOT_REACHED();
-        return PDFDisplayMode::SinglePageContinuous;
+        return PDFPluginDisplayMode::SinglePageContinuous;
     }());
 }
 
-void UnifiedPDFPlugin::setDisplayMode(PDFDisplayMode mode)
+void UnifiedPDFPlugin::setDisplayMode(PDFPluginDisplayMode mode)
 {
 #if PLATFORM(IOS_FAMILY)
     if (RefPtr frame = m_frame.get()) {
@@ -4392,7 +4392,7 @@ void UnifiedPDFPlugin::setDisplayMode(PDFDisplayMode mode)
     setPresentationController(PDFPresentationController::createForMode(mode, *this));
 }
 
-void UnifiedPDFPlugin::setDisplayModeAndUpdateLayout(PDFDisplayMode mode)
+void UnifiedPDFPlugin::setDisplayModeAndUpdateLayout(PDFPluginDisplayMode mode)
 {
     auto shouldAdjustPageScale = m_shouldUpdateAutoSizeScale == ShouldUpdateAutoSizeScale::Yes ? AdjustScaleAfterLayout::No : AdjustScaleAfterLayout::Yes;
     Ref presentationController = *m_presentationController;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1156,7 +1156,7 @@ PDFPluginIdentifier PluginView::pdfPluginIdentifier() const
     return m_plugin->identifier();
 }
 
-void PluginView::setPDFDisplayMode(PDFDisplayMode mode)
+void PluginView::setPDFDisplayMode(PDFPluginDisplayMode mode)
 {
     m_plugin->setDisplayModeAndUpdateLayout(mode);
 }

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -59,7 +59,7 @@ namespace WebKit {
 class PDFPluginBase;
 class WebFrame;
 class WebPage;
-enum class PDFDisplayMode : uint8_t;
+enum class PDFPluginDisplayMode : uint8_t;
 enum class SelectionEndpoint : bool;
 enum class SelectionWasFlipped : bool;
 struct DocumentEditingContextRequest;
@@ -159,7 +159,7 @@ public:
 
     PDFPluginIdentifier NODELETE pdfPluginIdentifier() const;
 
-    void setPDFDisplayMode(PDFDisplayMode);
+    void setPDFDisplayMode(PDFPluginDisplayMode);
 
     void openWithPreview(CompletionHandler<void(const String&, std::optional<FrameInfoData>&&, std::span<const uint8_t>)>&&);
 

--- a/Source/WebKit/WebProcess/Storage/RemoteWorkerLibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Storage/RemoteWorkerLibWebRTCProvider.h
@@ -38,12 +38,12 @@ namespace WebKit {
 #if ENABLE(WEB_RTC)
 
 #if USE(LIBWEBRTC)
-using LibWebRTCProviderBase = WebCore::LibWebRTCProvider;
+using RemoteWorkerLibWebRTCProviderBase = WebCore::LibWebRTCProvider;
 #else
-using LibWebRTCProviderBase = WebCore::GStreamerWebRTCProvider;
+using RemoteWorkerLibWebRTCProviderBase = WebCore::GStreamerWebRTCProvider;
 #endif
 
-class RemoteWorkerLibWebRTCProvider final : public LibWebRTCProviderBase {
+class RemoteWorkerLibWebRTCProvider final : public RemoteWorkerLibWebRTCProviderBase {
 public:
     RemoteWorkerLibWebRTCProvider() = default;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
@@ -36,7 +36,7 @@
 
 namespace WebKit {
 
-static inline IPC::Connection& networkProcessConnection()
+static inline IPC::Connection& broadcastChannelNetworkProcessConnection()
 {
     return WebProcess::singleton().ensureNetworkProcessConnection().connection();
 }
@@ -62,7 +62,7 @@ void WebBroadcastChannelRegistry::registerChannel(const WebCore::PartitionedSecu
 
     if (channelsForName.size() == 1) {
         if (auto clientOrigin = toClientOrigin(origin))
-            protect(networkProcessConnection())->send(Messages::NetworkBroadcastChannelRegistry::RegisterChannel { *clientOrigin, name }, 0);
+            protect(broadcastChannelNetworkProcessConnection())->send(Messages::NetworkBroadcastChannelRegistry::RegisterChannel { *clientOrigin, name }, 0);
     }
 }
 
@@ -85,7 +85,7 @@ void WebBroadcastChannelRegistry::unregisterChannel(const WebCore::PartitionedSe
 
     channelsForOrigin.remove(channelsForOriginIterator);
     if (auto clientOrigin = toClientOrigin(origin))
-        protect(networkProcessConnection())->send(Messages::NetworkBroadcastChannelRegistry::UnregisterChannel { *clientOrigin, name }, 0);
+        protect(broadcastChannelNetworkProcessConnection())->send(Messages::NetworkBroadcastChannelRegistry::UnregisterChannel { *clientOrigin, name }, 0);
 
     if (channelsForOrigin.isEmpty())
         m_channelsPerOrigin.remove(channelsPerOriginIterator);
@@ -96,7 +96,7 @@ void WebBroadcastChannelRegistry::postMessage(const WebCore::PartitionedSecurity
     auto callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
     postMessageLocally(origin, name, source, message.copyRef(), callbackAggregator.copyRef());
     if (auto clientOrigin = toClientOrigin(origin))
-        protect(networkProcessConnection())->sendWithAsyncReply(Messages::NetworkBroadcastChannelRegistry::PostMessage { *clientOrigin, name, WebCore::MessageWithMessagePorts { WTF::move(message), { } } }, [callbackAggregator] { }, 0);
+        protect(broadcastChannelNetworkProcessConnection())->sendWithAsyncReply(Messages::NetworkBroadcastChannelRegistry::PostMessage { *clientOrigin, name, WebCore::MessageWithMessagePorts { WTF::move(message), { } } }, [callbackAggregator] { }, 0);
 }
 
 void WebBroadcastChannelRegistry::postMessageLocally(const WebCore::PartitionedSecurityOrigin& origin, const String& name, std::optional<WebCore::BroadcastChannelIdentifier> sourceInProcess, Ref<WebCore::SerializedScriptValue>&& message, Ref<WTF::CallbackAggregator>&& callbackAggregator)
@@ -135,7 +135,7 @@ void WebBroadcastChannelRegistry::networkProcessCrashed()
         if (!clientOrigin)
             continue;
         for (auto& name : channelsForOrigin.keys())
-            protect(networkProcessConnection())->send(Messages::NetworkBroadcastChannelRegistry::RegisterChannel { *clientOrigin, name }, 0);
+            protect(broadcastChannelNetworkProcessConnection())->send(Messages::NetworkBroadcastChannelRegistry::RegisterChannel { *clientOrigin, name }, 0);
     }
 
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -36,6 +36,7 @@
 #include "WebProcess.h"
 #include <WebCore/GraphicsLayerContentsDisplayDelegate.h>
 #include <WebCore/HTMLVideoElement.h>
+#include <WebCore/LocalFrameView.h>
 #include <WebCore/Model.h>
 #include <WebCore/PlatformCALayerDelegatedContents.h>
 #include <WebCore/PlatformScreen.h>

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -499,7 +499,7 @@ enum class ImageOption : uint8_t;
 enum class NavigatingToAppBoundDomain : bool;
 enum class MediaPlaybackState : uint8_t;
 #if ENABLE(UNIFIED_PDF)
-enum class PDFDisplayMode : uint8_t;
+enum class PDFPluginDisplayMode : uint8_t;
 #endif
 enum class SnapshotOption : uint16_t;
 enum class SyntheticEditingCommandType : uint8_t;
@@ -668,8 +668,8 @@ public:
 #endif
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(UNIFIED_PDF)
-    void setPDFDisplayMode(PDFDisplayMode);
-    void requestPDFDisplayMode(PDFDisplayMode);
+    void setPDFDisplayMode(PDFPluginDisplayMode);
+    void requestPDFDisplayMode(PDFPluginDisplayMode);
 #endif
 
 #if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -237,7 +237,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     GetPDFFirstPageSize(WebCore::FrameIdentifier frameID) -> (WebCore::FloatSize size)
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(UNIFIED_PDF)
-    RequestPDFDisplayMode(enum:uint8_t WebKit::PDFDisplayMode mode)
+    RequestPDFDisplayMode(enum:uint8_t WebKit::PDFPluginDisplayMode mode)
 #endif
 
     Reload(WebCore::NavigationIdentifier navigationID, OptionSet<WebCore::ReloadOption> reloadOptions, WebKit::SandboxExtensionHandle sandboxExtensionHandle)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5084,12 +5084,12 @@ void WebPage::removePDFPageNumberIndicator(PDFPluginBase& plugin)
 
 #if ENABLE(UNIFIED_PDF)
 
-void WebPage::setPDFDisplayMode(PDFDisplayMode mode)
+void WebPage::setPDFDisplayMode(PDFPluginDisplayMode mode)
 {
     send(Messages::WebPageProxy::SetPDFDisplayMode(mode));
 }
 
-void WebPage::requestPDFDisplayMode(PDFDisplayMode mode)
+void WebPage::requestPDFDisplayMode(PDFPluginDisplayMode mode)
 {
     if (RefPtr pluginView = mainFramePlugIn())
         return pluginView->setPDFDisplayMode(mode);

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -50,6 +50,7 @@
 #import "WebInspectorBackend.h"
 #import "WebKeyboardEvent.h"
 #import "WebMouseEvent.h"
+#import "MessageSenderInlines.h"
 #import "WebPageOverlay.h"
 #import "WebPageProxyMessages.h"
 #import "WebPasteboardOverrides.h"
@@ -57,6 +58,7 @@
 #import "WebProcess.h"
 #import <Quartz/Quartz.h>
 #import <QuartzCore/QuartzCore.h>
+#import <WebCore/AXIsolatedTree.h>
 #import <WebCore/AXObjectCache.h>
 #import <WebCore/BackForwardController.h>
 #import <WebCore/BoundaryPointInlines.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMDocumentFragment.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMDocumentFragment.mm
@@ -27,6 +27,8 @@
 
 #import "DOMElementInternal.h"
 #import "DOMHTMLCollectionInternal.h"
+#import "DOMNodeInternal.h"
+#import "DOMNodeListInternal.h"
 #import "ExceptionHandlers.h"
 #import <WebCore/DocumentFragment.h>
 #import <WebCore/JSExecState.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTableSectionElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTableSectionElement.mm
@@ -32,6 +32,7 @@
 #import <WebCore/HTMLCollection.h>
 #import <WebCore/HTMLElement.h>
 #import <WebCore/HTMLNames.h>
+#import <WebCore/HTMLTableRowElement.h>
 #import <WebCore/HTMLTableSectionElement.h>
 #import <WebCore/JSExecState.h>
 #import <WebCore/ThreadCheck.h>

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
@@ -38,6 +38,10 @@
 
 #import <wtf/SetForScope.h>
 
+#if PLATFORM(MAC)
+#import <pal/spi/mac/NSWindowSPI.h>
+#endif
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebViewRenderingUpdateScheduler);
 
 WebViewRenderingUpdateScheduler::WebViewRenderingUpdateScheduler(WebView* webView)

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2790,10 +2790,6 @@ def check_using_namespace(clean_lines, line_number, file_extension, error):
       error: The function to call with any errors found.
     """
 
-    # This check applies only to headers.
-    if file_extension != 'h':
-        return
-
     line = clean_lines.elided[line_number]  # Get rid of comments and strings.
 
     using_namespace_match = match(r'\s*using\s+namespace\s+(?P<method_name>\S+)\s*;\s*$', line)
@@ -2801,8 +2797,25 @@ def check_using_namespace(clean_lines, line_number, file_extension, error):
         return
 
     method_name = using_namespace_match.group('method_name')
-    error(line_number, 'build/using_namespace', 4,
-          "Do not use 'using namespace %s;'." % method_name)
+
+    if file_extension == 'h':
+        error(line_number, 'build/using_namespace', 4,
+              "Do not use 'using namespace %s;'." % method_name)
+        return
+
+    # In implementation files, only flag true file scope: a using-directive that
+    # appears before any 'namespace X {' opener. Inside a namespace body the
+    # directive is contained, which is the recommended fix; inside a function
+    # (indented) it is scoped.
+    if file_extension in ('cpp', 'cc', 'mm', 'm') and not line.startswith((' ', '\t')):
+        if method_name.startswith('std::literals'):
+            return
+        for preceding in clean_lines.elided[:line_number]:
+            if match(r'\s*namespace\s+[\w:]*\s*{', preceding):
+                return
+        error(line_number, 'build/using_namespace', 4,
+              "Do not use 'using namespace %s;' at file or namespace scope; "
+              "global using namespace is likely to cause name collisions in the unified build." % method_name)
 
 
 def check_max_min_macros(clean_lines, line_number, file_state, error):

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6047,6 +6047,35 @@ class WebKitStyleTest(CppStyleTestBase):
             "  [build/using_namespace] [4]",
             'foo.h')
 
+        self.assert_lint(
+            'using namespace WebCore;',
+            "Do not use 'using namespace WebCore;' at file or namespace scope; "
+            "global using namespace is likely to cause name collisions in the unified build."
+            "  [build/using_namespace] [4]",
+            'foo.cpp')
+
+        self.assert_lint(
+            'using namespace WebKit;',
+            "Do not use 'using namespace WebKit;' at file or namespace scope; "
+            "global using namespace is likely to cause name collisions in the unified build."
+            "  [build/using_namespace] [4]",
+            'foo.mm')
+
+        # Function-scope (indented) using-directives are fine.
+        self.assert_lint('    using namespace WebCore;', '', 'foo.cpp')
+
+        # Inside a namespace body the directive is contained, which is the
+        # recommended fix for unified-build collisions.
+        self.assert_multi_line_lint(
+            'namespace WebCore {\n'
+            'using namespace JSC;\n'
+            '}\n',
+            '', 'foo.cpp')
+
+        # std::literals namespaces are exempt at file scope.
+        self.assert_lint('using namespace std::literals;', '', 'foo.cpp')
+        self.assert_lint('using namespace std::literals::chrono_literals;', '', 'foo.cpp')
+
     def test_max_macro(self):
         self.assert_lint(
             'int i = MAX(0, 1);',

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DecidePolicyForNavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DecidePolicyForNavigationAction.mm
@@ -47,7 +47,7 @@
 static bool shouldCancelNavigation;
 static bool shouldDelayDecision;
 static bool decidedPolicy;
-static bool finishedNavigation;
+static bool decidePolicyFinishedNavigation;
 static RetainPtr<WKNavigationAction> action;
 static RetainPtr<WKWebView> newWebView;
 static BlockPtr<void(WKNavigationActionPolicy)> delayedDecision;
@@ -89,7 +89,7 @@ static NSString *thirdURL = @"data:text/html,Third";
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    finishedNavigation = true;
+    decidePolicyFinishedNavigation = true;
 }
 
 - (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
@@ -114,9 +114,9 @@ TEST(WebKit, DecidePolicyForNavigationActionReload)
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:firstURL]]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
     decidedPolicy = false;
     [webView reload];
@@ -144,9 +144,9 @@ TEST(WebKit, DecidePolicyForNavigationActionReloadFromOrigin)
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:firstURL]]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
     decidedPolicy = false;
     [webView reloadFromOrigin];
@@ -174,13 +174,13 @@ TEST(WebKit, DecidePolicyForNavigationActionGoBack)
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:firstURL]]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:secondURL]]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
     decidedPolicy = false;
     [webView goBack];
@@ -208,17 +208,17 @@ TEST(WebKit, DecidePolicyForNavigationActionGoForward)
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:firstURL]]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:secondURL]]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView goBack];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
     decidedPolicy = false;
     [webView goForward];
@@ -241,25 +241,25 @@ TEST(WebKit, DecidePolicyForNavigationActionCancelAndGoBack)
     RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:firstURL]]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:secondURL]]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     shouldCancelNavigation = true;
     decidedPolicy = false;
     [webView goBack];
     TestWebKitAPI::Util::run(&decidedPolicy);
     [webView waitForNextPresentationUpdate];
-    EXPECT_FALSE(finishedNavigation);
+    EXPECT_FALSE(decidePolicyFinishedNavigation);
 
     shouldCancelNavigation = false;
     [webView goBack];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
     EXPECT_WK_STREQ(firstURL, [webView URL].absoluteString);
 
     newWebView = nullptr;
@@ -412,9 +412,9 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedHyperlink)
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadHTMLString:@"<a style=\"display: block; height: 100%\" href=\"https://webkit.org/destination2.html\" target=\"B\">" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
     didCreateWebView = false;
     [webView evaluateJavaScript:@"window.open(\"https://webkit.org/destination1.html\", \"B\")" completionHandler:nil];
@@ -468,10 +468,10 @@ TEST(WebKit, DecidePolicyForNavigationActionForLoadHTMLStringAllow)
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     decidedPolicy = false;
     [webView loadHTMLString:@"TEST" baseURL:[NSURL URLWithString:@"about:blank"]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
     EXPECT_TRUE(decidedPolicy);
 }
 
@@ -487,11 +487,11 @@ TEST(WebKit, DecidePolicyForNavigationActionForLoadHTMLStringDeny)
     [webView setUIDelegate:controller.get()];
 
     shouldCancelNavigation = true;
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     decidedPolicy = false;
     [webView loadHTMLString:@"TEST" baseURL:[NSURL URLWithString:@"about:blank"]];
     TestWebKitAPI::Util::runFor(0.5_s);
-    EXPECT_FALSE(finishedNavigation);
+    EXPECT_FALSE(decidePolicyFinishedNavigation);
     shouldCancelNavigation = false;
 }
 
@@ -506,9 +506,9 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedWindowOpen)
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadHTMLString:@"<a style=\"display: block; height: 100%\" href=\"javascript:window.open('https://webkit.org/destination2.html', 'B')\">" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
     didCreateWebView = false;
     [webView evaluateJavaScript:@"window.open(\"https://webkit.org/destination1.html\", \"B\")" completionHandler:nil];
@@ -557,9 +557,9 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedFormSubmission)
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadHTMLString:@"<form action=\"https://webkit.org/destination1.html\" target=\"B\"><input type=\"submit\" name=\"submit\" value=\"Submit\" style=\"-webkit-appearance: none; height: 100%; width: 100%\"></form>" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
     didCreateWebView = false;
     [webView evaluateJavaScript:@"window.open(\"https://webkit.org/destination2.html\", \"B\")" completionHandler:nil];
@@ -621,9 +621,9 @@ static void runDecidePolicyForNavigationActionForHyperlinkThatRedirects(ShouldEn
     [webView setUIDelegate:controller.get()];
 
     [TestProtocol registerWithScheme:@"http"];
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadHTMLString:@"<a style=\"display: block; height: 100%\" href=\"http://redirect/?result\">" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
     decidedPolicy = false;
     [newWebView setNavigationDelegate:controller.get()];
@@ -686,9 +686,9 @@ TEST(WebKit, DecidePolicyForNavigationActionForPOSTFormSubmissionThatRedirectsTo
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadHTMLString:@"<form action=\"http://redirect/?result\" method=\"POST\"><input type=\"submit\" name=\"submitButton\" value=\"Submit\"></form>" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
     [TestProtocol registerWithScheme:@"http"];
     decidedPolicy = false;
@@ -733,9 +733,9 @@ TEST(WebKit, DecidePolicyForNavigationActionForPOSTFormSubmissionThatRedirectsTo
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
-    finishedNavigation = false;
+    decidePolicyFinishedNavigation = false;
     [webView loadHTMLString:@"<form action=\"http://307-redirect/?result\" method=\"POST\"><input type=\"submit\" name=\"submitButton\" value=\"Submit\"></form>" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&decidePolicyFinishedNavigation);
 
     [TestProtocol registerWithScheme:@"http"];
     decidedPolicy = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ExitFullscreenOnEnterPiP.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ExitFullscreenOnEnterPiP.mm
@@ -37,8 +37,8 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/Seconds.h>
 
-static bool didEnterFullscreen;
-static bool didExitFullscreen;
+static bool pipDidEnterFullscreen;
+static bool pipDidExitFullscreen;
 
 @interface ExitFullscreenOnEnterPiPUIDelegate : NSObject <WKUIDelegate, _WKFullscreenDelegate>
 @end
@@ -55,12 +55,12 @@ static bool didExitFullscreen;
 
 - (void)_webViewDidEnterFullscreen:(WKWebView *)webView
 {
-    didEnterFullscreen = true;
+    pipDidEnterFullscreen = true;
 }
 
 - (void)_webViewDidExitFullscreen:(WKWebView *)webView
 {
-    didExitFullscreen = true;
+    pipDidExitFullscreen = true;
 }
 @end
 
@@ -83,16 +83,16 @@ TEST(ExitFullscreenOnEnterPiP, VideoFullscreen)
 
     [webView synchronouslyLoadTestPageNamed:@"ExitFullscreenOnEnterPiP"];
 
-    didEnterFullscreen = false;
+    pipDidEnterFullscreen = false;
     [webView evaluateJavaScript:@"document.getElementById('enter-video-fullscreen').click()" completionHandler: nil];
-    TestWebKitAPI::Util::run(&didEnterFullscreen);
-    ASSERT_TRUE(didEnterFullscreen);
+    TestWebKitAPI::Util::run(&pipDidEnterFullscreen);
+    ASSERT_TRUE(pipDidEnterFullscreen);
 
     didEnterPiP = false;
-    didExitFullscreen = false;
+    pipDidExitFullscreen = false;
     [webView evaluateJavaScript:@"document.getElementById('enter-pip').click()" completionHandler: nil];
     TestWebKitAPI::Util::run(&didEnterPiP);
-    TestWebKitAPI::Util::run(&didExitFullscreen);
+    TestWebKitAPI::Util::run(&pipDidExitFullscreen);
 
     sleep(1_s); // Wait for PIPAgent to launch, or it won't call -pipDidClose: callback.
 
@@ -123,10 +123,10 @@ TEST(ExitFullscreenOnEnterPiP, DISABLED_ElementFullscreen)
         @"WebKit2Logging": @"",
     }];
 
-    didEnterFullscreen = false;
+    pipDidEnterFullscreen = false;
     [webView evaluateJavaScript:@"document.getElementById('enter-element-fullscreen').click()" completionHandler: nil];
-    ASSERT_TRUE(TestWebKitAPI::Util::runFor(&didEnterFullscreen, 10_s));
-    ASSERT_TRUE(didEnterFullscreen);
+    ASSERT_TRUE(TestWebKitAPI::Util::runFor(&pipDidEnterFullscreen, 10_s));
+    ASSERT_TRUE(pipDidEnterFullscreen);
 
     // Make the video the "main content" by playing with a user gesture.
     __block bool didBeginPlaying = false;
@@ -135,10 +135,10 @@ TEST(ExitFullscreenOnEnterPiP, DISABLED_ElementFullscreen)
     ASSERT_TRUE(TestWebKitAPI::Util::runFor(&didBeginPlaying, 10_s));
 
     didEnterPiP = false;
-    didExitFullscreen = false;
+    pipDidExitFullscreen = false;
     [webView evaluateJavaScript:@"document.getElementById('enter-pip').click()" completionHandler: nil];
     ASSERT_TRUE(TestWebKitAPI::Util::runFor(&didEnterPiP, 10_s));
-    ASSERT_TRUE(TestWebKitAPI::Util::runFor(&didExitFullscreen, 10_s));
+    ASSERT_TRUE(TestWebKitAPI::Util::runFor(&pipDidExitFullscreen, 10_s));
 
     sleep(1_s); // Wait for PIPAgent to launch, or it won't call -pipDidClose: callback.
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ImageAnalysisTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ImageAnalysisTests.mm
@@ -46,7 +46,7 @@
 #import <pal/cocoa/VisionKitCoreSoftLink.h>
 #import <pal/spi/cocoa/VisionKitCoreSPI.h>
 
-static unsigned gDidProcessRequestCount = 0;
+static unsigned gImageAnalysisDidProcessRequestCount = 0;
 
 #if PLATFORM(IOS_FAMILY)
 
@@ -78,25 +78,25 @@ static CGPoint swizzledLocationInView(id, SEL, UIView *)
 - (void)waitForImageAnalysisRequests:(unsigned)numberOfRequests
 {
     TestWebKitAPI::Util::waitForConditionWithLogging([&] {
-        return gDidProcessRequestCount == numberOfRequests;
+        return gImageAnalysisDidProcessRequestCount == numberOfRequests;
     }, 3, @"Timed out waiting for %u image analysis requests to complete.", numberOfRequests);
 
     [self waitForNextPresentationUpdate];
-    EXPECT_EQ(gDidProcessRequestCount, numberOfRequests);
+    EXPECT_EQ(gImageAnalysisDidProcessRequestCount, numberOfRequests);
 }
 
 #if PLATFORM(IOS_FAMILY)
 
 - (unsigned)simulateImageAnalysisGesture:(CGPoint)location
 {
-    auto numberOfRequestsAtStart = gDidProcessRequestCount;
+    auto numberOfRequestsAtStart = gImageAnalysisDidProcessRequestCount;
     gSwizzledLocationInView = location;
     InstanceMethodSwizzler gestureLocationSwizzler { UILongPressGestureRecognizer.class, @selector(locationInView:), reinterpret_cast<IMP>(swizzledLocationInView) };
     [self.textInputContentView imageAnalysisGestureDidBegin:self._imageAnalysisGestureRecognizer];
     // The process of image analysis involves at most 2 round trips to the web process.
     [self waitForNextPresentationUpdate];
     [self waitForNextPresentationUpdate];
-    return gDidProcessRequestCount - numberOfRequestsAtStart;
+    return gImageAnalysisDidProcessRequestCount - numberOfRequestsAtStart;
 }
 
 #endif // PLATFORM(IOS_FAMILY)
@@ -128,14 +128,14 @@ static RetainPtr<TestWKWebView> createWebViewWithTextRecognitionEnhancements()
 
 static void processRequestWithError(id, SEL, VKImageAnalyzerRequest *request, void (^)(double progress), void (^completion)(VKImageAnalysis *analysis, NSError *error))
 {
-    gDidProcessRequestCount++;
+    gImageAnalysisDidProcessRequestCount++;
     processedRequests().append({ request });
     completion(nil, [NSError errorWithDomain:NSCocoaErrorDomain code:1 userInfo:nil]);
 }
 
 static void processRequestWithResults(id, SEL, VKImageAnalyzerRequest *request, void (^)(double progress), void (^completion)(VKImageAnalysis *, NSError *))
 {
-    gDidProcessRequestCount++;
+    gImageAnalysisDidProcessRequestCount++;
     processedRequests().append({ request });
     completion(createImageAnalysisWithSimpleFixedResults().get(), nil);
 }
@@ -146,7 +146,7 @@ static VKImageAnalyzerRequest *makeFakeRequest(id, SEL, CGImageRef image, VKImag
 }
 
 template <typename FunctionType>
-std::pair<std::unique_ptr<InstanceMethodSwizzler>, std::unique_ptr<InstanceMethodSwizzler>> makeImageAnalysisRequestSwizzler(FunctionType function)
+std::pair<std::unique_ptr<InstanceMethodSwizzler>, std::unique_ptr<InstanceMethodSwizzler>> imageAnalysisMakeRequestSwizzler(FunctionType function)
 {
     return std::pair {
         makeUnique<InstanceMethodSwizzler>(PAL::getVKImageAnalyzerClassSingleton(), @selector(processRequest:progressHandler:completionHandler:), reinterpret_cast<IMP>(function)),
@@ -158,7 +158,7 @@ std::pair<std::unique_ptr<InstanceMethodSwizzler>, std::unique_ptr<InstanceMetho
 
 TEST(ImageAnalysisTests, DoNotAnalyzeImagesInEditableContent)
 {
-    auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithError);
+    auto requestSwizzler = imageAnalysisMakeRequestSwizzler(processRequestWithError);
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     [webView _setEditable:YES];
@@ -168,7 +168,7 @@ TEST(ImageAnalysisTests, DoNotAnalyzeImagesInEditableContent)
 
 TEST(ImageAnalysisTests, HandleImageAnalyzerErrors)
 {
-    auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithError);
+    auto requestSwizzler = imageAnalysisMakeRequestSwizzler(processRequestWithError);
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"image"];
@@ -178,7 +178,7 @@ TEST(ImageAnalysisTests, HandleImageAnalyzerErrors)
 
 TEST(ImageAnalysisTests, DoNotCrashWhenHitTestingOutsideOfWebView)
 {
-    auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithError);
+    auto requestSwizzler = imageAnalysisMakeRequestSwizzler(processRequestWithError);
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"image"];
@@ -189,7 +189,7 @@ TEST(ImageAnalysisTests, DoNotCrashWhenHitTestingOutsideOfWebView)
 
 TEST(ImageAnalysisTests, AvoidRedundantTextRecognitionRequests)
 {
-    auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithResults);
+    auto requestSwizzler = imageAnalysisMakeRequestSwizzler(processRequestWithResults);
 
     auto webView = createWebViewWithTextRecognitionEnhancements();
     [webView synchronouslyLoadTestPageNamed:@"image"];
@@ -204,7 +204,7 @@ TEST(ImageAnalysisTests, AvoidRedundantTextRecognitionRequests)
 
 TEST(ImageAnalysisTests, StartImageAnalysisWithoutIdentifier)
 {
-    auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithResults);
+    auto requestSwizzler = imageAnalysisMakeRequestSwizzler(processRequestWithResults);
 
     auto webView = createWebViewWithTextRecognitionEnhancements();
     [webView synchronouslyLoadTestPageNamed:@"multiple-images"];
@@ -219,7 +219,7 @@ TEST(ImageAnalysisTests, StartImageAnalysisWithoutIdentifier)
 
 TEST(ImageAnalysisTests, AnalyzeImagesInSubframes)
 {
-    auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithResults);
+    auto requestSwizzler = imageAnalysisMakeRequestSwizzler(processRequestWithResults);
 
     auto webView = createWebViewWithTextRecognitionEnhancements();
     [webView synchronouslyLoadTestPageNamed:@"multiple-images"];
@@ -236,7 +236,7 @@ TEST(ImageAnalysisTests, AnalyzeImagesInSubframes)
 
 TEST(ImageAnalysisTests, AnalyzeImageAfterChangingSource)
 {
-    auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithResults);
+    auto requestSwizzler = imageAnalysisMakeRequestSwizzler(processRequestWithResults);
 
     auto webView = createWebViewWithTextRecognitionEnhancements();
     [webView synchronouslyLoadTestPageNamed:@"image"];
@@ -249,7 +249,7 @@ TEST(ImageAnalysisTests, AnalyzeImageAfterChangingSource)
 
 TEST(ImageAnalysisTests, AnalyzeDynamicallyLoadedImages)
 {
-    auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithResults);
+    auto requestSwizzler = imageAnalysisMakeRequestSwizzler(processRequestWithResults);
 
     auto webView = createWebViewWithTextRecognitionEnhancements();
     [webView synchronouslyLoadTestPageNamed:@"multiple-images"];
@@ -266,12 +266,12 @@ TEST(ImageAnalysisTests, AnalyzeDynamicallyLoadedImages)
     [webView waitForNextPresentationUpdate];
     [webView objectByEvaluatingJavaScript:@"showAllImages()"];
     [webView waitForNextPresentationUpdate];
-    EXPECT_EQ(gDidProcessRequestCount, 7U);
+    EXPECT_EQ(gImageAnalysisDidProcessRequestCount, 7U);
 }
 
 TEST(ImageAnalysisTests, ResetImageAnalysisAfterNavigation)
 {
-    auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithResults);
+    auto requestSwizzler = imageAnalysisMakeRequestSwizzler(processRequestWithResults);
 
     auto webView = createWebViewWithTextRecognitionEnhancements();
     [webView synchronouslyLoadTestPageNamed:@"multiple-images"];
@@ -283,12 +283,12 @@ TEST(ImageAnalysisTests, ResetImageAnalysisAfterNavigation)
 
     [webView synchronouslyLoadTestPageNamed:@"multiple-images"];
     [webView waitForNextPresentationUpdate];
-    EXPECT_EQ(gDidProcessRequestCount, 5U);
+    EXPECT_EQ(gImageAnalysisDidProcessRequestCount, 5U);
 }
 
 TEST(ImageAnalysisTests, ImageAnalysisPrioritizesVisibleImages)
 {
-    auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithResults);
+    auto requestSwizzler = imageAnalysisMakeRequestSwizzler(processRequestWithResults);
     auto webView = createWebViewWithTextRecognitionEnhancements();
     [webView synchronouslyLoadTestPageNamed:@"offscreen-image"];
     [webView _startImageAnalysis:nil target:nil];
@@ -304,7 +304,7 @@ TEST(ImageAnalysisTests, ImageAnalysisPrioritizesVisibleImages)
 
 TEST(ImageAnalysisTests, ImageAnalysisWithTransparentImages)
 {
-    auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithError);
+    auto requestSwizzler = imageAnalysisMakeRequestSwizzler(processRequestWithError);
     auto webView = createWebViewWithTextRecognitionEnhancements();
     [webView synchronouslyLoadTestPageNamed:@"fade-in-image"];
     [webView _startImageAnalysis:@"en_US" target:@"zh_TW"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBPersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBPersistence.mm
@@ -445,7 +445,7 @@ TEST(IndexedDB, MigrateThirdPartyDataToGeneralStorageDirectory)
     EXPECT_TRUE([fileManager fileExistsAtPath:webkitIframeDatabaseFile.path]);
 }
 
-static const char* workerBytes = R"TESTRESOURCE(
+static const char* indexedDBWorkerBytes = R"TESTRESOURCE(
 try {
     var request = indexedDB.open('IndexedDBThirdPartyWorkerHasAccess');
     var db = null;
@@ -493,7 +493,7 @@ TEST(IndexedDB, IndexedDBThirdPartyWorkerHasAccess)
         } else {
             EXPECT_WK_STREQ("iframe:///worker.js", requestURL.absoluteString);
             response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/javascript" expectedContentLength:0 textEncodingName:nil]);
-            data = [NSData dataWithBytes:workerBytes length:strlen(workerBytes)];
+            data = [NSData dataWithBytes:indexedDBWorkerBytes length:strlen(indexedDBWorkerBytes)];
         }
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JavaScriptDuringNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JavaScriptDuringNavigation.mm
@@ -30,11 +30,11 @@
 #import <WebKit/WKWebView.h>
 #import <wtf/RetainPtr.h>
 
-static bool navigationComplete;
+static bool jsNavigationComplete;
 static size_t alerts;
 static bool receivedBothAlerts;
-static RetainPtr<NSURL> firstURL;
-static RetainPtr<NSURL> secondURL;
+static RetainPtr<NSURL> jsNavigationFirstURL;
+static RetainPtr<NSURL> jsNavigationSecondURL;
 
 @interface JSNavigationDelegate : NSObject <WKNavigationDelegate, WKUIDelegate>
 @end
@@ -43,12 +43,12 @@ static RetainPtr<NSURL> secondURL;
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    navigationComplete = true;
+    jsNavigationComplete = true;
 }
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
-    if ([navigationAction.request.URL.absoluteString isEqualToString:[secondURL absoluteString]]) {
+    if ([navigationAction.request.URL.absoluteString isEqualToString:[jsNavigationSecondURL absoluteString]]) {
         [webView evaluateJavaScript:@"alert(document.location);" completionHandler:^(id, NSError *) {
             decisionHandler(WKNavigationActionPolicyAllow);
         }];
@@ -58,7 +58,7 @@ static RetainPtr<NSURL> secondURL;
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler
 {
-    if ([navigationResponse.response.URL.absoluteString isEqualToString:[secondURL absoluteString]]) {
+    if ([navigationResponse.response.URL.absoluteString isEqualToString:[jsNavigationSecondURL absoluteString]]) {
         [webView evaluateJavaScript:@"alert(document.location);" completionHandler:^(id, NSError *) {
             decisionHandler(WKNavigationResponsePolicyAllow);
         }];
@@ -68,7 +68,7 @@ static RetainPtr<NSURL> secondURL;
 
 - (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler
 {
-    EXPECT_STREQ(message.UTF8String, [[firstURL absoluteString] UTF8String]);
+    EXPECT_STREQ(message.UTF8String, [[jsNavigationFirstURL absoluteString] UTF8String]);
     if (++alerts == 2)
         receivedBothAlerts = true;
     completionHandler();
@@ -78,17 +78,17 @@ static RetainPtr<NSURL> secondURL;
 
 TEST(WebKit, JavaScriptDuringNavigation)
 {
-    firstURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    secondURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    jsNavigationFirstURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    jsNavigationSecondURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     
     RetainPtr webView = adoptNS([[WKWebView alloc] init]);
     RetainPtr delegate = adoptNS([[JSNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
-    [webView loadRequest:[NSURLRequest requestWithURL:firstURL.get()]];
-    TestWebKitAPI::Util::run(&navigationComplete);
+    [webView loadRequest:[NSURLRequest requestWithURL:jsNavigationFirstURL.get()]];
+    TestWebKitAPI::Util::run(&jsNavigationComplete);
 
-    [webView loadRequest:[NSURLRequest requestWithURL:secondURL.get()]];
+    [webView loadRequest:[NSURLRequest requestWithURL:jsNavigationSecondURL.get()]];
     TestWebKitAPI::Util::run(&receivedBothAlerts);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAndDecodeImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAndDecodeImage.mm
@@ -44,7 +44,7 @@
 
 namespace TestWebKitAPI {
 
-static bool done;
+static bool loadAndDecodeDone;
 
 TEST(WebKit, LoadAndDecodeImage)
 {
@@ -77,13 +77,13 @@ TEST(WebKit, LoadAndDecodeImage)
     auto imageOrError = [&] (auto requestPath, CGSize size = CGSizeZero) -> Expected<RetainPtr<Util::PlatformImage>, RetainPtr<NSError>> {
         __block RetainPtr<Util::PlatformImage> image;
         __block RetainPtr<NSError> error;
-        __block bool done { false };
+        __block bool loadAndDecodeDone { false };
         [webView _loadAndDecodeImage:server.request(requestPath) constrainedToSize:size maximumBytesFromNetwork:std::numeric_limits<size_t>::max() completionHandler:^(Util::PlatformImage *imageResult, NSError *errorResult) {
             image = imageResult;
             error = errorResult;
-            done = true;
+            loadAndDecodeDone = true;
         }];
-        Util::run(&done);
+        Util::run(&loadAndDecodeDone);
         EXPECT_NE(!image, !error);
         if (image)
             return image;
@@ -140,34 +140,34 @@ TEST(WebKit, LoadAndDecodeImage)
     [navigationDelegate allowAnyTLSCertificate];
     webView.get().navigationDelegate = navigationDelegate.get();
 
-    __block bool done { false };
+    __block bool loadAndDecodeDone { false };
     [webView _loadAndDecodeImage:tlsServer.request() constrainedToSize:CGSizeZero maximumBytesFromNetwork:36541 completionHandler:^(Util::PlatformImage *image, NSError *error) {
         EXPECT_EQ(image.size.height, 174);
         EXPECT_EQ(image.size.width, 215);
         EXPECT_NULL(error);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     [webView _loadAndDecodeImage:tlsServer.request() constrainedToSize:CGSizeZero maximumBytesFromNetwork:36540 completionHandler:^(Util::PlatformImage *image, NSError *error) {
         EXPECT_NULL(image);
         EXPECT_EQ(error.code, NSURLErrorDataLengthExceedsMaximum);
         EXPECT_WK_STREQ(error.domain, NSURLErrorDomain);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     [webView _loadAndDecodeImage:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://127.0.0.1:1/"]] constrainedToSize:CGSizeZero maximumBytesFromNetwork:std::numeric_limits<size_t>::max() completionHandler:^(Util::PlatformImage *image, NSError *error) {
         EXPECT_NULL(image);
         EXPECT_EQ(error.code, 103);
         EXPECT_WK_STREQ(error.domain, "WebKitErrorDomain");
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     RetainPtr syncedWebView = adoptNS([TestWKWebView new]);
     [syncedWebView synchronouslyLoadHTMLString:@""];
     [syncedWebView _close];
@@ -175,15 +175,15 @@ TEST(WebKit, LoadAndDecodeImage)
         EXPECT_NULL(image);
         EXPECT_EQ(error.code, NSURLErrorCannotDecodeContentData);
         EXPECT_WK_STREQ(error.domain, "NSURLErrorDomain");
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 }
 
 TEST(WebKit, GetInformationFromImageData)
 {
     RetainPtr webView = adoptNS([WKWebView new]);
-    done = false;
+    loadAndDecodeDone = false;
     RetainPtr pngData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]];
     [webView _getInformationFromImageData:pngData.get() completionHandler:^(NSString *typeIdentifier, NSArray<NSValue *> *availableSizes, NSError *error) {
         EXPECT_NULL(error);
@@ -192,11 +192,11 @@ TEST(WebKit, GetInformationFromImageData)
         NSValue *size = [availableSizes firstObject];
         EXPECT_EQ(215, [size sizeValue].width);
         EXPECT_EQ(174, [size sizeValue].height);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     RetainPtr gifData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"apple" withExtension:@"gif"]];
     [webView _getInformationFromImageData:gifData.get() completionHandler:^(NSString *typeIdentifier, NSArray<NSValue *> *availableSizes, NSError *error) {
         EXPECT_NULL(error);
@@ -206,35 +206,35 @@ TEST(WebKit, GetInformationFromImageData)
             EXPECT_EQ(52, [size sizeValue].width);
             EXPECT_EQ(64, [size sizeValue].height);
         }
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     RetainPtr svgData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"AllAhem" withExtension:@"svg"]];
     [webView _getInformationFromImageData:svgData.get() completionHandler:^(NSString *typeIdentifier, NSArray<NSValue *> *availableSizes, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_TRUE([typeIdentifier isEqualToString:UTTypeSVG.identifier]);
         EXPECT_EQ(0u, availableSizes.count);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     RetainPtr pdfData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView _getInformationFromImageData:pdfData.get() completionHandler:^(NSString *typeIdentifier, NSArray<NSValue *> *availableSizes, NSError *error) {
         EXPECT_NOT_NULL(error);
         EXPECT_NULL(typeIdentifier);
         EXPECT_EQ(0u, availableSizes.count);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 }
 
 TEST(WebKit, GetImageMetadata)
 {
     RetainPtr webView = adoptNS([WKWebView new]);
-    done = false;
+    loadAndDecodeDone = false;
     RetainPtr pngData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]];
     [webView _getImageMetadata:pngData.get() completionHandler:^(NSDictionary *metadata, NSError *error) {
         EXPECT_NULL(error);
@@ -244,11 +244,11 @@ TEST(WebKit, GetImageMetadata)
         EXPECT_EQ(72, [metadata[@"DPIWidth"] floatValue]);
         EXPECT_EQ(72, [metadata[@"DPIHeight"] floatValue]);
         EXPECT_EQ(1, [metadata[@"ImageCount"] intValue]);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     RetainPtr gifData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"animated-red-green-blue-repeat-infinite" withExtension:@"gif"]];
     [webView _getImageMetadata:gifData.get() completionHandler:^(NSDictionary *metadata, NSError *error) {
         EXPECT_NULL(error);
@@ -257,11 +257,11 @@ TEST(WebKit, GetImageMetadata)
         EXPECT_EQ(72, [metadata[@"DPIWidth"] floatValue]);
         EXPECT_EQ(72, [metadata[@"DPIHeight"] floatValue]);
         EXPECT_EQ(3, [metadata[@"ImageCount"] intValue]);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     RetainPtr tiffData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-100px" withExtension:@"tiff"]];
     [webView _getImageMetadata:tiffData.get() completionHandler:^(NSDictionary *metadata, NSError *error) {
         EXPECT_NULL(error);
@@ -270,18 +270,18 @@ TEST(WebKit, GetImageMetadata)
         EXPECT_EQ(72, [metadata[@"DPIWidth"] floatValue]);
         EXPECT_EQ(72, [metadata[@"DPIHeight"] floatValue]);
         EXPECT_EQ(1, [metadata[@"ImageCount"] intValue]);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     RetainPtr svgData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"AllAhem" withExtension:@"svg"]];
     [webView _getImageMetadata:svgData.get() completionHandler:^(NSDictionary *metadata, NSError *error) {
         EXPECT_NOT_NULL(error);
         EXPECT_EQ(0u, [metadata count]);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 }
 
 TEST(WebKit, GetInformationFromImageDataAfterClosingWebView)
@@ -289,13 +289,13 @@ TEST(WebKit, GetInformationFromImageDataAfterClosingWebView)
     RetainPtr webView = adoptNS([WKWebView new]);
     [webView _close];
 
-    done = false;
+    loadAndDecodeDone = false;
     RetainPtr pngData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]];
     [webView _getInformationFromImageData:pngData.get() completionHandler:^(NSString *typeIdentifier, NSArray<NSValue *> *availableSizes, NSError *error) {
         EXPECT_NOT_NULL(error);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 }
 
 TEST(WebKit, CreateIconDataFromImageData)
@@ -306,34 +306,34 @@ TEST(WebKit, CreateIconDataFromImageData)
     RetainPtr length2 = [NSNumber numberWithUnsignedInt:256];
     NSArray *lengths = @[length1.get(), length2.get()];
     __block RetainPtr<NSData> iconData;
-    done = false;
+    loadAndDecodeDone = false;
     [webView _createIconDataFromImageData:imageData.get() withLengths:lengths completionHandler:^(NSData *result, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(result);
         iconData = result;
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     [webView _decodeImageData:iconData.get() preferredSize:[NSValue valueWithSize:NSMakeSize(16, 16)] completionHandler:^(CocoaImage *result, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(result);
         EXPECT_EQ(result.size.width, 16);
         EXPECT_EQ(result.size.height, 16);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     [webView _decodeImageData:iconData.get() preferredSize:[NSValue valueWithSize:NSMakeSize(32, 32)] completionHandler:^(CocoaImage *result, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(result);
         EXPECT_EQ(result.size.width, 256);
         EXPECT_EQ(result.size.height, 256);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 }
 
 RetainPtr<NSData> tiffRepresentation(CocoaImage *image)
@@ -364,47 +364,47 @@ TEST(WebKit, CreateIconDataFromImageDataSVG)
     RetainPtr length2 = [NSNumber numberWithUnsignedInt:256];
     NSArray *lengths = @[length1.get(), length2.get()];
     __block RetainPtr<NSData> iconData;
-    done = false;
+    loadAndDecodeDone = false;
     [webView _createIconDataFromImageData:imageData.get() withLengths:lengths completionHandler:^(NSData *result, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(result);
         iconData = result;
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     [webView _decodeImageData:iconData.get() preferredSize:nil completionHandler:^(CocoaImage *result, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(result);
         EXPECT_EQ(result.size.width, 256);
         EXPECT_EQ(result.size.height, 256);
         EXPECT_TRUE([tiffRepresentation(result) isEqualToData:expectedIconData256.get()]);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     [webView _decodeImageData:iconData.get() preferredSize:[NSValue valueWithSize:NSMakeSize(16, 16)] completionHandler:^(CocoaImage *result, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(result);
         EXPECT_EQ(result.size.width, 16);
         EXPECT_EQ(result.size.height, 16);
         EXPECT_TRUE([tiffRepresentation(result) isEqualToData:expectedIconData16.get()]);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     [webView _decodeImageData:iconData.get() preferredSize:[NSValue valueWithSize:NSMakeSize(32, 32)] completionHandler:^(CocoaImage *result, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(result);
         EXPECT_EQ(result.size.width, 256);
         EXPECT_EQ(result.size.height, 256);
         EXPECT_TRUE([tiffRepresentation(result) isEqualToData:expectedIconData256.get()]);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 }
 
 TEST(WebKit, CreateIconDataFromImageDataSVGWithSubresource)
@@ -412,7 +412,7 @@ TEST(WebKit, CreateIconDataFromImageDataSVGWithSubresource)
     RetainPtr webView = adoptNS([WKWebView new]);
     RetainPtr imageData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"icon-with-subresource" ofType:@"svg"]];
 
-    done = false;
+    loadAndDecodeDone = false;
     [webView _decodeImageData:imageData.get() preferredSize:nil completionHandler:^(CocoaImage *result, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(result);
@@ -425,17 +425,17 @@ TEST(WebKit, CreateIconDataFromImageDataSVGWithSubresource)
         EXPECT_TRUE(Util::compareColors(Util::pixelColor(result, { 3, 3 }), lime, 0.025));
         EXPECT_TRUE(Util::compareColors(Util::pixelColor(result, { 8, 8 }), lime, 0.025));
 
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
-    done = false;
+    loadAndDecodeDone = false;
     [webView _createIconDataFromImageData:imageData.get() withLengths:nil completionHandler:^(NSData *result, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(result);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 }
 
 TEST(WebKit, LoadAndDecodeImageInvalidURL)
@@ -445,13 +445,13 @@ TEST(WebKit, LoadAndDecodeImageInvalidURL)
     auto pid = [webView _webProcessIdentifier];
     EXPECT_NE(pid, 0);
 
-    __block bool done { false };
+    __block bool loadAndDecodeDone { false };
     [webView _loadAndDecodeImage:[NSURLRequest requestWithURL:[NSURL URLWithString:@""]] constrainedToSize:CGSizeZero maximumBytesFromNetwork:std::numeric_limits<size_t>::max() completionHandler:^(Util::PlatformImage *image, NSError *error) {
         EXPECT_NULL(image);
         EXPECT_NOT_NULL(error);
-        done = true;
+        loadAndDecodeDone = true;
     }];
-    Util::run(&done);
+    Util::run(&loadAndDecodeDone);
 
     EXPECT_EQ(pid, [webView _webProcessIdentifier]);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadFileThenReload.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadFileThenReload.mm
@@ -31,6 +31,8 @@
 #import <WebKit/WebKit.h>
 #import <wtf/RetainPtr.h>
 
+static bool loadFileThenReloadDone;
+
 @interface LoadFileThenReloadDelegate : NSObject <WKNavigationDelegate>
 @end
 
@@ -38,7 +40,7 @@
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    done = true;
+    loadFileThenReloadDone = true;
 }
 
 - (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error
@@ -64,5 +66,5 @@ TEST(WKWebView, LoadFileThenReload)
     [webView loadFileURL:file allowingReadAccessToURL:file.URLByDeletingLastPathComponent];
     [webView reload];
 
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&loadFileThenReloadDone);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadInvalidURLRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadInvalidURLRequest.mm
@@ -40,7 +40,7 @@ static bool didFinishTest;
 static bool didFailProvisionalLoad;
 static const char literal[] = "https://www.example.com<>/";
 
-static NSURL *literalURL(const char* literal)
+static NSURL *loadInvalidLiteralURL(const char* literal)
 {
     return WTF::URLWithData([NSData dataWithBytes:literal length:strlen(literal)], nil);
 }
@@ -123,7 +123,7 @@ TEST(WebKit, LoadInvalidURLRequest)
 
         RetainPtr<LoadInvalidURLNavigationActionDelegate> delegate = adoptNS([[LoadInvalidURLNavigationActionDelegate alloc] init]);
         [webView setNavigationDelegate:delegate.get()];
-        [webView loadRequest:[NSURLRequest requestWithURL:literalURL(literal)]];
+        [webView loadRequest:[NSURLRequest requestWithURL:loadInvalidLiteralURL(literal)]];
 
         didFinishTest = false;
         didFailProvisionalLoad = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LocalStoragePersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LocalStoragePersistence.mm
@@ -45,7 +45,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/text/WTFString.h>
 
-static RetainPtr<WKWebView> createdWebView;
+static RetainPtr<WKWebView> localStorageCreatedWebView;
 
 @interface LocalStorageMessageHandler : NSObject <WKScriptMessageHandler>
 @end
@@ -70,9 +70,9 @@ static RetainPtr<WKWebView> createdWebView;
 
 - (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
 {
-    createdWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
-    [createdWebView setNavigationDelegate:self];
-    return createdWebView.get();
+    localStorageCreatedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    [localStorageCreatedWebView setNavigationDelegate:self];
+    return localStorageCreatedWebView.get();
 }
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
@@ -382,7 +382,7 @@ TEST(WKWebView, AuxiliaryWindowsShareLocalStorage)
     TestWebKitAPI::Util::run(&finishedRunningScript);
     finishedRunningScript = false;
     
-    createdWebView = nullptr;
+    localStorageCreatedWebView = nullptr;
     [webView evaluateJavaScript:@"open(window.location)" completionHandler: [&] (id result, NSError *error) {
         finishedRunningScript = true;
     }];
@@ -392,9 +392,9 @@ TEST(WKWebView, AuxiliaryWindowsShareLocalStorage)
     TestWebKitAPI::Util::run(&didFinishNavigationBoolean);
     didFinishNavigationBoolean = false;
     
-    EXPECT_TRUE(!!createdWebView);
+    EXPECT_TRUE(!!localStorageCreatedWebView);
     
-    [createdWebView evaluateJavaScript:@"localStorage.getItem('testItem');" completionHandler: [&] (id result, NSError *error) {
+    [localStorageCreatedWebView evaluateJavaScript:@"localStorage.getItem('testItem');" completionHandler: [&] (id result, NSError *error) {
         NSString *value = (NSString *)result;
         EXPECT_WK_STREQ(@"Persistent item!", value);
         finishedRunningScript = true;
@@ -402,13 +402,13 @@ TEST(WKWebView, AuxiliaryWindowsShareLocalStorage)
     TestWebKitAPI::Util::run(&finishedRunningScript);
     finishedRunningScript = false;
     
-    [createdWebView evaluateJavaScript:@"localStorage.setItem('testItem', 'ChangedValue');" completionHandler: [&] (id result, NSError *error) {
+    [localStorageCreatedWebView evaluateJavaScript:@"localStorage.setItem('testItem', 'ChangedValue');" completionHandler: [&] (id result, NSError *error) {
         finishedRunningScript = true;
     }];
     TestWebKitAPI::Util::run(&finishedRunningScript);
     finishedRunningScript = false;
     
-    [createdWebView evaluateJavaScript:@"localStorage.getItem('testItem');" completionHandler: [&] (id result, NSError *error) {
+    [localStorageCreatedWebView evaluateJavaScript:@"localStorage.getItem('testItem');" completionHandler: [&] (id result, NSError *error) {
         NSString *value = (NSString *)result;
         EXPECT_WK_STREQ(@"ChangedValue", value);
         finishedRunningScript = true;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ModalAlerts.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ModalAlerts.mm
@@ -38,8 +38,8 @@
 
 @class ModalAlertsUIDelegate;
 
-static RetainPtr<TestWKWebView> openedWebView;
-static RetainPtr<ModalAlertsUIDelegate> sharedUIDelegate;
+static RetainPtr<TestWKWebView> modalAlertsOpenedWebView;
+static RetainPtr<ModalAlertsUIDelegate> modalAlertsUIDelegate;
 
 static unsigned dialogsSeen;
 
@@ -58,8 +58,8 @@ static void sawDialog()
     // FIXME: Remove this guard once we fix <https://bugs.webkit.org/show_bug.cgi?id=172614>.
 #if PLATFORM(MAC)
     if (dialogsSeen == dialogsBeforeUnloadConfirmPanel) {
-        [openedWebView sendClicksAtPoint:NSMakePoint(5, 5) numberOfClicks:1];
-        [openedWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"data:text/html"]]];
+        [modalAlertsOpenedWebView sendClicksAtPoint:NSMakePoint(5, 5) numberOfClicks:1];
+        [modalAlertsOpenedWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"data:text/html"]]];
         return;
     }
 #endif
@@ -75,9 +75,9 @@ static void sawDialog()
 
 - (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
 {
-    openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
-    [openedWebView setUIDelegate:sharedUIDelegate.get()];
-    return openedWebView.get();
+    modalAlertsOpenedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    [modalAlertsOpenedWebView setUIDelegate:modalAlertsUIDelegate.get()];
+    return modalAlertsOpenedWebView.get();
 }
 
 - (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler
@@ -133,8 +133,8 @@ TEST(WebKit, ModalAlerts)
 {
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    sharedUIDelegate = adoptNS([[ModalAlertsUIDelegate alloc] init]);
-    [webView setUIDelegate:sharedUIDelegate.get()];
+    modalAlertsUIDelegate = adoptNS([[ModalAlertsUIDelegate alloc] init]);
+    [webView setUIDelegate:modalAlertsUIDelegate.get()];
 
     [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm
@@ -841,7 +841,7 @@ TEST(WKNavigation, NavigationActionSPI)
     EXPECT_TRUE([delegate spiCalled]);
 }
 
-static bool navigationComplete;
+static bool navigationTestComplete;
 
 @interface BackForwardDelegate : NSObject<WKNavigationDelegatePrivate>
 @end
@@ -858,7 +858,7 @@ static bool navigationComplete;
 }
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    navigationComplete = true;
+    navigationTestComplete = true;
 }
 @end
 
@@ -868,10 +868,10 @@ TEST(WKNavigation, WillGoToBackForwardListItem)
     RetainPtr delegate = adoptNS([[BackForwardDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
-    TestWebKitAPI::Util::run(&navigationComplete);
-    navigationComplete = false;
+    TestWebKitAPI::Util::run(&navigationTestComplete);
+    navigationTestComplete = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]]];
-    TestWebKitAPI::Util::run(&navigationComplete);
+    TestWebKitAPI::Util::run(&navigationTestComplete);
     [webView goBack];
     TestWebKitAPI::Util::run(&isDone);
 }
@@ -908,7 +908,7 @@ static bool didRejectNavigation = false;
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    navigationComplete = true;
+    navigationTestComplete = true;
 }
 @end
 
@@ -936,26 +936,26 @@ static bool didRejectNavigation = false;
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    navigationComplete = true;
+    navigationTestComplete = true;
 }
 @end
 
 TEST(WKNavigation, ShouldGoToBackForwardListItem)
 {
     RetainPtr webView = adoptNS([[WKWebView alloc] init]);
-    navigationComplete = false;
+    navigationTestComplete = false;
     RetainPtr delegate = adoptNS([[BackForwardDelegateWithShouldGo alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
-    TestWebKitAPI::Util::run(&navigationComplete);
-    navigationComplete = false;
+    TestWebKitAPI::Util::run(&navigationTestComplete);
+    navigationTestComplete = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]]];
-    TestWebKitAPI::Util::run(&navigationComplete);
-    navigationComplete = false;
+    TestWebKitAPI::Util::run(&navigationTestComplete);
+    navigationTestComplete = false;
     delegate.get().targetItem = webView.get().backForwardList.backItem;
     delegate.get().allowNavigation = YES;
     [webView goBack];
-    TestWebKitAPI::Util::run(&navigationComplete);
+    TestWebKitAPI::Util::run(&navigationTestComplete);
 
     EXPECT_FALSE(didRejectNavigation);
 
@@ -964,12 +964,12 @@ TEST(WKNavigation, ShouldGoToBackForwardListItem)
     [webView goForward];
     TestWebKitAPI::Util::run(&didRejectNavigation);
 
-    navigationComplete = false;
+    navigationTestComplete = false;
     delegate.get().allowNavigation = YES;
     [webView goForward];
-    TestWebKitAPI::Util::run(&navigationComplete);
+    TestWebKitAPI::Util::run(&navigationTestComplete);
 
-    navigationComplete = false;
+    navigationTestComplete = false;
     didRejectNavigation = false;
 
     RetainPtr delegate2 = adoptNS([[BackForwardDelegateWithShouldGoSPI alloc] init]);
@@ -978,7 +978,7 @@ TEST(WKNavigation, ShouldGoToBackForwardListItem)
     delegate2.get().allowNavigation = YES;
 
     [webView goBack];
-    TestWebKitAPI::Util::run(&navigationComplete);
+    TestWebKitAPI::Util::run(&navigationTestComplete);
 
     EXPECT_FALSE(didRejectNavigation);
 
@@ -1028,7 +1028,7 @@ RetainPtr<WKBackForwardListItem> secondItem;
 }
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    navigationComplete = true;
+    navigationTestComplete = true;
 }
 @end
 
@@ -1038,10 +1038,10 @@ TEST(WKNavigation, ListItemAddedRemoved)
     RetainPtr delegate = adoptNS([[ListItemDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
-    TestWebKitAPI::Util::run(&navigationComplete);
-    navigationComplete = false;
+    TestWebKitAPI::Util::run(&navigationTestComplete);
+    navigationTestComplete = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]]];
-    TestWebKitAPI::Util::run(&navigationComplete);
+    TestWebKitAPI::Util::run(&navigationTestComplete);
     [[webView backForwardList] _removeAllItems];
     TestWebKitAPI::Util::run(&isDone);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkProcess.mm
@@ -301,17 +301,17 @@ TEST(NetworkProcess, CORSPreflightCachePartitioned)
 }
 
 
-static Vector<RetainPtr<WKScriptMessage>> receivedMessagesVector;
-static bool receivedMessage = false;
+static Vector<RetainPtr<WKScriptMessage>> networkProcessReceivedMessagesVector;
+static bool networkProcessReceivedMessage = false;
 static RetainPtr<WKScriptMessage> waitAndGetNextMessage()
 {
-    if (receivedMessagesVector.isEmpty()) {
-        receivedMessage = false;
-        TestWebKitAPI::Util::run(&receivedMessage);
+    if (networkProcessReceivedMessagesVector.isEmpty()) {
+        networkProcessReceivedMessage = false;
+        TestWebKitAPI::Util::run(&networkProcessReceivedMessage);
     }
 
-    EXPECT_EQ(receivedMessagesVector.size(), 1U);
-    return receivedMessagesVector.takeLast();
+    EXPECT_EQ(networkProcessReceivedMessagesVector.size(), 1U);
+    return networkProcessReceivedMessagesVector.takeLast();
 }
 
 @interface NetworkProcessTestMessageHandler : NSObject <WKScriptMessageHandler>
@@ -320,8 +320,8 @@ static RetainPtr<WKScriptMessage> waitAndGetNextMessage()
 @implementation NetworkProcessTestMessageHandler
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {
-    receivedMessagesVector.append(message);
-    receivedMessage = true;
+    networkProcessReceivedMessagesVector.append(message);
+    networkProcessReceivedMessage = true;
 }
 @end
 
@@ -355,8 +355,8 @@ TEST(NetworkProcess, BroadcastChannelCrashRecovery)
     RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    receivedMessage = false;
-    receivedMessagesVector.clear();
+    networkProcessReceivedMessage = false;
+    networkProcessReceivedMessagesVector.clear();
 
     NSString *html = [NSString stringWithFormat:@"<script>let bc = new BroadcastChannel('test'); bc.onmessage = (msg) => { webkit.messageHandlers.test.postMessage(msg.data); };</script>"];
     NSURL *baseURL = [NSURL URLWithString:@"http://example.com/"];
@@ -373,12 +373,12 @@ TEST(NetworkProcess, BroadcastChannelCrashRecovery)
     auto networkPID = [[WKWebsiteDataStore defaultDataStore] _networkProcessIdentifier];
     EXPECT_NE(networkPID, 0);
 
-    EXPECT_FALSE(receivedMessage);
-    EXPECT_TRUE(receivedMessagesVector.isEmpty());
+    EXPECT_FALSE(networkProcessReceivedMessage);
+    EXPECT_TRUE(networkProcessReceivedMessagesVector.isEmpty());
 
     // Test that initial communication from webView1 to webView2 works.
-    receivedMessage = false;
-    receivedMessagesVector.clear();
+    networkProcessReceivedMessage = false;
+    networkProcessReceivedMessagesVector.clear();
     bool finishedRunningScript = false;
     [webView1 evaluateJavaScript:@"bc.postMessage('foo')" completionHandler: [&] (id result, NSError *error) {
         EXPECT_TRUE(!error);
@@ -386,16 +386,16 @@ TEST(NetworkProcess, BroadcastChannelCrashRecovery)
     }];
     TestWebKitAPI::Util::run(&finishedRunningScript);
 
-    TestWebKitAPI::Util::run(&receivedMessage);
+    TestWebKitAPI::Util::run(&networkProcessReceivedMessage);
     TestWebKitAPI::Util::spinRunLoop(10);
 
-    EXPECT_EQ(receivedMessagesVector.size(), 1U);
-    EXPECT_EQ([receivedMessagesVector[0] webView], webView2);
-    EXPECT_WK_STREQ([receivedMessagesVector[0] body], @"foo");
+    EXPECT_EQ(networkProcessReceivedMessagesVector.size(), 1U);
+    EXPECT_EQ([networkProcessReceivedMessagesVector[0] webView], webView2);
+    EXPECT_WK_STREQ([networkProcessReceivedMessagesVector[0] body], @"foo");
 
     // Test that initial communication from webView2 to webView1 works.
-    receivedMessage = false;
-    receivedMessagesVector.clear();
+    networkProcessReceivedMessage = false;
+    networkProcessReceivedMessagesVector.clear();
     finishedRunningScript = false;
     [webView2 evaluateJavaScript:@"bc.postMessage('bar')" completionHandler: [&] (id result, NSError *error) {
         EXPECT_TRUE(!error);
@@ -403,12 +403,12 @@ TEST(NetworkProcess, BroadcastChannelCrashRecovery)
     }];
     TestWebKitAPI::Util::run(&finishedRunningScript);
 
-    TestWebKitAPI::Util::run(&receivedMessage);
+    TestWebKitAPI::Util::run(&networkProcessReceivedMessage);
     TestWebKitAPI::Util::spinRunLoop(10);
 
-    EXPECT_EQ(receivedMessagesVector.size(), 1U);
-    EXPECT_EQ([receivedMessagesVector[0] webView], webView1);
-    EXPECT_WK_STREQ([receivedMessagesVector[0] body], @"bar");
+    EXPECT_EQ(networkProcessReceivedMessagesVector.size(), 1U);
+    EXPECT_EQ([networkProcessReceivedMessagesVector[0] webView], webView1);
+    EXPECT_WK_STREQ([networkProcessReceivedMessagesVector[0] body], @"bar");
 
     // Kill the network process.
     kill(networkPID, 9);
@@ -418,8 +418,8 @@ TEST(NetworkProcess, BroadcastChannelCrashRecovery)
     waitUntilNetworkProcessIsResponsive(webView1.get(), webView2.get());
 
     // Test that initial communication from webView1 to webView2 works.
-    receivedMessage = false;
-    receivedMessagesVector.clear();
+    networkProcessReceivedMessage = false;
+    networkProcessReceivedMessagesVector.clear();
     finishedRunningScript = false;
     [webView1 evaluateJavaScript:@"bc.postMessage('foo2')" completionHandler: [&] (id result, NSError *error) {
         EXPECT_TRUE(!error);
@@ -427,16 +427,16 @@ TEST(NetworkProcess, BroadcastChannelCrashRecovery)
     }];
     TestWebKitAPI::Util::run(&finishedRunningScript);
 
-    TestWebKitAPI::Util::run(&receivedMessage);
+    TestWebKitAPI::Util::run(&networkProcessReceivedMessage);
     TestWebKitAPI::Util::spinRunLoop(10);
 
-    EXPECT_EQ(receivedMessagesVector.size(), 1U);
-    EXPECT_EQ([receivedMessagesVector[0] webView], webView2);
-    EXPECT_WK_STREQ([receivedMessagesVector[0] body], @"foo2");
+    EXPECT_EQ(networkProcessReceivedMessagesVector.size(), 1U);
+    EXPECT_EQ([networkProcessReceivedMessagesVector[0] webView], webView2);
+    EXPECT_WK_STREQ([networkProcessReceivedMessagesVector[0] body], @"foo2");
 
     // Test that initial communication from webView2 to webView1 works.
-    receivedMessage = false;
-    receivedMessagesVector.clear();
+    networkProcessReceivedMessage = false;
+    networkProcessReceivedMessagesVector.clear();
     finishedRunningScript = false;
     [webView2 evaluateJavaScript:@"bc.postMessage('bar2')" completionHandler: [&] (id result, NSError *error) {
         EXPECT_TRUE(!error);
@@ -444,12 +444,12 @@ TEST(NetworkProcess, BroadcastChannelCrashRecovery)
     }];
     TestWebKitAPI::Util::run(&finishedRunningScript);
 
-    TestWebKitAPI::Util::run(&receivedMessage);
+    TestWebKitAPI::Util::run(&networkProcessReceivedMessage);
     TestWebKitAPI::Util::spinRunLoop(10);
 
-    EXPECT_EQ(receivedMessagesVector.size(), 1U);
-    EXPECT_EQ([receivedMessagesVector[0] webView], webView1);
-    EXPECT_WK_STREQ([receivedMessagesVector[0] body], @"bar2");
+    EXPECT_EQ(networkProcessReceivedMessagesVector.size(), 1U);
+    EXPECT_EQ([networkProcessReceivedMessagesVector[0] webView], webView1);
+    EXPECT_WK_STREQ([networkProcessReceivedMessagesVector[0] body], @"bar2");
 
     auto networkPID2 = [[WKWebsiteDataStore defaultDataStore] _networkProcessIdentifier];
     EXPECT_NE(networkPID2, 0);
@@ -898,7 +898,7 @@ worker.onmessage = (event) => {
 </script>
 )TESTRESOURCE"_s;
 
-static constexpr auto workerBytes = R"TESTRESOURCE(
+static constexpr auto networkProcessWorkerBytes = R"TESTRESOURCE(
 caches.open("test").then(() => {
     self.postMessage('cache is opened');
 }, () => {
@@ -910,7 +910,7 @@ TEST(NetworkProcess, DoNotLaunchForDOMCacheDestruction)
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { mainBytes } },
-        { "/worker.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, workerBytes } }
+        { "/worker.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, networkProcessWorkerBytes } }
     });
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration.get().websiteDataStore _setResourceLoadStatisticsEnabled:NO];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PermissionsAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PermissionsAPI.mm
@@ -36,7 +36,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/text/StringBuilder.h>
 
-static bool didReceiveMessage;
+static bool permissionsDidReceiveMessage;
 static bool didReceiveQueryPermission;
 static WKPermissionDecision queryPermissionDelegateResult;
 static RetainPtr<WKScriptMessage> scriptMessage;
@@ -58,7 +58,7 @@ enum class GeolocationPermissionState {
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {
     scriptMessage = message;
-    didReceiveMessage = true;
+    permissionsDidReceiveMessage = true;
 }
 @end
 
@@ -112,7 +112,7 @@ TEST(PermissionsAPI, DataURL)
     [webView setUIDelegate:delegate.get()];
 
     queryPermissionDelegateResult = WKPermissionDecisionDeny;
-    didReceiveMessage = false;
+    permissionsDidReceiveMessage = false;
     didReceiveQueryPermission = false;
 
     char script[] = "<script>\
@@ -131,7 +131,7 @@ TEST(PermissionsAPI, DataURL)
     RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:buffer.createNSString().get()]).get()]);
     [webView loadRequest:request.get()];
 
-    TestWebKitAPI::Util::run(&didReceiveMessage);
+    TestWebKitAPI::Util::run(&permissionsDidReceiveMessage);
     EXPECT_STREQ(((NSString *)[scriptMessage body]).UTF8String, "prompt");
 
     EXPECT_FALSE(didReceiveQueryPermission);
@@ -148,7 +148,7 @@ TEST(PermissionsAPI, OnChange)
     [webView setUIDelegate:delegate.get()];
 
     queryPermissionDelegateResult = WKPermissionDecisionGrant;
-    didReceiveMessage = false;
+    permissionsDidReceiveMessage = false;
     didReceiveQueryPermission = false;
 
     NSString *script = @"<script>"
@@ -164,17 +164,17 @@ TEST(PermissionsAPI, OnChange)
 
     [webView synchronouslyLoadHTMLString:script baseURL:[NSURL URLWithString:@"https://example.com/"]];
 
-    TestWebKitAPI::Util::run(&didReceiveMessage);
+    TestWebKitAPI::Util::run(&permissionsDidReceiveMessage);
     EXPECT_STREQ(((NSString *)[scriptMessage body]).UTF8String, "granted");
 
-    didReceiveMessage = false;
+    permissionsDidReceiveMessage = false;
     queryPermissionDelegateResult = WKPermissionDecisionPrompt;
 
     auto originString = adoptWK(WKStringCreateWithUTF8CString("https://example.com/"));
     auto origin = adoptWK(WKSecurityOriginCreateFromString(originString.get()));
     [WKWebView _permissionChanged:@"geolocation" forOrigin:(__bridge WKSecurityOrigin *)origin.get()];
 
-    TestWebKitAPI::Util::run(&didReceiveMessage);
+    TestWebKitAPI::Util::run(&permissionsDidReceiveMessage);
     EXPECT_STREQ(((NSString *)[scriptMessage body]).UTF8String, "prompt");
 }
 
@@ -217,7 +217,7 @@ static void testPermissionsAPIForGeolocation(GeolocationPermissionState geolocat
         break;
     }
 
-    didReceiveMessage = false;
+    permissionsDidReceiveMessage = false;
     didReceiveQueryPermission = false;
 
     NSString *scriptWithGeolocationRequestedSincePageLoad = @"<script>"
@@ -251,7 +251,7 @@ static void testPermissionsAPIForGeolocation(GeolocationPermissionState geolocat
     else
         [webView synchronouslyLoadHTMLString:scriptWithoutGeolocationRequestedSincePageLoad baseURL:[NSURL URLWithString:@"https://example.com/"]];
 
-    TestWebKitAPI::Util::run(&didReceiveMessage);
+    TestWebKitAPI::Util::run(&permissionsDidReceiveMessage);
     EXPECT_STREQ(((NSString *)[scriptMessage body]).UTF8String, expectedResult.utf8().data());
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessPreWarming.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessPreWarming.mm
@@ -32,7 +32,7 @@
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <wtf/RetainPtr.h>
 
-static NSString *loadableURL = @"data:text/html,no%20error%20A";
+static NSString *preWarmingLoadableURL = @"data:text/html,no%20error%20A";
 
 TEST(WKProcessPool, WarmInitialProcess)
 {
@@ -68,7 +68,7 @@ static void runInitialWarmedProcessUsedTest(ShouldUseEphemeralStore shouldUseEph
 
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:preWarmingLoadableURL]]];
 
     EXPECT_FALSE([pool _hasPrewarmedWebProcess]);
     EXPECT_EQ(1U, [pool _webPageContentProcessCount]);
@@ -106,7 +106,7 @@ static void runAutomaticProcessWarmingTest(unsigned prewarmedProcessCountLimit)
     EXPECT_FALSE([pool _hasPrewarmedWebProcess]);
     EXPECT_EQ(1U, [pool _webPageContentProcessCount]);
 
-    [webView1 loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL]]];
+    [webView1 loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:preWarmingLoadableURL]]];
     [webView1 _test_waitForDidFinishNavigation];
 
     RetainPtr<NSSet> prewarmedProcessIdentifiers;
@@ -118,7 +118,7 @@ static void runAutomaticProcessWarmingTest(unsigned prewarmedProcessCountLimit)
     EXPECT_EQ(1U + prewarmedProcessCountLimit, [pool _webPageContentProcessCount]);
 
     RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-    [webView2 loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL]]];
+    [webView2 loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:preWarmingLoadableURL]]];
     [webView2 _test_waitForDidFinishNavigation];
 
     auto webView2ProcessIdentifier = [webView2 _webProcessIdentifier];
@@ -192,10 +192,10 @@ TEST(WKProcessPool, TryUsingPrewarmedProcessThatJustCrashed)
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     delegate.get().webContentProcessDidTerminate = ^(WKWebView *view, _WKProcessTerminationReason) {
-        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL]]];
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:preWarmingLoadableURL]]];
     };
     [webView setNavigationDelegate:delegate.get()];
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:preWarmingLoadableURL]]];
     [delegate waitForDidFinishNavigation];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PushAPI.mm
@@ -69,7 +69,7 @@ static String expectedMessage;
 @end
 
 // FIXME: Update the test to do subscription before pushing message.
-static constexpr auto mainBytes = R"SWRESOURCE(
+static constexpr auto pushAPIMainBytes = R"SWRESOURCE(
 <script>
 function log(msg)
 {
@@ -130,7 +130,7 @@ static void clearWebsiteDataStore(WKWebsiteDataStore *store)
 static bool pushMessageProcessed = false;
 static bool pushMessageSuccessful = false;
 
-static bool waitUntilEvaluatesToTrue(const Function<bool()>& f)
+static bool pushAPIWaitUntilEvaluatesToTrue(const Function<bool()>& f)
 {
     unsigned timeout = 0;
     do {
@@ -157,7 +157,7 @@ static RetainPtr<WKWebViewConfiguration> createConfigurationWithNotificationsEna
 TEST(PushAPI, firePushEvent)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
+        { "/"_s, { pushAPIMainBytes } },
         { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, scriptBytes } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
@@ -271,7 +271,7 @@ TEST(PushAPI, notificationPermissionsDelegateInvalidResponse)
 TEST(PushAPI, firePushEventDataStoreDelegate)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
+        { "/"_s, { pushAPIMainBytes } },
         { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
@@ -379,7 +379,7 @@ self.addEventListener("push", (event) => {
 TEST(PushAPI, testSilentFlag)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
+        { "/"_s, { pushAPIMainBytes } },
         { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, testSilentFlagScriptBytes } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
@@ -537,7 +537,7 @@ static void terminateNetworkProcessWhileRegistrationIsStored(WKWebViewConfigurat
 TEST(PushAPI, firePushEventWithNoPagesSuccessful)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
+        { "/"_s, { pushAPIMainBytes } },
         { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, waitOneSecondScriptBytes } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
@@ -572,12 +572,12 @@ TEST(PushAPI, firePushEventWithNoPagesSuccessful)
         pushMessageProcessed = true;
     }];
 
-    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return [[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
+    EXPECT_TRUE(pushAPIWaitUntilEvaluatesToTrue([&] { return [[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
 
     TestWebKitAPI::Util::run(&pushMessageProcessed);
     EXPECT_TRUE(pushMessageSuccessful);
 
-    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return ![[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
+    EXPECT_TRUE(pushAPIWaitUntilEvaluatesToTrue([&] { return ![[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
 
     clearWebsiteDataStore([configuration websiteDataStore]);
 }
@@ -585,7 +585,7 @@ TEST(PushAPI, firePushEventWithNoPagesSuccessful)
 TEST(PushAPI, firePushEventWithNoPagesFail)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
+        { "/"_s, { pushAPIMainBytes } },
         { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, waitOneSecondScriptBytes } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
@@ -620,11 +620,11 @@ TEST(PushAPI, firePushEventWithNoPagesFail)
         pushMessageProcessed = true;
     }];
 
-    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return [[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
+    EXPECT_TRUE(pushAPIWaitUntilEvaluatesToTrue([&] { return [[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
 
     TestWebKitAPI::Util::run(&pushMessageProcessed);
     EXPECT_FALSE(pushMessageSuccessful);
-    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return ![[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
+    EXPECT_TRUE(pushAPIWaitUntilEvaluatesToTrue([&] { return ![[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
 
     clearWebsiteDataStore([configuration websiteDataStore]);
 }
@@ -632,7 +632,7 @@ TEST(PushAPI, firePushEventWithNoPagesFail)
 TEST(PushAPI, firePushEventWithNoPagesTimeout)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
+        { "/"_s, { pushAPIMainBytes } },
         { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, waitOneSecondScriptBytes } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
@@ -676,12 +676,12 @@ TEST(PushAPI, firePushEventWithNoPagesTimeout)
         pushMessageProcessed = true;
     }];
 
-    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return [[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
+    EXPECT_TRUE(pushAPIWaitUntilEvaluatesToTrue([&] { return [[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
 
     TestWebKitAPI::Util::run(&pushMessageProcessed);
     fprintf(stderr, "totot4\n");
     EXPECT_FALSE(pushMessageSuccessful);
-    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return ![[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
+    EXPECT_TRUE(pushAPIWaitUntilEvaluatesToTrue([&] { return ![[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
 
     clearWebsiteDataStore([configuration websiteDataStore]);
 }
@@ -725,7 +725,7 @@ self.addEventListener("push", (event) => {
 TEST(PushAPI, pushEventsAndInspectedServiceWorker)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
+        { "/"_s, { pushAPIMainBytes } },
         { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, pushEventsAndInspectedServiceWorkerScriptBytes } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
@@ -840,7 +840,7 @@ self.addEventListener("push", async (event) => {
 static void testInspectedServiceWorkerWithoutPage(bool enableServiceWorkerInspection)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
+        { "/"_s, { pushAPIMainBytes } },
         { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, inspectedServiceWorkerWithoutPageScriptBytes } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ResourceLoadStatistics.mm
@@ -51,7 +51,7 @@
 #import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 
-static bool finishedNavigation = false;
+static bool resourceLoadStatisticsFinishedNavigation = false;
 
 @interface _WKResourceLoadStatisticsFirstParty : NSObject
 @property (nonatomic, readonly) NSString *firstPartyDomain;
@@ -77,7 +77,7 @@ static bool finishedNavigation = false;
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    finishedNavigation = true;
+    resourceLoadStatisticsFinishedNavigation = true;
 }
 
 @end
@@ -226,7 +226,7 @@ TEST(ResourceLoadStatistics, IPCAfterStoreDestruction)
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"notify-resourceLoadObserver" withExtension:@"html"]]];
 
-    TestWebKitAPI::Util::run(&finishedNavigation);
+    TestWebKitAPI::Util::run(&resourceLoadStatisticsFinishedNavigation);
 }
 
 static void cleanupITPDatabase(WKWebsiteDataStore *dataStore)
@@ -1602,9 +1602,9 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTrigger)
         didReceiveStorageAccessPrompt = true;
     }];
 
-    __block bool finishedNavigation = false;
+    __block bool resourceLoadStatisticsFinishedNavigation = false;
     navigationDelegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
-        finishedNavigation = true;
+        resourceLoadStatisticsFinishedNavigation = true;
     };
 
     [webView setNavigationDelegate:navigationDelegate.get()];
@@ -1612,8 +1612,8 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTrigger)
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site1.example/page1a"]]];
 
-    Util::run(&finishedNavigation);
-    finishedNavigation = false;
+    Util::run(&resourceLoadStatisticsFinishedNavigation);
+    resourceLoadStatisticsFinishedNavigation = false;
 
     [webView evaluateJavaScript:@"let iframe = document.createElement(\"iframe\"); iframe.src = \"https://site2.example/page1b\"; document.body.appendChild(iframe);" completionHandler:^(id value, NSError *error) {
         done = true;
@@ -1626,8 +1626,8 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTrigger)
     didReceiveStorageAccessPrompt = false;
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site1.example/page2a"]]];
-    Util::run(&finishedNavigation);
-    finishedNavigation = false;
+    Util::run(&resourceLoadStatisticsFinishedNavigation);
+    resourceLoadStatisticsFinishedNavigation = false;
 
     [webView evaluateJavaScript:@"let iframe = document.createElement(\"iframe\"); iframe.src = \"https://site2.example/page2b\"; document.body.appendChild(iframe);" completionHandler:^(id value, NSError *error) {
         done = true;
@@ -1645,8 +1645,8 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTrigger)
     TestWebKitAPI::Util::run(&done);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site1.example/page3a"]]];
-    Util::run(&finishedNavigation);
-    finishedNavigation = false;
+    Util::run(&resourceLoadStatisticsFinishedNavigation);
+    resourceLoadStatisticsFinishedNavigation = false;
 
     [webView evaluateJavaScript:@"let iframe = document.createElement(\"iframe\"); iframe.src = \"https://site3.example/page1c\"; document.body.appendChild(iframe);" completionHandler:^(id value, NSError *error) {
         done = true;
@@ -1687,9 +1687,9 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithOutQuirk)
         done = true;
     };
 
-    __block bool finishedNavigation = false;
+    __block bool resourceLoadStatisticsFinishedNavigation = false;
     delegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
-        finishedNavigation = true;
+        resourceLoadStatisticsFinishedNavigation = true;
     };
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
@@ -1697,9 +1697,9 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithOutQuirk)
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site3.example/page1"]]];
     TestWebKitAPI::Util::run(&done);
-    Util::run(&finishedNavigation);
+    Util::run(&resourceLoadStatisticsFinishedNavigation);
     done = false;
-    finishedNavigation = false;
+    resourceLoadStatisticsFinishedNavigation = false;
 
     [webView evaluateJavaScript:@"document.cookie" completionHandler:^(id value, NSError *error) {
         EXPECT_NULL(error);
@@ -1712,13 +1712,13 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithOutQuirk)
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site1.example/page1"]]];
     TestWebKitAPI::Util::run(&done);
-    Util::run(&finishedNavigation);
+    Util::run(&resourceLoadStatisticsFinishedNavigation);
     done = false;
-    finishedNavigation = false;
+    resourceLoadStatisticsFinishedNavigation = false;
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site3.example/page3"]]];
     TestWebKitAPI::Util::run(&done);
-    Util::run(&finishedNavigation);
+    Util::run(&resourceLoadStatisticsFinishedNavigation);
     done = false;
 
     [webView evaluateJavaScript:@"document.cookie" completionHandler:^(id value, NSError *error) {
@@ -1785,9 +1785,9 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithQuirk)
         done = true;
     };
 
-    __block bool finishedNavigation = false;
+    __block bool resourceLoadStatisticsFinishedNavigation = false;
     delegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
-        finishedNavigation = true;
+        resourceLoadStatisticsFinishedNavigation = true;
     };
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
@@ -1795,9 +1795,9 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithQuirk)
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site3.example/page1"]]];
     TestWebKitAPI::Util::run(&done);
-    Util::run(&finishedNavigation);
+    Util::run(&resourceLoadStatisticsFinishedNavigation);
     done = false;
-    finishedNavigation = false;
+    resourceLoadStatisticsFinishedNavigation = false;
 
     [webView evaluateJavaScript:@"document.cookie" completionHandler:^(id value, NSError *error) {
         EXPECT_NULL(error);
@@ -1810,13 +1810,13 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithQuirk)
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site1.example/page1"]]];
     TestWebKitAPI::Util::run(&done);
-    Util::run(&finishedNavigation);
+    Util::run(&resourceLoadStatisticsFinishedNavigation);
     done = false;
-    finishedNavigation = false;
+    resourceLoadStatisticsFinishedNavigation = false;
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site3.example/page3"]]];
     TestWebKitAPI::Util::run(&done);
-    Util::run(&finishedNavigation);
+    Util::run(&resourceLoadStatisticsFinishedNavigation);
     done = false;
 
     [webView evaluateJavaScript:@"document.cookie" completionHandler:^(id value, NSError *error) {
@@ -1830,15 +1830,15 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithQuirk)
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site1.example/page2"]]];
     TestWebKitAPI::Util::run(&done);
-    Util::run(&finishedNavigation);
+    Util::run(&resourceLoadStatisticsFinishedNavigation);
     done = false;
-    finishedNavigation = false;
+    resourceLoadStatisticsFinishedNavigation = false;
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site4.example/page2"]]];
     TestWebKitAPI::Util::run(&done);
-    Util::run(&finishedNavigation);
+    Util::run(&resourceLoadStatisticsFinishedNavigation);
     done = false;
-    finishedNavigation = false;
+    resourceLoadStatisticsFinishedNavigation = false;
 
     [webView evaluateJavaScript:@"document.cookie" completionHandler:^(id value, NSError *error) {
         EXPECT_NULL(error);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SafeBrowsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SafeBrowsing.mm
@@ -51,8 +51,11 @@
 #import <wtf/URL.h>
 #import <wtf/Vector.h>
 
+#if !defined(TestWebKitAPI_SSBLookupContext_SoftLinked)
+#define TestWebKitAPI_SSBLookupContext_SoftLinked
 SOFT_LINK_PRIVATE_FRAMEWORK(SafariSafeBrowsing);
 SOFT_LINK_CLASS(SafariSafeBrowsing, SSBLookupContext);
+#endif
 SOFT_LINK_CLASS(SafariSafeBrowsing, SSBLookupResult);
 SOFT_LINK_CLASS(SafariSafeBrowsing, SSBServiceLookupResult);
 
@@ -186,13 +189,13 @@ static RetainPtr<WKWebView> safeBrowsingView()
 }
 
 #if PLATFORM(MAC)
-static void checkTitleAndClick(NSButton *button, const char* expectedTitle)
+static void safeBrowsingCheckTitleAndClick(NSButton *button, const char* expectedTitle)
 {
     EXPECT_STREQ(button.title.UTF8String, expectedTitle);
     [button performClick:nil];
 }
 #else
-static void checkTitleAndClick(UIButton *button, const char* expectedTitle)
+static void safeBrowsingCheckTitleAndClick(UIButton *button, const char* expectedTitle)
 {
     EXPECT_STREQ([button attributedTitleForState:UIControlStateNormal].string.UTF8String, expectedTitle);
     UIView *target = button.superview.superview;
@@ -205,7 +208,7 @@ template<typename ViewType> void goBack(ViewType *view, bool mainFrame = true)
 {
     WKWebView *webView = (WKWebView *)view.superview;
     auto box = view.subviews.firstObject;
-    checkTitleAndClick(box.subviews[3], "Go Back");
+    safeBrowsingCheckTitleAndClick(box.subviews[3], "Go Back");
     if (mainFrame)
         EXPECT_EQ([webView _safeBrowsingWarning], nil);
     else
@@ -260,7 +263,7 @@ TEST(SafeBrowsing, VisitUnsafeWebsite)
     EXPECT_GT(warning.subviews.firstObject.subviews[2].frame.size.height, 0);
 #endif
     EXPECT_WK_STREQ([webView title], "Deceptive Website Warning");
-    checkTitleAndClick(warning.subviews.firstObject.subviews[4], "Show Details");
+    safeBrowsingCheckTitleAndClick(warning.subviews.firstObject.subviews[4], "Show Details");
     EXPECT_EQ(warning.subviews.count, 2ull);
     EXPECT_FALSE(committedNavigation);
     [webView visitUnsafeSite];
@@ -294,7 +297,7 @@ TEST(SafeBrowsing, ShowWarningSPI)
     };
 
     showWarning();
-    checkTitleAndClick([webView _safeBrowsingWarning].subviews.firstObject.subviews[3], "Go Back");
+    safeBrowsingCheckTitleAndClick([webView _safeBrowsingWarning].subviews.firstObject.subviews[3], "Go Back");
     TestWebKitAPI::Util::run(&completionHandlerCalled);
     EXPECT_FALSE(shouldContinueValue);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -78,7 +78,7 @@
 static NSString *serviceWorkerRegistrationFilename = @"ServiceWorkerRegistrations-8.sqlite3";
 static bool serviceWorkerGlobalObjectIsAvailable;
 
-static String expectedMessage;
+static String serviceWorkerExpectedMessage;
 static String retrievedString;
 
 @interface SWMessageHandler : NSObject <WKScriptMessageHandler>
@@ -104,10 +104,10 @@ static String retrievedString;
 @end
 
 @interface SWMessageHandlerForRestoreFromDiskTest : NSObject <WKScriptMessageHandler> {
-    NSString *_expectedMessage;
+    NSString *_serviceWorkerExpectedMessage;
 }
-- (instancetype)initWithExpectedMessage:(NSString *)expectedMessage;
-- (void)resetExpectedMessage:(NSString *)expectedMessage;
+- (instancetype)initWithExpectedMessage:(NSString *)serviceWorkerExpectedMessage;
+- (void)resetExpectedMessage:(NSString *)serviceWorkerExpectedMessage;
 @end
 
 @interface SWMessageHandlerWithExpectedMessage : NSObject <WKScriptMessageHandler>
@@ -116,31 +116,31 @@ static String retrievedString;
 @implementation SWMessageHandlerWithExpectedMessage
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {
-    EXPECT_WK_STREQ(message.body, expectedMessage);
+    EXPECT_WK_STREQ(message.body, serviceWorkerExpectedMessage);
     done = true;
 }
 @end
 
 @implementation SWMessageHandlerForRestoreFromDiskTest
 
-- (instancetype)initWithExpectedMessage:(NSString *)expectedMessage
+- (instancetype)initWithExpectedMessage:(NSString *)serviceWorkerExpectedMessage
 {
     if (!(self = [super init]))
         return nil;
 
-    _expectedMessage = expectedMessage;
+    _serviceWorkerExpectedMessage = serviceWorkerExpectedMessage;
 
     return self;
 }
 
-- (void)resetExpectedMessage:(NSString *)expectedMessage
+- (void)resetExpectedMessage:(NSString *)serviceWorkerExpectedMessage
 {
-    _expectedMessage = expectedMessage;
+    _serviceWorkerExpectedMessage = serviceWorkerExpectedMessage;
 }
 
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {
-    EXPECT_WK_STREQ(message.body, _expectedMessage);
+    EXPECT_WK_STREQ(message.body, _serviceWorkerExpectedMessage);
     done = true;
 }
 @end
@@ -213,7 +213,7 @@ doTest();
 </script>
 )SWRESOURCE"_s;
 
-static constexpr auto mainBytes = R"SWRESOURCE(
+static constexpr auto serviceWorkerMainBytes = R"SWRESOURCE(
 <script>
 
 function log(msg)
@@ -240,7 +240,7 @@ navigator.serviceWorker.register('/sw.js').then(function(reg) {
 </script>
 )SWRESOURCE"_s;
 
-static constexpr auto scriptBytes = R"SWRESOURCE(
+static constexpr auto serviceWorkerScriptBytes = R"SWRESOURCE(
 
 self.addEventListener("message", (event) => {
     event.source.postMessage("ServiceWorker received: " + event.data);
@@ -481,7 +481,7 @@ navigator.serviceWorker.getRegistrations().then(function(registrations) {
 </script>
 )SWRESOURCE"_s;
 
-static constexpr auto mainBytesForSessionIDTest = R"SWRESOURCE(
+static constexpr auto serviceWorkerMainBytesForSessionIDTest = R"SWRESOURCE(
 <script>
 
 function log(msg)
@@ -511,7 +511,7 @@ navigator.serviceWorker.register('/sw.js').then(function(reg) {
 </script>
 )SWRESOURCE"_s;
 
-static constexpr auto scriptBytesForSessionIDTest = R"SWRESOURCE(
+static constexpr auto serviceWorkerScriptBytesForSessionIDTest = R"SWRESOURCE(
 
 var wasActivated = false;
 
@@ -543,8 +543,8 @@ static void setViewDataStore(WKWebViewConfiguration* viewConfiguration, ShouldRu
 static void runBasicSWTest(ShouldRunServiceWorkersOnMainThread shouldRunServiceWorkersOnMainThread)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
@@ -623,23 +623,23 @@ TEST(ServiceWorkers, BasicWithMainThreadSW)
 
 @interface SWUserAgentMessageHandler : NSObject <WKScriptMessageHandler> {
 @public
-    NSString *expectedMessage;
+    NSString *serviceWorkerExpectedMessage;
 }
-- (instancetype)initWithExpectedMessage:(NSString *)expectedMessage;
+- (instancetype)initWithExpectedMessage:(NSString *)serviceWorkerExpectedMessage;
 @end
 
 @implementation SWUserAgentMessageHandler
 
-- (instancetype)initWithExpectedMessage:(NSString *)_expectedMessage
+- (instancetype)initWithExpectedMessage:(NSString *)_serviceWorkerExpectedMessage
 {
     self = [super init];
-    expectedMessage = _expectedMessage;
+    serviceWorkerExpectedMessage = _serviceWorkerExpectedMessage;
     return self;
 }
 
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {
-    EXPECT_WK_STREQ(expectedMessage, [message body]);
+    EXPECT_WK_STREQ(serviceWorkerExpectedMessage, [message body]);
     done = true;
 }
 @end
@@ -672,7 +672,7 @@ TEST(ServiceWorkers, UserAgentOverride)
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
         { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, userAgentSWBytes } },
     });
 
@@ -730,7 +730,7 @@ TEST(ServiceWorkers, RestoreFromDisk)
     TestWebKitAPI::HTTPServer server({
         { "/first.html"_s, { mainRegisteringWorkerBytes } },
         { "/second.html"_s, { mainRegisteringAlreadyExistingWorkerBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -773,7 +773,7 @@ TEST(ServiceWorkers, ImportRegistrationsForOriginWithEmptyDatabase)
 
     TestWebKitAPI::HTTPServer server({
         { "/first.html"_s, { mainRegisteringWorkerBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     // Phase 1: register a service worker so the per-origin registration database is written to disk.
@@ -884,7 +884,7 @@ TEST(ServiceWorkers, UpdateCheckAfterRestoreFromDisk)
     TestWebKitAPI::HTTPServer server({
         { "/scope/first.html"_s, { mainRegisteringWorkerInScopeBytes } },
         { "/second.html"_s, { mainUpdatingRestoredWorkerBytes } },
-        { "/scope/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/scope/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -948,7 +948,7 @@ TEST(ServiceWorkers, CheckRegistrationWithoutMainScript)
     TestWebKitAPI::HTTPServer server({
         { "/scope/first.html"_s, { mainRegisteringWorkerInScopeBytes } },
         { "/scope/second.html"_s, { mainUpdatingRestoredWorkerBytes } },
-        { "/scope/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/scope/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -1032,7 +1032,7 @@ TEST(ServiceWorkers, CheckRegistrationWithoutImportedScript)
         { "/scope/first.html"_s, { mainRegisteringWorkerInScopeBytes } },
         { "/scope/second.html"_s, { mainUpdatingRestoredWorkerBytes } },
         { "/scope/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, "importScripts('/scope/importedScript.js');"_s } },
-        { "/scope/importedScript.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/scope/importedScript.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -1077,7 +1077,7 @@ TEST(ServiceWorkers, CheckRegistrationWithoutImportedScript)
                 NSNumber *fileSizeNumber;
                 if (![fileURL getResourceValue:&fileSizeNumber forKey:NSURLFileSizeKey error:NULL])
                     continue;
-                if ([fileSizeNumber unsignedLongLongValue] == scriptBytes.length())
+                if ([fileSizeNumber unsignedLongLongValue] == serviceWorkerScriptBytes.length())
                     [[NSFileManager defaultManager] removeItemAtURL:fileURL error:nil];
             }
         }
@@ -1102,7 +1102,7 @@ TEST(ServiceWorkers, CheckRegistrationWithoutImportedScript)
     TestWebKitAPI::Util::run(&done);
 }
 
-static constexpr auto scriptBytesWithFetchSupport = R"SWRESOURCE(
+static constexpr auto serviceWorkerScriptBytesWithFetchSupport = R"SWRESOURCE(
 
 self.addEventListener("message", (event) => {
     if (event.data = 'do-fetch') {
@@ -1169,7 +1169,7 @@ TEST(ServiceWorkers, ThirdPartyRestoredFromDisk)
         { "/index.html"_s, { "<script>onload = () => { webkit.messageHandlers.sw.postMessage('LOADED'); }</script>"_s } },
         { "/thirdPartyIframeWithSW.html"_s, { mainRegisteringWorkerBytes } },
         { "/thirdPartyIframeWithSW2.html"_s, { mainRegisteringAlreadyExistingWorkerRequestFetchBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytesWithFetchSupport } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytesWithFetchSupport } },
         { "/foo.txt"_s, { "FOO"_s } }
     });
 
@@ -1385,7 +1385,7 @@ TEST(ServiceWorkers, InterceptFirstLoadAfterRestoreFromDisk)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    expectedMessage = "Service Worker activated"_s;
+    serviceWorkerExpectedMessage = "Service Worker activated"_s;
     [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
@@ -1402,7 +1402,7 @@ TEST(ServiceWorkers, InterceptFirstLoadAfterRestoreFromDisk)
 
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    expectedMessage = "Intercepted by worker"_s;
+    serviceWorkerExpectedMessage = "Intercepted by worker"_s;
     [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
@@ -1437,7 +1437,7 @@ TEST(ServiceWorkers, MainThreadSWInterceptsLoad)
 
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    expectedMessage = "Service Worker activated"_s;
+    serviceWorkerExpectedMessage = "Service Worker activated"_s;
     [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
@@ -1455,7 +1455,7 @@ TEST(ServiceWorkers, MainThreadSWInterceptsLoad)
 
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    expectedMessage = "Intercepted by worker"_s;
+    serviceWorkerExpectedMessage = "Intercepted by worker"_s;
     [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
@@ -1489,7 +1489,7 @@ TEST(ServiceWorkers, WaitForPolicyDelegate)
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     // Register a service worker and activate it.
-    expectedMessage = "Service Worker activated"_s;
+    serviceWorkerExpectedMessage = "Service Worker activated"_s;
     [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
@@ -1507,7 +1507,7 @@ TEST(ServiceWorkers, WaitForPolicyDelegate)
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     // Verify service worker is intercepting load.
-    expectedMessage = "Intercepted by worker"_s;
+    serviceWorkerExpectedMessage = "Intercepted by worker"_s;
     [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
@@ -1601,8 +1601,8 @@ TEST(ServiceWorkers, SWProcessConnectionCreation)
 
     TestWebKitAPI::HTTPServer server({
         { "/first.html"_s, { regularPageWithConnectionBytes } },
-        { "/second.html"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/second.html"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
         { "/third.html"_s, { regularPageWithConnectionBytes } },
         { "/fourth.html"_s, { regularPageWithConnectionBytes } },
     });
@@ -1649,7 +1649,7 @@ TEST(ServiceWorkers, SWProcessConnectionCreation)
     TestWebKitAPI::Util::run(&done);
 }
 
-static constexpr auto mainBytesWithScope = R"SWRESOURCE(
+static constexpr auto serviceWorkerMainBytesWithScope = R"SWRESOURCE(
 <script>
 
 function log(msg)
@@ -1707,10 +1707,10 @@ TEST(ServiceWorkers, ServiceWorkerProcessCreation)
     [[configuration userContentController] addScriptMessageHandler:regularPageMessageHandler.get() name:@"regularPage"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/first.html"_s, { mainBytesWithScope } },
+        { "/first.html"_s, { serviceWorkerMainBytesWithScope } },
         { "/second.html"_s, { regularPageWithConnectionBytes } },
-        { "/third.html"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/third.html"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -2028,8 +2028,8 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageDefaultDirectories)
     [[configuration userContentController] addScriptMessageHandler:directoryPageMessageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/first.html"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/first.html"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
         { "/second.html"_s, { regularPageGrabbingCacheStorageDirectory } },
     });
 
@@ -2079,8 +2079,8 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageSpecificDirectories)
     [[configuration userContentController] addScriptMessageHandler:directoryPageMessageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/first.html"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/first.html"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
         { "/second.html"_s, { regularPageGrabbingCacheStorageDirectory } },
     });
 
@@ -2139,11 +2139,11 @@ TEST(ServiceWorkers, NonDefaultSessionID)
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytesForSessionIDTest } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytesForSessionIDTest } },
+        { "/"_s, { serviceWorkerMainBytesForSessionIDTest } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytesForSessionIDTest } },
     });
 
-    expectedMessage = "PASS: activation successful"_s;
+    serviceWorkerExpectedMessage = "PASS: activation successful"_s;
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadRequest:server.request()];
@@ -2206,12 +2206,12 @@ TEST(ServiceWorkers, ProcessPerSite)
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server1({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
     TestWebKitAPI::HTTPServer server2({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     WKProcessPool *processPool = configuration.get().processPool;
@@ -2285,12 +2285,12 @@ TEST(ServiceWorkers, ParallelProcessLaunch)
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server1({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
     TestWebKitAPI::HTTPServer server2({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     auto *processPool = configuration.get().processPool;
@@ -2325,8 +2325,8 @@ static size_t launchServiceWorkerProcess(bool useSeparateServiceWorkerProcess, b
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, scriptBytes } }
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } }
     });
 
     auto *processPool = configuration.get().processPool;
@@ -2529,8 +2529,8 @@ void testSuspendServiceWorkerProcessBasedOnClientProcesses(UseSeparateServiceWor
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     auto *processPool = configuration.get().processPool;
@@ -2645,14 +2645,14 @@ TEST(ServiceWorkers, SuspendAndTerminateWorker)
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     auto *processPool = configuration.get().processPool;
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    expectedMessage = "Message from worker: ServiceWorker received: Hello from the web page"_s;
+    serviceWorkerExpectedMessage = "Message from worker: ServiceWorker received: Hello from the web page"_s;
     [webView loadRequest:server.request()];
     // Wait until ServiceWorker is launched.
     TestWebKitAPI::Util::run(&done);
@@ -2696,7 +2696,7 @@ TEST(ServiceWorkers, SuspendAndTerminateWorker)
     EXPECT_TRUE(serviceWorkersAllTerminated);
 
     // Let's verify the WKWebView did not crash and has the same PID as before.
-    expectedMessage = "OK"_s;
+    serviceWorkerExpectedMessage = "OK"_s;
     [webView evaluateJavaScript:@"log('OK')" completionHandler: nil];
     TestWebKitAPI::Util::run(&done);
     done = false;
@@ -2722,8 +2722,8 @@ TEST(ServiceWorkers, ThrottleCrash)
     RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
@@ -2794,8 +2794,8 @@ TEST(ServiceWorkers, LoadData)
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -2813,7 +2813,7 @@ TEST(ServiceWorkers, LoadData)
     done = false;
 
     // Now try a data load.
-    NSData *data = [NSData dataWithBytes:mainBytes length:strlen(mainBytes)];
+    NSData *data = [NSData dataWithBytes:serviceWorkerMainBytes length:strlen(serviceWorkerMainBytes)];
     [webView loadData:data MIMEType:@"text/html" characterEncodingName:@"UTF-8" baseURL:server.request().URL];
 
     TestWebKitAPI::Util::run(&done);
@@ -2835,7 +2835,7 @@ TEST(ServiceWorkers, RestoreFromDiskNonDefaultStore)
 
     TestWebKitAPI::HTTPServer server({
         { "/first.html"_s, { mainRegisteringWorkerBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
         { "/second.html"_s, { mainRegisteringAlreadyExistingWorkerBytes } },
     });
 
@@ -2909,9 +2909,9 @@ TEST(ServiceWorkers, SuspendNetworkProcess)
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/first.html"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
-        { "/second.html"_s, { mainBytes } },
+        { "/first.html"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
+        { "/second.html"_s, { serviceWorkerMainBytes } },
     });
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -3047,8 +3047,8 @@ TEST(ServiceWorkers, ProcessPerSession)
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server1({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     WKProcessPool *processPool = configuration.get().processPool;
@@ -3063,8 +3063,8 @@ TEST(ServiceWorkers, ProcessPerSession)
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
 
     TestWebKitAPI::HTTPServer server2({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -3121,7 +3121,7 @@ TEST(ServiceWorkers, ContentRuleList)
     using namespace TestWebKitAPI;
     HTTPServer server([] (Connection connection) {
         connection.receiveHTTPRequest([=](Vector<char>&&) {
-            connection.send(HTTPResponse({ { "Content-Type"_s, "text/html"_s } }, mainBytes).serialize(), [=] {
+            connection.send(HTTPResponse({ { "Content-Type"_s, "text/html"_s } }, serviceWorkerMainBytes).serialize(), [=] {
                 connection.receiveHTTPRequest([=](Vector<char>&&) {
                     connection.send(HTTPResponse({ { "Content-Type"_s, "application/javascript"_s } }, contentRuleListWorkerScript).serialize(), [=] {
                         connection.receiveHTTPRequest([=](Vector<char>&& lastRequest) {
@@ -3134,7 +3134,7 @@ TEST(ServiceWorkers, ContentRuleList)
         });
     });
 
-    expectedMessage = @"Message from worker: PASS - blocked first request, allowed second";
+    serviceWorkerExpectedMessage = @"Message from worker: PASS - blocked first request, allowed second";
 
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
@@ -3352,8 +3352,8 @@ TEST(ServiceWorkers, ClearDOMCacheAlsoIncludesServiceWorkerRegistrations)
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -3408,8 +3408,8 @@ TEST(ServiceWorkers, CustomDataStorePathsVersusCompletionHandlers)
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
-        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptBytes } },
     });
 
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -4282,7 +4282,7 @@ TEST(ServiceWorker, ServiceWorkerWindowClientFocus)
 #endif
 
     done = false;
-    expectedMessage = "focused"_s;
+    serviceWorkerExpectedMessage = "focused"_s;
     [webView1 evaluateJavaScript:@"focusClient()" completionHandler: nil];
     TestWebKitAPI::Util::run(&done);
 #if PLATFORM(MAC)
@@ -4295,18 +4295,18 @@ TEST(ServiceWorker, ServiceWorkerWindowClientFocus)
 
     // FIXME: We should be able to run these tests in iOS once pages are actually visible.
     done = false;
-    expectedMessage = "PASS"_s;
+    serviceWorkerExpectedMessage = "PASS"_s;
     [webView1 evaluateJavaScript:@"checkFocusValue(true, 'webView1')" completionHandler:nil];
     TestWebKitAPI::Util::run(&done);
 
     done = false;
-    expectedMessage = "PASS"_s;
+    serviceWorkerExpectedMessage = "PASS"_s;
     [webView2 evaluateJavaScript:@"checkFocusValue(false, 'webView2')" completionHandler:nil];
     TestWebKitAPI::Util::run(&done);
 #endif
 
     done = false;
-    expectedMessage = "focused"_s;
+    serviceWorkerExpectedMessage = "focused"_s;
     [webView2 evaluateJavaScript:@"focusClient()" completionHandler: nil];
     TestWebKitAPI::Util::run(&done);
 #if PLATFORM(MAC)
@@ -4318,7 +4318,7 @@ TEST(ServiceWorker, ServiceWorkerWindowClientFocus)
 
     // FIXME: We should be able to run these tests in iOS once pages are actually visible.
     done = false;
-    expectedMessage = "PASS"_s;
+    serviceWorkerExpectedMessage = "PASS"_s;
     [webView2 evaluateJavaScript:@"checkFocusValue(true, 'webView2')" completionHandler:nil];
     TestWebKitAPI::Util::run(&done);
 #endif
@@ -4360,7 +4360,7 @@ TEST(ServiceWorker, ServiceWorkerWindowClientFocusRequiresUserGesture)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully registered");
 
     done = false;
-    expectedMessage = "not focused"_s;
+    serviceWorkerExpectedMessage = "not focused"_s;
     [webView evaluateJavaScript:@"focusClient()" completionHandler: nil];
     TestWebKitAPI::Util::run(&done);
 }
@@ -4444,7 +4444,7 @@ TEST(ServiceWorker, openWindowWithoutDelegate)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully registered");
 
     done = false;
-    expectedMessage = "opened without client"_s;
+    serviceWorkerExpectedMessage = "opened without client"_s;
     [webView evaluateJavaScript:@"openWindowClient()" completionHandler: nil];
     TestWebKitAPI::Util::run(&done);
 }
@@ -5042,7 +5042,7 @@ TEST(ServiceWorkers, ServiceWorkerStorageTiming)
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     done = false;
-    expectedMessage = "Message from worker: V1"_s;
+    serviceWorkerExpectedMessage = "Message from worker: V1"_s;
     RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow: YES]);
     [webView1 loadRequest:server.request()];
     TestWebKitAPI::Util::run(&done);
@@ -5053,7 +5053,7 @@ TEST(ServiceWorkers, ServiceWorkerStorageTiming)
     server.setResponse("/sw.js"_s, TestWebKitAPI::HTTPResponse { WTF::move(sourceHeaders), serviceWorkerStorageTimingScriptBytesV2 });
 
     done = false;
-    expectedMessage = "Message from worker: V1"_s;
+    serviceWorkerExpectedMessage = "Message from worker: V1"_s;
     RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView2 loadRequest:server.request()];
     TestWebKitAPI::Util::run(&done);
@@ -5069,7 +5069,7 @@ TEST(ServiceWorkers, ServiceWorkerStorageTiming)
     [[webView1 configuration].websiteDataStore _terminateNetworkProcess];
 
     done = false;
-    expectedMessage = "Message from worker: V2"_s;
+    serviceWorkerExpectedMessage = "Message from worker: V2"_s;
     RetainPtr webView3 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView3 loadRequest:server.request()];
     TestWebKitAPI::Util::run(&done);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShouldOpenExternalURLsInNewWindowActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShouldOpenExternalURLsInNewWindowActions.mm
@@ -36,7 +36,7 @@
 #import <wtf/RetainPtr.h>
 
 static bool decidedPolicy;
-static bool finishedNavigation;
+static bool shouldOpenExternalURLsFinishedNavigation;
 static RetainPtr<WKNavigationAction> action;
 static RetainPtr<WKWebView> newWebView;
 
@@ -55,7 +55,7 @@ static RetainPtr<WKWebView> newWebView;
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    finishedNavigation = true;
+    shouldOpenExternalURLsFinishedNavigation = true;
 }
 
 - (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
@@ -81,8 +81,8 @@ TEST(WebKit, ShouldOpenExternalURLsInWindowOpen)
     [webView setUIDelegate:controller.get()];
 
     [webView loadHTMLString:@"<body onclick=\"window.open('https://webkit.org/destination')\">" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
-    finishedNavigation = false;
+    TestWebKitAPI::Util::run(&shouldOpenExternalURLsFinishedNavigation);
+    shouldOpenExternalURLsFinishedNavigation = false;
 
     NSPoint clickPoint = NSMakePoint(100, 100);
 
@@ -105,8 +105,8 @@ TEST(WebKit, ShouldOpenExternalURLsInWindowOpen)
     ASSERT_FALSE([action _shouldOpenAppLinks]);
 
     [webView loadHTMLString:@"<body onclick=\"window.open('http://apple.com/destination')\">" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
-    finishedNavigation = false;
+    TestWebKitAPI::Util::run(&shouldOpenExternalURLsFinishedNavigation);
+    shouldOpenExternalURLsFinishedNavigation = false;
 
     [[webView hitTest:clickPoint] mouseDown:[NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:clickPoint modifierFlags:0 timestamp:0 windowNumber:[window windowNumber] context:nil eventNumber:0 clickCount:1 pressure:1]];
     [[webView hitTest:clickPoint] mouseUp:[NSEvent mouseEventWithType:NSEventTypeLeftMouseUp location:clickPoint modifierFlags:0 timestamp:0 windowNumber:[window windowNumber] context:nil eventNumber:0 clickCount:1 pressure:1]];
@@ -142,8 +142,8 @@ TEST(WebKit, ShouldOpenExternalURLsInTargetedLink)
     [webView setUIDelegate:controller.get()];
 
     [webView loadHTMLString:@"<a style=\"display: block; height: 100%\" href=\"https://webkit.org/destination.html\" target=\"_blank\">" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
-    finishedNavigation = false;
+    TestWebKitAPI::Util::run(&shouldOpenExternalURLsFinishedNavigation);
+    shouldOpenExternalURLsFinishedNavigation = false;
 
     NSPoint clickPoint = NSMakePoint(100, 100);
 
@@ -174,8 +174,8 @@ TEST(WebKit, ShouldOpenExternalURLsInTargetedLink)
     ASSERT_FALSE([action _shouldOpenAppLinks]);
 
     [webView loadHTMLString:@"<a style=\"display: block; height: 100%\" href=\"http://apple.com/destination.html\" target=\"_blank\">" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
-    TestWebKitAPI::Util::run(&finishedNavigation);
-    finishedNavigation = false;
+    TestWebKitAPI::Util::run(&shouldOpenExternalURLsFinishedNavigation);
+    shouldOpenExternalURLsFinishedNavigation = false;
 
     decidedPolicy = false;
     [[webView hitTest:clickPoint] mouseDown:[NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:clickPoint modifierFlags:0 timestamp:0 windowNumber:[window windowNumber] context:nil eventNumber:0 clickCount:1 pressure:1]];
@@ -216,11 +216,11 @@ TEST(WebKit, RestoreShouldOpenExternalURLsPolicyAfterCrash)
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
-    finishedNavigation = false;
+    shouldOpenExternalURLsFinishedNavigation = false;
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"should-open-external-schemes" withExtension:@"html"]];
     [webView loadRequest:request];
-    TestWebKitAPI::Util::run(&finishedNavigation);
-    finishedNavigation = false;
+    TestWebKitAPI::Util::run(&shouldOpenExternalURLsFinishedNavigation);
+    shouldOpenExternalURLsFinishedNavigation = false;
 
     // Before crash
     decidedPolicy = false;
@@ -235,9 +235,9 @@ TEST(WebKit, RestoreShouldOpenExternalURLsPolicyAfterCrash)
     [webView _killWebContentProcessAndResetState];
     [webView reload];
 
-    finishedNavigation = false;
-    TestWebKitAPI::Util::run(&finishedNavigation);
-    finishedNavigation = false;
+    shouldOpenExternalURLsFinishedNavigation = false;
+    TestWebKitAPI::Util::run(&shouldOpenExternalURLsFinishedNavigation);
+    shouldOpenExternalURLsFinishedNavigation = false;
 
     // After crash
     decidedPolicy = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -2324,7 +2324,7 @@ TEST(SiteIsolation, FrameMetrics)
     EXPECT_TRUE(info._visibleContentSizeExcludingScrollbars.width < info._visibleContentSize.width);
 }
 
-void writeImageDataToPasteboard(NSString *type, NSData *data)
+void siteIsolationWriteImageDataToPasteboard(NSString *type, NSData *data)
 {
     [NSPasteboard.generalPasteboard declareTypes:@[type] owner:nil];
     [NSPasteboard.generalPasteboard setData:data forType:type];
@@ -2366,7 +2366,7 @@ TEST(SiteIsolation, PasteGIF)
     [webView waitForPendingMouseEvents];
 
     auto *data = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-400px" ofType:@"gif"]];
-    writeImageDataToPasteboard(UTTypeGIF.identifier, data);
+    siteIsolationWriteImageDataToPasteboard(UTTypeGIF.identifier, data);
     [webView paste:nil];
 
     [webView mouseEnterAtPoint:eventLocationInWindow];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpeechRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpeechRecognition.mm
@@ -38,8 +38,8 @@
 static bool shouldGrantPermissionRequest = true;
 static bool permissionRequested = false;
 static bool captureStateDidChange;
-static bool isCapturing;
-static RetainPtr<WKWebView> createdWebView;
+static bool speechRecognitionIsCapturing;
+static RetainPtr<WKWebView> speechRecognitionCreatedWebView;
 
 @interface SpeechRecognitionUIDelegate : NSObject<WKUIDelegatePrivate>
 - (void)_webView:(WKWebView *)webView requestSpeechRecognitionPermissionForOrigin:(WKSecurityOrigin *)origin decisionHandler:(void (^)(BOOL))decisionHandler;
@@ -69,13 +69,13 @@ static RetainPtr<WKWebView> createdWebView;
 
 - (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
 {
-    createdWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
-    return createdWebView.get();
+    speechRecognitionCreatedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    return speechRecognitionCreatedWebView.get();
 }
 
 - (void)_webView:(WKWebView *)webView mediaCaptureStateDidChange:(_WKMediaCaptureStateDeprecated)state
 {
-    isCapturing = state == _WKMediaCaptureStateDeprecatedActiveMicrophone;
+    speechRecognitionIsCapturing = state == _WKMediaCaptureStateDeprecatedActiveMicrophone;
     captureStateDidChange = true;
 }
 @end
@@ -253,7 +253,7 @@ TEST(WebKit2, SpeechRecognitionPageIsDestroyed)
     RetainPtr delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
     RetainPtr navigationDelegate = adoptNS([[SpeechRecognitionNavigationDelegate alloc] init]);
     shouldGrantPermissionRequest = true;
-    createdWebView = nullptr;
+    speechRecognitionCreatedWebView = nullptr;
 
     @autoreleasepool {
         RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -274,7 +274,7 @@ TEST(WebKit2, SpeechRecognitionPageIsDestroyed)
 
     TestWebKitAPI::Util::runFor(0.5_s);
 
-    EXPECT_TRUE(!!createdWebView);
+    EXPECT_TRUE(!!speechRecognitionCreatedWebView);
 }
 
 TEST(WebKit2, SpeechRecognitionMediaCaptureStateChange)
@@ -294,12 +294,12 @@ TEST(WebKit2, SpeechRecognitionMediaCaptureStateChange)
     [webView synchronouslyLoadTestPageNamed:@"speechrecognition-basic"];
     [webView stringByEvaluatingJavaScript:@"start()"];
     TestWebKitAPI::Util::run(&captureStateDidChange);
-    EXPECT_TRUE(isCapturing);
+    EXPECT_TRUE(speechRecognitionIsCapturing);
 
     captureStateDidChange = false;
     [webView stringByEvaluatingJavaScript:@"stop()"];
     TestWebKitAPI::Util::run(&captureStateDidChange);
-    EXPECT_FALSE(isCapturing);
+    EXPECT_FALSE(speechRecognitionIsCapturing);
 }
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/StorageQuota.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/StorageQuota.mm
@@ -108,7 +108,7 @@ struct ResourceInfo {
     const char* data;
 };
 
-static bool receivedMessage;
+static bool storageQuotaReceivedMessage;
 
 @interface QuotaMessageHandler : NSObject <WKScriptMessageHandler>
 - (void)setExpectedMessage:(NSString *)message;
@@ -127,7 +127,7 @@ static bool receivedMessage;
     }
 
     if (_expectedMessages.isEmpty())
-        receivedMessage = true;
+        storageQuotaReceivedMessage = true;
 }
 
 - (void)setExpectedMessage:(NSString *)message
@@ -281,10 +281,10 @@ TEST(WebKit, QuotaDelegateHidden)
     NSLog(@"QuotaDelegateHidden 1");
 
     receivedQuotaDelegateCalled = false;
-    receivedMessage = false;
+    storageQuotaReceivedMessage = false;
     [messageHandler setExpectedMessage: @"put failed"];
     [webView loadRequest:server.request()];
-    Util::run(&receivedMessage);
+    Util::run(&storageQuotaReceivedMessage);
 
     NSLog(@"QuotaDelegateHidden 2");
 
@@ -293,7 +293,7 @@ TEST(WebKit, QuotaDelegateHidden)
     [hostWindow deminiaturize:hostWindow];
 
     receivedQuotaDelegateCalled = false;
-    receivedMessage = false;
+    storageQuotaReceivedMessage = false;
     [messageHandler setExpectedMessage: @"put succeeded"];
     [webView reload];
     Util::run(&receivedQuotaDelegateCalled);
@@ -301,7 +301,7 @@ TEST(WebKit, QuotaDelegateHidden)
     NSLog(@"QuotaDelegateHidden 3");
 
     [delegate grantQuota];
-    Util::run(&receivedMessage);
+    Util::run(&storageQuotaReceivedMessage);
 
     NSLog(@"QuotaDelegateHidden 4");
 }
@@ -350,17 +350,17 @@ TEST(WebKit, QuotaDelegate)
     [webView2 setUIDelegate:delegate2.get()];
     setVisible(webView2.get());
 
-    receivedMessage = false;
+    storageQuotaReceivedMessage = false;
     [webView2 loadRequest:server.requestWithLocalhost()];
     [messageHandler setExpectedMessage: @"start"];
-    Util::run(&receivedMessage);
+    Util::run(&storageQuotaReceivedMessage);
 
     EXPECT_FALSE(delegate2.get().quotaDelegateCalled);
     [delegate1 grantQuota];
 
     [messageHandler setExpectedMessage: @"pass"];
-    receivedMessage = false;
-    Util::run(&receivedMessage);
+    storageQuotaReceivedMessage = false;
+    Util::run(&storageQuotaReceivedMessage);
 
     while (!delegate2.get().quotaDelegateCalled)
         TestWebKitAPI::Util::runFor(0.1_s);
@@ -368,8 +368,8 @@ TEST(WebKit, QuotaDelegate)
     [delegate2 denyQuota];
 
     [messageHandler setExpectedMessage: @"fail"];
-    receivedMessage = false;
-    Util::run(&receivedMessage);
+    storageQuotaReceivedMessage = false;
+    Util::run(&storageQuotaReceivedMessage);
 
     NSLog(@"QuotaDelegate 6");
 }
@@ -404,25 +404,25 @@ TEST(WebKit, QuotaDelegateReload)
     setVisible(webView.get());
 
     [messageHandler setExpectedMessages: @[@"start", @"fail"]];
-    receivedMessage = false;
+    storageQuotaReceivedMessage = false;
     receivedQuotaDelegateCalled = false;
     [webView loadRequest:server.request()];
     Util::run(&receivedQuotaDelegateCalled);
 
     [delegate denyQuota];
-    Util::run(&receivedMessage);
+    Util::run(&storageQuotaReceivedMessage);
 
     while (!receivedQuotaDelegateCalled)
         TestWebKitAPI::Util::spinRunLoop();
     
     [messageHandler setExpectedMessages: @[@"start", @"pass"]];
-    receivedMessage = false;
+    storageQuotaReceivedMessage = false;
     receivedQuotaDelegateCalled = false;
     [webView reload];
     Util::run(&receivedQuotaDelegateCalled);
 
     [delegate grantQuota];
-    Util::run(&receivedMessage);
+    Util::run(&storageQuotaReceivedMessage);
 }
 
 TEST(WebKit, QuotaDelegateNavigateFragment)
@@ -455,18 +455,18 @@ TEST(WebKit, QuotaDelegateNavigateFragment)
     setVisible(webView.get());
 
     [messageHandler setExpectedMessage: @"start"];
-    receivedMessage = false;
+    storageQuotaReceivedMessage = false;
     receivedQuotaDelegateCalled = false;
     [webView loadRequest:server.request("/main.html"_s)];
-    Util::run(&receivedMessage);
+    Util::run(&storageQuotaReceivedMessage);
 
     while (!receivedQuotaDelegateCalled)
         TestWebKitAPI::Util::spinRunLoop();
 
     [messageHandler setExpectedMessage: @"fail"];
-    receivedMessage = false;
+    storageQuotaReceivedMessage = false;
     [delegate denyQuota];
-    Util::run(&receivedMessage);
+    Util::run(&storageQuotaReceivedMessage);
 
     receivedQuotaDelegateCalled = false;
     [webView loadRequest:server.request("/main.html#fragment"_s)];
@@ -475,12 +475,12 @@ TEST(WebKit, QuotaDelegateNavigateFragment)
     [webView evaluateJavaScript:@"doTestAgain()" completionHandler:nil];
 
     [messageHandler setExpectedMessage: @"start"];
-    receivedMessage = false;
-    Util::run(&receivedMessage);
+    storageQuotaReceivedMessage = false;
+    Util::run(&storageQuotaReceivedMessage);
 
     [messageHandler setExpectedMessage: @"fail"];
-    receivedMessage = false;
-    Util::run(&receivedMessage);
+    storageQuotaReceivedMessage = false;
+    Util::run(&storageQuotaReceivedMessage);
 
     EXPECT_FALSE(receivedQuotaDelegateCalled);
 }
@@ -527,8 +527,8 @@ TEST(WebKit, DefaultQuota)
     for (int i = 0; i < 10; ++i) {
         [webView stringByEvaluatingJavaScript:@"doTest(10)"];
         [messageHandler setExpectedMessage: @"pass"];
-        receivedMessage = false;
-        Util::run(&receivedMessage);
+        storageQuotaReceivedMessage = false;
+        Util::run(&storageQuotaReceivedMessage);
     }
     EXPECT_FALSE(receivedQuotaDelegateCalled);
 }
@@ -580,21 +580,21 @@ TEST(StorageQuota, OriginQuotaSharedByCacheStorageAndIndexedDB)
         request.onsuccess = function() { sendMessage('Unexpected success'); }; \
         request.onerror = function(event) { sendMessage(event.target.error.name); }; \
     </script>";
-    receivedMessage = false;
+    storageQuotaReceivedMessage = false;
     [messageHandler setExpectedMessage: @"Continue"];
     [webView loadHTMLString:cacheScriptString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
-    Util::run(&receivedMessage);
+    Util::run(&storageQuotaReceivedMessage);
 
-    receivedMessage = false;
+    storageQuotaReceivedMessage = false;
     [messageHandler setExpectedMessage: @"QuotaExceededError"];
     [webView loadHTMLString:indexedDBString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
-    Util::run(&receivedMessage);
+    Util::run(&storageQuotaReceivedMessage);
 
     // Terminate network process to ensure storage usage is read from disk.
     [websiteDataStore _terminateNetworkProcess];
 
-    receivedMessage = false;
+    storageQuotaReceivedMessage = false;
     [messageHandler setExpectedMessage: @"QuotaExceededError"];
     [webView loadHTMLString:indexedDBString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
-    Util::run(&receivedMessage);
+    Util::run(&storageQuotaReceivedMessage);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -61,8 +61,11 @@
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/MakeString.h>
 
+#if !defined(TestWebKitAPI_SSBLookupContext_SoftLinked)
+#define TestWebKitAPI_SSBLookupContext_SoftLinked
 SOFT_LINK_PRIVATE_FRAMEWORK(SafariSafeBrowsing);
 SOFT_LINK_CLASS(SafariSafeBrowsing, SSBLookupContext);
+#endif
 
 #if ENABLE(SCREEN_TIME)
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UIDelegate.mm
@@ -82,7 +82,7 @@
 #import "UIKitUtilities.h"
 #endif
 
-static bool didReceiveMessage;
+static bool uiDelegateDidReceiveMessage;
 
 @interface AudioObserver : NSObject
 @end
@@ -284,7 +284,7 @@ TEST(WebKit, GeolocationPermission)
 @implementation GeolocationPermissionMessageHandler
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {
-    didReceiveMessage = true;
+    uiDelegateDidReceiveMessage = true;
 }
 @end
 
@@ -350,9 +350,9 @@ TEST(WebKit, GeolocationPermissionInIFrame)
     }];
 
     done = false;
-    didReceiveMessage = false;
+    uiDelegateDidReceiveMessage = false;
     [webView loadRequest:server1.request()];
-    TestWebKitAPI::Util::run(&didReceiveMessage);
+    TestWebKitAPI::Util::run(&uiDelegateDidReceiveMessage);
     EXPECT_TRUE(done);
 }
 
@@ -416,11 +416,11 @@ TEST(WebKit, GeolocationPermissionInIFrameExampleWebArchive)
     NSString *getCurrentPosition = @"navigator.geolocation.getCurrentPosition(() => { webkit.messageHandlers.testHandler.postMessage(\"ok\") }, () => { webkit.messageHandlers.testHandler.postMessage(\"ko\") });";
 
     done = false;
-    didReceiveMessage = false;
+    uiDelegateDidReceiveMessage = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/"]]];
     [navigationDelegate waitForDidFinishNavigation];
     [webView evaluateJavaScript:getCurrentPosition completionHandler:nil];
-    TestWebKitAPI::Util::run(&didReceiveMessage);
+    TestWebKitAPI::Util::run(&uiDelegateDidReceiveMessage);
     TestWebKitAPI::Util::run(&done);
 
 #if ENABLE(WEB_ARCHIVE)
@@ -437,9 +437,9 @@ TEST(WebKit, GeolocationPermissionInIFrameExampleWebArchive)
     TestWebKitAPI::Util::run(&doneEvaluatingJavaScript);
 
     done = false;
-    didReceiveMessage = false;
+    uiDelegateDidReceiveMessage = false;
     [webView evaluateJavaScript:getCurrentPosition completionHandler:nil];
-    TestWebKitAPI::Util::run(&didReceiveMessage);
+    TestWebKitAPI::Util::run(&uiDelegateDidReceiveMessage);
     TestWebKitAPI::Util::run(&done);
 
     // Reset web process state.
@@ -449,7 +449,7 @@ TEST(WebKit, GeolocationPermissionInIFrameExampleWebArchive)
     [navigationDelegate waitForDidFinishNavigation];
 
     done = false;
-    didReceiveMessage = false;
+    uiDelegateDidReceiveMessage = false;
     doneEvaluatingJavaScript = false;
     [webView callAsyncJavaScript:@"return (await new Promise(function (resolve, reject) {"
         "navigator.geolocation.getCurrentPosition((position) => { resolve(JSON.stringify(position.toJSON())) }, (error) => { reject(error.message) });"
@@ -460,7 +460,7 @@ TEST(WebKit, GeolocationPermissionInIFrameExampleWebArchive)
         doneEvaluatingJavaScript = true;
     }];
     TestWebKitAPI::Util::run(&doneEvaluatingJavaScript);
-    EXPECT_FALSE(didReceiveMessage);
+    EXPECT_FALSE(uiDelegateDidReceiveMessage);
     EXPECT_TRUE(done);
 #endif
 }
@@ -510,9 +510,9 @@ TEST(WebKit, GeolocationPermissionInDisallowedIFrame)
     webView.get().navigationDelegate = navigationDelegate.get();
 
     done = false;
-    didReceiveMessage = false;
+    uiDelegateDidReceiveMessage = false;
     [webView loadRequest:server1.request()];
-    TestWebKitAPI::Util::run(&didReceiveMessage);
+    TestWebKitAPI::Util::run(&uiDelegateDidReceiveMessage);
     EXPECT_FALSE(done);
 }
 
@@ -707,7 +707,7 @@ INSTANTIATE_TEST_SUITE_P(WebKit, ScreenWakeLockTests, testing::Values(
 @class UITestDelegate;
 
 static RetainPtr<WKWebView> webViewFromDelegateCallback;
-static RetainPtr<WKWebView> createdWebView;
+static RetainPtr<WKWebView> uiDelegateCreatedWebView;
 static RetainPtr<UITestDelegate> delegate;
 
 @interface UITestDelegate : NSObject <WKUIDelegatePrivate, WKURLSchemeHandler>
@@ -717,9 +717,9 @@ static RetainPtr<UITestDelegate> delegate;
 
 - (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
 {
-    createdWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
-    [createdWebView setUIDelegate:delegate.get()];
-    return createdWebView.get();
+    uiDelegateCreatedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    [uiDelegateCreatedWebView setUIDelegate:delegate.get()];
+    return uiDelegateCreatedWebView.get();
 }
 
 - (void)_showWebView:(WKWebView *)webView
@@ -752,7 +752,7 @@ TEST(WebKit, ShowWebView)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"test:///first"]]];
     TestWebKitAPI::Util::run(&done);
     
-    ASSERT_EQ(webViewFromDelegateCallback, createdWebView);
+    ASSERT_EQ(webViewFromDelegateCallback, uiDelegateCreatedWebView);
 }
 
 static bool receivedWindowFrame;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
@@ -703,7 +703,7 @@ TEST(WKUserContentController, UserStyleSheetAffectingOnlySpecificWebViewRemovalA
     expectScriptEvaluatesToColor(webView.get(), backgroundColorScript, blueInRGB);
 }
 
-static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
+static RetainPtr<_WKProcessPoolConfiguration> userContentControllerPSONProcessPoolConfiguration()
 {
     RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().processSwapsOnNavigation = YES;
@@ -714,7 +714,7 @@ static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
 
 TEST(WKUserContentController, UserStyleSheetAffectingOnlySpecificWebViewRemovalAfterNavigationPSON)
 {
-    auto processPoolConfiguration = psonProcessPoolConfiguration();
+    auto processPoolConfiguration = userContentControllerPSONProcessPoolConfiguration();
     RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
     RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserInitiatedActionInNavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserInitiatedActionInNavigationAction.mm
@@ -34,7 +34,7 @@
 #import <WebKit/_WKUserInitiatedAction.h>
 #import <wtf/RetainPtr.h>
 
-static bool finishedNavigation;
+static bool userInitiatedActionFinishedNavigation;
 
 @interface UserInitiatedActionInNavigationActionDelegate : NSObject <WKNavigationDelegate>
 @property (nonatomic, copy) void (^policyForNavigationAction)(WKNavigationAction *, void (^)(WKNavigationActionPolicy));
@@ -54,7 +54,7 @@ static bool finishedNavigation;
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    finishedNavigation = true;
+    userInitiatedActionFinishedNavigation = true;
 }
 
 @end
@@ -89,8 +89,8 @@ public:
     void loadTest(NSString *test)
     {
         [webView loadRequest:[NSURLRequest requestWithURL:URLWithFragment(test)]];
-        TestWebKitAPI::Util::run(&finishedNavigation);
-        finishedNavigation = false;
+        TestWebKitAPI::Util::run(&userInitiatedActionFinishedNavigation);
+        userInitiatedActionFinishedNavigation = false;
     }
 
     void click()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ViewExposedRect.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ViewExposedRect.mm
@@ -39,12 +39,12 @@
 - (WKPageRef)_pageForTesting;
 @end
 
-static bool didForceRepaint;
+static bool viewExposedRectDidForceRepaint;
 
-static void forceRepaintCallback(WKErrorRef error, void*)
+static void viewExposedRectForceRepaintCallback(WKErrorRef error, void*)
 {
     EXPECT_NULL(error);
-    didForceRepaint = true;
+    viewExposedRectDidForceRepaint = true;
 }
 
 TEST(WebKit, InitialTileCoverageUsesViewExposedRect)
@@ -55,9 +55,9 @@ TEST(WebKit, InitialTileCoverageUsesViewExposedRect)
     [webView addToTestWindow];
     [webView synchronouslyLoadHTMLString:@""];
 
-    didForceRepaint = false;
-    WKPageForceRepaint([webView _pageForTesting], 0, forceRepaintCallback);
-    TestWebKitAPI::Util::run(&didForceRepaint);
+    viewExposedRectDidForceRepaint = false;
+    WKPageForceRepaint([webView _pageForTesting], 0, viewExposedRectForceRepaintCallback);
+    TestWebKitAPI::Util::run(&viewExposedRectDidForceRepaint);
 }
 
 #endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentExtensionStore.mm
@@ -549,7 +549,7 @@ TEST_F(WKContentRuleListStoreTest, NonASCIISource)
 }
 
 static size_t alertCount { 0 };
-static bool receivedAlert { false };
+static bool contentExtensionReceivedAlert { false };
 
 @interface ContentRuleListDelegate : NSObject <WKUIDelegate>
 @end
@@ -570,7 +570,7 @@ static bool receivedAlert { false };
     default:
         EXPECT_TRUE(false);
     }
-    receivedAlert = true;
+    contentExtensionReceivedAlert = true;
     completionHandler();
 }
 
@@ -601,15 +601,15 @@ TEST_F(WKContentRuleListStoreTest, AddRemove)
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"contentBlockerCheck" withExtension:@"html"]];
     alertCount = 0;
-    receivedAlert = false;
+    contentExtensionReceivedAlert = false;
     [webView loadRequest:request];
-    TestWebKitAPI::Util::run(&receivedAlert);
+    TestWebKitAPI::Util::run(&contentExtensionReceivedAlert);
 
     [[configuration userContentController] removeContentRuleList:ruleList.get()];
 
-    receivedAlert = false;
+    contentExtensionReceivedAlert = false;
     [webView reload];
-    TestWebKitAPI::Util::run(&receivedAlert);
+    TestWebKitAPI::Util::run(&contentExtensionReceivedAlert);
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm
@@ -484,7 +484,7 @@ TEST(WKHTTPCookieStore, ObserveCookiesReceivedFromHTTP)
     runTest([WKWebsiteDataStore nonPersistentDataStore]);
 }
 
-static bool finished;
+static bool cookieStoreFinished;
 
 @interface CookieUIDelegate : NSObject <WKUIDelegate>
 @end
@@ -493,7 +493,7 @@ static bool finished;
 - (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler
 {
     EXPECT_STREQ("PersistentCookieName=CookieValue; SessionCookieName=CookieValue", message.UTF8String);
-    finished = true;
+    cookieStoreFinished = true;
     completionHandler();
 }
 @end
@@ -519,25 +519,25 @@ void runWKHTTPCookieStoreWithoutProcessPool(ShouldEnableProcessPrewarming should
     // NonPersistentDataStore
     RetainPtr<WKWebsiteDataStore> ephemeralStoreWithCookies = [WKWebsiteDataStore nonPersistentDataStore];
 
-    finished = false;
+    cookieStoreFinished = false;
     [ephemeralStoreWithCookies.get().httpCookieStore setCookie:persistentCookie.get() completionHandler:^{
         WKWebsiteDataStore *ephemeralStoreWithIndependentCookieStorage = [WKWebsiteDataStore nonPersistentDataStore];
         [ephemeralStoreWithIndependentCookieStorage.httpCookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
             ASSERT_EQ(0u, cookies.count);
-            finished = true;
+            cookieStoreFinished = true;
         }];
     }];
-    TestWebKitAPI::Util::run(&finished);
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
 
-    finished = false;
+    cookieStoreFinished = false;
     [ephemeralStoreWithCookies.get().httpCookieStore setCookie:sessionCookie.get() completionHandler:^{
         [ephemeralStoreWithCookies.get().httpCookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
             ASSERT_EQ(2u, cookies.count);
-            finished = true;
+            cookieStoreFinished = true;
         }];
     }];
-    TestWebKitAPI::Util::run(&finished);
-    finished = false;
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
+    cookieStoreFinished = false;
 
     RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().prewarmsProcessesAutomatically = shouldEnableProcessPrewarming == ShouldEnableProcessPrewarming::Yes;
@@ -550,50 +550,50 @@ void runWKHTTPCookieStoreWithoutProcessPool(ShouldEnableProcessPrewarming should
     RetainPtr delegate = adoptNS([[CookieUIDelegate alloc] init]);
     webView.get().UIDelegate = delegate.get();
     [webView loadHTMLString:alertCookieHTML baseURL:[NSURL URLWithString:@"http://127.0.0.1"]];
-    TestWebKitAPI::Util::run(&finished);
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
 
-    finished = false;
+    cookieStoreFinished = false;
     [ephemeralStoreWithCookies.get().httpCookieStore deleteCookie:sessionCookie.get() completionHandler:^{
         [ephemeralStoreWithCookies.get().httpCookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
             ASSERT_EQ(1u, cookies.count);
-            finished = true;
+            cookieStoreFinished = true;
         }];
     }];
-    TestWebKitAPI::Util::run(&finished);
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
     
     // DefaultDataStore
     auto defaultStore = [WKWebsiteDataStore defaultDataStore];
-    finished = false;
+    cookieStoreFinished = false;
     [defaultStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:[] {
-        finished = true;
+        cookieStoreFinished = true;
     }];
-    TestWebKitAPI::Util::run(&finished);
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
 
-    finished = false;
+    cookieStoreFinished = false;
     [defaultStore.httpCookieStore setCookie:persistentCookie.get() completionHandler:^{
         [defaultStore.httpCookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
             ASSERT_EQ(1u, cookies.count);
-            finished = true;
+            cookieStoreFinished = true;
         }];
     }];
-    TestWebKitAPI::Util::run(&finished);
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
 
-    finished = false;
+    cookieStoreFinished = false;
     [defaultStore.httpCookieStore setCookie:sessionCookie.get() completionHandler:^{
         [defaultStore.httpCookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
             ASSERT_EQ(2u, cookies.count);
-            finished = true;
+            cookieStoreFinished = true;
         }];
     }];
-    TestWebKitAPI::Util::run(&finished);
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
 
-    finished = false;
+    cookieStoreFinished = false;
     configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = defaultStore;
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
     [webView loadHTMLString:alertCookieHTML baseURL:[NSURL URLWithString:@"http://127.0.0.1"]];
-    TestWebKitAPI::Util::run(&finished);
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
 }
 
 TEST(WKHTTPCookieStore, WithoutProcessPoolWithoutPrewarming)
@@ -618,7 +618,7 @@ TEST(WKHTTPCookieStore, WithoutProcessPoolWithPrewarming)
 - (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler
 {
     _message = message;
-    finished = true;
+    cookieStoreFinished = true;
     completionHandler();
 }
 
@@ -685,10 +685,10 @@ TEST(WKHTTPCookieStore, WithoutProcessPoolEphemeralSession)
     }];
     
     [ephemeralStoreWithCookies.get().httpCookieStore setCookie:sessionCookie.get() completionHandler:^{
-        finished = true;
+        cookieStoreFinished = true;
     }];
-    TestWebKitAPI::Util::run(&finished);
-    finished = false;
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
+    cookieStoreFinished = false;
     
     [webView loadHTMLString:[delegate alertCookieHTML] baseURL:[NSURL URLWithString:@"http://127.0.0.1"]];
     EXPECT_WK_STREQ([delegate waitForMessage], "SessionCookieName=CookieValue");
@@ -714,27 +714,27 @@ TEST(WKHTTPCookieStore, WithoutProcessPoolDuplicates)
     RetainPtr<NSHTTPCookie> sessionCookieDifferentDomain = [NSHTTPCookie cookieWithProperties:properties.get()];
     properties.get()[NSHTTPCookieValue] = @"OtherCookieValue";
     RetainPtr<NSHTTPCookie> sessionCookieDifferentValue = [NSHTTPCookie cookieWithProperties:properties.get()];
-    finished = false;
+    cookieStoreFinished = false;
 
     clearCookies([WKWebsiteDataStore defaultDataStore]);
 
     [httpCookieStore.get() setCookie:sessionCookie.get() completionHandler:^{
-        finished = true;
+        cookieStoreFinished = true;
     }];
-    TestWebKitAPI::Util::run(&finished);
-    finished = false;
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
+    cookieStoreFinished = false;
 
     [httpCookieStore.get() setCookie:sessionCookieDifferentDomain.get() completionHandler:^{
-        finished = true;
+        cookieStoreFinished = true;
     }];
-    TestWebKitAPI::Util::run(&finished);
-    finished = false;
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
+    cookieStoreFinished = false;
 
     [httpCookieStore.get() setCookie:sessionCookieDifferentValue.get() completionHandler:^{
-        finished = true;
+        cookieStoreFinished = true;
     }];
-    TestWebKitAPI::Util::run(&finished);
-    finished = false;
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
+    cookieStoreFinished = false;
 
     [httpCookieStore.get() getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
         EXPECT_EQ(2u, cookies.count);
@@ -746,9 +746,9 @@ TEST(WKHTTPCookieStore, WithoutProcessPoolDuplicates)
                 otherSessionCookieExists = true;
         }
         EXPECT_TRUE(sessionCookieExists && otherSessionCookieExists);
-        finished = true;
+        cookieStoreFinished = true;
     }];
-    TestWebKitAPI::Util::run(&finished);
+    TestWebKitAPI::Util::run(&cookieStoreFinished);
 }
 
 TEST(WKHTTPCookieStore, CookiesForURL)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm
@@ -147,14 +147,14 @@
 @end
 
 
-static constexpr auto mainBytes = u8""
+static constexpr auto schemeHandlerMainBytes = u8""
 "<html>"
 "<img src='testing:image'>"
 "</html>"_span;
 
-static RetainPtr<NSData> mainBytesData()
+static RetainPtr<NSData> schemeHandlerMainBytesData()
 {
-    return toNSData(byteCast<uint8_t>(mainBytes));
+    return toNSData(byteCast<uint8_t>(schemeHandlerMainBytes));
 }
 
 TEST(URLSchemeHandler, Basic)
@@ -163,7 +163,7 @@ TEST(URLSchemeHandler, Basic)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:mainBytesData().get() mimeType:@"text/html"]);
+    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:schemeHandlerMainBytesData().get() mimeType:@"text/html"]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -186,7 +186,7 @@ TEST(URLSchemeHandler, BasicWithHTTPS)
     done = false;
 
     HTTPServer httpsServer({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, mainBytes } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, schemeHandlerMainBytes } },
     }, HTTPServer::Protocol::HttpsProxy);
 
     RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
@@ -198,7 +198,7 @@ TEST(URLSchemeHandler, BasicWithHTTPS)
     RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:mainBytesData().get() mimeType:@"text/html"]);
+    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:schemeHandlerMainBytesData().get() mimeType:@"text/html"]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -224,7 +224,7 @@ TEST(URLSchemeHandler, BasicWithAsyncPolicyDelegate)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:mainBytesData().get() mimeType:@"text/html"]);
+    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:schemeHandlerMainBytesData().get() mimeType:@"text/html"]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -251,7 +251,7 @@ TEST(URLSchemeHandler, NoMIMEType)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:mainBytesData().get() mimeType:nil]);
+    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:schemeHandlerMainBytesData().get() mimeType:nil]);
     handler.get().shouldFinish = NO;
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
 
@@ -552,7 +552,7 @@ static bool receivedStop;
 
 @end
 
-static bool receivedMessage;
+static bool schemeHandlerReceivedMessage;
 
 @interface SyncMessageHandler : NSObject <WKScriptMessageHandler>
 @end
@@ -565,7 +565,7 @@ static bool receivedMessage;
     else
         [receivedMessages addObject:@""];
 
-    receivedMessage = true;
+    schemeHandlerReceivedMessage = true;
 }
 @end
 
@@ -607,8 +607,8 @@ TEST(URLSchemeHandler, SyncXHR)
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"syncxhr://host/main.html"]];
         [webView loadRequest:request];
 
-        TestWebKitAPI::Util::run(&receivedMessage);
-        receivedMessage = false;
+        TestWebKitAPI::Util::run(&schemeHandlerReceivedMessage);
+        schemeHandlerReceivedMessage = false;
 
         EXPECT_EQ((unsigned)receivedMessages.get().count, (unsigned)1);
         EXPECT_TRUE([receivedMessages.get()[0] isEqualToString:@"My XHR text!"]);
@@ -619,7 +619,7 @@ TEST(URLSchemeHandler, SyncXHR)
         [webView loadRequest:request];
 
         TestWebKitAPI::Util::run(&startedXHR);
-        receivedMessage = false;
+        schemeHandlerReceivedMessage = false;
 
         [webView _close];
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebContentProcessDidTerminate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebContentProcessDidTerminate.mm
@@ -48,7 +48,7 @@ static bool shouldLoadAgainOnCrash;
 static bool calledAllCallbacks;
 static unsigned callbackCount;
 static unsigned crashHandlerCount;
-static unsigned loadCount;
+static unsigned terminateLoadCount;
 static unsigned expectedLoadCount;
 
 static NSString *testHTML = @"<script>window.webkit.messageHandlers.testHandler.postMessage('LOADED');</script>";
@@ -339,7 +339,7 @@ TEST(WKNavigation, ProcessCrashDuringCallback)
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    if (++loadCount == expectedLoadCount)
+    if (++terminateLoadCount == expectedLoadCount)
         finishedLoad = true;
 }
 
@@ -366,7 +366,7 @@ TEST(WKNavigation, ReloadRelatedViewsInProcessDidTerminate)
         [webView setNavigationDelegate:delegate.get()];
 
     crashHandlerCount = 0;
-    loadCount = 0;
+    terminateLoadCount = 0;
     expectedLoadCount = numberOfViews;
     finishedLoad = false;
 
@@ -381,7 +381,7 @@ TEST(WKNavigation, ReloadRelatedViewsInProcessDidTerminate)
     for (auto& webView : webViews)
         EXPECT_EQ(pidBefore, [webView _webProcessIdentifier]);
 
-    loadCount = 0;
+    terminateLoadCount = 0;
     finishedLoad = false;
 
     // Kill the WebContent process. The crash handler should reload all views.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebPushDaemon.mm
@@ -143,7 +143,7 @@ template<> bool isValidEnum<WebCore::NotificationDirection>(std::underlying_type
 
 namespace TestWebKitAPI {
 
-static bool done;
+static bool webPushDaemonDone;
 
 static RetainPtr<NSURL> testWebPushDaemonLocation()
 {
@@ -559,7 +559,7 @@ TEST(WebPushD, BasicCommunication)
     // FIXME: This is a false positive. <rdar://164843889>
     SUPPRESS_RETAINPTR_CTOR_ADOPT OSObjectPtr connection = adoptOSObject(xpc_connection_create_mach_service("org.webkit.webpushtestdaemon.service", mainDispatchQueueSingleton(), 0));
 
-    __block bool done = false;
+    __block bool webPushDaemonDone = false;
     __block bool interrupted = false;
     xpc_connection_set_event_handler(connection.get(), ^(xpc_object_t request) {
         if (request == XPC_ERROR_CONNECTION_INTERRUPTED) {
@@ -573,9 +573,9 @@ TEST(WebPushD, BasicCommunication)
     auto sender = WebPushXPCConnectionMessageSender { connection.get() };
     sender.sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(defaultWebPushDaemonConfiguration()));
     sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushTopicsForTesting(), ^(Vector<String>, Vector<String>) {
-        done = true;
+        webPushDaemonDone = true;
     });
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
     // Sending a message with a higher protocol version should cause the connection to be terminated.
     sender.setShouldIncrementProtocolVersionForTesting();
@@ -1003,16 +1003,16 @@ public:
         [m_dataStore _setResourceLoadStatisticsEnabled:YES];
         clearWebsiteDataStore(m_dataStore.get());
 
-        __block bool done = false;
+        __block bool webPushDaemonDone = false;
         [m_dataStore _setPrevalentDomain:m_url.get() completionHandler:^{
-            done = true;
+            webPushDaemonDone = true;
         }];
-        Util::run(&done);
-        done = false;
+        Util::run(&webPushDaemonDone);
+        webPushDaemonDone = false;
         [m_dataStore _logUserInteraction:m_url.get() completionHandler:^{
-            done = true;
+            webPushDaemonDone = true;
         }];
-        Util::run(&done);
+        Util::run(&webPushDaemonDone);
 
         [configuration setProcessPool:processPool];
         [configuration setWebsiteDataStore:m_dataStore.get()];
@@ -1137,15 +1137,15 @@ public:
     // active service worker).
     bool hasPushSubscriptionForTesting()
     {
-        __block bool done = false;
+        __block bool webPushDaemonDone = false;
         __block bool result = false;
 
         [m_dataStore _scopeURL:m_url.get() hasPushSubscriptionForTesting:^(BOOL fetchedResult) {
             result = fetchedResult;
-            done = true;
+            webPushDaemonDone = true;
         }];
 
-        TestWebKitAPI::Util::run(&done);
+        TestWebKitAPI::Util::run(&webPushDaemonDone);
         return result;
     }
 
@@ -1181,14 +1181,14 @@ public:
 
     NSNumber *getAppBadge()
     {
-        __block bool done = false;
+        __block bool webPushDaemonDone = false;
         __block NSNumber *result = nil;
         [m_webView.get().configuration.websiteDataStore _getAppBadgeForTesting:^(NSNumber *badge) {
             result = badge;
-            done = true;
+            webPushDaemonDone = true;
         }];
 
-        TestWebKitAPI::Util::run(&done);
+        TestWebKitAPI::Util::run(&webPushDaemonDone);
         return result;
     }
 
@@ -1221,13 +1221,13 @@ public:
 
         auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
         auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
-        __block bool done = false;
+        __block bool webPushDaemonDone = false;
         sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::InjectPushMessageForTesting(message), ^(const String& error) {
             if (!error.isEmpty())
                 NSLog(@"ERROR: %s", error.utf8().data());
-            done = true;
+            webPushDaemonDone = true;
         });
-        TestWebKitAPI::Util::run(&done);
+        TestWebKitAPI::Util::run(&webPushDaemonDone);
     }
 #endif
 
@@ -1269,11 +1269,11 @@ public:
 
         auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
         auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
-        __block bool done = false;
+        __block bool webPushDaemonDone = false;
         sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::InjectEncryptedPushMessageForTesting(message), ^(bool injected) {
-            done = true;
+            webPushDaemonDone = true;
         });
-        TestWebKitAPI::Util::run(&done);
+        TestWebKitAPI::Util::run(&webPushDaemonDone);
     }
 
     RetainPtr<NSDictionary> fetchPushMessage()
@@ -1346,17 +1346,17 @@ public:
         static constexpr Seconds days { 3600.0 * 24 };
         auto advance = days * daysToAdvance;
 
-        __block bool done = false;
+        __block bool webPushDaemonDone = false;
         [m_dataStore _setResourceLoadStatisticsTimeAdvanceForTesting:advance.value() completionHandler:^{
-            done = true;
+            webPushDaemonDone = true;
         }];
-        TestWebKitAPI::Util::run(&done);
+        TestWebKitAPI::Util::run(&webPushDaemonDone);
 
-        done = false;
+        webPushDaemonDone = false;
         [m_dataStore _processStatisticsAndDataRecords:^{
-            done = true;
+            webPushDaemonDone = true;
         }];
-        Util::run(&done);
+        Util::run(&webPushDaemonDone);
     }
 
     void assertPushEventSucceeds(unsigned daysToAdvance)
@@ -1381,11 +1381,11 @@ public:
 
     void processPushMessage(NSDictionary *pushMessage)
     {
-        __block bool done = false;
+        __block bool webPushDaemonDone = false;
         [m_dataStore _processPushMessage:pushMessage completionHandler:^(bool result) {
-            done = true;
+            webPushDaemonDone = true;
         }];
-        TestWebKitAPI::Util::run(&done);
+        TestWebKitAPI::Util::run(&webPushDaemonDone);
     }
 
     void captureAllMessages()
@@ -1462,13 +1462,13 @@ public:
         Vector<String> ignoredTopics;
         auto connection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
         auto sender = WebPushXPCConnectionMessageSender { connection.get() };
-        bool done = false;
+        bool webPushDaemonDone = false;
         sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushTopicsForTesting(), [&](Vector<String> enabled, Vector<String> ignored) {
             enabledTopics = enabled;
             ignoredTopics = ignored;
-            done = true;
+            webPushDaemonDone = true;
         });
-        TestWebKitAPI::Util::run(&done);
+        TestWebKitAPI::Util::run(&webPushDaemonDone);
 
         return std::make_pair(WTF::move(enabledTopics), WTF::move(ignoredTopics));
     }
@@ -1541,12 +1541,12 @@ TEST_F(WebPushDTest, SubscribeTest)
     auto connection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
     auto sender = WebPushXPCConnectionMessageSender { connection.get() };
     Vector<WebCore::SecurityOriginData> origins;
-    bool done = false;
+    bool webPushDaemonDone = false;
     sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetAllPushSubscriptionOrigins(), [&](Vector<WebCore::SecurityOriginData> result) {
         origins = WTF::move(result);
-        done = true;
+        webPushDaemonDone = true;
     });
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
     ASSERT_TRUE(origins.contains(WebCore::SecurityOriginData::fromURL(URL { "https://example.com"_s })));
 }
 
@@ -1554,11 +1554,11 @@ TEST_F(WebPushDTest, SubscribeWithBadIPCVersionRaisesExceptionTest)
 {
     auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
     auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
-    bool done = false;
-    sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SetProtocolVersionForTesting(WebKit::WebPushD::protocolVersionValue + 1), [&done]() {
-        done = true;
+    bool webPushDaemonDone = false;
+    sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SetProtocolVersionForTesting(WebKit::WebPushD::protocolVersionValue + 1), [&webPushDaemonDone]() {
+        webPushDaemonDone = true;
     });
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
     for (auto& v : webViews()) {
         ASSERT_FALSE(v->hasPushSubscription());
@@ -1571,11 +1571,11 @@ TEST_F(WebPushDTest, GetPushSubscriptionWithBadIPCVersionRaisesExceptionTest)
 {
     auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
     auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
-    bool done = false;
-    sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SetProtocolVersionForTesting(WebKit::WebPushD::protocolVersionValue + 1), [&done]() {
-        done = true;
+    bool webPushDaemonDone = false;
+    sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SetProtocolVersionForTesting(WebKit::WebPushD::protocolVersionValue + 1), [&webPushDaemonDone]() {
+        webPushDaemonDone = true;
     });
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
     for (auto& v : webViews()) {
         ASSERT_FALSE(v->hasPushSubscription());
@@ -1897,11 +1897,11 @@ TEST_F(WebPushDTest, GetPushSubscriptionWithMismatchedPublicToken)
     // If the public token changes, all subscriptions should be invalidated.
     auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
     auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
-    bool done = false;
+    bool webPushDaemonDone = false;
     sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SetPublicTokenForTesting("foobar"_s), [&]() {
-        done = true;
+        webPushDaemonDone = true;
     });
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
     for (auto& v : webViews())
         ASSERT_FALSE(v->hasPushSubscription());
@@ -1963,25 +1963,25 @@ TEST_F(WebPushDBuiltInTest, ShowAndGetNotifications)
     // No badge had been set, so confirm its `nil`
     EXPECT_FALSE(view->getAppBadge());
 
-    done = false;
+    webPushDaemonDone = false;
     sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::InjectPushMessageForTesting(message), ^(const String& error) {
         if (!error.isEmpty())
             NSLog(@"ERROR: %s", error.utf8().data());
-        done = true;
+        webPushDaemonDone = true;
     });
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
-    done = false;
+    webPushDaemonDone = false;
     RetainPtr delegate = (PushNotificationDelegate *)dataStore.get()._delegate;
     [dataStore _getPendingPushMessages:^(NSArray<NSDictionary *> *messages) {
         EXPECT_EQ(messages.count, 1u);
 
         [dataStore _processPushMessage:messages.firstObject completionHandler:^(bool handled) {
             EXPECT_TRUE(handled);
-            done = true;
+            webPushDaemonDone = true;
         }];
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
     id result = view->getNotifications();
     EXPECT_TRUE([result isEqualToString:@"0 - title: notification body:  tag:  dir: auto silent: null data: null "]);
@@ -2102,11 +2102,11 @@ TEST_F(WebPushDBuiltInTest, ImplicitSilentPushTimerIgnoredForInspectedContexts)
     auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
 
     auto setServiceWorkerIsBeingInspected = [&](const String& originString) {
-        __block bool done = false;
+        __block bool webPushDaemonDone = false;
         sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SetServiceWorkerIsBeingInspected(URL(originString), true), ^() {
-            done = true;
+            webPushDaemonDone = true;
         });
-        TestWebKitAPI::Util::run(&done);
+        TestWebKitAPI::Util::run(&webPushDaemonDone);
     };
 
     for (auto& v : webViews()) {
@@ -2779,7 +2779,7 @@ TEST(WebPushD, DeclarativeParsing)
     clearWebsiteDataStore(dataStore.get());
 
     auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
-    static bool done = false;
+    static bool webPushDaemonDone = false;
 
     WebKit::WebPushD::PushMessageForTesting message;
     message.targetAppCodeSigningIdentifier = "com.apple.WebKit.TestWebKitAPI"_s;
@@ -2789,31 +2789,31 @@ TEST(WebPushD, DeclarativeParsing)
     unsigned i = 0;
     while (!jsonAndErrors[i].first.isNull()) {
         message.payload = jsonAndErrors[i].first;
-        done = false;
+        webPushDaemonDone = false;
         sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::InjectPushMessageForTesting(message), [&](const String& error) {
             if (!error.isEmpty())
                 EXPECT_TRUE(error.endsWith(jsonAndErrors[i].second));
             else
                 EXPECT_FALSE(strcmp(jsonAndErrors[i].second, " "));
 
-            done = true;
+            webPushDaemonDone = true;
         });
-        TestWebKitAPI::Util::run(&done);
+        TestWebKitAPI::Util::run(&webPushDaemonDone);
         ++i;
     }
 
     // Now retrieve the successfully parsed messages like a client would,
     // but validate they make sense like you only can in internals.
-    done = false;
+    webPushDaemonDone = false;
     [dataStore _getPendingPushMessages:^(NSArray<NSDictionary *> *messages) {
         EXPECT_EQ(messages.count, expectedSuccessfulMessages());
 
         for (NSDictionary *message in messages)
             EXPECT_TRUE(message[@"WebKitNotificationPayload"]);
 
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 }
 
 // Verifies that handling a declarative web push message - with no service worker even registered - calls
@@ -2833,7 +2833,7 @@ TEST(WebPushD, DeclarativeWebPushHandling)
 
     auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
     auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
-    static bool done = false;
+    static bool webPushDaemonDone = false;
 
     WebKit::WebPushD::PushMessageForTesting message;
     message.pushPartitionString = "TestWebKitAPI"_s;
@@ -2843,17 +2843,17 @@ TEST(WebPushD, DeclarativeWebPushHandling)
     message.payload = json33;
     sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::InjectPushMessageForTesting(message), [&](const String& error) {
         EXPECT_TRUE(error.isEmpty());
-        done = true;
+        webPushDaemonDone = true;
     });
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
     // Verify that even after having sent a push message to the daemon, there are no pending messages, as it was already handled.
-    done = false;
+    webPushDaemonDone = false;
     [dataStore _getPendingPushMessages:^(NSArray<NSDictionary *> *messages) {
         EXPECT_EQ(messages.count, 0u);
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
     RetainPtr configuration = adoptNS([[_WKWebPushDaemonConnectionConfiguration alloc] init]);
@@ -2863,16 +2863,16 @@ TEST(WebPushD, DeclarativeWebPushHandling)
     configuration.get().partition = @"TestWebKitAPI";
     RetainPtr connection = adoptNS([[_WKWebPushDaemonConnection alloc] initWithConfiguration:configuration.get()]);
 
-    done = false;
+    webPushDaemonDone = false;
 
     [connection getNotifications:message.registrationURL.createNSURL().get() tag:@"" completionHandler:^(NSArray<_WKNotificationData *> *notifications, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(notifications);
         EXPECT_EQ(notifications.count, 1u);
         EXPECT_TRUE([notifications[0].title isEqualToString:@"Hello world!"]);
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 #endif // HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
 
     // FIXME: Figure out how to activate the notification programtically to verify the appropriate delegate callbacks are made
@@ -2890,26 +2890,26 @@ TEST(WebPushD, WKWebPushDaemonConnectionRequestPushPermission)
     RetainPtr connection = adoptNS([[_WKWebPushDaemonConnection alloc] initWithConfiguration:configuration.get()]);
     RetainPtr url = adoptNS([[NSURL alloc] initWithString:@"https://webkit.org"]);
 
-    __block bool done = false;
+    __block bool webPushDaemonDone = false;
     [connection getPushPermissionStateForOrigin:url.get() completionHandler:^(_WKWebPushPermissionState state) {
-        done = true;
+        webPushDaemonDone = true;
         EXPECT_EQ(state, _WKWebPushPermissionStatePrompt);
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
-    done = false;
+    webPushDaemonDone = false;
     [connection requestPushPermissionForOrigin:url.get() completionHandler:^(BOOL granted) {
-        done = true;
+        webPushDaemonDone = true;
         EXPECT_TRUE(granted);
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
-    done = false;
+    webPushDaemonDone = false;
     [connection getPushPermissionStateForOrigin:url.get() completionHandler:^(_WKWebPushPermissionState state) {
-        done = true;
+        webPushDaemonDone = true;
         EXPECT_EQ(state, _WKWebPushPermissionStateGranted);
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 }
 #endif
 
@@ -2926,49 +2926,49 @@ TEST(WebPushD, WKWebPushDaemonConnectionPushNotifications)
     RetainPtr url = adoptNS([[NSURL alloc] initWithString:@"https://webkit.org/sw.js"]);
     RetainPtr applicationServerKey = [NSData dataWithBytes:(const void *)validServerKey.characters() length:validServerKey.length()];
 
-    __block bool done = false;
+    __block bool webPushDaemonDone = false;
     [connection subscribeToPushServiceForScope:url.get() applicationServerKey:applicationServerKey.get() completionHandler:^(_WKWebPushSubscriptionData *subscription, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(subscription);
         EXPECT_WK_STREQ(@"https://webkit.org/push", subscription.endpoint.absoluteString);
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
-    done = false;
+    webPushDaemonDone = false;
     [connection getSubscriptionForScope:url.get() completionHandler:^(_WKWebPushSubscriptionData *subscription, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(subscription);
         EXPECT_WK_STREQ(@"https://webkit.org/push", subscription.endpoint.absoluteString);
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
-    done = false;
+    webPushDaemonDone = false;
     [connection unsubscribeFromPushServiceForScope:url.get() completionHandler:^(BOOL unsubscribed, NSError * error) {
         EXPECT_NULL(error);
         EXPECT_TRUE(unsubscribed);
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
-    done = false;
+    webPushDaemonDone = false;
     [connection getSubscriptionForScope:url.get() completionHandler:^(_WKWebPushSubscriptionData *subscription, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NULL(subscription);
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
-    done = false;
+    webPushDaemonDone = false;
     [connection getNotifications:url.get() tag:@"" completionHandler:^(NSArray<_WKNotificationData *> *notifications, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(notifications);
         EXPECT_EQ(notifications.count, 0u);
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
     RetainPtr notification = adoptNS([[_WKMutableNotificationData alloc] init]);
     notification.get().title = @"Hello World!";
@@ -2983,13 +2983,13 @@ TEST(WebPushD, WKWebPushDaemonConnectionPushNotifications)
     RetainPtr uuid1 = [NSUUID UUID];
     notification.get().uuid = uuid1.get();
 
-    done = false;
+    webPushDaemonDone = false;
     [connection showNotification:notification.get() completionHandler:^{
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
-    done = false;
+    webPushDaemonDone = false;
     [connection getNotifications:url.get() tag:@"" completionHandler:^(NSArray<_WKNotificationData *> *notifications, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_EQ(notifications.count, 1u);
@@ -3005,68 +3005,68 @@ TEST(WebPushD, WKWebPushDaemonConnectionPushNotifications)
             EXPECT_TRUE([notifications[0].serviceWorkerRegistrationURL isEqual:url.get()]);
             EXPECT_TRUE([notifications[0].uuid isEqual:uuid1.get()]);
         }
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
     [connection cancelNotification:url.get() uuid:uuid1.get()];
 
-    done = false;
+    webPushDaemonDone = false;
     [connection getNotifications:url.get() tag:@"" completionHandler:^(NSArray<_WKNotificationData *> *notifications, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_NOT_NULL(notifications);
         EXPECT_EQ(notifications.count, 0u);
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
-    done = false;
+    webPushDaemonDone = false;
     [connection showNotification:notification.get() completionHandler:^{
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
     notification.get().body = @"Body2";
     notification.get().tag = @"Tag2";
     RetainPtr uuid2 = [NSUUID UUID];
     notification.get().uuid = uuid2.get();
-    done = false;
+    webPushDaemonDone = false;
     [connection showNotification:notification.get() completionHandler:^{
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
-    done = false;
+    webPushDaemonDone = false;
     [connection getNotifications:url.get() tag:@"" completionHandler:^(NSArray<_WKNotificationData *> *notifications, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_EQ(notifications.count, 2u);
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
-    done = false;
+    webPushDaemonDone = false;
     [connection getNotifications:url.get() tag:@"Tag1" completionHandler:^(NSArray<_WKNotificationData *> *notifications, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_EQ(notifications.count, 1u);
         if (notifications.count)
             EXPECT_TRUE([notifications[0].body isEqualToString:@"Body1"]);
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
-    done = false;
+    webPushDaemonDone = false;
     [connection getNotifications:url.get() tag:@"Tag2" completionHandler:^(NSArray<_WKNotificationData *> *notifications, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_EQ(notifications.count, 1u);
         if (notifications.count)
             EXPECT_TRUE([notifications[0].body isEqualToString:@"Body2"]);
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
     [connection cancelNotification:url.get() uuid:uuid1.get()];
 
-    done = false;
+    webPushDaemonDone = false;
     [connection getNotifications:url.get() tag:@"" completionHandler:^(NSArray<_WKNotificationData *> *notifications, NSError *error) {
         EXPECT_NULL(error);
         EXPECT_EQ(notifications.count, 1u);
@@ -3074,9 +3074,9 @@ TEST(WebPushD, WKWebPushDaemonConnectionPushNotifications)
             EXPECT_TRUE([notifications[0].body isEqualToString:@"Body2"]);
             EXPECT_TRUE([notifications[0].uuid isEqual:uuid2.get()]);
         }
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 #endif // HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
 }
 
@@ -3086,11 +3086,11 @@ TEST(WebPushD, WKWebPushDaemonConnectionSubscribeWithBadIPCVersionRaisesExceptio
 
     auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
     auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
-    bool done = false;
-    sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SetProtocolVersionForTesting(WebKit::WebPushD::protocolVersionValue + 1), [&done]() {
-        done = true;
+    bool webPushDaemonDone = false;
+    sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SetProtocolVersionForTesting(WebKit::WebPushD::protocolVersionValue + 1), [&webPushDaemonDone]() {
+        webPushDaemonDone = true;
     });
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
     RetainPtr configuration = adoptNS([[_WKWebPushDaemonConnectionConfiguration alloc] init]);
     configuration.get().machServiceName = @"org.webkit.webpushtestdaemon.service";
@@ -3101,13 +3101,13 @@ TEST(WebPushD, WKWebPushDaemonConnectionSubscribeWithBadIPCVersionRaisesExceptio
     RetainPtr url = adoptNS([[NSURL alloc] initWithString:@"https://webkit.org/sw.js"]);
     RetainPtr applicationServerKey = [NSData dataWithBytes:(const void *)validServerKey.characters() length:validServerKey.length()];
 
-    done = false;
+    webPushDaemonDone = false;
     RetainPtr<NSError> error;
-    [connection subscribeToPushServiceForScope:url.get() applicationServerKey:applicationServerKey.get() completionHandler:[&done, &error] (_WKWebPushSubscriptionData *subscription, NSError *subscriptionError) {
+    [connection subscribeToPushServiceForScope:url.get() applicationServerKey:applicationServerKey.get() completionHandler:[&webPushDaemonDone, &error] (_WKWebPushSubscriptionData *subscription, NSError *subscriptionError) {
         error = subscriptionError;
-        done = true;
+        webPushDaemonDone = true;
     }];
-    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&webPushDaemonDone);
 
     ASSERT_TRUE([[error description] containsString:@"Connection to web push daemon failed"]);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
@@ -73,12 +73,12 @@
 
 @end
 
-enum class ShouldEnableProcessPrewarming : bool { No, Yes };
+enum class CustomPathsShouldEnableProcessPrewarming : bool { No, Yes };
 
-static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldEnableProcessPrewarming)
+static void runWebsiteDataStoreCustomPaths(CustomPathsShouldEnableProcessPrewarming shouldEnableProcessPrewarming)
 {
     RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
-    processPoolConfiguration.get().prewarmsProcessesAutomatically = shouldEnableProcessPrewarming == ShouldEnableProcessPrewarming::Yes ? YES : NO;
+    processPoolConfiguration.get().prewarmsProcessesAutomatically = shouldEnableProcessPrewarming == CustomPathsShouldEnableProcessPrewarming::Yes ? YES : NO;
     RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
     RetainPtr handler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
@@ -276,12 +276,12 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
 
 TEST(WebKit, WebsiteDataStoreCustomPathsWithoutPrewarming)
 {
-    runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming::No);
+    runWebsiteDataStoreCustomPaths(CustomPathsShouldEnableProcessPrewarming::No);
 }
 
 TEST(WebKit, WebsiteDataStoreCustomPathsWithPrewarming)
 {
-    runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming::Yes);
+    runWebsiteDataStoreCustomPaths(CustomPathsShouldEnableProcessPrewarming::Yes);
 }
 
 TEST(WebKit, CustomDataStoreDestroyWhileFetchingNetworkProcessData)
@@ -1633,7 +1633,7 @@ TEST(WKWebsiteDataStore, MigrateCacheStorageDataToGeneralStorageDirectory)
     EXPECT_TRUE([fileManager fileExistsAtPath:newCacheStorageCachesListFile.path]);
 }
 
-static constexpr auto mainBytes = R"SWRESOURCE(
+static constexpr auto customPathsMainBytes = R"SWRESOURCE(
 <script>
 function log(message)
 {
@@ -1665,7 +1665,7 @@ navigator.serviceWorker.getRegistration('/migratetest/').then((registration) => 
 </script>
 )SWRESOURCE"_s;
 
-static constexpr auto scriptBytes = R"SWRESOURCE(
+static constexpr auto customPathsScriptBytes = R"SWRESOURCE(
 
 self.addEventListener('message', (event) => {
     event.source.postMessage(event.data);
@@ -1684,8 +1684,8 @@ TEST(WKWebsiteDataStore, MigrateServiceWorkerRegistrationToGeneralStorageDirecto
     [fileManager removeItemAtURL:generalStorageDirectory error:nil];
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
-        { "/migratetest/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { customPathsMainBytes } },
+        { "/migratetest/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, customPathsScriptBytes } },
     });
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
     RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
@@ -1778,8 +1778,8 @@ static RetainPtr<WKWebsiteDataStore> createCustomWebsiteDataStoreForServiceWorke
 TEST(WKWebsiteDataStore, RemoveServiceWorkerData)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
-        { "/migratetest/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { customPathsMainBytes } },
+        { "/migratetest/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, customPathsScriptBytes } },
     });
 
     RetainPtr websiteDataStore = createCustomWebsiteDataStoreForServiceWorker(&server);
@@ -1812,8 +1812,8 @@ TEST(WKWebsiteDataStore, RemoveServiceWorkerData)
 TEST(WKWebsiteDataStore, RemoveServiceWorkerDataByOrigin)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBytes } },
-        { "/migratetest/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+        { "/"_s, { customPathsMainBytes } },
+        { "/migratetest/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, customPathsScriptBytes } },
     });
     auto websiteDataStore = createCustomWebsiteDataStoreForServiceWorker(&server);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FirstResponderSuppression.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FirstResponderSuppression.mm
@@ -32,7 +32,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 
-static bool finishedLoad = false;
+static bool firstResponderFinishedLoad = false;
 
 @interface FirstResponderNavigationDelegate : NSObject <WKNavigationDelegate>
 @end
@@ -40,7 +40,7 @@ static bool finishedLoad = false;
 @implementation FirstResponderNavigationDelegate
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    finishedLoad = true;
+    firstResponderFinishedLoad = true;
 }
 @end
 
@@ -65,15 +65,15 @@ TEST(WebKit, FirstResponderSuppression)
     // Ensure having an autofocused input field does not steal focus.
     NSString *testHTML = @"<!doctype html><html><body><input type=\"text\" autofocus /></body></html>";
     [webView loadHTMLString:testHTML baseURL:nil];
-    TestWebKitAPI::Util::run(&finishedLoad);
+    TestWebKitAPI::Util::run(&firstResponderFinishedLoad);
     EXPECT_EQ([window firstResponder], [window contentView]);
-    finishedLoad = false;
+    firstResponderFinishedLoad = false;
 
     [webView _setShouldSuppressFirstResponderChanges:NO];
 
     // Ensure having an autofocused input field does steal focus.
     [webView loadHTMLString:testHTML baseURL:nil];
-    TestWebKitAPI::Util::run(&finishedLoad);
+    TestWebKitAPI::Util::run(&firstResponderFinishedLoad);
 
     [webView waitForNextPresentationUpdate];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/JavascriptURLNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/JavascriptURLNavigation.mm
@@ -46,7 +46,7 @@
 #import <wtf/text/StringHash.h>
 #import <wtf/text/WTFString.h>
 
-static RetainPtr<WKWebView> createdWebView;
+static RetainPtr<WKWebView> javascriptURLCreatedWebView;
 static RetainPtr<TestNavigationDelegate> navDelegate;
 
 @interface JavascriptURLNavigationDelegate : NSObject <WKUIDelegatePrivate>
@@ -55,26 +55,26 @@ static RetainPtr<TestNavigationDelegate> navDelegate;
 
 - (void)_webViewRunModal:(WKWebView *)webView
 {
-    EXPECT_EQ(webView, createdWebView.get());
+    EXPECT_EQ(webView, javascriptURLCreatedWebView.get());
 }
 
 - (nullable WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
 {
-    createdWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
-    [createdWebView setUIDelegate:self];
+    javascriptURLCreatedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    [javascriptURLCreatedWebView setUIDelegate:self];
 
     navDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navDelegate setDecidePolicyForNavigationAction:[&] (WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
         decisionHandler(WKNavigationActionPolicyAllow);
     }];
-    [createdWebView setNavigationDelegate:navDelegate.get()];
+    [javascriptURLCreatedWebView setNavigationDelegate:navDelegate.get()];
 
-    return createdWebView.get();
+    return javascriptURLCreatedWebView.get();
 }
 
 - (void)_webViewClose:(WKWebView *)webView
 {
-    EXPECT_EQ(webView, createdWebView.get());
+    EXPECT_EQ(webView, javascriptURLCreatedWebView.get());
     [webView _close];
 }
 


### PR DESCRIPTION
#### 7d2f95f11d86bf1a74828e28a4267dd7e5c673b8
<pre>
[CMake] Unified-source hygiene fixes for larger bundles
<a href="https://bugs.webkit.org/show_bug.cgi?id=315878">https://bugs.webkit.org/show_bug.cgi?id=315878</a>
<a href="https://rdar.apple.com/178278128">rdar://178278128</a>

Reviewed by David Kilzer and Mike Wyrzykowski.

Fix name collisions and ODR issues that surface when the unified-source
bundle size grows beyond 8. No behavior change at the current bundle size;
prepares for a follow-up that raises bundle size to speed up clean builds
(without regressing incremental builds).

- Fixed missing includes (for files that move between bundles)

- Resolved conflicts from file-scoped &quot;using namespace&quot;:
    * Removed &quot;using namespace&quot; in some cases
    * Added namespace qualifications in other cases

- Resolved SoftLinking conflicts:
    * Class -&gt; ::Class
    * Un-forwarded *_FOR_SOURCE macros so legacy and per-framework-source
    soft-link macros coexist in one TU
    * Guarded duplicate use of SOFT_LINK

- TestWebKitAPI: uniquify file-static globals

- WebKit::PDFDisplayMode -&gt; PDFPluginDisplayMode (shadows SDK type)
- Qualified WTF::toNSData
- Qualified MathMLNames::
- WorldMap -&gt; DOMWrapperWorldMap
- WeakMapImpl.h: forward-declare takeSnapshot specializations
- HTMLMediaElement.h: remove bogus MachSendRightAnnotated forward declaration

Canonical link: <a href="https://commits.webkit.org/314190@main">https://commits.webkit.org/314190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b3f80e1010f7ab7594a09d18b27cf37d360d01f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165389 "16 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122644 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f7d22a6-9b58-4b9e-a6c2-9eda55dcdfe0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128521 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a156423a-0b65-49a4-8a40-f12ffee017fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168348 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/30837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109046 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d68ff1b3-61c9-490c-8740-999fe17b78a8) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/164707 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28506 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22506 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157546 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176954 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26282 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136846 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38947 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136782 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148084 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101990 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25165 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32058 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24951 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111220 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37543 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3030 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37790 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37687 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->