### PR TITLE
webgpu.github.io/webgpu-samples/?sample=primitivePicking fails to open in Safari

### DIFF
--- a/LayoutTests/fast/webgpu/primitive-index-expected.txt
+++ b/LayoutTests/fast/webgpu/primitive-index-expected.txt
@@ -1,0 +1,15 @@
+Tests the primitive_index builtin from the WGSL primitive_index extension. Renders 4 non-overlapping triangles in a single draw call and uses @builtin(primitive_index) in the fragment shader to write each primitive's index into a storage buffer indexed by pixel position. Verifies the index seen by the fragment shader matches the draw order.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Adapter advertises 'primitive-index' feature
+Per-pixel primitive_index+1: 1,2,3,4
+PASS primitiveIndexBuf[0] is 1
+PASS primitiveIndexBuf[1] is 2
+PASS primitiveIndexBuf[2] is 3
+PASS primitiveIndexBuf[3] is 4
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/webgpu/primitive-index.html
+++ b/LayoutTests/fast/webgpu/primitive-index.html
@@ -1,0 +1,175 @@
+<script src="../../resources/js-test-pre.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+description("Tests the primitive_index builtin from the WGSL primitive_index extension. " +
+            "Renders 4 non-overlapping triangles in a single draw call and uses " +
+            "@builtin(primitive_index) in the fragment shader to write each primitive's " +
+            "index into a storage buffer indexed by pixel position. " +
+            "Verifies the index seen by the fragment shader matches the draw order.");
+
+const WIDTH = 4;
+const HEIGHT = 1;
+const NUM_PRIMITIVES = 4;
+
+const SHADER = `
+enable primitive_index;
+
+struct VOut {
+    @builtin(position) position: vec4f,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vid: u32) -> VOut {
+    // Render NUM_PRIMITIVES triangles into a NUM_PRIMITIVES x 1 framebuffer,
+    // one triangle per strip. Each triangle is wide enough at the pixel center
+    // line (NDC y = 0) to cover its strip's pixel center, but the triangles do
+    // not overlap (so each strip pixel is rasterized by exactly one primitive).
+    let triIndex   = vid / 3u;
+    let cornerIdx  = vid % 3u;
+    let stripCount = f32(${NUM_PRIMITIVES});
+    let stripIndex = f32(triIndex);
+
+    // Strip pixel-x [stripIndex, stripIndex+1] -> NDC x.
+    let xLeft  = (stripIndex        / stripCount) * 2.0 - 1.0;
+    let xRight = ((stripIndex + 1.0) / stripCount) * 2.0 - 1.0;
+
+    // Triangle with the strip as the base (at NDC y = -1) and apex at the strip
+    // midpoint at NDC y = 1. At the pixel center (NDC y = 0), the triangle's
+    // x-extent equals half the strip width centered on the strip midpoint, which
+    // covers the pixel center for any 1-pixel-wide strip.
+    var corners = array<vec2f, 3>(
+        vec2f(xLeft,  -1.0),
+        vec2f(xRight, -1.0),
+        vec2f((xLeft + xRight) * 0.5, 1.0),
+    );
+
+    var out: VOut;
+    out.position = vec4f(corners[cornerIdx], 0.0, 1.0);
+    return out;
+}
+
+struct FIn {
+    @builtin(position) position: vec4f,
+    @builtin(primitive_index) prim: u32,
+};
+
+@group(0) @binding(0) var<storage, read_write> out_buf: array<u32, ${WIDTH * HEIGHT}>;
+
+@fragment
+fn fs_main(in: FIn) -> @location(0) vec4f {
+    let x = u32(in.position.x);
+    let y = u32(in.position.y);
+    let idx = y * ${WIDTH}u + x;
+    if (idx < ${WIDTH * HEIGHT}u) {
+        // Write prim+1 so a "no fragment ran here" (initial 0) is distinguishable
+        // from a fragment that observed primitive_index 0.
+        out_buf[idx] = in.prim + 1u;
+    }
+    return vec4f(f32(in.prim) / 255.0, 0.0, 0.0, 1.0);
+}
+`;
+
+let primitiveIndexBuf;
+
+async function main() {
+    const adapter = await navigator.gpu.requestAdapter({});
+    if (!adapter) {
+        testFailed("requestAdapter returned null");
+        return;
+    }
+
+    if (!adapter.features.has("primitive-index")) {
+        testFailed("Adapter does not advertise the 'primitive-index' feature");
+        return;
+    }
+    testPassed("Adapter advertises 'primitive-index' feature");
+
+    const device = await adapter.requestDevice({
+        requiredFeatures: ["primitive-index"],
+    });
+
+    const shaderModule = device.createShaderModule({ code: SHADER });
+
+    const colorTexture = device.createTexture({
+        size: { width: WIDTH, height: HEIGHT, depthOrArrayLayers: 1 },
+        format: "rgba8unorm",
+        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    });
+
+    const storageBuffer = device.createBuffer({
+        size: WIDTH * HEIGHT * 4,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+
+    const readBuffer = device.createBuffer({
+        size: WIDTH * HEIGHT * 4,
+        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+    });
+
+    const bindGroupLayout = device.createBindGroupLayout({
+        entries: [{
+            binding: 0,
+            visibility: GPUShaderStage.FRAGMENT,
+            buffer: { type: "storage" },
+        }],
+    });
+
+    const pipelineLayout = device.createPipelineLayout({
+        bindGroupLayouts: [bindGroupLayout],
+    });
+
+    const pipeline = device.createRenderPipeline({
+        layout: pipelineLayout,
+        vertex:   { module: shaderModule, entryPoint: "vs_main" },
+        fragment: { module: shaderModule, entryPoint: "fs_main",
+                    targets: [{ format: "rgba8unorm" }] },
+        primitive: { topology: "triangle-list" },
+    });
+
+    const bindGroup = device.createBindGroup({
+        layout: bindGroupLayout,
+        entries: [{ binding: 0, resource: { buffer: storageBuffer } }],
+    });
+
+    const encoder = device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+        colorAttachments: [{
+            view: colorTexture.createView(),
+            clearValue: { r: 0, g: 0, b: 0, a: 1 },
+            loadOp: "clear",
+            storeOp: "store",
+        }],
+    });
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    // Single draw, single instance, NUM_PRIMITIVES triangles. The fragment shader
+    // should observe primitive_index 0..NUM_PRIMITIVES-1 across the strips.
+    pass.draw(NUM_PRIMITIVES * 3, 1, 0, 0);
+    pass.end();
+
+    encoder.copyBufferToBuffer(storageBuffer, 0, readBuffer, 0, WIDTH * HEIGHT * 4);
+    device.queue.submit([encoder.finish()]);
+
+    await readBuffer.mapAsync(GPUMapMode.READ);
+    primitiveIndexBuf = new Uint32Array(readBuffer.getMappedRange()).slice();
+    readBuffer.unmap();
+
+    debug("Per-pixel primitive_index+1: " + Array.from(primitiveIndexBuf).join(","));
+
+    // Each strip i should have been rasterized by primitive i; we wrote prim+1.
+    for (let i = 0; i < NUM_PRIMITIVES; ++i)
+        shouldBe(`primitiveIndexBuf[${i}]`, `${i + 1}`);
+}
+
+globalThis.testRunner?.waitUntilDone();
+
+main().catch(e => {
+    testFailed("Exception: " + e);
+}).finally(() => {
+    finishJSTest();
+});
+
+</script>
+<script src="../../resources/js-test-post.js"></script>

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
@@ -87,6 +87,7 @@ static GPUFeatureName convertFeatureNameToEnum(const String& stringValue)
         { "float32-filterable"_s, GPUFeatureName::Float32Filterable },
         { "float32-renderable"_s, GPUFeatureName::Float32Renderable },
         { "indirect-first-instance"_s, GPUFeatureName::IndirectFirstInstance },
+        { "primitive-index"_s, GPUFeatureName::PrimitiveIndex },
         { "rg11b10ufloat-renderable"_s, GPUFeatureName::Rg11b10ufloatRenderable },
         { "shader-f16"_s, GPUFeatureName::ShaderF16 },
         { "texture-compression-astc"_s, GPUFeatureName::TextureCompressionAstc },

--- a/Source/WebCore/Modules/WebGPU/GPUFeatureName.h
+++ b/Source/WebCore/Modules/WebGPU/GPUFeatureName.h
@@ -51,6 +51,7 @@ enum class GPUFeatureName : uint8_t {
     Float32Renderable,
     CoreFeaturesAndLimits,
     TextureFormatsTier1,
+    PrimitiveIndex,
 };
 
 inline WebGPU::FeatureName convertToBacking(GPUFeatureName featureName)
@@ -96,6 +97,8 @@ inline WebGPU::FeatureName convertToBacking(GPUFeatureName featureName)
         return WebGPU::FeatureName::CoreFeaturesAndLimits;
     case GPUFeatureName::TextureFormatsTier1:
         return WebGPU::FeatureName::TextureFormatsTier1;
+    case GPUFeatureName::PrimitiveIndex:
+        return WebGPU::FeatureName::PrimitiveIndex;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
@@ -48,4 +48,5 @@
     "float32-renderable",
     "core-features-and-limits",
     "texture-formats-tier1",
+    "primitive-index",
 };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
@@ -236,6 +236,8 @@ WGPUFeatureName ConvertToBackingContext::convertToBacking(FeatureName featureNam
         return WGPUFeatureName_CoreFeaturesAndLimits;
     case FeatureName::TextureFormatsTier1:
         return WGPUFeatureName_TextureFormatsTier1;
+    case FeatureName::PrimitiveIndex:
+        return WGPUFeatureName_PrimitiveIndex;
     }
 }
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h
@@ -50,6 +50,7 @@ enum class FeatureName : uint8_t {
     Float32Renderable,
     CoreFeaturesAndLimits,
     TextureFormatsTier1,
+    PrimitiveIndex,
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebGPU/WGSL/IOValidator.cpp
+++ b/Source/WebGPU/WGSL/IOValidator.cpp
@@ -321,6 +321,24 @@ case Builtin::__case: \
     CASE(LocalInvocationId, VEC_CHECK(3, u32), Compute, Input)
     CASE(LocalInvocationIndex, TYPE_CHECK(u32), Compute, Input)
     CASE(NumWorkgroups, VEC_CHECK(3, u32), Compute, Input)
+    case Builtin::PrimitiveIndex: {
+        // primitive_index requires the extension to be enabled
+        if (!m_shaderModule.enabledExtensions().contains(Extension::PrimitiveIndex)) [[unlikely]] {
+            error(span, "@builtin(primitive_index) requires the 'primitive_index' extension to be enabled"_s);
+            return;
+        }
+        // Type check: must be u32
+        if (type != m_shaderModule.types().u32Type()) [[unlikely]] {
+            error(span, "store type of @builtin(primitive_index) must be 'u32'"_s);
+            return;
+        }
+        // Stage and direction check: must be fragment shader input
+        if (stage != ShaderStage::Fragment || direction != Direction::Input) [[unlikely]] {
+            error(span, "@builtin(primitive_index) can only be used for fragment shader input"_s);
+            return;
+        }
+        break;
+    }
     CASE(SampleIndex, TYPE_CHECK(u32), Fragment, Input)
     CASE(VertexIndex, TYPE_CHECK(u32), Vertex, Input)
     CASE(WorkgroupId, VEC_CHECK(3, u32), Compute, Input)

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1134,6 +1134,9 @@ void FunctionDefinitionWriter::visit(AST::BuiltinAttribute& builtin)
     case Builtin::Position:
         m_body.append("[[position]]"_s);
         break;
+    case Builtin::PrimitiveIndex:
+        m_body.append("[[primitive_id]]"_s);
+        break;
     case Builtin::SampleIndex:
         m_body.append("[[sample_id]]"_s);
         break;

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -426,7 +426,7 @@ Result<void> Parser<Lexer>::parseEnableDirective()
         CONSUME_TYPE_NAMED(identifier, Identifier);
         auto* extension = parseExtension(identifier.ident);
         if (!extension)
-            FAIL("Expected 'clip_distances' or 'f16'"_s);
+            FAIL("Expected 'clip_distances', 'f16', or 'primitive_index'"_s);
         m_shaderModule.enabledExtensions().add(*extension);
 
         if (current().type != TokenType::Comma)
@@ -701,7 +701,7 @@ Result<std::optional<AST::Attribute::Ref>> Parser<Lexer>::parseAttribute()
         PARSE(name, Identifier);
         auto* builtin = parseBuiltin(name);
         if (!builtin)
-            FAIL("Unknown builtin value. Expected 'clip_distances', 'vertex_index', 'instance_index', 'position', 'front_facing', 'frag_depth', 'sample_index', 'sample_mask', 'local_invocation_id', 'local_invocation_index', 'global_invocation_id', 'workgroup_id' or 'num_workgroups'"_s);
+            FAIL("Unknown builtin value. Expected 'clip_distances', 'vertex_index', 'instance_index', 'position', 'primitive_index', 'front_facing', 'frag_depth', 'sample_index', 'sample_mask', 'local_invocation_id', 'local_invocation_index', 'global_invocation_id', 'workgroup_id' or 'num_workgroups'"_s);
         switch (*builtin) {
         case Builtin::FragDepth:
             m_shaderModule.setUsesFragDepth();

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -83,6 +83,8 @@ static ASCIILiteral wgslExtensionToWebGPUFeatureName(Extension extension)
         return "clip-distances"_s;
     case Extension::F16:
         return "shader-f16"_s;
+    case Extension::PrimitiveIndex:
+        return "primitive-index"_s;
     }
 }
 

--- a/Source/WebGPU/WGSL/WGSLEnums.h
+++ b/Source/WebGPU/WGSL/WGSLEnums.h
@@ -125,6 +125,7 @@ namespace WGSL {
     value(LocalInvocationIndex, local_invocation_index) \
     value(NumWorkgroups, num_workgroups) \
     value(Position, position) \
+    value(PrimitiveIndex, primitive_index) \
     value(SampleIndex, sample_index) \
     value(SampleMask, sample_mask) \
     value(VertexIndex, vertex_index) \
@@ -133,6 +134,7 @@ namespace WGSL {
 #define ENUM_Extension(value) \
     value(ClipDistances, clip_distances, 1 << 0) \
     value(F16, f16, 1 << 1) \
+    value(PrimitiveIndex, primitive_index, 1 << 2) \
 
 #define ENUM_LanguageFeature(value) \
     value(Packed4x8IntegerDotProduct, packed_4x8_integer_dot_product, 1 << 0) \

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -120,6 +120,7 @@ static Vector<WGPUFeatureName> baseFeatures(id<MTLDevice> device, const Hardware
     features.append(WGPUFeatureName_Float32Blendable);
 
     features.append(WGPUFeatureName_ClipDistances);
+    features.append(WGPUFeatureName_PrimitiveIndex);
     features.append(WGPUFeatureName_DepthClipControl);
     features.append(WGPUFeatureName_Depth32FloatStencil8);
 

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1421,6 +1421,8 @@ static NSString* errorValidatingInterstageShaderInterfaces(WebGPU::Device &devic
             return @"maxFragmentShaderInputComponents is less than zero due to sample index";
         if (fragmentModule->usesSampleMaskInInput(fragmentEntryPoint) && !decrementByVariable(maxFragmentShaderInputComponents))
             return @"maxFragmentShaderInputComponents is less than zero due to sample mask";
+        if (fragmentModule->usesPrimitiveIndexInInput(fragmentEntryPoint) && !decrementByVariable(maxFragmentShaderInputComponents))
+            return @"maxFragmentShaderInputComponents is less than zero due to primitive index";
 
         if (fragmentInputs) {
             WGSL::AST::Interpolation defaultInterpolation {

--- a/Source/WebGPU/WebGPU/ShaderModule.h
+++ b/Source/WebGPU/WebGPU/ShaderModule.h
@@ -104,6 +104,7 @@ public:
     bool usesSampleMaskInInput(const String&) const;
     bool usesSampleMaskInOutput(const String&) const;
     bool usesFragDepth(const String&) const;
+    bool usesPrimitiveIndexInInput(const String&) const;
     uint32_t clipDistancesCount(const String&) const;
 
 private:
@@ -140,6 +141,7 @@ private:
         bool usesSampleMaskInInput { false };
         bool usesSampleMaskInOutput { false };
         bool usesFragDepth { false };
+        bool usesPrimitiveIndexInInput { false };
         uint32_t clipDistancesCount { 0 }; // Number of clip distances (0 if not used)
     };
     const ShaderModuleState* shaderModuleState(const String&) const;

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -510,6 +510,13 @@ bool ShaderModule::usesFragDepth(const String& entryPoint) const
     return false;
 }
 
+bool ShaderModule::usesPrimitiveIndexInInput(const String& entryPoint) const
+{
+    if (auto state = shaderModuleState(entryPoint))
+        return state->usesPrimitiveIndexInInput;
+    return false;
+}
+
 uint32_t ShaderModule::clipDistancesCount(const String& entryPoint) const
 {
     if (auto state = shaderModuleState(entryPoint))
@@ -546,6 +553,9 @@ void ShaderModule::populateFragmentInputs(const WGSL::Type& type, ShaderModule::
             case NumWorkgroups:
                 break;
             case Position:
+                break;
+            case PrimitiveIndex:
+                populateShaderModuleState(entryPointName).usesPrimitiveIndexInInput = true;
                 break;
             case SampleIndex:
                 populateShaderModuleState(entryPointName).usesSampleIndexInInput = true;
@@ -1164,6 +1174,8 @@ String wgpuAdapterFeatureName(WGPUFeatureName feature)
         return "float32-blendable"_s;
     case WGPUFeatureName_ClipDistances:
         return "clip-distances"_s;
+    case WGPUFeatureName_PrimitiveIndex:
+        return "primitive-index"_s;
     case WGPUFeatureName_DualSourceBlending:
         return "dual-source-blending"_s;
     case WGPUFeatureName_Float16Renderable:

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -390,10 +390,11 @@ typedef enum WGPUFeatureName {
     WGPUFeatureName_Float32Blendable = 0x0000000E,
     WGPUFeatureName_ClipDistances = 0x0000000F,
     WGPUFeatureName_DualSourceBlending = 0x00000010,
-    WGPUFeatureName_Float16Renderable = 0x00000011,
-    WGPUFeatureName_Float32Renderable = 0x00000012,
-    WGPUFeatureName_CoreFeaturesAndLimits = 0x00000013,
-    WGPUFeatureName_TextureFormatsTier1 = 0x00000014,
+    WGPUFeatureName_PrimitiveIndex = 0x00000011,
+    WGPUFeatureName_Float16Renderable = 0x00000012,
+    WGPUFeatureName_Float32Renderable = 0x00000013,
+    WGPUFeatureName_CoreFeaturesAndLimits = 0x00000014,
+    WGPUFeatureName_TextureFormatsTier1 = 0x00000015,
     WGPUFeatureName_Force32 = 0x7FFFFFFF
 } WGPUFeatureName WGPU_ENUM_ATTRIBUTE;
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in
@@ -42,5 +42,6 @@ enum class WebCore::WebGPU::FeatureName : uint8_t {
     Float32Renderable,
     CoreFeaturesAndLimits,
     TextureFormatsTier1,
+    PrimitiveIndex,
 };
 #endif


### PR DESCRIPTION
#### 8e166397db87d25722f77438fa0acb6bb7b4e784
<pre>
webgpu.github.io/webgpu-samples/?sample=primitivePicking fails to open in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=315876">https://bugs.webkit.org/show_bug.cgi?id=315876</a>
<a href="https://rdar.apple.com/178277160">rdar://178277160</a>

Reviewed by Dan Glastonbury.

Mostly mechanical changes so webgpu.github.io/webgpu-samples/?sample=primitivePicking
works in Safari.

Test: fast/webgpu/primitive-index.html

* LayoutTests/fast/webgpu/primitive-index-expected.txt: Added.
* LayoutTests/fast/webgpu/primitive-index.html: Added.
* Source/WebCore/Modules/WebGPU/GPUAdapter.cpp:
(WebCore::convertFeatureNameToEnum):
* Source/WebCore/Modules/WebGPU/GPUFeatureName.h:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUFeatureName.idl:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp:
(WebCore::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h:
* Source/WebGPU/WGSL/IOValidator.cpp:
(WGSL::IOValidator::validateBuiltinIO):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseEnableDirective):
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::wgslExtensionToWebGPUFeatureName):
* Source/WebGPU/WGSL/WGSLEnums.h:
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::baseFeatures):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::errorValidatingInterstageShaderInterfaces):
* Source/WebGPU/WebGPU/ShaderModule.h:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::usesPrimitiveIndexInInput const):
(WebGPU::ShaderModule::populateFragmentInputs):
(wgpuAdapterFeatureName):
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in:

Canonical link: <a href="https://commits.webkit.org/314288@main">https://commits.webkit.org/314288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a92126971038ba55aadb7351dec046c779c0a20e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174516 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122729 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0f0ba67-9113-4ca3-acf7-c5c575b1a60f) 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128590 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90516 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f44597be-5d87-4aab-9a2f-d7f05c3564e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168433 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30942 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109115 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c59008b6-025f-4480-83c0-218da1c7a7db) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29947 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28579 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22592 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177040 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29949 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28068 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136915 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136851 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36924 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148159 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102107 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32122 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25026 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38231 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111305 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37628 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3106 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37874 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37772 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->