### PR TITLE
REGRESSION(312305@main): Books EPUB inline video controls icons are missing

### DIFF
--- a/LayoutTests/media/modern-media-controls/icon-service/icon-service-bundle-load-expected.txt
+++ b/LayoutTests/media/modern-media-controls/icon-service/icon-service-bundle-load-expected.txt
@@ -1,0 +1,11 @@
+Verifies that media-control button icons load from the WebCore framework bundle. This test catches regressions where modern-media-controls/images/ is missing from WebCore.framework on a given platform.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS buttonsChecked > 0 is true
+PASS buttonsWithEmptyIcon is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/icon-service/icon-service-bundle-load.html
+++ b/LayoutTests/media/modern-media-controls/icon-service/icon-service-bundle-load.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Modern media controls button icons load from the WebCore framework bundle</title>
+</head>
+<body>
+<video src="../../content/test.mp4" controls></video>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+window.jsTestIsAsync = true;
+description("Verifies that media-control button icons load from the WebCore framework bundle. This test catches regressions where modern-media-controls/images/ is missing from WebCore.framework on a given platform.");
+
+const video = document.querySelector("video");
+
+video.addEventListener("canplaythrough", async () => {
+    await UIHelper.animationFrame();
+
+    const shadowRoot = internals.shadowRoot(video);
+    const mediaControls = shadowRoot.lastChild;
+    const buttons = Array.from(mediaControls.querySelectorAll("button"));
+
+    window.buttonsChecked = 0;
+    window.buttonsWithEmptyIcon = 0;
+    for (const button of buttons) {
+        const picture = button.querySelector("picture");
+        if (!picture)
+            continue;
+
+        const maskImage = window.getComputedStyle(picture).maskImage;
+        const match = maskImage.match(/url\("?([^"\s)]+)"?\)/);
+        if (!match || !match[1].startsWith("blob:"))
+            continue;
+
+        const response = await fetch(match[1]);
+        const blob = await response.blob();
+        buttonsChecked++;
+        if (blob.size === 0)
+            buttonsWithEmptyIcon++;
+    }
+
+    shouldBeTrue("buttonsChecked > 0");
+    shouldBe("buttonsWithEmptyIcon", "0");
+
+    finishJSTest();
+});
+
+video.addEventListener("error", () => {
+    testFailed("video element failed to load.");
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -89,6 +89,7 @@ webxr [ Pass ]
 http/tests/iframe-monitor [ Pass ]
 
 media/modern-media-controls/visionos-inline-media-controls [ Pass ]
+media/modern-media-controls/icon-service/icon-service-bundle-load.html [ Pass ]
 
 http/tests/pdf [ Pass ]
 pdf [ Pass ]


### PR DESCRIPTION
#### 58ef21234ab508c2fefe249d3a43c49578bbdf79
<pre>
REGRESSION(312305@main): Books EPUB inline video controls icons are missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=315884">https://bugs.webkit.org/show_bug.cgi?id=315884</a>
<a href="https://rdar.apple.com/177548584">rdar://177548584</a>

Reviewed by Andy Estes and Tim Horton.

The &quot;Copy Modern Media Controls Images&quot; PBXCopyFilesBuildPhase introduced
in 312305@main replaced an rsync-based script that fell through to the
iOS icons for any non-macOS, non-watchOS platform. The replacement
attached `platformFilters = (ios, xros, );` to the iOS folder entries —
already omitting macCatalyst and tvOS — and the array was subsequently
collapsed to the singular `platformFilter = ios;` form in 312813@main
(almost certainly an unfortunate merge conflict resolution), excluding
visionOS as well.

As a result, WebCore.framework on visionOS, tvOS, and macCatalyst was
missing modern media controls images.

In this patch, we add (tvos, xros, maccatalyst) to platform filters,
matching the previous fall-through behavior of the rsync-based script.
We also add test coverage exercising the bundle path end-to-end via a
real &lt;video controls&gt; element. Existing tests manually set the icon
service directory path to the source tree, so we never fetch icons from
the framework&apos;s resources.

Test: media/modern-media-controls/icon-service/icon-service-bundle-load.html

* LayoutTests/media/modern-media-controls/icon-service/icon-service-bundle-load-expected.txt: Added.
* LayoutTests/media/modern-media-controls/icon-service/icon-service-bundle-load.html: Added.
* LayoutTests/platform/visionos/TestExpectations:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/314200@main">https://commits.webkit.org/314200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53faea70aa7cfd0a7dccb971a69a94cbf5efe3c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122673 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a50f391a-5e53-41bf-ab56-d040ed8d0461) 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128544 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/479fd3d7-5357-4647-9484-ced49e21e585) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168377 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/30854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109069 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/440e2b7e-e11a-44e2-8748-051a1f158913) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28531 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22535 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139796 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176984 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136869 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136805 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36876 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148109 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102028 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32077 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24976 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38175 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111249 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37572 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3056 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37716 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->