### PR TITLE
Support setting _extensibleSSOEnabled after a WebView is loaded

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -64,6 +64,7 @@
 #import "WebFrameProxy.h"
 #import "WebNavigationState.h"
 #import "WebPageProxy.h"
+#import "WebPreferences.h"
 #import "WebProcessProxy.h"
 #import "WebProtectionSpace.h"
 #import "WebsiteDataStore.h"
@@ -431,7 +432,7 @@ void NavigationState::NavigationClient::shouldGoToBackForwardListItem(WebPagePro
 static void trySOAuthorization(Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Function<void(bool)>&& completionHandler)
 {
 #if HAVE(APP_SSO)
-    if (!navigationAction->shouldPerformSOAuthorization()) {
+    if (!navigationAction->shouldPerformSOAuthorization() || !protect(page.preferences())->isExtensibleSSOEnabled()) {
         callOnMainRunLoop([completionHandler = WTF::move(completionHandler)] mutable {
             completionHandler(false);
         });

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
@@ -199,6 +199,7 @@ private:
 @property bool shouldOpenExternalSchemes;
 @property bool allowSOAuthorizationLoad;
 @property bool isAsyncExecution;
+@property bool disableExtensibleSSODuringPolicyDecision;
 - (instancetype)init;
 @end
 
@@ -211,6 +212,7 @@ private:
         self.shouldOpenExternalSchemes = false;
         self.allowSOAuthorizationLoad = true;
         self.isAsyncExecution = false;
+        self.disableExtensibleSSODuringPolicyDecision = false;
     }
     return self;
 }
@@ -227,6 +229,8 @@ private:
     delegateNavigationAction = navigationAction;
     navigationPolicyDecided = true;
     EXPECT_EQ(navigationAction._shouldOpenExternalSchemes, self.shouldOpenExternalSchemes);
+    if (self.disableExtensibleSSODuringPolicyDecision)
+        webView.configuration.preferences._extensibleSSOEnabled = NO;
     if (self.isDefaultPolicy) {
         decisionHandler(WKNavigationActionPolicyAllow);
         return;
@@ -533,6 +537,30 @@ TEST(SOAuthorizationRedirect, DisableSSO)
     Util::run(&navigationCompleted);
 
     EXPECT_FALSE(policyForAppSSOPerformed);
+    EXPECT_WK_STREQ(testURL.get().absoluteString, finalURL);
+}
+
+TEST(SOAuthorizationRedirect, DisableSSODuringPolicyDecision)
+{
+    resetState();
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
+
+    RetainPtr testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    EXPECT_TRUE(configuration.get().preferences._isExtensibleSSOEnabled);
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
+    delegate.get().isDefaultPolicy = false;
+    delegate.get().disableExtensibleSSODuringPolicyDecision = true;
+
+    [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
+    Util::run(&navigationCompleted);
+
+    EXPECT_FALSE(policyForAppSSOPerformed);
+    EXPECT_FALSE(configuration.get().preferences._isExtensibleSSOEnabled);
     EXPECT_WK_STREQ(testURL.get().absoluteString, finalURL);
 }
 


### PR DESCRIPTION
#### ea0c784f0e7c9de1554c481f80c2dced82ec495d
<pre>
Support setting _extensibleSSOEnabled after a WebView is loaded
<a href="https://rdar.apple.com/178276637">rdar://178276637</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315885">https://bugs.webkit.org/show_bug.cgi?id=315885</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

WebsiteDataStore::soAuthorizationCoordinator() RELEASE_ASSERTs that Extensible
SSO is enabled, but trySOAuthorization() in NavigationState only checked
NavigationAction::shouldPerformSOAuthorization() and the URL scheme handler
before calling it.

That flag is cleared up front in WebPageProxy::decidePolicyForNavigationActionShared()
when the preference is disabled, but the policy decision is resolved asynchronously by
the client, so a client that disables Extensible SSO on a web view after the decision
has begun leaves the flag set from when SSO was still on. trySOAuthorization() then reached
the coordinator and hit the assertion. Re-check the preference at the point of use, matching
the existing WebPageProxy variant.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm

* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::trySOAuthorization):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm:
(-[TestSOAuthorizationDelegate init]):
(-[TestSOAuthorizationDelegate webView:decidePolicyForNavigationAction:decisionHandler:]):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, DisableSSODuringPolicyDecision)):

Canonical link: <a href="https://commits.webkit.org/314291@main">https://commits.webkit.org/314291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e82127461f65c2270736580d1521e29adbe7941

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174448 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122661 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80f8edc2-a02e-4f01-bb19-3b82853d97a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38900 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128534 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90464 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27d5e992-9360-4a58-81ab-4021cd49398a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168365 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30845 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109059 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b6008c3-59cf-4417-80bb-3026b0e130ba) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29893 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28521 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22523 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176972 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29875 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136861 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136797 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36925 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148097 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102008 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32069 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24964 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111237 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37560 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3043 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37806 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->