### PR TITLE
[view-transitions] Defer finished promise resolution

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/finished-promise-defers-cleanup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/finished-promise-defers-cleanup-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View transition cleanup is deferred until after the frame where `finished` promise resolves assert_equals: expected object "[object ViewTransition]" but got null
+PASS View transition cleanup is deferred until after the frame where `finished` promise resolves
 

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -200,7 +200,11 @@ void EventLoop::queueTask(std::unique_ptr<EventLoopTask>&& task)
     ASSERT(task->taskSource() != TaskSource::Microtask);
     ASSERT(task->group());
     ASSERT(isContextThread());
-    scheduleToRunIfNeeded();
+    // Always restart the run timer so that tasks queued via queueTask fire after any
+    // EventLoopTimers (e.g. setTimeout) whose startOneShot was called before this point.
+    // This preserves FIFO ordering across task sources as required by the HTML spec.
+    microtaskQueue().setIsScheduledToRun(true);
+    scheduleToRun();
     m_tasks.append(WTF::move(task));
 }
 

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -797,6 +797,16 @@ void ViewTransition::activateViewTransition()
     protect(m_ready.second)->resolve();
 }
 
+// https://github.com/w3c/csswg-drafts/issues/12442
+void ViewTransition::finishDone()
+{
+    if (m_phase != ViewTransitionPhase::PendingDone)
+        return;
+    m_phase = ViewTransitionPhase::Done;
+    clearViewTransition();
+    protect(m_finished.second)->resolve();
+}
+
 // https://drafts.csswg.org/css-view-transitions/#handle-transition-frame-algorithm
 void ViewTransition::handleTransitionFrame()
 {
@@ -833,10 +843,15 @@ void ViewTransition::handleTransitionFrame()
             || checkForActiveAnimations({ PseudoElementType::ViewTransitionOld, name });
     }
 
-    if (!hasActiveAnimations) {
-        m_phase = ViewTransitionPhase::Done;
-        clearViewTransition();
-        protect(m_finished.second)->resolve();
+    if (!hasActiveAnimations && m_phase == ViewTransitionPhase::Animating) {
+        // Set phase to pending-done and defer the actual cleanup to an async task so that
+        // the finished promise resolves after the frame in which animations finish.
+        // https://github.com/w3c/csswg-drafts/issues/12442
+        m_phase = ViewTransitionPhase::PendingDone;
+        protect(document()->eventLoop())->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->finishDone();
+        });
         return;
     }
 
@@ -1142,6 +1157,7 @@ TextStream& operator<<(TextStream& ts, ViewTransitionPhase phase)
     case ViewTransitionPhase::CapturingOldState: ts << "CapturingOldState"_s; break;
     case ViewTransitionPhase::UpdateCallbackCalled: ts << "UpdateCallbackCalled"_s; break;
     case ViewTransitionPhase::Animating: ts << "Animating"_s; break;
+    case ViewTransitionPhase::PendingDone: ts << "PendingDone"_s; break;
     case ViewTransitionPhase::Done: ts << "Done"_s; break;
     }
     return ts;

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -64,6 +64,7 @@ enum class ViewTransitionPhase : uint8_t {
     CapturingOldState, // Not part of the spec.
     UpdateCallbackCalled,
     Animating,
+    PendingDone,
     Done
 };
 
@@ -188,6 +189,7 @@ public:
     void skipViewTransition(ExceptionOr<JSC::JSValue>&&);
 
     void setupViewTransition();
+    void finishDone();
     void handleTransitionFrame();
 
     void activateViewTransition();


### PR DESCRIPTION
#### 467dc61383b484a42e93ee1113c940747219f184
<pre>
[view-transitions] Defer finished promise resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=315907">https://bugs.webkit.org/show_bug.cgi?id=315907</a>
<a href="https://rdar.apple.com/178317398">rdar://178317398</a>

Reviewed by NOBODY (OOPS!).

As per: <a href="https://github.com/w3c/csswg-drafts/issues/12442">https://github.com/w3c/csswg-drafts/issues/12442</a> &amp; <a href="https://github.com/w3c/csswg-drafts/pull/12957">https://github.com/w3c/csswg-drafts/pull/12957</a>

This matches Firefox &amp; Chrome.

The change in EventLoop::queueTask is required to pass the test. The test relies on the timing of the task relative to
the timing of the setTimeout() call being correct.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/finished-promise-defers-cleanup-expected.txt:
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::queueTask):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::finishDone):
(WebCore::ViewTransition::handleTransitionFrame):
(WebCore::operator&lt;&lt;):
* Source/WebCore/dom/ViewTransition.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/467dc61383b484a42e93ee1113c940747219f184

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174499 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122712 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38951 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128577 "Found 19 new test failures: fast/dom/frame-src-javascript-url-async.html fast/frames/message-port-postMessage-unload-event.html fast/frames/out-of-document-iframe-has-child-frame.html http/tests/dom/document-fragment.html http/tests/messaging/cross-domain-message-event-dispatch.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/cloneNode.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-in-viewport.html imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/jsurl-navigation-then-form-submit.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-toggle-source.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90501 "2 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e15f7cf-d50b-4059-8724-2005296bb738) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168416 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30887 "Found 10 new test failures: fast/dom/frame-src-javascript-url-async.html fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html fast/frames/message-port-postMessage-unload-event.html fast/frames/out-of-document-iframe-has-child-frame.html fast/mediastream/media-stream-track-source-failure.html fast/mediastream/mediaPlayer-visibility.html http/tests/dom/document-fragment.html media/W3C/video/currentSrc/currentSrc_nonempty_after_adding_source_child.html media/remove-from-document.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109102 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cdf850e9-de66-4104-9515-ec20835c79ac) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29933 "Found 13 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html imported/w3c/web-platform-tests/css/css-view-transitions/start-view-transtion-skips-active.html imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/jsurl-navigation-then-form-submit.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-toggle-source.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/toggle-events.html imported/w3c/web-platform-tests/html/semantics/popovers/popover-toggle-source.html imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting.html imported/w3c/web-platform-tests/selection/onselectionchange-on-distinct-text-controls.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28565 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22574 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139828 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26347 "Found 1 new test failure: http/tests/dom/document-fragment.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177023 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29932 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28052 "Found 31 new test failures: fast/css/acid2-pixel.html fast/dom/frame-src-javascript-url-async.html fast/frames/message-port-postMessage-unload-event.html fast/frames/out-of-document-iframe-has-child-frame.html fast/mediastream/media-stream-track-source-failure.html fast/mediastream/mediaPlayer-visibility.html http/tests/dom/document-fragment.html http/tests/media/video-error-all-zero-address-blocked.html http/tests/messaging/cross-domain-message-event-dispatch.html http/tests/misc/acid2-pixel.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136901 "Found 19 new test failures: fast/dom/frame-src-javascript-url-async.html fast/frames/message-port-postMessage-unload-event.html fast/frames/out-of-document-iframe-has-child-frame.html http/tests/dom/document-fragment.html http/tests/messaging/cross-domain-message-event-dispatch.html imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/cloneNode.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-loading-lazy-in-viewport.html imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/jsurl-navigation-then-form-submit.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-toggle-source.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39016 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32703 "Found 34 new test failures: accessibility/video-element-url-attribute.html fast/css/acid2-pixel.html fast/dom/frame-src-javascript-url-async.html fast/frames/message-port-postMessage-unload-event.html fast/frames/out-of-document-iframe-has-child-frame.html fast/mediastream/media-stream-track-source-failure.html fast/mediastream/mediaPlayer-visibility.html http/tests/dom/document-fragment.html http/tests/media/video-error-all-zero-address-blocked.html http/tests/messaging/cross-domain-message-event-dispatch.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136837 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148143 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102083 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32108 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25010 "Found 33 new test failures: fast/css/acid2-pixel.html fast/dom/frame-src-javascript-url-async.html fast/frames/message-port-postMessage-unload-event.html fast/frames/out-of-document-iframe-has-child-frame.html fast/mediastream/media-stream-track-source-failure.html fast/mediastream/mediaPlayer-visibility.html http/tests/dom/document-fragment.html http/tests/media/video-error-all-zero-address-blocked.html http/tests/messaging/cross-domain-message-event-dispatch.html http/tests/misc/acid2-pixel.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38214 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111288 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37611 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3090 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37857 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37755 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->