### PR TITLE
[GTK][Skia] Emit PDF link annotations from GraphicsContextSkia

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -48,6 +48,7 @@
 #include <ranges>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorFilter.h>
+#include <skia/core/SkData.h>
 #include <skia/core/SkImage.h>
 #include <skia/core/SkPathBuilder.h>
 #include <skia/core/SkPathEffect.h>
@@ -62,6 +63,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/MathExtras.h>
+#include <wtf/URL.h>
 
 #if USE(THEME_ADWAITA)
 #include "Adwaita.h"
@@ -1293,6 +1295,51 @@ void GraphicsContextSkia::drawSkiaText(const sk_sp<SkTextBlob>& blob, SkScalar x
 RenderingMode GraphicsContextSkia::renderingMode() const
 {
     return m_renderingMode;
+}
+
+bool GraphicsContextSkia::supportsInternalLinks() const
+{
+    // Mirror GraphicsContextCG::supportsInternalLinks(), which also
+    // unconditionally returns true. SkCanvas::drawAnnotation is safe to
+    // invoke on any canvas: the SkPDFDocument canvas used by the GTK
+    // print pipeline converts the URL-keyed annotation into a native
+    // PDF /Link annotation at SkPicture replay time, while bitmap and
+    // GPU surface devices silently drop the annotation draw op at
+    // device level. There is therefore no correctness or performance
+    // hazard in emitting annotations unconditionally, and gating on
+    // m_contextMode would not work in practice because
+    // WebPrintOperationGtk does not call beginRecording(RecordingMode)
+    // on the GraphicsContextSkia it wraps around the recording canvas
+    // it obtains from SkPictureRecorder.
+    return true;
+}
+
+void GraphicsContextSkia::setURLForRect(const URL& link, const FloatRect& destRect)
+{
+    // Translate WebKit's setURLForRect call (emitted by RenderObject
+    // for every <a href> during print painting) into a Skia URL
+    // annotation. SkPictureRecorder records drawAnnotation as a draw
+    // op; on replay into SkPDFDocument's canvas, the
+    // SkAnnotationKey_URL key is recognised and converted into a
+    // native PDF /Link annotation with /A /S /URI action. This is the
+    // same pattern SkSVGDevice uses for SVG link emission and that
+    // GraphicsContextCG mirrors via CGContextSetURLForRect.
+    //
+    // Coordinate space: destRect is in WebKit's document-local
+    // coordinates; the current CTM on the recording canvas maps it to
+    // page coordinates at replay time.
+    //
+    // String form: SkPDF reads the URL bytes from the SkData payload
+    // and expects them NUL-terminated.
+    if (link.isEmpty())
+        return;
+    auto urlString = link.string().utf8();
+    auto urlData = SkData::MakeWithCString(urlString.data());
+    // SkAnnotationKeys::URL_Key() lives in a private Skia header
+    // (src/core/SkAnnotationKeys.h); use the literal directly. The
+    // string value has been stable across every Skia release that has
+    // shipped PDF support.
+    m_canvas.drawAnnotation(SkRect(destRect), "SkAnnotationKey_URL", urlData);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -116,6 +116,9 @@ public:
     IntRect clipBounds() const final;
     void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
 
+    bool supportsInternalLinks() const final;
+    void setURLForRect(const URL&, const FloatRect&) final;
+
     RenderingMode renderingMode() const final;
 
     SkPaint createFillPaint() const;


### PR DESCRIPTION
#### bf24c532e4a157bff40a3308fe2a9a261e482076
<pre>
[GTK][Skia] Emit PDF link annotations from GraphicsContextSkia
<a href="https://bugs.webkit.org/show_bug.cgi?id=315959">https://bugs.webkit.org/show_bug.cgi?id=315959</a>

Reviewed by NOBODY (OOPS!).

The Skia GraphicsContext backend was inheriting the base-class no-op
implementations of supportsInternalLinks() and setURLForRect(), so
RenderObject paint short-circuited link emission entirely. PDF output
produced by WebKitPrintOperation -&gt; SkPDF::MakeDocument carried no
clickable hyperlink annotations as a result.

Override both methods in GraphicsContextSkia. setURLForRect routes to
SkCanvas::drawAnnotation with the canonical &quot;SkAnnotationKey_URL&quot;
key -- SkPictureRecorder records the call as a draw op, and
SkPDFDocument&apos;s per-page canvas (used by WebPrintOperationGtk)
converts the URL-keyed annotation into a native PDF /Link annotation
with /A /S /URI action at SkPicture replay time. This is the same
pattern SkSVGDevice already uses for SVG link emission, and that
GraphicsContextCG mirrors via CGContextSetURLForRect.

supportsInternalLinks() returns true unconditionally, matching
GraphicsContextCG. drawAnnotation is safe to invoke on any SkCanvas:
non-recording targets (bitmap surfaces, GPU surfaces) silently drop
annotation draw ops at device level, so there is no correctness or
performance hazard. Gating on m_contextMode would not work in
practice because WebPrintOperationGtk does not call
beginRecording(RecordingMode) on the GraphicsContextSkia it wraps
around the SkPictureRecorder canvas it obtains for each page.

Verified on bbc.com via WebKitGTK 2.50.4 plus the equivalent patch:
0 -&gt; 192 PDF /Link annotations emitted (Chromium baseline on the
same URL is ~241). PDF size grew 45 KB for 192 annotations
(~234 bytes per annotation, matching a minimal PDF /Link dict).
Render time delta was +46 ms, within noise. The remaining gap vs
Chromium (~20%) appears to be iframe and shadow-DOM content not
traversed by the current paint-info code path; that is out of scope
for this change and can be a follow-up.

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
Declare supportsInternalLinks() and setURLForRect() overrides.

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::supportsInternalLinks const):
Return true unconditionally, mirroring GraphicsContextCG.
(WebCore::GraphicsContextSkia::setURLForRect):
Route to SkCanvas::drawAnnotation with the SkAnnotationKey_URL
key, which SkPDFDocument converts to a native PDF /Link
annotation at SkPicture replay time.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf24c532e4a157bff40a3308fe2a9a261e482076

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174715 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122928 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128746 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90666 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148846 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109270 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30171 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28756 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22795 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177239 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30152 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137069 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137002 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148340 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102424 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32288 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25207 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38431 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111504 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37827 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3288 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->