### PR TITLE
Cherry-pick(s) 899331a21899. rdar://176058667

### DIFF
--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -99,6 +99,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
             JSValue value = JSValue::decode(values[i]);
             unsigned index = property.location().info();
 
+<<<<<<< HEAD
             // When a double array element's Phi resolves to PNaN (the hole default), the OSR exit
             // compiler boxes it as jsNumber(NaN). To preserve hole semantics for double Arrays,
             // store PNaN directly instead of going through putDirectIndex which would trigger a
@@ -125,6 +126,16 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
                 array->butterfly()->arrayStorage()->m_vector[index].clear();
             else
                 array->putDirectIndex(globalObject, index, value);
+=======
+            if (value.isEmpty()) {
+                ASSERT(!hasDouble(materialization->indexingType()));
+                if (hasAnyArrayStorage(array->indexingType()))
+                    array->butterfly()->arrayStorage()->m_vector[index].clear();
+                else
+                    array->butterfly()->contiguous().atUnsafe(index).clear();
+                continue;
+            }
+>>>>>>> 899331a21899 ([JSC] Array rematerialization should know how to have a bad time)
 
             scope.assertNoExceptionExceptTermination();
         }


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176058667 to main. The following sources [eba64ef44de3] will still need to be cherry-picked once the conflict is resolved.

```[JSC] Array rematerialization should know how to have a bad time
https://bugs.webkit.org/show_bug.cgi?id=311883
rdar://174420676

Reviewed by Keith Miller.

Sunk Arrays that are rematerialized with a butterfly are always rematerialized
with a contiguous butterfly. If, in the meantime, the VM had a bad time and
moved all Array structures to SlowPutArrayStorage, rematerialization can end up
treating remterialized Arrays, which are now ArrayStorage, as if they had
contiguous butterflies.

This PR fixes that by always rematerializing with the contiguous butterfly, but
switching to SlowPutArrayStorage after the fact if the VM is having a bad time.

Test: JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time.js

* JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time.js: Added.
(cb):
(collect):
(opt):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Originally-landed-as: 305413.641@rapid/safari-7624.2.5.110-branch (899331a21899). rdar://176058667

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82a3daa4b57f79f0285615ea455c1dbdcf7c2f93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165430 "2 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/38920 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32501 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174472 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/122685 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39256 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38924 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/174472 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/122685 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/168389 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39256 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/32501 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174472 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39256 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/38924 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/22547 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/157587 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39256 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/32501 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176996 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/26323 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29902 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32501 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/176996 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/38989 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/38924 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/176996 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/39677 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/32501 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102048 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/39677 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/32501 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/197831 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/38187 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/111261 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/197831 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/37584 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/32501 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/37830 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/37728 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->