### PR TITLE
Annotate more string methods as NODELETE

### DIFF
--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -80,22 +80,22 @@ public:
 
     bool contains(char16_t character) const { return m_string.contains(character); }
     bool contains(ASCIILiteral literal) const { return m_string.contains(literal); }
-    bool contains(StringView) const;
-    bool containsIgnoringASCIICase(StringView) const;
+    bool NODELETE contains(StringView) const;
+    bool NODELETE containsIgnoringASCIICase(StringView) const;
 
     size_t find(char16_t character, size_t start = 0) const { return m_string.find(character, start); }
     size_t find(ASCIILiteral literal, size_t start = 0) const { return m_string.find(literal, start); }
-    size_t find(StringView, size_t start = 0) const;
-    size_t findIgnoringASCIICase(StringView) const;
-    size_t findIgnoringASCIICase(StringView, size_t start) const;
+    size_t NODELETE find(StringView, size_t start = 0) const;
+    size_t NODELETE findIgnoringASCIICase(StringView) const;
+    size_t NODELETE findIgnoringASCIICase(StringView, size_t start) const;
     size_t find(CodeUnitMatchFunction matchFunction, size_t start = 0) const { return m_string.find(matchFunction, start); }
 
-    bool startsWith(StringView) const;
-    bool startsWithIgnoringASCIICase(StringView) const;
+    bool NODELETE startsWith(StringView) const;
+    bool NODELETE startsWithIgnoringASCIICase(StringView) const;
     bool startsWith(char16_t character) const { return m_string.startsWith(character); }
 
-    bool endsWith(StringView) const;
-    bool endsWithIgnoringASCIICase(StringView) const;
+    bool NODELETE endsWith(StringView) const;
+    bool NODELETE endsWithIgnoringASCIICase(StringView) const;
     bool endsWith(char16_t character) const { return m_string.endsWith(character); }
 
     WTF_EXPORT_PRIVATE AtomString convertToASCIILowercase() const;

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -1188,12 +1188,12 @@ inline size_t NODELETE find(std::span<const CharacterType1> characters, Characte
     return notFound;
 }
 
-ALWAYS_INLINE size_t find(std::span<const char16_t> characters, Latin1Character matchCharacter, size_t index = 0)
+ALWAYS_INLINE size_t NODELETE find(std::span<const char16_t> characters, Latin1Character matchCharacter, size_t index = 0)
 {
     return find(characters, static_cast<char16_t>(matchCharacter), index);
 }
 
-inline size_t find(std::span<const Latin1Character> characters, char16_t matchCharacter, size_t index = 0)
+inline size_t NODELETE find(std::span<const Latin1Character> characters, char16_t matchCharacter, size_t index = 0)
 {
     if (!isLatin1(matchCharacter))
         return notFound;
@@ -1201,19 +1201,19 @@ inline size_t find(std::span<const Latin1Character> characters, char16_t matchCh
 }
 
 template<OneByteCharacterType CharacterType>
-inline size_t find(std::span<const CharacterType> characters, ASCIILiteral matchCharacters)
+inline size_t NODELETE find(std::span<const CharacterType> characters, ASCIILiteral matchCharacters)
 {
     return find(characters, byteCast<CharacterType>(matchCharacters.span()));
 }
 
 template<std::integral CharacterType1, std::integral CharacterType2>
-inline bool contains(std::span<const CharacterType1> characters, CharacterType2 matchCharacter, size_t index = 0)
+inline bool NODELETE contains(std::span<const CharacterType1> characters, CharacterType2 matchCharacter, size_t index = 0)
 {
     return find(characters, matchCharacter, index) != notFound;
 }
 
 template<OneByteCharacterType CharacterType>
-inline bool contains(std::span<const CharacterType> characters, ASCIILiteral matchCharacters)
+inline bool NODELETE contains(std::span<const CharacterType> characters, ASCIILiteral matchCharacters)
 {
     return contains(characters, byteCast<CharacterType>(matchCharacters.span()));
 }

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -87,7 +87,7 @@ template<typename> struct HashAndCharactersTranslator;
 // Define STRING_STATS to 1 turn on runtime statistics of string sizes and memory usage.
 #define STRING_STATS 0
 
-template<bool isSpecialCharacter(char16_t), typename CharacterType, std::size_t Extent = std::dynamic_extent> bool containsOnly(std::span<const CharacterType, Extent>);
+template<bool isSpecialCharacter(char16_t), typename CharacterType, std::size_t Extent = std::dynamic_extent> bool NODELETE containsOnly(std::span<const CharacterType, Extent>);
 
 #if STRING_STATS
 
@@ -478,19 +478,19 @@ public:
 
     bool containsOnlyASCII() const;
     bool containsOnlyLatin1() const;
-    template<bool isSpecialCharacter(char16_t)> bool containsOnly() const;
+    template<bool isSpecialCharacter(char16_t)> bool NODELETE containsOnly() const;
 
     size_t NODELETE find(Latin1Character, size_t start = 0);
-    size_t find(char, size_t start = 0);
-    size_t find(char16_t, size_t start = 0);
+    size_t NODELETE find(char, size_t start = 0);
+    size_t NODELETE find(char16_t, size_t start = 0);
     template<typename CodeUnitMatchFunction>
         requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
-    size_t find(CodeUnitMatchFunction, size_t start = 0);
+    size_t NODELETE find(CodeUnitMatchFunction, size_t start = 0);
     ALWAYS_INLINE size_t find(ASCIILiteral literal, size_t start = 0) { return find(literal.span8(), start); }
-    WTF_EXPORT_PRIVATE size_t find(StringView);
-    WTF_EXPORT_PRIVATE size_t find(StringView, size_t start);
-    WTF_EXPORT_PRIVATE size_t findIgnoringASCIICase(StringView) const;
-    WTF_EXPORT_PRIVATE size_t findIgnoringASCIICase(StringView, size_t start) const;
+    WTF_EXPORT_PRIVATE size_t NODELETE find(StringView);
+    WTF_EXPORT_PRIVATE size_t NODELETE find(StringView, size_t start);
+    WTF_EXPORT_PRIVATE size_t NODELETE findIgnoringASCIICase(StringView) const;
+    WTF_EXPORT_PRIVATE size_t NODELETE findIgnoringASCIICase(StringView, size_t start) const;
 
     WTF_EXPORT_PRIVATE size_t NODELETE reverseFind(char16_t, size_t start = MaxLength);
     WTF_EXPORT_PRIVATE size_t NODELETE reverseFind(StringView, size_t start = MaxLength);
@@ -704,7 +704,8 @@ template<typename CodeUnit, typename CodeUnitMatchFunction>
 inline size_t find(std::span<const CodeUnit> characters, CodeUnitMatchFunction&& matchFunction, size_t start)
 {
     while (start < characters.size()) {
-        if (matchFunction(characters[start]))
+        // FIXME: support NODELETE predicates (rdar://178355573).
+        SUPPRESS_NODELETE if (matchFunction(characters[start]))
             return start;
         ++start;
     }

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -158,12 +158,12 @@ public:
     SplitResult split(char16_t) const;
     SplitResult splitAllowingEmptyEntries(char16_t) const;
 
-    size_t find(char16_t, unsigned start = 0) const;
-    size_t find(Latin1Character, unsigned start = 0) const;
+    size_t NODELETE find(char16_t, unsigned start = 0) const;
+    size_t NODELETE find(Latin1Character, unsigned start = 0) const;
     ALWAYS_INLINE size_t find(char c, unsigned start = 0) const { return find(byteCast<Latin1Character>(c), start); }
     template<typename CodeUnitMatchFunction>
         requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
-    size_t find(CodeUnitMatchFunction&&, unsigned start = 0) const;
+    size_t NODELETE find(CodeUnitMatchFunction&&, unsigned start = 0) const;
     ALWAYS_INLINE size_t find(ASCIILiteral literal, unsigned start = 0) const { return find(literal.span8(), start); }
     WTF_EXPORT_PRIVATE size_t NODELETE find(StringView, unsigned start = 0) const;
     WTF_EXPORT_PRIVATE size_t NODELETE find(AdaptiveStringSearcherTables&, StringView, unsigned start = 0) const;
@@ -181,17 +181,17 @@ public:
 
     WTF_EXPORT_PRIVATE std::optional<char32_t> NODELETE convertToSingleCodePoint() const;
 
-    bool contains(char16_t) const;
+    bool NODELETE contains(char16_t) const;
     template<typename CodeUnitMatchFunction>
         requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
-    bool contains(CodeUnitMatchFunction&&) const;
+    bool NODELETE contains(CodeUnitMatchFunction&&) const;
     bool contains(ASCIILiteral literal) const { return find(literal) != notFound; }
     bool contains(StringView string) const { return find(string) != notFound; }
 
     WTF_EXPORT_PRIVATE bool NODELETE containsIgnoringASCIICase(StringView) const;
     WTF_EXPORT_PRIVATE bool NODELETE containsIgnoringASCIICase(StringView, unsigned start) const;
 
-    template<bool isSpecialCharacter(char16_t)> bool containsOnly() const;
+    template<bool isSpecialCharacter(char16_t)> bool NODELETE containsOnly() const;
 
     WTF_EXPORT_PRIVATE bool NODELETE startsWith(char16_t) const;
     WTF_EXPORT_PRIVATE bool NODELETE startsWith(StringView) const;
@@ -1322,7 +1322,7 @@ inline size_t findCommon(StringView haystack, StringView needle, unsigned start)
     return findInner(haystack.span16().subspan(start), needle.span16(), start);
 }
 
-SUPPRESS_NODELETE inline size_t findIgnoringASCIICase(StringView source, StringView stringToFind, unsigned start)
+SUPPRESS_NODELETE inline size_t NODELETE findIgnoringASCIICase(StringView source, StringView stringToFind, unsigned start)
 {
     unsigned sourceStringLength = source.length();
     unsigned matchLength = stringToFind.length();
@@ -1347,7 +1347,7 @@ SUPPRESS_NODELETE inline size_t findIgnoringASCIICase(StringView source, StringV
     return WTF::findIgnoringASCIICase(source.span16(), stringToFind.span16(), static_cast<size_t>(start));
 }
 
-inline bool startsWith(StringView reference, StringView prefix)
+inline bool NODELETE startsWith(StringView reference, StringView prefix)
 {
     if (prefix.length() > reference.length())
         return false;
@@ -1377,7 +1377,7 @@ inline bool NODELETE startsWithIgnoringASCIICase(StringView reference, StringVie
     return equalIgnoringASCIICaseWithLength(reference.span16(), prefix.span16(), prefix.length());
 }
 
-inline bool endsWith(StringView reference, StringView suffix)
+inline bool NODELETE endsWith(StringView reference, StringView suffix)
 {
     unsigned suffixLength = suffix.length();
     unsigned referenceLength = reference.length();

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -53,7 +53,7 @@ WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const char16_t>, bool* ok =
 WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const Latin1Character>, size_t& parsedLength);
 WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const char16_t>, size_t& parsedLength);
 
-template<bool isSpecialCharacter(char16_t), typename CharacterType, std::size_t Extent> bool containsOnly(std::span<const CharacterType, Extent>);
+template<bool isSpecialCharacter(char16_t), typename CharacterType, std::size_t Extent> bool NODELETE containsOnly(std::span<const CharacterType, Extent>);
 
 enum class TrailingZerosPolicy : bool { Keep, Truncate };
 
@@ -153,10 +153,10 @@ public:
     size_t find(Latin1Character character, unsigned start = 0) const { return m_impl ? m_impl->find(character, start) : notFound; }
     size_t find(char character, unsigned start = 0) const { return m_impl ? m_impl->find(character, start) : notFound; }
 
-    size_t find(StringView) const;
-    size_t find(StringView, unsigned start) const;
-    size_t findIgnoringASCIICase(StringView) const;
-    size_t findIgnoringASCIICase(StringView, unsigned start) const;
+    size_t NODELETE find(StringView) const;
+    size_t NODELETE find(StringView, unsigned start) const;
+    size_t NODELETE findIgnoringASCIICase(StringView) const;
+    size_t NODELETE findIgnoringASCIICase(StringView, unsigned start) const;
 
     template<typename CodeUnitMatchFunction>
         requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
@@ -175,23 +175,23 @@ public:
 
     bool contains(char16_t character) const { return find(character) != notFound; }
     bool contains(ASCIILiteral literal) const { return find(literal) != notFound; }
-    bool contains(StringView) const;
+    bool NODELETE contains(StringView) const;
     template<typename CodeUnitMatchFunction>
         requires (std::is_invocable_r_v<bool, CodeUnitMatchFunction, char16_t>)
     bool contains(CodeUnitMatchFunction matchFunction) const { return find(matchFunction, 0) != notFound; }
-    bool containsIgnoringASCIICase(StringView) const;
-    bool containsIgnoringASCIICase(StringView, unsigned start) const;
+    bool NODELETE containsIgnoringASCIICase(StringView) const;
+    bool NODELETE containsIgnoringASCIICase(StringView, unsigned start) const;
 
-    bool startsWith(StringView) const;
-    bool startsWithIgnoringASCIICase(StringView) const;
+    bool NODELETE startsWith(StringView) const;
+    bool NODELETE startsWithIgnoringASCIICase(StringView) const;
     bool startsWith(char16_t character) const { return m_impl && m_impl->startsWith(character); }
-    bool hasInfixStartingAt(StringView prefix, unsigned start) const;
+    bool NODELETE hasInfixStartingAt(StringView prefix, unsigned start) const;
 
-    bool endsWith(StringView) const;
-    bool endsWithIgnoringASCIICase(StringView) const;
+    bool NODELETE endsWith(StringView) const;
+    bool NODELETE endsWithIgnoringASCIICase(StringView) const;
     bool endsWith(char16_t character) const { return m_impl && m_impl->endsWith(character); }
     bool endsWith(char character) const { return endsWith(static_cast<char16_t>(character)); }
-    bool hasInfixEndingAt(StringView suffix, unsigned end) const;
+    bool NODELETE hasInfixEndingAt(StringView suffix, unsigned end) const;
 
     [[nodiscard]] String substring(unsigned position, unsigned length = MaxLength) const;
     [[nodiscard]] WTF_EXPORT_PRIVATE String substringSharingImpl(unsigned position, unsigned length = MaxLength) const;


### PR DESCRIPTION
#### 29b03b7c66e097cedc5d6fa01348389b69d4343c
<pre>
Annotate more string methods as NODELETE
<a href="https://bugs.webkit.org/show_bug.cgi?id=315946">https://bugs.webkit.org/show_bug.cgi?id=315946</a>

Reviewed by Darin Adler.

This is useful for bug 315737, where I have a patch that proves that
this works, but it seemed best to land this as its own change.

This suppresses the invocation of a predicate in find() under the
assumption that we&apos;d never write a predicate that would violate
NODELETE. It has a FIXME to make that more robust in the future.

Canonical link: <a href="https://commits.webkit.org/314238@main">https://commits.webkit.org/314238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/864aa5ac4eec2128816b17f91c3fbfd6628ef4d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174589 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122802 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e17a0da-63b9-4168-80da-f0a48000d28f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128653 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90581 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b75a30d8-0d95-43b5-b2e4-cdb63458d1f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168506 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30976 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109177 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e63a3b25-72b5-48db-b2f7-6b111a378d66) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28646 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22667 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157704 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139907 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177113 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26440 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30023 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136979 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136913 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148224 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102247 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25187 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32189 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25091 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38304 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111378 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37701 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3171 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37947 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37845 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->