### PR TITLE
[JSC] Add support for Regular Expression Buffer Boundaries proposal

### DIFF
--- a/JSTests/stress/regexp-boundary-assertions.js
+++ b/JSTests/stress/regexp-boundary-assertions.js
@@ -1,0 +1,39 @@
+//@ requireOptions("--useRegExpBufferBoundaries=1")
+
+function assertEqual(a, b) {
+    if (a !== b)
+        throw new Error(`Assertion ${a} === ${b} failed`);
+}
+
+const re1 = /\Afoo\z/u;
+assertEqual(re1.test("foo"), true);
+assertEqual(re1.test("foo\nbar"), false);
+
+const re2 = /\Afoo\z/um;
+assertEqual(re2.test("foo"), true);
+assertEqual(re2.test("foo\nbar"), false);
+
+// mixing buffer boundaries and anchors
+const re3 = /\Afoo|^bar$|baz\z/um;
+assertEqual(re3.test("foo"), true);
+assertEqual(re3.test("foo\n"), true);
+assertEqual(re3.test("\nfoo"), false);
+assertEqual(re3.test("bar"), true);
+assertEqual(re3.test("bar\n"), true);
+assertEqual(re3.test("\nbar"), true);
+assertEqual(re3.test("baz"), true);
+assertEqual(re3.test("baz\n"), false);
+assertEqual(re3.test("\nbaz"), true);
+
+// matching at line terminator sequence at end of buffer
+const re4 = /end\Z/u;
+assertEqual(re4.test("The end"), true);
+assertEqual(re4.test("The end\n"), true);
+assertEqual(re4.test("The end\r\n"), true);
+assertEqual(re4.test("The end\u2028"), true);
+assertEqual(re4.test("The end\n...or is it?"), false);
+
+const re5 = /\Aa/;
+assertEqual(re5.test("Aa"), true);
+assertEqual(re5.test("bAab"), true);
+assertEqual(re5.test("a"), false);

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -48,7 +48,7 @@ static constexpr unsigned offsetNoMatch = std::numeric_limits<unsigned>::max();
 
 // The below limit restricts the number of "recursive" match calls in order to
 // avoid spending exponential time on complex regular expressions.
-static constexpr unsigned matchLimit = 100000000;
+static constexpr unsigned matchLimit = 100'000'000;
 
 enum class MatchFrom { VMThread, CompilerThread };
 

--- a/Source/JavaScriptCore/yarr/YarrDisassembler.h
+++ b/Source/JavaScriptCore/yarr/YarrDisassembler.h
@@ -43,7 +43,7 @@ class YarrCodeBlock;
 
 class YarrJITInfo {
 public:
-    virtual ~YarrJITInfo() { };
+    virtual ~YarrJITInfo() = default;
     virtual const char* variant() = 0;
     virtual unsigned opCount() = 0;
     virtual void dumpPatternString(PrintStream&) = 0;

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -713,6 +713,42 @@ public:
         return (input.atEnd()) || (term.multiline() && testCharacterClass(pattern->newlineCharacterClass, input.read()));
     }
 
+    bool matchAssertionBOI(ByteTerm& term)
+    {
+        return input.atStart(term.inputPosition);
+    }
+
+    bool matchAssertionEOI(ByteTerm& term)
+    {
+        // \z: succeed at EOI
+        if (!term.m_withOptionalLineTerminator)
+            return term.inputPosition ? input.atEnd(term.inputPosition) : input.atEnd();
+
+        // \Z: succeed at EOI, or at a line terminator immediately before EOI.
+        unsigned assertionPos = input.getPos() - term.inputPosition;
+        unsigned inputLength = input.end();
+
+        if (assertionPos == inputLength)
+            return true;
+
+        char32_t ch = input.readCheckedDontAdvance(term.inputPosition);
+
+        if (!testCharacterClass(pattern->newlineCharacterClass, ch))
+            return false;
+
+        if (ch != '\r')
+            return assertionPos + 1 == inputLength;
+
+        if (assertionPos + 1 == inputLength)
+            return true; // \r alone at EOI
+
+        if (assertionPos + 2 != inputLength)
+            return false;
+
+        // Check for \r\n: read the char at assertionPos + 1.
+        return input.reread(assertionPos + 1) == '\n';
+    }
+
     bool matchAssertionWordBoundary(ByteTerm& term)
     {
         unsigned inputOffset = term.inputPosition;
@@ -1832,6 +1868,14 @@ public:
             if (matchAssertionEOL(currentTerm()))
                 MATCH_NEXT();
             BACKTRACK();
+        case ByteTerm::Type::AssertionBOI:
+            if (matchAssertionBOI(currentTerm()))
+                MATCH_NEXT();
+            BACKTRACK();
+        case ByteTerm::Type::AssertionEOI:
+            if (matchAssertionEOI(currentTerm()))
+                MATCH_NEXT();
+            BACKTRACK();
         case ByteTerm::Type::AssertionWordBoundary:
             if (matchAssertionWordBoundary(currentTerm()))
                 MATCH_NEXT();
@@ -2143,6 +2187,8 @@ public:
 
         case ByteTerm::Type::AssertionBOL:
         case ByteTerm::Type::AssertionEOL:
+        case ByteTerm::Type::AssertionBOI:
+        case ByteTerm::Type::AssertionEOI:
         case ByteTerm::Type::AssertionWordBoundary:
             BACKTRACK();
 
@@ -2375,6 +2421,16 @@ public:
     void assertionEOL(unsigned inputPosition, OptionSet<Flags> flags)
     {
         m_bodyDisjunction->terms.append(ByteTerm::EOL(inputPosition, flags));
+    }
+
+    void assertionBOI(unsigned inputPosition, OptionSet<Flags> flags)
+    {
+        m_bodyDisjunction->terms.append(ByteTerm::BOI(inputPosition, flags));
+    }
+
+    void assertionEOI(bool withOptionalLineTerminator, unsigned inputPosition, OptionSet<Flags> flags)
+    {
+        m_bodyDisjunction->terms.append(ByteTerm::EOI(inputPosition, flags, withOptionalLineTerminator));
     }
 
     void assertionWordBoundary(bool invert, MatchDirection matchDirection, unsigned inputPosition, OptionSet<Flags> flags)
@@ -2794,6 +2850,22 @@ public:
                     break;
                 }
 
+                case PatternTerm::Type::AssertionBOI: {
+                    auto currentInputPosition = currentCountAlreadyChecked - term.inputPosition;
+                    if (currentInputPosition.hasOverflowed())
+                        return ErrorCode::OffsetTooLarge;
+                    assertionBOI(currentInputPosition, term.m_currentFlags);
+                    break;
+                }
+
+                case PatternTerm::Type::AssertionEOI: {
+                    auto currentInputPosition = currentCountAlreadyChecked - term.inputPosition;
+                    if (currentInputPosition.hasOverflowed())
+                        return ErrorCode::OffsetTooLarge;
+                    assertionEOI(term.m_withOptionalLineTerminator, currentInputPosition, term.m_currentFlags);
+                    break;
+                }
+
                 case PatternTerm::Type::AssertionWordBoundary: {
                     auto currentInputPosition = currentCountAlreadyChecked - term.inputPosition;
                     if (currentInputPosition.hasOverflowed())
@@ -3064,6 +3136,14 @@ void ByteTermDumper::dumpTerm(size_t idx, ByteTerm term)
     case ByteTerm::Type::AssertionEOL:
         outputTermIndexAndNest(idx, m_nesting);
         out.print("AssertionEOL");
+        break;
+    case ByteTerm::Type::AssertionBOI:
+        outputTermIndexAndNest(idx, m_nesting);
+        out.print("AssertionBOI");
+        break;
+    case ByteTerm::Type::AssertionEOI:
+        outputTermIndexAndNest(idx, m_nesting);
+        out.print("AssertionEOI ", term.m_withOptionalLineTerminator ? "(\\Z)" : "(\\z)");
         break;
     case ByteTerm::Type::AssertionWordBoundary:
         outputTermIndexAndNest(idx, m_nesting);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.h
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.h
@@ -90,6 +90,8 @@ struct ByteTerm {
         SubpatternEnd,
         AssertionBOL,
         AssertionEOL,
+        AssertionBOI, // beginning of input (\A)
+        AssertionEOI, // end of input (\z, \Z)
         AssertionWordBoundary,
         // Character Types
         PatternCharacterOnce,
@@ -119,6 +121,7 @@ struct ByteTerm {
     OptionSet<Flags> m_flags;
     bool m_capture : 1;
     bool m_invert : 1;
+    bool m_withOptionalLineTerminator : 1;
     MatchDirection m_matchDirection : 1;
     unsigned inputPosition { 0 };
 
@@ -127,6 +130,7 @@ struct ByteTerm {
         , m_flags(flags)
         , m_capture(false)
         , m_invert(false)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(Forward)
         , inputPosition(inputPos)
     {
@@ -155,6 +159,7 @@ struct ByteTerm {
         , m_flags(flags)
         , m_capture(false)
         , m_invert(false)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(Forward)
         , inputPosition(inputPos)
     {
@@ -184,6 +189,7 @@ struct ByteTerm {
         , m_flags(flags)
         , m_capture(false)
         , m_invert(invert)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(Forward)
         , inputPosition(inputPos)
     {
@@ -198,6 +204,7 @@ struct ByteTerm {
         , m_flags(flags)
         , m_capture(capture)
         , m_invert(false)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(Forward)
         , inputPosition(inputPos)
     {
@@ -214,6 +221,7 @@ struct ByteTerm {
         , m_flags(flags)
         , m_capture(false)
         , m_invert(invert)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(Forward)
     {
         atom.quantityType = QuantifierType::FixedCount;
@@ -226,6 +234,7 @@ struct ByteTerm {
         , m_flags(flags)
         , m_capture(capture)
         , m_invert(invert)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(Forward)
         , inputPosition(inputPos)
     {
@@ -241,6 +250,7 @@ struct ByteTerm {
         , m_flags(flags)
         , m_capture(capture)
         , m_invert(invert)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(matchDirection)
         , inputPosition(inputPos)
     {
@@ -254,6 +264,13 @@ struct ByteTerm {
     static ByteTerm BOL(unsigned inputPos, OptionSet<Flags> flags)
     {
         ByteTerm term(Type::AssertionBOL, flags);
+        term.inputPosition = inputPos;
+        return term;
+    }
+
+    static ByteTerm BOI(unsigned inputPos, OptionSet<Flags> flags)
+    {
+        ByteTerm term(Type::AssertionBOI, flags);
         term.inputPosition = inputPos;
         return term;
     }
@@ -283,6 +300,14 @@ struct ByteTerm {
     {
         ByteTerm term(Type::AssertionEOL, flags);
         term.inputPosition = inputPos;
+        return term;
+    }
+
+    static ByteTerm EOI(unsigned inputPos, OptionSet<Flags> flags, bool withOptionalLineTerminator)
+    {
+        ByteTerm term(Type::AssertionEOI, flags);
+        term.inputPosition = inputPos;
+        term.m_withOptionalLineTerminator = withOptionalLineTerminator;
         return term;
     }
 

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2195,6 +2195,92 @@ class YarrGenerator final : public YarrJITInfo {
         backtrackTermDefault(opIndex);
     }
 
+    void generateAssertionBOI(size_t opIndex)
+    {
+        YarrOp& op = m_ops[opIndex];
+        PatternTerm* term = op.m_term;
+
+        if (term->inputPosition)
+            op.m_jumps.append(m_jit.jump());
+        else
+            op.m_jumps.append(m_jit.branch32(MacroAssembler::NotEqual, m_regs.index, MacroAssembler::Imm32(op.m_checkedOffset)));
+    }
+    void backtrackAssertionBOI(size_t opIndex)
+    {
+        backtrackTermDefault(opIndex);
+    }
+
+    void generateAssertionEOI(size_t opIndex)
+    {
+        YarrOp& op = m_ops[opIndex];
+        PatternTerm* term = op.m_term;
+
+        if (term->m_withOptionalLineTerminator) {
+            // Equivalent to (?=(?:\r\n|\n|\r|\u2028|\u2029)?(?-m:$))
+
+            const MacroAssembler::RegisterID character = m_regs.regT0;
+            const MacroAssembler::RegisterID scratch = m_regs.regT1;
+
+            MacroAssembler::JumpList success;
+
+            // Condition 1: already at EOI
+            if (term->inputPosition == op.m_checkedOffset)
+                success.append(atEndOfInput());
+
+            readCharacter(op.m_checkedOffset - term->inputPosition, character);
+
+            // Not a line terminator -> failure.
+            MacroAssembler::JumpList isLineTerminator;
+            matchCharacterClass(character, scratch, isLineTerminator, m_pattern.newlineCharacterClass());
+            op.m_jumps.append(m_jit.jump());
+            isLineTerminator.link(&m_jit);
+
+            // Condition 2: consuming this one line terminator reaches EOI
+            if (term->inputPosition == op.m_checkedOffset) {
+                m_jit.sub32(m_regs.length, MacroAssembler::TrustedImm32(1), scratch);
+                success.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, scratch));
+            } else if (term->inputPosition + 1 == op.m_checkedOffset)
+                success.append(atEndOfInput());
+
+            // Dispatch on \r vs single-char line terminator
+            MacroAssembler::Jump isCR = m_jit.branch32(MacroAssembler::Equal, character, MacroAssembler::TrustedImm32('\r'));
+            op.m_jumps.append(m_jit.jump()); // single-char line terminator not at EOI -> failure.
+
+            // \r: condition 3 (\r\n)
+            isCR.link(&m_jit);
+
+            // Condition 3: \r\n
+            if (term->inputPosition == op.m_checkedOffset) {
+                m_jit.sub32(m_regs.length, MacroAssembler::TrustedImm32(2), scratch);
+                op.m_jumps.append(m_jit.branch32(MacroAssembler::NotEqual, m_regs.index, scratch));
+                m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index, scratch);
+                readCharacter(0, character, scratch);
+                op.m_jumps.append(m_jit.branch32(MacroAssembler::NotEqual, character, MacroAssembler::TrustedImm32('\n')));
+            } else if (term->inputPosition + 1 == op.m_checkedOffset) {
+                m_jit.sub32(m_regs.length, MacroAssembler::TrustedImm32(1), scratch);
+                op.m_jumps.append(m_jit.branch32(MacroAssembler::NotEqual, m_regs.index, scratch));
+                readCharacter(0, character);
+                op.m_jumps.append(m_jit.branch32(MacroAssembler::NotEqual, character, MacroAssembler::TrustedImm32('\n')));
+            } else if (term->inputPosition + 2 == op.m_checkedOffset) {
+                op.m_jumps.append(m_jit.branch32(MacroAssembler::NotEqual, m_regs.index, m_regs.length));
+                readCharacter(1, character);
+                op.m_jumps.append(m_jit.branch32(MacroAssembler::NotEqual, character, MacroAssembler::TrustedImm32('\n')));
+            } else
+                op.m_jumps.append(m_jit.jump()); // \r not at EOI -> failure.
+
+            success.link(&m_jit);
+        } else {
+            if (term->inputPosition == op.m_checkedOffset)
+                op.m_jumps.append(notAtEndOfInput());
+            else
+                op.m_jumps.append(m_jit.jump());
+        }
+    }
+    void backtrackAssertionEOI(size_t opIndex)
+    {
+        backtrackTermDefault(opIndex);
+    }
+
     // Also falls though on nextIsNotWordChar.
     void matchAssertionWordchar(size_t opIndex, MacroAssembler::JumpList& nextIsWordChar, MacroAssembler::JumpList& nextIsNotWordChar)
     {
@@ -3678,6 +3764,14 @@ class YarrGenerator final : public YarrJITInfo {
             generateAssertionEOL(opIndex);
             break;
 
+        case PatternTerm::Type::AssertionBOI:
+            generateAssertionBOI(opIndex);
+            break;
+
+        case PatternTerm::Type::AssertionEOI:
+            generateAssertionEOI(opIndex);
+            break;
+
         case PatternTerm::Type::AssertionWordBoundary:
             generateAssertionWordBoundary(opIndex);
             break;
@@ -3758,6 +3852,14 @@ class YarrGenerator final : public YarrJITInfo {
 
         case PatternTerm::Type::AssertionEOL:
             backtrackAssertionEOL(opIndex);
+            break;
+
+        case PatternTerm::Type::AssertionBOI:
+            backtrackAssertionBOI(opIndex);
+            break;
+
+        case PatternTerm::Type::AssertionEOI:
+            backtrackAssertionEOI(opIndex);
             break;
 
         case PatternTerm::Type::AssertionWordBoundary:
@@ -5885,6 +5987,8 @@ class YarrGenerator final : public YarrJITInfo {
         switch (term.type) {
         case PatternTerm::Type::AssertionBOL:
         case PatternTerm::Type::AssertionEOL:
+        case PatternTerm::Type::AssertionBOI:
+        case PatternTerm::Type::AssertionEOI:
         case PatternTerm::Type::AssertionWordBoundary:
             // Conservatively say any assertions just match.
             return cursor;
@@ -7280,6 +7384,14 @@ public:
 
             case PatternTerm::Type::AssertionEOL:
                 out.printf("Assert EOL checked-offset:(%u)", op.m_checkedOffset.value());
+                break;
+
+            case PatternTerm::Type::AssertionBOI:
+                out.printf("Assert BOI checked-offset:(%u),with-line-terminator:(%u)", op.m_checkedOffset.value(), term->m_withOptionalLineTerminator);
+                break;
+
+            case PatternTerm::Type::AssertionEOI:
+                out.printf("Assert EOI checked-offset:(%u),with-line-terminator:(%u)", op.m_checkedOffset.value(), term->m_withOptionalLineTerminator);
                 break;
 
             case PatternTerm::Type::NumberedBackReference:

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -51,6 +51,8 @@ enum class CharacterClassSetOp : uint8_t {
 template <class T> concept YarrSyntaxCheckable = requires (T& checker, Vector<Vector<char32_t>>& disjunctionStrings, const String& subpatternName) {
     { checker.assertionBOL() } -> std::same_as<void>;
     { checker.assertionEOL() } -> std::same_as<void>;
+    { checker.assertionBOI() } -> std::same_as<void>;
+    { checker.assertionEOI(bool { }) } -> std::same_as<void>;
     { checker.assertionWordBoundary(bool { }) } -> std::same_as<void>;
     { checker.atomPatternCharacter(char32_t { }, bool { }) } -> std::same_as<void>;
     { checker.atomBuiltInCharacterClass(BuiltInCharacterClassID { }, bool { }) } -> std::same_as<void>;
@@ -84,13 +86,14 @@ template <class T> concept YarrSyntaxCheckable = requires (T& checker, Vector<Ve
 template<YarrSyntaxCheckable Delegate, typename CharType>
 class Parser {
 public:
-    Parser(Delegate& delegate, std::span<const CharType> pattern, CompileMode compileMode, unsigned backReferenceLimit, bool isNamedForwardReferenceAllowed)
+    Parser(Delegate& delegate, std::span<const CharType> pattern, CompileMode compileMode, unsigned backReferenceLimit, bool isNamedForwardReferenceAllowed, bool allowRegExpBufferBoundaries)
         : m_delegate(delegate)
         , m_data(pattern.data())
         , m_size(pattern.size())
         , m_compileMode(compileMode)
         , m_backReferenceLimit(backReferenceLimit)
         , m_isNamedForwardReferenceAllowed(isNamedForwardReferenceAllowed)
+        , m_allowRegExpBufferBoundaries(allowRegExpBufferBoundaries)
     {
     }
 
@@ -119,7 +122,7 @@ private:
     static constexpr char32_t errorCodePoint = 0xFFFFFFFFu;
 
     template<YarrSyntaxCheckable FriendDelegate>
-    friend ErrorCode parse(FriendDelegate&, StringView pattern, CompileMode, unsigned backReferenceLimit, bool isNamedForwardReferenceAllowed);
+    friend ErrorCode parse(FriendDelegate&, StringView pattern, CompileMode, unsigned backReferenceLimit, bool isNamedForwardReferenceAllowed, bool allowRegExpBufferBoundaries);
 
     enum class UnicodeParseContext : uint8_t { PatternCodePoint, GroupName };
 
@@ -363,6 +366,8 @@ private:
 
         // parseEscape() should never call these delegate methods when
         // invoked with inCharacterClass set.
+        NO_RETURN_DUE_TO_ASSERT void assertionBOI() { RELEASE_ASSERT_NOT_REACHED(); }
+        NO_RETURN_DUE_TO_ASSERT void assertionEOI(bool) { RELEASE_ASSERT_NOT_REACHED(); }
         NO_RETURN_DUE_TO_ASSERT void assertionWordBoundary(bool) { RELEASE_ASSERT_NOT_REACHED(); }
         NO_RETURN_DUE_TO_ASSERT void atomBackReference(unsigned) { RELEASE_ASSERT_NOT_REACHED(); }
         NO_RETURN_DUE_TO_ASSERT void atomNamedBackReference(const String&) { RELEASE_ASSERT_NOT_REACHED(); }
@@ -772,6 +777,8 @@ private:
 
         // parseEscape() should never call these delegate methods when
         // invoked with inCharacterClass set.
+        NO_RETURN_DUE_TO_ASSERT void assertionBOI() { RELEASE_ASSERT_NOT_REACHED(); }
+        NO_RETURN_DUE_TO_ASSERT void assertionEOI(bool) { RELEASE_ASSERT_NOT_REACHED(); }
         NO_RETURN_DUE_TO_ASSERT void assertionWordBoundary(bool) { RELEASE_ASSERT_NOT_REACHED(); }
         NO_RETURN_DUE_TO_ASSERT void atomBackReference(unsigned) { RELEASE_ASSERT_NOT_REACHED(); }
         NO_RETURN_DUE_TO_ASSERT void atomNamedBackReference(const String&) { RELEASE_ASSERT_NOT_REACHED(); }
@@ -842,6 +849,8 @@ private:
         bool mayContainStrings() { return m_mayContainStrings; }
 
         // parseEscape() should never call these delegate methods when parsing a class string disjunction.
+        NO_RETURN_DUE_TO_ASSERT void assertionBOI() { RELEASE_ASSERT_NOT_REACHED(); }
+        NO_RETURN_DUE_TO_ASSERT void assertionEOI(bool) { RELEASE_ASSERT_NOT_REACHED(); }
         NO_RETURN_DUE_TO_ASSERT void assertionWordBoundary(bool) { RELEASE_ASSERT_NOT_REACHED(); }
         NO_RETURN_DUE_TO_ASSERT void atomBackReference(unsigned) { RELEASE_ASSERT_NOT_REACHED(); }
         NO_RETURN_DUE_TO_ASSERT void atomNamedBackReference(const String&) { RELEASE_ASSERT_NOT_REACHED(); }
@@ -895,6 +904,8 @@ private:
      *    void atomPatternCharacter(char32_t ch, bool hyphenIsRange);
      *
      *   Optional methods based on parseEscapeMode:
+     *    void assertionBOI();
+     *    void assertionEOI(bool withOptionalLineTerminator);
      *    void assertionWordBoundary(bool invert);
      *    void atomBuiltInCharacterClass(BuiltInCharacterClassID classID, bool invert);
      *    void atomBackReference(unsigned subpatternId);
@@ -911,6 +922,29 @@ private:
         if (atEndOfPattern()) {
             m_errorCode = ErrorCode::EscapeUnterminated;
             return TokenType::NotAtom;
+        }
+
+        if (m_allowRegExpBufferBoundaries && isEitherUnicodeCompilation()) [[unlikely]] {
+            switch (peek()) {
+            case 'A':
+                consume();
+                if (parseEscapeMode != ParseEscapeMode::Normal) {
+                    m_errorCode = ErrorCode::InvalidIdentityEscape;
+                    return TokenType::Atom;
+                }
+                delegate.assertionBOI();
+                return TokenType::NotAtom;
+            case 'z':
+            case 'Z': {
+                char32_t escapeChar = consume();
+                if (parseEscapeMode != ParseEscapeMode::Normal) {
+                    m_errorCode = ErrorCode::InvalidIdentityEscape;
+                    return TokenType::Atom;
+                }
+                delegate.assertionEOI(/* withOptionalLineTerminator */ escapeChar == 'Z');
+                return TokenType::NotAtom;
+            }
+            }
         }
 
         switch (peek()) {
@@ -2214,6 +2248,7 @@ private:
     unsigned m_maxSeenBackReference { 0 };
     unsigned m_numCaptures { 0 };
     bool m_isNamedForwardReferenceAllowed;
+    bool m_allowRegExpBufferBoundaries;
     bool m_kIdentityEscapeSeen { false };
     Vector<ParenthesesType, 16> m_parenthesesStack;
     NamedCaptureGroups m_namedCaptureGroups;
@@ -2275,11 +2310,11 @@ inline CompileMode compileMode(std::optional<OptionSet<Flags>> flags)
 }
 
 template<YarrSyntaxCheckable Delegate>
-ErrorCode parse(Delegate& delegate, const StringView pattern, CompileMode compileMode, unsigned backReferenceLimit = quantifyInfinite, bool isNamedForwardReferenceAllowed = true)
+ErrorCode parse(Delegate& delegate, const StringView pattern, CompileMode compileMode, unsigned backReferenceLimit = quantifyInfinite, bool isNamedForwardReferenceAllowed = true, bool allowRegExpBufferBoundaries = false)
 {
     if (pattern.is8Bit())
-        return Parser<Delegate, Latin1Character>(delegate, pattern.span8(), compileMode, backReferenceLimit, isNamedForwardReferenceAllowed).parse();
-    return Parser<Delegate, char16_t>(delegate, pattern.span16(), compileMode, backReferenceLimit, isNamedForwardReferenceAllowed).parse();
+        return Parser<Delegate, Latin1Character>(delegate, pattern.span8(), compileMode, backReferenceLimit, isNamedForwardReferenceAllowed, allowRegExpBufferBoundaries).parse();
+    return Parser<Delegate, char16_t>(delegate, pattern.span16(), compileMode, backReferenceLimit, isNamedForwardReferenceAllowed, allowRegExpBufferBoundaries).parse();
 }
 
 } } // namespace JSC::Yarr

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1292,6 +1292,20 @@ public:
     {
         m_alternative->m_terms.append(PatternTerm::EOL(m_flags));
     }
+    void assertionBOI()
+    {
+        // FIXME: \A always anchors to the start of input, like ^ in non-multiline mode,
+        // but unlike assertionBOL(), this doesn't set m_startsWithBOL/m_containsBOL,
+        // and recomputeStartsWithBOL() doesn't recognize AssertionBOI. Wiring it in
+        // would let optimizeBOL() & friends unroll \A-anchored alternatives too.
+        auto boiTerm = PatternTerm::BOI(m_flags);
+        boiTerm.setMatchDirection(parenthesisMatchDirection());
+        m_alternative->m_terms.append(boiTerm);
+    }
+    void assertionEOI(bool withOptionalLineTerminator)
+    {
+        m_alternative->m_terms.append(PatternTerm::EOI(withOptionalLineTerminator, m_flags));
+    }
     void assertionWordBoundary(bool invert)
     {
         m_alternative->m_terms.append(PatternTerm::WordBoundary(invert, m_flags));
@@ -1899,6 +1913,8 @@ public:
             switch (term.type) {
             case PatternTerm::Type::AssertionBOL:
             case PatternTerm::Type::AssertionEOL:
+            case PatternTerm::Type::AssertionBOI:
+            case PatternTerm::Type::AssertionEOI:
             case PatternTerm::Type::AssertionWordBoundary:
                 term.inputPosition = currentInputPosition;
                 break;
@@ -3065,7 +3081,7 @@ ErrorCode YarrPattern::compile(StringView patternString)
     YarrPatternConstructor constructor(*this, m_flags);
 
     {
-        ErrorCode error = parse(constructor, patternString, compileMode());
+        ErrorCode error = parse(constructor, patternString, compileMode(), quantifyInfinite, true, Options::useRegExpBufferBoundaries());
         if (hasError(constructor.error()))
             return constructor.error();
 
@@ -3293,6 +3309,12 @@ void PatternTerm::dump(PrintStream& out, YarrPattern* thisPattern, unsigned nest
         break;
     case Type::AssertionEOL:
         out.println("EOL");
+        break;
+    case Type::AssertionBOI:
+        out.println("BOI");
+        break;
+    case Type::AssertionEOI:
+        out.println("EOI ", m_withOptionalLineTerminator ? "(\\Z)" : "(\\z)");
         break;
     case Type::AssertionWordBoundary:
         out.println("word boundary");

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -226,6 +226,8 @@ struct PatternTerm {
     enum class Type : uint8_t {
         AssertionBOL,
         AssertionEOL,
+        AssertionBOI,
+        AssertionEOI,
         AssertionWordBoundary,
         PatternCharacter,
         CharacterClass,
@@ -241,6 +243,7 @@ struct PatternTerm {
     OptionSet<Flags> m_currentFlags;
     bool m_capture : 1;
     bool m_invert : 1;
+    bool m_withOptionalLineTerminator : 1;
     MatchDirection m_matchDirection : 1;
     QuantifierType quantityType;
     Checked<unsigned> quantityMinCount;
@@ -277,6 +280,7 @@ struct PatternTerm {
         , m_currentFlags(currFlags)
         , m_capture(false)
         , m_invert(false)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(matchDirection)
     {
         patternCharacter = ch;
@@ -289,6 +293,7 @@ struct PatternTerm {
         , m_currentFlags(currFlags)
         , m_capture(false)
         , m_invert(invert)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(matchDirection)
     {
         characterClass = charClass;
@@ -301,6 +306,7 @@ struct PatternTerm {
         , m_currentFlags(currFlags)
         , m_capture(capture)
         , m_invert(invert)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(matchDirection)
     {
         parentheses.disjunction = disjunction;
@@ -318,6 +324,7 @@ struct PatternTerm {
         , m_currentFlags(currFlags)
         , m_capture(false)
         , m_invert(invert)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(Forward)
     {
         quantityType = QuantifierType::FixedCount;
@@ -329,6 +336,7 @@ struct PatternTerm {
         , m_currentFlags(currFlags)
         , m_capture(false)
         , m_invert(false)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(Forward)
     {
         backReferenceSubpatternId = spatternId;
@@ -341,6 +349,7 @@ struct PatternTerm {
         , m_currentFlags(currFlags)
         , m_capture(false)
         , m_invert(false)
+        , m_withOptionalLineTerminator(false)
         , m_matchDirection(Forward)
     {
         anchors.bolAnchor = bolAnchor;
@@ -379,6 +388,18 @@ struct PatternTerm {
     static PatternTerm EOL(OptionSet<Flags> currFlags)
     {
         return PatternTerm(Type::AssertionEOL, currFlags);
+    }
+
+    static PatternTerm BOI(OptionSet<Flags> currFlags)
+    {
+        return PatternTerm(Type::AssertionBOI, currFlags);
+    }
+
+    static PatternTerm EOI(bool withOptionalLineTerminator, OptionSet<Flags> currFlags)
+    {
+        auto term = PatternTerm(Type::AssertionEOI, currFlags);
+        term.m_withOptionalLineTerminator = withOptionalLineTerminator;
+        return term;
     }
 
     static PatternTerm WordBoundary(bool invert, OptionSet<Flags> currFlags)

--- a/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
+++ b/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "YarrSyntaxChecker.h"
 
+#include "Options.h"
 #include "YarrFlags.h"
 #include "YarrParser.h"
 
@@ -36,6 +37,8 @@ class SyntaxChecker {
 public:
     void NODELETE assertionBOL() { }
     void NODELETE assertionEOL() { }
+    void NODELETE assertionBOI() { }
+    void NODELETE assertionEOI(bool) { }
     void NODELETE assertionWordBoundary(bool) { }
     void NODELETE atomPatternCharacter(char32_t, bool) { }
     void NODELETE atomBuiltInCharacterClass(BuiltInCharacterClassID, bool) { }
@@ -72,7 +75,7 @@ ErrorCode checkSyntax(StringView pattern, StringView flags)
     if (!parsedFlags)
         return ErrorCode::InvalidRegularExpressionFlags;
 
-    return parse(syntaxChecker, pattern, compileMode(parsedFlags));
+    return parse(syntaxChecker, pattern, compileMode(parsedFlags), quantifyInfinite, true, Options::useRegExpBufferBoundaries());
 }
 
 }} // JSC::Yarr

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7110,6 +7110,19 @@ ReadableStreamTransferEnabled:
     WebKit:
       default: true
 
+RegExpBufferBoundariesEnabled:
+  type: bool
+  status: testable
+  category: javascript
+  humanReadableName: "RegExp Buffer Boundaries"
+  humanReadableDescription: "Allow the use in regular expressions of \\\\A, \\\\z and \\\\Z from the RegExp Buffer Boundaries proposal"
+  webcoreBinding: none
+  jscOptionName: useRegExpBufferBoundaries
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKit:
+      default: false
+
 RemoteMediaSessionManagerEnabled:
   type: bool
   status: unstable

--- a/Source/WebCore/contentextensions/URLFilterParser.cpp
+++ b/Source/WebCore/contentextensions/URLFilterParser.cpp
@@ -163,6 +163,25 @@ public:
         m_floatingTerm = Term(Term::EndOfLineAssertionTerm);
     }
 
+    void assertionBOI()
+    {
+        if (hasError())
+            return;
+
+        if (m_floatingTerm.isValid() || !m_sunkTerms.isEmpty() || !m_openGroups.isEmpty()) {
+            fail(URLFilterParser::MisplacedStartOfLine);
+            return;
+        }
+
+        m_hasBeginningOfLineAssertion = true;
+    }
+
+    void assertionEOI(bool)
+    {
+        // URLs do not contain newlines, so \z and \Z are equivalent here.
+        assertionEOL();
+    }
+
     void NODELETE assertionWordBoundary(bool)
     {
         fail(URLFilterParser::WordBoundary);
@@ -389,7 +408,7 @@ URLFilterParser::ParseStatus URLFilterParser::addPattern(StringView pattern, boo
 
     ParseStatus status = Ok;
     PatternParser patternParser(patternIsCaseSensitive);
-    if (!JSC::Yarr::hasError(JSC::Yarr::parse(patternParser, pattern, JSC::Yarr::CompileMode::Legacy, 0, false)))
+    if (!JSC::Yarr::hasError(JSC::Yarr::parse(patternParser, pattern, JSC::Yarr::CompileMode::Legacy, 0, false, false)))
         patternParser.finalize(patternId, m_combinedURLFilters);
     else
         status = YarrError;


### PR DESCRIPTION
#### 2f66f5ed23f9a3ce154e7b5745861f76eeda67f0
<pre>
[JSC] Add support for Regular Expression Buffer Boundaries proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=315887">https://bugs.webkit.org/show_bug.cgi?id=315887</a>
<a href="https://rdar.apple.com/178287060">rdar://178287060</a>

Reviewed by Yusuke Suzuki.

This patch adds support for regexp buffer boundary assertions (\A, \z, \Z).
See <a href="https://github.com/tc39/proposal-regexp-buffer-boundaries">https://github.com/tc39/proposal-regexp-buffer-boundaries</a> for details.

Test: JSTests/stress/regexp-boundary-assertions.js

* JSTests/stress/regexp-boundary-assertions.js: Added.
(assertEqual):
* Source/JavaScriptCore/yarr/Yarr.h:
* Source/JavaScriptCore/yarr/YarrDisassembler.h:
(JSC::Yarr::YarrJITInfo::~YarrJITInfo): Deleted.
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::matchAssertionBOI):
(JSC::Yarr::Interpreter::matchAssertionEOI):
(JSC::Yarr::Interpreter::matchDisjunction):
(JSC::Yarr::ByteCompiler::assertionBOI):
(JSC::Yarr::ByteCompiler::assertionEOI):
(JSC::Yarr::ByteCompiler::emitDisjunction):
(JSC::Yarr::ByteTermDumper::dumpTerm):
* Source/JavaScriptCore/yarr/YarrInterpreter.h:
(JSC::Yarr::ByteTerm::ByteTerm):
(JSC::Yarr::ByteTerm::BOI):
(JSC::Yarr::ByteTerm::EOI):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::requires):
(JSC::Yarr::Parser::Parser):
(JSC::Yarr::Parser::CharacterClassParserDelegate::assertionBOI):
(JSC::Yarr::Parser::CharacterClassParserDelegate::assertionEOI):
(JSC::Yarr::Parser::ClassSetParserDelegate::assertionBOI):
(JSC::Yarr::Parser::ClassSetParserDelegate::assertionEOI):
(JSC::Yarr::Parser::ClassStringDisjunctionParserDelegate::assertionBOI):
(JSC::Yarr::Parser::ClassStringDisjunctionParserDelegate::assertionEOI):
(JSC::Yarr::Parser::parseEscape):
(JSC::Yarr::parse):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::assertionBOI):
(JSC::Yarr::YarrPatternConstructor::assertionEOI):
(JSC::Yarr::YarrPatternConstructor::setupAlternativeOffsets):
(JSC::Yarr::YarrPattern::compile):
(JSC::Yarr::PatternTerm::dump):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::PatternTerm::PatternTerm):
(JSC::Yarr::PatternTerm::BOI):
(JSC::Yarr::PatternTerm::EOI):
* Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp:
(JSC::Yarr::SyntaxChecker::assertionBOI):
(JSC::Yarr::SyntaxChecker::assertionEOI):
(JSC::Yarr::checkSyntax):
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/contentextensions/URLFilterParser.cpp:
(WebCore::ContentExtensions::PatternParser::assertionBOI):
(WebCore::ContentExtensions::PatternParser::assertionEOI):
(WebCore::ContentExtensions::URLFilterParser::addPattern):

Canonical link: <a href="https://commits.webkit.org/318415@main">https://commits.webkit.org/318415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bd09860bcf10892b7afb6ed1a52c92f62b0a057

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141123 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e90b4462-99cb-43a4-8a8d-8b816786e2f0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138651 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89a66a89-23b4-44f8-b07a-58ec503e5e4a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119114 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9d88b082-1ba1-4da8-ad91-07318a004786) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40846 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39201 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1083 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7887 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151251 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38887 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35947 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39147 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189915 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51481 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147788 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39769 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52163 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147558 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42264 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124415 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118846 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50671 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13866 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50067 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50307 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50129 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->