### PR TITLE
[EvaluationTimeZoom] Add way to access device scale factor cheaply during layout.

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -348,6 +348,11 @@ inline float RenderStyle::usedZoom() const
     return m_computedStyle.usedZoom();
 }
 
+inline float RenderStyle::deviceScaleFactor() const
+{
+    return m_computedStyle.deviceScaleFactor();
+}
+
 inline Style::ZoomFactor RenderStyle::usedZoomForLength() const
 {
     return m_computedStyle.usedZoomForLength();

--- a/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
@@ -304,6 +304,11 @@ inline bool RenderStyle::setUsedZoom(float zoomLevel)
     return m_computedStyle.setUsedZoom(zoomLevel);
 }
 
+inline void RenderStyle::setDeviceScaleFactor(float deviceScaleFactor)
+{
+    m_computedStyle.setDeviceScaleFactor(deviceScaleFactor);
+}
+
 // MARK: - Aggregates
 
 inline Style::Animations& RenderStyle::ensureAnimations()

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -237,6 +237,9 @@ public:
     inline float usedZoom() const;
     inline bool setUsedZoom(float);
 
+    inline float deviceScaleFactor() const;
+    inline void setDeviceScaleFactor(float);
+
     inline Style::ZoomFactor usedZoomForLength() const;
 
     // MARK: - Fonts

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -343,6 +343,7 @@ public:
             || a.lineFitEdge != b.lineFitEdge
             || a.usedZoom != b.usedZoom
             || a.textZoom != b.textZoom
+            || a.deviceScaleFactor != b.deviceScaleFactor
     #if ENABLE(TEXT_AUTOSIZING)
             || a.textSizeAdjust != b.textSizeAdjust
     #endif

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -115,6 +115,7 @@ RenderStyle resolveForDocument(const Document& document)
     documentStyle.setFontCascade(WTF::move(fontCascade));
 
     documentStyle.setEvaluationTimeZoomEnabled(document.settings().evaluationTimeZoomEnabled());
+    documentStyle.setDeviceScaleFactor(document.deviceScaleFactor());
 
     return documentStyle;
 }

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -307,6 +307,11 @@ inline float ComputedStyleBase::usedZoom() const
     return m_inheritedRareData->usedZoom;
 }
 
+inline float ComputedStyleBase::deviceScaleFactor() const
+{
+    return m_inheritedRareData->deviceScaleFactor;
+}
+
 inline ZoomFactor ComputedStyleBase::usedZoomForLength() const
 {
     static constexpr ZoomFactor unzoomed(1.0f);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -251,6 +251,11 @@ inline bool ComputedStyleBase::setUsedZoom(float zoomLevel)
     return true;
 }
 
+inline void ComputedStyleBase::setDeviceScaleFactor(float scaleFactor)
+{
+    SET(m_inheritedRareData, deviceScaleFactor, scaleFactor);
+}
+
 // MARK: - Aggregates
 
 inline Animations& ComputedStyleBase::ensureAnimations()

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -614,6 +614,9 @@ public:
     inline float usedZoom() const;
     inline bool setUsedZoom(float);
 
+    inline float deviceScaleFactor() const;
+    inline void setDeviceScaleFactor(float);
+
     void setZoomFromAnimation(Zoom);
 
     inline ZoomFactor usedZoomForLength() const;

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
@@ -35,6 +35,7 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(InheritedRareData);
 
 InheritedRareData::InheritedRareData()
     : usedZoom(1.0f)
+    , deviceScaleFactor(2.0f)
     , textStrokeWidth(ComputedStyle::initialTextStrokeWidth())
     , textStrokeColor(ComputedStyle::initialTextStrokeColor())
     , textFillColor(ComputedStyle::initialTextFillColor())
@@ -140,6 +141,7 @@ InheritedRareData::InheritedRareData()
 inline InheritedRareData::InheritedRareData(const InheritedRareData& o)
     : RefCounted<InheritedRareData>()
     , usedZoom(o.usedZoom)
+    , deviceScaleFactor(o.deviceScaleFactor)
     , textStrokeWidth(o.textStrokeWidth)
     , textStrokeColor(o.textStrokeColor)
     , textFillColor(o.textFillColor)
@@ -253,6 +255,7 @@ InheritedRareData::~InheritedRareData() = default;
 bool InheritedRareData::operator==(const InheritedRareData& o) const
 {
     return usedZoom == o.usedZoom
+        && deviceScaleFactor == o.deviceScaleFactor
         && textStrokeWidth == o.textStrokeWidth
         && textStrokeColor == o.textStrokeColor
         && textFillColor == o.textFillColor
@@ -360,6 +363,7 @@ void InheritedRareData::dumpDifferences(TextStream& ts, const InheritedRareData&
     customProperties->dumpDifferences(ts, other.customProperties);
 
     LOG_IF_DIFFERENT(usedZoom);
+    LOG_IF_DIFFERENT(deviceScaleFactor);
 
     LOG_IF_DIFFERENT(listStyleImage);
 

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.h
@@ -105,6 +105,10 @@ public:
 #endif
 
     float usedZoom;
+    // This lives here so that we can access the device scale factor cheaply during
+    // layout in order to perform pixel snapping for StyleLineWidth evaluations.
+    // Otherwise, we get significant regressions on performance benchmarks.
+    float deviceScaleFactor;
     WebkitTextStrokeWidth textStrokeWidth;
 
     Color textStrokeColor;


### PR DESCRIPTION
#### 11673bb9c2c0a3290320bd80bfd78ae3d16cc48e
<pre>
[EvaluationTimeZoom] Add way to access device scale factor cheaply during layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=316009">https://bugs.webkit.org/show_bug.cgi?id=316009</a>
<a href="https://rdar.apple.com/problem/178439138">rdar://problem/178439138</a>

Reviewed by Simon Fraser and Vitor Roriz.

It seems like in order to properly mark StyleLineWidth as an “Unzoomed&quot; type,
we will need access to the device scale factor since we will need it for pixel
snapping. Currently, the only way to access it during layout, which is where
most of the evaluation occurs, is to get it off of the Page since that is
where it lives. This requires jumping through quite a few pointers since we need
to go from the renderer and through its Node, Document, and finally get to the
Page. Unfortunately, A/B testing shows that this results in quite a significant
Speedometer regression. Some investigation uncovered that the reason for this
is due to these device scale factor accesses and not other factors, such as
the extra work that comes from the pixel snapping logic.

The goal of this patch is to introduce a new way to access the device scale
factor during layout without suffering from performance regressions. After
experimenting with a few different approaches, it seems like the best option
will be to have it live on InheritedRareData. There was a point in time where
we were already doing this, but I ended up removing it in a previous commit
(308616@main) as a cleanup patch since it was unused at the time.

A/B testing with this patch and one that marked StyleLineWidth as Unzoomed was
neutral on both Speedometer and MotionMark.

Here are a few other ideas that I had but did not perform as well as the above with
respect to perf:

1.) Adding a fast path static function that could be used. The idea was that
we could keep a synchronized device scale factor on Page that would exist and
be returned if the value was the same across all the pages and otherwise use
a passed in callback if it did not. This was a Speedometer regression across
the board on different devices and subtests.

2.) Storing the value on NonInheritedMiscData. This could arguably make more
sense than the current location on InheritedRareData, but this results in
quite a severe regression on certain devices. Specifically, on devices where
The device scale factor does not match the initial value. We do a lot more work
to get this value updated across all the Style objects.

3.) Directly on the Style object itself. This also resulted in a Speedometer
regression, but I did not investigate super deeply into the cause of it. I
presume it comes from changing memory/caching characteristics since we are
increasing the style of the object.

Canonical link: <a href="https://commits.webkit.org/314472@main">https://commits.webkit.org/314472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/728697cb0b338bd9670d4e658b0b6fb9feabacda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174796 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123009 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db1a6ed2-f2a3-4e84-b272-58a92f3fbd41) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39248 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128814 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90724 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23a987c1-1023-4d9b-a2cf-59ff0d46db9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109338 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cde0c92c-1982-4d70-87a6-c5777d4ed47e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30137 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28830 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22879 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177321 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30236 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137147 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137075 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37038 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148408 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102528 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25275 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38512 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111585 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 32442 issues") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37908 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3357 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38154 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38052 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->