### PR TITLE
Cherry-pick(s) a0acd4b94ec1. rdar://176061626

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1774,7 +1774,11 @@ public:
         return m_error;
     }
 
+<<<<<<< HEAD
     [[nodiscard]] ErrorCode setupAlternativeOffsets(PatternAlternative* alternative, CheckedUint32 currentCallFrameSize, unsigned initialInputPosition, CheckedUint32& newCallFrameSize)
+=======
+    WARN_UNUSED_RETURN ErrorCode setupAlternativeOffsets(PatternAlternative* alternative, CheckedUint32 currentCallFrameSize, unsigned initialInputPosition, CheckedUint32& newCallFrameSize)
+>>>>>>> a0acd4b94ec1 ([JSC] Make RegExp tolerant against excessive stress)
     {
         if (!isSafeToRecurse()) [[unlikely]]
             return ErrorCode::TooManyDisjunctions;
@@ -1930,8 +1934,11 @@ public:
             if (initialCallFrameSize.hasOverflowed())
                 return ErrorCode::FrameTooLarge;
         }
+<<<<<<< HEAD
 
         bool shareOffsets = (disjunction == m_pattern.m_body);
+=======
+>>>>>>> a0acd4b94ec1 ([JSC] Make RegExp tolerant against excessive stress)
 
         unsigned minimumInputSize = UINT_MAX;
         unsigned maximumCallFrameSize = 0;
@@ -1942,7 +1949,11 @@ public:
         for (unsigned alt = 0; alt < disjunction->m_alternatives.size(); ++alt) {
             PatternAlternative* alternative = disjunction->m_alternatives[alt].get();
             CheckedUint32 currentAlternativeCallFrameSize;
+<<<<<<< HEAD
             error = setupAlternativeOffsets(alternative, perAlternativeInitial, initialInputPosition, currentAlternativeCallFrameSize);
+=======
+            error = setupAlternativeOffsets(alternative, initialCallFrameSize, initialInputPosition, currentAlternativeCallFrameSize);
+>>>>>>> a0acd4b94ec1 ([JSC] Make RegExp tolerant against excessive stress)
             if (hasError(error))
                 return error;
             minimumInputSize = std::min(minimumInputSize, alternative->m_minimumSize);

--- a/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
+++ b/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
@@ -34,6 +34,7 @@ namespace JSC { namespace Yarr {
 
 class SyntaxChecker {
 public:
+<<<<<<< HEAD
     void NODELETE assertionBOL() { }
     void NODELETE assertionEOL() { }
     void NODELETE assertionWordBoundary(bool) { }
@@ -58,6 +59,32 @@ public:
     void NODELETE quantifyAtom(unsigned, unsigned, bool) { }
     void NODELETE disjunction(CreateDisjunctionPurpose) { }
     void NODELETE resetForReparsing() { }
+=======
+    void assertionBOL() { }
+    void assertionEOL() { }
+    void assertionWordBoundary(bool) { }
+    void atomPatternCharacter(char32_t, bool) { }
+    void atomBuiltInCharacterClass(BuiltInCharacterClassID, bool) { }
+    void atomCharacterClassBegin(bool = false) { }
+    void atomCharacterClassAtom(char16_t) { }
+    void atomCharacterClassRange(char16_t, char16_t) { }
+    void atomCharacterClassBuiltIn(BuiltInCharacterClassID, bool) { }
+    void atomClassStringDisjunction(Vector<Vector<char32_t>>&) { }
+    void atomCharacterClassSetOp(CharacterClassSetOp) { }
+    void atomCharacterClassPushNested(bool) { }
+    void atomCharacterClassPopNested(bool) { }
+    void atomCharacterClassEnd() { }
+    void atomParenthesesSubpatternBegin(bool, std::optional<String> = std::nullopt) { }
+    void atomParentheticalAssertionBegin(bool, MatchDirection) { }
+    void atomParentheticalModifierBegin(OptionSet<Flags>, OptionSet<Flags>) { }
+    void atomParenthesesEnd() { }
+    void atomBackReference(unsigned) { }
+    void atomNamedBackReference(const String&) { }
+    void atomNamedForwardReference(const String&) { }
+    void quantifyAtom(unsigned, unsigned, bool) { }
+    void disjunction(CreateDisjunctionPurpose) { }
+    void resetForReparsing() { }
+>>>>>>> a0acd4b94ec1 ([JSC] Make RegExp tolerant against excessive stress)
 
     constexpr static bool NODELETE abortedDueToError() { return false; }
     constexpr static ErrorCode NODELETE abortErrorCode() { return ErrorCode::NoError; }


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176061626 to main. The following sources [7663d811d06c] will still need to be cherry-picked once the conflict is resolved.

```[JSC] Make RegExp tolerant against excessive stress
https://bugs.webkit.org/show_bug.cgi?id=309601
rdar://171448096

Reviewed by Yijia Huang.

We fixed three issues. But only one is actually critical security issue.
Remaining two are making RegExp tolerant against excessive patterns.

1. We have no guard against too large JIT code generation (4GB~). We fix
   AssemblerBuffer to detect and crash safely.
2. We add RegExp capture limit which is aligned to V8's number.
3. We add RegExp frame size limit, which makes RegExp parsing failed
   when frame size exceeds `unsigned` entries.

Tests: JSTests/stress/regexp-alternative-heavy.js
       JSTests/stress/regexp-combined-large.js
       JSTests/stress/regexp-deep-nested.js
       JSTests/stress/regexp-heavy-mixed.js
       JSTests/stress/regexp-lookahead-heavy.js

* JSTests/stress/regexp-alternative-heavy.js: Added.
(tryCompileAndRun):
* JSTests/stress/regexp-bol-optimize-out-of-stack.js:
* JSTests/stress/regexp-combined-large.js: Added.
(tryCompileAndRun):
* JSTests/stress/regexp-deep-nested.js: Added.
(tryCompileAndRun):
* JSTests/stress/regexp-heavy-mixed.js: Added.
(tryCompileAndRun):
* JSTests/stress/regexp-lookahead-heavy.js: Added.
(tryCompileAndRun):
* LayoutTests/js/script-tests/stack-overflow-regexp.js:
(shouldThrow.recursiveCall):
(shouldThrow):
* LayoutTests/js/stack-overflow-regexp-expected.txt:
* Source/JavaScriptCore/assembler/AssemblerBuffer.h:
(JSC::AssemblerDataImpl::grow):
(JSC::AssemblerBuffer::AssemblerBuffer):
(JSC::AssemblerBuffer::isAvailable):
(JSC::AssemblerBuffer::LocalWriter::putIntegralUnchecked):
(JSC::AssemblerBuffer::putIntegral):
* Source/JavaScriptCore/yarr/YarrErrorCode.cpp:
(JSC::Yarr::errorMessage):
(JSC::Yarr::errorToThrow):
* Source/JavaScriptCore/yarr/YarrErrorCode.h:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::requires):
(JSC::Yarr::Parser::parse):
(JSC::Yarr::Parser::parseParenthesesBegin):
(JSC::Yarr::Parser::countCaptures):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::atomParenthesesSubpatternBegin):
(JSC::Yarr::YarrPatternConstructor::setupAlternativeOffsets):
(JSC::Yarr::YarrPatternConstructor::setupDisjunctionOffsets):
(JSC::Yarr::YarrPatternConstructor::setupOffsets):
* Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp:
(JSC::Yarr::SyntaxChecker::atomParenthesesSubpatternBegin):

Originally-landed-as: 305413.479@rapid/safari-7624.2.5.110-branch (a0acd4b94ec1). rdar://176061626

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/009171656376d40f919b4fb47dd7e907bf8bc328

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165565 "5 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39055 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32636 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174607 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122820 "Hash 00917165 for PR 66125 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39391 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39059 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/174607 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/122820 "Hash 00917165 for PR 66125 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168524 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/39391 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/32636 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/174607 "Hash 00917165 for PR 66125 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/39391 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/39059 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22685 "Hash 00917165 for PR 66125 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157722 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/39391 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/32636 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177131 "Hash 00917165 for PR 66125 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26458 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30042 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/32636 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/177131 "Hash 00917165 for PR 66125 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39124 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/39059 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/177131 "Hash 00917165 for PR 66125 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39812 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/32636 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102280 "Hash 00917165 for PR 66125 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/39812 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/32636 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197966 "Hash 00917165 for PR 66125 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38323 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111396 "Failed to build and analyze WebKit") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/197966 "Hash 00917165 for PR 66125 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37719 "Hash 00917165 for PR 66125 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/32636 "Hash 00917165 for PR 66125 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37965 "Hash 00917165 for PR 66125 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37863 "Hash 00917165 for PR 66125 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->