### PR TITLE
Cherry-pick(s) 1c245d737355. rdar://176061205

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5830,8 +5830,19 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
         m_mainFrameWebsitePolicies = mainFrameWebsitePolicies->copy();
 
     // There is no way we'll be able to return to the page in the previous page so close it.
+<<<<<<< HEAD
     if (!didSuspendPreviousPage && shouldClosePreviousPage(*provisionalPage))
         protect(legacyMainFrameProcess())->sendPageCloseMessage(identifier(), webPageIDInMainFrameProcess());
+=======
+    if (!didSuspendPreviousPage && shouldClosePreviousPage(*provisionalPage)) {
+        auto pageID = identifier();
+        Ref oldProcess = legacyMainFrameProcess();
+        oldProcess->addPagePendingClose(pageID);
+        sendWithAsyncReply(Messages::WebPage::CloseWithReply(), [oldProcess, pageID] {
+            oldProcess->removePagePendingClose(pageID);
+        });
+    }
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     if (m_immersive)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -955,6 +955,7 @@ void WebProcessProxy::removeWebPage(WebPageProxy& webPage, EndsUsingDataStore en
     maybeShutDown();
 }
 
+<<<<<<< HEAD
 void WebProcessProxy::sendPageCloseMessage(std::optional<WebPageProxyIdentifier> pageProxyID, WebCore::PageIdentifier pageID, CompletionHandler<void()>&& completionHandler)
 {
     if (pageProxyID)
@@ -967,6 +968,16 @@ void WebProcessProxy::sendPageCloseMessage(std::optional<WebPageProxyIdentifier>
         if (completionHandler)
             completionHandler();
     }, pageID);
+=======
+void WebProcessProxy::addPagePendingClose(WebPageProxyIdentifier pageID)
+{
+    m_pagesPendingClose.add(pageID);
+}
+
+void WebProcessProxy::removePagePendingClose(WebPageProxyIdentifier pageID)
+{
+    m_pagesPendingClose.remove(pageID);
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
 }
 
 void WebProcessProxy::addVisitedLinkStoreUser(VisitedLinkStore& visitedLinkStore, WebPageProxyIdentifier pageID)
@@ -2373,7 +2384,10 @@ bool WebProcessProxy::isAssociatedWithPage(WebPageProxyIdentifier pageID) const
 {
     if (m_pageMap.contains(pageID))
         return true;
+<<<<<<< HEAD
 
+=======
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
     for (Ref remotePage : m_remotePages) {
         if (remotePage->page() && remotePage->page()->identifier() == pageID)
             return true;

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -275,6 +275,8 @@ public:
 
     enum class EndsUsingDataStore : bool { No, Yes };
     void removeWebPage(WebPageProxy&, EndsUsingDataStore);
+    void addPagePendingClose(WebPageProxyIdentifier);
+    void removePagePendingClose(WebPageProxyIdentifier);
 
     void sendPageCloseMessage(std::optional<WebPageProxyIdentifier>, WebCore::PageIdentifier, CompletionHandler<void()>&& = [] { });
 
@@ -812,7 +814,11 @@ private:
     WeakHashSet<RemotePageProxy> m_remotePages;
     WeakHashSet<ProvisionalPageProxy> m_provisionalPages;
     WeakHashSet<SuspendedPageProxy> m_suspendedPages;
+<<<<<<< HEAD
     HashCountedSet<WebPageProxyIdentifier> m_pagesPendingClose;
+=======
+    HashSet<WebPageProxyIdentifier> m_pagesPendingClose;
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
     UserInitiatedActionMap m_userInitiatedActionMap;
     HashMap<WebCore::PageIdentifier, UserInitiatedActionByAuthorizationTokenMap> m_userInitiatedActionByAuthorizationTokenMap;
     uint64_t m_frameProcessCount { 0 };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2103,7 +2103,17 @@ void WebPage::exitAcceleratedCompositingMode(WebCore::Frame& frame)
     protect(drawingArea())->setRootCompositingLayer(frame, nullptr);
 }
 
+<<<<<<< HEAD
 void WebPage::close(CompletionHandler<void()>&& completionHandler)
+=======
+void WebPage::closeWithReply(CompletionHandler<void()>&& completionHandler)
+{
+    close();
+    completionHandler();
+}
+
+void WebPage::close()
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
 {
     if (m_isClosed) {
         completionHandler();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -623,7 +623,12 @@ public:
     void reinitializeWebPage(WebPageCreationParameters&&);
     void platformReinitializeAccessibilityToken();
 
+<<<<<<< HEAD
     void close(CompletionHandler<void()>&&);
+=======
+    void closeWithReply(CompletionHandler<void()>&&);
+    void close();
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
 
     static WebPage* fromCorePage(WebCore::Page&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -311,7 +311,12 @@ messages -> WebPage WantsAsyncDispatchMessage {
     Suspend() -> (bool success)
     Resume() -> (bool success)
 
+<<<<<<< HEAD
     Close() -> ()
+=======
+    Close()
+    CloseWithReply() -> ()
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
     TryClose() -> (bool shouldClose)
     DispatchCrossOriginBeforeUnloadCheckForFrame(WebCore::FrameIdentifier frameID, WebCore::SecurityOriginData navigatingFrameOrigin)
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176061205 to main. The following sources [1ad0d2a7c3b7] will still need to be cherry-picked once the conflict is resolved.

```Cross-Process Page Identity Confusion in didPostMessage
https://bugs.webkit.org/show_bug.cgi?id=310078
rdar://172392170

Reviewed by Brady Eidson and Ryosuke Niwa.

WebProcessProxy::didPostMessage() may look up a WebPageProxy belonging
to another web process if given a bad WebPageProxyIdentifier from a
compromised WebProcess.

Address the issue by adding a MESSAGE_CHECK that checks that the page
is associated with the current WebProcess, using the pre-existing
WebProcessProxy::isAssociatedWithPage() utility function. Note that I
had to tweak isAssociatedWithPage() to also check m_remotePages to keep
site isolation tests working.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::commitProvisionalPage):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::addPagePendingClose):
(WebKit::WebProcessProxy::removePagePendingClose):
(WebKit::WebProcessProxy::isAssociatedWithPage const):
(WebKit::WebProcessProxy::didPostMessage):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::closeWithReply):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Originally-landed-as: 305413.544@rapid/safari-7624.2.5.110-branch (1c245d737355). rdar://176061205

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90ccf8f64ea102b8587a38eaf53e642f50315106

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165384 "6 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38874 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174426 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122639 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39210 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38878 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/174426 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122639 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/168343 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39210 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/32455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174426 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39210 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38878 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/22501 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39210 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/32455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176949 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29851 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/176949 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38942 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/38878 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176949 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/39631 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/32455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/101984 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/39631 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/38141 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/111215 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/37538 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/32455 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37785 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/37682 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->