### PR TITLE
[JSC] `Array#join` returns wrong result for self-referential arrays after DFG tier-up

### DIFF
--- a/JSTests/stress/array-join-dfg-string-recursion-check.js
+++ b/JSTests/stress/array-join-dfg-string-recursion-check.js
@@ -1,0 +1,36 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected ' + expected);
+}
+
+function joinDash(arr) {
+    return arr.join("-");
+}
+noInline(joinDash);
+
+function joinDefault(arr) {
+    return arr.join();
+}
+noInline(joinDefault);
+
+var selfArray = [1, 2];
+selfArray.push(selfArray);
+
+var mutualA = [1];
+var mutualB = [2];
+mutualA.push(mutualB);
+mutualB.push(mutualA);
+
+var reenterArray = [1, 2, {
+    toString() {
+        return reenterArray.join("*");
+    }
+}];
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(joinDash(selfArray), "1-2-");
+    shouldBe(joinDefault(selfArray), "1,2,");
+    shouldBe(joinDash(mutualA), "1-2,");
+    shouldBe(joinDefault(mutualB), "2,1,");
+    shouldBe(joinDash(reenterArray), "1-2-");
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -98,6 +98,7 @@
 #include "StringConstructor.h"
 #include "StringPrototype.h"
 #include "StringPrototypeInlines.h"
+#include "StringRecursionChecker.h"
 #include "SuperSampler.h"
 #include "Symbol.h"
 #include "TypeProfilerLog.h"
@@ -1578,6 +1579,11 @@ static ALWAYS_INLINE JSString* arrayJoinWithStringSeparator(JSGlobalObject* glob
         if (joined)
             return joined;
     }
+
+    StringRecursionChecker checker(globalObject, array);
+    EXCEPTION_ASSERT(!scope.exception() || checker.earlyReturnValue());
+    if (JSValue earlyReturnValue = checker.earlyReturnValue())
+        return jsEmptyString(globalObject->vm());
 
     auto view = separator->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });


### PR DESCRIPTION
#### fac4c07a6086ab0b4a00d592e1f2bf0142f283be
<pre>
[JSC] `Array#join` returns wrong result for self-referential arrays after DFG tier-up
<a href="https://bugs.webkit.org/show_bug.cgi?id=315919">https://bugs.webkit.org/show_bug.cgi?id=315919</a>

Reviewed by NOBODY (OOPS!).

The ArrayJoin DFG operations added in <a href="https://commits.webkit.org/313949@main">313949@main</a> call fastArrayJoin
without registering the array with StringRecursionChecker, unlike
arrayProtoFuncJoin. As a result, re-entrant joins on the same array are
detected one level too late and produce a different string after tier-up:

    var array = [1, 2];
    array.push(array);
    array.join(&quot;-&quot;); // Baseline: &quot;1-2-&quot;, DFG/FTL: &quot;1-2-1,2,&quot;

This patch adds the StringRecursionChecker to arrayJoinWithStringSeparator,
in the same way as arrayProtoFuncJoin and JSArray::fastToString.

Test: JSTests/stress/array-join-dfg-string-recursion-check.js

* JSTests/stress/array-join-dfg-string-recursion-check.js: Added.
(shouldBe):
(joinDash):
(joinDefault):
(toString):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::arrayJoinWithStringSeparator):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fac4c07a6086ab0b4a00d592e1f2bf0142f283be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122733 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128594 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90519 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168437 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30907 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109119 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29951 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28583 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22597 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157635 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177044 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26371 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29953 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136919 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136855 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148158 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102113 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25025 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198914 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38235 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111309 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53416 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37632 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3105 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->