### PR TITLE
Implement the Origin-Agent-Cluster header

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -799,7 +799,7 @@ imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-cross-origin-redirect-no-bfcache.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/history_pushstate_url.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/traverse_the_history_3.html [ Skip ]
-imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/ [ Skip ]
+imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/going-back.sub.https.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/origin/relaxing-the-same-origin-restriction/document_domain_feature_policy.tentative.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/sandboxing/sandbox-document-open.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/sandboxing/sandbox-inherited-from-required-csp.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-bad-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-bad-subdomain.sub.https-expected.txt
@@ -1,0 +1,23 @@
+
+PASS "": frame insertion
+PASS "": setting document.domain must give sync access
+PASS "": originAgentCluster must equal false
+PASS "?0": frame insertion
+PASS "?0": setting document.domain must give sync access
+PASS "?0": originAgentCluster must equal false
+PASS "true": frame insertion
+PASS "true": setting document.domain must give sync access
+PASS "true": originAgentCluster must equal false
+PASS ""?1"": frame insertion
+PASS ""?1"": setting document.domain must give sync access
+PASS ""?1"": originAgentCluster must equal false
+PASS "1": frame insertion
+PASS "1": setting document.domain must give sync access
+PASS "1": originAgentCluster must equal false
+PASS "?2": frame insertion
+PASS "?2": setting document.domain must give sync access
+PASS "?2": originAgentCluster must equal false
+PASS "(?1)": frame insertion
+PASS "(?1)": setting document.domain must give sync access
+PASS "(?1)": originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-yes-port.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-yes-port.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal false
+PASS child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-yes-same.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-yes-same.sub.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS setting document.domain must give sync access
+PASS parent: originAgentCluster must equal false
+PASS child: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-yes-subdomain-with-redirect.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-yes-subdomain-with-redirect.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal false
+PASS child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-yes-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-yes-subdomain.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal false
+PASS child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-yeswithparams-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-no-child-yeswithparams-subdomain.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal false
+PASS child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-no-port.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-no-port.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal true
+PASS child: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-no-same.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-no-same.sub.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS setting document.domain must give sync access
+PASS parent: originAgentCluster must equal true
+PASS child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-no-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-no-subdomain.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal true
+PASS child: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-yes-port.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-yes-port.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal true
+PASS child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-yes-same.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-yes-same.sub.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS setting document.domain must give sync access
+PASS parent: originAgentCluster must equal true
+PASS child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-yes-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/1-iframe/parent-yes-child-yes-subdomain.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal true
+PASS child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-no-child1-no-subdomain-child2-yes-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-no-child1-no-subdomain-child2-yes-subdomain.sub.https-expected.txt
@@ -1,0 +1,9 @@
+
+PASS Parent to child1: setting document.domain must give sync access
+PASS Parent to child2: setting document.domain must give sync access
+PASS child1 to child2: setting document.domain must give sync access
+PASS child2 to child1: setting document.domain must give sync access
+PASS parent: originAgentCluster must equal false
+PASS child1: originAgentCluster must equal false
+PASS child2: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-no-child1-no-subdomain-child2-yes-subdomainport.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-no-child1-no-subdomain-child2-yes-subdomainport.sub.https-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Parent to child1: setting document.domain must give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: messageerror event must occur
+PASS child1 to child2: setting document.domain must not give sync access
+PASS child2 to child1: messageerror event must occur
+PASS child2 to child1: setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal false
+PASS child1: originAgentCluster must equal false
+PASS child2: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-no-child1-no-subdomain1-child2-yes-subdomain2.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-no-child1-no-subdomain1-child2-yes-subdomain2.sub.https-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Parent to child1: setting document.domain must give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: messageerror event must occur
+PASS child1 to child2: setting document.domain must not give sync access
+PASS child2 to child1: messageerror event must occur
+PASS child2 to child1: setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal false
+PASS child1: originAgentCluster must equal false
+PASS child2: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-no-child1-yes-subdomain-child2-no-port.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-no-child1-yes-subdomain-child2-no-port.sub.https-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Parent to child1: messageerror event must occur
+PASS Parent to child1: setting document.domain must not give sync access
+PASS Parent to child2: setting document.domain must give sync access
+PASS child1 to child2: messageerror event must occur
+PASS child1 to child2: setting document.domain must not give sync access
+PASS child2 to child1: messageerror event must occur
+PASS child2 to child1: setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal false
+PASS child1: originAgentCluster must equal true
+PASS child2: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-no-child1-yes-subdomain-child2-no-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-no-child1-yes-subdomain-child2-no-subdomain.sub.https-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Parent to child1: messageerror event must occur
+PASS Parent to child1: setting document.domain must not give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: setting document.domain must give sync access
+PASS child2 to child1: setting document.domain must give sync access
+PASS parent: originAgentCluster must equal false
+PASS child1: originAgentCluster must equal true
+PASS child2: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-no-subdomain-child2-no-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-no-subdomain-child2-no-subdomain.sub.https-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Parent to child1: messageerror event must occur
+PASS Parent to child1: setting document.domain must not give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: setting document.domain must give sync access
+PASS child2 to child1: setting document.domain must give sync access
+PASS parent: originAgentCluster must equal true
+PASS child1: originAgentCluster must equal false
+PASS child2: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-no-subdomain-child2-no-subdomain2.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-no-subdomain-child2-no-subdomain2.sub.https-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Parent to child1: messageerror event must occur
+PASS Parent to child1: setting document.domain must not give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: setting document.domain must give sync access
+PASS child2 to child1: setting document.domain must give sync access
+PASS parent: originAgentCluster must equal true
+PASS child1: originAgentCluster must equal false
+PASS child2: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-no-subdomain-child2-yes-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-no-subdomain-child2-yes-subdomain.sub.https-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Parent to child1: messageerror event must occur
+PASS Parent to child1: setting document.domain must not give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: setting document.domain must give sync access
+PASS child2 to child1: setting document.domain must give sync access
+PASS parent: originAgentCluster must equal true
+PASS child1: originAgentCluster must equal false
+PASS child2: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-no-subdomain-child2-yes-subdomain2.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-no-subdomain-child2-yes-subdomain2.sub.https-expected.txt
@@ -1,0 +1,13 @@
+
+PASS Parent to child1: messageerror event must occur
+PASS Parent to child1: setting document.domain must not give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: messageerror event must occur
+PASS child1 to child2: setting document.domain must not give sync access
+PASS child2 to child1: messageerror event must occur
+PASS child2 to child1: setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal true
+PASS child1: originAgentCluster must equal false
+PASS child2: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-no-subdomain-child2-yes-subdomainport.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-no-subdomain-child2-yes-subdomainport.sub.https-expected.txt
@@ -1,0 +1,13 @@
+
+PASS Parent to child1: messageerror event must occur
+PASS Parent to child1: setting document.domain must not give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: messageerror event must occur
+PASS child1 to child2: setting document.domain must not give sync access
+PASS child2 to child1: messageerror event must occur
+PASS child2 to child1: setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal true
+PASS child1: originAgentCluster must equal false
+PASS child2: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-yes-subdomain-child2-no-port.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-yes-subdomain-child2-no-port.sub.https-expected.txt
@@ -1,0 +1,13 @@
+
+PASS Parent to child1: messageerror event must occur
+PASS Parent to child1: setting document.domain must not give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: messageerror event must occur
+PASS child1 to child2: setting document.domain must not give sync access
+PASS child2 to child1: messageerror event must occur
+PASS child2 to child1: setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal true
+PASS child1: originAgentCluster must equal true
+PASS child2: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-yes-subdomain-child2-no-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-yes-subdomain-child2-no-subdomain.sub.https-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Parent to child1: messageerror event must occur
+PASS Parent to child1: setting document.domain must not give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: setting document.domain must give sync access
+PASS child2 to child1: setting document.domain must give sync access
+PASS parent: originAgentCluster must equal true
+PASS child1: originAgentCluster must equal true
+PASS child2: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-yes-subdomain-child2-yes-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-yes-subdomain-child2-yes-subdomain.sub.https-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Parent to child1: messageerror event must occur
+PASS Parent to child1: setting document.domain must not give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: setting document.domain must give sync access
+PASS child2 to child1: setting document.domain must give sync access
+PASS parent: originAgentCluster must equal true
+PASS child1: originAgentCluster must equal true
+PASS child2: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-yes-subdomain-child2-yes-subdomain2.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-yes-subdomain-child2-yes-subdomain2.sub.https-expected.txt
@@ -1,0 +1,13 @@
+
+PASS Parent to child1: messageerror event must occur
+PASS Parent to child1: setting document.domain must not give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: messageerror event must occur
+PASS child1 to child2: setting document.domain must not give sync access
+PASS child2 to child1: messageerror event must occur
+PASS child2 to child1: setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal true
+PASS child1: originAgentCluster must equal true
+PASS child2: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-yes-subdomain-child2-yes-subdomainport.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/2-iframes/parent-yes-child1-yes-subdomain-child2-yes-subdomainport.sub.https-expected.txt
@@ -1,0 +1,13 @@
+
+PASS Parent to child1: messageerror event must occur
+PASS Parent to child1: setting document.domain must not give sync access
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: messageerror event must occur
+PASS child1 to child2: setting document.domain must not give sync access
+PASS child2 to child1: messageerror event must occur
+PASS child2 to child1: setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal true
+PASS child1: originAgentCluster must equal true
+PASS child2: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/META.yml
@@ -1,5 +1,4 @@
 spec: https://html.spec.whatwg.org/multipage/#origin-keyed-agent-clusters
 suggested_reviewers:
-  - domenic
   - annevk
   - wjmaclean

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/about-blank.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/about-blank.https.sub-expected.txt
@@ -1,0 +1,10 @@
+
+PASS parent to about:blank: setting document.domain must give sync access
+PASS about:blank to child2: messageerror event must occur
+PASS about:blank to child2: setting document.domain must not give sync access
+PASS child2 to about:blank: messageerror event must occur
+PASS child2 to about:blank: setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal true
+PASS about:blank: originAgentCluster must equal true
+PASS child2: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/about-blank.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/about-blank.https.sub.html
@@ -52,12 +52,13 @@ async function insertAboutBlankIframe() {
   await setBothDocumentDomains(iframe.contentWindow);
 }
 
-function createBlankIframe() {
+async function createBlankIframe() {
   const iframe = document.createElement("iframe");
   const promise = new Promise(resolve => {
     iframe.addEventListener("load", resolve);
   });
   document.body.append(iframe);
-  return promise;
+  await promise;
+  return iframe;
 }
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/document-domain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/document-domain.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS Setting document.domain must not change same-originness
+PASS The registrable domain suffix check must happen before the bail-out
+PASS Having an origin-keyed subdomain child try to set document.domain must not change the document.domain value it sees
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/cross-origin-isolated.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/cross-origin-isolated.sub.https-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS self: originAgentCluster must equal true
+PASS child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/csp-sandbox-no.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/csp-sandbox-no.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/csp-sandbox-yes.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/csp-sandbox-yes.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-to-javascript-no.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-to-javascript-no.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-to-javascript-yes.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-to-javascript-yes.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-url-no.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-url-no.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS data: URL child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-url-yes.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/data-url-yes.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS data: URL child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/javascript-url-no.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/javascript-url-no.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS data: URL child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/javascript-url-yes.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/javascript-url-yes.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS data: URL child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/removed-iframe.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/removed-iframe.sub.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Removing the iframe does not change originAgentCluster
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/resources/data-to-javascript-test.mjs
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/resources/data-to-javascript-test.mjs
@@ -2,7 +2,7 @@ import { insertCustomIframe, testSupportScript } from "./helpers.mjs";
 import { waitForIframe, testGetter } from "../../resources/helpers.mjs";
 
 const testSupportScriptSuitableForNesting =
-  testSupportScript.replace('</script>', '</scri`>');
+  testSupportScript.replace('</script>', '</scri` + `pt>');
 
 export default () => {
   promise_setup(async () => {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/sandboxed-iframe-no.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/sandboxed-iframe-no.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/sandboxed-iframe-yes.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/sandboxed-iframe-yes.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/sandboxed-same-origin-iframe-no.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/sandboxed-same-origin-iframe-no.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/sandboxed-same-origin-iframe-yes.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/sandboxed-same-origin-iframe-yes.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/two-sandboxed-iframes.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/two-sandboxed-iframes.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Sending a WebAssembly.Module between two sandboxed iframes must fire messageerror
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/two-sandboxed-iframes.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/getter-special-cases/two-sandboxed-iframes.https.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Two sandboxed iframes are in different agent clusters</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="log"></div>
+
+<script type="module">
+// Each sandboxed iframe (without allow-same-origin) gets a unique opaque
+// origin and so should be in its own agent cluster. Sending a
+// WebAssembly.Module from one sandboxed iframe to another should therefore
+// fire messageerror, not a successful message event.
+
+const helperSrcdoc = `
+  <script>
+    addEventListener("message", e => {
+      if (e.data && e.data.cmd === "send-wasm") {
+        const wasm = new WebAssembly.Module(new Uint8Array([0,97,115,109,1,0,0,0]));
+        parent.frames[e.data.targetIndex].postMessage(wasm, "*");
+        return;
+      }
+      if (e.data instanceof WebAssembly.Module) {
+        parent.postMessage({ result: "message" }, "*");
+      }
+    });
+    addEventListener("messageerror", () => {
+      parent.postMessage({ result: "messageerror" }, "*");
+    });
+  <\/script>
+`;
+
+function insertSandboxedIframe() {
+  const iframe = document.createElement("iframe");
+  iframe.sandbox = "allow-scripts";
+  iframe.srcdoc = helperSrcdoc;
+  const loaded = new Promise(resolve => iframe.addEventListener("load", resolve));
+  document.body.append(iframe);
+  return loaded.then(() => iframe);
+}
+
+function nextResult() {
+  return new Promise(resolve => {
+    addEventListener("message", e => {
+      if (e.data && e.data.result)
+        resolve(e.data.result);
+    }, { once: true });
+  });
+}
+
+promise_test(async () => {
+  const iframe1 = await insertSandboxedIframe();
+  await insertSandboxedIframe();
+
+  const result = nextResult();
+  iframe1.contentWindow.postMessage({ cmd: "send-wasm", targetIndex: 1 }, "*");
+  assert_equals(await result, "messageerror");
+}, "Sending a WebAssembly.Module between two sandboxed iframes must fire messageerror");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/going-back.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/going-back.sub.https-expected.txt
@@ -1,0 +1,15 @@
+
+PASS Before navigation: parent to child1: messageerror event must occur
+PASS Before navigation: parent to child1: setting document.domain must not give sync access
+PASS Navigation
+PASS Inserting a second iframe
+PASS After navigation: parent to child2: messageerror event must occur
+PASS After navigation: parent to child2: setting document.domain must not give sync access
+PASS Going back in history (navigating back the first iframe)
+PASS After back: parent to child1: messageerror event must occur
+PASS After back: parent to child1: setting document.domain must not give sync access
+PASS After back: parent to child2: messageerror event must occur
+PASS After back: parent to child2: setting document.domain must not give sync access
+PASS child1 to child2: setting document.domain must give sync access
+PASS child2 to child1: setting document.domain must give sync access
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-no-same-2-yes-port.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-no-same-2-yes-port.sub.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Before: parent to child: setting document.domain must give sync access
+PASS before parent: originAgentCluster must equal false
+PASS before child: originAgentCluster must equal false
+PASS Navigation
+PASS After: parent to child: messageerror event must occur
+PASS After: parent to child: setting document.domain must not give sync access
+PASS after parent: originAgentCluster must equal false
+PASS after child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-no-same-2-yes-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-no-same-2-yes-subdomain.sub.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Before: parent to child: setting document.domain must give sync access
+PASS before parent: originAgentCluster must equal false
+PASS before child: originAgentCluster must equal false
+PASS Navigation
+PASS After: parent to child: messageerror event must occur
+PASS After: parent to child: setting document.domain must not give sync access
+PASS after parent: originAgentCluster must equal false
+PASS after child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-no-subdomain-2-yes-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-no-subdomain-2-yes-subdomain.sub.https-expected.txt
@@ -1,0 +1,9 @@
+
+PASS Before: parent to child: setting document.domain must give sync access
+PASS before parent: originAgentCluster must equal false
+PASS before child: originAgentCluster must equal false
+PASS Navigation
+PASS After: parent to child: setting document.domain must give sync access
+PASS after parent: originAgentCluster must equal false
+PASS after child: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-no-subdomain-2-yes-subdomain2.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-no-subdomain-2-yes-subdomain2.sub.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Before: parent to child: setting document.domain must give sync access
+PASS before parent: originAgentCluster must equal false
+PASS before child: originAgentCluster must equal false
+PASS Navigation
+PASS After: parent to child: messageerror event must occur
+PASS After: parent to child: setting document.domain must not give sync access
+PASS after parent: originAgentCluster must equal false
+PASS after child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-subdomain-yes-2-subdomain2-no.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-subdomain-yes-2-subdomain2-no.sub.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Before: parent to child: messageerror event must occur
+PASS Before: parent to child: setting document.domain must not give sync access
+PASS before parent: originAgentCluster must equal false
+PASS before child: originAgentCluster must equal true
+PASS Navigation
+PASS After: parent to child: setting document.domain must give sync access
+PASS after parent: originAgentCluster must equal false
+PASS after child: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-yes-subdomain-2-no-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-no-1-yes-subdomain-2-no-subdomain.sub.https-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Before: parent to child: messageerror event must occur
+PASS Before: parent to child: setting document.domain must not give sync access
+PASS before parent: originAgentCluster must equal false
+PASS before child: originAgentCluster must equal true
+PASS Navigation
+PASS After: parent to child: messageerror event must occur
+PASS After: parent to child: setting document.domain must not give sync access
+PASS after parent: originAgentCluster must equal false
+PASS after child: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-yes-1-no-same-2-no-port.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-yes-1-no-same-2-no-port.sub.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Before: parent to child: setting document.domain must give sync access
+PASS before parent: originAgentCluster must equal true
+PASS before child: originAgentCluster must equal true
+PASS Navigation
+PASS After: parent to child: messageerror event must occur
+PASS After: parent to child: setting document.domain must not give sync access
+PASS after parent: originAgentCluster must equal true
+PASS after child: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-yes-1-no-same-2-no-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/iframe-navigation/parent-yes-1-no-same-2-no-subdomain.sub.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Before: parent to child: setting document.domain must give sync access
+PASS before parent: originAgentCluster must equal true
+PASS before child: originAgentCluster must equal true
+PASS Navigation
+PASS After: parent to child: messageerror event must occur
+PASS After: parent to child: setting document.domain must not give sync access
+PASS after parent: originAgentCluster must equal true
+PASS after child: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/insecure-http.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/insecure-http.sub-expected.txt
@@ -1,0 +1,5 @@
+
+PASS setting document.domain must give sync access
+PASS parent: originAgentCluster must equal false
+PASS child: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-no-openee-yes-port.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-no-openee-yes-port.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS opener: originAgentCluster must equal false
+PASS openee: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-no-openee-yes-same.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-no-openee-yes-same.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS message event must occur
+PASS setting document.domain must give sync access
+PASS opener: originAgentCluster must equal false
+PASS openee: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-no-openee-yes-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-no-openee-yes-subdomain.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS opener: originAgentCluster must equal false
+PASS openee: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-no-port.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-no-port.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS opener: originAgentCluster must equal true
+PASS openee: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-no-same.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-no-same.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS message event must occur
+PASS setting document.domain must give sync access
+PASS opener: originAgentCluster must equal true
+PASS openee: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-no-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-no-subdomain.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS opener: originAgentCluster must equal true
+PASS openee: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-yes-port.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-yes-port.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS opener: originAgentCluster must equal true
+PASS openee: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-yes-same.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-yes-same.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS message event must occur
+PASS setting document.domain must give sync access
+PASS opener: originAgentCluster must equal true
+PASS openee: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-yes-subdomain.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups/opener-yes-openee-yes-subdomain.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS messageerror event must occur
+PASS setting document.domain must not give sync access
+PASS opener: originAgentCluster must equal true
+PASS openee: originAgentCluster must equal true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/regression-1399759.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/regression-1399759.https.sub.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="variant" content="?pipe=header(Origin-Agent-Cluster,%3F0)">
+<meta name="variant" content="?pipe=header(Origin-Agent-Cluster,%3F1)">
+<title>Origin-Isolation after navigating about:blank.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+</head>
+<body>
+</body>
+<script>
+// Regression test for crbug.com/1399759. This is mainly based on
+// external/wpt/html/infrastructure/urls/base-url/document-base-url-initiated-grand-parent.https.window.js
+// but restricts itself to the exact error condition.
+//
+// This test is run in two variants which differ in the Origin-Agent-Cluster
+// http header values, ?0 and ?1. The test should pass in either case, but the
+// regression we're testing for involves inconsistent clustering decisions,
+// which requires clustering to be enabled in the first place.
+promise_test(async test => {
+  // Create a cross-origin iframe. Use the executor.html, so we can ask it
+  // to execute scripts for us.
+  const child_token = token();
+  const iframe = document.createElement("iframe");
+  iframe.src = get_host_info().HTTPS_REMOTE_ORIGIN +
+    `/common/dispatcher/executor.html?uuid=${child_token}`;
+  document.body.appendChild(iframe);
+
+  // The child creates a grand child in an iframe.
+  const reply_token = token();
+  send(child_token, `
+    const iframe = document.createElement("iframe");
+    iframe.src = "/common/blank.html";
+    iframe.onload = () => {
+      send("${reply_token}", "grand child loaded");
+    };
+    document.body.appendChild(iframe);
+  `);
+  assert_equals(await receive(reply_token), "grand child loaded");
+  const grandchild = iframe.contentWindow[0];
+
+  // Navigate the grand-child toward about:blank.
+  grandchild.location = "about:blank";
+  assert_equals(await receive(reply_token), "grand child loaded");
+
+  // This document and grandchild are same-origin, because about:blank
+  // inherits its origin from the initiator of the navigation, which is us.
+  // This access should not throw.
+  grandchild.document;
+}, "Check the baseURL of an about:blank document cross-origin with its parent");
+
+promise_test(async test => {
+  // This tests the same setup as above, but with about:srcdoc. Since one
+  // cannot just navigate to about:srcdoc, we'll have to include an extra
+  // step: Create an iframe with srcdoc attribute; navigate away; then
+  // navigate to about:srcdoc.
+  // srcdoc does not inherit the origin from the initiator - unlike
+  // about:blank - and so in this case the grandchild.document access should
+  // throw.
+
+  // Create a cross-origin iframe. Use the executor.html, so we can ask it
+  // to execute scripts for us.
+  const child_token = token();
+  const iframe = document.createElement("iframe");
+  iframe.src = get_host_info().HTTPS_REMOTE_ORIGIN +
+    `/common/dispatcher/executor.html?uuid=${child_token}`;
+  document.body.appendChild(iframe);
+
+  // The child creates a grand child in an iframe, using the srcdoc attribute.
+  const reply_token = token();
+  send(child_token, `
+    const iframe = document.createElement("iframe");
+    iframe.onload = () => {
+      send("${reply_token}", "grand child loaded");
+    };
+    iframe.srcdoc = "nothing interesting";
+    document.body.appendChild(iframe);
+  `);
+  assert_equals(await receive(reply_token), "grand child loaded");
+  const grandchild = iframe.contentWindow[0];
+
+  // Navigate the grand child toward a regular URL.
+  grandchild.location = get_host_info().HTTPS_REMOTE_ORIGIN + "/common/blank.html";
+  assert_equals(await receive(reply_token), "grand child loaded");
+
+  // Navigate the grand-child back, to about:srcdoc.
+  grandchild.location = "about:srcdoc";
+  assert_equals(await receive(reply_token), "grand child loaded");
+
+  // This document and grandchild are cross-origin. about:srcdoc does not
+  // inherits its origin from the initiator of the navigation. This access
+  // should throw:
+  assert_throws_dom("SecurityError", () => { grandchild.document; });
+}, "Check that about:srcdoc navigation does not follow about:blank rules.");
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/regression-1399759.https.sub_pipe=header(Origin-Agent-Cluster,_3F0)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/regression-1399759.https.sub_pipe=header(Origin-Agent-Cluster,_3F0)-expected.txt
@@ -1,0 +1,5 @@
+
+
+FAIL Check the baseURL of an about:blank document cross-origin with its parent promise_test: Unhandled rejection with value: object "SecurityError: Blocked a frame with origin "https://web-platform.test:9443" from accessing a cross-origin frame. Protocols, domains, and ports must match."
+PASS Check that about:srcdoc navigation does not follow about:blank rules.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/regression-1399759.https.sub_pipe=header(Origin-Agent-Cluster,_3F1)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/regression-1399759.https.sub_pipe=header(Origin-Agent-Cluster,_3F1)-expected.txt
@@ -1,0 +1,5 @@
+
+
+FAIL Check the baseURL of an about:blank document cross-origin with its parent promise_test: Unhandled rejection with value: object "SecurityError: Blocked a frame with origin "https://web-platform.test:9443" from accessing a cross-origin frame. Protocols, domains, and ports must match."
+PASS Check that about:srcdoc navigation does not follow about:blank rules.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/removing-iframes.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/removing-iframes.sub.https-expected.txt
@@ -1,0 +1,15 @@
+
+PASS Before: messageerror event must occur
+PASS Before: setting document.domain must not give sync access
+PASS parent: originAgentCluster must equal true
+PASS child1: originAgentCluster must equal false
+PASS Remove the iframe and insert new ones
+PASS Parent to child2: messageerror event must occur
+PASS Parent to child2: setting document.domain must not give sync access
+PASS Parent to child3: messageerror event must occur
+PASS Parent to child3: setting document.domain must not give sync access
+PASS child2 to child3: setting document.domain must give sync access
+PASS child3 to child2: setting document.domain must give sync access
+PASS child2: originAgentCluster must equal false
+PASS child3: originAgentCluster must equal false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/w3c-import.log
@@ -25,5 +25,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/insecure-http.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/insecure-http.sub.html.headers
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/popups-crash.https.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/regression-1399759.https.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/removing-iframes.sub.https.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/origin/origin-keyed-agent-clusters/removing-iframes.sub.https.html.headers

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=(Document_Window)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=(Document_Window)-expected.txt
@@ -44,7 +44,7 @@ PASS Window interface: attribute frameElement
 PASS Window interface: operation open(optional USVString, optional DOMString, optional DOMString)
 PASS Window interface: attribute navigator
 PASS Window interface: attribute clientInformation
-FAIL Window interface: attribute originAgentCluster assert_own_property: The global object must have a property "originAgentCluster" expected property "originAgentCluster" missing
+PASS Window interface: attribute originAgentCluster
 PASS Window interface: operation alert()
 PASS Window interface: operation alert(DOMString)
 PASS Window interface: operation confirm(optional DOMString)
@@ -93,7 +93,7 @@ PASS Window interface: window must inherit property "open(optional USVString, op
 PASS Window interface: calling open(optional USVString, optional DOMString, optional DOMString) on window with too few arguments must throw TypeError
 PASS Window interface: window must inherit property "navigator" with the proper type
 PASS Window interface: window must inherit property "clientInformation" with the proper type
-FAIL Window interface: window must inherit property "originAgentCluster" with the proper type assert_own_property: expected property "originAgentCluster" missing
+PASS Window interface: window must inherit property "originAgentCluster" with the proper type
 PASS Window interface: window must inherit property "alert()" with the proper type
 PASS Window interface: window must inherit property "alert(DOMString)" with the proper type
 PASS Window interface: calling alert(DOMString) on window with too few arguments must throw TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-domain-failure.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-domain-failure.https.sub-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL SharedArrayBuffer and a same-origin-domain (but not same-origin) iframe assert_equals: expected "www1.web-platform.test" but got "web-platform.test"
+FAIL SharedArrayBuffer and a same-origin-domain (but not same-origin) iframe assert_equals: expected false but got true
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6075,6 +6075,20 @@ OriginAPIEnabled:
     WebCore:
       default: true
 
+OriginAgentClusterEnabled:
+  type: bool
+  status: preview
+  category: security
+  humanReadableName: "Origin-Agent-Cluster header"
+  humanReadableDescription: "Support for the Origin-Agent-Cluster HTTP response header and window.originAgentCluster getter"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 OverlayRegionsEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1374,6 +1374,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/NodeRenderStyle.h
     dom/NodeTraversal.h
     dom/NodeType.h
+    dom/OriginKeyed.h
     dom/ParserContentPolicy.h
     dom/PointerEvent.h
     dom/PointerEventTypeNames.h
@@ -1892,6 +1893,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/NavigationRequester.h
     loader/NavigationScheduler.h
     loader/NetscapePlugInStreamLoader.h
+    loader/OriginAgentClusterPolicy.h
     loader/PCMSites.h
     loader/PCMTokens.h
     loader/PingLoader.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2110,6 +2110,7 @@ loader/NavigationAction.cpp
 loader/NavigationRequester.cpp
 loader/NavigationScheduler.cpp
 loader/NetscapePlugInStreamLoader.cpp
+loader/OriginAgentClusterPolicy.cpp
 loader/PingLoader.cpp
 loader/PolicyChecker.cpp
 loader/PolicyContainer.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -700,6 +700,7 @@ namespace WebCore {
     macro(onvrdisplaypresentchange) \
     macro(openDatabase) \
     macro(opener) \
+    macro(originAgentCluster) \
     macro(operations) \
     macro(ownerReadableStream) \
     macro(parent) \

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7325,6 +7325,7 @@ String Document::referrerForBindings()
     return shouldHideFromBindings ? emptyString() : referrer();
 }
 
+// https://html.spec.whatwg.org/multipage/origin.html#dom-document-domain
 String Document::domain() const
 {
     return securityOrigin().domain();
@@ -7349,6 +7350,9 @@ ExceptionOr<void> Document::setDomain(const String& newDomain)
 
     if (!securityOrigin().isMatchingRegistrableDomainSuffix(newDomain, settings().treatIPAddressAsDomain()))
         return Exception { ExceptionCode::SecurityError, "Attempted to use a non-registrable domain."_s };
+
+    if (originAgentCluster())
+        return { };
 
     securityOrigin().setDomainFromDOM(newDomain);
     return { };
@@ -8334,6 +8338,7 @@ void Document::initSecurityContext()
     contentSecurityPolicy->updateSourceSelf(protect(ownerFrame->document()->securityOrigin()));
 
     setCrossOriginEmbedderPolicy(ownerFrame->document()->crossOriginEmbedderPolicy());
+    setIsOriginKeyed(ownerFrame->document()->isOriginKeyed());
 
     // https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context (Step 12)
     // If creator is non-null and creator's origin is same origin with creator's relevant settings object's top-level origin, then set coop
@@ -8478,9 +8483,25 @@ String Document::agentClusterID() const
     Ref origin = securityOrigin();
     auto& data = origin->data();
     auto browsingContextGroupIdentifier = page() && page()->browsingContextGroupIdentifier() ? page()->browsingContextGroupIdentifier()->toUInt64() : 0;
+    if (origin->isOpaque()) {
+        auto opaqueID = data.opaqueOriginIdentifier();
+        return makeString(browsingContextGroupIdentifier, "-opaque-"_s, opaqueID ? opaqueID->toString() : String { });
+    }
     if (crossOriginIsolated())
         return makeString(browsingContextGroupIdentifier, "-coi-"_s, data.toString());
+    if (m_isOriginKeyed == OriginKeyed::Yes)
+        return makeString(browsingContextGroupIdentifier, "-oac-"_s, data.toString());
     return makeString(browsingContextGroupIdentifier, '-', Site(data).toString());
+}
+
+// https://html.spec.whatwg.org/multipage/origin.html#dom-originagentcluster
+bool Document::originAgentCluster() const
+{
+    if (securityOrigin().isOpaque())
+        return true;
+    if (crossOriginIsolated())
+        return true;
+    return m_isOriginKeyed == OriginKeyed::Yes;
 }
 
 void Document::updateURLForPushOrReplaceState(const URL& url)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -42,6 +42,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/HitTestSource.h>
 #include <WebCore/MutationObserverOptions.h>
+#include <WebCore/OriginKeyed.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PlaybackTargetClientContextIdentifier.h>
 #include <WebCore/PseudoElementIdentifier.h>
@@ -1435,6 +1436,7 @@ public:
     bool isContextThread() const final;
     bool isSecureContext() const final;
     bool NODELETE crossOriginIsolated() const final;
+    bool NODELETE originAgentCluster() const;
     String agentClusterID() const final;
     bool isJSExecutionForbidden() const final { return false; }
 
@@ -1665,6 +1667,10 @@ public:
     bool shouldForceNoOpenerBasedOnCOOP() const;
 
     WEBCORE_EXPORT CrossOriginOpenerPolicy crossOriginOpenerPolicy() const final;
+
+    // https://html.spec.whatwg.org/multipage/origin.html#origin-keyed-agent-clusters
+    OriginKeyed isOriginKeyed() const { return m_isOriginKeyed; }
+    void setIsOriginKeyed(OriginKeyed value) { m_isOriginKeyed = value; }
 
     void willLoadScriptElement(const URL&);
     void willLoadFrameElement(const URL&);
@@ -2769,6 +2775,8 @@ private:
     bool m_areDeviceMotionAndOrientationUpdatesSuspended { false };
 
     bool m_didEnqueueFirstContentfulPaint { false };
+
+    OriginKeyed m_isOriginKeyed { OriginKeyed::No };
 
     bool m_mayHaveRenderedSVGForeignObjects { false };
     bool m_mayHaveRenderedSVGRootElements { false };

--- a/Source/WebCore/dom/OriginKeyed.h
+++ b/Source/WebCore/dom/OriginKeyed.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+// https://html.spec.whatwg.org/multipage/origin.html#origin-keyed-agent-clusters
+enum class OriginKeyed : bool { No, Yes };
+
+} // namespace WebCore

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -48,6 +48,7 @@
 #include <WebCore/NavigationAction.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/NavigationRequester.h>
+#include <WebCore/OriginKeyed.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/ResourceLoaderOptions.h>
@@ -511,6 +512,8 @@ public:
 
     ContentSecurityPolicy* contentSecurityPolicy() const { return m_contentSecurityPolicy.get(); }
     const std::optional<CrossOriginOpenerPolicy>& crossOriginOpenerPolicy() const LIFETIME_BOUND { return m_responseCOOP; }
+    OriginKeyed isOriginKeyedFromUIProcess() const { return m_isOriginKeyedFromUIProcess; }
+    void setIsOriginKeyedFromUIProcess(OriginKeyed value) { m_isOriginKeyedFromUIProcess = value; }
     OptionSet<ClearSiteDataValue> responseClearSiteDataValues() const { return m_responseClearSiteDataValues; }
 
     std::unique_ptr<IntegrityPolicy> integrityPolicy();
@@ -696,6 +699,7 @@ private:
     Vector<ResourceResponse> m_responses;
 
     std::optional<CrossOriginOpenerPolicy> m_responseCOOP;
+    OriginKeyed m_isOriginKeyedFromUIProcess { OriginKeyed::No };
     OptionSet<ClearSiteDataValue> m_responseClearSiteDataValues;
     
     using SubstituteResourceMap = HashMap<Ref<ResourceLoader>, RefPtr<SubstituteResource>>;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -867,8 +867,12 @@ void FrameLoader::didBeginDocument(bool dispatch, LocalDOMWindow* previousWindow
         if (document->url().protocolIsBlob())
             protect(document->contentSecurityPolicy())->updateSourceSelf(SecurityOrigin::create(document->url()));
 
-        if (document->url().protocolIsInHTTPFamily() || document->url().protocolIsBlob())
+        if (document->url().protocolIsInHTTPFamily() || document->url().protocolIsBlob()) {
             document->setCrossOriginEmbedderPolicy(obtainCrossOriginEmbedderPolicy(documentLoader->response(), document.ptr()));
+
+            if (frame->settings().originAgentClusterEnabled() && !m_stateMachine.creatingInitialEmptyDocument())
+                document->setIsOriginKeyed(documentLoader->isOriginKeyedFromUIProcess());
+        }
 
         String referrerPolicy = documentLoader->response().httpHeaderField(HTTPHeaderName::ReferrerPolicy);
         if (!referrerPolicy.isNull())

--- a/Source/WebCore/loader/OriginAgentClusterPolicy.cpp
+++ b/Source/WebCore/loader/OriginAgentClusterPolicy.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "OriginAgentClusterPolicy.h"
+
+#include "HTTPHeaderNames.h"
+#include "RFC8941.h"
+#include "ResourceResponse.h"
+#include "ScriptExecutionContext.h"
+#include "SecurityOrigin.h"
+#include "Settings.h"
+
+namespace WebCore {
+
+// https://html.spec.whatwg.org/multipage/origin.html#initialise-the-document-object
+// (the Origin-Agent-Cluster portion)
+OriginKeyed obtainOriginAgentClusterPolicy(const ResourceResponse& response, const ScriptExecutionContext* context)
+{
+    if (context && !context->settingsValues().originAgentClusterEnabled)
+        return OriginKeyed::No;
+    if (!SecurityOrigin::create(response.url())->isPotentiallyTrustworthy())
+        return OriginKeyed::No;
+
+    auto parsingResult = RFC8941::parseItemStructuredFieldValue(response.httpHeaderField(HTTPHeaderName::OriginAgentCluster));
+    if (!parsingResult)
+        return OriginKeyed::No;
+
+    auto* boolValue = std::get_if<bool>(&parsingResult->first);
+    return boolValue && *boolValue ? OriginKeyed::Yes : OriginKeyed::No;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/loader/OriginAgentClusterPolicy.h
+++ b/Source/WebCore/loader/OriginAgentClusterPolicy.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/OriginKeyed.h>
+#include <WebCore/PlatformExportMacros.h>
+
+namespace WebCore {
+
+class ResourceResponse;
+class ScriptExecutionContext;
+
+// https://html.spec.whatwg.org/multipage/origin.html#origin-keyed-agent-clusters
+WEBCORE_EXPORT OriginKeyed obtainOriginAgentClusterPolicy(const ResourceResponse&, const ScriptExecutionContext*);
+
+} // namespace WebCore

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -520,6 +520,14 @@ ExceptionOr<bool> DOMWindow::crossOriginIsolated() const
     return localThis->crossOriginIsolated();
 }
 
+ExceptionOr<bool> DOMWindow::originAgentCluster() const
+{
+    auto* localThis = dynamicDowncast<LocalDOMWindow>(*this);
+    if (!localThis)
+        return Exception { ExceptionCode::SecurityError };
+    return localThis->originAgentCluster();
+}
+
 void DOMWindow::focus(LocalDOMWindow& incumbentWindow)
 {
     switch (m_type) {

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -169,6 +169,7 @@ public:
     ExceptionOr<String> origin() const;
     ExceptionOr<bool> isSecureContext() const;
     ExceptionOr<bool> crossOriginIsolated() const;
+    ExceptionOr<bool> originAgentCluster() const;
     ExceptionOr<void> print();
     ExceptionOr<void> stop();
     ExceptionOr<Performance&> performance() const;

--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -66,6 +66,7 @@
     // the current browsing context
     // FIXME: `document` should not be nullable.
     [LegacyUnforgeable] readonly attribute Document? document;
+    [EnabledBySetting=OriginAgentClusterEnabled] readonly attribute boolean originAgentCluster;
     attribute [AtomString] DOMString name;
     readonly attribute History history;
     [EnabledBySetting=NavigationAPIEnabled, Replaceable] readonly attribute Navigation navigation;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2022,6 +2022,13 @@ bool LocalDOMWindow::crossOriginIsolated() const
     return document && document->crossOriginIsolated();
 }
 
+// https://html.spec.whatwg.org/multipage/origin.html#dom-originagentcluster
+bool LocalDOMWindow::originAgentCluster() const
+{
+    auto* document = this->document();
+    return document && document->originAgentCluster();
+}
+
 static void didAddStorageEventListener(LocalDOMWindow& window)
 {
     // Creating these WebCore::Storage objects informs the system that we'd like to receive

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -265,6 +265,7 @@ public:
     bool isSecureContext() const;
 
     bool NODELETE crossOriginIsolated() const;
+    bool NODELETE originAgentCluster() const;
 
     // Events
     // EventTarget API

--- a/Source/WebCore/platform/network/HTTPHeaderNames.in
+++ b/Source/WebCore/platform/network/HTTPHeaderNames.in
@@ -77,6 +77,7 @@ Last-Modified
 Link
 Location
 Origin
+Origin-Agent-Cluster
 Ping-From
 Ping-To
 Pragma

--- a/Source/WebKit/Shared/PolicyDecision.h
+++ b/Source/WebKit/Shared/PolicyDecision.h
@@ -32,6 +32,7 @@
 #include "SessionState.h"
 #include "WebsitePoliciesData.h"
 #include <WebCore/NavigationIdentifier.h>
+#include <WebCore/OriginKeyed.h>
 
 namespace JSC {
 enum class MessageLevel : uint8_t;
@@ -56,6 +57,7 @@ struct PolicyDecision {
     std::optional<PolicyDecisionConsoleMessage> consoleMessage { std::nullopt };
     SafeBrowsingCheckOngoing isSafeBrowsingCheckOngoing { SafeBrowsingCheckOngoing::No };
     RefPtr<FrameState> backForwardFrameState { nullptr };
+    WebCore::OriginKeyed isOriginKeyed { WebCore::OriginKeyed::No };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/PolicyDecision.serialization.in
+++ b/Source/WebKit/Shared/PolicyDecision.serialization.in
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 enum class WebKit::SafeBrowsingCheckOngoing : bool;
+enum class WebCore::OriginKeyed : bool;
 
 [RValue] struct WebKit::PolicyDecision {
     std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain;
@@ -32,6 +33,7 @@ enum class WebKit::SafeBrowsingCheckOngoing : bool;
     std::optional<WebKit::PolicyDecisionConsoleMessage> consoleMessage;
     WebKit::SafeBrowsingCheckOngoing isSafeBrowsingCheckOngoing;
     RefPtr<WebKit::FrameState> backForwardFrameState;
+    WebCore::OriginKeyed isOriginKeyed;
 }
 
 [CustomHeader] struct WebKit::PolicyDecisionConsoleMessage {

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -334,4 +334,18 @@ bool BrowsingContextGroup::hasRemotePages(const WebPageProxy& page)
     return it != m_remotePages.end() && !it->value.isEmpty();
 }
 
+// https://html.spec.whatwg.org/multipage/origin.html#historical-agent-cluster-key-map
+WebCore::OriginKeyed BrowsingContextGroup::resolveAgentClusterKeying(const WebCore::SecurityOriginData& origin, WebCore::OriginKeyed requested)
+{
+    return m_historicalAgentClusterKeyMap.ensure(origin, [requested] {
+        return requested;
+    }).iterator->value;
+}
+
+void BrowsingContextGroup::clearBrowsingContextGroupForTesting()
+{
+    m_identifier = WebCore::BrowsingContextGroupIdentifier::generate();
+    m_historicalAgentClusterKeyMap.clear();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -29,6 +29,8 @@
 #include "LoadedWebArchive.h"
 #include "WebProcessProxy.h"
 #include <WebCore/BrowsingContextGroupIdentifier.h>
+#include <WebCore/OriginKeyed.h>
+#include <WebCore/SecurityOriginData.h>
 #include <WebCore/Site.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
@@ -89,6 +91,10 @@ public:
 
     bool NODELETE hasRemotePages(const WebPageProxy&);
 
+    WebCore::OriginKeyed resolveAgentClusterKeying(const WebCore::SecurityOriginData&, WebCore::OriginKeyed requested);
+
+    void clearBrowsingContextGroupForTesting();
+
 private:
     BrowsingContextGroup();
 
@@ -101,6 +107,8 @@ private:
     HashMap<WebCore::Site, WeakPtr<FrameProcess>> m_processMap;
     WeakListHashSet<WebPageProxy> m_pages;
     WeakHashMap<WebPageProxy, HashSet<Ref<RemotePageProxy>>> m_remotePages;
+
+    HashMap<WebCore::SecurityOriginData, WebCore::OriginKeyed> m_historicalAgentClusterKeyMap;
 } SWIFT_SHARED_REFERENCE(refBrowsingContextGroup, derefBrowsingContextGroup);
 
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -262,6 +262,7 @@
 #include <WebCore/ModalContainerTypes.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/OrganizationStorageAccessPromptQuirk.h>
+#include <WebCore/OriginAgentClusterPolicy.h>
 #include <WebCore/PerformanceLoggingClient.h>
 #include <WebCore/PermissionDescriptor.h>
 #include <WebCore/PermissionState.h>
@@ -5769,7 +5770,7 @@ void WebPageProxy::receivedNavigationResponsePolicyDecision(WebCore::PolicyActio
         else
             download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, request, downloadOriginatingPage(navigation).ptr(), navigation ? navigation->originatingFrameInfo() : std::nullopt);
 
-        download->setDidStartCallback([weakThis = WeakPtr { *this }, navigationResponse = WTF::move(navigationResponse)] (auto* downloadProxy) {
+        download->setDidStartCallback([weakThis = WeakPtr { *this }, navigationResponse = navigationResponse.copyRef()] (auto* downloadProxy) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis || !downloadProxy)
                 return;
@@ -5785,7 +5786,15 @@ void WebPageProxy::receivedNavigationResponsePolicyDecision(WebCore::PolicyActio
         downloadID = download->downloadID();
     }
 
-    completionHandler(PolicyDecision { isNavigatingToAppBoundDomain(), action, navigation ? std::optional { navigation->navigationID() } : std::nullopt, downloadID, { }, { } });
+    // https://html.spec.whatwg.org/multipage/origin.html#origin-keyed-agent-clusters
+    auto isOriginKeyed = OriginKeyed::No;
+    if (action == PolicyAction::Use && protect(m_preferences)->originAgentClusterEnabled()) {
+        auto& response = navigationResponse->response();
+        Ref responseOrigin = SecurityOrigin::create(response.url());
+        isOriginKeyed = protect(browsingContextGroup())->resolveAgentClusterKeying(responseOrigin->data(), obtainOriginAgentClusterPolicy(response, nullptr));
+    }
+
+    completionHandler(PolicyDecision { isNavigatingToAppBoundDomain(), action, navigation ? std::optional { navigation->navigationID() } : std::nullopt, downloadID, { }, { }, { }, SafeBrowsingCheckOngoing::No, nullptr, isOriginKeyed });
 }
 
 void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, std::optional<WebCore::NavigationIdentifier> navigationID, String&& mimeType, bool frameHasCustomContentProvider, FrameLoadType frameLoadType, const CertificateInfo& certificateInfo, bool usedLegacyTLS, bool privateRelayed, String&& proxyName, WebCore::ResourceResponseSource source, bool containsPluginDocument, HasInsecureContent hasInsecureContent, MouseEventPolicy mouseEventPolicy, DocumentSecurityPolicy&& documentSecurityPolicy, HashSet<WebCore::SecurityOriginData>&& cspOriginsThatUpgradeInsecureNavigations, const UserData& userData, RestoredFromBackForwardCache restoredFromBackForwardCache)

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebPageProxyTesting.h"
 
+#include "BrowsingContextGroup.h"
 #include "Connection.h"
 #include "MessageSenderInlines.h"
 #include "NetworkProcessMessages.h"
@@ -222,14 +223,17 @@ void WebPageProxyTesting::setObscuredContentInsets(float top, float right, float
 
 void WebPageProxyTesting::resetStateBetweenTests()
 {
-    page().legacyMainFrameProcess().resetState();
+    Ref page = m_page;
+    page->legacyMainFrameProcess().resetState();
 
-    if (auto* mainFrame = m_page->mainFrame())
+    if (auto* mainFrame = page->mainFrame())
         mainFrame->disownOpener();
 
-    protect(page())->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+    page->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         webProcess.send(Messages::WebPageTesting::ResetStateBetweenTests(), pageID);
     });
+
+    protect(page->browsingContextGroup())->clearBrowsingContextGroupForTesting();
 }
 
 void WebPageProxyTesting::clearBackForwardList(CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -638,10 +638,14 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& po
     }
 
     m_policyDownloadID = policyDecision.downloadID;
-    if (policyDecision.navigationID) {
-        auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
-        if (auto* documentLoader = localFrame ? localFrame->loader().policyDocumentLoader() : nullptr)
-            documentLoader->setNavigationID(*policyDecision.navigationID);
+    if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get())) {
+        auto& loader = localFrame->loader();
+        if (RefPtr policyDocumentLoader = loader.policyDocumentLoader()) {
+            if (policyDecision.navigationID)
+                policyDocumentLoader->setNavigationID(*policyDecision.navigationID);
+            policyDocumentLoader->setIsOriginKeyedFromUIProcess(policyDecision.isOriginKeyed);
+        } else if (RefPtr provisionalDocumentLoader = loader.provisionalDocumentLoader())
+            provisionalDocumentLoader->setIsOriginKeyedFromUIProcess(policyDecision.isOriginKeyed);
     }
 
     if (policyDecision.backForwardFrameState) {


### PR DESCRIPTION
#### b4c4069eb5b7eebcbcaaed64e00f6ce8ce08c5f0
<pre>
Implement the Origin-Agent-Cluster header
<a href="https://bugs.webkit.org/show_bug.cgi?id=216618">https://bugs.webkit.org/show_bug.cgi?id=216618</a>
<a href="https://rdar.apple.com/69452369">rdar://69452369</a>

Reviewed by Alex Christensen.

This implements origin-keyed agent clusters and gates it behind
OriginAgentClusterEnabled (set to preview). It is standardized here:

<a href="https://html.spec.whatwg.org/multipage/browsers.html#origin-isolation">https://html.spec.whatwg.org/multipage/browsers.html#origin-isolation</a>

This new keying does not impact process allocation, although we could
decide to make it impact that in the future if we wanted to. It impacts
document.domain, serialization and deserialization of certain objects,
and the new window.originAgentCluster getter.

We add a new test that is upstreamed at
<a href="https://github.com/web-platform-tests/wpt/pull/60311">https://github.com/web-platform-tests/wpt/pull/60311</a> that catches an
issue with our existing agent cluster implementation for opaque
origins and we also fix that issue.

As the test infrastructure continues to use the same browsing context
group for each test, we add a way to reset the browsing context group
state so it appears as if you are getting a fresh browsing context
group when you start a new test.

The subtest failures of regression-1399759.https.sub.html are due to
about:blank inheriting from the parent instead of the initiator of the
navigation. That&apos;s a distinct issue from this new feature.

going-back.sub.https.html is skipped because it times out on some bots
at the history.back() step, while the feature-related assertions pass.
I suspect it&apos;s related to the bfcache. I could not reproduce it locally
(1000 iterations of the test as well as 10 full-directory runs).

Canonical link: <a href="https://commits.webkit.org/314346@main">https://commits.webkit.org/314346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b06eacbb9df2f14d6521b1618c58ff20ead1d131

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123133 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128919 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168837 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109443 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28944 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23065 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158035 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177446 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26771 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30360 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137256 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137180 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36956 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148527 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102687 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32473 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25394 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111709 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38032 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3476 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38278 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38176 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->