### PR TITLE
Resync `html/rendering` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/w3c-import.log
@@ -15,6 +15,8 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/abs-pos-transferred-max-width-from-percentage-max-height-in-auto-height-containing-block-expected.png
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/abs-pos-transferred-max-width-from-percentage-max-height-in-auto-height-containing-block.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/blocked-by-csp-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/blocked-by-csp-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/blocked-by-csp.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
@@ -1,0 +1,12 @@
+
+
+FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 441
+FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 441
+FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 441
+FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 442
+PASS <select></select> has a shadow tree with slot
+PASS <select multiple=""></select> has a shadow tree with slot
+PASS <select size="4"></select> has a shadow tree with slot
+PASS <details></details> has a shadow tree with slot
+PASS <details open=""></details> has a shadow tree with slot
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<title>Internal shadow trees</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/3748">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+function test_has_shadow_root_with_no_slots(element) {
+  test(function(t) {
+    let child = element.appendChild(document.createElement("span"));
+    t.add_cleanup(() => child.remove());
+    assert_equals(child.getClientRects().length, 0, "child should not be rendered");
+    assert_equals(getComputedStyle(child).length, 0, "child should be outside the flat tree");
+  }, `${element.outerHTML} has a shadow tree with no slots`);
+}
+
+function test_has_shadow_root_with_slot(element, expectedProperties = { display: "contents" }) {
+  test(function(t) {
+    let child = element.appendChild(document.createElement("span"));
+    t.add_cleanup(() => child.remove());
+    let childStyle = getComputedStyle(child);
+    assert_not_equals(childStyle.length, 0, "child should be in the flat tree");
+    child.style.all = "inherit";
+    for (let [prop, value] of Object.entries(expectedProperties)) {
+      assert_equals(childStyle[prop], value, `Child should inherit ${prop}: ${value} from the slot`);
+    }
+  }, `${element.outerHTML} has a shadow tree with slot`);
+}
+</script>
+<video controls></video>
+<video></video>
+<audio></audio>
+<audio controls></audio>
+<select></select>
+<select multiple></select>
+<select size="4"></select>
+<details></details>
+<details open></details>
+<script>
+  for (let element of document.querySelectorAll("audio, video")) {
+    test_has_shadow_root_with_no_slots(element);
+  }
+  for (let element of document.querySelectorAll("select")) {
+    test_has_shadow_root_with_slot(element);
+  }
+  test_has_shadow_root_with_slot(document.querySelector("details"), {
+    display: "block",
+    contentVisibility: "hidden",
+  });
+  test_has_shadow_root_with_slot(document.querySelector("details[open]"), {
+    display: "block",
+    contentVisibility: "visible",
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/w3c-import.log
@@ -86,6 +86,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/input-time-content-size-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/input-time-content-size.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/select-wrap-no-spill.optional.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/text-control-client-width.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/text-control-flow-root-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/text-control-flow-root-ref.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
@@ -1,0 +1,12 @@
+
+
+FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 440
+FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 440
+FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 440
+FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 441
+PASS <select></select> has a shadow tree with slot
+PASS <select multiple=""></select> has a shadow tree with slot
+PASS <select size="4"></select> has a shadow tree with slot
+PASS <details></details> has a shadow tree with slot
+PASS <details open=""></details> has a shadow tree with slot
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
@@ -1,0 +1,12 @@
+
+
+FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
+FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
+FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
+FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 444
+PASS <select></select> has a shadow tree with slot
+PASS <select multiple=""></select> has a shadow tree with slot
+PASS <select size="4"></select> has a shadow tree with slot
+PASS <details></details> has a shadow tree with slot
+PASS <details open=""></details> has a shadow tree with slot
+


### PR DESCRIPTION
#### d04ed66e1991c1f50dc4a898cfb4b1d147722a05
<pre>
Resync `html/rendering` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=315955">https://bugs.webkit.org/show_bug.cgi?id=315955</a>
<a href="https://rdar.apple.com/178382649">rdar://178382649</a>

Reviewed by Brandon Stewart and Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/93d371423c2314ea3cc96c9dba5020d0ac82c555">https://github.com/web-platform-tests/wpt/commit/93d371423c2314ea3cc96c9dba5020d0ac82c555</a>

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/314321@main">https://commits.webkit.org/314321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74cf7a90b558e945e2860f001a39476b61a94da3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174700 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122913 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c1713eb-9e05-4241-b36d-23a7e96dc69a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128733 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90658 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6051470b-1502-499c-999d-2f09a625d782) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168617 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31068 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109257 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4452fc53-2a4b-4f04-a9c0-2ff72981dcb3) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30105 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28742 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22780 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177224 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137056 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136989 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36940 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148316 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102397 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32276 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25183 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38416 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37812 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3264 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38058 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37956 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->