### PR TITLE
[CMake] Adaptive unified sources

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -92,7 +92,7 @@
                 },
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/Tools/Scripts/caffeinate-ninja"
+                    "value": "${sourceDir}/Source/cmake/ninja-wrapper"
                 }
             },
             "environment": {

--- a/Source/cmake/WebKitCCache.cmake
+++ b/Source/cmake/WebKitCCache.cmake
@@ -55,3 +55,9 @@ if (("$ENV{WEBKIT_USE_SCCACHE}" STREQUAL "1") OR DEFINED ENV{SCCACHE_REDIS} OR D
         set(CMAKE_CXX_COMPILER_LAUNCHER ${SCCACHE_FOUND})
     endif ()
 endif ()
+
+if (APPLE AND CMAKE_GENERATOR STREQUAL "Ninja")
+    set(_clang_wrapper "${CMAKE_SOURCE_DIR}/Source/cmake/clang-wrapper")
+    list(INSERT CMAKE_CXX_COMPILER_LAUNCHER 0 "${_clang_wrapper}")
+    list(INSERT CMAKE_OBJCXX_COMPILER_LAUNCHER 0 "${_clang_wrapper}")
+endif ()

--- a/Source/cmake/clang-wrapper
+++ b/Source/cmake/clang-wrapper
@@ -1,0 +1,147 @@
+#!/bin/bash
+#
+# clang-wrapper <compile-command...>
+#
+# When WK_UNIFIED_SOURCES_BUNDLE_POLICY is "Bundle", or when compiling
+# a non-unified-source file, this script is a simple pass-through.
+#
+# Otherwise, this script makes N copies of <compile-command...>, one for each
+# unified source bundle member, and uses ninja + clang + libtool to compile
+# each one and then merge the results into a unified .o and .d file.
+#
+# The end result is as-if we built the unified bundle, but with the performance
+# of building indivdiual member files with individual dependency tracking.
+#
+# This works because ninja's only contract is: input => tool => (output, deps).
+# From the outer ninja's perspective, it doesn't matter how 'tool' computes
+# (output, deps).
+#
+# Bundling is purely an optimization decision. Either policy is always valid.
+#
+# The pass-through path is bash to minimize startup cost. The NoBundle path
+# re-execs this same file under perl -x, which skips ahead to the perl
+# shebang below.
+
+if [[ "$WK_UNIFIED_SOURCES_BUNDLE_POLICY" != NoBundle ]]; then
+    exec "$@"
+fi
+
+exec /usr/bin/perl -x "$0" "$@"
+
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+# Extract the flags that describe our input and output, and preserve the rest
+# for reuse in our ninja commands.
+my $sourceFile;
+my $outputFile;
+my $depFile;
+my @driverArgs;
+for (my $i = 0; $i < scalar(@ARGV); ++$i) {
+    my $arg = $ARGV[$i];
+    if ($arg eq '-c') {
+        $sourceFile = $ARGV[++$i];
+        next;
+    }
+    if ($arg eq '-o') {
+        $outputFile = $ARGV[++$i];
+        next;
+    }
+    if ($arg eq '-MF') {
+        $depFile = $ARGV[++$i];
+        next;
+    }
+    if ($arg eq '-MT' || $arg eq '-x') {
+        ++$i;
+        next;
+    }
+    push(@driverArgs, $arg);
+}
+
+# Pass through non-unified sources.
+if ($sourceFile !~ m{/unified-sources/UnifiedSource}) {
+    exec(@ARGV);
+}
+
+my ($extension) = $sourceFile =~ /\.(\w+)$/;
+my $membersFolder = "$outputFile.members";
+mkdir($membersFolder);
+
+# Expand the bundle into one stub source file per member.
+my @memberObjects;
+my $ccEdges = '';
+my $memberCount = 0;
+open(my $bundle, '<', $sourceFile) or die("$sourceFile: $!\n");
+while (my $line = <$bundle>) {
+    chomp($line);
+    if ($line !~ /^#include /) {
+        next;
+    }
+    my $stub = "$membersFolder/m$memberCount.$extension";
+    my $object = "$membersFolder/m$memberCount.o";
+    writeFileIfChanged($stub, "$line\n");
+    $ccEdges .= "build $object | $object.d: cc $stub\n";
+    push(@memberObjects, $object);
+    ++$memberCount;
+}
+close($bundle);
+
+my $ccPrefix = join(' ', map { shellQuote($_) } @driverArgs);
+my $quotedDepFile = shellQuote($depFile);
+my $memberObjectList = join(' ', @memberObjects);
+my $memberDepList = join(' ', map { "$_.d" } @memberObjects);
+
+# Rule bodies are literal: $cc_prefix, $in, $out, etc. are all ninja variables.
+my $rules = <<'END_OF_RULES';
+rule cc
+  command = $cc_prefix -MD -MT $out -MF $out.d -o $out -c $in
+  depfile = $out.d
+  description = member $in
+
+rule merge
+  command = $cc_prefix -Qunused-arguments -r -nostdlib -Wl,-keep_private_externs -o $out $in && cat $member_deps > $bundle_dep
+  description = merge $out
+END_OF_RULES
+
+my $buildNinja = <<"END_OF_NINJA";
+ninja_required_version = 1.3
+builddir = $membersFolder
+cc_prefix = $ccPrefix
+bundle_dep = $quotedDepFile
+member_deps = $memberDepList
+$rules
+$ccEdges
+build $outputFile | $depFile: merge $memberObjectList
+default $outputFile
+END_OF_NINJA
+
+writeFileIfChanged("$membersFolder/build.ninja", $buildNinja);
+
+exec('ninja', '--quiet', '-f', "$membersFolder/build.ninja");
+die("exec ninja: $!\n");
+
+sub shellQuote {
+    my ($s) = @_;
+    if ($s =~ /^[A-Za-z0-9_\-+=:,.\/]+$/) {
+        return $s;
+    }
+    $s =~ s/'/'\\''/g;
+    return "'$s'";
+}
+
+sub writeFileIfChanged {
+    my ($path, $newContent) = @_;
+    if (-f $path) {
+        local $/;
+        open(my $in, '<', $path);
+        my $oldContent = <$in>;
+        close($in);
+        if (defined($oldContent) && $oldContent eq $newContent) {
+            return;
+        }
+    }
+    open(my $out, '>', $path) or die("$path: $!\n");
+    print($out $newContent);
+    close($out);
+}

--- a/Source/cmake/ninja-wrapper
+++ b/Source/cmake/ninja-wrapper
@@ -1,0 +1,47 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Cwd qw(getcwd);
+use File::Path qw(make_path);
+
+# CMake configuration
+if (grep({ /^-t/ || /^--version$/ } @ARGV)) {
+    exec('ninja', @ARGV);
+}
+
+# CMake try_compile/check_*
+if (getcwd() =~ m{/CMakeFiles/}) {
+    exec('ninja', @ARGV);
+}
+
+# Real compilation
+my $bundlePolicy = $ENV{WK_UNIFIED_SOURCES_BUNDLE_POLICY};
+if (!defined($bundlePolicy)) {
+    my $dryRun = `ninja -n @ARGV 2>&1`;
+    my ($totalCommands) = $dryRun =~ m{/(\d+)\]};
+
+    # No-op build
+    if (!defined($totalCommands)) {
+        print($dryRun);
+        exit($? >> 8);
+    }
+
+    if ($dryRun =~ /\bRe-running CMake\b/) {
+        $bundlePolicy = "Bundle";
+    } elsif ($totalCommands > 8) {
+        $bundlePolicy = "Bundle";
+    } else {
+        $bundlePolicy = "NoBundle";
+    }
+
+    $ENV{WK_UNIFIED_SOURCES_BUNDLE_POLICY} = $bundlePolicy;
+}
+
+# Record the bundle policy for inspection; nothing reads this file.
+make_path("DerivedSources");
+if (open(my $fh, '>', "DerivedSources/unified-sources-bundle-policy")) {
+    print($fh $bundlePolicy);
+    close($fh);
+}
+
+exec('/usr/bin/caffeinate', '-i', 'ninja', @ARGV);

--- a/Tools/Scripts/caffeinate-ninja
+++ b/Tools/Scripts/caffeinate-ninja
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec /usr/bin/caffeinate -i xcrun ninja "$@"


### PR DESCRIPTION
#### 7b4cd9c48bd38a31ab9507213aea71ae106b57c7
<pre>
[CMake] Adaptive unified sources
<a href="https://bugs.webkit.org/show_bug.cgi?id=315896">https://bugs.webkit.org/show_bug.cgi?id=315896</a>
<a href="https://rdar.apple.com/178303933">rdar://178303933</a>

Reviewed by David Kilzer.

This patch introduces adaptive unified sources: In big builds we build
unified sources for maximum throughput and in small builds we build
individual files for minimum latency and maximum parallelism.

This enables a follow-on patch to grow unified sources and speed up
clean builds without regressing incremental builds. It&apos;s also an
incremental build speedup as-is. Today, touch-one-file builds pay
median 4x / p90 20x overhead vs solo compile. For example:

    Touch JavaScriptCore/b3/B3Width.cpp (previous: 5.57s):
        first: 3.536s
        second: 1.356s

    Touch JavaScriptCore/dfg/DFGPhase.cpp (previous: 5.41s):
        first: 3.165s
        second: 1.380s

    Touch Source/WebCore/dom/FindRevealAlgorithms.cpp (previous: 26.85s):
        first: 16.863s
        second: 5.488s

    Touch Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.cpp (previous: 20.69s):
        first: 12.322s
        second: 2.283s

* CMakePresets.json:
* Source/cmake/WebKitCCache.cmake: Install our compiler wrapper. This
has to happen in the ccache setup file because compiler wrappers chain,
and we want our wrapper to run before ccache in the chain.

Limited to Apple builds for now because I didn&apos;t test non-clang compilers
or non-libtool linkers, but I&apos;m not aware of any barriers to other ports
adopting.

* Source/cmake/clang-wrapper: Added. This wrapper script implements
the Bundle / NoBundle decision.

* Source/cmake/ninja-wrapper: Added.
* Tools/Scripts/caffeinate-ninja: Removed. Replaced caffeinate-ninja
with a more general-purpose wrapper. This wrapper script makes the
Bundle / NoBundle decision.

We set the cutoff at 8, which is a little higher than the ideal tradeoff,
based on the intuition that incremental builds pay off in the long term
if local development ends up building more than once.

Canonical link: <a href="https://commits.webkit.org/314224@main">https://commits.webkit.org/314224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/297737185c3cd23c5b1e55152e37697cabd56cf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122768 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7bdc3758-6db8-41ac-9d12-25b7efd71c65) 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128626 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6041c4f-df7d-48f9-bdce-502557416c2a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168472 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/30944 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109151 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a5d978c-931b-4c26-8fe1-4273c8bd9f2a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28617 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22633 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157670 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177079 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26406 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136952 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32757 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136887 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148194 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102179 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25180 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25061 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38270 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37667 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3141 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37811 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->