### PR TITLE
[JSC] Do not release scope while it is used before forEachInIterationRecord

### DIFF
--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -168,10 +168,7 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncToArray, (JSGlobalObject* globalObject
     });
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto* array = constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), value);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    return JSValue::encode(array);
+    RELEASE_AND_RETURN(scope, JSValue::encode(constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), value)));
 }
 
 // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.foreach
@@ -200,21 +197,23 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncForEach, (JSGlobalObject* globalObject
         CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(callbackArg), 2);
         RETURN_IF_EXCEPTION(scope, { });
 
+        scope.release();
         forEachInIteratorProtocol(globalObject, thisValue, [&](VM&, JSGlobalObject*, JSValue nextItem) ALWAYS_INLINE_LAMBDA {
             cachedCall.callWithArguments(globalObject, jsUndefined(), nextItem, jsNumber(counter++));
         });
-    } else {
-        forEachInIteratorProtocol(globalObject, thisValue, [&](VM&, JSGlobalObject*, JSValue nextItem) ALWAYS_INLINE_LAMBDA {
-            MarkedArgumentBuffer args;
-            args.append(nextItem);
-            args.append(jsNumber(counter++));
-            ASSERT(!args.hasOverflowed());
-
-            call(globalObject, callbackArg, callData, jsUndefined(), args);
-        });
+        return JSValue::encode(jsUndefined());
     }
 
-    RETURN_IF_EXCEPTION(scope, { });
+    scope.release();
+    forEachInIteratorProtocol(globalObject, thisValue, [&](VM&, JSGlobalObject*, JSValue nextItem) ALWAYS_INLINE_LAMBDA {
+        MarkedArgumentBuffer args;
+        args.append(nextItem);
+        args.append(jsNumber(counter++));
+        ASSERT(!args.hasOverflowed());
+
+        call(globalObject, callbackArg, callData, jsUndefined(), args);
+    });
+
     return JSValue::encode(jsUndefined());
 }
 

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -220,7 +220,6 @@ static uint32_t getSetSizeAsInt(JSGlobalObject* globalObject, JSValue value)
 static EncodedJSValue fastSetIntersection(JSGlobalObject* globalObject, JSSet* thisSet, JSSet* otherSet)
 {
     VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSSet* result = JSSet::create(vm, globalObject->setStructure());
 
@@ -232,6 +231,8 @@ static EncodedJSValue fastSetIntersection(JSGlobalObject* globalObject, JSSet* t
         return JSValue::encode(result);
 
     forEachInSetStorage(vm, globalObject, sourceStorageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
         bool targetHasEntry = targetSet->has(globalObject, entryKey);
         RETURN_IF_EXCEPTION(scope, void());
         if (targetHasEntry) {
@@ -239,7 +240,6 @@ static EncodedJSValue fastSetIntersection(JSGlobalObject* globalObject, JSSet* t
             RETURN_IF_EXCEPTION(scope, void());
         }
     });
-    RETURN_IF_EXCEPTION(scope, { });
 
     return JSValue::encode(result);
 }
@@ -256,10 +256,8 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
 
     if (otherValue.isCell()) [[likely]] {
         if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
-            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
-                scope.release();
-                return fastSetIntersection(globalObject, thisSet, otherSet);
-            }
+            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]]
+                RELEASE_AND_RETURN(scope, fastSetIntersection(globalObject, thisSet, otherSet));
         }
     }
 
@@ -292,7 +290,10 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
             RETURN_IF_EXCEPTION(scope, { });
         }
 
+        scope.release();
         forEachInSetStorage(vm, globalObject, storageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) {
+            auto scope = DECLARE_THROW_SCOPE(vm);
+
             JSValue hasResult;
             if (cachedHasCall) [[likely]] {
                 hasResult = cachedHasCall->callWithArguments(globalObject, otherValue, entryKey);
@@ -312,8 +313,6 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
                 RETURN_IF_EXCEPTION(scope, void());
             }
         });
-        RETURN_IF_EXCEPTION(scope, { });
-
         return JSValue::encode(result);
     }
 
@@ -322,8 +321,11 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
     ASSERT(!args.hasOverflowed());
     JSValue iterator = call(globalObject, keys, keysCallData, otherValue, args);
     RETURN_IF_EXCEPTION(scope, { });
+
     scope.release();
     forEachInIteratorProtocol(globalObject, iterator, [&](VM&, JSGlobalObject* globalObject, JSValue key) -> void {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
         bool thisSetHasKey = thisSet->has(globalObject, key);
         RETURN_IF_EXCEPTION(scope, void());
         if (thisSetHasKey) {
@@ -331,7 +333,6 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
             RETURN_IF_EXCEPTION(scope, void());
         }
     });
-
     return JSValue::encode(result);
 }
 
@@ -344,14 +345,13 @@ static EncodedJSValue fastSetUnion(JSGlobalObject* globalObject, JSSet* thisSet,
     RETURN_IF_EXCEPTION(scope, { });
 
     JSCell* otherStorageCell = otherSet->storageOrSentinel(vm);
-    if (otherStorageCell != vm.orderedHashTableSentinel()) {
-        forEachInSetStorage(vm, globalObject, otherStorageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) {
-            result->add(globalObject, entryKey);
-            RETURN_IF_EXCEPTION(scope, void());
-        });
-        RETURN_IF_EXCEPTION(scope, { });
-    }
+    if (otherStorageCell == vm.orderedHashTableSentinel())
+        return JSValue::encode(result);
 
+    scope.release();
+    forEachInSetStorage(vm, globalObject, otherStorageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) {
+        result->add(globalObject, entryKey);
+    });
     return JSValue::encode(result);
 }
 
@@ -367,10 +367,8 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncUnion, (JSGlobalObject* globalObject, CallF
 
     if (otherValue.isCell()) [[likely]] {
         if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
-            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
-                scope.release();
-                return fastSetUnion(globalObject, thisSet, otherSet);
-            }
+            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]]
+                RELEASE_AND_RETURN(scope, fastSetUnion(globalObject, thisSet, otherSet));
         }
     }
 
@@ -406,16 +404,13 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncUnion, (JSGlobalObject* globalObject, CallF
     scope.release();
     forEachInIterationRecord(globalObject, iterationRecord, [&](VM&, JSGlobalObject* globalObject, JSValue key) -> void {
         result->add(globalObject, key);
-        RETURN_IF_EXCEPTION(scope, void());
     });
-
     return JSValue::encode(result);
 }
 
 static EncodedJSValue fastSetIsSubsetOf(JSGlobalObject* globalObject, JSSet* thisSet, JSSet* otherSet)
 {
     VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (thisSet->size() > otherSet->size())
         return JSValue::encode(jsBoolean(false));
@@ -426,23 +421,23 @@ static EncodedJSValue fastSetIsSubsetOf(JSGlobalObject* globalObject, JSSet* thi
 
     bool isSubset = true;
     forEachInSetStorage(vm, globalObject, thisStorageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) -> IterationStatus {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
         bool otherHasEntry = otherSet->has(globalObject, entryKey);
         RETURN_IF_EXCEPTION(scope, IterationStatus::Done);
+
         if (!otherHasEntry) {
             isSubset = false;
             return IterationStatus::Done;
         }
         return IterationStatus::Continue;
     });
-    RETURN_IF_EXCEPTION(scope, { });
-
     return JSValue::encode(jsBoolean(isSubset));
 }
 
 static EncodedJSValue fastSetDifference(JSGlobalObject* globalObject, JSSet* thisSet, JSSet* otherSet)
 {
     VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSSet* result = JSSet::create(vm, globalObject->setStructure());
 
@@ -451,6 +446,8 @@ static EncodedJSValue fastSetDifference(JSGlobalObject* globalObject, JSSet* thi
         return JSValue::encode(result);
 
     forEachInSetStorage(vm, globalObject, thisStorageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
         bool otherHasEntry = otherSet->has(globalObject, entryKey);
         RETURN_IF_EXCEPTION(scope, void());
         if (!otherHasEntry) {
@@ -458,8 +455,6 @@ static EncodedJSValue fastSetDifference(JSGlobalObject* globalObject, JSSet* thi
             RETURN_IF_EXCEPTION(scope, void());
         }
     });
-    RETURN_IF_EXCEPTION(scope, { });
-
     return JSValue::encode(result);
 }
 
@@ -475,10 +470,8 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
 
     if (otherValue.isCell()) [[likely]] {
         if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
-            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
-                scope.release();
-                return fastSetDifference(globalObject, thisSet, otherSet);
-            }
+            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]]
+                RELEASE_AND_RETURN(scope, fastSetDifference(globalObject, thisSet, otherSet));
         }
     }
 
@@ -513,7 +506,10 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
             RETURN_IF_EXCEPTION(scope, { });
         }
 
+        scope.release();
         forEachInSetStorage(vm, globalObject, resultStorageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) {
+            auto scope = DECLARE_THROW_SCOPE(vm);
+
             JSValue hasResult;
             if (cachedHasCall) [[likely]] {
                 hasResult = cachedHasCall->callWithArguments(globalObject, otherValue, entryKey);
@@ -533,8 +529,6 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
                 RETURN_IF_EXCEPTION(scope, void());
             }
         });
-        RETURN_IF_EXCEPTION(scope, { });
-
         return JSValue::encode(result);
     }
 
@@ -603,22 +597,24 @@ static EncodedJSValue fastSetSymmetricDifference(JSGlobalObject* globalObject, J
     RETURN_IF_EXCEPTION(scope, { });
 
     JSCell* otherStorageCell = otherSet->storageOrSentinel(vm);
-    if (otherStorageCell != vm.orderedHashTableSentinel()) {
-        forEachInSetStorage(vm, globalObject, otherStorageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) {
-            bool thisHasEntry = thisSet->has(globalObject, entryKey);
+    if (otherStorageCell == vm.orderedHashTableSentinel())
+        return JSValue::encode(result);
+
+    scope.release();
+    forEachInSetStorage(vm, globalObject, otherStorageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
+        bool thisHasEntry = thisSet->has(globalObject, entryKey);
+        RETURN_IF_EXCEPTION(scope, void());
+
+        if (thisHasEntry) {
+            result->remove(globalObject, entryKey);
             RETURN_IF_EXCEPTION(scope, void());
-
-            if (thisHasEntry) {
-                result->remove(globalObject, entryKey);
-                RETURN_IF_EXCEPTION(scope, void());
-            } else {
-                result->add(globalObject, entryKey);
-                RETURN_IF_EXCEPTION(scope, void());
-            }
-        });
-        RETURN_IF_EXCEPTION(scope, { });
-    }
-
+        } else {
+            result->add(globalObject, entryKey);
+            RETURN_IF_EXCEPTION(scope, void());
+        }
+    });
     return JSValue::encode(result);
 }
 
@@ -634,10 +630,8 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncSymmetricDifference, (JSGlobalObject* globa
 
     if (otherValue.isCell()) [[likely]] {
         if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
-            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
-                scope.release();
-                return fastSetSymmetricDifference(globalObject, thisSet, otherSet);
-            }
+            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]]
+                RELEASE_AND_RETURN(scope, fastSetSymmetricDifference(globalObject, thisSet, otherSet));
         }
     }
 
@@ -732,10 +726,8 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSubsetOf, (JSGlobalObject* globalObject, 
 
     if (otherValue.isCell()) [[likely]] {
         if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
-            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
-                scope.release();
-                return fastSetIsSubsetOf(globalObject, thisSet, otherSet);
-            }
+            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]]
+                RELEASE_AND_RETURN(scope, fastSetIsSubsetOf(globalObject, thisSet, otherSet));
         }
     }
 
@@ -769,8 +761,11 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSubsetOf, (JSGlobalObject* globalObject, 
         RETURN_IF_EXCEPTION(scope, { });
     }
 
+    scope.release();
     bool isSubset = true;
     forEachInSetStorage(vm, globalObject, thisStorageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) -> IterationStatus {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
         JSValue hasResult;
         if (cachedHasCall) [[likely]] {
             hasResult = cachedHasCall->callWithArguments(globalObject, otherValue, entryKey);
@@ -791,15 +786,12 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSubsetOf, (JSGlobalObject* globalObject, 
         }
         return IterationStatus::Continue;
     });
-    RETURN_IF_EXCEPTION(scope, { });
-
     return JSValue::encode(jsBoolean(isSubset));
 }
 
 static EncodedJSValue fastSetIsSupersetOf(JSGlobalObject* globalObject, JSSet* thisSet, JSSet* otherSet)
 {
     VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (thisSet->size() < otherSet->size())
         return JSValue::encode(jsBoolean(false));
@@ -810,6 +802,8 @@ static EncodedJSValue fastSetIsSupersetOf(JSGlobalObject* globalObject, JSSet* t
 
     bool isSuperset = true;
     forEachInSetStorage(vm, globalObject, otherStorageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) -> IterationStatus {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
         bool thisHasEntry = thisSet->has(globalObject, entryKey);
         RETURN_IF_EXCEPTION(scope, IterationStatus::Done);
         if (!thisHasEntry) {
@@ -818,8 +812,6 @@ static EncodedJSValue fastSetIsSupersetOf(JSGlobalObject* globalObject, JSSet* t
         }
         return IterationStatus::Continue;
     });
-    RETURN_IF_EXCEPTION(scope, { });
-
     return JSValue::encode(jsBoolean(isSuperset));
 }
 
@@ -835,10 +827,8 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSupersetOf, (JSGlobalObject* globalObject
 
     if (otherValue.isCell()) [[likely]] {
         if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
-            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
-                scope.release();
-                return fastSetIsSupersetOf(globalObject, thisSet, otherSet);
-            }
+            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]]
+                RELEASE_AND_RETURN(scope, fastSetIsSupersetOf(globalObject, thisSet, otherSet));
         }
     }
 
@@ -921,7 +911,6 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSupersetOf, (JSGlobalObject* globalObject
 static EncodedJSValue fastSetIsDisjointFrom(JSGlobalObject* globalObject, JSSet* thisSet, JSSet* otherSet)
 {
     VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSSet* smallerSet = otherSet;
     JSSet* largerSet = thisSet;
@@ -936,6 +925,8 @@ static EncodedJSValue fastSetIsDisjointFrom(JSGlobalObject* globalObject, JSSet*
 
     bool isDisjoint = true;
     forEachInSetStorage(vm, globalObject, smallerStorageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) -> IterationStatus {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
         bool largerHasEntry = largerSet->has(globalObject, entryKey);
         RETURN_IF_EXCEPTION(scope, IterationStatus::Done);
         if (largerHasEntry) {
@@ -944,8 +935,6 @@ static EncodedJSValue fastSetIsDisjointFrom(JSGlobalObject* globalObject, JSSet*
         }
         return IterationStatus::Continue;
     });
-    RETURN_IF_EXCEPTION(scope, { });
-
     return JSValue::encode(jsBoolean(isDisjoint));
 }
 
@@ -961,10 +950,8 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
 
     if (otherValue.isCell()) [[likely]] {
         if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
-            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
-                scope.release();
-                return fastSetIsDisjointFrom(globalObject, thisSet, otherSet);
-            }
+            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]]
+                RELEASE_AND_RETURN(scope, fastSetIsDisjointFrom(globalObject, thisSet, otherSet));
         }
     }
 
@@ -996,8 +983,11 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
             RETURN_IF_EXCEPTION(scope, { });
         }
 
+        scope.release();
         bool isDisjoint = true;
         forEachInSetStorage(vm, globalObject, thisStorageCell, 0, [&](VM&, JSGlobalObject* globalObject, JSValue entryKey) -> IterationStatus {
+            auto scope = DECLARE_THROW_SCOPE(vm);
+
             JSValue hasResult;
             if (cachedHasCall) [[likely]] {
                 hasResult = cachedHasCall->callWithArguments(globalObject, otherValue, entryKey);
@@ -1018,8 +1008,6 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
             }
             return IterationStatus::Continue;
         });
-        RETURN_IF_EXCEPTION(scope, { });
-
         return JSValue::encode(jsBoolean(isDisjoint));
     }
 


### PR DESCRIPTION
#### ed0f115abfab2ffbe860b8167234dd4d3020d13e
<pre>
[JSC] Do not release scope while it is used before forEachInIterationRecord
<a href="https://bugs.webkit.org/show_bug.cgi?id=315927">https://bugs.webkit.org/show_bug.cgi?id=315927</a>
<a href="https://rdar.apple.com/178332419">rdar://178332419</a>

Reviewed by Yijia Huang.

forEachInIterationRecord&apos;s lambda was using scope even after calling `scope.release()`,
which incorrectly suppressing the exception checks. This patch makes
SetPrototype.cpp code more idiomatic: use a new scope inside lambda, and
do scope.release() only when we no longer use scope.

* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::fastSetIntersection):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::fastSetUnion):
(JSC::fastSetIsSubsetOf):
(JSC::fastSetDifference):
(JSC::fastSetSymmetricDifference):
(JSC::fastSetIsSupersetOf):
(JSC::fastSetIsDisjointFrom):

Canonical link: <a href="https://commits.webkit.org/314246@main">https://commits.webkit.org/314246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c02c666d236429f0e7bd49bfad2111fd6f7c147

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174537 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122750 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/802f0bb6-f1d5-445c-8d9c-ed36da6e5a4d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128611 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90537 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e219227d-14e9-4ba0-9f37-155c6a0fd8f5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168454 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30924 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109136 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a809b7ef-b75b-4a30-9a07-6e58a4ef9984) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29967 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28600 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22615 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157652 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177061 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26388 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29970 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136935 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136871 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39742 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148178 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102147 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25193 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25045 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111326 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37649 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3125 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37895 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37793 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->