### PR TITLE
[Test Coverage] CSS outline on an inline <svg> is not repainted when toggled on :hover (appears stale / missing)

### DIFF
--- a/LayoutTests/platform/ios/svg/repaint/svg-outline-repaint-on-hover-expected.txt
+++ b/LayoutTests/platform/ios/svg/repaint/svg-outline-repaint-on-hover-expected.txt
@@ -1,0 +1,6 @@
+ SVG border box: 100x100 at (50,50)
+
+Repaint rects on hover (outline added):
+
+Repaint rects on un-hover (outline removed):
+

--- a/LayoutTests/svg/repaint/svg-outline-repaint-on-hover-expected.txt
+++ b/LayoutTests/svg/repaint/svg-outline-repaint-on-hover-expected.txt
@@ -1,0 +1,17 @@
+ SVG border box: 100x100 at (50,50)
+
+Repaint rects on hover (outline added):
+(repaint rects
+  (rect 50 50 100 100)
+  (rect 35 35 130 130)
+  (rect 0 0 800 204)
+)
+
+Repaint rects on un-hover (outline removed):
+(repaint rects
+  (rect 35 35 130 130)
+  (rect 35 35 130 130)
+  (rect 35 35 130 130)
+  (rect 0 0 800 204)
+)
+

--- a/LayoutTests/svg/repaint/svg-outline-repaint-on-hover.html
+++ b/LayoutTests/svg/repaint/svg-outline-repaint-on-hover.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG root: repaint rects when toggling outline on :hover</title>
+<style>
+    body { margin: 0; }
+    svg { margin: 50px; }
+    svg:hover { outline: 10px solid green; outline-offset: 5px; }
+</style>
+</head>
+<body>
+<svg width="100" height="100"><rect width="100" height="100" fill="blue"/></svg>
+<pre id="result">FAIL: test did not run.</pre>
+<script>
+function run() {
+    const result = document.getElementById("result");
+    if (!window.internals || !window.eventSender || !window.testRunner) {
+        result.textContent = "This test requires window.internals, window.eventSender and window.testRunner.";
+        return;
+    }
+    testRunner.dumpAsText();
+
+    const svg = document.querySelector("svg");
+
+    // Establish a clean, un-hovered baseline.
+    eventSender.mouseMoveTo(400, 400);
+    document.body.offsetHeight;
+
+    const box = svg.getBoundingClientRect();
+    const cx = box.left + box.width / 2;
+    const cy = box.top + box.height / 2;
+
+    // 1) Hover -> :hover adds the outline.
+    internals.startTrackingRepaints();
+    eventSender.mouseMoveTo(cx, cy);
+    document.body.offsetHeight;
+    const hoverRects = internals.repaintRectsAsText();
+    internals.stopTrackingRepaints();
+
+    // 2) Un-hover -> outline removed.
+    internals.startTrackingRepaints();
+    eventSender.mouseMoveTo(400, 400);
+    document.body.offsetHeight;
+    const unhoverRects = internals.repaintRectsAsText();
+    internals.stopTrackingRepaints();
+
+    result.textContent =
+        "SVG border box: " + box.width + "x" + box.height + " at (" + box.left + "," + box.top + ")\n\n" +
+        "Repaint rects on hover (outline added):\n" + hoverRects + "\n" +
+        "Repaint rects on un-hover (outline removed):\n" + unhoverRects;
+}
+
+run();
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 4ad0a5f848b133318fc64266e559bd641b6d98cb
<pre>
[Test Coverage] CSS outline on an inline &lt;svg&gt; is not repainted when toggled on :hover (appears stale / missing)
<a href="https://bugs.webkit.org/show_bug.cgi?id=285420">https://bugs.webkit.org/show_bug.cgi?id=285420</a>
<a href="https://rdar.apple.com/142807293">rdar://142807293</a>

Reviewed by Taher Ali.

This bug is progressed by 315468@main, so this is just to add additional
test case so we have regression coverage for this case as well.

* LayoutTests/svg/repaint/svg-outline-repaint-on-hover.html: Added.
* LayoutTests/svg/repaint/svg-outline-repaint-on-hover-expected.txt: Added.

&gt; Platform Specific Expectation due to no hover on iOS:
* LayoutTests/platform/ios/svg/repaint/svg-outline-repaint-on-hover-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/315822@main">https://commits.webkit.org/315822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6084d48679856fd1128296e55233b0f49c3c90e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127087 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56ca86b7-7ce0-48ee-b1e7-63ad056c0083) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131934 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92870 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2370cc9-7a0f-446f-ace7-272281fbabbe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112438 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf922071-e9e2-477f-9944-12b947a60088) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33515 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32115 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27431 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143505 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181331 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140387 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140223 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37952 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43642 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28624 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107672 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35494 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42152 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6713 "Passed tests") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41545 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41800 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41688 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->