### PR TITLE
Unable to select text on Facebook Messenger website with Magic Keyboard attached

### DIFF
--- a/LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element-expected.txt
@@ -1,0 +1,12 @@
+Verifies that text in a non-editable element can be selected by long-pressing while a separate editable element is focused (i.e. the keyboard is visible), and that the focused element is not blurred in the process. Requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS keyboardWasShowing is true
+PASS getSelection().toString() became 'Hello'
+PASS keyboardStillShowing is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello

--- a/LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element.html
+++ b/LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+.target {
+    font-size: 40px;
+    width: 300px;
+}
+
+input {
+    display: block;
+    margin-top: 40px;
+    width: 300px;
+    height: 80px;
+    font-size: 40px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+description("Verifies that text in a non-editable element can be selected by long-pressing while a separate editable element is focused (i.e. the keyboard is visible), and that the focused element is not blurred in the process. Requires WebKitTestRunner.");
+
+addEventListener("load", async () => {
+    const input = document.querySelector("input");
+    const inputRect = input.getBoundingClientRect();
+    await UIHelper.activateAndWaitForInputSessionAt(inputRect.left + inputRect.width / 2, inputRect.top + inputRect.height / 2);
+
+    window.keyboardWasShowing = await UIHelper.isShowingKeyboard();
+    shouldBeTrue("keyboardWasShowing");
+
+    await UIHelper.longPressElement(document.querySelector(".target"));
+    await shouldBecomeEqual("getSelection().toString()", "'Hello'");
+
+    window.keyboardStillShowing = await UIHelper.isShowingKeyboard();
+    shouldBeTrue("keyboardStillShowing");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <span class="target">Hello</span>
+    <input>
+</body>
+</html>

--- a/LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard-expected.txt
@@ -1,0 +1,12 @@
+Verifies that text in a non-editable element can be selected by long-pressing while a separate editable element is focused with a hardware (Magic) keyboard attached, and that the focused element is not blurred in the process. This models rdar://137221436, where the software keyboard is not presented because a hardware keyboard is in use. Requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS focusedElementIsInput is true
+PASS getSelection().toString() became 'Hello'
+PASS focusedElementStillInput is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello

--- a/LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard.html
+++ b/LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+.target {
+    font-size: 40px;
+    width: 300px;
+}
+
+input {
+    display: block;
+    margin-top: 40px;
+    width: 300px;
+    height: 80px;
+    font-size: 40px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+description("Verifies that text in a non-editable element can be selected by long-pressing while a separate editable element is focused with a hardware (Magic) keyboard attached, and that the focused element is not blurred in the process. This models rdar://137221436, where the software keyboard is not presented because a hardware keyboard is in use. Requires WebKitTestRunner.");
+
+addEventListener("load", async () => {
+    const input = document.querySelector("input");
+    await UIHelper.activateElementAndWaitForInputSession(input);
+
+    window.focusedElementIsInput = document.activeElement === input;
+    shouldBeTrue("focusedElementIsInput");
+
+    // Note: this test runs with useHardwareKeyboardMode=true, which models a Magic Keyboard by making
+    // -[UIKeyboard isInHardwareKeyboardMode] return YES (the predicate the selection code branches on). The
+    // runner does not necessarily suppress the keyboard view, so we deliberately do not assert on keyboard
+    // visibility here; the meaningful invariants are that the selection succeeds and the field stays focused.
+    await UIHelper.longPressElement(document.querySelector(".target"));
+    await shouldBecomeEqual("getSelection().toString()", "'Hello'");
+
+    // The focused field must remain focused; selecting non-editable content should not blur it.
+    window.focusedElementStillInput = document.activeElement === input;
+    shouldBeTrue("focusedElementStillInput");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <span class="target">Hello</span>
+    <input>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -580,6 +580,7 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _usingMouseDragForSelection;
     BOOL _inspectorNodeSearchEnabled;
     BOOL _isChangingFocusUsingAccessoryTab;
+    BOOL _selectedNonEditableContentWhileFocused;
     BOOL _didAccessoryTabInitiateFocus;
     BOOL _isExpectingFastSingleTapCommit;
     BOOL _showDebugTapHighlightsForFastClicking;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1549,6 +1549,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _didAccessoryTabInitiateFocus = NO;
     _isChangingFocusUsingAccessoryTab = NO;
     _isExpectingFastSingleTapCommit = NO;
+    _selectedNonEditableContentWhileFocused = NO;
     _needsDeferredEndScrollingSelectionUpdate = NO;
     [_formInputSession invalidate];
     _formInputSession = nil;
@@ -3799,8 +3800,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return YES;
 #endif
 
-    // If we're currently focusing an editable element, only allow the selection to move within that focused element.
-    if (self.isFocusingElement)
+    // If we're currently focusing an editable element, only allow the selection to move within that focused
+    // element. The loupe is exempt: it may begin a new selection on non-editable content outside the field.
+    if (self.isFocusingElement && gesture != WKBEGestureTypeLoupe)
         return _positionInformation.elementContext && _positionInformation.elementContext->isSameElement(_focusedElementInformation.elementContext);
 
     if (_positionInformation.prefersDraggingOverTextSelection)
@@ -5511,6 +5513,11 @@ static void selectionChangedWithTouch(WKTextInteractionWrapper *interaction, con
     return _focusedElementInformation.elementType != WebKit::InputType::None;
 }
 
+- (BOOL)_isInteractingWithFocusedElement
+{
+    return self._hasFocusedElement && !_selectedNonEditableContentWhileFocused;
+}
+
 - (BOOL)_isSameAsFocusedElement:(const WebCore::ElementContext&)element
 {
     return [self _hasFocusedElement] && _focusedElementInformation.elementContext.isSameElement(element);
@@ -5527,7 +5534,7 @@ static void selectionChangedWithTouch(WKTextInteractionWrapper *interaction, con
 
     _autocorrectionContextNeedsUpdate = YES;
     _usingGestureForSelection = YES;
-    protect(_page)->selectWithGesture(WebCore::IntPoint(point), toGestureType(gestureType), toGestureRecognizerState(state), self._hasFocusedElement, [self, strongSelf = retainPtr(self), state, flags](const WebCore::IntPoint& point, WebKit::GestureType gestureType, WebKit::GestureRecognizerState gestureState, OptionSet<WebKit::SelectionFlags> innerFlags) {
+    protect(_page)->selectWithGesture(WebCore::IntPoint(point), toGestureType(gestureType), toGestureRecognizerState(state), self._isInteractingWithFocusedElement, [self, strongSelf = retainPtr(self), state, flags](const WebCore::IntPoint& point, WebKit::GestureType gestureType, WebKit::GestureRecognizerState gestureState, OptionSet<WebKit::SelectionFlags> innerFlags) {
         selectionChangedWithGesture(_textInteractionWrapper.get(), point, gestureType, gestureState, toSelectionFlags(flags) | innerFlags);
         if (state == UIGestureRecognizerStateEnded || state == UIGestureRecognizerStateCancelled)
             _usingGestureForSelection = NO;
@@ -5858,7 +5865,8 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 - (void)selectPositionAtPoint:(CGPoint)point completionHandler:(void (^)(void))completionHandler
 {
     _autocorrectionContextNeedsUpdate = YES;
-    [self _selectPositionAtPoint:point stayingWithinFocusedElement:self._hasFocusedElement completionHandler:completionHandler];
+    BOOL stayingWithinFocusedElement = self._hasFocusedElement && _focusedElementInformation.interactionRect.contains(WebCore::roundedIntPoint(point));
+    [self _selectPositionAtPoint:point stayingWithinFocusedElement:stayingWithinFocusedElement completionHandler:completionHandler];
 }
 
 - (void)_selectPositionAtPoint:(CGPoint)point stayingWithinFocusedElement:(BOOL)stayingWithinFocusedElement completionHandler:(void (^)(void))completionHandler
@@ -5867,6 +5875,17 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
     _autocorrectionContextNeedsUpdate = YES;
     _usingGestureForSelection = YES;
+
+    if (!stayingWithinFocusedElement && self._hasFocusedElement) {
+        _selectedNonEditableContentWhileFocused = YES;
+        [self.textInteractionLoupeGestureRecognizer _wk_cancel];
+        protect(_page)->selectWithGesture(WebCore::IntPoint(point), WebKit::GestureType::Loupe, WebKit::GestureRecognizerState::Began, /* isInteractingWithFocusedElement */ false,
+            [view = retainPtr(self), completionHandler = makeBlockPtr(completionHandler)](const WebCore::IntPoint&, WebKit::GestureType, WebKit::GestureRecognizerState, OptionSet<WebKit::SelectionFlags>) {
+                completionHandler();
+                view->_usingGestureForSelection = NO;
+            });
+        return;
+    }
 
     protect(_page)->selectPositionAtPoint(WebCore::IntPoint(point), stayingWithinFocusedElement, [view = retainPtr(self), completionHandler = makeBlockPtr(completionHandler)]() {
         completionHandler();
@@ -5880,7 +5899,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
     _autocorrectionContextNeedsUpdate = YES;
     _usingGestureForSelection = YES;
-    protect(_page)->selectPositionAtBoundaryWithDirection(WebCore::IntPoint(point), toWKTextGranularity(granularity), toWKSelectionDirection(direction), self._hasFocusedElement, [view = retainPtr(self), completionHandler = makeBlockPtr(completionHandler)]() {
+    protect(_page)->selectPositionAtBoundaryWithDirection(WebCore::IntPoint(point), toWKTextGranularity(granularity), toWKSelectionDirection(direction), self._isInteractingWithFocusedElement, [view = retainPtr(self), completionHandler = makeBlockPtr(completionHandler)]() {
         completionHandler();
         view->_usingGestureForSelection = NO;
     });
@@ -5908,7 +5927,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
     _usingMouseDragForSelection = [_mouseInteraction mouseTouchGestureRecognizer]._wk_hasRecognizedOrEnded;
 #endif
     ++_suppressNonEditableSingleTapTextInteractionCount;
-    protect(_page)->selectTextWithGranularityAtPoint(WebCore::IntPoint(point), toWKTextGranularity(granularity), self._hasFocusedElement, [view = retainPtr(self), selectionHandler = makeBlockPtr(completionHandler)] {
+    protect(_page)->selectTextWithGranularityAtPoint(WebCore::IntPoint(point), toWKTextGranularity(granularity), self._isInteractingWithFocusedElement, [view = retainPtr(self), selectionHandler = makeBlockPtr(completionHandler)] {
         selectionHandler();
         view->_usingGestureForSelection = NO;
         --view->_suppressNonEditableSingleTapTextInteractionCount;
@@ -5967,7 +5986,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
 - (void)updateSelectionWithExtentPoint:(CGPoint)point hasFocusedElement:(BOOL)hasFocusedElement respectSelectionAnchor:(WebKit::RespectSelectionAnchor)respectSelectionAnchor completionHandler:(void (^)(BOOL selectionEndIsMoving))completionHandler
 {
-    protect(_page)->updateSelectionWithExtentPoint(WebCore::IntPoint(point), self._hasFocusedElement, respectSelectionAnchor, [completionHandler = makeBlockPtr(completionHandler)](bool endIsMoving) {
+    protect(_page)->updateSelectionWithExtentPoint(WebCore::IntPoint(point), self._isInteractingWithFocusedElement, respectSelectionAnchor, [completionHandler = makeBlockPtr(completionHandler)](bool endIsMoving) {
         completionHandler(static_cast<BOOL>(endIsMoving));
     });
 }
@@ -5975,7 +5994,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 - (void)updateSelectionWithExtentPointAndBoundary:(CGPoint)point textGranularity:(WebCore::TextGranularity)textGranularity textInteractionSource:(WebKit::TextInteractionSource)interactionSource completionHandler:(void (^)(BOOL selectionEndIsMoving))completionHandler
 {
     ++_suppressNonEditableSingleTapTextInteractionCount;
-    protect(_page)->updateSelectionWithExtentPointAndBoundary(WebCore::IntPoint(point), textGranularity, self._hasFocusedElement, interactionSource, [completionHandler = makeBlockPtr(completionHandler), protectedSelf = retainPtr(self)] (bool endIsMoving) {
+    protect(_page)->updateSelectionWithExtentPointAndBoundary(WebCore::IntPoint(point), textGranularity, self._isInteractingWithFocusedElement, interactionSource, [completionHandler = makeBlockPtr(completionHandler), protectedSelf = retainPtr(self)] (bool endIsMoving) {
         completionHandler(static_cast<BOOL>(endIsMoving));
         --protectedSelf->_suppressNonEditableSingleTapTextInteractionCount;
     });
@@ -8785,6 +8804,7 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
     _additionalContextForStrongPasswordAssistance = nil;
     _waitingForKeyboardAppearanceAnimationToStart = NO;
     _revealFocusedElementDeferrer = nullptr;
+    _selectedNonEditableContentWhileFocused = NO;
 
     // When defocusing an editable element reset a seen keydown before calling -_hideKeyboard so that we
     // re-evaluate whether we still need a keyboard when UIKit calls us back in -_requiresKeyboardWhenFirstResponder.
@@ -9432,7 +9452,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
         if (postLayoutData.selectionIsTransparentOrFullyClipped)
             selectionIsTransparentOrFullyClipped = YES;
 
-        if (self._hasFocusedElement) {
+        if (self._hasFocusedElement && editorState.isContentEditable) {
             auto elementArea = visualData.editableRootBounds.area<RecordOverflow>();
             if (!elementArea.hasOverflowed() && elementArea < minimumFocusedElementAreaForSuppressingSelectionAssistant)
                 focusedElementIsTooSmall = YES;
@@ -9455,6 +9475,17 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
     _autocorrectionContextNeedsUpdate = YES;
 
     [self _updateSelectionAssistantSuppressionState];
+
+    Ref page = *_page;
+    if (_selectedNonEditableContentWhileFocused && self._hasFocusedElement) {
+        auto& editorState = page->editorState();
+        bool selectionCleared = editorState.selectionType == WebCore::SelectionType::None;
+        if (selectionCleared || editorState.isContentEditable) {
+            _selectedNonEditableContentWhileFocused = NO;
+            if (selectionCleared)
+                page->restoreSelectionInFocusedEditableElement();
+        }
+    }
 
     _cachedSelectionContainerView = nil;
     _cachedSelectedTextRange = nil;
@@ -9480,7 +9511,6 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 
     [_webView.get() _didChangeEditorState];
 
-    Ref page = *_page;
     if (page->editorState().hasPostLayoutAndVisualData()) {
         _lastInsertedCharacterToOverrideCharacterBeforeSelection = std::nullopt;
 


### PR DESCRIPTION
#### 66902e993a35c43f1ab2152244d8d72b6a8aaaa2
<pre>
Unable to select text on Facebook Messenger website with Magic Keyboard attached
<a href="https://bugs.webkit.org/show_bug.cgi?id=315882">https://bugs.webkit.org/show_bug.cgi?id=315882</a>
<a href="https://rdar.apple.com/137221436">rdar://137221436</a>

Reviewed by NOBODY (OOPS!).

Previously, when an editable element was focused (keyboard visible) or
magic keyboard attached, long-pressing non-editable text outside the field
would fail to start a selection: every selection gesture was forced to
stay within the focused element because the WebKit layer was always told
it was &quot;interacting with the focused element&quot;.

This patch distinguishes &quot;has a focused element&quot; from &quot;is interacting with
the focused element&quot;. When the loupe begins a new selection on non-editable
content outside the focused field, we now let the selection escape the field
and we keep the field focused.

Test: editing/selection/ios/select-text-by-long-press-with-focused-element.html

* LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element.html: Added.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):
(-[WKContentView textInteractionGesture:shouldBeginAtPoint:]):
(-[WKContentView _isInteractingWithFocusedElement]):
(-[WKContentView changeSelectionWithGestureAt:withGesture:withState:withFlags:]):
(-[WKContentView selectPositionAtPoint:completionHandler:]):
(-[WKContentView _selectPositionAtPoint:stayingWithinFocusedElement:completionHandler:]):
(-[WKContentView selectPositionAtBoundary:inDirection:fromPoint:completionHandler:]):
(-[WKContentView selectTextWithGranularity:atPoint:completionHandler:]):
(-[WKContentView updateSelectionWithExtentPoint:hasFocusedElement:respectSelectionAnchor:completionHandler:]):
(-[WKContentView updateSelectionWithExtentPointAndBoundary:textGranularity:textInteractionSource:completionHandler:]):
(-[WKContentView _elementDidBlur]):
(-[WKContentView _updateSelectionAssistantSuppressionState]):
(-[WKContentView _selectionChanged]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66902e993a35c43f1ab2152244d8d72b6a8aaaa2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174825 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123038 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/703f716b-b98f-47be-a440-a95e34a9f6a1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128838 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90742 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af71562c-1727-4f4e-b880-70016b42ae6d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109362 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/909976a7-885b-42e8-9f38-a426f72bd76e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30184 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28857 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22908 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177350 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26676 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30265 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137173 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137101 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148439 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102561 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32387 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25306 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38541 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111614 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37937 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3388 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38183 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38081 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->