### PR TITLE
Use protect() instead of RefPtr { } in MediaRecorderPrivateEncoder, PDFPluginAnnotation, PDFPluginPasswordForm

### DIFF
--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
@@ -634,7 +634,7 @@ Ref<GenericPromise> MediaRecorderPrivateEncoder::encodePendingVideoFrames(const 
     if (m_videoEncoderCreationPromise) {
         GenericPromise::Producer producer;
         Ref promise = producer.promise();
-        RefPtr { m_videoEncoderCreationPromise }->chainTo(WTF::move(producer));
+        protect(m_videoEncoderCreationPromise)->chainTo(WTF::move(producer));
         return promise;
     }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
@@ -83,7 +83,7 @@ void PDFPluginAnnotation::attach(Element* parent)
 
     updateGeometry();
 
-    RefPtr { m_parent.get() }->appendChild(element);
+    protect(m_parent.get())->appendChild(element);
 
     // FIXME: The text cursor doesn't blink after this. Why?
     element->focus();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm
@@ -80,7 +80,7 @@ Ref<Element> PDFPluginPasswordForm::createAnnotationElement()
 
 void PDFPluginPasswordForm::unlockFailed()
 {
-    RefPtr { m_subtitleElement }->setTextContent(pdfPasswordFormInvalidPasswordSubtitle());
+    protect(m_subtitleElement)->setTextContent(pdfPasswordFormInvalidPasswordSubtitle());
 }
 
 void PDFPluginPasswordForm::updateGeometry()


### PR DESCRIPTION
#### ead8c91f579068cb9c7b52a0eed60f1a9b93d2f3
<pre>
Use protect() instead of RefPtr { } in MediaRecorderPrivateEncoder, PDFPluginAnnotation, PDFPluginPasswordForm
<a href="https://bugs.webkit.org/show_bug.cgi?id=315894">https://bugs.webkit.org/show_bug.cgi?id=315894</a>
<a href="https://rdar.apple.com/178298727">rdar://178298727</a>

Reviewed by Anne van Kesteren.

Use protect(foo) instead of RefPtr {foo } to align with WebKit&apos;s transition from
brace-initialized smart pointer temporaries.

No new tests needed.

* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::encodePendingVideoFrames):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm:
(WebKit::PDFPluginAnnotation::attach):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm:
(WebKit::PDFPluginPasswordForm::unlockFailed):

Canonical link: <a href="https://commits.webkit.org/314300@main">https://commits.webkit.org/314300@main</a>
</pre>
