### PR TITLE
EWS test for deferring ES process swapping

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3509,4 +3509,21 @@ void NetworkProcess::isEnhancedSecurityLink(const URL& url, CompletionHandler<vo
 }
 #endif
 
+void NetworkProcess::holdLoaderForProcessTransfer(WebCore::ProcessIdentifier webProcessIdentifier, WebCore::ResourceLoaderIdentifier resourceLoaderIdentifier, CompletionHandler<void(std::optional<NetworkResourceLoadIdentifier>)>&& completionHandler)
+{
+    RefPtr connection = webProcessConnection(webProcessIdentifier);
+    if (!connection)
+        return completionHandler(std::nullopt);
+
+    RefPtr loader = connection->takeNetworkResourceLoader(resourceLoaderIdentifier);
+    if (!loader)
+        return completionHandler(std::nullopt);
+
+    auto networkResourceLoadIdentifier = loader->identifier();
+    if (CheckedPtr session = connection->networkSession())
+        session->addLoaderAwaitingWebProcessTransfer(loader.releaseNonNull());
+
+    completionHandler(networkResourceLoadIdentifier);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -33,6 +33,7 @@
 #include "DownloadManager.h"
 #include "NetworkActivityTracker.h"
 #include "NetworkContentRuleListManager.h"
+#include "NetworkResourceLoadIdentifier.h"
 #include "QuotaIncreaseRequestIdentifier.h"
 #include "SharedPreferencesForWebProcess.h"
 #include "UseDownloadPlaceholder.h"
@@ -497,6 +498,8 @@ public:
 #if HAVE(ENHANCED_SECURITY_LINKS)
     void isEnhancedSecurityLink(const URL&, CompletionHandler<void(bool)>&&);
 #endif
+
+    void holdLoaderForProcessTransfer(WebCore::ProcessIdentifier, WebCore::ResourceLoaderIdentifier, CompletionHandler<void(std::optional<NetworkResourceLoadIdentifier>)>&&);
 
 private:
     explicit NetworkProcess(AuxiliaryProcessInitializationParameters&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -303,4 +303,6 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 #if HAVE(ENHANCED_SECURITY_LINKS)
     IsEnhancedSecurityLink(URL url) -> (bool isEnhancedSecurityLink)
 #endif
+
+    HoldLoaderForProcessTransfer(WebCore::ProcessIdentifier webProcessIdentifier, WebCore::ResourceLoaderIdentifier resourceLoaderIdentifier) -> (std::optional<WebKit::NetworkResourceLoadIdentifier> networkResourceLoadIdentifier)
 }

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -183,6 +183,11 @@ bool BrowsingContextGroup::addFrameProcessWithoutInjectingPageContext(FrameProce
     return true;
 }
 
+void BrowsingContextGroup::clearProcessForSite(const WebCore::Site& site)
+{
+    m_processMap.remove(site);
+}
+
 void BrowsingContextGroup::removeFrameProcess(FrameProcess& process)
 {
     if (process.isSharedProcess()) {
@@ -190,7 +195,10 @@ void BrowsingContextGroup::removeFrameProcess(FrameProcess& process)
         m_sharedProcessSites.clear();
     } else {
         auto& site = *process.site();
-        ASSERT(site.isEmpty() || m_processMap.get(site) == &process || process.process().state() == WebProcessProxy::State::Terminated);
+        // When a deferred ES process swap replaces the site's process entry, the old FrameProcess
+        // may destruct after the new one is registered. In this case, just skip the removal.
+        if (m_processMap.get(site) != &process)
+            return;
         m_processMap.remove(site);
     }
     m_remotePages.removeIf([&] (auto& pair) {

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -72,6 +72,7 @@ public:
     void addFrameProcessAndInjectPageContextIf(FrameProcess&, Function<bool(WebPageProxy&)>);
     bool addFrameProcessWithoutInjectingPageContext(FrameProcess&);
     void removeFrameProcess(FrameProcess&);
+    void clearProcessForSite(const WebCore::Site&);
     void processDidTerminate(WebPageProxy&, WebProcessProxy&);
 
     void addPage(WebPageProxy&);

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
@@ -29,6 +29,7 @@
 
 #include "APIWebsitePolicies.h"
 #include "WebPreferences.h"
+#include <WebCore/HTTPHeaderNames.h>
 #include <WebCore/IPAddressSpace.h>
 #include <WebCore/SecurityOrigin.h>
 #include <wtf/Condition.h>
@@ -105,6 +106,7 @@ void EnhancedSecurityTracking::reset()
 {
     m_activeState = ActivationState::None;
     m_activeReason = EnhancedSecurityReason::None;
+    m_deferredInsecureProvisional = false;
 }
 
 void EnhancedSecurityTracking::makeDormant()
@@ -192,7 +194,7 @@ static bool shouldExpectHTTPSUpgrade(const URL& requestURL, API::WebsitePolicies
     return !isSameSiteBypassEnabled;
 }
 
-bool EnhancedSecurityTracking::enableIfRequired(const API::Navigation& navigation, API::WebsitePolicies* websitePolicies, const WebPreferences& preferences, const URL& sourceURL, bool httpFallbackInProgress)
+bool EnhancedSecurityTracking::enableIfRequired(const API::Navigation& navigation, API::WebsitePolicies* websitePolicies, const WebPreferences& preferences, const URL& sourceURL, bool httpFallbackInProgress, bool canDeferToResponse)
 {
     if (navigation.isEnhancedSecurityLinkForCurrentSite()) {
         enableFor(EnhancedSecurityReason::LinkSecurity, navigation);
@@ -204,12 +206,17 @@ bool EnhancedSecurityTracking::enableIfRequired(const API::Navigation& navigatio
     if (currentRequestURL.protocolIs("http"_s)
         && !SecurityOrigin::isLocalHostOrLoopbackIPAddress(currentRequestURL.host())
         && !shouldExpectHTTPSUpgrade(currentRequestURL, websitePolicies, preferences, sourceURL, httpFallbackInProgress)) {
+        if (canDeferToResponse && !httpFallbackInProgress) {
+            m_deferredInsecureProvisional = true;
+            return false;
+        }
         enableFor(EnhancedSecurityReason::InsecureProvisional, navigation);
         return true;
     }
 
     return false;
 }
+
 
 void EnhancedSecurityTracking::handleBackForwardNavigation(const API::Navigation& navigation)
 {
@@ -222,7 +229,7 @@ void EnhancedSecurityTracking::handleBackForwardNavigation(const API::Navigation
         enableFor(reasonForEnhancedSecurity(priorState), navigation);
 }
 
-void EnhancedSecurityTracking::trackNavigation(const API::Navigation& navigation, bool hasOpenedPage, API::WebsitePolicies* websitePolicies, const WebPreferences& preferences, const URL& sourceURL, bool httpFallbackInProgress)
+void EnhancedSecurityTracking::trackNavigation(const API::Navigation& navigation, bool hasOpenedPage, API::WebsitePolicies* websitePolicies, const WebPreferences& preferences, const URL& sourceURL, bool httpFallbackInProgress, bool canDeferToResponse)
 {
     auto lastNavigationAction = navigation.lastNavigationAction();
     if (lastNavigationAction && lastNavigationAction->hasOpener)
@@ -244,9 +251,25 @@ void EnhancedSecurityTracking::trackNavigation(const API::Navigation& navigation
 
     if (m_activeState != ActivationState::None && isInitialUIDriven && !isReload)
         reset();
+    else if (isInitialUIDriven && !isReload)
+        m_deferredInsecureProvisional = false;
 
-    if (m_activeState != ActivationState::Active && enableIfRequired(navigation, websitePolicies, preferences, sourceURL, httpFallbackInProgress))
+    if (m_activeState != ActivationState::Active && enableIfRequired(navigation, websitePolicies, preferences, sourceURL, httpFallbackInProgress, canDeferToResponse))
         return;
+
+    // If we deferred an InsecureProvisional check and this is a cross-site redirect,
+    // activate ES now — the navigation chain originated from insecure HTTP.
+    if (m_deferredInsecureProvisional && navigation.currentRequestIsRedirect()) {
+        bool isCrossSiteRedirect = RegistrableDomain { navigation.originalRequest().url() } != RegistrableDomain { navigation.currentRequest().url() };
+        if (isCrossSiteRedirect) {
+            m_deferredInsecureProvisional = false;
+            enableFor(EnhancedSecurityReason::InsecureProvisional, navigation);
+            return;
+        }
+        // Same-site HTTPS redirect — the upgrade completed, clear deferred state.
+        if (navigation.currentRequest().url().protocolIs("https"_s))
+            m_deferredInsecureProvisional = false;
+    }
 
     if (m_activeState == ActivationState::Active
         && m_activeReason == EnhancedSecurityReason::InsecureProvisional) {
@@ -280,6 +303,22 @@ void EnhancedSecurityTracking::trackNavigation(const API::Navigation& navigation
         else
             enabledSitesMap().set(RegistrableDomain { navigation.currentRequest().url() }, m_activeReason);
     }
+}
+
+bool EnhancedSecurityTracking::shouldTriggerSwapForResponse(API::Navigation& navigation, const WebCore::ResourceResponse& response, bool isMainFrame)
+{
+    if (!isMainFrame || !m_deferredInsecureProvisional || m_activeState == ActivationState::Active)
+        return false;
+
+    if (response.isRedirection())
+        return false;
+
+    if (!response.url().protocolIs("http"_s) || SecurityOrigin::isLocalHostOrLoopbackIPAddress(response.url().host()))
+        return false;
+
+    m_deferredInsecureProvisional = false;
+    enableFor(EnhancedSecurityReason::InsecureProvisional, navigation);
+    return true;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.h
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.h
@@ -30,6 +30,7 @@
 #include "EnhancedSecurity.h"
 
 #include <WebCore/RegistrableDomain.h>
+#include <WebCore/ResourceResponse.h>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Seconds.h>
@@ -46,31 +47,37 @@ class EnhancedSecurityTracking final : public CanMakeWeakPtr<EnhancedSecurityTra
 public:
     void initializeWithWebsiteDataStore(WebsiteDataStore&);
 
-    void trackNavigation(const API::Navigation&, bool hasOpenedPage, API::WebsitePolicies*, const WebPreferences&, const URL& sourceURL, bool httpFallbackInProgress);
+    void trackNavigation(const API::Navigation&, bool hasOpenedPage, API::WebsitePolicies*, const WebPreferences&, const URL& sourceURL, bool httpFallbackInProgress, bool canDeferToResponse = false);
 
     bool isEnhancedSecurityEnabled() const { return isEnhancedSecurityEnabledForState(enhancedSecurityState()); }
     EnhancedSecurity NODELETE enhancedSecurityState() const;
     EnhancedSecurityReason enhancedSecurityReason() const { return m_activeReason; }
+
+    // Response-time ES activation: when InsecureProvisional was deferred at navigation
+    // time, check the response to decide if ES should now activate.
+    bool shouldTriggerSwapForResponse(API::Navigation&, const WebCore::ResourceResponse&, bool isMainFrame);
+
+    void reset();
+    void enableFor(EnhancedSecurityReason, const API::Navigation&);
 
     void initializeFrom(const EnhancedSecurityTracking&);
 
 private:
     enum class ActivationState : uint8_t { None, Dormant, Active };
 
-    void NODELETE reset();
     void NODELETE makeDormant();
     void NODELETE makeActive();
 
     void handleBackForwardNavigation(const API::Navigation&);
 
-    void enableFor(EnhancedSecurityReason, const API::Navigation&);
-    bool enableIfRequired(const API::Navigation&, API::WebsitePolicies*, const WebPreferences&, const URL& sourceURL, bool httpFallbackInProgress);
+    bool enableIfRequired(const API::Navigation&, API::WebsitePolicies*, const WebPreferences&, const URL& sourceURL, bool httpFallbackInProgress, bool canDeferToResponse);
 
     void trackSameSiteNavigation(const API::Navigation&);
     void trackChangingSiteNavigation();
 
     ActivationState m_activeState { ActivationState::None };
     EnhancedSecurityReason m_activeReason { EnhancedSecurityReason::None };
+    bool m_deferredInsecureProvisional { false };
 
     WebCore::RegistrableDomain m_initialProtectedDomain;
 };

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -540,13 +540,13 @@ void ProvisionalPageProxy::decidePolicyForNavigationActionAsync(IPC::Connection&
         completionHandler({ });
 }
 
-void ProvisionalPageProxy::decidePolicyForResponse(FrameInfoData&& frameInfo, std::optional<WebCore::NavigationIdentifier> navigationID, const WebCore::ResourceResponse& response, const WebCore::ResourceRequest& request, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&& completionHandler)
+void ProvisionalPageProxy::decidePolicyForResponse(FrameInfoData&& frameInfo, std::optional<WebCore::NavigationIdentifier> navigationID, const WebCore::ResourceResponse& response, const WebCore::ResourceRequest& request, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, std::optional<WebCore::ResourceLoaderIdentifier> mainResourceLoaderIdentifier, CompletionHandler<void(PolicyDecision&&)>&& completionHandler)
 {
     if (!validateInput(frameInfo.frameID, navigationID))
         return completionHandler({ });
 
     if (RefPtr page = m_page.get())
-        page->decidePolicyForResponseShared(protect(process()), m_webPageID, WTF::move(frameInfo), navigationID, response, request, canShowMIMEType, WTF::move(downloadAttribute), isShowingInitialAboutBlank, activeDocumentCOOPValue, WTF::move(completionHandler));
+        page->decidePolicyForResponseShared(protect(process()), m_webPageID, WTF::move(frameInfo), navigationID, response, request, canShowMIMEType, WTF::move(downloadAttribute), isShowingInitialAboutBlank, activeDocumentCOOPValue, mainResourceLoaderIdentifier, WTF::move(completionHandler));
     else
         completionHandler({ });
 }

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -172,7 +172,7 @@ private:
     bool sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&&, AsyncReplyHandler, OptionSet<IPC::SendOption>) final;
 
     void decidePolicyForNavigationActionAsync(IPC::Connection&, NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
-    void decidePolicyForResponse(FrameInfoData&&, std::optional<WebCore::NavigationIdentifier>, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&&);
+    void decidePolicyForResponse(FrameInfoData&&, std::optional<WebCore::NavigationIdentifier>, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, std::optional<WebCore::ResourceLoaderIdentifier> mainResourceLoaderIdentifier, CompletionHandler<void(PolicyDecision&&)>&&);
     void didChangeProvisionalURLForFrame(WebCore::FrameIdentifier, std::optional<WebCore::NavigationIdentifier>, URL&&);
     void didPerformServerRedirect(String&& sourceURLString, String&& destinationURLString, WebCore::FrameIdentifier);
     void didReceiveServerRedirectForProvisionalLoadForFrame(WebCore::FrameIdentifier, std::optional<WebCore::NavigationIdentifier>, WebCore::ResourceRequest&&, const UserData&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2265,7 +2265,7 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
         loadParameters.hadUserGesture = action->userGestureTokenIdentifier.has_value();
         loadParameters.requester = action->requester;
     }
-    if (shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision)
+    if (shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision || shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted)
         loadParameters.originalRequest = navigation.originalRequest();
 
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -5473,8 +5473,12 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
     auto lockdownMode = (websitePolicies ? websitePolicies->lockdownModeEnabled() : shouldEnableLockdownMode()) ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled;
 
     Ref browsingContextGroup = browsingContextGroupForNavigation(frame, navigation, websiteDataStore, processSwapRequestedByClient);
+    bool canDeferInsecureProvisionalToResponse = frame.isMainFrame()
+        && !preferences->enhancedSecurityForceDisabled()
+        && m_configuration->processPool().configuration().processSwapsOnNavigation();
+
     if (frame.isMainFrame() && preferences->enhancedSecurityHeuristicsEnabled())
-        internals().enhancedSecurityTracker.trackNavigation(navigation, hasOpenedPage(), websitePolicies.get(), preferences.get(), sourceURL, internals().pageLoadState.httpFallbackInProgress());
+        internals().enhancedSecurityTracker.trackNavigation(navigation, hasOpenedPage(), websitePolicies.get(), preferences.get(), sourceURL, internals().pageLoadState.httpFallbackInProgress(), canDeferInsecureProvisionalToResponse);
 
     auto enhancedSecurity = currentEnhancedSecurityState(websitePolicies.get());
 
@@ -5940,7 +5944,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
             loadParameters.requester = action->requester;
             loadParameters.hadUserGesture = action->userGestureTokenIdentifier.has_value();
         }
-        if (navigation.currentRequestIsRedirect())
+        if (navigation.currentRequestIsRedirect() || navigation.originalRequest().url() != navigation.currentRequest().url())
             loadParameters.originalRequest = navigation.originalRequest();
 
         if (isPendingInitialHistoryItem)
@@ -9541,15 +9545,15 @@ void WebPageProxy::decidePolicyForNewWindowAction(IPC::Connection& connection, N
         m_navigationClient->decidePolicyForNavigationAction(*this, navigationAction.get(), WTF::move(listener));
 }
 
-void WebPageProxy::decidePolicyForResponse(IPC::Connection& connection, FrameInfoData&& frameInfo, std::optional<WebCore::NavigationIdentifier> navigationID, const ResourceResponse& response, const ResourceRequest& request, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&& completionHandler)
+void WebPageProxy::decidePolicyForResponse(IPC::Connection& connection, FrameInfoData&& frameInfo, std::optional<WebCore::NavigationIdentifier> navigationID, const ResourceResponse& response, const ResourceRequest& request, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, std::optional<WebCore::ResourceLoaderIdentifier> mainResourceLoaderIdentifier, CompletionHandler<void(PolicyDecision&&)>&& completionHandler)
 {
     RefPtr frame = WebFrameProxy::webFrame(frameInfo.frameID);
     if (!frame)
         return completionHandler({ });
-    decidePolicyForResponseShared(WebProcessProxy::fromConnection(connection), m_webPageID, WTF::move(frameInfo), navigationID, response, request, canShowMIMEType, WTF::move(downloadAttribute), isShowingInitialAboutBlank, activeDocumentCOOPValue, WTF::move(completionHandler));
+    decidePolicyForResponseShared(WebProcessProxy::fromConnection(connection), m_webPageID, WTF::move(frameInfo), navigationID, response, request, canShowMIMEType, WTF::move(downloadAttribute), isShowingInitialAboutBlank, activeDocumentCOOPValue, mainResourceLoaderIdentifier, WTF::move(completionHandler));
 }
 
-void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process, PageIdentifier webPageID, FrameInfoData&& frameInfo, std::optional<WebCore::NavigationIdentifier> navigationID, const ResourceResponse& response, const ResourceRequest& request, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&& completionHandler)
+void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process, PageIdentifier webPageID, FrameInfoData&& frameInfo, std::optional<WebCore::NavigationIdentifier> navigationID, const ResourceResponse& response, const ResourceRequest& request, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, std::optional<WebCore::ResourceLoaderIdentifier> mainResourceLoaderIdentifier, CompletionHandler<void(PolicyDecision&&)>&& completionHandler)
 {
     RefPtr protectedPageClient { pageClient() };
 
@@ -9565,6 +9569,15 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
     if (frameInfo.isMainFrame && coopValuesRequireBrowsingContextGroupSwitch(isShowingInitialAboutBlank, activeDocumentCOOPValue, frameInfo.securityOrigin.securityOrigin().get(), obtainCrossOriginOpenerPolicy(response).value, SecurityOrigin::create(response.url()).get())) {
         mainFrame()->disownOpener();
         m_openedMainFrameName = { };
+    }
+
+    // Response-time Enhanced Security check: if this is an HTTP response with
+    // content (not a redirect), activate ES and trigger the process swap.
+    if (navigation && internals().enhancedSecurityTracker.shouldTriggerSwapForResponse(*navigation, response, frameInfo.isMainFrame)) {
+        auto navigationIdentifier = navigation->navigationID();
+        auto responseSite = Site { response.url() };
+        triggerEnhancedSecurityProcessSwapForNavigation(navigationIdentifier, responseSite, mainResourceLoaderIdentifier, WTF::move(process), WTF::move(completionHandler));
+        return;
     }
 
     auto expectSafeBrowsing = ShouldExpectSafeBrowsingResult::No;
@@ -9723,6 +9736,67 @@ void WebPageProxy::showBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&& safeBro
         });
     });
     m_uiClient->didShowSafeBrowsingWarning();
+}
+
+void WebPageProxy::triggerEnhancedSecurityProcessSwapForNavigation(WebCore::NavigationIdentifier navigationID, const Site& responseSite, std::optional<WebCore::ResourceLoaderIdentifier> mainResourceLoaderIdentifier, Ref<WebProcessProxy>&& sourceProcess, CompletionHandler<void(PolicyDecision&&)>&& completionHandler)
+{
+    RefPtr navigation = m_navigationState->navigation(navigationID);
+    if (!navigation) {
+        completionHandler({ });
+        return;
+    }
+
+    WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "triggerEnhancedSecurityProcessSwapForNavigation: Process-swapping due to deferred EnhancedSecurity for insecure HTTP load");
+
+    auto lockdownMode = m_provisionalPage ? m_provisionalPage->process().lockdownMode() : m_legacyMainFrameProcess->lockdownMode();
+    auto enhancedSecurity = EnhancedSecurity::EnabledInsecure;
+
+    RefPtr processForNavigation = protect(m_configuration->processPool())->processForSite(protect(websiteDataStore()), WebProcessProxy::IsolatedProcessType::MainFrame, responseSite, responseSite, { }, lockdownMode, enhancedSecurity, m_configuration, WebCore::ProcessSwapDisposition::None);
+
+    auto domain = RegistrableDomain { navigation->currentRequest().url() };
+
+    // Ask the NetworkProcess to hold the in-flight loader for transfer to the new process.
+    auto sourceProcessIdentifier = sourceProcess->coreProcessIdentifier();
+
+    auto continueWithNetworkLoadIdentifier = [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler), processForNavigation, preventProcessShutdownScope = processForNavigation->shutdownPreventingScope(), navigationID, domain](std::optional<NetworkResourceLoadIdentifier> networkResourceLoadIdentifier) mutable {
+
+        RefPtr navigation = m_navigationState->navigation(navigationID);
+        RefPtr mainFrame = m_mainFrame;
+        if (!navigation || !mainFrame) {
+            completionHandler({ });
+            return;
+        }
+
+        protect(protect(websiteDataStore())->networkProcess())->addAllowedFirstPartyForCookies(*processForNavigation, domain, LoadedWebArchive::No, [this, protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler), processForNavigation, preventProcessShutdownScope = WTF::move(preventProcessShutdownScope), navigationID, networkResourceLoadIdentifier]() mutable {
+            RefPtr navigation = m_navigationState->navigation(navigationID);
+            RefPtr mainFrame = m_mainFrame;
+            if (!navigation || !mainFrame) {
+                completionHandler({ });
+                return;
+            }
+
+            if (!m_provisionalPage)
+                send(Messages::WebPage::StopLoadingDueToProcessSwap());
+
+            // With site isolation, the BCG may already have a process registered for this site
+            // from the deferred initial load. Remove it so the new ES process can register.
+            auto site = Site { navigation->currentRequest().url() };
+            Ref browsingContextGroup = m_browsingContextGroup;
+            if (RefPtr existingFrameProcess = browsingContextGroup->processForSite(site))
+                browsingContextGroup->removeFrameProcess(*existingFrameProcess);
+
+            continueNavigationInNewProcess(*navigation, *mainFrame, nullptr, m_browsingContextGroup, processForNavigation.releaseNonNull(), ProcessSwapRequestedByClient::No, ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted, networkResourceLoadIdentifier, LoadedWebArchive::No, NavigationUpgradeToHTTPSBehavior::BasedOnPolicy, WebCore::ProcessSwapDisposition::None, nullptr);
+
+            completionHandler(PolicyDecision { .policyAction = PolicyAction::LoadWillContinueInAnotherProcess });
+        });
+    };
+
+    if (mainResourceLoaderIdentifier) {
+        protect(protect(websiteDataStore())->networkProcess())->sendWithAsyncReply(
+            Messages::NetworkProcess::HoldLoaderForProcessTransfer(sourceProcessIdentifier, *mainResourceLoaderIdentifier),
+            WTF::move(continueWithNetworkLoadIdentifier));
+    } else
+        continueWithNetworkLoadIdentifier(std::nullopt);
 }
 
 void WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation(WebCore::NavigationIdentifier navigationID, BrowsingContextGroupSwitchDecision browsingContextGroupSwitchDecision, const Site& responseSite, NetworkResourceLoadIdentifier existingNetworkResourceLoadIdentifierToResume, CompletionHandler<void(bool success)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1053,6 +1053,7 @@ public:
     void setUnderlayColor(const WebCore::Color&);
 
     void triggerBrowsingContextGroupSwitchForNavigation(WebCore::NavigationIdentifier, WebCore::BrowsingContextGroupSwitchDecision, const WebCore::Site& responseSite, NetworkResourceLoadIdentifier existingNetworkResourceLoadIdentifierToResume, CompletionHandler<void(bool success)>&&);
+    void triggerEnhancedSecurityProcessSwapForNavigation(WebCore::NavigationIdentifier, const WebCore::Site& responseSite, std::optional<WebCore::ResourceLoaderIdentifier> mainResourceLoaderIdentifier, Ref<WebProcessProxy>&& sourceProcess, CompletionHandler<void(PolicyDecision&&)>&&);
 
     // At this time, pageExtendedBackgroundColor can be set via pageExtendedBackgroundColorDidChange() which is a message
     // from the UIProcess, or by didCommitLayerTree(). When PLATFORM(MAC) adopts UI side compositing, we should get rid of
@@ -2323,7 +2324,7 @@ public:
     void didChangeProvisionalURLForFrameShared(Ref<WebProcessProxy>&&, WebCore::FrameIdentifier, std::optional<WebCore::NavigationIdentifier>, URL&&);
     void decidePolicyForNavigationActionAsync(IPC::Connection&, NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
     void decidePolicyForNavigationActionSync(IPC::Connection&, NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
-    void decidePolicyForResponseShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, FrameInfoData&&, std::optional<WebCore::NavigationIdentifier>, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&&);
+    void decidePolicyForResponseShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, FrameInfoData&&, std::optional<WebCore::NavigationIdentifier>, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, std::optional<WebCore::ResourceLoaderIdentifier> mainResourceLoaderIdentifier, CompletionHandler<void(PolicyDecision&&)>&&);
     void startURLSchemeTaskShared(IPC::Connection&, Ref<WebProcessProxy>&&, WebCore::PageIdentifier, URLSchemeTaskParameters&&);
     void loadDataWithNavigationShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, API::Navigation&, Ref<WebCore::SharedBuffer>&&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, RefPtr<API::WebsitePolicies>&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::SessionHistoryVisibility);
     void loadRequestWithNavigationShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, API::Navigation&, WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::NavigationUpgradeToHTTPSBehavior, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, RefPtr<API::WebsitePolicies>&&, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume);
@@ -3095,7 +3096,7 @@ private:
     void decidePolicyForNavigationAction(Ref<WebProcessProxy>&&, WebFrameProxy&, NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
     RefPtr<FrameState> frameStateForBackForwardChildFrame(WebFrameProxy&, WebCore::BackForwardItemIdentifier);
     void decidePolicyForNewWindowAction(IPC::Connection&, NavigationActionData&&, const String& frameName, CompletionHandler<void(PolicyDecision&&)>&&);
-    void decidePolicyForResponse(IPC::Connection&, FrameInfoData&&, std::optional<WebCore::NavigationIdentifier>, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&&);
+    void decidePolicyForResponse(IPC::Connection&, FrameInfoData&&, std::optional<WebCore::NavigationIdentifier>, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, std::optional<WebCore::ResourceLoaderIdentifier> mainResourceLoaderIdentifier, CompletionHandler<void(PolicyDecision&&)>&&);
     void beginSafeBrowsingCheck(const URL&, API::Navigation&, bool forMainFrameNavigation);
     void showBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&&);
     void deferModalUntilSafeBrowsingCompletes(CompletionHandler<void(bool shouldShow)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -130,7 +130,7 @@ messages -> WebPageProxy {
     [EnabledBy=InputTypeDateEnabled || InputTypeDateTimeLocalEnabled || InputTypeMonthEnabled || InputTypeTimeEnabled || InputTypeWeekEnabled] EndDateTimePicker();
 
     # Policy messages
-    DecidePolicyForResponse(struct WebKit::FrameInfoData frameInfo, std::optional<WebCore::NavigationIdentifier> navigationID, WebCore::ResourceResponse response, WebCore::ResourceRequest request, bool canShowMIMEType, String downloadAttribute, bool isShowingInitialAboutBlank, enum:uint8_t WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue) -> (struct WebKit::PolicyDecision PolicyDecision)
+    DecidePolicyForResponse(struct WebKit::FrameInfoData frameInfo, std::optional<WebCore::NavigationIdentifier> navigationID, WebCore::ResourceResponse response, WebCore::ResourceRequest request, bool canShowMIMEType, String downloadAttribute, bool isShowingInitialAboutBlank, enum:uint8_t WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, std::optional<WebCore::ResourceLoaderIdentifier> mainResourceLoaderIdentifier) -> (struct WebKit::PolicyDecision PolicyDecision)
     DecidePolicyForNavigationActionAsync(struct WebKit::NavigationActionData data) -> (struct WebKit::PolicyDecision PolicyDecision)
     DecidePolicyForNavigationActionSync(struct WebKit::NavigationActionData data) -> (struct WebKit::PolicyDecision PolicyDecision) Synchronous
     DecidePolicyForNewWindowAction(struct WebKit::NavigationActionData navigationActionData, String frameName) -> (struct WebKit::PolicyDecision PolicyDecision)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -983,7 +983,13 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForResponse(const ResourceRe
     bool isShowingInitialAboutBlank = m_localFrame->loader().stateMachine().isDisplayingInitialEmptyDocument();
     auto activeDocumentCOOPValue = m_localFrame->document() ? protect(m_localFrame->document())->crossOriginOpenerPolicy().value : CrossOriginOpenerPolicyValue::SameOrigin;
 
-    webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForResponse(frame->info(), navigationID, response, request, canShowResponse, downloadAttribute, isShowingInitialAboutBlank, activeDocumentCOOPValue), [frame, listenerID] (PolicyDecision&& policyDecision) {
+    std::optional<ResourceLoaderIdentifier> mainResourceLoaderIdentifier;
+    if (policyDocumentLoader) {
+        if (auto* mainLoader = policyDocumentLoader->mainResourceLoader())
+            mainResourceLoaderIdentifier = mainLoader->identifier();
+    }
+
+    webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForResponse(frame->info(), navigationID, response, request, canShowResponse, downloadAttribute, isShowingInitialAboutBlank, activeDocumentCOOPValue, mainResourceLoaderIdentifier), [frame, listenerID] (PolicyDecision&& policyDecision) {
         frame->didReceivePolicyDecision(listenerID, WTF::move(policyDecision));
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm
@@ -334,6 +334,179 @@ static void runHttpLocalhostLoad(bool useSiteIsolation)
 }
 TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpLocalhostLoad)
 
+// MARK: - HTTP Proxy Tests
+
+static void runHttpsLoadWithHttpProxy(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://secure.example.internal/"_s, { "<script>alert('insecure-page')</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('secure-page')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.example.internal/", {
+        { "secure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpsLoadWithHttpProxy)
+
+static void runMultipleHttpsNavigationsWithHttpProxy(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://site1.example/"_s, { "<script>alert('insecure-site1')</script>"_s } },
+        { "http://site2.example/"_s, { "<script>alert('insecure-site2')</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('secure-page')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://site1.example/", {
+        { "secure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://site2.example/", {
+        { "secure-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(MultipleHttpsNavigationsWithHttpProxy)
+
+static void runHttpToHttpsRedirectProcessCycling(bool useSiteIsolation)
+{
+    // Simulates the WWeb_v7_3_Proxy power test workload: a mix of http:// and https:// navigations
+    // where http:// URLs redirect to https://. This pattern triggers EnhancedSecurity for the
+    // initial http:// load (InsecureProvisional), then swaps back when HTTPS upgrade completes.
+    // We track unique process PIDs and their variants to measure the process cycling cost.
+
+    HTTPServer plaintextServer({
+        { "http://site1.example/"_s, { 302, { { "Location"_s, "https://site1.example/"_s } }, emptyString() } },
+        { "http://site2.example/"_s, { 302, { { "Location"_s, "https://site2.example/"_s } }, emptyString() } },
+        { "http://site3.example/"_s, { 302, { { "Location"_s, "https://site3.example/"_s } }, emptyString() } },
+        { "http://site4.example/"_s, { 302, { { "Location"_s, "https://site4.example/"_s } }, emptyString() } },
+        { "http://site5.example/"_s, { 302, { { "Location"_s, "https://site5.example/"_s } }, emptyString() } },
+        { "http://site6.example/"_s, { 302, { { "Location"_s, "https://site6.example/"_s } }, emptyString() } },
+        { "http://site7.example/"_s, { 302, { { "Location"_s, "https://site7.example/"_s } }, emptyString() } },
+        { "http://site8.example/"_s, { 302, { { "Location"_s, "https://site8.example/"_s } }, emptyString() } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<html><body>secure</body></html>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    processPoolConfiguration.get().prewarmsProcessesAutomatically = YES;
+    processPoolConfiguration.get().prewarmedProcessCountLimitForTesting = 3;
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get().processPool = pool.get();
+
+    auto preferences = [[configuration preferences] retain];
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ((useSiteIsolation && [feature.key isEqualToString:@"SiteIsolationEnabled"])
+            || [feature.key isEqualToString:@"EnhancedSecurityHeuristicsEnabled"])
+            [preferences _setEnabled:YES forFeature:feature];
+    }
+    [preferences release];
+
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setHTTPProxy:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", plaintextServer.port()]]];
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", secureServer.port()]]];
+    [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) configuration:configuration.get()]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    __block bool finishedNavigation = false;
+    navigationDelegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
+        finishedNavigation = true;
+    };
+
+    NSMutableSet<NSNumber *> *allPIDs = [NSMutableSet set];
+    NSMutableSet<NSNumber *> *committedEnhancedSecurityPIDs = [NSMutableSet set];
+    NSMutableSet<NSNumber *> *committedRegularPIDs = [NSMutableSet set];
+
+    __block NSMutableSet<NSNumber *> *provisionalPIDs = [NSMutableSet set];
+
+    navigationDelegate.get().didStartProvisionalNavigation = ^(WKWebView *wv, WKNavigation *) {
+        pid_t pid = [(WKWebView *)wv _webProcessIdentifier];
+        if (pid > 0)
+            [provisionalPIDs addObject:@(pid)];
+
+        pid_t provPid = [(WKWebView *)wv _provisionalWebProcessIdentifier];
+        if (provPid > 0)
+            [provisionalPIDs addObject:@(provPid)];
+    };
+
+    // Navigate through a mix of http:// (redirect to https://) and direct https:// loads,
+    // similar to the WWeb_v7_3_Proxy workload pattern.
+    NSArray<NSString *> *urls = @[
+        @"http://site1.example/",   // HTTP -> HTTPS redirect
+        @"https://site2.example/",  // Direct HTTPS
+        @"http://site3.example/",   // HTTP -> HTTPS redirect
+        @"http://site4.example/",   // HTTP -> HTTPS redirect
+        @"https://site5.example/",  // Direct HTTPS
+        @"http://site6.example/",   // HTTP -> HTTPS redirect
+        @"https://site7.example/",  // Direct HTTPS
+        @"http://site8.example/",   // HTTP -> HTTPS redirect
+    ];
+
+    for (NSString *url in urls) {
+        NSSet<NSNumber *> *prewarmedBeforeNav = [pool _prewarmedProcessIdentifiersForTesting];
+
+        finishedNavigation = false;
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
+        TestWebKitAPI::Util::run(&finishedNavigation);
+
+        pid_t pid = [webView _webProcessIdentifier];
+        [allPIDs addObject:@(pid)];
+
+        NSString *variant = [webView _webContentProcessVariantForFrame:nil];
+        if ([variant isEqualToString:@"security"])
+            [committedEnhancedSecurityPIDs addObject:@(pid)];
+        else
+            [committedRegularPIDs addObject:@(pid)];
+
+        NSSet<NSNumber *> *prewarmedAfterNav = [pool _prewarmedProcessIdentifiersForTesting];
+        NSLog(@"  Navigation to %@ — pid: %d, prewarmed before: %lu after: %lu, provisionalPid: %d", url, pid, (unsigned long)prewarmedBeforeNav.count, (unsigned long)prewarmedAfterNav.count, [webView _provisionalWebProcessIdentifier]);
+
+        // Allow time for process pre-warming to complete between navigations,
+        // simulating real browsing where users spend time on each page.
+        TestWebKitAPI::Util::runFor(2.0_s);
+    }
+
+    // Collect all PIDs seen during the session (provisional + committed)
+    [allPIDs unionSet:provisionalPIDs];
+
+    NSSet<NSNumber *> *prewarmedPIDs = [pool _prewarmedProcessIdentifiersForTesting];
+    NSLog(@"HttpToHttpsRedirectProcessCycling results (siteIsolation=%d):", useSiteIsolation);
+    NSLog(@"  Total unique PIDs observed: %lu", (unsigned long)allPIDs.count);
+    NSLog(@"  Committed Regular WebContent PIDs: %lu", (unsigned long)committedRegularPIDs.count);
+    NSLog(@"  Committed EnhancedSecurity PIDs: %lu", (unsigned long)committedEnhancedSecurityPIDs.count);
+    NSLog(@"  Provisional PIDs (includes intermediate ES processes): %lu", (unsigned long)provisionalPIDs.count);
+    NSLog(@"  Currently prewarmed PIDs: %@", prewarmedPIDs);
+
+    // After all navigations, the final committed pages should all be HTTPS,
+    // so the final process should NOT be Enhanced Security.
+    NSString *finalVariant = [webView _webContentProcessVariantForFrame:nil];
+    EXPECT_FALSE([finalVariant isEqualToString:@"security"]);
+
+    // The number of unique PIDs indicates process cycling. With the current architecture,
+    // HTTP -> HTTPS redirects cause EnhancedSecurity processes to be spawned then abandoned.
+    // This test establishes a baseline for measuring improvements.
+    EXPECT_GT(allPIDs.count, 1u);
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpToHttpsRedirectProcessCycling)
+
 // MARK: - HTTPS First Upgrade Tests
 
 static void runHttpsFirstUpgradeDisablesEnhancedSecurity(bool useSiteIsolation)


### PR DESCRIPTION
#### 60fa83ab78d37a21b42b9de03d01708aaf0996f0
<pre>
EWS test for deferring ES process swapping
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60fa83ab78d37a21b42b9de03d01708aaf0996f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174667 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122880 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/644d4162-ccf5-4f34-86b6-c274a02a77cf) 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128712 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90636 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05bb5f82-4d15-41f4-bb83-d4f5ff1def0f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168584 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31042 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109236 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e630f1a-549e-4633-b3c8-fe4876ab02ae) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30079 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28714 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22747 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177191 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30103 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137038 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136971 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148295 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102362 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32254 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25162 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38383 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111456 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37779 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3243 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38025 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37923 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->