### PR TITLE
Support locale changes for ::first-letter & text-transform

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-digraph-document-lang-dynamic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-digraph-document-lang-dynamic-expected.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Reference: ::first-letter Dutch 'ij' digraph</title>
+  <style>
+  div { font-size: 32px; }
+  div p { margin: 0; color: lightgray; }
+  div p span { color: green; }
+  </style>
+</head>
+<body>
+  <p>Test passes if both "I" and "J" are green:</p>
+  <div>
+    <p><span>ij</span>sselmeer</p>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-digraph-document-lang-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-digraph-document-lang-dynamic.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait" lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test: ::first-letter Dutch 'ij' digraph reacts to dynamic lang change on the document element</title>
+  <link rel="match" href="reference/first-letter-digraph-document-lang-dynamic-ref.html">
+  <link rel="help" href="https://drafts.csswg.org/selectors-3/#first-letter">
+  <meta name="assert" content="Changing the lang attribute on the document element updates the locale used by ::first-letter for descendants that inherit the language.">
+  <style>
+  div { font-size: 32px; }
+  div p { margin: 0; color: lightgray; }
+  div p::first-letter { color: green; }
+  </style>
+  <script>
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      document.documentElement.setAttribute("lang", "nl");
+      document.documentElement.classList.remove("reftest-wait");
+    });
+  });
+  </script>
+</head>
+<body>
+  <p>Test passes if both "I" and "J" are green:</p>
+  <div>
+    <p>ijsselmeer</p>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-digraph-dynamic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-digraph-dynamic-expected.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Reference: ::first-letter Dutch 'ij' digraph</title>
+  <style>
+  div { font-size: 32px; }
+  div p { margin: 0; color: lightgray; }
+  div p span { color: green; }
+  </style>
+</head>
+<body>
+  <p>Test passes if both "I" and "J" are green in the first three examples, and only "I" is green in the last:</p>
+  <div>
+    <p><span>ij</span>sselmeer</p>
+  </div>
+  <div>
+    <p><span>ij</span>sselmeer</p>
+  </div>
+  <div>
+    <p><span>ij</span>sselmeer</p>
+  </div>
+  <div>
+    <p><span>i</span>jsselmeer</p>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-digraph-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-digraph-dynamic.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html class="reftest-wait" lang="nl">
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test: ::first-letter Dutch 'ij' digraph reacts to dynamic lang changes</title>
+  <link rel="match" href="reference/first-letter-digraph-dynamic-ref.html">
+  <link rel="help" href="https://drafts.csswg.org/selectors-3/#first-letter">
+  <meta name="assert" content="Dynamic changes to lang or xml:lang (on the element or an ancestor; via setAttribute or removeAttribute) update the locale used by ::first-letter, including the Dutch 'ij' digraph and the reverse direction.">
+  <style>
+  div { font-size: 32px; }
+  div p { margin: 0; color: lightgray; }
+  div p::first-letter { color: green; }
+  </style>
+  <script>
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      document.getElementById("element-set").setAttribute("lang", "nl");
+      document.getElementById("ancestor-remove").removeAttribute("lang");
+      document.getElementById("xml-lang-set").setAttributeNS("http://www.w3.org/XML/1998/namespace", "xml:lang", "nl");
+      document.getElementById("reverse").setAttribute("lang", "en");
+      document.documentElement.classList.remove("reftest-wait");
+    });
+  });
+  </script>
+</head>
+<body>
+  <p>Test passes if both "I" and "J" are green in the first three examples, and only "I" is green in the last:</p>
+  <div>
+    <p id="element-set" lang="en">ijsselmeer</p>
+  </div>
+  <div id="ancestor-remove" lang="en">
+    <p>ijsselmeer</p>
+  </div>
+  <div>
+    <p id="xml-lang-set" xml:lang="en">ijsselmeer</p>
+  </div>
+  <div>
+    <p id="reverse" lang="nl">ijsselmeer</p>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/reference/first-letter-digraph-document-lang-dynamic-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/reference/first-letter-digraph-document-lang-dynamic-ref.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Reference: ::first-letter Dutch 'ij' digraph</title>
+  <style>
+  div { font-size: 32px; }
+  div p { margin: 0; color: lightgray; }
+  div p span { color: green; }
+  </style>
+</head>
+<body>
+  <p>Test passes if both "I" and "J" are green:</p>
+  <div>
+    <p><span>ij</span>sselmeer</p>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/reference/first-letter-digraph-dynamic-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/reference/first-letter-digraph-dynamic-ref.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Reference: ::first-letter Dutch 'ij' digraph</title>
+  <style>
+  div { font-size: 32px; }
+  div p { margin: 0; color: lightgray; }
+  div p span { color: green; }
+  </style>
+</head>
+<body>
+  <p>Test passes if both "I" and "J" are green in the first three examples, and only "I" is green in the last:</p>
+  <div>
+    <p><span>ij</span>sselmeer</p>
+  </div>
+  <div>
+    <p><span>ij</span>sselmeer</p>
+  </div>
+  <div>
+    <p><span>ij</span>sselmeer</p>
+  </div>
+  <div>
+    <p><span>i</span>jsselmeer</p>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/reference/text-transform-tailoring-document-lang-dynamic-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/reference/text-transform-tailoring-document-lang-dynamic-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: text-transform: capitalize, Dutch IJ digraph</title>
+<style>
+.test { font-size: 36px; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+</style>
+<div class="test">IJsland</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/reference/text-transform-tailoring-dynamic-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/reference/text-transform-tailoring-dynamic-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: text-transform locale-tailored casing</title>
+<style>
+.test { font-size: 36px; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+</style>
+<div class="test">IJsland</div>
+<div>
+  <div class="test">IJsland</div>
+</div>
+<div class="test">IJsland</div>
+<div class="test">Ijsland</div>
+<div class="test">İSTANBUL</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-tailoring-document-lang-dynamic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-tailoring-document-lang-dynamic-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: text-transform: capitalize, Dutch IJ digraph</title>
+<style>
+.test { font-size: 36px; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+</style>
+<div class="test">IJsland</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-tailoring-document-lang-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-tailoring-document-lang-dynamic.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html class="reftest-wait" lang="en">
+<meta charset="utf-8">
+<title>CSS Text, text-transform: capitalize reacts to dynamic lang change on the document element</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-transform">
+<link rel="match" href="reference/text-transform-tailoring-document-lang-dynamic-ref.html">
+<meta name="assert" content="Changing the lang attribute on the document element updates the locale used by text-transform: capitalize for descendants that inherit the language.">
+<style>
+.test { text-transform: capitalize; font-size: 36px; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+</style>
+<script>
+requestAnimationFrame(() => {
+  requestAnimationFrame(() => {
+    document.documentElement.setAttribute("lang", "nl");
+    document.documentElement.classList.remove("reftest-wait");
+  });
+});
+</script>
+<div class="test">ijsland</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-tailoring-dynamic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-tailoring-dynamic-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: text-transform locale-tailored casing</title>
+<style>
+.test { font-size: 36px; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+</style>
+<div class="test">IJsland</div>
+<div>
+  <div class="test">IJsland</div>
+</div>
+<div class="test">IJsland</div>
+<div class="test">Ijsland</div>
+<div class="test">İSTANBUL</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-tailoring-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-tailoring-dynamic.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html class="reftest-wait" lang="nl">
+<meta charset="utf-8">
+<title>CSS Text, text-transform reacts to dynamic lang changes for locale-tailored casing</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-transform">
+<link rel="match" href="reference/text-transform-tailoring-dynamic-ref.html">
+<meta name="assert" content="Dynamic changes to lang or xml:lang (on the element or an ancestor; via setAttribute or removeAttribute) update the locale used by text-transform, including the Dutch 'ij' digraph for capitalize, the Turkish 'i' for uppercase, and the reverse direction.">
+<style>
+.test, .test-upper { font-size: 36px; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test { text-transform: capitalize; }
+.test-upper { text-transform: uppercase; }
+</style>
+<script>
+requestAnimationFrame(() => {
+  requestAnimationFrame(() => {
+    document.getElementById("element-set").setAttribute("lang", "nl");
+    document.getElementById("ancestor-remove").removeAttribute("lang");
+    document.getElementById("xml-lang-set").setAttributeNS("http://www.w3.org/XML/1998/namespace", "xml:lang", "nl");
+    document.getElementById("reverse").setAttribute("lang", "en");
+    document.getElementById("turkish-uppercase").setAttribute("lang", "tr");
+    document.documentElement.classList.remove("reftest-wait");
+  });
+});
+</script>
+<div class="test" id="element-set" lang="en">ijsland</div>
+<div id="ancestor-remove" lang="en">
+  <div class="test">ijsland</div>
+</div>
+<div class="test" id="xml-lang-set" xml:lang="en">ijsland</div>
+<div class="test" id="reverse" lang="nl">ijsland</div>
+<div class="test-upper" id="turkish-uppercase" lang="en">istanbul</div>
+</html>

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -176,7 +176,7 @@ static constexpr char16_t NODELETE convertNoBreakSpaceToSpace(char16_t character
     return character == noBreakSpace ? ' ' : character;
 }
 
-static inline size_t capitalizeCharacter(String textContent, unsigned startCharacterOffset, StringBuilder& output)
+static inline size_t capitalizeCharacter(StringView textContent, unsigned startCharacterOffset, StringBuilder& output)
 {
     if (startCharacterOffset >= textContent.length()) {
         ASSERT_NOT_REACHED();
@@ -234,7 +234,7 @@ static inline size_t capitalizeCharacter(String textContent, unsigned startChara
 // Titlecase the first letter of a word using ICU's locale-aware u_strToTitle.
 // CSS capitalize only uppercases the first letter; u_strToTitle also lowercases
 // the rest. We determine the titlecased prefix and return only that.
-static size_t capitalizeWordWithLocale(const String& textContent, unsigned startOffset, unsigned endOffset, const AtomString& locale, StringBuilder& output)
+static size_t capitalizeWordWithLocale(StringView textContent, unsigned startOffset, unsigned endOffset, const AtomString& locale, StringBuilder& output)
 {
     auto localeUTF8 = locale.string().utf8();
     unsigned wordLength = std::min(endOffset, textContent.length()) - startOffset;
@@ -548,7 +548,9 @@ void RenderText::styleDidChange(Style::Difference diff, const RenderStyle* oldSt
             return true;
         if (oldStyle->textTransform() != newStyle.textTransform())
             return true;
-        return oldStyle->textSecurity() != newStyle.textSecurity();
+        if (oldStyle->textSecurity() != newStyle.textSecurity())
+            return true;
+        return !newStyle.textTransform().isNone() && oldStyle->computedLocale() != newStyle.computedLocale();
     };
     if (needsRenderedTextUpdateOnly())
         updateRenderedText();

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -149,13 +149,50 @@ static inline bool shouldSkipBeforeFirstLetter(char32_t c)
         || isPrecedingTypographicSpaceForFirstLetter(c);
 }
 
-static bool isDutchIJDigraph(const String& text, unsigned offset)
+static bool isDutchIJDigraph(StringView text, unsigned offset)
 {
     if (offset + 1 >= text.length())
         return false;
     auto first = text[offset];
     auto second = text[offset + 1];
     return (first == 'i' && second == 'j') || (first == 'I' && second == 'J');
+}
+
+static unsigned firstLetterLength(StringView text, const AtomString& specifiedLocale)
+{
+    if (text.isEmpty())
+        return 0;
+
+    unsigned length = 0;
+
+    // Account for leading spaces and punctuation.
+    while (length < text.length() && shouldSkipBeforeFirstLetter(text.codePointAt(length)))
+        length += numCodeUnitsInGraphemeClusters(text.substring(length), 1);
+
+    // Account for first grapheme cluster.
+    length += numCodeUnitsInGraphemeClusters(text.substring(length), 1);
+
+    // In Dutch, "ij" is a digraph treated as a single letter for ::first-letter.
+    if (length < text.length() && isDutchLocale(specifiedLocale) && isDutchIJDigraph(text, length - 1))
+        length += numCodeUnitsInGraphemeClusters(text.substring(length), 1);
+
+    // Keep looking for following punctuation and intervening typographic space,
+    // but avoid accumulating just whitespace into the :first-letter.
+    unsigned numCodeUnits = 0;
+    for (unsigned scanLength = length; scanLength < text.length(); scanLength += numCodeUnits) {
+        char32_t c = text.codePointAt(scanLength);
+
+        bool isFollowingPunctuation = isFollowingPunctuationForFirstLetter(c);
+        if (!isFollowingPunctuation && !isFollowingTypographicSpaceForFirstLetter(c))
+            break;
+
+        numCodeUnits = numCodeUnitsInGraphemeClusters(text.substring(scanLength), 1);
+
+        if (isFollowingPunctuation)
+            length = scanLength + numCodeUnits;
+    }
+
+    return length;
 }
 
 static bool supportsFirstLetter(RenderBlock& block)
@@ -211,7 +248,10 @@ void RenderTreeBuilder::FirstLetter::updateAfterDescendants(RenderBlock& block)
                 return false;
             // If a new text node was inserted before the first-letter's text node,
             // the first letter of the block has changed and the split must be rebuilt.
-            return is<Text>(textNode->previousSibling());
+            if (is<Text>(textNode->previousSibling()))
+                return true;
+            // Length can change due to a locale change.
+            return firstLetterLength(textNode->data(), remainingText->style().fontDescription().specifiedLocale()) != remainingText->start();
         };
         if (isFirstLetterStale()) {
             ASSERT(remainingText.get());
@@ -322,34 +362,7 @@ void RenderTreeBuilder::FirstLetter::createRenderers(RenderText& currentTextChil
     ASSERT(!oldText.isNull());
 
     if (!oldText.isEmpty()) {
-        unsigned length = 0;
-
-        // Account for leading spaces and punctuation.
-        while (length < oldText.length() && shouldSkipBeforeFirstLetter(oldText.codePointAt(length)))
-            length += numCodeUnitsInGraphemeClusters(StringView(oldText).substring(length), 1);
-
-        // Account for first grapheme cluster.
-        length += numCodeUnitsInGraphemeClusters(StringView(oldText).substring(length), 1);
-
-        // In Dutch, "ij" is a digraph treated as a single letter for ::first-letter.
-        if (length < oldText.length() && isDutchLocale(currentTextChild.style().fontDescription().specifiedLocale()) && isDutchIJDigraph(oldText, length - 1))
-            length += numCodeUnitsInGraphemeClusters(StringView(oldText).substring(length), 1);
-
-        // Keep looking for following punctuation and intervening typographic space,
-        // but avoid accumulating just whitespace into the :first-letter.
-        unsigned numCodeUnits = 0;
-        for (unsigned scanLength = length; scanLength < oldText.length(); scanLength += numCodeUnits) {
-            char32_t c = oldText.codePointAt(scanLength);
-
-            bool isFollowingPunctuation = isFollowingPunctuationForFirstLetter(c);
-            if (!isFollowingPunctuation && !isFollowingTypographicSpaceForFirstLetter(c))
-                break;
-
-            numCodeUnits = numCodeUnitsInGraphemeClusters(StringView(oldText).substring(scanLength), 1);
-
-            if (isFollowingPunctuation)
-                length = scanLength + numCodeUnits;
-        }
+        unsigned length = firstLetterLength(oldText, currentTextChild.style().fontDescription().specifiedLocale());
 
         RefPtr textNode = currentTextChild.textNode();
         WeakPtr beforeChild = currentTextChild.nextSibling();


### PR DESCRIPTION
#### 44c7f42714580ed19ed26993f26cd1219eeb2cfa
<pre>
Support locale changes for ::first-letter &amp; text-transform
<a href="https://bugs.webkit.org/show_bug.cgi?id=315915">https://bugs.webkit.org/show_bug.cgi?id=315915</a>
<a href="https://rdar.apple.com/178197936">rdar://178197936</a>

Reviewed by Darin Adler.

It&apos;s somewhat hard to imagine a concrete use case for this, but this is
technically correct and matches Firefox (which also supports this).

Tests: imported/w3c/web-platform-tests/css/css-pseudo/first-letter-digraph-dynamic.html
       imported/w3c/web-platform-tests/css/css-pseudo/first-letter-digraph-document-lang-dynamic.html
       imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-tailoring-dynamic.html
       imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-tailoring-document-lang-dynamic.html

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/60298">https://github.com/web-platform-tests/wpt/pull/60298</a>
Canonical link: <a href="https://commits.webkit.org/314358@main">https://commits.webkit.org/314358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f192ae522de17f337164b14089d98f52bfddeaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123143 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128928 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109455 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28952 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23075 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140237 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177457 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30370 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137266 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137193 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36965 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148536 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102699 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32478 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25403 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111719 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38042 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3485 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38288 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38186 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->