### PR TITLE
Fix role computation and ElementTargetingController for elements with prefixes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html-aam/aside-in-prefixed-article-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html-aam/aside-in-prefixed-article-expected.txt
@@ -1,0 +1,4 @@
+x
+
+PASS el-aside-in-prefixed-article
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html-aam/aside-in-prefixed-article.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html-aam/aside-in-prefixed-article.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+<title>HTML-AAM: aside nested in a prefixed article ancestor</title>
+<link rel="help" href="https://w3c.github.io/html-aam/#el-aside">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</head>
+<body>
+<script>
+const xhtmlNS = "http://www.w3.org/1999/xhtml";
+
+promise_test(async () => {
+  // Construct an HTML <article> with a non-null prefix. The element's
+  // identity for HTML-AAM purposes is its expanded name (namespace +
+  // local name); the prefix is incidental.
+  const article = document.createElementNS(xhtmlNS, "foo:article");
+  const aside = document.createElement("aside");
+  aside.textContent = "x";
+  article.appendChild(aside);
+  document.body.appendChild(article);
+
+  const role = await test_driver.get_computed_role(aside);
+  // Per HTML-AAM, an <aside> inside an <article> ancestor is generic.
+  // ARIA WG has accepted "generic", "", and "none" as equivalent for
+  // testing purposes; see https://github.com/web-platform-tests/interop-accessibility/issues/48.
+  assert_in_array(role, ["generic", "", "none"]);
+}, "el-aside-in-prefixed-article");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1350,6 +1350,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/LoadableScript.h
     dom/LoadableScriptClient.h
     dom/LoadableScriptError.h
+    dom/LocalNameWithNamespace.h
     dom/MessagePort.h
     dom/MessagePortIdentifier.h
     dom/ModuleFetchParameters.h

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -776,7 +776,7 @@ AccessibilityRole AccessibilityNodeObject::roleFromInputElement(const HTMLInputE
     return AccessibilityRole::TextField;
 }
 
-bool AccessibilityNodeObject::isDescendantOfElementType(const HashSet<QualifiedName>& tagNames) const
+bool AccessibilityNodeObject::isDescendantOfElementType(const HashSet<LocalNameWithNamespace>& tagNames) const
 {
     if (!m_node)
         return false;

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -33,6 +33,7 @@
 #include "AXUtilities.h"
 #include "AccessibilityObject.h"
 #include "LayoutRect.h"
+#include "LocalNameWithNamespace.h"
 #include "RenderStyleConstants.h"
 #include <wtf/Forward.h>
 
@@ -343,7 +344,7 @@ private:
     bool needsToUpdateChildren() const final { return m_childrenDirty; }
     void setNeedsToUpdateSubtree() final { m_subtreeDirty = true; }
 
-    bool isDescendantOfElementType(const HashSet<QualifiedName>&) const;
+    bool isDescendantOfElementType(const HashSet<LocalNameWithNamespace>&) const;
 
     AXObjectRareData* rareDataWithCleanTableChildren();
     // Returns the number of columns the table should have.

--- a/Source/WebCore/dom/LocalNameWithNamespace.h
+++ b/Source/WebCore/dom/LocalNameWithNamespace.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/QualifiedName.h>
+
+namespace WebCore {
+
+// An element or attribute name without a namespace prefix: a (namespace, local name) pair.
+// Use this in HashMap/HashSet keys and in matching predicates where two names with the same
+// expanded name should be treated as identical regardless of how they were prefixed.
+class LocalNameWithNamespace {
+public:
+    LocalNameWithNamespace(const AtomString& namespaceURI, const AtomString& localName)
+        : m_canonical(nullAtom(), localName, namespaceURI) { }
+    LocalNameWithNamespace(const QualifiedName& qualifiedName)
+        : m_canonical(qualifiedName.hasPrefix()
+            ? QualifiedName(nullAtom(), qualifiedName.localName(), qualifiedName.namespaceURI())
+            : qualifiedName) { }
+    template<typename T>
+    LocalNameWithNamespace(const LazyNeverDestroyed<T>& lazy)
+        : LocalNameWithNamespace(lazy.get()) { }
+    explicit LocalNameWithNamespace(WTF::HashTableDeletedValueType)
+        : m_canonical(WTF::HashTableDeletedValue) { }
+
+    const AtomString& namespaceURI() const LIFETIME_BOUND { return m_canonical.namespaceURI(); }
+    const AtomString& localName() const LIFETIME_BOUND { return m_canonical.localName(); }
+
+    bool isHashTableDeletedValue() const { return m_canonical.isHashTableDeletedValue(); }
+    QualifiedName::QualifiedNameImpl* impl() const { return m_canonical.impl(); }
+
+    friend bool operator==(const LocalNameWithNamespace&, const LocalNameWithNamespace&) = default;
+
+private:
+    QualifiedName m_canonical;
+};
+
+struct LocalNameWithNamespaceHash {
+    static unsigned hash(const LocalNameWithNamespace& name) { return QualifiedNameHash::hash(name.impl()); }
+    static bool equal(const LocalNameWithNamespace& a, const LocalNameWithNamespace& b) { return a == b; }
+    static constexpr bool safeToCompareToEmptyOrDeleted = false;
+    static constexpr bool hasHashInValue = true;
+};
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<typename T> struct DefaultHash;
+
+template<> struct DefaultHash<WebCore::LocalNameWithNamespace> : WebCore::LocalNameWithNamespaceHash { };
+
+template<> struct HashTraits<WebCore::LocalNameWithNamespace> : SimpleClassHashTraits<WebCore::LocalNameWithNamespace> {
+    static const bool emptyValueIsZero = false;
+    static WebCore::LocalNameWithNamespace emptyValue() { return { nullAtom(), nullAtom() }; }
+};
+
+} // namespace WTF

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -54,6 +54,7 @@
 #include "HitTestResult.h"
 #include "LocalFrameInlines.h"
 #include "LocalFrameView.h"
+#include "LocalNameWithNamespace.h"
 #include "NamedNodeMap.h"
 #include "NodeList.h"
 #include "NodeRenderStyle.h"
@@ -251,7 +252,7 @@ static inline String computeTagAndAttributeSelector(const Element& element, cons
     if (!element.hasAttributes())
         return emptyString();
 
-    static NeverDestroyed<MemoryCompactLookupOnlyRobinHoodHashSet<QualifiedName>> attributesToExclude { std::initializer_list<QualifiedName> {
+    static NeverDestroyed<MemoryCompactLookupOnlyRobinHoodHashSet<LocalNameWithNamespace>> attributesToExclude { std::initializer_list<LocalNameWithNamespace> {
         HTMLNames::classAttr,
         HTMLNames::idAttr,
         HTMLNames::styleAttr,
@@ -427,7 +428,7 @@ static String parentRelativeSelectorRecursive(Element& element, ElementSelectorC
 
 static String computeHasChildSelector(Element& element)
 {
-    static NeverDestroyed<MemoryCompactLookupOnlyRobinHoodHashSet<QualifiedName>> tagsToCheckForUniqueAttributes { std::initializer_list<QualifiedName> {
+    static NeverDestroyed<MemoryCompactLookupOnlyRobinHoodHashSet<LocalNameWithNamespace>> tagsToCheckForUniqueAttributes { std::initializer_list<LocalNameWithNamespace> {
         HTMLNames::aTag,
         HTMLNames::imgTag,
         HTMLNames::timeTag,


### PR DESCRIPTION
#### beaf8935202344cba601a2641ff0833e626e6bb4
<pre>
Fix role computation and ElementTargetingController for elements with prefixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=315941">https://bugs.webkit.org/show_bug.cgi?id=315941</a>

Reviewed by Tyler Wilcock.

Introduce a wrapper class LocalNameWithNamespace for QualifiedName that
disregards the prefix for hashing and comparison purposes as the
identity of an element is established by its local name and namespace
alone.

As a start we adopt it in two places to address a bug. Long term it
could potentially replace QualifiedName with prefix becoming a rare
data concept.

Test: imported/w3c/web-platform-tests/html-aam/aside-in-prefixed-article.html
Canonical link: <a href="https://commits.webkit.org/314273@main">https://commits.webkit.org/314273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f24675b9fed9da1af44a18cdffa477b627eaea5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122795 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68d83bb8-1db9-4a82-b27d-a0269d2e6c9d) 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128649 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90575 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cef6c928-ab85-4656-92f3-3ffed855a266) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168499 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30971 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109173 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c39338ce-0729-4f6b-812d-7b8abb4d29e6) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30008 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28640 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22660 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177106 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30016 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136975 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136909 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36913 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148218 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102228 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25085 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38297 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111371 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37694 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3165 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37940 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37838 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->