### PR TITLE
:last-child and friends should not gate on parser state outside style resolution

### DIFF
--- a/LayoutTests/fast/selectors/nth-last-child-cannot-match-during-parsing-1-expected.txt
+++ b/LayoutTests/fast/selectors/nth-last-child-cannot-match-during-parsing-1-expected.txt
@@ -1,10 +1,10 @@
-The selector :nth-last-child() should fail to match if the following sibling have not been parsed yet.
+The selector :nth-last-child() matches during parsing for querySelector(), but style resolution does not update until the following siblings are parsed.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
 Testing the state in the middle of HTML parsing.
-PASS document.querySelectorAll("target:nth-last-child(n)").length is 0
+PASS document.querySelectorAll("target:nth-last-child(n)").length is 1
 PASS getComputedStyle(document.getElementById("target")).backgroundColor is "rgb(255, 255, 255)"
 Testing the state after parsing the test sub-tree.
 PASS document.querySelectorAll("target:nth-last-child(n)").length is 2

--- a/LayoutTests/fast/selectors/nth-last-child-cannot-match-during-parsing-1.html
+++ b/LayoutTests/fast/selectors/nth-last-child-cannot-match-during-parsing-1.html
@@ -15,9 +15,9 @@ target:nth-last-child(n) {
     <div style="display:none" id="test-root">
         <target id="target"></target>
         <script>
-            description('The selector :nth-last-child() should fail to match if the following sibling have not been parsed yet.');
+            description('The selector :nth-last-child() matches during parsing for querySelector(), but style resolution does not update until the following siblings are parsed.');
             debug("Testing the state in the middle of HTML parsing.")
-            shouldBe('document.querySelectorAll("target:nth-last-child(n)").length', '0');
+            shouldBe('document.querySelectorAll("target:nth-last-child(n)").length', '1');
             shouldBeEqualToString('getComputedStyle(document.getElementById("target")).backgroundColor', 'rgb(255, 255, 255)');
         </script>
         <target></target>

--- a/LayoutTests/fast/selectors/nth-last-child-of-cannot-match-during-parsing-1-expected.txt
+++ b/LayoutTests/fast/selectors/nth-last-child-of-cannot-match-during-parsing-1-expected.txt
@@ -1,10 +1,10 @@
-The selector :nth-last-child() should fail to match if the following sibling have not been parsed yet.
+The selector :nth-last-child() matches during parsing for querySelector(), but style resolution does not update until the following siblings are parsed.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
 Testing the state in the middle of HTML parsing.
-PASS document.querySelectorAll(":nth-last-child(n of target)").length is 0
+PASS document.querySelectorAll(":nth-last-child(n of target)").length is 1
 PASS getComputedStyle(document.getElementById("target")).backgroundColor is "rgb(255, 255, 255)"
 Testing the state after parsing the test sub-tree.
 PASS document.querySelectorAll(":nth-last-child(n of target)").length is 2

--- a/LayoutTests/fast/selectors/nth-last-child-of-cannot-match-during-parsing-1.html
+++ b/LayoutTests/fast/selectors/nth-last-child-of-cannot-match-during-parsing-1.html
@@ -16,9 +16,9 @@ target {
     <div style="display:none" id="test-root">
         <target id="target"></target>
         <script>
-            description('The selector :nth-last-child() should fail to match if the following sibling have not been parsed yet.');
+            description('The selector :nth-last-child() matches during parsing for querySelector(), but style resolution does not update until the following siblings are parsed.');
             debug("Testing the state in the middle of HTML parsing.")
-            shouldBe('document.querySelectorAll(":nth-last-child(n of target)").length', '0');
+            shouldBe('document.querySelectorAll(":nth-last-child(n of target)").length', '1');
             shouldBeEqualToString('getComputedStyle(document.getElementById("target")).backgroundColor', 'rgb(255, 255, 255)');
         </script>
         <target></target>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/child-indexed-during-parse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/child-indexed-during-parse-expected.txt
@@ -1,0 +1,8 @@
+
+PASS :last-child against an element still being parsed
+PASS :only-child against an element still being parsed
+PASS :last-of-type against an element still being parsed
+PASS :only-of-type against an element still being parsed
+PASS :nth-last-child(1) against an element still being parsed
+PASS :nth-last-of-type(1) against an element still being parsed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/child-indexed-during-parse.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/child-indexed-during-parse.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Child-indexed pseudo-classes match correctly while the parent is still being parsed</title>
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#child-index">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-last-child-pseudo">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-only-child-pseudo">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-last-of-type-pseudo">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-only-of-type-pseudo">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-nth-last-child-pseudo">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-nth-last-of-type-pseudo">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<div id="last-child-container">
+<div id="last-child-target">
+<script>
+test(() => {
+  const container = document.getElementById("last-child-container");
+  const target = document.getElementById("last-child-target");
+  assert_true(target.matches(":last-child"), "matches");
+  assert_equals(container.querySelector(":scope > :last-child"), target, "querySelector");
+  assert_array_equals([...container.querySelectorAll(":scope > :last-child")], [target], "querySelectorAll");
+}, ":last-child against an element still being parsed");
+</script>
+</div>
+</div>
+
+<div id="only-child-container">
+<div id="only-child-target">
+<script>
+test(() => {
+  const container = document.getElementById("only-child-container");
+  const target = document.getElementById("only-child-target");
+  assert_true(target.matches(":only-child"), "matches");
+  assert_equals(container.querySelector(":scope > :only-child"), target, "querySelector");
+  assert_array_equals([...container.querySelectorAll(":scope > :only-child")], [target], "querySelectorAll");
+}, ":only-child against an element still being parsed");
+</script>
+</div>
+</div>
+
+<div id="last-of-type-container">
+<p></p>
+<div id="last-of-type-target">
+<script>
+test(() => {
+  const container = document.getElementById("last-of-type-container");
+  const target = document.getElementById("last-of-type-target");
+  assert_true(target.matches(":last-of-type"), "matches");
+  assert_equals(container.querySelector(":scope > div:last-of-type"), target, "querySelector");
+  assert_array_equals([...container.querySelectorAll(":scope > div:last-of-type")], [target], "querySelectorAll");
+}, ":last-of-type against an element still being parsed");
+</script>
+</div>
+</div>
+
+<div id="only-of-type-container">
+<p></p>
+<div id="only-of-type-target">
+<script>
+test(() => {
+  const container = document.getElementById("only-of-type-container");
+  const target = document.getElementById("only-of-type-target");
+  assert_true(target.matches(":only-of-type"), "matches");
+  assert_equals(container.querySelector(":scope > div:only-of-type"), target, "querySelector");
+  assert_array_equals([...container.querySelectorAll(":scope > div:only-of-type")], [target], "querySelectorAll");
+}, ":only-of-type against an element still being parsed");
+</script>
+</div>
+</div>
+
+<div id="nth-last-child-container">
+<div id="nth-last-child-target">
+<script>
+test(() => {
+  const container = document.getElementById("nth-last-child-container");
+  const target = document.getElementById("nth-last-child-target");
+  assert_true(target.matches(":nth-last-child(1)"), "matches");
+  assert_equals(container.querySelector(":scope > :nth-last-child(1)"), target, "querySelector");
+  assert_array_equals([...container.querySelectorAll(":scope > :nth-last-child(1)")], [target], "querySelectorAll");
+}, ":nth-last-child(1) against an element still being parsed");
+</script>
+</div>
+</div>
+
+<div id="nth-last-of-type-container">
+<p></p>
+<div id="nth-last-of-type-target">
+<script>
+test(() => {
+  const container = document.getElementById("nth-last-of-type-container");
+  const target = document.getElementById("nth-last-of-type-target");
+  assert_true(target.matches(":nth-last-of-type(1)"), "matches");
+  assert_equals(container.querySelector(":scope > div:nth-last-of-type(1)"), target, "querySelector");
+  assert_array_equals([...container.querySelectorAll(":scope > div:nth-last-of-type(1)")], [target], "querySelectorAll");
+}, ":nth-last-of-type(1) against an element still being parsed");
+</script>
+</div>
+</div>
+
+</body>

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -147,6 +147,11 @@ static inline bool NODELETE isLastChildElement(const Element& element)
     return !ElementTraversal::nextSibling(element);
 }
 
+static inline bool NODELETE doesNotMatchDuringParsing(const SelectorChecker::CheckingContext& checkingContext, const Element& parentElement)
+{
+    return checkingContext.resolvingMode != SelectorChecker::Mode::QueryingRules && !parentElement.isFinishedParsingChildren();
+}
+
 static inline bool NODELETE isFirstOfType(const Element& element, const QualifiedName& type)
 {
     for (const Element* sibling = ElementTraversal::previousSibling(element); sibling; sibling = ElementTraversal::previousSibling(*sibling)) {
@@ -929,7 +934,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
             // last-child matches the last child that is an element
             bool isLastChild = isLastChildElement(element);
             if (CheckedPtr parentElement = dynamicDowncast<Element>(element->parentNode())) {
-                if (!parentElement->isFinishedParsingChildren())
+                if (doesNotMatchDuringParsing(checkingContext, *parentElement))
                     isLastChild = false;
                 addStyleRelation(checkingContext, *parentElement, Style::Relation::ChildrenAffectedByLastChildRules);
             }
@@ -943,7 +948,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
             if (CheckedPtr parentElement = dynamicDowncast<Element>(element->parentNode())) {
                 auto relation = context.isSubjectOrAdjacentElement ? Style::Relation::ChildrenAffectedByBackwardPositionalRules : Style::Relation::DescendantsAffectedByBackwardPositionalRules;
                 addStyleRelation(checkingContext, *parentElement, relation);
-                if (!parentElement->isFinishedParsingChildren())
+                if (doesNotMatchDuringParsing(checkingContext, *parentElement))
                     return false;
             }
             return isLastOfType(element, element->tagQName());
@@ -954,7 +959,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
             if (CheckedPtr parentElement = dynamicDowncast<Element>(element->parentNode())) {
                 addStyleRelation(checkingContext, *parentElement, Style::Relation::ChildrenAffectedByFirstChildRules);
                 addStyleRelation(checkingContext, *parentElement, Style::Relation::ChildrenAffectedByLastChildRules);
-                if (!parentElement->isFinishedParsingChildren())
+                if (doesNotMatchDuringParsing(checkingContext, *parentElement))
                     onlyChild = false;
             }
             if (firstChild)
@@ -971,7 +976,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
                 auto backwardRelation = context.isSubjectOrAdjacentElement ? Style::Relation::ChildrenAffectedByBackwardPositionalRules : Style::Relation::DescendantsAffectedByBackwardPositionalRules;
                 addStyleRelation(checkingContext, *parentElement, backwardRelation);
 
-                if (!parentElement->isFinishedParsingChildren())
+                if (doesNotMatchDuringParsing(checkingContext, *parentElement))
                     return false;
             }
             return isFirstOfType(element, element->tagQName()) && isLastOfType(element, element->tagQName());
@@ -1068,7 +1073,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
                     auto relation = context.isSubjectOrAdjacentElement ? Style::Relation::ChildrenAffectedByBackwardPositionalRules : Style::Relation::DescendantsAffectedByBackwardPositionalRules;
                     addStyleRelation(checkingContext, *parentElement, relation);
                 }
-                if (!parentElement->isFinishedParsingChildren())
+                if (doesNotMatchDuringParsing(checkingContext, *parentElement))
                     return false;
             }
 
@@ -1088,7 +1093,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
                 auto relation = context.isSubjectOrAdjacentElement ? Style::Relation::ChildrenAffectedByBackwardPositionalRules : Style::Relation::DescendantsAffectedByBackwardPositionalRules;
                 addStyleRelation(checkingContext, *parentElement, relation);
 
-                if (!parentElement->isFinishedParsingChildren())
+                if (doesNotMatchDuringParsing(checkingContext, *parentElement))
                     return false;
             }
             int count = 1 + countElementsOfTypeAfter(element, element->tagQName());

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -3988,16 +3988,7 @@ void SelectorCodeGenerator::generateElementIsLastChild(Assembler::JumpList& fail
     if (m_selectorContext == SelectorContext::QuerySelector) {
         Assembler::JumpList successCase = jumpIfNoNextAdjacentElement();
         failureCases.append(m_assembler.jump());
-
         successCase.link(&m_assembler);
-
-        LocalRegister parent(m_registerAllocator);
-        generateWalkToParentNode(parent);
-        auto noParentCase = m_assembler.branchTestPtr(Assembler::Zero, parent);
-
-        failureCases.append(m_assembler.branchTest16(Assembler::NonZero, Assembler::Address(parent, Node::stateFlagsMemoryOffset()), Assembler::TrustedImm32(Node::flagIsParsingChildren())));
-
-        noParentCase.link(&m_assembler);
         return;
     }
 
@@ -4050,14 +4041,6 @@ void SelectorCodeGenerator::generateElementIsOnlyChild(Assembler::JumpList& fail
         Assembler::JumpList nextSuccessCase = jumpIfNoNextAdjacentElement();
         failureCases.append(m_assembler.jump());
         nextSuccessCase.link(&m_assembler);
-
-        LocalRegister parent(m_registerAllocator);
-        generateWalkToParentNode(parent);
-        auto noParentCase = m_assembler.branchTestPtr(Assembler::Zero, parent);
-
-        failureCases.append(m_assembler.branchTest16(Assembler::NonZero, Assembler::Address(parent, Node::stateFlagsMemoryOffset()), Assembler::TrustedImm32(Node::flagIsParsingChildren())));
-
-        noParentCase.link(&m_assembler);
         return;
     }
 
@@ -4375,8 +4358,10 @@ void SelectorCodeGenerator::generateNthLastChildParentCheckAndRelationUpdate(Ass
     generateAddStyleRelationIfResolvingStyle(parentNode, relation);
     notElementCase.link(&m_assembler);
 
-    failureCases.append(m_assembler.branchTest16(Assembler::NonZero, Assembler::Address(parentNode, Node::stateFlagsMemoryOffset()),
-        Assembler::TrustedImm32(Node::flagIsParsingChildren())));
+    if (m_selectorContext != SelectorContext::QuerySelector) {
+        failureCases.append(m_assembler.branchTest16(Assembler::NonZero, Assembler::Address(parentNode, Node::stateFlagsMemoryOffset()),
+            Assembler::TrustedImm32(Node::flagIsParsingChildren())));
+    }
 
     noParentCase.link(&m_assembler);
 }


### PR DESCRIPTION
#### 748f060a3b77ae67930d9c71ff5c3f159ab51c9a
<pre>
:last-child and friends should not gate on parser state outside style resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=315904">https://bugs.webkit.org/show_bug.cgi?id=315904</a>

Reviewed by Antti Koivisto.

SelectorChecker and the selector JIT forced :last-child, :last-of-type,
:only-child, :only-of-type, :nth-last-child, and :nth-last-of-type to
return false whenever the candidate&apos;s parent had not yet finished
parsing children. While matching Chromium as an optimization for
style-resolution, it does not for querySelector().

This is the real reason a subtest in
imported/w3c/web-platform-tests/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-009.html
fails. Bug 315847 also addresses it by fixing a different bug, but does
not fix the root cause.

Test: imported/w3c/web-platform-tests/css/selectors/child-indexed-during-parse.html

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/60294">https://github.com/web-platform-tests/wpt/pull/60294</a>
Canonical link: <a href="https://commits.webkit.org/316495@main">https://commits.webkit.org/316495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5c14378323d991539e79a642ab3c81c0f44cdf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181929 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130029 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7768585e-ae4a-41a1-ad45-9b22132cd74c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134146 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13dc2770-3e57-4a83-a9ef-bf44979eadcd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114618 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f6ec120-b3b1-4b61-9af4-4d0dcf0c9f3a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36195 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30530 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184462 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37141 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38699 "Found 2 new test failures: fast/events/wheel/wheel-event-destroys-overflow.html http/tests/site-isolation/page-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142921 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142799 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38574 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46741 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111521 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37833 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118492 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45258 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9124 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44658 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44890 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44717 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->