### PR TITLE
REGRESSION(313609@main): [visionOS debug] pdf/pdf-plugin-hang-during-destruction.html is a constant crash.

### DIFF
--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -189,8 +189,6 @@ overlay-region/sticky.html [ Failure ]
 
 webkit.org/b/313782 interaction-region/paused-video-regions.html [ Failure ]
 
-webkit.org/b/315675 pdf/pdf-plugin-hang-during-destruction.html [ Skip ]
-
 ### END OF Triaged failures
 ###################################################################################################
 

--- a/Source/WTF/wtf/MainThread.cpp
+++ b/Source/WTF/wtf/MainThread.cpp
@@ -44,6 +44,7 @@ void initializeMainThread()
         initialize();
         initializeMainThreadPlatform();
         RunLoop::initializeMain();
+        RELEASE_ASSERT(!isMainThread() || Thread::currentSingleton().uid() == 1);
     });
 }
 

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -133,7 +133,16 @@ static std::optional<size_t> NODELETE stackSize(ThreadType threadType)
 #endif
 }
 
-std::atomic<uint32_t> ThreadLike::s_uid;
+#if PLATFORM(COCOA)
+// uid 1 is reserved for the main thread, assigned in Thread::initializeCurrentTLS
+// when pthread_main_np() returns true. ++s_uid yields >= 2 for every non-main thread.
+std::atomic<uint32_t> ThreadLike::s_uid { 1 };
+#else
+// On platforms without a way to detect the main thread before initializeMainThread()
+// has run, ++s_uid yields uids starting at 1 — the first Thread to be lazily
+// constructed gets uid 1 which currently is the main thread.
+std::atomic<uint32_t> ThreadLike::s_uid { 0 };
+#endif
 
 uint32_t ThreadLike::currentSequence()
 {
@@ -259,7 +268,7 @@ Ref<Thread> Thread::create(ASCIILiteral name, Function<void()>&& entryPoint, Thr
 {
     WTF::initialize();
 
-    Ref thread = adoptRef(*new Thread(schedulingPolicy));
+    Ref thread = adoptRef(*new Thread(schedulingPolicy, Thread::IsMain::No));
 
     Ref context = adoptRef(*new NewThreadContext { name, WTF::move(entryPoint), thread.get() });
     {

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -294,8 +294,11 @@ public:
 #endif
 
 protected:
-    explicit Thread(SchedulingPolicy schedulingPolicy)
+    enum class IsMain : uint8_t { No, Yes, Unknown };
+
+    explicit Thread(SchedulingPolicy schedulingPolicy, IsMain isMain = IsMain::Unknown)
         : m_isRealtime(schedulingPolicy == SchedulingPolicy::Realtime)
+        , m_uid(isMain == IsMain::Yes ? 1 : ++s_uid)
     {
     }
 
@@ -379,7 +382,7 @@ protected:
     StackBounds m_stack { StackBounds::emptyBounds() };
     ThreadSafeWeakHashSet<ThreadGroup> m_threadGroups;
     PlatformThreadHandle m_handle;
-    uint32_t m_uid { ++s_uid };
+    const uint32_t m_uid;
 #if OS(WINDOWS)
     ThreadIdentifier m_id { 0 };
 #elif OS(DARWIN)

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -452,7 +452,11 @@ Thread& Thread::initializeCurrentTLS()
 {
     // Not a WTF-created thread, Thread is not established yet.
     WTF::initialize();
+#if PLATFORM(COCOA)
+    Ref thread = adoptRef(*new Thread(SchedulingPolicy::Other, pthread_main_np() ? IsMain::Yes : IsMain::No));
+#else
     Ref thread = adoptRef(*new Thread(SchedulingPolicy::Other));
+#endif
     thread->establishPlatformSpecificHandle(pthread_self());
     thread->initializeInThread();
     initializeCurrentThreadEvenIfNonWTFCreated();

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -93,7 +93,6 @@
 #include <windows.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
-#include <wtf/MainThread.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/ThreadingPrimitives.h>

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -1021,23 +1021,26 @@ public:
 private:
     explicit ScriptExecutionContextDispatcher(ScriptExecutionContext& context)
         : m_identifier(context.identifier())
-        , m_threadId(context.isWorkerGlobalScope() ? Thread::currentSingleton().uid() : 1)
+        , m_workerThreadId(context.isWorkerGlobalScope() ? std::optional { Thread::currentSingleton().uid() } : std::nullopt)
     {
     }
 
     // GuaranteedSerialFunctionDispatcher
     void dispatch(Function<void()>&& callback) final
     {
-        if (m_threadId == 1) {
+        if (!m_workerThreadId) {
             callOnMainThread(WTF::move(callback));
             return;
         }
         ScriptExecutionContext::postTaskTo(m_identifier, WTF::move(callback));
     }
-    bool isCurrent() const final { return m_threadId == Thread::currentSingleton().uid(); }
+    bool isCurrent() const final
+    {
+        return m_workerThreadId ? *m_workerThreadId == Thread::currentSingleton().uid() : isMainThread();
+    }
 
     ScriptExecutionContextIdentifier m_identifier;
-    const uint32_t m_threadId { 1 };
+    const std::optional<uint32_t> m_workerThreadId;
 };
 
 GuaranteedSerialFunctionDispatcher& ScriptExecutionContext::nativePromiseDispatcher()


### PR DESCRIPTION
#### a98eac5157ce2230198592b9c97155b1b2cf707d
<pre>
REGRESSION(313609@main): [visionOS debug] pdf/pdf-plugin-hang-during-destruction.html is a constant crash.
<a href="https://bugs.webkit.org/show_bug.cgi?id=315675">https://bugs.webkit.org/show_bug.cgi?id=315675</a>
<a href="https://rdar.apple.com/178065646">rdar://178065646</a>

Reviewed by Chris Dumez and Youenn Fablet

313609@main added work on the libxpc bootstrap dispatch queue in
XPCServiceMain.mm that runs before WTF::initializeMainThread() —
specifically String::utf8() inside setUserDirSuffix(suffix.utf8().data()).
String::utf8() allocates a CStringBuffer, which derives from non-thread-safe
RefCounted. On debug builds (ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS))
the RefCounted constructor records the owning thread via
RefCountDebugger::initialOwnerThread(), which calls Thread::currentSingleton()
and lazily constructs the dispatch-queue Thread. That Thread got uid 1 from
m_uid { ++s_uid } (s_uid was default-zero-initialised). The main thread&apos;s
later Thread then got uid 2. On release builds the RefCountDebugger path
is compiled out, so the dispatch queue did not construct its Thread first
and the main thread kept uid 1 — which is why this only manifested on debug.

The main thread&apos;s uid being 1 is not local to ScriptExecutionContextDispatcher.
WorkQueue and Thread deliberately share one id namespace (WorkQueueCocoa.cpp):
non-main work queues take their id from ++s_uid, while the main work queue is
constructed with the constant mainThreadID (== 1, ThreadAssertions.h).
ThreadLike::currentSequence() returns that id when running inside a tracked
queue, and Thread::currentSingleton().uid() when running on a bare thread. For
an &quot;is current&quot; assertion tagged with the main sequence (1) to hold when checked
on the main thread, the main Thread&apos;s uid must also be 1. When 313609@main
pushed main&apos;s uid to 2 this shared-namespace assumption broke;
ScriptExecutionContextDispatcher&apos;s queue.isCurrent() RELEASE_ASSERT in
NativePromise&lt;T&gt;::ThenCallback::processResult (on main-thread native-promise
resolution — DOMCacheEngine, IDB, etc.) is simply the path that fired in the
affected test.

uid 1 == main was a consequence of startup ordering, not a guaranteed
invariant. We make it explicit on platforms where main can be detected
without prior initialisation, and assert the invariant unconditionally:

 - Thread&apos;s constructor takes an IsMain { No, Yes, Unknown } argument and
   sets m_uid to 1 for IsMain::Yes, otherwise ++s_uid. Thread::create()
   passes IsMain::No (a created thread is never main).

 - On Cocoa (PLATFORM(COCOA)), ThreadLike::s_uid is initialised to 1 so
   ++s_uid yields uids &gt;= 2 for every non-main thread, and
   Thread::initializeCurrentTLS() passes IsMain::Yes when pthread_main_np()
   returns true. pthread_main_np() works without any setup, closing the
   window for the libxpc dispatch-queue race.

 - initializeCurrentTLS() uses pthread_main_np() directly rather than
   isMainThread(): under USE(WEB_THREAD) isMainThread() is also true on the
   WebThread, which would stamp uid 1 onto two threads. pthread_main_np()
   identifies only the genuine UI thread, keeping uid 1 unique.

 - On other platforms (Windows, generic POSIX) main cannot be detected
   before initializeMainThreadPlatform() captures s_mainThread, so
   initializeCurrentTLS() constructs with IsMain::Unknown. ThreadLike::s_uid
   is initialised to 0 there, so ++s_uid assigns uid 1 to whichever Thread
   constructs first — the main thread, matching pre-regression
   startup-ordering behaviour. These ports do not have the libxpc bootstrap
   path that triggers this regression.

 - WTF::initializeMainThread() asserts the invariant unconditionally
   (RELEASE_ASSERT). On Cocoa it is guaranteed by construction (above). On
   Windows/generic POSIX it rests on main being the first thread to construct
   its Thread; the RELEASE_ASSERT enforces it by aborting at startup if that
   ever fails, rather than letting a sequence assertion mis-fire later.

ScriptExecutionContextDispatcher is refactored to use
std::optional&lt;uint32_t&gt; m_workerThreadId and isMainThread() for the
non-worker branch, removing the dependency on the magic number.

Covered by existing tests.

* LayoutTests/platform/visionos/TestExpectations:
* Source/WTF/wtf/MainThread.cpp:
(WTF::initializeMainThread):
* Source/WTF/wtf/Threading.cpp:
(WTF::Thread::create):
* Source/WTF/wtf/Threading.h:
(WTF::Thread::Thread):
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp:
(WTF::Thread::initializeCurrentTLS):
* Source/WTF/wtf/win/ThreadingWin.cpp:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContextDispatcher::ScriptExecutionContextDispatcher):
(WebCore::ScriptExecutionContextDispatcher::dispatch):
(WebCore::ScriptExecutionContextDispatcher::isCurrent):

Canonical link: <a href="https://commits.webkit.org/314233@main">https://commits.webkit.org/314233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d8b00419d5de7979db045ebf9e6cbe3e040cac8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122792 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afc3356e-3e67-4586-8505-d93e1bbcf9f4) 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128647 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2bcf7c4-76ba-405f-a412-5841181abbb5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168496 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30968 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109171 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/483cb2db-a4dd-4ed1-a598-0a0f852f6117) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28637 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22657 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157694 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177103 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26430 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30013 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28125 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136973 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39096 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32779 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-display/display-contents-svg-elements.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136907 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36894 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148215 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102223 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32180 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25082 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38294 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111368 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37691 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3162 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37937 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37835 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->