### PR TITLE
Unreviewed, reverting 314143@main (d1483c00ac69) and 313609@main (c0c27847a68a)

### DIFF
--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -188,6 +188,8 @@ overlay-region/sticky.html [ Failure ]
 
 webkit.org/b/313782 interaction-region/paused-video-regions.html [ Failure ]
 
+webkit.org/b/315675 pdf/pdf-plugin-hang-during-destruction.html [ Skip ]
+
 ### END OF Triaged failures
 ###################################################################################################
 

--- a/Source/WTF/wtf/MainThread.cpp
+++ b/Source/WTF/wtf/MainThread.cpp
@@ -44,7 +44,6 @@ void initializeMainThread()
         initialize();
         initializeMainThreadPlatform();
         RunLoop::initializeMain();
-        RELEASE_ASSERT(Thread::currentSingleton().uid() == 1);
     });
 }
 

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -133,16 +133,7 @@ static std::optional<size_t> NODELETE stackSize(ThreadType threadType)
 #endif
 }
 
-#if PLATFORM(COCOA)
-// uid 1 is reserved for the main thread, assigned in Thread::initializeCurrentTLS
-// when pthread_main_np() returns true. ++s_uid yields >= 2 for every non-main thread.
-std::atomic<uint32_t> ThreadLike::s_uid { 1 };
-#else
-// On platforms without a way to detect the main thread before initializeMainThread()
-// has run, ++s_uid yields uids starting at 1 — the first Thread to be lazily
-// constructed gets uid 1 which currently is the main thread.
-std::atomic<uint32_t> ThreadLike::s_uid { 0 };
-#endif
+std::atomic<uint32_t> ThreadLike::s_uid;
 
 uint32_t ThreadLike::currentSequence()
 {
@@ -268,7 +259,7 @@ Ref<Thread> Thread::create(ASCIILiteral name, Function<void()>&& entryPoint, Thr
 {
     WTF::initialize();
 
-    Ref thread = adoptRef(*new Thread(schedulingPolicy, Thread::IsMain::No));
+    Ref thread = adoptRef(*new Thread(schedulingPolicy));
 
     Ref context = adoptRef(*new NewThreadContext { name, WTF::move(entryPoint), thread.get() });
     {

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -294,11 +294,8 @@ public:
 #endif
 
 protected:
-    enum class IsMain : uint8_t { No, Yes, Unknown };
-
-    explicit Thread(SchedulingPolicy schedulingPolicy, IsMain isMain = IsMain::Unknown)
+    explicit Thread(SchedulingPolicy schedulingPolicy)
         : m_isRealtime(schedulingPolicy == SchedulingPolicy::Realtime)
-        , m_uid(isMain == IsMain::Yes ? 1 : ++s_uid)
     {
     }
 
@@ -382,7 +379,7 @@ protected:
     StackBounds m_stack { StackBounds::emptyBounds() };
     ThreadSafeWeakHashSet<ThreadGroup> m_threadGroups;
     PlatformThreadHandle m_handle;
-    const uint32_t m_uid;
+    uint32_t m_uid { ++s_uid };
 #if OS(WINDOWS)
     ThreadIdentifier m_id { 0 };
 #elif OS(DARWIN)

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -452,11 +452,7 @@ Thread& Thread::initializeCurrentTLS()
 {
     // Not a WTF-created thread, Thread is not established yet.
     WTF::initialize();
-#if PLATFORM(COCOA)
-    Ref thread = adoptRef(*new Thread(SchedulingPolicy::Other, pthread_main_np() ? IsMain::Yes : IsMain::No));
-#else
     Ref thread = adoptRef(*new Thread(SchedulingPolicy::Other));
-#endif
     thread->establishPlatformSpecificHandle(pthread_self());
     thread->initializeInThread();
     initializeCurrentThreadEvenIfNonWTFCreated();

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -93,6 +93,7 @@
 #include <windows.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
+#include <wtf/MainThread.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/ThreadingPrimitives.h>

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -1021,26 +1021,23 @@ public:
 private:
     explicit ScriptExecutionContextDispatcher(ScriptExecutionContext& context)
         : m_identifier(context.identifier())
-        , m_workerThreadId(context.isWorkerGlobalScope() ? std::optional { Thread::currentSingleton().uid() } : std::nullopt)
+        , m_threadId(context.isWorkerGlobalScope() ? Thread::currentSingleton().uid() : 1)
     {
     }
 
     // GuaranteedSerialFunctionDispatcher
     void dispatch(Function<void()>&& callback) final
     {
-        if (!m_workerThreadId) {
+        if (m_threadId == 1) {
             callOnMainThread(WTF::move(callback));
             return;
         }
         ScriptExecutionContext::postTaskTo(m_identifier, WTF::move(callback));
     }
-    bool isCurrent() const final
-    {
-        return m_workerThreadId ? *m_workerThreadId == Thread::currentSingleton().uid() : isMainThread();
-    }
+    bool isCurrent() const final { return m_threadId == Thread::currentSingleton().uid(); }
 
     ScriptExecutionContextIdentifier m_identifier;
-    const std::optional<uint32_t> m_workerThreadId;
+    const uint32_t m_threadId { 1 };
 };
 
 GuaranteedSerialFunctionDispatcher& ScriptExecutionContext::nativePromiseDispatcher()

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -128,10 +128,10 @@ static void checkFrameworkVersion(xpc_object_t message)
 
 static bool s_isWebProcess = false;
 
-static void setUserDirSuffix(String&& suffix)
+static void setUserDirSuffix(ASCIILiteral suffix)
 {
 #if PLATFORM(IOS_FAMILY)
-    if (_set_user_dir_suffix(suffix.utf8().data())) {
+    if (_set_user_dir_suffix(suffix)) {
         RELEASE_LOG(IPC, "Successfully set temp dir");
         confstr(_CS_DARWIN_USER_TEMP_DIR, nullptr, 0);
         return;
@@ -209,14 +209,10 @@ void XPCServiceEventHandler(xpc_connection_t peer)
                 return;
             }
 
-            String uiProcessName = xpcDictionaryGetString(event, "ui-process-name"_s);
-
             CFStringRef entryPointFunctionName = nullptr;
             if (serviceName.startsWith(webContentServiceName)) {
                 s_isWebProcess = true;
-#if USE(EXTENSIONKIT)
-                setUserDirSuffix(WTF::move(uiProcessName));
-#else
+#if !USE(EXTENSIONKIT)
                 setUserDirSuffix(webContentServiceName);
 #endif
                 entryPointFunctionName = CFSTR(STRINGIZE_VALUE_OF(WEBCONTENT_SERVICE_INITIALIZER));
@@ -224,9 +220,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
                 setUserDirSuffix(networkingServiceName);
                 entryPointFunctionName = CFSTR(STRINGIZE_VALUE_OF(NETWORK_SERVICE_INITIALIZER));
             } else if (serviceName == gpuServiceName) {
-#if USE(EXTENSIONKIT)
-                setUserDirSuffix(WTF::move(uiProcessName));
-#else
+#if !USE(EXTENSIONKIT)
                 setUserDirSuffix(gpuServiceName);
 #endif
                 entryPointFunctionName = CFSTR(STRINGIZE_VALUE_OF(GPU_SERVICE_INITIALIZER));


### PR DESCRIPTION
#### d91139f073255bfdc110d17d8c8f5165f00808c3
<pre>
Unreviewed, reverting 314143@main (d1483c00ac69) and 313609@main (c0c27847a68a)
<a href="https://bugs.webkit.org/show_bug.cgi?id=315890">https://bugs.webkit.org/show_bug.cgi?id=315890</a>
<a href="https://rdar.apple.com/178289711">rdar://178289711</a>

REGRESSION(314143@main): Trunk macOS performance testing failing due to ncscript crash

Reverted changes:

    REGRESSION(313609@main): [visionOS debug] pdf/pdf-plugin-hang-during-destruction.html is a constant crash.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315675">https://bugs.webkit.org/show_bug.cgi?id=315675</a>
    <a href="https://rdar.apple.com/178065646">rdar://178065646</a>
    314143@main (d1483c00ac69)

    [iOS] Use temp directories per App for extensions
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315107">https://bugs.webkit.org/show_bug.cgi?id=315107</a>
    <a href="https://rdar.apple.com/177441499">rdar://177441499</a>
    313609@main (c0c27847a68a)

Canonical link: <a href="https://commits.webkit.org/314192@main">https://commits.webkit.org/314192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86700fb3bcd9bbf1f6abd4073bdbd07f7e6a856b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38895 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174447 "Failed to checkout and rebase branch from PR 66066") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167271 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38899 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/174447 "Failed to checkout and rebase branch from PR 66066") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168364 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/148601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/174447 "Failed to checkout and rebase branch from PR 66066") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22522 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/157562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/26299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176971 "Failed to checkout and rebase branch from PR 66066") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26298 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/28004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/176971 "Failed to checkout and rebase branch from PR 66066") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38963 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/176971 "Failed to checkout and rebase branch from PR 66066") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39652 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/148095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25166 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/32066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38162 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/111236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/37559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/3041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37703 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->