### PR TITLE
[macOS] imported/w3c/web-platform-tests/hr-time/timeOrigin.html is a flaky text failure.

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2290,8 +2290,6 @@ webkit.org/b/308856 [ Debug ] http/tests/websocket/tests/hybi/handshake-ok-with-
 
 webkit.org/b/309850 [ Debug ] imported/w3c/web-platform-tests/uievents/mouse/mouse_boundary_events_after_removing_last_over_element.html [ Pass Failure ]
 
-webkit.org/b/315780 imported/w3c/web-platform-tests/hr-time/timeOrigin.html [ Pass Failure ]
-
 webkit.org/b/314136 accessibility/mac/client/div-bounds.html [ Pass Failure ]
 
 webkit.org/b/315776 [ arm64 ] inspector/timeline/timeline-recording.html [ Pass Failure ]

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -100,6 +100,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/ReducedResolutionSeconds.h>
 #include <wtf/SafeStrerror.h>
 #include <wtf/Scope.h>
 #include <wtf/StringPrintStream.h>
@@ -3382,7 +3383,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDropAllLocks, (JSGlobalObject* globalObject, Ca
 JSC_DEFINE_HOST_FUNCTION(functionPerformanceNow, (JSGlobalObject*, CallFrame*))
 {
     static const MonotonicTime timeOrigin = MonotonicTime::now();
-    return JSValue::encode(jsNumber((MonotonicTime::now() - timeOrigin).reduceTimeResolution(Seconds::highTimePrecision()).milliseconds()));
+    return JSValue::encode(jsNumber(ReducedResolutionSeconds::reduce(MonotonicTime::now() - timeOrigin, Seconds::highTimePrecision()).milliseconds()));
 }
 
 static String asSignpostString(JSGlobalObject* globalObject, JSValue v)

--- a/Source/WTF/wtf/ReducedResolutionSeconds.h
+++ b/Source/WTF/wtf/ReducedResolutionSeconds.h
@@ -32,7 +32,7 @@
 
 namespace WTF {
 
-// A timestamp that has gone through privacy-driven coarsening via Seconds::reduceTimeResolution.
+// A timestamp that has gone through privacy-driven coarsening via ReducedResolutionSeconds::reduce.
 // Unit-conversion methods round at microsecond precision so that callers observe consistent
 // DOMHighResTimeStamp values regardless of the conversion path they take, absorbing the
 // sub-microsecond IEEE-754 noise introduced by seconds-double ↔ milliseconds-double conversion.
@@ -45,6 +45,11 @@ public:
     static constexpr ReducedResolutionSeconds fromSeconds(Seconds value)
     {
         return fromRawSeconds(value.value());
+    }
+
+    static constexpr ReducedResolutionSeconds reduce(Seconds value, Seconds resolution)
+    {
+        return fromRawSeconds(std::floor(value.value() / resolution.value()) * resolution.value());
     }
 
     double seconds() const { return std::round(m_value * 1000000.0) / 1000000.0; }

--- a/Source/WTF/wtf/Seconds.h
+++ b/Source/WTF/wtf/Seconds.h
@@ -213,12 +213,6 @@ public:
         return *this;
     }
 
-    constexpr Seconds reduceTimeResolution(Seconds resolution)
-    {
-        double reduced = std::floor(seconds() / resolution.seconds()) * resolution.seconds();
-        return Seconds(reduced);
-    }
-
 private:
     double m_value { 0 };
 };

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -59,6 +59,7 @@
 #include <gst/sdp/sdp.h>
 #include <wtf/MainThread.h>
 #include <wtf/ObjectIdentifier.h>
+#include <wtf/ReducedResolutionSeconds.h>
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/UniqueRef.h>

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -32,6 +32,7 @@
 #include <openssl/ssl.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/ReducedResolutionSeconds.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WallTime.h>
 #include <wtf/WeakRandomNumber.h>
@@ -734,7 +735,7 @@ StatsTimestampConverter& StatsTimestampConverter::singleton()
     return sharedInstance;
 }
 
-Seconds StatsTimestampConverter::convertFromMonotonicTime(Seconds value) const
+ReducedResolutionSeconds StatsTimestampConverter::convertFromMonotonicTime(Seconds value) const
 {
     auto monotonicOffset = value - m_initialMonotonicTime;
     auto newTimestamp = m_epoch.secondsSinceEpoch() + monotonicOffset;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -377,7 +377,7 @@ class StatsTimestampConverter {
 public:
     static StatsTimestampConverter& singleton();
 
-    Seconds convertFromMonotonicTime(Seconds value) const;
+    ReducedResolutionSeconds convertFromMonotonicTime(Seconds value) const;
 
 private:
     explicit StatsTimestampConverter() = default;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
@@ -37,6 +37,7 @@
 #include <webrtc/api/stats/rtcstats_objects.h>
 #include <wtf/Assertions.h>
 #include <wtf/MainThread.h>
+#include <wtf/ReducedResolutionSeconds.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -168,12 +168,12 @@ DOMHighResTimeStamp Performance::timeOrigin() const
 
 ReducedResolutionSeconds Performance::nowInReducedResolutionSeconds() const
 {
-    return ReducedResolutionSeconds::fromSeconds((MonotonicTime::now() - m_timeOrigin).reduceTimeResolution(timePrecision));
+    return reduceTimeResolution(MonotonicTime::now() - m_timeOrigin);
 }
 
-Seconds Performance::reduceTimeResolution(Seconds seconds)
+ReducedResolutionSeconds Performance::reduceTimeResolution(Seconds seconds)
 {
-    return seconds.reduceTimeResolution(timePrecision);
+    return ReducedResolutionSeconds::reduce(seconds, timePrecision);
 }
 
 void Performance::allowHighPrecisionTime()
@@ -188,7 +188,7 @@ Seconds Performance::timeResolution()
 
 ReducedResolutionSeconds Performance::relativeTimeFromTimeOriginInReducedResolutionSeconds(MonotonicTime timestamp) const
 {
-    return ReducedResolutionSeconds::fromSeconds(reduceTimeResolution(timestamp - m_timeOrigin));
+    return reduceTimeResolution(timestamp - m_timeOrigin);
 }
 
 MonotonicTime Performance::monotonicTimeFromOriginRelative(Seconds offset) const

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -130,7 +130,7 @@ public:
 
     static void NODELETE allowHighPrecisionTime();
     static Seconds NODELETE timeResolution();
-    static Seconds reduceTimeResolution(Seconds);
+    static ReducedResolutionSeconds reduceTimeResolution(Seconds);
 
     ReducedResolutionSeconds relativeTimeFromTimeOriginInReducedResolutionSeconds(MonotonicTime) const;
     DOMHighResTimeStamp relativeTimeFromTimeOriginInReducedResolution(MonotonicTime) const;

--- a/Source/WebCore/page/PerformanceNavigationTiming.cpp
+++ b/Source/WebCore/page/PerformanceNavigationTiming.cpp
@@ -29,6 +29,7 @@
 #include "CachedResource.h"
 #include "Performance.h"
 #include "ResourceTiming.h"
+#include <wtf/ReducedResolutionSeconds.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/page/PerformanceResourceTiming.cpp
+++ b/Source/WebCore/page/PerformanceResourceTiming.cpp
@@ -40,6 +40,7 @@
 #include "PerformanceServerTiming.h"
 #include "ResourceResponse.h"
 #include "ResourceTiming.h"
+#include <wtf/ReducedResolutionSeconds.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -51,7 +52,7 @@ static double networkLoadTimeToDOMHighResTimeStamp(MonotonicTime timeOrigin, Mon
         return 0.0;
     auto result = Performance::reduceTimeResolution(timeStamp - timeOrigin);
     if (!result)
-        result = Performance::timeResolution();
+        result = ReducedResolutionSeconds::fromSeconds(Performance::timeResolution());
     return result.milliseconds();
 }
 

--- a/Source/WebCore/page/PerformanceTiming.cpp
+++ b/Source/WebCore/page/PerformanceTiming.cpp
@@ -41,6 +41,7 @@
 #include "NetworkLoadMetrics.h"
 #include "Performance.h"
 #include "ResourceResponse.h"
+#include <wtf/ReducedResolutionSeconds.h>
 
 namespace WebCore {
 
@@ -389,7 +390,7 @@ unsigned long long PerformanceTiming::monotonicTimeToIntegerMilliseconds(Monoton
     ASSERT(timeStamp.secondsSinceEpoch().seconds() >= 0);
     if (!timeStamp)
         return 0;
-    Seconds reduced = Performance::reduceTimeResolution(timeStamp.approximate<WallTime>().secondsSinceEpoch());
+    auto reduced = Performance::reduceTimeResolution(timeStamp.approximate<WallTime>().secondsSinceEpoch());
     return static_cast<unsigned long long>(reduced.milliseconds());
 }
 


### PR DESCRIPTION
#### 086636ae5104545f47d901c6dc6ee634ca547a3b
<pre>
[macOS] imported/w3c/web-platform-tests/hr-time/timeOrigin.html is a flaky text failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=315780">https://bugs.webkit.org/show_bug.cgi?id=315780</a>
<a href="https://rdar.apple.com/178175122">rdar://178175122</a>

Reviewed by Ryosuke Niwa.

Performance::reduceTimeResolution(Seconds) returned plain Seconds, leaving
its callers free to invoke .milliseconds() directly on the result — which
is just value * 1000 and carries up to ~2.4e-4 ms of IEEE-754 noise for
inputs whose millisecond boundary round-trips inexactly through 0.001.
Performance::timeOrigin() and several other DOMHighResTimeStamp sites
take that lossy path, so the JS-visible timeOrigin can come out as e.g.,
1779973524567.0002 instead of 1779973524567. That is the precise symptom
that made imported/w3c/web-platform-tests/hr-time/timeOrigin.html flake
on the worker-vs-window comparison whenever the two origins straddled a
&quot;noisy&quot; millisecond boundary.

ReducedResolutionSeconds (added in 313153@main) already absorbs this noise
in its conversion methods (std::round(value * 1e6) / 1e3 etc.); the missing
piece was for reduceTimeResolution to return the rounded type rather than
plain Seconds. Folded the floor-and-coarsen step into a new
ReducedResolutionSeconds::reduce(Seconds value, Seconds resolution) factory,
removed the now-orphaned Seconds::reduceTimeResolution, and updated callers.

Canonical link: <a href="https://commits.webkit.org/314230@main">https://commits.webkit.org/314230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a01191501672b9418e985d8bf05363f6375168db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122719 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23bffb6c-7edb-4f34-b813-bfc959726f82) 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128583 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90509 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bbf2c59f-453b-4928-ba7c-b168989b4c45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168423 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30894 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109108 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f7a76f32-7879-41de-8fd4-9ae3276e2e3f) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29940 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28572 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22581 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157621 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177030 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26357 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29939 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136908 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136844 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36891 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148150 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102098 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32115 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25017 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38221 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111295 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37618 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3097 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37864 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37762 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->