### PR TITLE
[SVG] Non-BMP character before a tspan boundary shifts the x/y value list by one

### DIFF
--- a/LayoutTests/svg/text/surrogate-pair-addressable-character-expected.txt
+++ b/LayoutTests/svg/text/surrogate-pair-addressable-character-expected.txt
@@ -1,0 +1,7 @@
+𑀏𑀏
+𑀏𑀏
+
+PASS A surrogate pair consumes one x list position (flat layout)
+PASS A surrogate pair consumes one x list position (tspan layout)
+PASS Wrapping the second code point in a tspan does not change its position
+

--- a/LayoutTests/svg/text/surrogate-pair-addressable-character.html
+++ b/LayoutTests/svg/text/surrogate-pair-addressable-character.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<title>SVG text: a non-BMP code point consumes a single x/y list position</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextLayoutAlgorithm">
+<meta name="assert" content="Each character (Unicode code point), not each UTF-16 code unit, advances the x/y value list. A surrogate pair must consume one list entry, so x='0 100' places the first non-BMP glyph at x=0 and the second at x=100.">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<svg width="200" height="100">
+  <!-- Test: second code point wrapped in a tspan. -->
+  <text id="withTspan" font-size="50" x="0 100" y="50"></text>
+  <!-- Reference layout: both code points as direct children. -->
+  <text id="flat" font-size="50" x="0 100" y="50"></text>
+</svg>
+<script>
+const svgNS = "http://www.w3.org/2000/svg";
+// U+1100F is a non-BMP code point, i.e. a surrogate pair in UTF-16.
+const astral = String.fromCodePoint(0x1100F);
+
+const withTspan = document.getElementById("withTspan");
+withTspan.appendChild(document.createTextNode(astral));
+const tspan = document.createElementNS(svgNS, "tspan");
+tspan.appendChild(document.createTextNode(astral));
+withTspan.appendChild(tspan);
+
+const flat = document.getElementById("flat");
+flat.appendChild(document.createTextNode(astral + astral));
+
+// The first/last addressable glyph regardless of whether the DOM char APIs
+// index by code unit or by character: index 0 is the first glyph, and
+// getNumberOfChars() - 1 lands inside (and clamps to the start of) the second.
+function firstGlyphX(text) {
+  return text.getStartPositionOfChar(0).x;
+}
+function lastGlyphX(text) {
+  return text.getStartPositionOfChar(text.getNumberOfChars() - 1).x;
+}
+
+test(() => {
+  assert_equals(firstGlyphX(flat), 0, "first glyph uses x list entry 0");
+  assert_equals(lastGlyphX(flat), 100, "second glyph uses x list entry 1, not entry 2");
+}, "A surrogate pair consumes one x list position (flat layout)");
+
+test(() => {
+  assert_equals(firstGlyphX(withTspan), 0, "first glyph uses x list entry 0");
+  assert_equals(lastGlyphX(withTspan), 100, "second glyph (in tspan) uses x list entry 1, not entry 2");
+}, "A surrogate pair consumes one x list position (tspan layout)");
+
+test(() => {
+  assert_equals(firstGlyphX(withTspan), firstGlyphX(flat), "first glyph matches reference");
+  assert_equals(lastGlyphX(withTspan), lastGlyphX(flat), "second glyph matches reference");
+}, "Wrapping the second code point in a tspan does not change its position");
+</script>

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
@@ -85,16 +85,24 @@ static inline void NODELETE processRenderSVGInlineText(const RenderSVGInlineText
 {
     auto& string = text.text();
     auto length = string.length();
+
+    // The value list position advances once per character (code point), so a non-BMP character
+    // encoded as a UTF-16 surrogate pair must count once, not once per code unit. This keeps the
+    // value list keys consistent with the per-character lookup in measureTextRendererWithIterator().
     if (text.style().whiteSpaceCollapse() == WhiteSpaceCollapse::Preserve) {
-        atCharacter += length;
+        for (unsigned i = 0; i < length;) {
+            U16_FWD_1(string, i, length);
+            ++atCharacter;
+        }
         if (length)
             lastCharacterWasSpace = string[length - 1] == ' ';
         return;
     }
 
     // FIXME: This is not a complete whitespace collapsing implementation; it doesn't handle newlines or tabs.
-    for (unsigned i = 0; i < length; ++i) {
-        char16_t character = string[i];
+    for (unsigned i = 0; i < length;) {
+        char32_t character;
+        U16_NEXT(string, i, length, character);
         if (character == ' ' && lastCharacterWasSpace)
             continue;
 

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -253,7 +253,12 @@ std::tuple<unsigned, char16_t> SVGTextMetricsBuilder::measureTextRendererWithIte
         lastCharacter = currentCharacter;
     }
 
-    return std::tuple { valueListPosition + m_textPosition - skippedCharacters, lastCharacter };
+    // m_textPosition counts UTF-16 code units, but the value list position advances once per
+    // character. Subtract the surrogate pairs seen in this renderer so the position handed to the
+    // next renderer stays character-based (otherwise a non-BMP character before a tspan boundary
+    // shifts the following value list lookups by one). See lookup above which applies the same
+    // correction within a single renderer.
+    return std::tuple { valueListPosition + m_textPosition - skippedCharacters - surrogatePairCharacters, lastCharacter };
 }
 
 void SVGTextMetricsBuilder::walkTree(RenderElement& start, RenderSVGInlineText* stopAtLeaf, MeasureTextData& data)


### PR DESCRIPTION
#### 75322e6f014a74fd4d150fcb1f11028a540f8e8c
<pre>
[SVG] Non-BMP character before a tspan boundary shifts the x/y value list by one
<a href="https://bugs.webkit.org/show_bug.cgi?id=315942">https://bugs.webkit.org/show_bug.cgi?id=315942</a>
<a href="https://rdar.apple.com/178360036">rdar://178360036</a>

Reviewed by Taher Ali.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Inspired by: <a href="https://chromium.googlesource.com/chromium/src.git/+/9331211c22aee7b499131aa1c58ce515deceeb45">https://chromium.googlesource.com/chromium/src.git/+/9331211c22aee7b499131aa1c58ce515deceeb45</a>

Value list positions (x/y/dx/dy/rotate) advance once per character, not
per UTF-16 code unit. The value list lookup in SVGTextMetricsBuilder
already mapped a glyph&apos;s code-unit position to a character ordinal, but
the map keys were built by counting code units in
SVGTextLayoutAttributesBuilder, and the position carried to the next
renderer was code-unit based too. A non-BMP character (a surrogate pair)
therefore desynced the two across a renderer boundary, so an x/y list
spanning a surrogate pair into a sibling/child tspan placed the
following glyph one slot off (e.g. &lt;text x=&quot;0 100&quot;&gt;&amp;#x1100F;&lt;tspan&gt;
&amp;#x1100F;&lt;/tspan&gt;&lt;/text&gt; failed to put the tspan glyph at x=100).

Count code points, not code units, when building value list keys, and
carry a character-based position across renderers.

* Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp:
(WebCore::processRenderSVGInlineText):
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::SVGTextMetricsBuilder::measureTextRendererWithIterator):
* LayoutTests/svg/text/surrogate-pair-addressable-character-expected.txt: Added.
* LayoutTests/svg/text/surrogate-pair-addressable-character.html: Added.

Canonical link: <a href="https://commits.webkit.org/315418@main">https://commits.webkit.org/315418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/431f8613aef8043d2968cc64959d49ad64b00582

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123475 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb1c7105-ced3-4fb0-8bdf-301255e98245) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129200 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91005 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96cf99c9-4aa0-453b-8a0a-6f13089c0483) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109725 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d455c5a0-889c-48d5-a6b2-768234691d59) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30557 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29251 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23408 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140525 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177800 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137548 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137475 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37648 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40467 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25712 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103103 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32769 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112052 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38978 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3798 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38375 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38518 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->