### PR TITLE
Mark WeakPtrFactory::initializeIfNeeded as NODELETE

### DIFF
--- a/Source/WTF/wtf/WeakPtrFactory.h
+++ b/Source/WTF/wtf/WeakPtrFactory.h
@@ -85,7 +85,7 @@ public:
         return m_impl.get();
     }
 
-    void initializeIfNeeded(const T& object) const
+    SUPPRESS_NODELETE void NODELETE initializeIfNeeded(const T& object) const
     {
         if (m_impl)
             return;
@@ -161,7 +161,7 @@ public:
         return m_impl.pointer();
     }
 
-    void initializeIfNeeded(const T& object) const
+    SUPPRESS_NODELETE void NODELETE initializeIfNeeded(const T& object) const
     {
         if (m_impl.pointer())
             return;


### PR DESCRIPTION
#### 3d78c651c5aa543f4769e813aec31c91d650ec69
<pre>
Mark WeakPtrFactory::initializeIfNeeded as NODELETE
<a href="https://bugs.webkit.org/show_bug.cgi?id=315901">https://bugs.webkit.org/show_bug.cgi?id=315901</a>

Reviewed by Geoffrey Garen.

WeakPtrFactory::initializeIfNeeded should be considered NODELETE since it won&apos;t clear m_impl.

No new tests since there should be no behavioral changes.

* Source/WTF/wtf/WeakPtrFactory.h:
(WTF::WeakPtrFactory::initializeIfNeeded const):
(WTF::WeakPtrFactoryWithBitField::initializeIfNeeded const):

Canonical link: <a href="https://commits.webkit.org/314385@main">https://commits.webkit.org/314385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61019ed37fd278f02aebbbce068bf3c504605284

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122691 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128557 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90488 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168395 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30873 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148630 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109082 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29919 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28546 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22553 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157593 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139814 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177002 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26329 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29910 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136883 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38995 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32684 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-display/display-contents-svg-elements.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136819 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148124 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102057 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25264 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32093 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24991 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38193 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111267 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37590 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3071 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37836 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37734 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->