### PR TITLE
Quip comments panel can be blank when opened sometimes

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-anchoring/scroll-anchoring-on-first-async-commit-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/scroll-anchoring-on-first-async-commit-expected.txt
@@ -1,0 +1,11 @@
+Test that when the first scrolling tree commit for an overflow scroller contains a delta, the UI process ends up with the correct scroll position
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS scroller.scrollTop is 4600
+PASS uiScrollY is 4600
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-anchoring/scroll-anchoring-on-first-async-commit.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/scroll-anchoring-on-first-async-commit.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<style>
+.scroller {
+    width: 400px;
+    height: 400px;
+    overflow: hidden;
+    border: 1px solid black;
+}
+
+.scroller.scrollable {
+    overflow-y: scroll;
+}
+
+.changing {
+    height: 300px;
+    background-color: orange;
+}
+
+.scroller.changed .changing {
+    height: 400px;
+}
+
+.anchor {
+    height: 300px;
+    background-color: limegreen;
+}
+
+.content {
+    height: 8000px;
+    background: repeating-linear-gradient(white, silver 200px);
+    padding: 8px;
+}
+</style>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<script>
+jsTestIsAsync = true;
+
+description("Test that when the first scrolling tree commit for an overflow scroller contains a delta, the UI process ends up with the correct scroll position");
+
+let scroller;
+let uiScrollY;
+
+function uiSideScrollY(treeText)
+{
+    // Non-root scrolling node's current position is dumped as
+    //   (scroll position (X,Y))   (omitted when zero).
+    let m = treeText.match(/\(scroll position \((-?[\d.]+),(-?[\d.]+)\)\)/);
+    if (!m)
+        return 0;
+    return parseFloat(m[2]);
+}
+
+async function runTest()
+{
+    scroller = document.querySelector('.scroller');
+
+    scroller.scrollTo(0, 4500);
+    scroller.classList.add('scrollable');
+    scroller.scrollTo(0, 4500);
+    scroller.classList.add('changed');
+
+    await UIHelper.renderingUpdate();
+
+    shouldBe('scroller.scrollTop', '4600');
+
+    uiScrollY = uiSideScrollY(await UIHelper.getScrollingTree());
+    shouldBe('uiScrollY', '4600');
+
+    finishJSTest();
+}
+
+window.addEventListener('load', runTest);
+</script>
+</head>
+<body>
+<div class="scroller">
+    <div class="changing"></div>
+    <div class="anchor"></div>
+    <div class="content"></div>
+</div>
+<div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/tiled-drawing/scrolling/clamp-out-of-bounds-scrolls-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/clamp-out-of-bounds-scrolls-expected.txt
@@ -58,6 +58,7 @@ Attempted scroll to -5000, -5000
 Attempted scroll to 10000, 0
 
 (Frame scrolling node
+  (scroll position 4223 0)
   (scrollable area size 785 585)
   (contents size 5008 5021)
   (requested scroll position 4223 0)
@@ -78,7 +79,7 @@ Attempted scroll to 10000, 0
 Attempted scroll to 0, 10000
 
 (Frame scrolling node
-  (scroll position 4223 0)
+  (scroll position 0 4436)
   (scrollable area size 785 585)
   (contents size 5008 5021)
   (requested scroll position 0 4436)
@@ -99,7 +100,7 @@ Attempted scroll to 0, 10000
 Attempted scroll to 10000, 10000
 
 (Frame scrolling node
-  (scroll position 0 4436)
+  (scroll position 4223 4436)
   (scrollable area size 785 585)
   (contents size 5008 5021)
   (requested scroll position 4223 4436)

--- a/LayoutTests/tiled-drawing/scrolling/scrolling-tree-after-scroll-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/scrolling-tree-after-scroll-expected.txt
@@ -1,5 +1,6 @@
 
 (Frame scrolling node
+  (scroll position 0 3000)
   (scrollable area size 785 600)
   (contents size 785 5021)
   (requested scroll position 0 3000)

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -454,6 +454,7 @@ bool AsyncScrollingCoordinator::requestScrollToPosition(ScrollableArea& scrollab
 
     willSendScrollPositionRequest(*scrollingNodeID, requestedScrollData);
     stateNode->setRequestedScrollData(WTF::move(requestedScrollData));
+    stateNode->setScrollPosition(scrollableArea.scrollPosition()); // applyScrollUpdate() above may have modified the scroll position after the call to setScrollingNodeScrollableAreaGeometry().
 
     LOG_WITH_STREAM(Scrolling, stream << "AsyncScrollingCoordinator::requestScrollToPosition " << scrollPosition << " for nodeID " << scrollingNodeID << " requestedScrollData " << stateNode->requestedScrollData());
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -76,8 +76,19 @@ bool ScrollingTreeScrollingNode::commitStateBeforeChildren(const ScrollingStateN
 
     if (state->hasChangedProperty(ScrollingStateNode::Property::ScrollPosition)) {
         m_lastCommittedScrollPosition = state->scrollPosition();
-        if (m_isFirstCommit && !state->hasScrollPositionRequest())
-            m_currentScrollPosition = m_lastCommittedScrollPosition;
+        if (m_isFirstCommit) {
+            // If the first commit contains a scroll delta, prime m_currentScrollPosition so we apply
+            // the delta relative to it later (otherwise we'll apply the delta relative to (0,0) and
+            // end up with the wrong scroll position).
+            FloatSize deltaForFirstCommit;
+            for (auto& request : state->requestedScrollData()) {
+                if (auto* delta = std::get_if<FloatSize>(&request.scrollPositionOrDelta)) {
+                    deltaForFirstCommit = *delta;
+                    break;
+                }
+            }
+            m_currentScrollPosition = m_lastCommittedScrollPosition - deltaForFirstCommit;
+        }
     }
 
     if (state->hasChangedProperty(ScrollingStateNode::Property::ScrollOrigin))


### PR DESCRIPTION
#### ec7e3b45991386815ab248173fe74697f77569a2
<pre>
Quip comments panel can be blank when opened sometimes
<a href="https://bugs.webkit.org/show_bug.cgi?id=315893">https://bugs.webkit.org/show_bug.cgi?id=315893</a>
<a href="https://rdar.apple.com/178255628">rdar://178255628</a>

Reviewed by Abrar Rahman Protyasha.

The Quip page happened to make an overflow scroller scrollable, and trigger scroll anchoring
in the same rendering update. Thus, the first scrolling tree commit to the UI process had
a scroll position request containing a scroll delta.

The existing could would resolve this delta against (0,0) which caused the UI process to
get a bad scroll offset (which resulting missing tiles). Fix to compute the right
`m_currentScrollPosition` in this case so that we end up at the right scroll position.

This revealed another issue where the scrolling state node in the first scrolling tree commit
would only contain an offset for the first `scrollBy` in `fast/scrolling/programmatic-scroll-merge-delta.html`,
because the node `scrollPosition` is updated in `setScrollingNodeScrollableAreaGeometry()`, before
the `applyScrollUpdate()`; fix by upating it again near the end of
`AsyncScrollingCoordinator::requestScrollToPosition()`. This affects two `tiled-drawing`
tests whose results make more sense now.

Test: fast/scrolling/scroll-anchoring/scroll-anchoring-on-first-async-commit.html

* LayoutTests/fast/scrolling/scroll-anchoring/scroll-anchoring-on-first-async-commit-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-anchoring/scroll-anchoring-on-first-async-commit.html: Added.
* LayoutTests/tiled-drawing/scrolling/clamp-out-of-bounds-scrolls-expected.txt:
* LayoutTests/tiled-drawing/scrolling/scrolling-tree-after-scroll-expected.txt:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::requestScrollToPosition):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::commitStateBeforeChildren):

Canonical link: <a href="https://commits.webkit.org/314371@main">https://commits.webkit.org/314371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03543f0a6eafe72116635326a376972ff5b8f404

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165764 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39254 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123019 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42f5ee96-8d62-4796-a28c-e9a7c13ccd19) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128822 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90730 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa2cd2fd-da4e-4206-a5f4-733aec3fff1f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168723 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31149 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109346 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5170fe10-668e-4e15-b86d-629407ca4c9a) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30128 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28841 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22889 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177331 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30246 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137157 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137085 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36977 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40011 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148424 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102539 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32373 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25291 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38522 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111595 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37918 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3373 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38164 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38062 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->