### PR TITLE
[Yarr] Change Yarr m_matches / m_ranges / m_matchesUnicode / m_rangesUnicode ranges

### DIFF
--- a/JSTests/stress/regexp-character-class-latin1-boundary.js
+++ b/JSTests/stress/regexp-character-class-latin1-boundary.js
@@ -1,0 +1,126 @@
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(message + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+function repeat(fn) {
+    for (let i = 0; i < testLoopCount; ++i)
+        fn();
+}
+
+repeat(() => {
+    shouldBe(/abc/i.test("ABC"), true, "ASCII /i positive");
+    shouldBe(/abc/i.test("abd"), false, "ASCII /i negative");
+});
+
+repeat(() => {
+    shouldBe(/à/i.test("À"), true, "à/i matches À");
+    shouldBe(/À/i.test("à"), true, "À/i matches à");
+    shouldBe(/[À-Þ]/i.test("é"), true, "[À-Þ]/i matches é");
+    shouldBe(/[À-Þ]/.test("é"), false, "[À-Þ] does not match é");
+});
+
+repeat(() => {
+    shouldBe(/[þÿ]/.test("þ"), true, "0xFE in [0xFE,0xFF]");
+    shouldBe(/[þÿ]/.test("ÿ"), true, "0xFF in [0xFE,0xFF]");
+    shouldBe(/[þÿ]/.test("Ā"), false, "0x100 not in [0xFE,0xFF]");
+    shouldBe(/Ā/.test("Ā"), true, "literal 0x100");
+    shouldBe(/[Ā-ſ]/.test("ŝ"), true, "non-Latin-1 range matches");
+    shouldBe(/[Ā-ſ]/.test("ÿ"), false, "non-Latin-1 range excludes 0xFF");
+    shouldBe(/[ð-Đ]/.test("ÿ"), true, "boundary-crossing range, Latin-1 side");
+    shouldBe(/[ð-Đ]/.test("Ā"), true, "boundary-crossing range, non-Latin-1 side");
+    shouldBe(/[ð-Đ]/.test(""), false, "boundary-crossing range below");
+    shouldBe(/[ð-Đ]/.test("đ"), false, "boundary-crossing range above");
+});
+
+repeat(() => {
+    shouldBe(/ÿ/i.test("ÿ"), true, "ÿ/i matches ÿ");
+    shouldBe(/ÿ/i.test("Ÿ"), true, "ÿ/i matches Ÿ");
+    shouldBe(/Ÿ/i.test("ÿ"), true, "Ÿ/i matches ÿ");
+    shouldBe(/Ÿ/iu.test("ÿ"), true, "Ÿ/iu matches ÿ");
+});
+
+repeat(() => {
+    shouldBe(/µ/i.test("µ"), true, "µ/i matches µ");
+    shouldBe(/µ/i.test("Μ"), true, "µ/i matches Μ");
+    shouldBe(/µ/i.test("μ"), true, "µ/i matches μ");
+    shouldBe(/Μ/i.test("µ"), true, "Μ/i matches µ");
+});
+
+repeat(() => {
+    shouldBe(/ß/i.test("ß"), true, "ß/i matches ß");
+    shouldBe(/ß/i.test("S"), false, "ß/i does not match S in UCS2");
+    shouldBe(/ß/i.test("s"), false, "ß/i does not match s in UCS2");
+    shouldBe(/ß/iu.test("ẞ"), true, "ß/iu matches U+1E9E");
+});
+
+repeat(() => {
+    shouldBe(/abcd|wxyz/i.test("AbCd"), true, "masked /i alt 1");
+    shouldBe(/abcd|wxyz/i.test("WxYz"), true, "masked /i alt 2");
+    shouldBe(/abcd|wxyz/i.test("abce"), false, "masked /i no match");
+    shouldBe(/abcd|wxyz/i.test("ééAbCdé"), true, "masked /i with Latin-1 surrounding");
+});
+
+repeat(() => {
+    shouldBe(/./.test("a"), true, ". matches a");
+    shouldBe(/./.test("é"), true, ". matches é");
+    shouldBe(/./.test("ÿ"), true, ". matches ÿ");
+    shouldBe(/./.test("Ā"), true, ". matches 0x100");
+    shouldBe(/./.test("\n"), false, ". does not match newline");
+});
+
+repeat(() => {
+    shouldBe(/[^a]/.test("é"), true, "[^a] matches é");
+    shouldBe(/[^abc]/.test("a"), false, "[^abc] does not match a");
+    shouldBe(/[^a-z]/.test("é"), true, "[^a-z] matches é");
+    shouldBe(/[^Ā-ſ]/.test("é"), true, "inverted non-Latin-1 range");
+    shouldBe(/[^à-ÿ]/.test("ÿ"), false, "inverted Latin-1 range rejects ÿ");
+    shouldBe(/[^à-ÿ]/.test("Ā"), true, "inverted Latin-1 range accepts 0x100");
+});
+
+repeat(() => {
+    shouldBe(/\w/.test("é"), false, "\\w legacy");
+    shouldBe(/\W/.test("é"), true, "\\W legacy");
+    shouldBe(/\s/.test(" "), true, "\\s NBSP");
+    shouldBe(/\d/.test("5"), true, "\\d");
+    shouldBe(/\D/.test("é"), true, "\\D");
+});
+
+repeat(() => {
+    shouldBe(/\p{L}/u.test("é"), true, "/u \\p{L} é");
+    shouldBe(/\p{L}/u.test("a"), true, "/u \\p{L} a");
+    shouldBe(/\p{L}/u.test("5"), false, "/u \\p{L} digit");
+    shouldBe(/\p{L}/u.test("Ā"), true, "/u \\p{L} 0x100");
+});
+
+repeat(() => {
+    shouldBe(/[\p{L}--\p{ASCII}]/v.test("é"), true, "/v [L--ASCII] é");
+    shouldBe(/[\p{L}--\p{ASCII}]/v.test("a"), false, "/v [L--ASCII] a");
+    shouldBe(/[\p{L}--\p{ASCII}]/v.test("Ā"), true, "/v [L--ASCII] non-Latin-1");
+    shouldBe(/[\p{L}&&\p{ASCII}]/v.test("a"), true, "/v [L&&ASCII] a");
+    shouldBe(/[\p{L}&&\p{ASCII}]/v.test("é"), false, "/v [L&&ASCII] é");
+});
+
+repeat(() => {
+    shouldBe(/[éŸ]/.test("é"), true, "mixed class Char16 Latin-1 hit");
+    shouldBe(/[éŸ]/.test("Ÿ"), true, "mixed class Char16 non-Latin-1 hit");
+    shouldBe(/[éŸ]/.test("e"), false, "mixed class miss");
+});
+
+repeat(() => {
+    shouldBe(/[éŸ]/.test("abcé"), true, "Char8 input hits Latin-1 entry");
+    shouldBe(/[éŸ]/.test("abcdef"), false, "Char8 input misses");
+});
+
+repeat(() => {
+    let m = /[À-Þ]+/i.exec("aAbBÀàÁxy");
+    shouldBe(m !== null, true, "Latin-1 alpha range exec exists");
+    shouldBe(m[0], "ÀàÁ", "Latin-1 alpha range match");
+    shouldBe(m.index, 4, "Latin-1 alpha range index");
+});
+
+repeat(() => {
+    shouldBe(/[^\p{ASCII}]/u.test("a"), false, "/u [^ASCII] a");
+    shouldBe(/[^\p{ASCII}]/u.test("é"), true, "/u [^ASCII] é");
+    shouldBe(/[^\p{ASCII}]/u.test("Ā"), true, "/u [^ASCII] 0x100");
+});

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -550,36 +550,36 @@ public:
 
         const size_t thresholdForBinarySearch = 6;
 
-        if (!isASCII(ch)) {
-            if (characterClass->m_matchesUnicode.size()) {
-                if (characterClass->m_matchesUnicode.size() > thresholdForBinarySearch) {
-                    if (binarySearchMatches(characterClass->m_matchesUnicode))
+        if (!isLatin1(ch)) {
+            if (characterClass->m_matches32.size()) {
+                if (characterClass->m_matches32.size() > thresholdForBinarySearch) {
+                    if (binarySearchMatches(characterClass->m_matches32))
                         return true;
-                } else if (linearSearchMatches(characterClass->m_matchesUnicode))
+                } else if (linearSearchMatches(characterClass->m_matches32))
                     return true;
             }
 
-            if (characterClass->m_rangesUnicode.size()) {
-                if (characterClass->m_rangesUnicode.size() > thresholdForBinarySearch) {
-                    if (binarySearchRanges(characterClass->m_rangesUnicode))
+            if (characterClass->m_ranges32.size()) {
+                if (characterClass->m_ranges32.size() > thresholdForBinarySearch) {
+                    if (binarySearchRanges(characterClass->m_ranges32))
                         return true;
-                } else if (linearSearchRanges(characterClass->m_rangesUnicode))
+                } else if (linearSearchRanges(characterClass->m_ranges32))
                     return true;
             }
         } else {
-            if (characterClass->m_matches.size()) {
-                if (characterClass->m_matches.size() > thresholdForBinarySearch) {
-                    if (binarySearchMatches(characterClass->m_matches))
+            if (characterClass->m_matches8.size()) {
+                if (characterClass->m_matches8.size() > thresholdForBinarySearch) {
+                    if (binarySearchMatches(characterClass->m_matches8))
                         return true;
-                } else if (linearSearchMatches(characterClass->m_matches))
+                } else if (linearSearchMatches(characterClass->m_matches8))
                     return true;
             }
 
-            if (characterClass->m_ranges.size()) {
-                if (characterClass->m_ranges.size() > thresholdForBinarySearch) {
-                    if (binarySearchRanges(characterClass->m_ranges))
+            if (characterClass->m_ranges8.size()) {
+                if (characterClass->m_ranges8.size() > thresholdForBinarySearch) {
+                    if (binarySearchRanges(characterClass->m_ranges8))
                         return true;
-                } else if (linearSearchRanges(characterClass->m_ranges))
+                } else if (linearSearchRanges(characterClass->m_ranges8))
                     return true;
             }
         }

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -338,16 +338,16 @@ public:
     {
         // Don't handle inverted classes or classes with ranges for now
         // Only handle simple character sets like [acg] or [cgt]
-        if (charClass.m_matches.isEmpty())
+        if (charClass.m_matches8.isEmpty())
             return false;
-        if (!charClass.m_ranges.isEmpty())
+        if (!charClass.m_ranges8.isEmpty())
             return false;
-        if (!charClass.m_matchesUnicode.isEmpty() || !charClass.m_rangesUnicode.isEmpty())
+        if (!charClass.m_matches32.isEmpty() || !charClass.m_ranges32.isEmpty())
             return false;
 
         // Collect all characters (and their case variants if ignoreCase)
         Vector<uint8_t, 32> chars;
-        for (char32_t ch : charClass.m_matches) {
+        for (char32_t ch : charClass.m_matches8) {
             if (!isASCII(ch))
                 return false; // ASCII only
 
@@ -1141,10 +1141,15 @@ class YarrGenerator final : public YarrJITInfo {
 
         Vector<char32_t, 32> unifiedMatches;
         Vector<CharacterRange, 32> unifiedRanges;
-        unifiedMatches.appendVector(charClass->m_matches);
-        unifiedMatches.appendVector(charClass->m_matchesUnicode);
-        unifiedRanges.appendVector(charClass->m_ranges);
-        unifiedRanges.appendVector(charClass->m_rangesUnicode);
+        unifiedMatches.appendVector(charClass->m_matches8);
+        unifiedRanges.appendVector(charClass->m_ranges8);
+        // m_matches32 / m_ranges32 hold non-Latin-1 entries (>= 0x100). For Char8
+        // input the character register can only ever hold a value <= 0xff, so those entries
+        // are unreachable — skip them to avoid emitting dead compares.
+        if (m_charSize != CharSize::Char8) {
+            unifiedMatches.appendVector(charClass->m_matches32);
+            unifiedRanges.appendVector(charClass->m_ranges32);
+        }
 
         ASSERT(std::is_sorted(unifiedMatches.begin(), unifiedMatches.end(), [](auto& lhs, auto& rhs) {
             return lhs < rhs;
@@ -1185,9 +1190,13 @@ class YarrGenerator final : public YarrJITInfo {
 #endif
             if (term->invert())
                 matchCharacterClass(character, scratch, failures, characterClassToProcess);
-            else if (characterClassToProcess->m_matches.isEmpty() && characterClassToProcess->m_matchesUnicode.isEmpty()
-                && (characterClassToProcess->m_ranges.size() + characterClassToProcess->m_rangesUnicode.size()) == 1) {
-                matchCharacterClassOnlyOneRange(character, scratch, failures, characterClassToProcess->m_ranges.size() ? characterClassToProcess->m_ranges : characterClassToProcess->m_rangesUnicode);
+            else if (characterClassToProcess->m_matches8.isEmpty() && characterClassToProcess->m_matches32.isEmpty()
+                && (characterClassToProcess->m_ranges8.size() + characterClassToProcess->m_ranges32.size()) == 1) {
+                if (m_charSize == CharSize::Char8 && characterClassToProcess->m_ranges8.isEmpty()) {
+                    // The sole range is in m_ranges32 (>= 0x100), unreachable for Char8 input.
+                    failures.append(m_jit.jump());
+                } else
+                    matchCharacterClassOnlyOneRange(character, scratch, failures, characterClassToProcess->m_ranges8.size() ? characterClassToProcess->m_ranges8 : characterClassToProcess->m_ranges32);
             } else {
                 MacroAssembler::JumpList matchDest;
                 // If we are matching the "any character" builtin class for non-unicode patterns,
@@ -1201,13 +1210,7 @@ class YarrGenerator final : public YarrJITInfo {
             }
         };
 
-        if (m_charSize == CharSize::Char8) {
-            CharacterClass characterClass8Bit;
-
-            characterClass8Bit.copyOnly8BitCharacterData(*term->characterClass);
-            processCharacterClass(&characterClass8Bit);
-        } else
-            processCharacterClass(term->characterClass);
+        processCharacterClass(term->characterClass);
 
         // Note that this falls through on a successful characterClass match.
     }
@@ -1344,8 +1347,8 @@ class YarrGenerator final : public YarrJITInfo {
         MacroAssembler::JumpList& failures)
     {
         ASSERT(m_charSize == CharSize::Char16);
-        ASSERT(trailsOnlyClass->m_matches.isEmpty());
-        ASSERT(trailsOnlyClass->m_ranges.isEmpty());
+        ASSERT(trailsOnlyClass->m_matches8.isEmpty());
+        ASSERT(trailsOnlyClass->m_ranges8.isEmpty());
 
         MacroAssembler::BaseIndex address = negativeOffsetIndexedAddress(negativeCharacterOffset, character, indexReg);
         m_jit.getEffectiveAddress(address, m_regs.regUnicodeInputAndTrail);
@@ -1357,8 +1360,8 @@ class YarrGenerator final : public YarrJITInfo {
         // into each cmp — no separate and+cmp+lsr needed. ARM64's cached-temp
         // tracker emits movk-only updates between consecutive compares since only
         // the upper 16 bits change.
-        if (trailsOnlyClass->m_rangesUnicode.isEmpty() && !trailsOnlyClass->m_matchesUnicode.isEmpty()) {
-            const auto& matches = trailsOnlyClass->m_matchesUnicode;
+        if (trailsOnlyClass->m_ranges32.isEmpty() && !trailsOnlyClass->m_matches32.isEmpty()) {
+            const auto& matches = trailsOnlyClass->m_matches32;
 #if CPU(ARM64)
             // For 2+ matches, fold the chain into cmp + ccmp(NE, Z=1) ... + b.ne.
             // ccmp keeps the EQ flag sticky once any compare matches, so the
@@ -1390,8 +1393,8 @@ class YarrGenerator final : public YarrJITInfo {
 
         // Fast path for a single trail-only range (e.g., FlushRegExp's [0xa1-0xae]):
         // emit a single sub+cmp+b.hi straight to outer failures with no trampolines.
-        if (trailsOnlyClass->m_matchesUnicode.isEmpty() && trailsOnlyClass->m_rangesUnicode.size() == 1) {
-            const auto& range = trailsOnlyClass->m_rangesUnicode[0];
+        if (trailsOnlyClass->m_matches32.isEmpty() && trailsOnlyClass->m_ranges32.size() == 1) {
+            const auto& range = trailsOnlyClass->m_ranges32[0];
 #if CPU(ARM64)
             // Fold the lead-check and range-check into a single conditional branch
             // via ccmp. Saves one instruction and one branch per inner iteration.
@@ -1433,20 +1436,20 @@ class YarrGenerator final : public YarrJITInfo {
 
     static void buildTrailsOnlyClass(const CharacterClass& source, CharacterClass& dest)
     {
-        for (auto cp : source.m_matchesUnicode) {
+        for (auto cp : source.m_matches32) {
             ASSERT(!U_IS_BMP(cp));
-            dest.m_matchesUnicode.append(U16_TRAIL(cp));
+            dest.m_matches32.append(U16_TRAIL(cp));
         }
 
-        for (auto& range : source.m_rangesUnicode) {
+        for (auto& range : source.m_ranges32) {
             ASSERT(!U_IS_BMP(range.begin));
             ASSERT(!U_IS_BMP(range.end));
             char32_t trailBegin = U16_TRAIL(range.begin);
             char32_t trailEnd = U16_TRAIL(range.end);
-            dest.m_rangesUnicode.append(CharacterRange(trailBegin, trailEnd));
+            dest.m_ranges32.append(CharacterRange(trailBegin, trailEnd));
         }
-        std::ranges::sort(dest.m_matchesUnicode);
-        std::ranges::sort(dest.m_rangesUnicode, [](auto& a, auto& b) { return a.begin < b.begin; });
+        std::ranges::sort(dest.m_matches32);
+        std::ranges::sort(dest.m_ranges32, [](auto& a, auto& b) { return a.begin < b.begin; });
     }
 #endif
 
@@ -6054,14 +6057,14 @@ class YarrGenerator final : public YarrJITInfo {
                     bmInfo.shortenLength(cursor + 1);
                 return cursor;
             }
-            if (!characterClass.m_rangesUnicode.isEmpty())
-                bmInfo.addRanges(cursor, characterClass.m_rangesUnicode);
-            if (!characterClass.m_matchesUnicode.isEmpty())
-                bmInfo.addCharacters(cursor, characterClass.m_matchesUnicode);
-            if (!characterClass.m_ranges.isEmpty())
-                bmInfo.addRanges(cursor, characterClass.m_ranges);
-            if (!characterClass.m_matches.isEmpty())
-                bmInfo.addCharacters(cursor, characterClass.m_matches);
+            if (!characterClass.m_ranges32.isEmpty())
+                bmInfo.addRanges(cursor, characterClass.m_ranges32);
+            if (!characterClass.m_matches32.isEmpty())
+                bmInfo.addCharacters(cursor, characterClass.m_matches32);
+            if (!characterClass.m_ranges8.isEmpty())
+                bmInfo.addRanges(cursor, characterClass.m_ranges8);
+            if (!characterClass.m_matches8.isEmpty())
+                bmInfo.addCharacters(cursor, characterClass.m_matches8);
 
             // If this is greedy one-character pattern "a?", we should not increase cursor.
             // If we see greedy pattern, then we cut bmInfo here to avoid possibility explosion.

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -60,10 +60,10 @@ public:
     void reset()
     {
         m_strings.clear();
-        m_matches.clear();
-        m_ranges.clear();
-        m_matchesUnicode.clear();
-        m_rangesUnicode.clear();
+        m_matches8.clear();
+        m_ranges8.clear();
+        m_matches32.clear();
+        m_ranges32.clear();
         m_setOp = CharacterClassSetOp::Default;
         m_anyCharacter = false;
         m_mayContainStrings = false;
@@ -86,14 +86,14 @@ public:
 
         for (size_t i = 0; i < other->m_strings.size(); ++i)
             m_strings.append(other->m_strings[i]);
-        for (size_t i = 0; i < other->m_matches.size(); ++i)
-            addSorted(m_matches, other->m_matches[i]);
-        for (size_t i = 0; i < other->m_ranges.size(); ++i)
-            addSortedRange(m_ranges, other->m_ranges[i].begin, other->m_ranges[i].end);
-        for (size_t i = 0; i < other->m_matchesUnicode.size(); ++i)
-            addSorted(m_matchesUnicode, other->m_matchesUnicode[i]);
-        for (size_t i = 0; i < other->m_rangesUnicode.size(); ++i)
-            addSortedRange(m_rangesUnicode, other->m_rangesUnicode[i].begin, other->m_rangesUnicode[i].end);
+        for (size_t i = 0; i < other->m_matches8.size(); ++i)
+            addSorted(m_matches8, other->m_matches8[i]);
+        for (size_t i = 0; i < other->m_ranges8.size(); ++i)
+            addSortedRange(m_ranges8, other->m_ranges8[i].begin, other->m_ranges8[i].end);
+        for (size_t i = 0; i < other->m_matches32.size(); ++i)
+            addSorted(m_matches32, other->m_matches32[i]);
+        for (size_t i = 0; i < other->m_ranges32.size(); ++i)
+            addSortedRange(m_ranges32, other->m_ranges32[i].begin, other->m_ranges32[i].end);
         m_mayContainStrings |= other->hasStrings();
     }
 
@@ -153,8 +153,8 @@ public:
             m_invertedStrings = true;
         }
 
-        addSortedInverted(0, 0x7f, other->m_matches, other->m_ranges, m_matches, m_ranges);
-        addSortedInverted(0x80, UCHAR_MAX_VALUE, other->m_matchesUnicode, other->m_rangesUnicode, m_matchesUnicode, m_rangesUnicode);
+        addSortedInverted(0, 0xff, other->m_matches8, other->m_ranges8, m_matches8, m_ranges8);
+        addSortedInverted(0x100, UCHAR_MAX_VALUE, other->m_matches32, other->m_ranges32, m_matches32, m_ranges32);
     }
 
     void putChar(char32_t ch)
@@ -170,10 +170,10 @@ public:
         if (m_canonicalMode == CanonicalMode::UCS2 && isASCII(ch)) {
             // Handle ASCII cases.
             if (isASCIIAlpha(ch)) {
-                addSorted(m_matches, toASCIIUpper(ch));
-                addSorted(m_matches, toASCIILower(ch));
+                addSorted(m_matches8, toASCIIUpper(ch));
+                addSorted(m_matches8, toASCIILower(ch));
             } else
-                addSorted(m_matches, ch);
+                addSorted(m_matches8, ch);
             return;
         }
 
@@ -187,22 +187,22 @@ public:
 
     void putCharNonUnion(char32_t ch)
     {
-        Vector<char32_t> asciiMatches;
-        Vector<char32_t> unicodeMatches;
+        Vector<char32_t> matches8;
+        Vector<char32_t> matches32;
         Vector<CharacterRange> emptyRanges;
 
         if (m_setOp == CharacterClassSetOp::Intersection)
             m_strings.clear();
 
         auto addChar = [&] (char32_t ch) {
-            if (isASCII(ch))
-                asciiMatches.append(ch);
+            if (isLatin1(ch))
+                matches8.append(ch);
             else
-                unicodeMatches.append(ch);
+                matches32.append(ch);
         };
 
         auto performOp = [&] () {
-            performSetOpWithMatches(asciiMatches, emptyRanges, unicodeMatches, emptyRanges);
+            performSetOpWithMatches(matches8, emptyRanges, matches32, emptyRanges);
         };
 
         if (!m_isCaseInsensitive) {
@@ -255,24 +255,25 @@ public:
 
     void putRange(char32_t lo, char32_t hi)
     {
+        // This is ASCII-case-folding fast path. So intentionally using isASCII (not isLatin1).
         if (isASCII(lo)) {
             char asciiLo = lo;
             char asciiHi = std::min<char32_t>(hi, 0x7f);
-            addSortedRange(m_ranges, lo, asciiHi);
+            addSortedRange(lo, asciiHi);
 
             if (m_isCaseInsensitive) {
                 if ((asciiLo <= 'Z') && (asciiHi >= 'A'))
-                    addSortedRange(m_ranges, std::max(asciiLo, 'A')+('a'-'A'), std::min(asciiHi, 'Z')+('a'-'A'));
+                    addSortedRange(std::max(asciiLo, 'A')+('a'-'A'), std::min(asciiHi, 'Z')+('a'-'A'));
                 if ((asciiLo <= 'z') && (asciiHi >= 'a'))
-                    addSortedRange(m_ranges, std::max(asciiLo, 'a')+('A'-'a'), std::min(asciiHi, 'z')+('A'-'a'));
+                    addSortedRange(std::max(asciiLo, 'a')+('A'-'a'), std::min(asciiHi, 'z')+('A'-'a'));
             }
         }
         if (isASCII(hi))
             return;
 
         lo = std::max<char32_t>(lo, 0x80);
-        addSortedRange(m_rangesUnicode, lo, hi);
-        
+        addSortedRange(lo, hi);
+
         if (!m_isCaseInsensitive)
             return;
 
@@ -324,17 +325,17 @@ public:
     void atomClassStringDisjunction(Vector<Vector<char32_t>>& disjunctionStrings)
     {
         Vector<Vector<char32_t>> utf32Strings;
-        Vector<char32_t> matches;
-        Vector<char32_t> matchesUnicode;
+        Vector<char32_t> matches8;
+        Vector<char32_t> matches32;
         Vector<CharacterRange> emptyRanges;
 
         sort(disjunctionStrings);
 
         auto addCh = [&](char32_t ch) {
-            if (isASCII(ch))
-                matches.append(ch);
+            if (isLatin1(ch))
+                matches8.append(ch);
             else
-                matchesUnicode.append(ch);
+                matches32.append(ch);
         };
 
         for (auto string : disjunctionStrings) {
@@ -365,7 +366,7 @@ public:
         }
 
         performSetOpWithStrings(utf32Strings);
-        performSetOpWithMatches(matches, emptyRanges, matchesUnicode, emptyRanges);
+        performSetOpWithMatches(matches8, emptyRanges, matches32, emptyRanges);
     }
 
     void invertMatches()
@@ -373,20 +374,20 @@ public:
         if (!m_strings.isEmpty())
             m_invertedStrings = true;
 
-        asciiInvert();
-        unicodeInvert();
+        latin1Invert();
+        nonLatin1Invert();
     }
 
     void performSetOpWith(CharacterClassConstructor* rhs)
     {
         performSetOpWithStrings(rhs->m_strings);
-        performSetOpWithMatches(rhs->m_matches, rhs->m_ranges, rhs->m_matchesUnicode, rhs->m_rangesUnicode);
+        performSetOpWithMatches(rhs->m_matches8, rhs->m_ranges8, rhs->m_matches32, rhs->m_ranges32);
     }
 
     void performSetOpWith(const CharacterClass* rhs)
     {
         performSetOpWithStrings(rhs->m_strings);
-        performSetOpWithMatches(rhs->m_matches, rhs->m_ranges, rhs->m_matchesUnicode, rhs->m_rangesUnicode);
+        performSetOpWithMatches(rhs->m_matches8, rhs->m_ranges8, rhs->m_matches32, rhs->m_ranges32);
     }
 
     void performSetOpWithStrings(const Vector<Vector<char32_t>>& utf32Strings)
@@ -410,18 +411,18 @@ public:
         }
     }
 
-    void performSetOpWithMatches(const Vector<char32_t>& rhsMatches, const Vector<CharacterRange>& rhsRanges, const Vector<char32_t>& rhsMatchesUnicode, const Vector<CharacterRange>& rhsRangesUnicode)
+    void performSetOpWithMatches(const Vector<char32_t>& rhsMatches8, const Vector<CharacterRange>& rhsRanges8, const Vector<char32_t>& rhsMatches32, const Vector<CharacterRange>& rhsRanges32)
     {
         if (m_compileMode != CompileMode::UnicodeSets)
             return;
 
-        asciiOp(rhsMatches, rhsRanges);
-        // Sort the incoming Unicode matches, since Unicode case folding canonicalization may cause
-        // characters to be added to rhsMatches out of code point order.
-        Vector<char32_t> rhsSortedMatchesUnicode(rhsMatchesUnicode);
-        std::ranges::sort(rhsSortedMatchesUnicode);
+        latin1Op(rhsMatches8, rhsRanges8);
+        // Sort the incoming non-Latin-1 matches, since Unicode case folding canonicalization may cause
+        // characters to be added to rhsMatches32 out of code point order.
+        Vector<char32_t> rhsSortedMatches32(rhsMatches32);
+        std::ranges::sort(rhsSortedMatches32);
 
-        unicodeOpSorted(rhsSortedMatchesUnicode, rhsRangesUnicode);
+        nonLatin1OpSorted(rhsSortedMatches32, rhsRanges32);
     }
 
     bool NODELETE hasInvertedStrings()
@@ -464,10 +465,10 @@ public:
         auto characterClass = makeUnique<CharacterClass>();
 
         characterClass->m_strings.swap(m_strings);
-        characterClass->m_matches.swap(m_matches);
-        characterClass->m_ranges.swap(m_ranges);
-        characterClass->m_matchesUnicode.swap(m_matchesUnicode);
-        characterClass->m_rangesUnicode.swap(m_rangesUnicode);
+        characterClass->m_matches8.swap(m_matches8);
+        characterClass->m_ranges8.swap(m_ranges8);
+        characterClass->m_matches32.swap(m_matches32);
+        characterClass->m_ranges32.swap(m_ranges32);
         characterClass->m_anyCharacter = anyCharacter();
         characterClass->m_characterWidths = characterWidths();
 
@@ -485,7 +486,7 @@ public:
 private:
     void addSorted(char32_t ch)
     {
-        addSorted(isASCII(ch) ? m_matches : m_matchesUnicode, ch);
+        addSorted(isLatin1(ch) ? m_matches8 : m_matches32, ch);
     }
 
     void addSorted(Vector<char32_t>& matches, char32_t ch)
@@ -511,7 +512,7 @@ private:
                         lo = ch - 1;
                         matches.removeAt(pos + index - 1);
                     }
-                    addSortedRange(isASCII(ch) ? m_ranges : m_rangesUnicode, lo, hi);
+                    addSortedRange(isLatin1(ch) ? m_ranges8 : m_ranges32, lo, hi);
                     return;
                 }
                 range = index;
@@ -524,7 +525,7 @@ private:
                         hi = ch + 1;
                         matches.removeAt(pos + index + 1);
                     }
-                    addSortedRange(isASCII(ch) ? m_ranges : m_rangesUnicode, lo, hi);
+                    addSortedRange(isLatin1(ch) ? m_ranges8 : m_ranges32, lo, hi);
                     return;
                 }
                 pos += (index+1);
@@ -580,13 +581,27 @@ private:
 
     void addSortedRange(char32_t lo, char32_t hi)
     {
-        if (isASCII(lo)) {
-            addSortedRange(m_ranges, lo, std::min<char32_t>(hi, 0x7f));
-            if (isASCII(hi))
-                return;
-            lo = 0x80;
+        if (lo == hi) {
+            addSorted(lo);
+            return;
         }
-        addSortedRange(m_rangesUnicode, lo, hi);
+
+        if (isLatin1(lo)) {
+            auto latin1Hi = std::min<char32_t>(hi, 0xff);
+            if (lo == latin1Hi)
+                addSorted(m_matches8, lo);
+            else
+                addSortedRange(m_ranges8, lo, latin1Hi);
+
+            if (isLatin1(hi))
+                return;
+            lo = 0x100;
+            if (lo == hi) {
+                addSorted(m_matches32, hi);
+                return;
+            }
+        }
+        addSortedRange(m_ranges32, lo, hi);
     }
 
     void mergeRangesFrom(Vector<CharacterRange>& ranges, size_t index)
@@ -694,41 +709,41 @@ private:
         m_mayContainStrings = !m_strings.isEmpty();
     }
 
-    void asciiOp(const Vector<char32_t>& rhsMatches, const Vector<CharacterRange>& rhsRanges)
+    void latin1Op(const Vector<char32_t>& rhsMatches, const Vector<CharacterRange>& rhsRanges)
     {
         Vector<char32_t> resultMatches;
         Vector<CharacterRange> resultRanges;
-        WTF::BitSet<0x80> lhsASCIIBitSet;
-        WTF::BitSet<0x80> rhsASCIIBitSet;
+        WTF::BitSet<0x100> lhsLatin1BitSet;
+        WTF::BitSet<0x100> rhsLatin1BitSet;
 
-        for (auto match : m_matches)
-            lhsASCIIBitSet.set(match);
+        for (auto match : m_matches8)
+            lhsLatin1BitSet.set(match);
 
-        for (auto range : m_ranges) {
+        for (auto range : m_ranges8) {
             for (char32_t ch = range.begin; ch <= range.end; ch++)
-                lhsASCIIBitSet.set(ch);
+                lhsLatin1BitSet.set(ch);
         }
 
         for (auto match : rhsMatches)
-            rhsASCIIBitSet.set(match);
+            rhsLatin1BitSet.set(match);
 
         for (auto range : rhsRanges) {
             for (char32_t ch = range.begin; ch <= range.end; ch++)
-                rhsASCIIBitSet.set(ch);
+                rhsLatin1BitSet.set(ch);
         }
 
         switch (m_setOp) {
         case CharacterClassSetOp::Default:
         case CharacterClassSetOp::Union:
-            lhsASCIIBitSet.merge(rhsASCIIBitSet);
+            lhsLatin1BitSet.merge(rhsLatin1BitSet);
             break;
 
         case CharacterClassSetOp::Intersection:
-            lhsASCIIBitSet.filter(rhsASCIIBitSet);
+            lhsLatin1BitSet.filter(rhsLatin1BitSet);
             break;
 
         case CharacterClassSetOp::Subtraction:
-            lhsASCIIBitSet.exclude(rhsASCIIBitSet);
+            lhsLatin1BitSet.exclude(rhsLatin1BitSet);
             break;
         }
 
@@ -743,7 +758,7 @@ private:
                 resultRanges.append(CharacterRange(lo, hi));
         };
 
-        for (auto setVal : lhsASCIIBitSet) {
+        for (auto setVal : lhsLatin1BitSet) {
             char32_t ch = setVal;
             if (firstCharUnset) {
                 lo = hi = ch;
@@ -761,25 +776,25 @@ private:
         if (!firstCharUnset)
             addCharToResults();
 
-        m_matches.swap(resultMatches);
-        m_ranges.swap(resultRanges);
+        m_matches8.swap(resultMatches);
+        m_ranges8.swap(resultRanges);
     }
 
-    void asciiInvert()
+    void latin1Invert()
     {
         Vector<char32_t> resultMatches;
         Vector<CharacterRange> resultRanges;
-        WTF::BitSet<0x80> ASCIIBitSet;
+        WTF::BitSet<0x100> latin1BitSet;
 
-        for (auto match : m_matches)
-            ASCIIBitSet.set(match);
+        for (auto match : m_matches8)
+            latin1BitSet.set(match);
 
-        for (auto range : m_ranges) {
+        for (auto range : m_ranges8) {
             for (char32_t ch = range.begin; ch <= range.end; ch++)
-                ASCIIBitSet.set(ch);
+                latin1BitSet.set(ch);
         }
 
-        ASCIIBitSet.invert();
+        latin1BitSet.invert();
 
         bool firstCharUnset = true;
         char32_t lo = 0;
@@ -792,7 +807,7 @@ private:
                 resultRanges.append(CharacterRange(lo, hi));
         };
 
-        for (auto setVal : ASCIIBitSet) {
+        for (auto setVal : latin1BitSet) {
             char32_t ch = setVal;
             if (firstCharUnset) {
                 lo = hi = ch;
@@ -810,11 +825,11 @@ private:
         if (!firstCharUnset)
             addCharToResults();
 
-        m_matches.swap(resultMatches);
-        m_ranges.swap(resultRanges);
+        m_matches8.swap(resultMatches);
+        m_ranges8.swap(resultRanges);
     }
 
-    void unicodeOpSorted(const Vector<char32_t>& rhsMatchesUnicode, const Vector<CharacterRange>& rhsRangesUnicode)
+    void nonLatin1OpSorted(const Vector<char32_t>& rhsMatches32, const Vector<CharacterRange>& rhsRanges32)
     {
         Vector<char32_t> resultMatches;
         Vector<CharacterRange> resultRanges;
@@ -830,32 +845,32 @@ private:
         size_t rhsMatchIndex = 0;
         size_t rhsRangeIndex = 0;
 
-        if (!m_matchesUnicode.isEmpty())
-            chunkLo = std::min(chunkLo, m_matchesUnicode[0]);
+        if (!m_matches32.isEmpty())
+            chunkLo = std::min(chunkLo, m_matches32[0]);
 
-        if (!m_rangesUnicode.isEmpty())
-            chunkLo = std::min(chunkLo, m_rangesUnicode[0].begin);
+        if (!m_ranges32.isEmpty())
+            chunkLo = std::min(chunkLo, m_ranges32[0].begin);
 
-        if (!rhsMatchesUnicode.isEmpty())
-            chunkLo = std::min(chunkLo, rhsMatchesUnicode[0]);
+        if (!rhsMatches32.isEmpty())
+            chunkLo = std::min(chunkLo, rhsMatches32[0]);
 
-        if (!rhsRangesUnicode.isEmpty())
-            chunkLo = std::min(chunkLo, rhsRangesUnicode[0].begin);
+        if (!rhsRanges32.isEmpty())
+            chunkLo = std::min(chunkLo, rhsRanges32[0].begin);
 
         // If both the LHS and RHS are empty, bail out.
         if (chunkLo == INT_MAX)
             return;
 
-        while (lhsMatchIndex < m_matchesUnicode.size() || lhsRangeIndex < m_rangesUnicode.size() || rhsMatchIndex < rhsMatchesUnicode.size() || rhsRangeIndex < rhsRangesUnicode.size()) {
-            if (rhsMatchIndex >= rhsMatchesUnicode.size() && rhsRangeIndex > rhsRangesUnicode.size() && m_setOp == CharacterClassSetOp::Intersection) {
+        while (lhsMatchIndex < m_matches32.size() || lhsRangeIndex < m_ranges32.size() || rhsMatchIndex < rhsMatches32.size() || rhsRangeIndex < rhsRanges32.size()) {
+            if (rhsMatchIndex >= rhsMatches32.size() && rhsRangeIndex > rhsRanges32.size() && m_setOp == CharacterClassSetOp::Intersection) {
                 // RHS is exhausted, we can short cut from here. Can't intersect anything more so bail out.
                 break;
             }
 
             chunkHi = chunkLo + chunkSize - 1;
 
-            for (; lhsMatchIndex < m_matchesUnicode.size(); ++lhsMatchIndex) {
-                char32_t ch = m_matchesUnicode[lhsMatchIndex];
+            for (; lhsMatchIndex < m_matches32.size(); ++lhsMatchIndex) {
+                char32_t ch = m_matches32[lhsMatchIndex];
                 if (ch > chunkHi)
                     break;
 
@@ -863,8 +878,8 @@ private:
                 lhsChunkBitSet.set(ch - chunkLo);
             }
 
-            for (; lhsRangeIndex < m_rangesUnicode.size(); ++lhsRangeIndex) {
-                auto range = m_rangesUnicode[lhsRangeIndex];
+            for (; lhsRangeIndex < m_ranges32.size(); ++lhsRangeIndex) {
+                auto range = m_ranges32[lhsRangeIndex];
                 if (range.begin > chunkHi)
                     break;
 
@@ -880,8 +895,8 @@ private:
                     break;
             }
 
-            for (; rhsMatchIndex < rhsMatchesUnicode.size(); ++rhsMatchIndex) {
-                char32_t ch = rhsMatchesUnicode[rhsMatchIndex];
+            for (; rhsMatchIndex < rhsMatches32.size(); ++rhsMatchIndex) {
+                char32_t ch = rhsMatches32[rhsMatchIndex];
                 if (ch > chunkHi)
                     break;
 
@@ -889,8 +904,8 @@ private:
                 rhsChunkBitSet.set(ch - chunkLo);
             }
 
-            for (; rhsRangeIndex < rhsRangesUnicode.size(); ++rhsRangeIndex) {
-                auto range = rhsRangesUnicode[rhsRangeIndex];
+            for (; rhsRangeIndex < rhsRanges32.size(); ++rhsRangeIndex) {
+                auto range = rhsRanges32[rhsRangeIndex];
                 if (range.begin > chunkHi)
                     break;
 
@@ -965,24 +980,24 @@ private:
             rhsChunkBitSet.clearAll();
         }
 
-        m_matchesUnicode.swap(resultMatches);
-        m_rangesUnicode.swap(resultRanges);
+        m_matches32.swap(resultMatches);
+        m_ranges32.swap(resultRanges);
     }
 
-    void unicodeInvert()
+    void nonLatin1Invert()
     {
         auto currentSetOp = m_setOp;
         m_setOp = CharacterClassSetOp::Subtraction;
 
         Vector<char32_t> matches { };
         Vector<CharacterRange> ranges {
-            CharacterRange(0x0080, UCHAR_MAX_VALUE)
+            CharacterRange(0x0100, UCHAR_MAX_VALUE)
         };
 
-        std::swap(m_matchesUnicode, matches);
-        std::swap(m_rangesUnicode, ranges);
+        std::swap(m_matches32, matches);
+        std::swap(m_ranges32, ranges);
 
-        unicodeOpSorted(matches, ranges);
+        nonLatin1OpSorted(matches, ranges);
 
         m_setOp = currentSetOp;
     }
@@ -1034,13 +1049,13 @@ private:
             }
         };
 
-        coalesceMatchesAndRanges(m_matches, m_ranges);
-        coalesceMatchesAndRanges(m_matchesUnicode, m_rangesUnicode);
+        coalesceMatchesAndRanges(m_matches8, m_ranges8);
+        coalesceMatchesAndRanges(m_matches32, m_ranges32);
 
-        if (!m_matches.size() && !m_matchesUnicode.size()
-            && m_ranges.size() == 1 && m_rangesUnicode.size() == 1
-            && m_ranges[0].begin == 0 && m_ranges[0].end == 0x7f
-            && m_rangesUnicode[0].begin == 0x80 && m_rangesUnicode[0].end == UCHAR_MAX_VALUE)
+        if (!m_matches8.size() && !m_matches32.size()
+            && m_ranges8.size() == 1 && m_ranges32.size() == 1
+            && m_ranges8[0].begin == 0 && m_ranges8[0].end == 0xff
+            && m_ranges32[0].begin == 0x100 && m_ranges32[0].end == UCHAR_MAX_VALUE)
             m_anyCharacter = true;
     }
 
@@ -1073,10 +1088,10 @@ private:
     CanonicalMode m_canonicalMode;
 
     Vector<Vector<char32_t>> m_strings;
-    Vector<char32_t> m_matches;
-    Vector<CharacterRange> m_ranges;
-    Vector<char32_t> m_matchesUnicode;
-    Vector<CharacterRange> m_rangesUnicode;
+    Vector<char32_t> m_matches8;
+    Vector<CharacterRange> m_ranges8;
+    Vector<char32_t> m_matches32;
+    Vector<CharacterRange> m_ranges32;
 };
 
 class YarrPatternConstructor {
@@ -2800,10 +2815,10 @@ void dumpCharacterClass(PrintStream& out, YarrPattern* pattern, CharacterClass* 
     };
 
     out.print("[");
-    dumpMatches("ASCII", characterClass->m_matches);
-    dumpRanges("ASCII", characterClass->m_ranges);
-    dumpMatches("Unicode", characterClass->m_matchesUnicode);
-    dumpRanges("Unicode", characterClass->m_rangesUnicode);
+    dumpMatches("Latin1", characterClass->m_matches8);
+    dumpRanges("Latin1", characterClass->m_ranges8);
+    dumpMatches("NonLatin1", characterClass->m_matches32);
+    dumpRanges("NonLatin1", characterClass->m_ranges32);
     out.print("]");
 }
 
@@ -3061,51 +3076,11 @@ void YarrPattern::dumpPattern(PrintStream& out, StringView patternString)
 std::unique_ptr<CharacterClass> anycharCreate()
 {
     auto characterClass = makeUnique<CharacterClass>();
-    characterClass->m_ranges.append(CharacterRange(0x00, 0x7f));
-    characterClass->m_rangesUnicode.append(CharacterRange(0x0080, UCHAR_MAX_VALUE));
+    characterClass->m_ranges8.append(CharacterRange(0x00, 0xff));
+    characterClass->m_ranges32.append(CharacterRange(0x0100, UCHAR_MAX_VALUE));
     characterClass->m_characterWidths = CharacterClassWidths::HasBothBMPAndNonBMP;
     characterClass->m_anyCharacter = true;
     return characterClass;
-}
-
-void CharacterClass::copyOnly8BitCharacterData(const CharacterClass& other)
-{
-    RELEASE_ASSERT(!m_table);
-
-    m_strings.clear();
-    m_matches.clear();
-    m_ranges.clear();
-    m_matchesUnicode.clear();
-    m_rangesUnicode.clear();
-    m_characterWidths = CharacterClassWidths::Unknown;
-    m_tableInverted = false;
-    m_anyCharacter = false;
-    m_inCanonicalForm = other.m_inCanonicalForm;
-
-    for (auto match : other.m_matches)
-        m_matches.append(match);
-
-    for (auto range : other.m_ranges)
-        m_ranges.append(range);
-
-    for (auto match : other.m_matchesUnicode) {
-        if (match <= 0xff)
-            m_matchesUnicode.append(match);
-    }
-
-    for (auto range : other.m_rangesUnicode) {
-        if (range.begin <= 0xff)
-            m_rangesUnicode.append(CharacterRange(range.begin, std::min<char32_t>(range.end, 0xff)));
-    }
-
-    m_table = other.m_table;
-    m_tableInverted = other.m_tableInverted;
-
-    if (m_matches.isEmpty() && m_matchesUnicode.isEmpty()
-        && m_ranges.size() == 1 && m_rangesUnicode.size() == 1
-        && !m_ranges[0].begin && m_rangesUnicode[0].end == 0xff
-        && m_ranges[0].end == m_rangesUnicode[0].begin - 1)
-        m_anyCharacter = true;
 }
 
 std::optional<char16_t> CharacterClass::hasSharedLeadSurrogate() const
@@ -3115,11 +3090,11 @@ std::optional<char16_t> CharacterClass::hasSharedLeadSurrogate() const
     if (!m_strings.isEmpty())
         return std::nullopt;
 
-    ASSERT(m_matches.isEmpty());
-    ASSERT(m_ranges.isEmpty());
+    ASSERT(m_matches8.isEmpty());
+    ASSERT(m_ranges8.isEmpty());
 
     std::optional<char16_t> commonLeadSurrogate;
-    for (auto cp : m_matchesUnicode) {
+    for (auto cp : m_matches32) {
         ASSERT(!U_IS_BMP(cp));
         char16_t leadSurrogate = U16_LEAD(cp);
         if (!commonLeadSurrogate)
@@ -3128,7 +3103,7 @@ std::optional<char16_t> CharacterClass::hasSharedLeadSurrogate() const
             return std::nullopt;
     }
 
-    for (auto& range : m_rangesUnicode) {
+    for (auto& range : m_ranges32) {
         ASSERT(!U_IS_BMP(range.begin));
         ASSERT(!U_IS_BMP(range.end));
         char16_t leadSurrogateBegin = U16_LEAD(range.begin);

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -106,11 +106,11 @@ public:
     {
     }
 
-    CharacterClass(std::initializer_list<char32_t> matches, std::initializer_list<CharacterRange> ranges, std::initializer_list<char32_t> matchesUnicode, std::initializer_list<CharacterRange> rangesUnicode, CharacterClassWidths widths)
-        : m_matches(matches)
-        , m_ranges(ranges)
-        , m_matchesUnicode(matchesUnicode)
-        , m_rangesUnicode(rangesUnicode)
+    CharacterClass(std::initializer_list<char32_t> matches8, std::initializer_list<CharacterRange> ranges8, std::initializer_list<char32_t> matches32, std::initializer_list<CharacterRange> ranges32, CharacterClassWidths widths)
+        : m_matches8(matches8)
+        , m_ranges8(ranges8)
+        , m_matches32(matches32)
+        , m_ranges32(ranges32)
         , m_table(nullptr)
         , m_characterWidths(widths)
         , m_tableInverted(false)
@@ -118,12 +118,12 @@ public:
     {
     }
 
-    CharacterClass(std::initializer_list<Vector<char32_t>> strings, std::initializer_list<char32_t> matches, std::initializer_list<CharacterRange> ranges, std::initializer_list<char32_t> matchesUnicode, std::initializer_list<CharacterRange> rangesUnicode, CharacterClassWidths widths, bool inCanonicalForm)
+    CharacterClass(std::initializer_list<Vector<char32_t>> strings, std::initializer_list<char32_t> matches8, std::initializer_list<CharacterRange> ranges8, std::initializer_list<char32_t> matches32, std::initializer_list<CharacterRange> ranges32, CharacterClassWidths widths, bool inCanonicalForm)
         : m_strings(strings)
-        , m_matches(matches)
-        , m_ranges(ranges)
-        , m_matchesUnicode(matchesUnicode)
-        , m_rangesUnicode(rangesUnicode)
+        , m_matches8(matches8)
+        , m_ranges8(ranges8)
+        , m_matches32(matches32)
+        , m_ranges32(ranges32)
         , m_table(nullptr)
         , m_characterWidths(widths)
         , m_tableInverted(false)
@@ -132,22 +132,20 @@ public:
     {
     }
 
-    void copyOnly8BitCharacterData(const CharacterClass& other);
-
     bool NODELETE hasNonBMPCharacters() const { return m_characterWidths & CharacterClassWidths::HasNonBMPChars; }
 
     bool hasOneCharacterSize() const { return m_characterWidths == CharacterClassWidths::HasBMPChars || m_characterWidths == CharacterClassWidths::HasNonBMPChars; }
     bool hasOnlyNonBMPCharacters() const { return m_characterWidths == CharacterClassWidths::HasNonBMPChars; }
     bool hasStrings() const { return !m_strings.isEmpty(); }
-    bool hasSingleCharacters() const { return !m_matches.isEmpty() || !m_ranges.isEmpty() || !m_matchesUnicode.isEmpty() || !m_rangesUnicode.isEmpty(); }
+    bool hasSingleCharacters() const { return !m_matches8.isEmpty() || !m_ranges8.isEmpty() || !m_matches32.isEmpty() || !m_ranges32.isEmpty(); }
 
     std::optional<char16_t> hasSharedLeadSurrogate() const;
 
     Vector<Vector<char32_t>> m_strings;
-    Vector<char32_t> m_matches;
-    Vector<CharacterRange> m_ranges;
-    Vector<char32_t> m_matchesUnicode;
-    Vector<CharacterRange> m_rangesUnicode;
+    Vector<char32_t> m_matches8;
+    Vector<CharacterRange> m_ranges8;
+    Vector<char32_t> m_matches32;
+    Vector<CharacterRange> m_ranges32;
 
     Table m_table;
     CharacterClassWidths m_characterWidths;
@@ -171,14 +169,14 @@ public:
     {
     }
 
-    ClassSet(std::initializer_list<char32_t> matches, std::initializer_list<CharacterRange> ranges, std::initializer_list<char32_t> matchesUnicode, std::initializer_list<CharacterRange> rangesUnicode, CharacterClassWidths widths)
-        : CharacterClass(matches, ranges, matchesUnicode, rangesUnicode, widths)
+    ClassSet(std::initializer_list<char32_t> matches8, std::initializer_list<CharacterRange> ranges8, std::initializer_list<char32_t> matches32, std::initializer_list<CharacterRange> ranges32, CharacterClassWidths widths)
+        : CharacterClass(matches8, ranges8, matches32, ranges32, widths)
         , m_inCanonicalForm(true)
     {
     }
 
-    ClassSet(std::initializer_list<Vector<char32_t>> strings, std::initializer_list<char32_t> matches, std::initializer_list<CharacterRange> ranges, std::initializer_list<char32_t> matchesUnicode, std::initializer_list<CharacterRange> rangesUnicode, CharacterClassWidths widths)
-        : CharacterClass(matches, ranges, matchesUnicode, rangesUnicode, widths)
+    ClassSet(std::initializer_list<Vector<char32_t>> strings, std::initializer_list<char32_t> matches8, std::initializer_list<CharacterRange> ranges8, std::initializer_list<char32_t> matches32, std::initializer_list<CharacterRange> ranges32, CharacterClassWidths widths)
+        : CharacterClass(matches8, ranges8, matches32, ranges32, widths)
         , m_strings(strings)
         , m_inCanonicalForm(true)
     {

--- a/Source/JavaScriptCore/yarr/create_regex_tables
+++ b/Source/JavaScriptCore/yarr/create_regex_tables
@@ -56,9 +56,9 @@ for name, classes in types.items():
                 min = ord(min)
             if type(max) == str:
                 max = ord(max)
-            if max > 0x7f and min <= 0x7f:
-                ranges.append((min, 0x7f))
-                min = 0x80
+            if max > 0xff and min <= 0xff:
+                ranges.append((min, 0xff))
+                min = 0x100
             ranges.append((min,max))
     ranges.sort();
     
@@ -109,15 +109,15 @@ for name, classes in types.items():
         if max >= 0x10000:
             hasNonBMPCharacters = True
         if (min == max):
-            if (min > 127):
-                function += ("    characterClass->m_matchesUnicode.append(0x%04x);\n" % min)
+            if (min > 0xff):
+                function += ("    characterClass->m_matches32.append(0x%04x);\n" % min)
             else:
-                function += ("    characterClass->m_matches.append(0x%02x);\n" % min)
+                function += ("    characterClass->m_matches8.append(0x%02x);\n" % min)
             continue
-        if (min > 127) or (max > 127):
-            function += ("    characterClass->m_rangesUnicode.append(CharacterRange(0x%04x, 0x%04x));\n" % (min, max))
+        if (min > 0xff) or (max > 0xff):
+            function += ("    characterClass->m_ranges32.append(CharacterRange(0x%04x, 0x%04x));\n" % (min, max))
         else:
-            function += ("    characterClass->m_ranges.append(CharacterRange(0x%02x, 0x%02x));\n" % (min, max))
+            function += ("    characterClass->m_ranges8.append(CharacterRange(0x%02x, 0x%02x));\n" % (min, max))
     function += ("    characterClass->m_characterWidths = CharacterClassWidths::%s;\n" % (("Unknown", "HasBMPChars", "HasNonBMPChars", "HasBothBMPAndNonBMP")[int(hasNonBMPCharacters) * 2 + int(hasBMPCharacters)]))
     function += ("    return characterClass;\n")
     function += ("}\n\n")

--- a/Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py
+++ b/Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py
@@ -88,8 +88,9 @@ SupportedSequenceProperties = [
     "Basic_Emoji", "Emoji_Keycap_Sequence", "RGI_Emoji", "RGI_Emoji_Flag_Sequence", "RGI_Emoji_Modifier_Sequence",
     "RGI_Emoji_Tag_Sequence", "RGI_Emoji_ZWJ_Sequence"]
 
+lastLatin1CodePoint = 0xff
 lastASCIICodePoint = 0x7f
-firstUnicodeCodePoint = 0x80
+firstNonLatin1CodePoint = 0x100
 MaxUnicode = 0x10ffff
 MaxBMP = 0xffff
 commonAndSimpleLinesRE = re.compile(r"(?P<code>[0-9A-F]+)\s*;\s*[CS]\s*;\s*(?P<mapping>[0-9A-F]+)", re.IGNORECASE)
@@ -261,7 +262,7 @@ class PropertyData:
             self.hasBMPCharacters = True
         else:
             self.hasNonBMPCharacters = True
-        if codePoint <= lastASCIICodePoint:
+        if codePoint <= lastLatin1CodePoint:
             if (len(self.matches) and self.matches[-1] > codePoint) or (len(self.ranges) and self.ranges[-1][1] > codePoint):
                 self.addMatchUnordered(codePoint)
                 return
@@ -299,7 +300,7 @@ class PropertyData:
             self.hasBMPCharacters = True
         if highCodePoint > MaxBMP:
             self.hasNonBMPCharacters = True
-        if highCodePoint <= lastASCIICodePoint:
+        if highCodePoint <= lastLatin1CodePoint:
             if (len(self.matches) and self.matches[-1] > lowCodePoint) or (len(self.ranges) and self.ranges[-1][1] > lowCodePoint):
                 self.addRangeUnordered(lowCodePoint, highCodePoint)
                 return
@@ -311,15 +312,15 @@ class PropertyData:
                 priorRange = self.ranges.pop()
                 lowCodePoint = priorRange[0]
             self.ranges.append((lowCodePoint, highCodePoint))
-        elif lowCodePoint <= lastASCIICodePoint:
-            if lowCodePoint == lastASCIICodePoint:
+        elif lowCodePoint <= lastLatin1CodePoint:
+            if lowCodePoint == lastLatin1CodePoint:
                 self.addMatch(lowCodePoint)
             else:
-                self.addRange(lowCodePoint, lastASCIICodePoint)
-            if highCodePoint == firstUnicodeCodePoint:
+                self.addRange(lowCodePoint, lastLatin1CodePoint)
+            if highCodePoint == firstNonLatin1CodePoint:
                 self.addMatch(highCodePoint)
             else:
-                self.addRange(firstUnicodeCodePoint, highCodePoint)
+                self.addRange(firstNonLatin1CodePoint, highCodePoint)
         else:
             if (len(self.unicodeMatches) and self.unicodeMatches[-1] > lowCodePoint) or (len(self.unicodeRanges) and self.unicodeRanges[-1][1] > lowCodePoint):
                 self.addRangeUnordered(lowCodePoint, highCodePoint)
@@ -457,25 +458,25 @@ class PropertyData:
         self.codePointCount = self.codePointCount + (highCodePoint - lowCodePoint) + 1
 
     def addMatchUnordered(self, codePoint):
-        if codePoint <= lastASCIICodePoint:
+        if codePoint <= lastLatin1CodePoint:
             self.addMatchUnorderedForMatchesAndRanges(codePoint, self.matches, self.ranges)
         else:
             self.addMatchUnorderedForMatchesAndRanges(codePoint, self.unicodeMatches, self.unicodeRanges)
 
     def addRangeUnordered(self, lowCodePoint, highCodePoint):
-        if highCodePoint <= lastASCIICodePoint:
+        if highCodePoint <= lastLatin1CodePoint:
             self.addRangeUnorderedForMatchesAndRanges(lowCodePoint, highCodePoint, self.matches, self.ranges)
-        elif lowCodePoint >= firstUnicodeCodePoint:
+        elif lowCodePoint >= firstNonLatin1CodePoint:
             self.addRangeUnorderedForMatchesAndRanges(lowCodePoint, highCodePoint, self.unicodeMatches, self.unicodeRanges)
         else:
-            if lowCodePoint == lastASCIICodePoint:
+            if lowCodePoint == lastLatin1CodePoint:
                 self.addMatchUnorderedForMatchesAndRanges(lowCodePoint, self.matches, self.ranges)
             else:
-                self.addRangeUnorderedForMatchesAndRanges(lowCodePoint, lastASCIICodePoint, self.unicodeMatches, self.ranges)
-            if highCodePoint == firstUnicodeCodePoint:
+                self.addRangeUnorderedForMatchesAndRanges(lowCodePoint, lastLatin1CodePoint, self.unicodeMatches, self.ranges)
+            if highCodePoint == firstNonLatin1CodePoint:
                 self.addMatchUnorderedForMatchesAndRanges(highCodePoint, self.unicodeMatches, self.unicodeRanges)
             else:
-                self.addRangeUnorderedForMatchesAndRanges(firstUnicodeCodePoint, highCodePoint, self.unicodeMatches, self.unicodeRanges)
+                self.addRangeUnorderedForMatchesAndRanges(firstNonLatin1CodePoint, highCodePoint, self.unicodeMatches, self.unicodeRanges)
 
     def removeMatchFromRanges(self, codePoint, ranges):
         for idx in range(len(ranges)):
@@ -507,7 +508,7 @@ class PropertyData:
                 return
 
     def removeMatch(self, codePoint):
-        if codePoint <= lastASCIICodePoint:
+        if codePoint <= lastLatin1CodePoint:
             if codePoint in self.matches:
                 self.matches.remove(codePoint)
                 self.codePointCount = self.codePointCount - 1


### PR DESCRIPTION
#### bd24d5579c471255533ccd95390dd2176539a206
<pre>
[Yarr] Change Yarr m_matches / m_ranges / m_matchesUnicode / m_rangesUnicode ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=315926">https://bugs.webkit.org/show_bug.cgi?id=315926</a>
<a href="https://rdar.apple.com/178330634">rdar://178330634</a>

Reviewed by Yijia Huang.

Yarr was splitting m_matches / m_ranges / m_matchesUnicode / m_rangesUnicode ranges
previously with ASCII v.s. non-ASCII. But given that we are having Char8
/ Char16, it is more efficient and natural to split them with Latin1
v.s. non-Latin1. This patch changes this. Also we improve addSorted /
addSortedRange for edge cases: we carefully avoid adding singleton range
(only one element) for boundary char code. Also, based on the above
boundary, we rename them to m_matches8, m_ranges8, m_matches32, m_ranges32.

Test: JSTests/stress/regexp-character-class-latin1-boundary.js

* JSTests/stress/regexp-character-class-latin1-boundary.js: Added.
(shouldBe):
(repeat):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::testCharacterClass):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::MaskedAlternativeInfo::computeMaskForCharacterClass):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::reset):
(JSC::Yarr::CharacterClassConstructor::append):
(JSC::Yarr::CharacterClassConstructor::appendInverted):
(JSC::Yarr::CharacterClassConstructor::putChar):
(JSC::Yarr::CharacterClassConstructor::putCharNonUnion):
(JSC::Yarr::CharacterClassConstructor::putRange):
(JSC::Yarr::CharacterClassConstructor::atomClassStringDisjunction):
(JSC::Yarr::CharacterClassConstructor::invertMatches):
(JSC::Yarr::CharacterClassConstructor::performSetOpWith):
(JSC::Yarr::CharacterClassConstructor::performSetOpWithMatches):
(JSC::Yarr::CharacterClassConstructor::charClass):
(JSC::Yarr::CharacterClassConstructor::addSorted):
(JSC::Yarr::CharacterClassConstructor::addSortedRange):
(JSC::Yarr::CharacterClassConstructor::latin1Op):
(JSC::Yarr::CharacterClassConstructor::latin1Invert):
(JSC::Yarr::CharacterClassConstructor::nonLatin1OpSorted):
(JSC::Yarr::CharacterClassConstructor::nonLatin1Invert):
(JSC::Yarr::CharacterClassConstructor::coalesceTables):
(JSC::Yarr::dumpCharacterClass):
(JSC::Yarr::anycharCreate):
(JSC::Yarr::CharacterClass::hasSharedLeadSurrogate const):
(JSC::Yarr::CharacterClassConstructor::asciiOp): Deleted.
(JSC::Yarr::CharacterClassConstructor::asciiInvert): Deleted.
(JSC::Yarr::CharacterClassConstructor::unicodeOpSorted): Deleted.
(JSC::Yarr::CharacterClassConstructor::unicodeInvert): Deleted.
(JSC::Yarr::CharacterClass::copyOnly8BitCharacterData): Deleted.
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::CharacterClass::CharacterClass):
(JSC::Yarr::CharacterClass::hasSingleCharacters const):
(JSC::Yarr::ClassSet::ClassSet):
* Source/JavaScriptCore/yarr/create_regex_tables:
(in):
* Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py:
(PropertyData.addMatch):
(PropertyData.addRange):
(PropertyData.addMatchUnordered):
(PropertyData.addRangeUnordered):
(PropertyData.removeMatch):

Canonical link: <a href="https://commits.webkit.org/314305@main">https://commits.webkit.org/314305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73890cfdb83c411c4c5197b331ca3c42be3e1501

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165489 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174531 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122744 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f3fdeaf-45eb-46e8-a7c0-9363b14f7129) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128605 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90531 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0818e243-3f4e-456e-8177-f5bc19ed21ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168448 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30920 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109130 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e023605-fd93-49d2-a227-4fdea2adc313) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29963 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28595 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22609 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157646 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177055 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26382 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29964 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136929 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39048 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136865 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148174 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102137 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25230 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32139 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25041 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38246 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111320 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37643 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3121 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37889 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37787 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->