### PR TITLE
[JSC] Map/Set iterator fast path in `forEachInIteratorProtocol` should perform IteratorClose when the callback throws

### DIFF
--- a/JSTests/stress/iterator-prototype-forEach-map-set-iterator-close.js
+++ b/JSTests/stress/iterator-prototype-forEach-map-set-iterator-close.js
@@ -1,0 +1,228 @@
+// Regression test for the Map/Set iterator fast path in forEachInIteratorProtocol.
+// When the callback passed to Iterator.prototype.forEach throws, the iterator's
+// "return" method (IteratorClose) must be invoked, even for Map/Set iterators
+// that have an own "return" property.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function shouldThrow(func, errorMessage) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!error)
+        throw new Error("not thrown");
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}, expected: ${errorMessage}`);
+}
+
+// Map values iterator with own "return": callback throws -> return must be called.
+{
+    const map = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+    const iterator = map.values();
+    let returnCalled = 0;
+    let returnThisValue = null;
+    iterator.return = function () {
+        ++returnCalled;
+        returnThisValue = this;
+        return { done: true, value: undefined };
+    };
+    shouldThrow(() => {
+        iterator.forEach(() => { throw new Error("callback error"); });
+    }, "Error: callback error");
+    shouldBe(returnCalled, 1);
+    shouldBe(returnThisValue, iterator);
+}
+
+// Map keys iterator with own "return".
+{
+    const map = new Map([[1, "a"], [2, "b"]]);
+    const iterator = map.keys();
+    let returnCalled = 0;
+    iterator.return = function () {
+        ++returnCalled;
+        return { done: true, value: undefined };
+    };
+    shouldThrow(() => {
+        iterator.forEach(() => { throw new Error("callback error"); });
+    }, "Error: callback error");
+    shouldBe(returnCalled, 1);
+}
+
+// Map entries iterator with own "return".
+{
+    const map = new Map([[1, "a"], [2, "b"]]);
+    const iterator = map.entries();
+    let returnCalled = 0;
+    iterator.return = function () {
+        ++returnCalled;
+        return { done: true, value: undefined };
+    };
+    shouldThrow(() => {
+        iterator.forEach(() => { throw new Error("callback error"); });
+    }, "Error: callback error");
+    shouldBe(returnCalled, 1);
+}
+
+// Set values iterator with own "return": callback throws -> return must be called.
+{
+    const set = new Set([1, 2, 3]);
+    const iterator = set.values();
+    let returnCalled = 0;
+    let returnThisValue = null;
+    iterator.return = function () {
+        ++returnCalled;
+        returnThisValue = this;
+        return { done: true, value: undefined };
+    };
+    shouldThrow(() => {
+        iterator.forEach(() => { throw new Error("callback error"); });
+    }, "Error: callback error");
+    shouldBe(returnCalled, 1);
+    shouldBe(returnThisValue, iterator);
+}
+
+// Set keys iterator with own "return".
+{
+    const set = new Set([1, 2]);
+    const iterator = set.keys();
+    let returnCalled = 0;
+    iterator.return = function () {
+        ++returnCalled;
+        return { done: true, value: undefined };
+    };
+    shouldThrow(() => {
+        iterator.forEach(() => { throw new Error("callback error"); });
+    }, "Error: callback error");
+    shouldBe(returnCalled, 1);
+}
+
+// Set entries iterator with own "return".
+{
+    const set = new Set([1, 2]);
+    const iterator = set.entries();
+    let returnCalled = 0;
+    iterator.return = function () {
+        ++returnCalled;
+        return { done: true, value: undefined };
+    };
+    shouldThrow(() => {
+        iterator.forEach(() => { throw new Error("callback error"); });
+    }, "Error: callback error");
+    shouldBe(returnCalled, 1);
+}
+
+// The callback throws after consuming some elements: return is called once,
+// and iteration stops at the throwing element.
+{
+    const map = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+    const iterator = map.keys();
+    let returnCalled = 0;
+    iterator.return = function () {
+        ++returnCalled;
+        return { done: true, value: undefined };
+    };
+    const seen = [];
+    shouldThrow(() => {
+        iterator.forEach((key) => {
+            seen.push(key);
+            if (key === 2)
+                throw new Error("stop");
+        });
+    }, "Error: stop");
+    shouldBe(seen.join(","), "1,2");
+    shouldBe(returnCalled, 1);
+}
+
+// When both the callback and "return" throw, the callback's exception wins.
+{
+    const set = new Set([1, 2, 3]);
+    const iterator = set.values();
+    let returnCalled = 0;
+    iterator.return = function () {
+        ++returnCalled;
+        throw new Error("return error");
+    };
+    shouldThrow(() => {
+        iterator.forEach(() => { throw new Error("callback error"); });
+    }, "Error: callback error");
+    shouldBe(returnCalled, 1);
+}
+
+// "return" is not called when iteration completes normally.
+{
+    const map = new Map([[1, "a"], [2, "b"]]);
+    const iterator = map.values();
+    let returnCalled = 0;
+    iterator.return = function () {
+        ++returnCalled;
+        return { done: true, value: undefined };
+    };
+    const seen = [];
+    iterator.forEach((value) => { seen.push(value); });
+    shouldBe(seen.join(","), "a,b");
+    shouldBe(returnCalled, 0);
+}
+
+// Non-JS (bound) callback to cover the non-CachedCall path.
+{
+    const map = new Map([[1, "a"], [2, "b"]]);
+    const iterator = map.values();
+    let returnCalled = 0;
+    iterator.return = function () {
+        ++returnCalled;
+        return { done: true, value: undefined };
+    };
+    const callback = function () { throw new Error(this.message); }.bind({ message: "bound callback error" });
+    shouldThrow(() => {
+        iterator.forEach(callback);
+    }, "Error: bound callback error");
+    shouldBe(returnCalled, 1);
+}
+
+// Fast path without own "return" still works (no regression).
+{
+    const map = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+    const seen = [];
+    map.values().forEach((value) => { seen.push(value); });
+    shouldBe(seen.join(","), "a,b,c");
+
+    const set = new Set([1, 2, 3]);
+    let sum = 0;
+    set.values().forEach((value) => { sum += value; });
+    shouldBe(sum, 6);
+}
+
+// Fast path without own "return": callback exceptions still propagate.
+{
+    const set = new Set([1, 2, 3]);
+    const seen = [];
+    shouldThrow(() => {
+        set.values().forEach((value) => {
+            seen.push(value);
+            if (value === 2)
+                throw new Error("no return");
+        });
+    }, "Error: no return");
+    shouldBe(seen.join(","), "1,2");
+}
+
+// Repeat to make sure JIT tiers behave the same.
+for (let i = 0; i < 1e3; ++i) {
+    const map = new Map([[i, i * 10], [i + 1, (i + 1) * 10]]);
+    const iterator = map.values();
+    let returnCalled = 0;
+    iterator.return = function () {
+        ++returnCalled;
+        return { done: true, value: undefined };
+    };
+    shouldThrow(() => {
+        iterator.forEach(() => { throw new Error("loop error"); });
+    }, "Error: loop error");
+    shouldBe(returnCalled, 1);
+}

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2311,6 +2311,21 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_arrayPrototype.get(), vm.propertyNames->isConcatSpreadableSymbol, objectPrototype()), m_arrayIsConcatSpreadableWatchpointSet);
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_objectPrototype.get(), vm.propertyNames->isConcatSpreadableSymbol, nullptr), m_arrayIsConcatSpreadableWatchpointSet);
 
+    // The iterator protocol fast paths assume that IteratorClose is unobservable, so they must be
+    // invalidated when a "return" property appears anywhere on the iterator's prototype chain.
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, arrayIteratorPrototype, vm.propertyNames->returnKeyword, m_iteratorPrototype.get()), m_arrayIteratorProtocolWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, mapIteratorPrototype, vm.propertyNames->returnKeyword, m_iteratorPrototype.get()), m_mapIteratorProtocolWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, setIteratorPrototype, vm.propertyNames->returnKeyword, m_iteratorPrototype.get()), m_setIteratorProtocolWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_stringIteratorPrototype.get(), vm.propertyNames->returnKeyword, m_iteratorPrototype.get()), m_stringIteratorProtocolWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_iteratorPrototype.get(), vm.propertyNames->returnKeyword, objectPrototype()), m_arrayIteratorProtocolWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_iteratorPrototype.get(), vm.propertyNames->returnKeyword, objectPrototype()), m_mapIteratorProtocolWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_iteratorPrototype.get(), vm.propertyNames->returnKeyword, objectPrototype()), m_setIteratorProtocolWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_iteratorPrototype.get(), vm.propertyNames->returnKeyword, objectPrototype()), m_stringIteratorProtocolWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_objectPrototype.get(), vm.propertyNames->returnKeyword, nullptr), m_arrayIteratorProtocolWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_objectPrototype.get(), vm.propertyNames->returnKeyword, nullptr), m_mapIteratorProtocolWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_objectPrototype.get(), vm.propertyNames->returnKeyword, nullptr), m_setIteratorProtocolWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_objectPrototype.get(), vm.propertyNames->returnKeyword, nullptr), m_stringIteratorProtocolWatchpointSet);
+
     // Array Species watchpoint.
     {
         RELEASE_ASSERT(!m_arrayPrototypeConstructorWatchpoint);

--- a/Source/JavaScriptCore/runtime/MapIteratorPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/MapIteratorPrototypeInlines.h
@@ -44,6 +44,8 @@ ALWAYS_INLINE bool mapIteratorProtocolIsFastAndNonObservable(VM& vm, JSMapIterat
     if (mapIterator->hasCustomProperties()) {
         if (mapIterator->getDirectOffset(vm, vm.propertyNames->next) != invalidOffset)
             return false;
+        if (mapIterator->getDirectOffset(vm, vm.propertyNames->returnKeyword) != invalidOffset)
+            return false;
     }
 
     return true;

--- a/Source/JavaScriptCore/runtime/SetIteratorPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/SetIteratorPrototypeInlines.h
@@ -44,6 +44,8 @@ ALWAYS_INLINE bool setIteratorProtocolIsFastAndNonObservable(VM& vm, JSSetIterat
     if (setIterator->hasCustomProperties()) {
         if (setIterator->getDirectOffset(vm, vm.propertyNames->next) != invalidOffset)
             return false;
+        if (setIterator->getDirectOffset(vm, vm.propertyNames->returnKeyword) != invalidOffset)
+            return false;
     }
 
     return true;


### PR DESCRIPTION
#### 87547f94b76e48d4dbc6a550b0f8515a1b2f7936
<pre>
[JSC] Map/Set iterator fast path in `forEachInIteratorProtocol` should perform IteratorClose when the callback throws
<a href="https://bugs.webkit.org/show_bug.cgi?id=315979">https://bugs.webkit.org/show_bug.cgi?id=315979</a>

Reviewed by Yusuke Suzuki.

The Map/Set iterator fast paths in forEachInIteratorProtocol skip IteratorClose
when the callback throws, so a &quot;return&quot; method installed on the iterator itself
or anywhere on its prototype chain is never invoked.

Fix this by rejecting iterators with an own &quot;return&quot; property in the fast path
guards, and by installing &quot;return&quot; absence watchpoints on ArrayIterator.prototype,
MapIterator.prototype, SetIterator.prototype, StringIterator.prototype,
Iterator.prototype, and Object.prototype, wired to the corresponding iterator
protocol watchpoint sets. Iterators that are no longer fast and non-observable
go through the generic path, which performs IteratorClose.

Test: JSTests/stress/iterator-prototype-forEach-map-set-iterator-close.js

* JSTests/stress/iterator-prototype-forEach-map-set-iterator-close.js: Added.
(shouldBe):
(iterator.return):
(shouldThrow):
(shouldBe.iterator.return):
(shouldBe.const.iterator.set values):
(const.iterator.set keys):
(const.iterator.set entries):
(const.set new):
(const.iterator.set values):
(const.callback):
(shouldBe.const.set new):
(shouldBe.set values):
(set shouldBe):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/MapIteratorPrototypeInlines.h:
(JSC::mapIteratorProtocolIsFastAndNonObservable):
* Source/JavaScriptCore/runtime/SetIteratorPrototypeInlines.h:
(JSC::setIteratorProtocolIsFastAndNonObservable):

Canonical link: <a href="https://commits.webkit.org/314277@main">https://commits.webkit.org/314277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5b284ae38b11943527031e4684a00d7e6c364b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122896 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128724 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168600 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109248 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28731 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22763 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157798 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177207 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26534 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30119 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137048 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136981 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36914 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148311 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102380 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32268 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25178 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38399 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111472 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37795 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3259 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38041 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->