### PR TITLE
[JSC] Reject dictionary structures in `tryEnsureAbsence` in DFG

### DIFF
--- a/JSTests/stress/dfg-ensure-absence-dictionary-then-property.js
+++ b/JSTests/stress/dfg-ensure-absence-dictionary-then-property.js
@@ -1,0 +1,45 @@
+// Adding a property to an object with a (cacheable) dictionary structure does not
+// transition the structure. So, the DFG must not prove the absence of 'then' based on
+// a dictionary structure: neither CheckStructure nor a structure transition watchpoint
+// can detect a 'then' property added after compilation.
+
+function createDictionaryObject() {
+    const object = { x: 42 };
+    // Adding enough properties forces a transition to a cacheable dictionary structure.
+    for (let i = 0; i < 1000; i++)
+        object['p' + i] = i;
+    return object;
+}
+
+let getterCalled = false;
+
+function opt(object) {
+    object.x;
+    return Promise.resolve(object);
+}
+noInline(opt);
+
+function main() {
+    const object = createDictionaryObject();
+
+    for (let i = 0; i < testLoopCount; i++)
+        opt(object);
+
+    // With concurrent JIT, the optimized code may not be installed yet. Keep running
+    // until it is. numberOfDFGCompiles() returns a huge number when the DFG is
+    // disabled, so this loop terminates in every configuration.
+    for (let i = 0; i < 1e6 && numberOfDFGCompiles(opt) < 1; i++)
+        opt(object);
+
+    // This does not change object's structure because it is a dictionary structure.
+    object.__defineGetter__('then', function () {
+        getterCalled = true;
+    });
+
+    opt(object);
+
+    if (!getterCalled)
+        throw new Error("Promise.resolve() must observe the 'then' getter added after compilation");
+}
+
+main();

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1562,6 +1562,8 @@ ObjectPropertyConditionSet Graph::tryEnsureAbsence(JSGlobalObject* globalObject,
             return false;
         if (!structure->propertyAccessesAreCacheableForAbsence())
             return false;
+        if (structure->isDictionary())
+            return false;
         unsigned attributes;
         if (isValidOffset(structure->getConcurrently(identifier.uid(), attributes)))
             return false;


### PR DESCRIPTION
#### 177d2cad35bfdcf00d652eb92669d5cc9db9762e
<pre>
[JSC] Reject dictionary structures in `tryEnsureAbsence` in DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=315983">https://bugs.webkit.org/show_bug.cgi?id=315983</a>

Reviewed by Yusuke Suzuki.

The head structure check added in 314147@main accepts cacheable dictionary
structures because propertyAccessesAreCacheable() only excludes uncacheable
dictionaries. Adding a property to a dictionary does not transition the
structure, so once we prove the absence of &apos;then&apos; based on a dictionary
structure, adding a &apos;then&apos; getter to the object after compilation makes the
proof stale without firing any watchpoint or failing any structure check. As a
result, Promise.resolve() folded into NewResolvedPromise skips the user&apos;s
&apos;then&apos; getter, and when the getter does run on the operation slow path, it runs
at a point where the compiler assumes no side effects can happen. The
structures on the prototype chain are not affected since
generateConditionsForPropertyMissConcurrently already rejects dictionaries.

This patch makes tryEnsureAbsence reject dictionary structures.

Test: JSTests/stress/dfg-ensure-absence-dictionary-then-property.js

* JSTests/stress/dfg-ensure-absence-dictionary-then-property.js: Added.
(createDictionaryObject):
(opt):
(main):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::tryEnsureAbsence):

Canonical link: <a href="https://commits.webkit.org/314275@main">https://commits.webkit.org/314275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b348b99e76783b837fc635d4615eeb6a70d2fabd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174677 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122890 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128719 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168594 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109243 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28724 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22757 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157792 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177201 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26528 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28214 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137043 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136976 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36915 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102372 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32261 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25171 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38393 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111466 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37789 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3252 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38035 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->