### PR TITLE
[JSC] Iterator.prototype.inclues should throw RangeError if skippedElements > Number.MAX_SAFE_INTEGER

### DIFF
--- a/JSTests/stress/iterator-prototype-includes.js
+++ b/JSTests/stress/iterator-prototype-includes.js
@@ -1,5 +1,10 @@
 //@ requireOptions("--useIteratorIncludes=1")
 
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`); 
+}
+
 function sameValue(a, b, testname) {
     if (a !== b)
         throw new Error(`${testname}: Expected ${b} but got ${a}`);
@@ -21,12 +26,24 @@ function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
     }
 }
 
+function shouldNotThrow(fn, caseName) {
+    if (!caseName)
+        throw new Error(`must specify message`);
+
+    try {
+        fn();
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        throw new Error(`${caseName}: Expected not thrown but got ${actual}`);
+    }
+}
+
 function callTestTargetFunction(iterator, searchElement, skippedElements) {
     return Iterator.prototype.includes.call(iterator, searchElement, skippedElements);
 }
 
 class TestIterator extends Iterator {
-    value = 0;
+    begin = 0;
     isClosed = false;
     isDone = false;
     constructor(max) {
@@ -37,7 +54,7 @@ class TestIterator extends Iterator {
         this.max = max;
     }
     next() {
-        const value = this.value;
+        const value = this.begin;
         if (value > this.max) {
             this.isDone = true;
             return {
@@ -46,7 +63,7 @@ class TestIterator extends Iterator {
             };
         }
 
-        this.value += 1;
+        this.begin += 1;
         return {
             done: false,
             value,
@@ -444,19 +461,52 @@ class TestIterator extends Iterator {
 }
 
 {
-    const valid2ndArgument = [
+    const greaterThanIteratorSize = [
         [Number.POSITIVE_INFINITY, `+Infinity`],
         [Number.MAX_SAFE_INTEGER, `Number.MAX_SAFE_INTEGER`],
-        [Number.MAX_SAFE_INTEGER + 1, `(Number.MAX_SAFE_INTEGER + 1)`],
-        [Number.MAX_VALUE, `Number.MAX_VALUE`],
+        [Number.MAX_SAFE_INTEGER - 1, `Number.MAX_SAFE_INTEGER - 1`],
+        [1, ''],
     ];
 
-    for (const [skippedElements, label] of valid2ndArgument) {
-        const testName = `call on short iterator with 2nd arg (large number): ${label}`;
+    for (const [skippedElements, name] of greaterThanIteratorSize) {
+        const label = name ?? String(skippedElements);
+        const testName = `call on short iterator with 2nd arg (large number > the iterator): ${label}`;
         const iter = new TestIterator(0);
+        assert(iter.max < skippedElements, `${testName}: to avoid test stucking`);
         sameValue(callTestTargetFunction(iter, 0, skippedElements), false, `${testName}: calling .includes()`);
         sameValue(iter.isDone, true, `${testName}: iterator should be done`);
         sameValue(iter.isClosed, false, `${testName}: iterator should not be closed`);
+    }
+}
+
+{
+    const valid2ndArgumentAsLowerBound = [
+        [0, ],
+        [0.0, '0.0'],
+    ];
+
+    for (const [skippedElements, name] of valid2ndArgumentAsLowerBound) {
+        const label = name ?? String(skippedElements);
+        const testName = `call on iterator with args (1st should **not** found, 2nd is lower bound): ${label}`;
+        const iter = new TestIterator(0);
+        const searchElement = -1;
+        assert(searchElement < iter.begin, 'must not be found in the iterator');
+        shouldNotThrow(() => {
+            callTestTargetFunction(iter, searchElement, skippedElements);
+        }, `${testName}: calling .includes()`);
+        sameValue(iter.isDone, true, `${testName}: iterator should be done`);
+        sameValue(iter.isClosed, false, `${testName}: iterator should not be closed`);
+    }
+
+    for (const [skippedElements, name] of valid2ndArgumentAsLowerBound) {
+        const label = name ?? String(skippedElements);
+        const testName = `call on iterator with args (1st should be found, 2nd is lower bound): ${label}`;
+        const iter = new TestIterator(0);
+        const searchElement = 0;
+        assert(iter.begin <= searchElement && searchElement <= iter.max, `${testName}: must be found in the iterator's range`);
+        sameValue(callTestTargetFunction(iter, searchElement, skippedElements), true, `${testName}: calling .includes()`);
+        sameValue(iter.isDone, false, `${testName}: iterator should be done`);
+        sameValue(iter.isClosed, true, `${testName}: iterator should not be closed`);
     }
 }
 
@@ -481,7 +531,7 @@ class TestIterator extends Iterator {
 }
 
 {
-    const invalidSkippedElements = [
+    const invalidSkippedElementsAsTypeError = [
         ['', ],
         ['1', `'1'`],
         [true, ],
@@ -497,28 +547,30 @@ class TestIterator extends Iterator {
         [Number.MIN_VALUE, `Number.MIN_VALUE`],
     ];
 
-    for (const [skip, label] of invalidSkippedElements) {
+    for (const [skip, label] of invalidSkippedElementsAsTypeError) {
         const testName = label ?? String(skip);
         const validIter = new TestIterator(3);
         shouldThrow(`the 2nd arg is invalid: ${testName}`, function () {
             callTestTargetFunction(validIter, null, skip);
-        }, TypeError, "Iterator.prototype.includes requires that the second argument is a non-negative integral Number or Infinity.");
+        }, TypeError, "Iterator.prototype.includes requires that the second argument is a non-negative safe integral Number or Infinity.");
         sameValue(validIter.isClosed, true, 'the given iterator should be closed.');
     }
 }
 
 {
-    const invalidSkippedElements = [
+    const invalidSkippedElementsAsRangeError = [
+        [Number.MAX_VALUE, `Number.MAX_VALUE`],
+        [Number.MAX_SAFE_INTEGER + 1, `(Number.MAX_SAFE_INTEGER + 1)`],
         [-1, ],
         [Number.NEGATIVE_INFINITY, ],
         [Number.MIN_SAFE_INTEGER, `Number.MIN_SAFE_INTEGER`],
     ];
-    for (const [skip, label] of invalidSkippedElements) {
+    for (const [skip, label] of invalidSkippedElementsAsRangeError) {
         const testName = label ?? String(skip);
         const validIter = new TestIterator(3);
         shouldThrow(`the 2nd arg is not positive integer: ${String(testName)}`, function () {
             callTestTargetFunction(validIter, null, skip);
-        }, RangeError, "Iterator.prototype.includes requires that the second argument is a non-negative integral Number or Infinity.");
+        }, RangeError, "Iterator.prototype.includes requires that the second argument is a non-negative safe integral Number or Infinity.");
         sameValue(validIter.isClosed, true, 'the given iterator should be closed.');
     }
 }

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -231,7 +231,7 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncIncludes, (JSGlobalObject* globalObjec
     JSValue skippedElementsArg = callFrame->argument(1);
     uint64_t toSkip = 0;
     if (!skippedElementsArg.isUndefined()) {
-        constexpr ASCIILiteral errorMessage = "Iterator.prototype.includes requires that the second argument is a non-negative integral Number or Infinity."_s;
+        constexpr ASCIILiteral errorMessage = "Iterator.prototype.includes requires that the second argument is a non-negative safe integral Number or Infinity."_s;
 
         if (skippedElementsArg.isInt32()) [[likely]] {
             int32_t skippedAsInt32 = skippedElementsArg.asInt32();
@@ -243,14 +243,17 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncIncludes, (JSGlobalObject* globalObjec
             toSkip = skippedAsInt32;
         } else if (skippedElementsArg.isDouble()) {
             double skippedAsDouble = skippedElementsArg.asDouble();
-            uint64_t skippedAsUInt = truncateDoubleToUint64(skippedAsDouble);
-            if (skippedAsUInt == skippedAsDouble && skippedAsUInt < maxSafeIntegerAsUInt64())
-                toSkip = skippedAsUInt;
-            else if (!isInteger(skippedAsDouble) && !std::isinf(skippedAsDouble)) {
+            bool isInfinity = std::isinf(skippedAsDouble);
+            if (!isInteger(skippedAsDouble) && !isInfinity) {
                 iteratorClose(globalObject, thisValue);
                 TRY_CLEAR_EXCEPTION(scope, { });
-                return throwVMTypeError(globalObject, scope, errorMessage);                
-            } else if (skippedAsDouble > 0) {
+                return throwVMTypeError(globalObject, scope, errorMessage);
+            }
+
+            uint64_t skippedAsUInt = truncateDoubleToUint64(skippedAsDouble);
+            if (skippedAsUInt == skippedAsDouble && skippedAsUInt <= maxSafeIntegerAsUInt64())
+                toSkip = skippedAsUInt;
+            else if (isInfinity && skippedAsDouble > 0) {
                 // if the 2nd argument is +Infinity or too big, we should consume the iterator to the end.
                 toSkip = std::numeric_limits<uint64_t>::max();
             } else {


### PR DESCRIPTION
#### 40a1acb199d9f67d0f295c69f5d6922c96ef0e34
<pre>
[JSC] Iterator.prototype.inclues should throw RangeError if skippedElements &gt; Number.MAX_SAFE_INTEGER
<a href="https://bugs.webkit.org/show_bug.cgi?id=315920">https://bugs.webkit.org/show_bug.cgi?id=315920</a>

Reviewed by Sosuke Suzuki.

This update the behavior to match the spec change:

<a href="https://github.com/tc39/proposal-iterator-includes/commit/57a609c851ded1385e14f3c2f512c85f6d78363a">https://github.com/tc39/proposal-iterator-includes/commit/57a609c851ded1385e14f3c2f512c85f6d78363a</a>
Canonical link: <a href="https://commits.webkit.org/314330@main">https://commits.webkit.org/314330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f484441d78f53550567b6a9bda3ef921d53375a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174729 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122942 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128756 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90679 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109280 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30142 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28770 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22810 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157844 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177253 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26580 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30168 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137084 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137014 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36947 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148360 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102442 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32303 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25227 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38445 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111518 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37841 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3308 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->