### PR TITLE
[intersection-observer] IntersectionObserver::updateObservations could modify m_observationTargets when iterating through it

### DIFF
--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -687,21 +687,23 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
 
     auto needNotify = NeedNotify::No;
 
-    for (auto& target : observationTargets()) {
+    // Iterate on a copy of m_observationTargets, in case something in the loop mutates it.
+    auto observationTargets = m_observationTargets;
+    for (Ref target : observationTargets) {
         // For implicit-root observers, a target whose owning Document is not fully
         // active (e.g. created via document.implementation.createHTMLDocument) cannot
         // produce an intersection. Skip without advancing the registration state, so a
         // later adopt into a fully-active document is treated as the first observation.
         // Drop the first-observation keep-alive so a permanently detached target/document
         // can be collected (intersection-observer/no-document-leak.html).
-        if (!root() && !target.document().isFullyActive()) {
+        if (!root() && !target->document().isFullyActive()) {
             m_targetsWaitingForFirstObservation.removeFirstMatching([&](auto& pendingTarget) {
-                return pendingTarget.ptr() == &target;
+                return pendingTarget.ptr() == target.ptr();
             });
             continue;
         }
 
-        auto& targetRegistrations = target.intersectionObserverDataIfExists()->registrations;
+        auto& targetRegistrations = target->intersectionObserverDataIfExists()->registrations;
         auto index = targetRegistrations.findIf([&](auto& registration) {
             return registration.observer.get() == this;
         });
@@ -710,7 +712,7 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
 
         bool isSameOriginObservation = [&] () {
             if (RefPtr hostFrameSecurityOrigin = hostFrame.frameDocumentSecurityOrigin())
-                return protect(target.document().securityOrigin())->isSameOriginDomain(*hostFrameSecurityOrigin);
+                return protect(target->document().securityOrigin())->isSameOriginDomain(*hostFrameSecurityOrigin);
 
             return false;
         }();
@@ -735,8 +737,8 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
                 ASSERT(intersectionState.absoluteTargetRect);
                 ASSERT(intersectionState.absoluteRootBounds);
 
-                RefPtr targetFrameView = target.document().view();
-                auto targetZoomForClient = target.document().zoomForClient(target.renderer()->style());
+                RefPtr targetFrameView = target->document().view();
+                auto targetZoomForClient = target->document().zoomForClient(target->renderer()->style());
                 targetBoundingClientRect = targetFrameView->absoluteToClientRect(*intersectionState.absoluteTargetRect, targetZoomForClient);
                 clientRootBounds = hostFrameView->absoluteToLayoutViewportRect(*intersectionState.absoluteRootBounds);
 


### PR DESCRIPTION
#### 2757278b899d7543c54534314ddf8d7026ce7349
<pre>
[intersection-observer] IntersectionObserver::updateObservations could modify m_observationTargets when iterating through it
<a href="https://rdar.apple.com/178339073">rdar://178339073</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315957">https://bugs.webkit.org/show_bug.cgi?id=315957</a>

Reviewed by Simon Fraser.

313834@main adds this code to IntersectionObserver::updateObservations to avoid updating
observations if the target&apos;s document is detached:

for (auto&amp; target : observationTargets()) {
    if (!root() &amp;&amp; !target.document().isFullyActive()) {
        m_targetsWaitingForFirstObservation.removeFirstMatching([&amp;](auto&amp; pendingTarget) {
            return pendingTarget.ptr() == &amp;target;
        });
        continue;
    }
    [...]
 }

m_targetsWaitingForFirstObservation owns ref-counted Elements. If removeFirstMatching
removes an Element, and its only reference is in m_targetsWaitingForFirstObservation,
the element gets destroyed. As the element is used in an intersection observer, its
destructor calls IntersectionObserver::unobserve to de-register itself, which removes
the Element from m_observationTargets. But the for loop is also iterating through
m_observationTargets (by observationTargets()). This leads to use-after-free as the
iterator reaches the removed element. Fix this by making a copy of observationTargets()
before iterating through it. Also take this opportunity to make `target` refcounted.

This was found by ASan bot on this test: media/destructor-logging-crash.html

* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::updateObservations):

Canonical link: <a href="https://commits.webkit.org/314315@main">https://commits.webkit.org/314315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5325d8a2b5081c8bcb0decc7d13f83aff783829a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174643 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122856 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23852713-fbf7-41bf-b9f8-2fccbe5fc8bd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128697 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90625 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f16bbee-31ef-4c0f-8510-6717f890e5bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168560 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31022 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109221 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14a01332-6e39-4e70-b196-7594d61f1505) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30059 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28694 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22721 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177167 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30079 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137029 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136956 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36933 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148279 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102328 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32235 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25146 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38359 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111432 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37755 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3227 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38001 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37899 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->