### PR TITLE
[JSC] `Intl.DateTimeFormat` Temporal pattern generation should pass the calendar to ICU in BCP47 form

### DIFF
--- a/JSTests/stress/intl-datetimeformat-temporal-non-default-calendar.js
+++ b/JSTests/stress/intl-datetimeformat-temporal-non-default-calendar.js
@@ -1,0 +1,105 @@
+//@ requireOptions("--useTemporal=1")
+// Temporal formatter pattern generation must request the calendar from ICU in BCP47
+// form via the -u-ca- extension (e.g. "ar-SA-u-ca-gregory"). Passing a BCP47 calendar
+// value through ICU's legacy @calendar= keyword (e.g. "ar-SA@calendar=gregory") is
+// ignored by ICU when the BCP47 name differs from the legacy name ("gregory" vs
+// "gregorian", "ethioaa" vs "ethiopic-amete-alem"), so pattern selection silently
+// falls back to the locale's default calendar. For ar-SA (default: islamic-umalqura)
+// that injects a spurious era field and long month names into gregorian output.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function partTypes(parts) {
+    return parts.map((part) => part.type).join(",");
+}
+
+function hasEra(parts) {
+    return parts.some((part) => part.type === "era");
+}
+
+const plainDate = new Temporal.PlainDate(2024, 1, 15);
+const plainDateTime = new Temporal.PlainDateTime(2024, 1, 15, 10, 30, 45);
+const instant = new Temporal.Instant(BigInt(Date.UTC(2024, 0, 15, 10, 30, 45)) * 1_000_000n);
+const date = new Date(Date.UTC(2024, 0, 15));
+const dateTime = new Date(Date.UTC(2024, 0, 15, 10, 30, 45));
+
+// 1. GetDateTimeFormat path with default fields.
+//    ar-SA's default calendar is islamic-umalqura. With ca=gregory, Temporal values
+//    must be formatted with the gregorian pattern — identical to Date formatting.
+{
+    const fmt = new Intl.DateTimeFormat("ar-SA-u-ca-gregory", { timeZone: "UTC" });
+    shouldBe(fmt.resolvedOptions().calendar, "gregory", "resolved calendar");
+
+    shouldBe(hasEra(fmt.formatToParts(plainDate)), false,
+        "ar-SA-u-ca-gregory default fields: PlainDate must not include era");
+    shouldBe(partTypes(fmt.formatToParts(plainDate)), partTypes(fmt.formatToParts(date)),
+        "ar-SA-u-ca-gregory default fields: PlainDate parts vs Date parts");
+    shouldBe(fmt.format(plainDate), fmt.format(date),
+        "ar-SA-u-ca-gregory default fields: PlainDate vs Date");
+}
+
+// 2. GetDateTimeFormat path with explicit fields.
+{
+    const options = { year: "numeric", month: "numeric", day: "numeric", timeZone: "UTC" };
+    const fmt = new Intl.DateTimeFormat("ar-SA-u-ca-gregory", options);
+
+    shouldBe(hasEra(fmt.formatToParts(plainDate)), false,
+        "ar-SA-u-ca-gregory explicit fields: PlainDate must not include era");
+    shouldBe(partTypes(fmt.formatToParts(plainDate)), partTypes(fmt.formatToParts(date)),
+        "ar-SA-u-ca-gregory explicit fields: PlainDate parts vs Date parts");
+    shouldBe(fmt.format(plainDate), fmt.format(date),
+        "ar-SA-u-ca-gregory explicit fields: PlainDate vs Date");
+}
+
+// 3. GetDateTimeFormat path for other Temporal kinds.
+{
+    const fmt = new Intl.DateTimeFormat("ar-SA-u-ca-gregory", {
+        year: "numeric", month: "numeric", day: "numeric",
+        hour: "numeric", minute: "2-digit", second: "2-digit",
+        timeZone: "UTC",
+    });
+
+    shouldBe(hasEra(fmt.formatToParts(plainDateTime)), false,
+        "ar-SA-u-ca-gregory: PlainDateTime must not include era");
+    shouldBe(fmt.format(plainDateTime), fmt.format(dateTime),
+        "ar-SA-u-ca-gregory: PlainDateTime vs Date");
+
+    shouldBe(hasEra(fmt.formatToParts(instant)), false,
+        "ar-SA-u-ca-gregory: Instant must not include era");
+    shouldBe(fmt.format(instant), fmt.format(dateTime),
+        "ar-SA-u-ca-gregory: Instant vs Date");
+}
+
+// 4. AdjustDateTimeStyleFormat path: dateStyle+timeStyle formatting a PlainDate has
+//    conflicting (time) fields, forcing a date-only pattern to be regenerated.
+{
+    for (const dateStyle of ["full", "long", "medium", "short"]) {
+        const fmt = new Intl.DateTimeFormat("ar-SA-u-ca-gregory",
+            { dateStyle, timeStyle: "short", timeZone: "UTC" });
+        shouldBe(hasEra(fmt.formatToParts(plainDate)), false,
+            `ar-SA-u-ca-gregory dateStyle=${dateStyle}+timeStyle: PlainDate must not include era`);
+    }
+}
+
+// 5. ethioaa is the other calendar whose BCP47 name differs from the ICU legacy name
+//    ("ethiopic-amete-alem"). Temporal and Date formatting must agree.
+{
+    const fmt = new Intl.DateTimeFormat("en-u-ca-ethioaa", { timeZone: "UTC" });
+    shouldBe(fmt.resolvedOptions().calendar, "ethioaa", "resolved calendar");
+    shouldBe(partTypes(fmt.formatToParts(plainDate)), partTypes(fmt.formatToParts(date)),
+        "en-u-ca-ethioaa: PlainDate parts vs Date parts");
+    shouldBe(fmt.format(plainDate), fmt.format(date),
+        "en-u-ca-ethioaa: PlainDate vs Date");
+}
+
+// 6. Calendars whose BCP47 and ICU legacy names coincide must keep working.
+{
+    const fmt = new Intl.DateTimeFormat("en-u-ca-islamic-umalqura", { timeZone: "UTC" });
+    shouldBe(fmt.format(plainDate), fmt.format(date),
+        "en-u-ca-islamic-umalqura: PlainDate vs Date");
+    shouldBe(hasEra(fmt.formatToParts(plainDate)), true,
+        "en-u-ca-islamic-umalqura: PlainDate must include era");
+}

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -2190,8 +2190,8 @@ std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTim
 
     // Steps 7-8: BestFitFormatMatcher(formatOptions, formats).
     String generatorLocale = m_impl->m_dataLocale;
-    if (!generatorLocale.contains("calendar"_s) && !m_impl->m_calendar.isEmpty())
-        generatorLocale = makeString(generatorLocale, generatorLocale.contains('@') ? ";calendar="_s : "@calendar="_s, m_impl->m_calendar);
+    if (!m_impl->m_calendar.isEmpty())
+        generatorLocale = makeString(generatorLocale, "-u-ca-"_s, m_impl->m_calendar);
     auto generator = std::unique_ptr<UDateTimePatternGenerator, ICUDeleter<udatpg_close>>(udatpg_open(generatorLocale.utf8().data(), &status));
     if (U_FAILURE(status))
         return nullptr;
@@ -2336,8 +2336,8 @@ std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTim
     // We always use best-fit (spec also allows basicFormatMatcher but best-fit is the default).
     // The hourCycle field from step 12 is applied post-pattern via replaceHourCycleInPattern.
     String generatorLocale = m_impl->m_dataLocale;
-    if (!generatorLocale.contains("calendar"_s) && !m_impl->m_calendar.isEmpty())
-        generatorLocale = makeString(generatorLocale, generatorLocale.contains('@') ? ";calendar="_s : "@calendar="_s, m_impl->m_calendar);
+    if (!m_impl->m_calendar.isEmpty())
+        generatorLocale = makeString(generatorLocale, "-u-ca-"_s, m_impl->m_calendar);
     auto generator = std::unique_ptr<UDateTimePatternGenerator, ICUDeleter<udatpg_close>>(udatpg_open(generatorLocale.utf8().data(), &status));
     if (U_FAILURE(status))
         return nullptr;


### PR DESCRIPTION
#### 45b638378595675f5125fd46556497b739d7c66c
<pre>
[JSC] `Intl.DateTimeFormat` Temporal pattern generation should pass the calendar to ICU in BCP47 form
<a href="https://bugs.webkit.org/show_bug.cgi?id=315984">https://bugs.webkit.org/show_bug.cgi?id=315984</a>

Reviewed by Yusuke Suzuki.

computeGetDateTimeFormat and computeAdjustDateTimeStyleFormat build the
locale passed to udatpg_open as dataLocale + &quot;@calendar=&quot; + m_calendar.
However, m_calendar holds the BCP47 calendar name (e.g. &quot;gregory&quot;),
while ICU&apos;s legacy @calendar= keyword expects the legacy name
(e.g. &quot;gregorian&quot;). For calendars whose two names differ (gregory,
ethioaa), ICU silently ignores the unknown value, and the pattern
generator falls back to the locale&apos;s default calendar.

The formatter itself still uses the requested calendar, so the
formatted field values stay correct, but the selected pattern (field
order, month style, era visibility) is the one for the wrong calendar.
This is observable with ar-SA-u-ca-gregory, whose default calendar is
islamic-umalqura: formatting a Temporal.PlainDate produces a spurious
era field and a long month name, diverging from formatting the
equivalent Date with the same DateTimeFormat instance, which goes
through a correct code path.

Fix this by appending the calendar with the -u-ca- BCP47 extension,
matching how the rest of this file builds ICU locales
(initializeDateTimeFormat, createTemporalIntervalFormat).

Test: JSTests/stress/intl-datetimeformat-temporal-non-default-calendar.js

* JSTests/stress/intl-datetimeformat-temporal-non-default-calendar.js: Added.
(shouldBe):
(hasEra):
(const.dateTime.new.Date.Date.UTC):
(fmt.format):
(shouldBe.hasEra.fmt.formatToParts):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::computeAdjustDateTimeStyleFormat const):
(JSC::IntlDateTimeFormat::computeGetDateTimeFormat const):

Canonical link: <a href="https://commits.webkit.org/314687@main">https://commits.webkit.org/314687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e150cd7dddb0ac1429af3f28f9c822765aa605e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122893 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128721 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90644 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168597 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31051 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109245 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30088 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28728 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22760 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157795 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139981 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177204 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26531 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30116 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137046 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136979 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37176 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39885 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148307 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102377 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32264 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25174 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198862 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38396 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111469 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53412 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37792 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3255 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->