### PR TITLE
[JSC] Array rematerialization should preserve double Array holes when having a bad time

### DIFF
--- a/JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time-double-hole.js
+++ b/JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time-double-hole.js
@@ -1,0 +1,70 @@
+//@ runDefault("--jitPolicyScale=0.1")
+
+let trigger = false;
+let getterCalls = 0;
+let setterCalls = 0;
+
+function cb() {
+    if (trigger) {
+        Object.defineProperty(Array.prototype, 3, {
+            get() { getterCalls++; return 42; },
+            set(value) { setterCalls++; },
+            configurable: true
+        });
+    }
+}
+noInline(cb);
+
+function collect() { gc(); }
+noInline(collect);
+
+function opt(escape) {
+    let a = new Array(5);
+    a[0] = 1.1;
+    a[1] = 2.2;
+    a[2] = 3.3;
+    a[4] = 5.5;
+    cb();
+    collect();
+    // Index 3 is written only after the cb() call so that the OSR exit triggered by having a bad
+    // time during cb() rematerializes the sunk double Array while index 3 still holds the hole
+    // default (PNaN).
+    a[3] = 4.4;
+    if (escape)
+        return a;
+    return 0;
+}
+noInline(opt);
+
+for (let i = 0; i < 1000; i++)
+    opt(!(i % 10));
+
+trigger = true;
+let a = opt(true);
+
+// After having a bad time, the rematerialized Array uses SlowPutArrayStorage and index 3 must be
+// a hole at the OSR exit. The subsequent a[3] = 4.4 store in baseline code must therefore be
+// forwarded to the Array.prototype setter instead of creating an own property.
+if (a.hasOwnProperty(3))
+    throw new Error("index 3 should not be an own property, got value: " + a[3]);
+if (a[3] !== 42)
+    throw new Error("a[3] should return 42 from the prototype getter, got: " + a[3]);
+if (setterCalls !== 1)
+    throw new Error("Array.prototype setter should have been called once, got: " + setterCalls);
+if (a[0] !== 1.1 || a[1] !== 2.2 || a[2] !== 3.3 || a[4] !== 5.5)
+    throw new Error("other elements corrupted: " + a[0] + "," + a[1] + "," + a[2] + "," + a[4]);
+
+// The rematerialized ArrayStorage must also have an accurate m_numValuesInVector so that
+// hasHoles() is true. Otherwise Array.prototype.reverse takes a fast path that moves the raw
+// hole around without consulting the prototype accessors.
+let getterCallsBeforeReverse = getterCalls;
+let setterCallsBeforeReverse = setterCalls;
+a.reverse();
+if (getterCalls === getterCallsBeforeReverse || setterCalls === setterCallsBeforeReverse)
+    throw new Error("reverse should have consulted the prototype accessors (getter calls: "
+        + (getterCalls - getterCallsBeforeReverse) + ", setter calls: " + (setterCalls - setterCallsBeforeReverse) + ")");
+if (a[0] !== 5.5 || a[1] !== 42 || a[2] !== 3.3 || a[4] !== 1.1)
+    throw new Error("reverse produced wrong elements: " + a[0] + "," + a[1] + "," + a[2] + "," + a[4]);
+if (a.hasOwnProperty(3) || a[3] !== 42)
+    throw new Error("after reverse, index 3 should still be a hole reading 42 from the getter, got: " + a[3]);
+gc();

--- a/JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time-int32-hole.js
+++ b/JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time-int32-hole.js
@@ -1,0 +1,70 @@
+//@ runDefault("--jitPolicyScale=0.1")
+
+let trigger = false;
+let getterCalls = 0;
+let setterCalls = 0;
+
+function cb() {
+    if (trigger) {
+        Object.defineProperty(Array.prototype, 3, {
+            get() { getterCalls++; return 42; },
+            set(value) { setterCalls++; },
+            configurable: true
+        });
+    }
+}
+noInline(cb);
+
+function collect() { gc(); }
+noInline(collect);
+
+function opt(escape) {
+    let a = new Array(5);
+    a[0] = 1;
+    a[1] = 2;
+    a[2] = 3;
+    a[4] = 5;
+    cb();
+    collect();
+    // Index 3 is written only after the cb() call so that the OSR exit triggered by having a bad
+    // time during cb() rematerializes the sunk Int32 Array while index 3 still holds the hole
+    // default (the empty JSValue).
+    a[3] = 4;
+    if (escape)
+        return a;
+    return 0;
+}
+noInline(opt);
+
+for (let i = 0; i < 1000; i++)
+    opt(!(i % 10));
+
+trigger = true;
+let a = opt(true);
+
+// After having a bad time, the rematerialized Array uses SlowPutArrayStorage and index 3 must be
+// a hole at the OSR exit. The subsequent a[3] = 4 store in baseline code must therefore be
+// forwarded to the Array.prototype setter instead of creating an own property.
+if (a.hasOwnProperty(3))
+    throw new Error("index 3 should not be an own property, got value: " + a[3]);
+if (a[3] !== 42)
+    throw new Error("a[3] should return 42 from the prototype getter, got: " + a[3]);
+if (setterCalls !== 1)
+    throw new Error("Array.prototype setter should have been called once, got: " + setterCalls);
+if (a[0] !== 1 || a[1] !== 2 || a[2] !== 3 || a[4] !== 5)
+    throw new Error("other elements corrupted: " + a[0] + "," + a[1] + "," + a[2] + "," + a[4]);
+
+// The rematerialized ArrayStorage must also have an accurate m_numValuesInVector so that
+// hasHoles() is true. Otherwise Array.prototype.reverse takes a fast path that moves the raw
+// hole around without consulting the prototype accessors.
+let getterCallsBeforeReverse = getterCalls;
+let setterCallsBeforeReverse = setterCalls;
+a.reverse();
+if (getterCalls === getterCallsBeforeReverse || setterCalls === setterCallsBeforeReverse)
+    throw new Error("reverse should have consulted the prototype accessors (getter calls: "
+        + (getterCalls - getterCallsBeforeReverse) + ", setter calls: " + (setterCalls - setterCallsBeforeReverse) + ")");
+if (a[0] !== 5 || a[1] !== 42 || a[2] !== 3 || a[4] !== 1)
+    throw new Error("reverse produced wrong elements: " + a[0] + "," + a[1] + "," + a[2] + "," + a[4]);
+if (a.hasOwnProperty(3) || a[3] !== 42)
+    throw new Error("after reverse, index 3 should still be a hole reading 42 from the getter, got: " + a[3]);
+gc();

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -114,16 +114,25 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
             // butterfly to preserve the indexing type.
             //
             // If the VM had a bad time between FTL compilation and this OSR exit, the Array was
-            // switched to SlowPutArrayStorage in operationMaterializeObjectInOSR. A hole (empty
-            // JSValue) must then be cleared in the ArrayStorage vector rather than the contiguous
-            // butterfly to match the rematerialized layout.
-            if (hasDouble(array->indexingType()) && value.isNumber() && std::isnan(value.asNumber())) [[unlikely]]
+            // switched to SlowPutArrayStorage in operationMaterializeObjectInOSR. A hole must then
+            // be cleared in the ArrayStorage vector rather than the contiguous butterfly to match
+            // the rematerialized layout. Note that the hole arrives as the hole sentinel of the
+            // indexing type the Array was sunk with, not of the Array's current indexing type:
+            // boxed NaN if the Array was sunk as Double, the empty JSValue otherwise.
+            // m_numValuesInVector is also decremented because the cleared slot was counted when
+            // the sentinel-filled butterfly was converted to ArrayStorage.
+            bool valueIsHole = hasDouble(materialization->indexingType()) ? value.isNumber() && isHole(value.asNumber()) : !value;
+            if (hasDouble(array->indexingType()) && valueIsHole) [[unlikely]]
                 array->butterfly()->contiguousDouble().atUnsafe(index) = PNaN;
-            else if ((hasInt32(array->indexingType()) || hasContiguous(array->indexingType())) && !value) [[unlikely]]
+            else if ((hasInt32(array->indexingType()) || hasContiguous(array->indexingType())) && valueIsHole) [[unlikely]]
                 array->butterfly()->contiguous().atUnsafe(index).setStartingValue(JSValue());
-            else if (hasAnyArrayStorage(array->indexingType()) && !value) [[unlikely]]
-                array->butterfly()->arrayStorage()->m_vector[index].clear();
-            else
+            else if (hasAnyArrayStorage(array->indexingType()) && valueIsHole) [[unlikely]] {
+                ArrayStorage* storage = array->butterfly()->arrayStorage();
+                ASSERT(storage->m_vector[index]);
+                ASSERT(storage->m_numValuesInVector);
+                storage->m_vector[index].clear();
+                storage->m_numValuesInVector--;
+            } else
                 array->putDirectIndex(globalObject, index, value);
 
             scope.assertNoExceptionExceptTermination();


### PR DESCRIPTION
#### a82eb9dd7fabc6cfb8d9e5906e42411e27029e90
<pre>
[JSC] Array rematerialization should preserve double Array holes when having a bad time
<a href="https://bugs.webkit.org/show_bug.cgi?id=315922">https://bugs.webkit.org/show_bug.cgi?id=315922</a>

Reviewed by Yusuke Suzuki.

When a sunk double Array is rematerialized at an FTL OSR exit after the VM had
a bad time, an unwritten element arrives as boxed NaN (the hole default for
double Arrays), not the empty JSValue. Because the Array has already been
switched to SlowPutArrayStorage, no hole-preserving branch in
operationPopulateObjectInOSR matched and the NaN fell through to
putDirectIndex, turning the hole into an own property. After a bad time, holes
must instead forward to indexed accessors on the prototype chain.

This change determines hole-ness from the indexing type the Array was sunk
with and clears the ArrayStorage vector entry for holes. It also decrements
m_numValuesInVector, which the pre-existing empty-JSValue path missed.

Tests: JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time-double-hole.js
       JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time-int32-hole.js

* JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time-double-hole.js: Added.
(cb):
(collect):
(opt):
* JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time-int32-hole.js: Added.
(cb):
(collect):
(opt):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/314248@main">https://commits.webkit.org/314248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc7789c718579ffcf8e170e6e6c5910fe4d93f31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122736 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128596 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90523 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168440 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30913 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109121 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29957 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28586 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22601 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157638 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177047 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26374 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29956 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136921 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136857 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36903 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148165 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102118 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32129 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25032 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111312 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37635 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3112 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->