### PR TITLE
[JSC] Missing exception check in `forEachInIteratorProtocol` Set iterator fast path

### DIFF
--- a/JSTests/stress/iterator-helpers-set-entries-exception-check.js
+++ b/JSTests/stress/iterator-helpers-set-entries-exception-check.js
@@ -1,0 +1,59 @@
+//@ runDefault("--validateExceptionChecks=1")
+
+// Regression test for the Set-iterator fast path in forEachInIteratorProtocol.
+// JSSetIterator::next() can throw (constructArrayPair can OOM when kind is
+// Entries), so the fast path must check for an exception after next() before
+// invoking the user callback. With --validateExceptionChecks=1, a missing
+// check fires an "exception check validation failed" assertion on debug/ASan
+// builds when the callback (a JS function) is called.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+// Set entries iterator + Iterator.prototype.forEach (JS callback).
+{
+    const set = new Set([1, 2, 3]);
+    const seen = [];
+    set.entries().forEach((entry) => {
+        seen.push(entry[0], entry[1]);
+    });
+    shouldBe(seen.join(","), "1,1,2,2,3,3");
+}
+
+// Same, with a non-JS (bound) callback to cover the non-CachedCall path.
+{
+    const set = new Set(["a", "b"]);
+    const seen = [];
+    const callback = function (entry) { seen.push(this.prefix + entry[0] + entry[1]); }.bind({ prefix: "x" });
+    set.entries().forEach(callback);
+    shouldBe(seen.join(","), "xaa,xbb");
+}
+
+// Set entries iterator + Iterator.prototype.toArray.
+{
+    const set = new Set([1, 2, 3]);
+    const result = set.entries().toArray();
+    shouldBe(JSON.stringify(result), "[[1,1],[2,2],[3,3]]");
+}
+
+// Map entries iterator for symmetry (this path already had the check).
+{
+    const map = new Map([[1, "a"], [2, "b"]]);
+    const seen = [];
+    map.entries().forEach((entry) => {
+        seen.push(entry[0], entry[1]);
+    });
+    shouldBe(seen.join(","), "1,a,2,b");
+}
+
+// Repeat to make sure JIT tiers behave the same.
+for (let i = 0; i < 1e3; ++i) {
+    const set = new Set([i, i + 1]);
+    const seen = [];
+    set.entries().forEach((entry) => {
+        seen.push(entry[0], entry[1]);
+    });
+    shouldBe(seen.join(","), `${i},${i},${i + 1},${i + 1}`);
+}

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -354,9 +354,11 @@ void forEachInIteratorProtocol(JSGlobalObject* globalObject, JSValue iterable, N
             if (setIterator->iteratedObject()) {
                 JSValue value;
                 while (setIterator->next(globalObject, value)) {
+                    RETURN_IF_EXCEPTION(scope, void());
                     callback(vm, globalObject, value);
                     RETURN_IF_EXCEPTION(scope, void());
                 }
+                RETURN_IF_EXCEPTION(scope, void());
                 return;
             }
         }


### PR DESCRIPTION
#### b67282ad890b3a3f6306a0d11e81549167f14e39
<pre>
[JSC] Missing exception check in `forEachInIteratorProtocol` Set iterator fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=315924">https://bugs.webkit.org/show_bug.cgi?id=315924</a>

Reviewed by Yusuke Suzuki.

JSSetIterator::next() can throw an exception because constructArrayPair
can OOM when the iteration kind is Entries. The Set-iterator fast path
in forEachInIteratorProtocol added in 314169@main was missing the
exception check between next() and the user callback, so the callback
could run with a pending exception. Add the same exception checks the
Map-iterator path already has, making both branches consistent.

Test: JSTests/stress/iterator-helpers-set-entries-exception-check.js

* JSTests/stress/iterator-helpers-set-entries-exception-check.js: Added.
(shouldBe):
(throw.new.Error.set entries):
(const.callback):
(const.set new):
(const.result.set entries):
(set entries):
(throw.new.Error.const.set new):
(throw.new.Error):
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInIteratorProtocol):

Canonical link: <a href="https://commits.webkit.org/314249@main">https://commits.webkit.org/314249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cee729b9f91ef54c474ccc31a36ed809f118728f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174524 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122737 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167348 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128597 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90524 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168441 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30910 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109122 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29954 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28587 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22602 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157639 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139849 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177048 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26375 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29957 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136922 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136858 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36902 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102119 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32130 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25034 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111313 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37636 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3114 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37882 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->