### PR TITLE
Apply vector-effect transform to path geometry - not stroke geometry

### DIFF
--- a/LayoutTests/svg/custom/non-scaling-stroke-zero-length-subpath-linecaps-expected.html
+++ b/LayoutTests/svg/custom/non-scaling-stroke-zero-length-subpath-linecaps-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+path {
+  vector-effect: non-scaling-stroke;
+  stroke-width: 10px;
+  stroke: green;
+}
+</style>
+<svg>
+  <path d="M20,10L20,10M220,110L220,110" stroke-linecap="round"/>
+  <path d="M220,10L220,10M20,110L20,110" stroke-linecap="square"/>
+</svg>

--- a/LayoutTests/svg/custom/non-scaling-stroke-zero-length-subpath-linecaps.html
+++ b/LayoutTests/svg/custom/non-scaling-stroke-zero-length-subpath-linecaps.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+path {
+  vector-effect: non-scaling-stroke;
+  stroke-width: 10px;
+  stroke: green;
+}
+</style>
+<svg>
+  <g transform="scale(2,1)">
+    <path d="M10,10L10,10M110,110L110,110" stroke-linecap="round"/>
+    <path d="M110,10L110,10M10,110L10,110" stroke-linecap="square"/>
+  </g>
+</svg>

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -140,19 +140,6 @@ bool RenderSVGPath::shouldStrokeZeroLengthSubpath() const
     return !style().stroke().isNone() && style().capStyle() != LineCap::Butt;
 }
 
-Path* RenderSVGPath::zeroLengthLinecapPath(const FloatPoint& linecapPosition) const
-{
-    static NeverDestroyed<Path> tempPath;
-
-    tempPath.get().clear();
-    if (style().capStyle() == LineCap::Square)
-        tempPath.get().addRect(zeroLengthSubpathRect(linecapPosition, this->strokeWidth()));
-    else
-        tempPath.get().addEllipseInRect(zeroLengthSubpathRect(linecapPosition, this->strokeWidth()));
-
-    return &tempPath.get();
-}
-
 FloatRect RenderSVGPath::zeroLengthSubpathRect(const FloatPoint& linecapPosition, float strokeWidth) const
 {
     return FloatRect(linecapPosition.x() - strokeWidth / 2, linecapPosition.y() - strokeWidth / 2, strokeWidth, strokeWidth);
@@ -183,11 +170,20 @@ void RenderSVGPath::strokeZeroLengthSubpaths(GraphicsContext& context) const
 
     GraphicsContextStateSaver stateSaver(context, true);
     useStrokeStyleToFill(context);
-    for (size_t i = 0; i < m_zeroLengthLinecapLocations.size(); ++i) {
-        auto usePath = zeroLengthLinecapPath(m_zeroLengthLinecapLocations[i]);
-        if (hasNonScalingStroke())
-            usePath = nonScalingStrokePath(usePath, nonScalingTransform);
-        context.fillPath(*usePath);
+
+    float strokeWidth = this->strokeWidth();
+    bool isSquareCap = style().capStyle() == LineCap::Square;
+    for (auto& linecapLocation : m_zeroLengthLinecapLocations) {
+        // The linecap location is path geometry, not stroke geometry. So when
+        // vector-effect: non-scaling-stroke is in effect, the transform must be
+        // applied to the position where the cap is drawn -- not to the generated
+        // cap shape, which would otherwise be distorted by the transform.
+        auto position = hasNonScalingStroke() ? nonScalingTransform.mapPoint(linecapLocation) : linecapLocation;
+        auto subpathRect = zeroLengthSubpathRect(position, strokeWidth);
+        if (isSquareCap)
+            context.fillRect(subpathRect);
+        else
+            context.fillEllipse(subpathRect);
     }
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.h
@@ -53,7 +53,6 @@ private:
     void styleDidChange(Style::Difference, const RenderStyle*) final;
 
     bool NODELETE shouldStrokeZeroLengthSubpath() const;
-    Path* zeroLengthLinecapPath(const FloatPoint&) const;
     FloatRect NODELETE zeroLengthSubpathRect(const FloatPoint&, float) const;
     void updateZeroLengthSubpaths();
     void strokeZeroLengthSubpaths(GraphicsContext&) const;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -154,19 +154,6 @@ bool LegacyRenderSVGPath::shouldStrokeZeroLengthSubpath() const
     return !style().stroke().isNone() && style().capStyle() != LineCap::Butt;
 }
 
-Path* LegacyRenderSVGPath::zeroLengthLinecapPath(const FloatPoint& linecapPosition) const
-{
-    static NeverDestroyed<Path> tempPath;
-
-    tempPath.get().clear();
-    if (style().capStyle() == LineCap::Square)
-        tempPath.get().addRect(zeroLengthSubpathRect(linecapPosition, this->strokeWidth()));
-    else
-        tempPath.get().addEllipseInRect(zeroLengthSubpathRect(linecapPosition, this->strokeWidth()));
-
-    return &tempPath.get();
-}
-
 FloatRect LegacyRenderSVGPath::zeroLengthSubpathRect(const FloatPoint& linecapPosition, float strokeWidth) const
 {
     return FloatRect(linecapPosition.x() - strokeWidth / 2, linecapPosition.y() - strokeWidth / 2, strokeWidth, strokeWidth);
@@ -197,11 +184,20 @@ void LegacyRenderSVGPath::strokeZeroLengthSubpaths(GraphicsContext& context) con
 
     GraphicsContextStateSaver stateSaver(context, true);
     legacyUseStrokeStyleToFill(context);
-    for (size_t i = 0; i < m_zeroLengthLinecapLocations.size(); ++i) {
-        auto usePath = zeroLengthLinecapPath(m_zeroLengthLinecapLocations[i]);
-        if (hasNonScalingStroke())
-            usePath = nonScalingStrokePath(usePath, nonScalingTransform);
-        context.fillPath(*usePath);
+
+    float strokeWidth = this->strokeWidth();
+    bool isSquareCap = style().capStyle() == LineCap::Square;
+    for (auto& linecapLocation : m_zeroLengthLinecapLocations) {
+        // The linecap location is path geometry, not stroke geometry. So when
+        // vector-effect: non-scaling-stroke is in effect, the transform must be
+        // applied to the position where the cap is drawn -- not to the generated
+        // cap shape, which would otherwise be distorted by the transform.
+        auto position = hasNonScalingStroke() ? nonScalingTransform.mapPoint(linecapLocation) : linecapLocation;
+        auto subpathRect = zeroLengthSubpathRect(position, strokeWidth);
+        if (isSquareCap)
+            context.fillRect(subpathRect);
+        else
+            context.fillEllipse(subpathRect);
     }
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
@@ -50,7 +50,6 @@ private:
     void styleDidChange(Style::Difference, const RenderStyle*) final;
 
     bool NODELETE shouldStrokeZeroLengthSubpath() const;
-    Path* zeroLengthLinecapPath(const FloatPoint&) const;
     FloatRect NODELETE zeroLengthSubpathRect(const FloatPoint&, float) const;
     void updateZeroLengthSubpaths();
     void strokeZeroLengthSubpaths(GraphicsContext&) const;


### PR DESCRIPTION
#### 46269d2e53cdb264c66524bda9ae5003fdf56ca8
<pre>
Apply vector-effect transform to path geometry - not stroke geometry
<a href="https://bugs.webkit.org/show_bug.cgi?id=249265">https://bugs.webkit.org/show_bug.cgi?id=249265</a>
<a href="https://rdar.apple.com/103573160">rdar://103573160</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge (Test) &amp; Inspired by: <a href="https://chromium.googlesource.com/chromium/blink/+/dd578478d0d2affea98eb5cf59f9f6f525cfd890">https://chromium.googlesource.com/chromium/blink/+/dd578478d0d2affea98eb5cf59f9f6f525cfd890</a>

When drawing line caps for zero-length subpaths, the path-derived
geometry is the position of the linecap, and not the generated shape.
Hence the non-scaling-stroke transform should be applied to the position
where the line cap shape should be drawn, and not the shape itself.
Previously the transform was applied to the whole cap shape, so a
non-uniform transform (e.g. scale(2,1)) would distort the cap itself -
turning a round cap into an ellipse and a square cap into a rectangle -
which is exactly what vector-effect: non-scaling-stroke should prevent.

This also lets us simplify the code by calling fillRect/fillEllipse
directly instead of going through a temporary Path object, so the
zeroLengthLinecapPath() helper is removed.

NOTE: This patch fixes the bug in both Legacy and Layer based SVG engine.

* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::strokeZeroLengthSubpaths const):
(WebCore::RenderSVGPath::zeroLengthLinecapPath const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGPath.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::strokeZeroLengthSubpaths const):
(WebCore::LegacyRenderSVGPath::zeroLengthLinecapPath const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h:
* LayoutTests/svg/custom/non-scaling-stroke-zero-length-subpath-linecaps-expected.html: Added.
* LayoutTests/svg/custom/non-scaling-stroke-zero-length-subpath-linecaps.html: Added.

Canonical link: <a href="https://commits.webkit.org/314302@main">https://commits.webkit.org/314302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5862d9f8078e835f770da863af2d970ad171c72e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122801 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b74e9b1-b439-41f1-9d96-e9b75cca56c8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128652 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90580 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a25b7a40-1733-49b9-9c00-29a4a3d1eca8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168505 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30975 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109176 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6eb6029d-1228-4a06-b6c5-f334e5026c98) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30012 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28645 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22666 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177112 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30022 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136978 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136912 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36928 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148222 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102241 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32188 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25089 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38303 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111377 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37700 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3175 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37946 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37844 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->