### PR TITLE
[JSC][Temporal] `toLocaleString` should reuse the per-globalObject default `IntlDateTimeFormat` when locales/options are undefined

### DIFF
--- a/JSTests/microbenchmarks/temporal-instant-to-locale-string.js
+++ b/JSTests/microbenchmarks/temporal-instant-to-locale-string.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useTemporal=1")
+const instant = new Temporal.Instant(1705314645000000000n);
+for (var i = 0; i < 1e3; ++i)
+    instant.toLocaleString();

--- a/JSTests/microbenchmarks/temporal-plain-date-time-to-locale-string.js
+++ b/JSTests/microbenchmarks/temporal-plain-date-time-to-locale-string.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useTemporal=1")
+const plainDateTime = new Temporal.PlainDateTime(2024, 1, 15, 10, 30, 45);
+for (var i = 0; i < 1e3; ++i)
+    plainDateTime.toLocaleString();

--- a/JSTests/microbenchmarks/temporal-plain-date-to-locale-string.js
+++ b/JSTests/microbenchmarks/temporal-plain-date-to-locale-string.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useTemporal=1")
+const plainDate = new Temporal.PlainDate(2024, 1, 15);
+for (var i = 0; i < 1e3; ++i)
+    plainDate.toLocaleString();

--- a/JSTests/microbenchmarks/temporal-plain-time-to-locale-string.js
+++ b/JSTests/microbenchmarks/temporal-plain-time-to-locale-string.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useTemporal=1")
+const plainTime = new Temporal.PlainTime(10, 30, 45);
+for (var i = 0; i < 1e3; ++i)
+    plainTime.toLocaleString();

--- a/JSTests/stress/temporal-tolocalestring-default-formatter.js
+++ b/JSTests/stress/temporal-tolocalestring-default-formatter.js
@@ -1,0 +1,94 @@
+//@ requireOptions("--useTemporal=1")
+// Temporal.*.prototype.toLocaleString with undefined locales/options uses the
+// per-globalObject default IntlDateTimeFormat (shared with Date.prototype.toLocale*String).
+// Verify that the cached formatter path produces results identical to the
+// fresh-formatter path and stays consistent across repeated and interleaved calls.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg ?? "shouldBe"}: expected ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`);
+}
+
+function shouldThrow(func, errorType, msg) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error(`${msg ?? "shouldThrow"}: expected ${errorType.name} but got ${error}`);
+}
+
+const plainDate = new Temporal.PlainDate(2024, 1, 15);
+const plainTime = new Temporal.PlainTime(10, 30, 45);
+const plainDateTime = new Temporal.PlainDateTime(2024, 1, 15, 10, 30, 45);
+const plainYearMonth = new Temporal.PlainYearMonth(2024, 1);
+const plainMonthDay = new Temporal.PlainMonthDay(1, 15);
+const instant = new Temporal.Instant(1705314645000000000n); // 2024-01-15T10:30:45Z
+
+// PlainDate, PlainTime, PlainDateTime, and Instant format successfully with the
+// default formatter regardless of the locale's default calendar.
+const formattable = [plainDate, plainTime, plainDateTime, instant];
+
+// 1. Repeated calls on the cached default formatter must produce identical, non-empty results.
+for (const object of formattable) {
+    const tag = object[Symbol.toStringTag];
+    const first = object.toLocaleString();
+    shouldBe(typeof first, "string", `${tag} returns a string`);
+    shouldBe(first.length > 0, true, `${tag} returns a non-empty string`);
+    for (let i = 0; i < 100; ++i)
+        shouldBe(object.toLocaleString(), first, `${tag} repeated call ${i}`);
+}
+
+// 2. The cached formatter must produce the same result as a freshly created formatter.
+// Passing an empty options object forces the fresh-formatter path with identical effective options.
+for (const object of formattable) {
+    const tag = object[Symbol.toStringTag];
+    shouldBe(object.toLocaleString(), object.toLocaleString(undefined, {}), `${tag} cached vs fresh`);
+}
+
+// 3. PlainYearMonth/PlainMonthDay throw RangeError when the formatter's calendar (locale default)
+// does not match the object's calendar (iso8601). The cached path must throw the same way,
+// consistently, on every call.
+for (const object of [plainYearMonth, plainMonthDay]) {
+    const tag = object[Symbol.toStringTag];
+    if (new Intl.DateTimeFormat().resolvedOptions().calendar === "iso8601")
+        continue;
+    for (let i = 0; i < 10; ++i) {
+        shouldThrow(() => object.toLocaleString(), RangeError, `${tag} cached call ${i}`);
+        shouldThrow(() => object.toLocaleString(undefined, {}), RangeError, `${tag} fresh call ${i}`);
+    }
+    // With a matching calendar, formatting succeeds via the fresh-formatter path.
+    const formatted = object.toLocaleString(undefined, { calendar: "iso8601" });
+    shouldBe(typeof formatted, "string", `${tag} with iso8601 calendar`);
+    shouldBe(formatted.length > 0, true, `${tag} with iso8601 calendar non-empty`);
+}
+
+// 4. Interleaving with Date.prototype.toLocale*String (which shares the same per-globalObject
+// default formatters) must not change any result.
+const date = new Date(2024, 0, 15, 10, 30, 45);
+const dateExpected = [date.toLocaleString(), date.toLocaleDateString(), date.toLocaleTimeString()];
+const temporalExpected = formattable.map((object) => object.toLocaleString());
+for (let i = 0; i < 100; ++i) {
+    shouldBe(date.toLocaleString(), dateExpected[0], `Date#toLocaleString interleave ${i}`);
+    shouldBe(date.toLocaleDateString(), dateExpected[1], `Date#toLocaleDateString interleave ${i}`);
+    shouldBe(date.toLocaleTimeString(), dateExpected[2], `Date#toLocaleTimeString interleave ${i}`);
+    formattable.forEach((object, index) => {
+        shouldBe(object.toLocaleString(), temporalExpected[index], `${object[Symbol.toStringTag]} interleave ${i}`);
+    });
+}
+
+// 5. Explicit locales/options still take the fresh-formatter path and respect the arguments.
+// Compare against Intl.DateTimeFormat directly to stay independent of ICU/CLDR output differences.
+function shouldMatchDateTimeFormat(object, locale, options) {
+    const tag = object[Symbol.toStringTag];
+    shouldBe(object.toLocaleString(locale, options), new Intl.DateTimeFormat(locale, options).format(object), `${tag} toLocaleString vs Intl.DateTimeFormat`);
+}
+shouldMatchDateTimeFormat(plainDate, "en-US", { calendar: "iso8601" });
+shouldMatchDateTimeFormat(plainDate, "en-US", { month: "long", day: "numeric", year: "numeric", calendar: "iso8601" });
+shouldMatchDateTimeFormat(plainTime, "en-US", undefined);
+shouldMatchDateTimeFormat(plainDateTime, "en-US", { calendar: "iso8601" });
+shouldMatchDateTimeFormat(plainYearMonth, "en-US", { calendar: "iso8601" });
+shouldMatchDateTimeFormat(plainMonthDay, "en-US", { calendar: "iso8601" });
+shouldMatchDateTimeFormat(instant, "en-US", { timeZone: "UTC", calendar: "iso8601" });

--- a/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
@@ -434,8 +434,15 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncToLocaleString, (JSGlobalOb
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.toLocaleString called on value that's not a Instant"_s);
 
     // Step 3: Let dateFormat be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, locales, options, ANY, ALL).
-    IntlDateTimeFormat* formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
-    formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Any, IntlDateTimeFormat::Defaults::All);
+    JSValue locales = callFrame->argument(0);
+    JSValue options = callFrame->argument(1);
+    IntlDateTimeFormat* formatter;
+    if (locales.isUndefined() && options.isUndefined())
+        formatter = globalObject->defaultDateTimeFormat();
+    else {
+        formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
+        formatter->initializeDateTimeFormat(globalObject, locales, options, IntlDateTimeFormat::RequiredComponent::Any, IntlDateTimeFormat::Defaults::All);
+    }
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 4: Return ? FormatDateTime(dateFormat, instant).

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -479,8 +479,15 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToLocaleString, (JSGlobal
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toLocaleString called on value that's not a PlainDate"_s);
 
-    auto* formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
-    formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Date, IntlDateTimeFormat::Defaults::Date);
+    JSValue locales = callFrame->argument(0);
+    JSValue options = callFrame->argument(1);
+    IntlDateTimeFormat* formatter;
+    if (locales.isUndefined() && options.isUndefined())
+        formatter = globalObject->defaultDateFormat();
+    else {
+        formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
+        formatter->initializeDateTimeFormat(globalObject, locales, options, IntlDateTimeFormat::RequiredComponent::Date, IntlDateTimeFormat::Defaults::Date);
+    }
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -571,8 +571,15 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncToLocaleString, (JSGl
     if (!plainDateTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.toLocaleString called on value that's not a PlainDateTime"_s);
 
-    auto* formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
-    formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Any, IntlDateTimeFormat::Defaults::All);
+    JSValue locales = callFrame->argument(0);
+    JSValue options = callFrame->argument(1);
+    IntlDateTimeFormat* formatter;
+    if (locales.isUndefined() && options.isUndefined())
+        formatter = globalObject->defaultDateTimeFormat();
+    else {
+        formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
+        formatter->initializeDateTimeFormat(globalObject, locales, options, IntlDateTimeFormat::RequiredComponent::Any, IntlDateTimeFormat::Defaults::All);
+    }
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -132,8 +132,15 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToLocaleString, (JSGl
     if (!monthDay) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toLocaleString called on value that's not a PlainMonthDay"_s);
 
-    auto* formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
-    formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Date, IntlDateTimeFormat::Defaults::Date);
+    JSValue locales = callFrame->argument(0);
+    JSValue options = callFrame->argument(1);
+    IntlDateTimeFormat* formatter;
+    if (locales.isUndefined() && options.isUndefined())
+        formatter = globalObject->defaultDateFormat();
+    else {
+        formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
+        formatter->initializeDateTimeFormat(globalObject, locales, options, IntlDateTimeFormat::RequiredComponent::Date, IntlDateTimeFormat::Defaults::Date);
+    }
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
@@ -276,8 +276,15 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToLocaleString, (JSGlobal
     if (!plainTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.toLocaleString called on value that's not a PlainTime"_s);
 
-    auto* formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
-    formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Time, IntlDateTimeFormat::Defaults::Time);
+    JSValue locales = callFrame->argument(0);
+    JSValue options = callFrame->argument(1);
+    IntlDateTimeFormat* formatter;
+    if (locales.isUndefined() && options.isUndefined())
+        formatter = globalObject->defaultTimeFormat();
+    else {
+        formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
+        formatter->initializeDateTimeFormat(globalObject, locales, options, IntlDateTimeFormat::RequiredComponent::Time, IntlDateTimeFormat::Defaults::Time);
+    }
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
@@ -340,8 +340,15 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToLocaleString, (JSG
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.toLocaleString called on value that's not a PlainYearMonth"_s);
 
-    auto* formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
-    formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Date, IntlDateTimeFormat::Defaults::Date);
+    JSValue locales = callFrame->argument(0);
+    JSValue options = callFrame->argument(1);
+    IntlDateTimeFormat* formatter;
+    if (locales.isUndefined() && options.isUndefined())
+        formatter = globalObject->defaultDateFormat();
+    else {
+        formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
+        formatter->initializeDateTimeFormat(globalObject, locales, options, IntlDateTimeFormat::RequiredComponent::Date, IntlDateTimeFormat::Defaults::Date);
+    }
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));


### PR DESCRIPTION
#### 2b8c08245ca45124187a717bd6b26c4604f8b961
<pre>
[JSC][Temporal] `toLocaleString` should reuse the per-globalObject default `IntlDateTimeFormat` when locales/options are undefined
<a href="https://bugs.webkit.org/show_bug.cgi?id=315974">https://bugs.webkit.org/show_bug.cgi?id=315974</a>

Reviewed by Yusuke Suzuki.

All six Temporal toLocaleString implementations created and initialized a fresh
IntlDateTimeFormat on every call, even in the most common case where both locales
and options are undefined. initializeDateTimeFormat is the most expensive Intl
constructor (~100us per call), and because the formatter was discarded after each
call, its internal per-TemporalFieldKind formatter cache (m_temporalFormatterCache)
was rebuilt every time as well.

Follow the same approach as Date.prototype.toLocaleString / toLocaleDateString /
toLocaleTimeString: when both locales and options are undefined, reuse the
per-globalObject default formatters. The (RequiredComponent, Defaults) pairs used
by each Temporal type match the existing defaults exactly, so no new globalObject
members are needed:

  - PlainDate, PlainMonthDay, PlainYearMonth -&gt; defaultDateFormat() (Date, Date)
  - PlainTime -&gt; defaultTimeFormat() (Time, Time)
  - PlainDateTime, Instant -&gt; defaultDateTimeFormat() (Any, All)

This is unobservable: with undefined arguments, initializeDateTimeFormat runs no
user code, so the resulting configuration is deterministic. Sharing is also safe
because the legacy Date path formats through m_dateFormat while the Temporal path
formats through m_temporalFormatterCache, which are disjoint. As a bonus, the
Temporal formatter cache now survives across calls.

    temporal-plain-date-to-locale-string           87.4065+-0.6976     ^      0.6863+-0.0602        ^ definitely 127.3515x faster
    temporal-plain-time-to-locale-string           87.8948+-1.6492     ^      0.7042+-0.0537        ^ definitely 124.8110x faster
    temporal-plain-date-time-to-locale-string      95.9008+-0.7969     ^      0.9443+-0.0996        ^ definitely 101.5602x faster
    temporal-instant-to-locale-string              99.6770+-1.3693     ^      1.0900+-0.0762        ^ definitely 91.4445x faster

date-to-locale-string, date-to-locale-date-string, and date-to-locale-time-string
remain neutral.

Tests: JSTests/microbenchmarks/temporal-instant-to-locale-string.js
       JSTests/microbenchmarks/temporal-plain-date-time-to-locale-string.js
       JSTests/microbenchmarks/temporal-plain-date-to-locale-string.js
       JSTests/microbenchmarks/temporal-plain-time-to-locale-string.js
       JSTests/stress/temporal-tolocalestring-default-formatter.js

* JSTests/microbenchmarks/temporal-instant-to-locale-string.js: Added.
* JSTests/microbenchmarks/temporal-plain-date-time-to-locale-string.js: Added.
* JSTests/microbenchmarks/temporal-plain-date-to-locale-string.js: Added.
* JSTests/microbenchmarks/temporal-plain-time-to-locale-string.js: Added.
* JSTests/stress/temporal-tolocalestring-default-formatter.js: Added.
(shouldBe):
(const.object.of.formattable.object.toLocaleString):
(i.formattable.forEach):
* Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/315508@main">https://commits.webkit.org/315508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/198958413ccf69f5f9350f71772d9a6a22d932f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178608 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126964 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131825 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172211 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112329 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27308 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/530 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181208 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30507 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140280 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42830 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140120 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37699 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43519 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107440 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35390 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115284 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201931 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42029 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6576 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54161 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41422 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41677 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->