### PR TITLE
font-style: oblique angle applied to the variable font 'slnt' axis with the wrong sign

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4849,8 +4849,6 @@ imported/w3c/web-platform-tests/css/css-fonts/variation-sequences.html [ ImageOn
 imported/w3c/web-platform-tests/css/css-fonts/downloadable-font-scoped-to-document.html
 
 # Untriaged font-style/font-face @font-face descriptor bugs
-webkit.org/b/206881 imported/w3c/web-platform-tests/css/css-fonts/font-face-style-auto-variable.html [ ImageOnlyFailure ]
-webkit.org/b/206881 imported/w3c/web-platform-tests/css/css-fonts/font-face-style-default-variable.html [ ImageOnlyFailure ]
 webkit.org/b/206881 imported/w3c/web-platform-tests/css/css-fonts/font-face-weight-auto-variable.html [ ImageOnlyFailure ]
 webkit.org/b/206881 imported/w3c/web-platform-tests/css/css-fonts/font-face-weight-default-variable.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/fast/text/variations/basic-properties-expected.html
+++ b/LayoutTests/fast/text/variations/basic-properties-expected.html
@@ -26,7 +26,7 @@
 		<p style="font-family: 'Jost VF'; font-variation-settings: 'ital' 1;">
 			Italic
 		</p>
-		<p style="font-family: 'Roboto VF'; font-variation-settings: 'slnt' 10;">
+		<p style="font-family: 'Roboto VF'; font-variation-settings: 'slnt' -10;">
 			Slant
 		</p>
 	</body>

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
@@ -231,7 +231,7 @@ void UnrealizedCoreTextFont::modifyFromContext(CFMutableDictionaryRef attributes
         if (fontStyleAxis == FontStyleAxis::ital)
             variationsToBeApplied.set({ { 'i', 't', 'a', 'l' } }, 1);
         else
-            variationsToBeApplied.set({ { 's', 'l', 'n', 't' } }, slope);
+            variationsToBeApplied.set({ { 's', 'l', 'n', 't' } }, -slope);
     }
 
     // FIXME: Implement font-named-instance
@@ -366,7 +366,7 @@ RetainPtr<CTFontRef> UnrealizedCoreTextFont::realize() const
             if (m_fontStyleAxis == FontStyleAxis::ital)
                 variationsToBeApplied.set({ { 'i', 't', 'a', 'l' } }, 1);
             else
-                variationsToBeApplied.set({ { 's', 'l', 'n', 't' } }, slope);
+                variationsToBeApplied.set({ { 's', 'l', 'n', 't' } }, -slope);
 
             RetainPtr attributes = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -75,7 +75,8 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
             float slope = description.fontStyleSlope().value_or(normalItalicValue());
             if (auto slopeValue = fontCreationContext.fontFaceCapabilities().slope)
                 slope = std::max(std::min(slope, static_cast<float>(slopeValue->maximum)), static_cast<float>(slopeValue->minimum));
-            applyVariation({ { 's', 'l', 'n', 't' } }, slope);
+            // The 'slnt' axis is positive counter-clockwise; a CSS oblique angle is positive clockwise.
+            applyVariation({ { 's', 'l', 'n', 't' } }, -slope);
         }
 
         // FIXME: optical sizing.


### PR DESCRIPTION
#### 81a0be650077c18951b3362f01dd0e13a66228ee
<pre>
font-style: oblique angle applied to the variable font &apos;slnt&apos; axis with the wrong sign
<a href="https://bugs.webkit.org/show_bug.cgi?id=315914">https://bugs.webkit.org/show_bug.cgi?id=315914</a>
<a href="https://rdar.apple.com/178326843">rdar://178326843</a>

Reviewed by Vitor Roriz.

In UnrealizedCoreTextFont the CSS oblique angle was applied to the registered
&apos;slnt&apos; axis without negation. The &apos;slnt&apos; axis is positive counter-clockwise
while a CSS oblique angle is positive clockwise, so a forward oblique was
rendered as a backslant (or clamped to upright on fonts whose slnt axis only
covers the forward direction).

Negate the angle when setting the &apos;slnt&apos; axis, in both the OpenType and
TrueType GX (AAT) paths.

Apply same fix to skia path in FontCustomPlatformData::fontPlatformData.

* LayoutTests/TestExpectations: Progressions
* LayoutTests/fast/text/variations/basic-properties-expected.html: Fixed (matching now other browsers)
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp:
(WebCore::UnrealizedCoreTextFont::modifyFromContext):
(WebCore::UnrealizedCoreTextFont::realize const):
* Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):

Canonical link: <a href="https://commits.webkit.org/314399@main">https://commits.webkit.org/314399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/420f9eb45a46b7ed1b9bb03408e41119b4803a5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175036 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/faa013f5-6110-4703-be37-86e5a16e5a65) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129011 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2477f2e0-447b-43ad-b6d7-7a5fbfaca302) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109537 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49ec04fa-92d2-4dfa-b07d-b30d6b586060) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29038 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23177 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177570 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137354 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137281 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36989 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40237 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148628 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102828 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32568 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25495 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38748 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111822 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38145 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3578 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38390 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38288 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->