### PR TITLE
[GStreamer][WebRTC] webrtc/getDisplayMedia-pc-resolution.html almost consistently times out

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2862,7 +2862,7 @@ fast/mediastream/video-rotation2.html [ Failure ]
 
 http/wpt/mediastream/webrtc-vp9-colorspace.html [ Failure ]
 
-webkit.org/b/314659 webrtc/getDisplayMedia-pc-resolution.html [ Failure Timeout ]
+webkit.org/b/314659 webrtc/getDisplayMedia-pc-resolution.html [ Failure ]
 
 # Regressions introduced by https://commits.webkit.org/263750@main
 fast/mediastream/apply-constraints-advanced.html [ Failure ]

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -715,13 +715,16 @@ void GStreamerMediaEndpoint::linkOutgoingSources(GstSDPMessage* sdpMessage)
 
         GST_DEBUG_OBJECT(m_pipeline.get(), "Looking-up outgoing source with msid %s in %zu unlinked sources", msid.utf8(), m_unlinkedOutgoingSources.size());
         m_unlinkedOutgoingSources.removeFirstMatching([&, msid = String(msid.span())](auto& source) -> bool {
-            if (source->type() != sourceType)
+            if (source->type() != sourceType) {
+                GST_DEBUG_OBJECT(pipeline(), "Un-matched source type");
                 return false;
-
+            }
             if (const auto& track = source->track()) {
                 auto sourceMsid = makeString(source->mediaStreamID(), ' ', track->id());
-                if (!msid.isEmpty() && sourceMsid != msid)
+                if (!msid.isEmpty() && sourceMsid != msid) {
+                    GST_DEBUG_OBJECT(pipeline(), "Un-matched outgoing source msid: %s", sourceMsid.utf8().data());
                     return false;
+                }
             }
 
             auto allowedCaps = capsFromSDPMedia(media);
@@ -2334,6 +2337,54 @@ void GStreamerMediaEndpoint::onNegotiationNeeded()
 
         GST_DEBUG_OBJECT(m_pipeline.get(), "Negotiation needed!");
         peerConnectionBackend->markAsNeedingNegotiation(m_negotiationNeededEventId);
+    });
+}
+
+void GStreamerMediaEndpoint::trackWasReplaced(const String& previousId, const String& newId)
+{
+    struct TrackIds {
+        String previousId;
+        String newId;
+        bool wasTrackFound;
+    };
+
+    TrackIds ids { previousId, newId, false };
+    forEachTransceiver(m_webrtcBin, [&](auto&& transceiver) -> bool {
+        GRefPtr<GstCaps> caps;
+        g_object_get(transceiver.get(), "codec-preferences", &caps.outPtr(), nullptr);
+
+        auto newCaps = adoptGRef(gst_caps_make_writable(caps.leakRef()));
+        gst_caps_map_in_place(newCaps.get(), [](auto*, auto* structure, gpointer userData) -> gboolean {
+            auto msid = gstStructureGetString(structure, "a-msid"_s);
+            if (msid.isEmpty())
+                return TRUE;
+
+            String msidString = msid.span();
+            auto parts = msidString.split(' ');
+            if (parts.size() != 2)
+                return TRUE;
+
+            auto ids = static_cast<TrackIds*>(userData);
+            if (parts[1] != ids->previousId)
+                return TRUE;
+
+            ids->wasTrackFound = true;
+            if (ids->newId.isEmpty())
+                gst_structure_remove_field(structure, "a-msid");
+            else {
+                auto newMsid = makeString(parts[0], ' ', ids->newId);
+                gst_structure_set(structure, "a-msid", G_TYPE_STRING, newMsid.utf8().data(), nullptr);
+            }
+
+            return TRUE;
+        }, &ids);
+
+        if (ids.wasTrackFound) {
+            g_object_freeze_notify(G_OBJECT(transceiver.get()));
+            g_object_set(transceiver.get(), "codec-preferences", newCaps.get(), nullptr);
+            g_object_thaw_notify(G_OBJECT(transceiver.get()));
+        }
+        return ids.wasTrackFound;
     });
 }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -126,6 +126,8 @@ public:
 
     void onNegotiationNeeded();
 
+    void trackWasReplaced(const String& previousId, const String& newId);
+
 protected:
 #if !RELEASE_LOG_DISABLED
     void onStatsDelivered(const GstStructure*);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -489,6 +489,11 @@ RTCPeerConnection& GStreamerPeerConnectionBackend::connection()
     return m_peerConnection.get();
 }
 
+void GStreamerPeerConnectionBackend::trackWasReplaced(const String& previousId, const String& newId)
+{
+    m_endpoint->trackWasReplaced(previousId, newId);
+}
+
 void GStreamerPeerConnectionBackend::tearDown()
 {
     for (auto& transceiver : connection().currentTransceivers()) {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -117,6 +117,8 @@ private:
     void setReconfiguring(bool isReconfiguring) { m_isReconfiguring = isReconfiguring; }
     bool isReconfiguring() const { return m_isReconfiguring; }
 
+    void trackWasReplaced(const String& previousId, const String& newId);
+
     void tearDown();
 
     UDPPortsRange udpPortsRange() const { return m_udpPortsRange; }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -149,7 +149,7 @@ void GStreamerRtpSenderBackend::tearDown()
     m_rtcSender = nullptr;
 }
 
-bool GStreamerRtpSenderBackend::replaceTrack(RTCRtpSender&, MediaStreamTrack* track)
+bool GStreamerRtpSenderBackend::replaceTrack(RTCRtpSender& sender, MediaStreamTrack* track)
 {
     GST_DEBUG_OBJECT(m_rtcSender.get(), "Replacing sender track with track %p", track);
 
@@ -161,6 +161,7 @@ bool GStreamerRtpSenderBackend::replaceTrack(RTCRtpSender&, MediaStreamTrack* tr
     // FIXME: We might want to set the reconfiguring flag back to false once the webrtcbin sink pad
     // has renegotiated its caps. Perhaps a pad probe can be used for this.
 
+    auto previousTrackId = sender.trackId();
     RefPtr newTrack = track;
     switchOn(m_source, [&](Ref<RealtimeOutgoingAudioSourceGStreamer>& source) {
         source->replaceTrack(newTrack);
@@ -170,6 +171,7 @@ bool GStreamerRtpSenderBackend::replaceTrack(RTCRtpSender&, MediaStreamTrack* tr
         GST_DEBUG_OBJECT(m_rtcSender.get(), "No outgoing source yet");
     });
 
+    peerConnectionBackend->trackWasReplaced(previousTrackId, newTrack ? newTrack->id() : emptyString());
     return true;
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -386,20 +386,52 @@ void RealtimeOutgoingMediaSourceGStreamer::replaceTrack(const RefPtr<MediaStream
     if (newTrack)
         trackPrivate = newTrack->privateTrack();
 
-    if (m_outgoingSource)
+    if (m_outgoingSource) {
         webkitMediaStreamSrcReplaceTrack(WEBKIT_MEDIA_STREAM_SRC_CAST(m_outgoingSource.get()), RefPtr(trackPrivate));
-    else {
-        if (trackPrivate) {
-            m_outgoingSource = webkitMediaStreamSrcNew();
-            gst_bin_add(GST_BIN_CAST(m_bin.get()), m_outgoingSource.get());
-            webkitMediaStreamSrcAddTrack(WEBKIT_MEDIA_STREAM_SRC_CAST(m_outgoingSource.get()), trackPrivate.get());
+        auto srcPad = outgoingSourcePad();
+        if (!gst_pad_is_linked(srcPad.get())) {
             gst_element_link(m_outgoingSource.get(), m_inputSelector.get());
             gst_element_sync_state_with_parent(m_outgoingSource.get());
         }
-        auto srcPad = outgoingSourcePad();
-        auto activePad = adoptGRef(gst_pad_get_peer(srcPad.get()));
-        g_object_set(m_inputSelector.get(), "active-pad", activePad.get(), nullptr);
+    } else if (trackPrivate) {
+        m_outgoingSource = webkitMediaStreamSrcNew();
+        gst_bin_add(GST_BIN_CAST(m_bin.get()), m_outgoingSource.get());
+        webkitMediaStreamSrcAddTrack(WEBKIT_MEDIA_STREAM_SRC_CAST(m_outgoingSource.get()), trackPrivate.get());
+        gst_element_link(m_outgoingSource.get(), m_inputSelector.get());
+        gst_element_sync_state_with_parent(m_outgoingSource.get());
     }
+
+    auto srcPad = outgoingSourcePad();
+    auto activePad = adoptGRef(gst_pad_get_peer(srcPad.get()));
+    RELEASE_ASSERT(activePad);
+    g_object_set(m_inputSelector.get(), "active-pad", activePad.get(), nullptr);
+
+    if (m_transceiver) {
+        GRefPtr<GstCaps> caps;
+        g_object_get(m_transceiver.get(), "codec-preferences", &caps.outPtr(), nullptr);
+
+        m_pendingTrackId = trackPrivate ? trackPrivate->id() : emptyString();
+        auto newCaps = adoptGRef(gst_caps_make_writable(caps.leakRef()));
+        gst_caps_map_in_place(newCaps.get(), [](auto*, auto* structure, gpointer userData) -> gboolean {
+            if (!gst_structure_has_field_typed(structure, "a-msid", G_TYPE_STRING)) [[unlikely]]
+                return TRUE;
+
+            auto self = static_cast<RealtimeOutgoingMediaSourceGStreamer*>(userData);
+            if (self->m_pendingTrackId.isEmpty())
+                gst_structure_remove_field(structure, "a-msid");
+            else {
+                auto newMsid = makeString(self->m_mediaStreamId, ' ', self->m_pendingTrackId);
+                gst_structure_set(structure, "a-msid", G_TYPE_STRING, newMsid.utf8().data(), nullptr);
+            }
+
+            return TRUE;
+        }, this);
+        g_object_freeze_notify(G_OBJECT(m_transceiver.get()));
+        g_object_set(m_transceiver.get(), "codec-preferences", newCaps.get(), nullptr);
+        m_pendingTrackId = emptyString();
+        g_object_thaw_notify(G_OBJECT(m_transceiver.get()));
+    }
+
     if (!newTrack) {
         m_isStopped = true;
         m_track = nullptr;
@@ -407,6 +439,13 @@ void RealtimeOutgoingMediaSourceGStreamer::replaceTrack(const RefPtr<MediaStream
     }
 
     m_track = WTF::move(trackPrivate);
+
+    const auto& webrtcSinkPad = pad();
+    if (!webrtcSinkPad)
+        return;
+    if (!gst_pad_is_linked(webrtcSinkPad.get()))
+        return;
+
     start();
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -155,6 +155,8 @@ private:
     void stopUpdatingStats();
 
     RefPtr<GStreamerRTPPacketizer> getPacketizerForRid(const String&);
+
+    String m_pendingTrackId { emptyString() };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### cf5066c746424e11e238567eafb5f1a6919a959a
<pre>
[GStreamer][WebRTC] webrtc/getDisplayMedia-pc-resolution.html almost consistently times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=315917">https://bugs.webkit.org/show_bug.cgi?id=315917</a>

Reviewed by Xabier Rodriguez-Calvar.

The timeout was happening in the penultimate sub-test that calls replaceTrack before generating an
offer. In that situation the outgoing media track bin isn&apos;t fully linked and doesn&apos;t have a
transceiver yet. The transceiver codec-preferences were not updated so the attempt to link outgoing
sources in the end-point after creating the offer left an unlinked outgoing media track bin, because
the msid SDP attribute wasn&apos;t matched properly.

The proposed fix is to iterate over the webrtcbin transceivers after the replaceTrack call and
update a-msid attributes on their codec-preferences caps when appropriate.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::linkOutgoingSources):
(WebCore::GStreamerMediaEndpoint::trackWasReplaced):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::trackWasReplaced):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
(WebCore::GStreamerRtpSenderBackend::replaceTrack):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::replaceTrack):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/314285@main">https://commits.webkit.org/314285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b715648e3a99f9744a3f1cfd856f32a32fbd4dda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174720 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122933 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39172 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128749 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168637 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148849 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109273 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28760 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22800 "Hash b715648e for PR 66094 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177244 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30157 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137077 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137006 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36923 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148343 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102429 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32294 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25210 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38436 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111509 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37832 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3291 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->