### PR TITLE
[Cocoa] Avoid Path allocation when stroking a single line on CoreGraphics

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -548,6 +548,17 @@ void GraphicsContext::strokeArc(const PathArc& arc)
     strokePath(Path({ PathSegment { arc } }));
 }
 
+void GraphicsContext::strokeLine(const PathDataLine& line)
+{
+#if ENABLE(INLINE_PATH_DATA)
+    auto path = Path({ PathSegment { PathDataLine { { line.start() }, { line.end() } } } });
+#else
+    Path path;
+    path.moveTo(line.start());
+    path.addLineTo(line.end());
+#endif
+}
+
 void GraphicsContext::fillEllipseAsPath(const FloatRect& ellipse)
 {
     Path path;

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -211,6 +211,7 @@ public:
     virtual void strokePath(const Path&) = 0;
     WEBCORE_EXPORT virtual void drawPath(const Path&);
     WEBCORE_EXPORT virtual void strokeArc(const PathArc&);
+    WEBCORE_EXPORT virtual void strokeLine(const PathDataLine&);
 
     virtual void fillEllipse(const FloatRect& ellipse) { fillEllipseAsPath(ellipse); }
     virtual void strokeEllipse(const FloatRect& ellipse) { strokeEllipseAsPath(ellipse); }

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1345,6 +1345,24 @@ void GraphicsContextCG::strokeArc(const PathArc& arc)
     GraphicsContext::strokeArc(arc);
 }
 
+void GraphicsContextCG::strokeLine(const PathDataLine& line)
+{
+    // Gradient stroking requires building a stroked path and clipping to it,
+    // which CGContextStrokeLineSegments cannot do. Defer to strokePath() via
+    // the base class for that case. Patterns can be inlined as long as we set
+    // them up first, matching the fast path inside strokePath().
+    if (strokeGradient()) {
+        GraphicsContext::strokeLine(line);
+        return;
+    }
+    if (strokePattern())
+        applyStrokePattern();
+
+    CGContextRef context = platformContext();
+    CGPoint pts[2] = { line.start(), line.end() };
+    CGContextStrokeLineSegments(context, pts, 2);
+}
+
 void GraphicsContextCG::setLineCap(LineCap cap)
 {
     switch (cap) {

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -80,6 +80,7 @@ public:
     void clearRect(const FloatRect&) final;
     void strokeRect(const FloatRect&, float lineWidth) final;
     void strokeArc(const PathArc&) final;
+    void strokeLine(const PathDataLine&) final;
 
     void fillEllipse(const FloatRect& ellipse) final;
     void strokeEllipse(const FloatRect& ellipse) final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -645,14 +645,7 @@ void RemoteGraphicsContext::strokeRect(const FloatRect& rect, float lineWidth)
 
 void RemoteGraphicsContext::strokeLine(const PathDataLine& line)
 {
-#if ENABLE(INLINE_PATH_DATA)
-    auto path = Path({ PathSegment { PathDataLine { { line.start() }, { line.end() } } } });
-#else
-    Path path;
-    path.moveTo(line.start);
-    path.addLineTo(line.end);
-#endif
-    context().strokePath(path);
+    context().strokeLine(line);
 }
 
 void RemoteGraphicsContext::strokeLineWithColorAndThickness(const PathDataLine& line, std::optional<PackedColor::RGBA> strokeColor, std::optional<float> strokeThickness)


### PR DESCRIPTION
#### 3bb1910992a8f7a844a547104eb0f890696f339c
<pre>
[Cocoa] Avoid Path allocation when stroking a single line on CoreGraphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=315985">https://bugs.webkit.org/show_bug.cgi?id=315985</a>
<a href="https://rdar.apple.com/178398284">rdar://178398284</a>

Reviewed by Kimmo Kinnunen.

RemoteGraphicsContext::strokeLine() currently fulfils a single-segment line
stroke by constructing a Path containing one PathDataLine and calling
strokePath(). That allocates a Path, wraps the segment in a PathSegment, and
routes through the full path-stroking machinery — significant overhead for what,
on CoreGraphics, is one CGContextStrokeLineSegments() call.

CoreGraphics can stroke a line directly. The only case where we still need a
real path is when the stroke is a gradient: that is implemented by building the
stroked outline of the path and clipping the gradient fill to it, which
CGContextStrokeLineSegments() cannot express. Stroke patterns are fine as long
as the pattern is bound first, matching what strokePath() does on the fast path.

Introduce GraphicsContext::strokeLine(const PathDataLine&amp;) as a virtual method
with a Path-based default, override it in GraphicsContextCG to call
CGContextStrokeLineSegments() directly (falling back to the base class for
gradient strokes), and have RemoteGraphicsContext::strokeLine() forward to it
instead of synthesising a Path.

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::strokeLine):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::strokeLine):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp:
(WebKit::RemoteGraphicsContext::strokeLine):

Canonical link: <a href="https://commits.webkit.org/314279@main">https://commits.webkit.org/314279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61690d7ffe82c13424e190f7fcc6af3995988153

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122897 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/676f2040-5110-4d65-ba95-208fa326b64d) 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128725 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/825ea244-99c8-4db4-b213-20c035c50719) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168601 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31056 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109249 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8969f950-79e3-4d3c-90f5-d8fce743e153) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28730 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22764 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139986 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177208 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30120 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137049 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136982 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/36916 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102381 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25215 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32269 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25177 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38400 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111473 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37796 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3258 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38042 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37940 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->