### PR TITLE
[intersection-observer] Reference cycle between IntersectionObserver and m_targetsWaitingForFirstObservation

### DIFF
--- a/LayoutTests/intersection-observer/no-document-leak.html
+++ b/LayoutTests/intersection-observer/no-document-leak.html
@@ -48,7 +48,8 @@ window.onload = function () {
             {
                 let count = internals.numberOfIntersectionObservers(document);
                 return count < totalCount || count === 0;
-            }
+            },
+            documentCount: 100 // ensure a leak.
         }
     ).then(
         () => testPassed("Document did not leak"),

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -690,18 +690,11 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
     // Iterate on a copy of m_observationTargets, in case something in the loop mutates it.
     auto observationTargets = m_observationTargets;
     for (Ref target : observationTargets) {
-        // For implicit-root observers, a target whose owning Document is not fully
-        // active (e.g. created via document.implementation.createHTMLDocument) cannot
-        // produce an intersection. Skip without advancing the registration state, so a
-        // later adopt into a fully-active document is treated as the first observation.
-        // Drop the first-observation keep-alive so a permanently detached target/document
-        // can be collected (intersection-observer/no-document-leak.html).
-        if (!root() && !target->document().isFullyActive()) {
-            m_targetsWaitingForFirstObservation.removeFirstMatching([&](auto& pendingTarget) {
-                return pendingTarget.ptr() == target.ptr();
-            });
+        // Per HTML spec, "update the rendering" step (which includes "run the update intersection
+        // observations") should only occur for fully active documents. Hence skip updating the
+        // target if its document is not fully active.
+        if (!root() && !target->document().isFullyActive())
             continue;
-        }
 
         auto& targetRegistrations = target->intersectionObserverDataIfExists()->registrations;
         auto index = targetRegistrations.findIf([&](auto& registration) {
@@ -845,11 +838,18 @@ bool IntersectionObserver::isReachableFromOpaqueRoots(JSC::AbstractSlotVisitor& 
         if (containsWebCoreOpaqueRoot(visitor, target))
             return true;
     }
+
     for (auto& target : m_pendingTargets) {
         if (containsWebCoreOpaqueRoot(visitor, target.get()))
             return true;
     }
-    return !m_targetsWaitingForFirstObservation.isEmpty();
+
+    for (auto& target : m_targetsWaitingForFirstObservation) {
+        if (containsWebCoreOpaqueRoot(visitor, target.get()))
+            return true;
+    }
+
+    return false;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0fa28697001e02d0dbf4b9109bf7385f5f74f575
<pre>
[intersection-observer] Reference cycle between IntersectionObserver and m_targetsWaitingForFirstObservation
<a href="https://rdar.apple.com/178385445">rdar://178385445</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315964">https://bugs.webkit.org/show_bug.cgi?id=315964</a>

Reviewed by Ryosuke Niwa.

IntersectionObserver holds ref-counted elements in m_targetsWaitingForFirstObservation.
Its isReachableFromOpaqueRoots method looks like this:

bool IntersectionObserver::isReachableFromOpaqueRoots(JSC::AbstractSlotVisitor&amp; visitor) const
{
    for (auto&amp; target : m_observationTargets) {
        if (containsWebCoreOpaqueRoot(visitor, target))
            return true;
    }
    for (auto&amp; target : m_pendingTargets) {
        if (containsWebCoreOpaqueRoot(visitor, target.get()))
            return true;
    }
    return !m_targetsWaitingForFirstObservation.isEmpty(); &lt;== (1)
}

(1) means IntersectionObserver (more specifically, its JS wrapper) doesn&apos;t get
garbage collected if m_targetsWaitingForFirstObservation is not empty.

It&apos;s possible to set up a reference cycle such that IntersectionObserver keeps
elements in m_targetsWaitingForFirstObservation alive, and those elements also
keep IntersectionObserver alive.

intersection-observer/no-document-leak.html creates a lot of iframes, each creating
one IntersectionObserver, then discards the iframes. This is done in one go without
waiting for the main document to update its rendering between the steps, hence the
observers don&apos;t get updated. When they aren&apos;t, IntersectionObserver::notify doesn&apos;t
get called and m_targetsWaitingForFirstObservation doesn&apos;t get emptied.

After the iframe is removed:
(1) GC can&apos;t deallocate elements in m_targetsWaitingForFirstObservation, as they&apos;re
    being kept alive by the observer
(2) GC can&apos;t deallocate the observer, as IntersectionObserver::isReachableFromOpaqueRoots
    returns true because m_targetsWaitingForFirstObservation is not empty.

Hence the GC won&apos;t garbage collect either the elements or observer.

Fix this by checking if any elements in m_targetsWaitingForFirstObservation are reachable
using containsWebCoreOpaqueRoot, like how it&apos;s done to m_pendingTargets. When the iframe
is removed, containsWebCoreOpaqueRoot on the elements will be false, as their opaque root
(the iframe root node) is already GC&apos;ed when the iframe is removed. Then the observer
can be GC&apos;ed, and its destructor will destroy m_targetsWaitingForFirstObservation and
elements in it (because at this point m_targetsWaitingForFirstObservation holds the
only reference to the elements)

313834@main tried to fix this by adding:

// [...]
// Drop the first-observation keep-alive so a permanently detached target/document
// can be collected (intersection-observer/no-document-leak.html).
if (!root() &amp;&amp; !target.document().isFullyActive()) {
    m_targetsWaitingForFirstObservation.removeFirstMatching([&amp;](auto&amp; pendingTarget) {
        return pendingTarget.ptr() == &amp;target;
    });
    [...]

But this doesn&apos;t address the root cause of the issue. It just so happens that the
actual change (to make observer not update when the target&apos;s document is not fully
active) uncovers this bug.

Test: intersection-observer/no-document-leak.html

* LayoutTests/intersection-observer/no-document-leak.html:
    - Create more iframes to reliably reproduce the leak.

* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::updateObservations):
(WebCore::IntersectionObserver::isReachableFromOpaqueRoots const):

Canonical link: <a href="https://commits.webkit.org/314380@main">https://commits.webkit.org/314380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36d6e56a8e79e1bab512b0fe3e2ab1badf1f924b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174892 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123105 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39344 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128891 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109415 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30233 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28914 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22975 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177417 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30332 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28407 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137225 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137152 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36981 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148496 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102642 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32442 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25363 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38608 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111681 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38004 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3445 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38250 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38148 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->