### PR TITLE
CSSFontFeatureValuesRule.fontFamily should be settable, not readonly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/idlharness-expected.txt
@@ -67,7 +67,7 @@ PASS CSSFontFeatureValuesRule interface object name
 PASS CSSFontFeatureValuesRule interface: existence and properties of interface prototype object
 PASS CSSFontFeatureValuesRule interface: existence and properties of interface prototype object's "constructor" property
 PASS CSSFontFeatureValuesRule interface: existence and properties of interface prototype object's @@unscopables property
-FAIL CSSFontFeatureValuesRule interface: attribute fontFamily assert_equals: setter must be function for PutForwards, Replaceable, or non-readonly attributes expected "function" but got "undefined"
+PASS CSSFontFeatureValuesRule interface: attribute fontFamily
 FAIL CSSFontFeatureValuesRule interface: attribute annotation assert_true: The prototype object must have a property "annotation" expected true got false
 FAIL CSSFontFeatureValuesRule interface: attribute ornaments assert_true: The prototype object must have a property "ornaments" expected true got false
 FAIL CSSFontFeatureValuesRule interface: attribute stylistic assert_true: The prototype object must have a property "stylistic" expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSFontFeatureValuesRule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSFontFeatureValuesRule-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL CSSFontFeatureValuesRule is correctly parsed and accessible via CSSOM. undefined is not an object (evaluating 'rule.annotation.size')
-FAIL CSSFontFeatureValuesRule family is settable and readable. assert_equals: expected "test_changed_family" but got "test_family"
+PASS CSSFontFeatureValuesRule family is settable and readable.
 FAIL CSSFontFeatureValuesMap entries are settable to single values. undefined is not an object (evaluating 'rule.styleset.get')
 FAIL CSSFontFeatureValuesMap entries are settable to sequences of numbers. undefined is not an object (evaluating 'document.styleSheets[0].cssRules[0].styleset.get')
 FAIL New rules can be added. undefined is not an object (evaluating 'document.styleSheets[0].cssRules[1].annotation.size')

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,9 @@
 #include "CSSFontFeatureValuesRule.h"
 
 #include "CSSMarkup.h"
+#include "CSSPropertyParserConsumer+Font.h"
+#include "CSSStyleSheet.h"
+#include "CSSTokenizer.h"
 
 namespace WebCore {
 
@@ -83,6 +86,19 @@ String CSSFontFeatureValuesRule::cssText() const
 void CSSFontFeatureValuesRule::reattach(StyleRuleBase& rule)
 {
     m_fontFeatureValuesRule = downcast<StyleRuleFontFeatureValues>(rule);
+}
+
+// https://drafts.csswg.org/css-fonts/#dom-cssfontfeaturevaluesrule-fontfamily
+void CSSFontFeatureValuesRule::setFontFamily(const String& fontFamily)
+{
+    CSSTokenizer tokenizer(fontFamily);
+    auto tokenRange = tokenizer.tokenRange();
+    auto fontFamilies = CSSPropertyParserHelpers::consumeFontFeatureValuesPreludeFamilyNameList(tokenRange, parserContext());
+    if (fontFamilies.isEmpty() || !tokenRange.atEnd())
+        return;
+
+    CSSStyleSheet::RuleMutationScope mutationScope(this);
+    protect(m_fontFeatureValuesRule)->setFontFamilies(WTF::move(fontFamilies));
 }
 
 CSSFontFeatureValuesBlockRule::CSSFontFeatureValuesBlockRule(StyleRuleFontFeatureValuesBlock& block , CSSStyleSheet* parent)

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.h
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +56,8 @@ public:
         }
         return builder.toAtomString();
     }
+
+    void setFontFamily(const String&);
 
 private:
     CSSFontFeatureValuesRule(StyleRuleFontFeatureValues&, CSSStyleSheet* parent);

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.idl
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -24,7 +24,7 @@ typedef USVString CSSOMString;
 [
     Exposed=Window
 ] interface CSSFontFeatureValuesRule : CSSRule {
-    readonly attribute CSSOMString fontFamily;
+    attribute CSSOMString fontFamily;
 
     // FIXME: Implement support for CSSFontFeatureValuesMaps.
     // readonly attribute CSSFontFeatureValuesMap annotation;

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -1,7 +1,7 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -270,6 +270,7 @@ public:
     static Ref<StyleRuleFontFeatureValues> create(const Vector<AtomString>& fontFamilies, Ref<FontFeatureValues>&&);
 
     const Vector<AtomString>& fontFamilies() const LIFETIME_BOUND { return m_fontFamilies; }
+    void setFontFamilies(Vector<AtomString>&& fontFamilies) { m_fontFamilies = WTF::move(fontFamilies); }
 
     Ref<FontFeatureValues> value() const { return m_value; }
 


### PR DESCRIPTION
#### b41ac703ca9b5f49427371523aedbaa2cc42a983
<pre>
CSSFontFeatureValuesRule.fontFamily should be settable, not readonly
<a href="https://bugs.webkit.org/show_bug.cgi?id=315911">https://bugs.webkit.org/show_bug.cgi?id=315911</a>
<a href="https://rdar.apple.com/178323504">rdar://178323504</a>

Reviewed by Antti Koivisto.

The CSS Fonts specification [1] defines `fontFamily` on CSSFontFeatureValuesRule
as a writable attribute (`attribute CSSOMString fontFamily;`), but WebKit
exposed it as `readonly`, so assigning to it was silently ignored.

Make the attribute settable. The setter parses the assigned string as a
`&lt;family-name&gt;#` list using the same parser the rule uses at parse time
(consumeFontFeatureValuesPreludeFamilyNameList), and on success replaces the
rule&apos;s families inside a RuleMutationScope so the change is properly
invalidated. Invalid input (an empty list or trailing tokens) is ignored,
matching other CSSOM setters such as CSSCounterStyleRule::setName.

[1] <a href="https://drafts.csswg.org/css-fonts/#cssfontfeaturevaluesrule">https://drafts.csswg.org/css-fonts/#cssfontfeaturevaluesrule</a>

* Source/WebCore/css/CSSFontFeatureValuesRule.idl:
Drop `readonly` from the fontFamily attribute.

* Source/WebCore/css/CSSFontFeatureValuesRule.h:
* Source/WebCore/css/CSSFontFeatureValuesRule.cpp:
(WebCore::CSSFontFeatureValuesRule::setFontFamily): Added.

* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleFontFeatureValues::setFontFamilies): Added

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/idlharness-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSFontFeatureValuesRule-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/314602@main">https://commits.webkit.org/314602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4b68d3c2972b1c6d86b8ea838e33ae584d1c2f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175618 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123826 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13306e14-1528-419c-af0b-60a826f4c8e7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129506 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44745c0d-53f7-4638-bfa2-a60bd1529a7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110031 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37e7030f-a315-4156-9303-5cb4dc522098) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29570 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23759 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178152 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31052 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137862 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137780 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37127 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149165 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103548 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33073 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26030 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39328 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112403 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38725 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4120 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38970 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38868 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->