### PR TITLE
Run clip-path animations on the compositor

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -128,6 +128,20 @@ AXCustomColorModeEnabled:
     WebCore:
       default: false
 
+AcceleratedClipPathAnimationEnabled:
+  type: bool
+  status: unstable
+  humanReadableName: "Accelerated clip-path animation"
+  humanReadableDescription: "Enable accelerated clip-path animations"
+  condition: PLATFORM(IOS_FAMILY)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 AcceleratedCompositingEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2989,6 +2989,16 @@ void KeyframeEffect::computeHasReferenceFilter()
     }();
 }
 
+static HashSet<CSSPropertyID> allAcceleratedAnimationProperties([[maybe_unused]] const Settings& settings)
+{
+    HashSet<CSSPropertyID> allProperties { CSSProperty::allAcceleratedAnimationProperties(settings) };
+#if PLATFORM(IOS_FAMILY)
+    if (settings.acceleratedClipPathAnimationEnabled())
+        allProperties.add(CSSPropertyClipPath);
+#endif
+    return allProperties;
+}
+
 void KeyframeEffect::computeAnimationIsAcceleratedAndAffectsAnchorGeometry()
 {
     m_animationIsAcceleratedAndAffectsAnchorGeometry = [&]() {
@@ -3003,7 +3013,7 @@ void KeyframeEffect::computeAnimationIsAcceleratedAndAffectsAnchorGeometry()
             if (!protectedDocument)
                 return false;
 
-            HashSet<CSSPropertyID> geometryAffectingAcceleratedProperty { CSSProperty::allAcceleratedAnimationProperties(protectedDocument->settings()) };
+            HashSet<CSSPropertyID> geometryAffectingAcceleratedProperty { allAcceleratedAnimationProperties(protectedDocument->settings()) };
             // Allow properties we know don't affect geometry.
             geometryAffectingAcceleratedProperty.remove(CSSPropertyOpacity);
             geometryAffectingAcceleratedProperty.remove(CSSPropertyFilter);
@@ -3175,6 +3185,8 @@ static bool acceleratedPropertyDidChange(AnimatableCSSProperty property, const S
         return previousStyle.offsetAnchor() != currentStyle.offsetAnchor();
     case CSSPropertyOffsetRotate:
         return previousStyle.offsetRotate() != currentStyle.offsetRotate();
+    case CSSPropertyClipPath:
+        return previousStyle.clipPath() != currentStyle.clipPath();
     case CSSPropertyFilter:
         return previousStyle.filter() != currentStyle.filter();
     case CSSPropertyBackdropFilter:
@@ -3212,7 +3224,7 @@ void KeyframeEffect::lastStyleChangeEventStyleDidChange(const Style::ComputedSty
         auto& settings = document()->settings();
 
         ASSERT(previousStyle && currentStyle);
-        for (auto property : CSSProperty::allAcceleratedAnimationProperties(settings)) {
+        for (auto property : allAcceleratedAnimationProperties(settings)) {
             if (acceleratedPropertyDidChange(property, *previousStyle, *currentStyle, settings)) {
                 scheduleAssociatedAcceleratedEffectStackUpdate();
                 return;

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -77,7 +77,8 @@ enum class AcceleratedEffectProperty : uint16_t {
     OffsetAnchor = 1 << 9,
     OffsetRotate = 1 << 10,
     Filter = 1 << 11,
-    BackdropFilter = 1 << 12
+    BackdropFilter = 1 << 12,
+    ClipPath = 1 << 13
 };
 
 constexpr OptionSet<AcceleratedEffectProperty> transformRelatedAcceleratedProperties = {

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -138,6 +138,8 @@ static OptionSet<AcceleratedEffectProperty> acceleratedPropertyFromCSSProperty(A
         return AcceleratedEffectProperty::OffsetAnchor;
     case CSSPropertyOffsetRotate:
         return AcceleratedEffectProperty::OffsetRotate;
+    case CSSPropertyClipPath:
+        return AcceleratedEffectProperty::ClipPath;
     case CSSPropertyFilter:
         return AcceleratedEffectProperty::Filter;
     case CSSPropertyBackdropFilter:
@@ -172,6 +174,8 @@ static CSSPropertyID NODELETE cssPropertyFromAcceleratedProperty(AcceleratedEffe
         return CSSPropertyOffsetAnchor;
     case AcceleratedEffectProperty::OffsetRotate:
         return CSSPropertyOffsetRotate;
+    case AcceleratedEffectProperty::ClipPath:
+        return CSSPropertyClipPath;
     case AcceleratedEffectProperty::Filter:
         return CSSPropertyFilter;
     case AcceleratedEffectProperty::BackdropFilter:
@@ -406,6 +410,13 @@ static void blend(AcceleratedEffectProperty property, AcceleratedEffectValues& o
             blendingContext.normalizeProgress();
         }
         output.offsetRotate = blend(from.offsetRotate, to.offsetRotate, blendingContext);
+        break;
+    case AcceleratedEffectProperty::ClipPath:
+        if (!canBlend(from.clipPath, to.clipPath)) {
+            blendingContext.isDiscrete = true;
+            blendingContext.normalizeProgress();
+        }
+        output.clipPath = blend(from.clipPath, to.clipPath, blendingContext);
         break;
     case AcceleratedEffectProperty::Filter:
         output.filter = from.filter.blend(to.filter, blendingContext);

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -35,6 +35,7 @@
 #include "RenderElementStyleInlines.h"
 #include "RenderLayerModelObject.h"
 #include "StyleComputedStyle+GettersInlines.h"
+#include "StyleClipPath.h"
 #include "StyleOffsetAnchor.h"
 #include "StyleOffsetDistance.h"
 #include "StyleOffsetPath.h"
@@ -60,6 +61,7 @@ AcceleratedEffectValues AcceleratedEffectValues::clone() const
     auto clonedOffsetPosition = offsetPosition;
     auto clonedOffsetAnchor = offsetAnchor;
     auto clonedOffsetRotate = offsetRotate;
+    auto clonedClipPath = clipPath;
     auto clonedFilter = filter.clone();
     auto clonedBackdropFilter = backdropFilter.clone();
 
@@ -77,6 +79,7 @@ AcceleratedEffectValues AcceleratedEffectValues::clone() const
         WTF::move(clonedOffsetPosition),
         WTF::move(clonedOffsetAnchor),
         WTF::move(clonedOffsetRotate),
+        WTF::move(clonedClipPath),
         WTF::move(clonedFilter),
         WTF::move(clonedBackdropFilter)
     };
@@ -123,6 +126,11 @@ AcceleratedEffectValues::AcceleratedEffectValues(const Style::ComputedStyle& sty
     translate = Style::toPlatform(style.translate(), borderBoxSize, zoom);
     scale = Style::toPlatform(style.scale(), borderBoxSize, zoom);
     rotate = Style::toPlatform(style.rotate(), borderBoxSize, zoom);
+    if (!style.clipPath().isNone()) {
+        auto evaluatedClipPath = Style::evaluate<AcceleratedEffectClipPath>(style.clipPath(), *transformOperationData, zoom);
+        if (auto path = tryPath(evaluatedClipPath, *transformOperationData))
+            clipPath = WTF::move(evaluatedClipPath);
+    }
 
     if (transformOperationData && transformOperationData->motionPathData && !style.offsetPath().isNone()) {
         auto evaluatedOffsetPath = Style::evaluate<AcceleratedEffectOffsetPath>(style.offsetPath(), *transformOperationData, zoom);

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(THREADED_ANIMATIONS)
 
+#include <WebCore/AcceleratedEffectClipPath.h>
 #include <WebCore/AcceleratedEffectOffsetAnchor.h>
 #include <WebCore/AcceleratedEffectOffsetDistance.h>
 #include <WebCore/AcceleratedEffectOffsetPath.h>
@@ -66,13 +67,14 @@ struct AcceleratedEffectValues {
     AcceleratedEffectOffsetPosition offsetPosition { };
     AcceleratedEffectOffsetAnchor offsetAnchor { };
     AcceleratedEffectOffsetRotate offsetRotate { };
+    AcceleratedEffectClipPath clipPath { };
     FilterOperations filter { };
     FilterOperations backdropFilter { };
 
     AcceleratedEffectValues() = default;
     // FIXME: It is a layering violation to use `StyleComputedStyle` and `RenderLayerModelObject` here, as they are defined in the rendering directory.
     AcceleratedEffectValues(const Style::ComputedStyle&, const IntRect&, const RenderLayerModelObject*);
-    AcceleratedEffectValues(AcceleratedEffectOpacity opacity, std::optional<TransformOperationData>&& transformOperationData, AcceleratedEffectTransformOrigin transformOrigin, AcceleratedEffectTransformBox transformBox, TransformOperations&& transform, RefPtr<TransformOperation>&& translate, RefPtr<TransformOperation>&& scale, RefPtr<TransformOperation>&& rotate, AcceleratedEffectOffsetPath&& offsetPath, AcceleratedEffectOffsetDistance offsetDistance, AcceleratedEffectOffsetPosition offsetPosition, AcceleratedEffectOffsetAnchor offsetAnchor, AcceleratedEffectOffsetRotate offsetRotate, FilterOperations&& filter, FilterOperations&& backdropFilter)
+    AcceleratedEffectValues(AcceleratedEffectOpacity opacity, std::optional<TransformOperationData>&& transformOperationData, AcceleratedEffectTransformOrigin transformOrigin, AcceleratedEffectTransformBox transformBox, TransformOperations&& transform, RefPtr<TransformOperation>&& translate, RefPtr<TransformOperation>&& scale, RefPtr<TransformOperation>&& rotate, AcceleratedEffectOffsetPath&& offsetPath, AcceleratedEffectOffsetDistance offsetDistance, AcceleratedEffectOffsetPosition offsetPosition, AcceleratedEffectOffsetAnchor offsetAnchor, AcceleratedEffectOffsetRotate offsetRotate, AcceleratedEffectClipPath&& clipPath, FilterOperations&& filter, FilterOperations&& backdropFilter)
         : opacity(opacity)
         , transformOperationData(WTF::move(transformOperationData))
         , transformOrigin(transformOrigin)
@@ -86,6 +88,7 @@ struct AcceleratedEffectValues {
         , offsetPosition(offsetPosition)
         , offsetAnchor(offsetAnchor)
         , offsetRotate(offsetRotate)
+        , clipPath(WTF::move(clipPath))
         , filter(WTF::move(filter))
         , backdropFilter(WTF::move(backdropFilter))
     {

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3866,8 +3866,29 @@ bool RenderLayerCompositor::requiresCompositingForAnimation(RenderLayerModelObje
     if (auto styleable = Styleable::fromRenderer(renderer)) {
         if (styleable->hasRunningAcceleratedAnimations())
             return true;
+
         if (auto* effectsStack = styleable->keyframeEffectStack()) {
+            auto requiresCompositingForAcceleratedClipPath = [] (const RenderLayerModelObject& renderer, const KeyframeEffectStack& effectsStack) {
+                // We only support accelerated clip-path on iOS, on MacOS it is not supported due to lack of support for the "path" key in CAPresentationModifier.
+#if PLATFORM(IOS_FAMILY)
+                Ref settings = renderer.settings();
+                if (!settings->acceleratedClipPathAnimationEnabled())
+                    return false;
+#else
+                return false;
+#endif
+                CheckedPtr box = dynamicDowncast<RenderBox>(renderer);
+                if (!box)
+                    return false;
+                constexpr unsigned maxSupportedAcceleratedClipPathArea = 100 * 100;
+                if (!effectsStack.isCurrentlyAffectingProperty(CSSPropertyClipPath))
+                    return false;
+                float boxArea = box->borderBoxWidth() * box->borderBoxHeight();
+                return boxArea <= maxSupportedAcceleratedClipPathArea;
+            };
+
             return (effectsStack->isCurrentlyAffectingProperty(CSSPropertyOpacity) && (usesCompositing() || (m_compositingTriggers & ChromeClient::AnimatedOpacityTrigger)))
+                || requiresCompositingForAcceleratedClipPath(renderer, *effectsStack)
                 || effectsStack->isCurrentlyAffectingProperty(CSSPropertyFilter)
                 || effectsStack->isCurrentlyAffectingProperty(CSSPropertyBackdropFilter)
                 || effectsStack->isCurrentlyAffectingProperty(CSSPropertyWebkitBackdropFilter)

--- a/Source/WebCore/style/StyleInterpolation.cpp
+++ b/Source/WebCore/style/StyleInterpolation.cpp
@@ -257,6 +257,10 @@ bool isAccelerated(const AnimatableCSSProperty& property, const Settings& settin
 {
     return WTF::switchOn(property,
         [&](CSSPropertyID propertyId) {
+#if PLATFORM(IOS_FAMILY)
+            if (propertyId == CSSPropertyClipPath)
+                return settings.acceleratedClipPathAnimationEnabled();
+#endif
             return CSSProperty::animationIsAccelerated(propertyId, settings);
         },
         [](const AtomString&) {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4355,7 +4355,8 @@ enum class WebCore::StorageType : uint8_t {
     OffsetAnchor,
     OffsetRotate,
     Filter,
-    BackdropFilter
+    BackdropFilter,
+    ClipPath
 };
 
 header: <WebCore/WebAnimationTypes.h>
@@ -4643,6 +4644,7 @@ struct WebCore::AcceleratedEffectValues {
     WebCore::AcceleratedEffectOffsetPosition offsetPosition;
     WebCore::AcceleratedEffectOffsetAnchor offsetAnchor;
     WebCore::AcceleratedEffectOffsetRotate offsetRotate;
+    WebCore::AcceleratedEffectClipPath clipPath;
     WebCore::FilterOperations filter;
     WebCore::FilterOperations backdropFilter;
 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
@@ -84,7 +84,8 @@ private:
     enum class LayerProperty : uint8_t {
         Opacity = 1 << 1,
         Transform = 1 << 2,
-        Filter = 1 << 3
+        Filter = 1 << 3,
+        ClipPath = 1 << 4
     };
 
     OptionSet<LayerProperty> m_affectedLayerProperties;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
@@ -32,6 +32,7 @@
 #import "RemoteProgressBasedTimeline.h"
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebKit {
 
@@ -50,19 +51,21 @@ RemoteAnimationStack::RemoteAnimationStack(RemoteAnimations&& animations, WebCor
     bool affectsFilter = false;
     bool affectsOpacity = false;
     bool affectsTransform = false;
+    bool affectsClipPath = false;
 
     for (auto& animation : m_animations) {
         auto& properties = animation->animatedProperties();
         affectsFilter = affectsFilter || properties.containsAny({ WebCore::AcceleratedEffectProperty::Filter, WebCore::AcceleratedEffectProperty::BackdropFilter });
         affectsOpacity = affectsOpacity || properties.contains(WebCore::AcceleratedEffectProperty::Opacity);
         affectsTransform = affectsTransform || properties.containsAny(WebCore::transformRelatedAcceleratedProperties);
+        affectsClipPath = affectsClipPath || properties.contains(WebCore::AcceleratedEffectProperty::ClipPath);
         m_hasProgressBasedAnimations = m_hasProgressBasedAnimations || animation->timeline().isProgressBased();
         m_hasTimeBasedAnimations = m_hasTimeBasedAnimations || animation->timeline().isMonotonic();
-        if (affectsFilter && affectsOpacity && affectsTransform && m_hasProgressBasedAnimations && m_hasTimeBasedAnimations)
+        if (affectsFilter && affectsOpacity && affectsTransform && affectsClipPath && m_hasProgressBasedAnimations && m_hasTimeBasedAnimations)
             break;
     }
 
-    ASSERT(affectsFilter || affectsOpacity || affectsTransform);
+    ASSERT(affectsFilter || affectsOpacity || affectsTransform || affectsClipPath);
 
     if (affectsFilter)
         m_affectedLayerProperties.add(LayerProperty::Filter);
@@ -70,6 +73,8 @@ RemoteAnimationStack::RemoteAnimationStack(RemoteAnimations&& animations, WebCor
         m_affectedLayerProperties.add(LayerProperty::Opacity);
     if (affectsTransform)
         m_affectedLayerProperties.add(LayerProperty::Transform);
+    if (affectsClipPath)
+        m_affectedLayerProperties.add(LayerProperty::ClipPath);
 }
 
 #if PLATFORM(MAC)
@@ -211,6 +216,13 @@ void RemoteAnimationStack::applyEffectsFromMainThread(PlatformLayer *layer, bool
     if (m_affectedLayerProperties.contains(LayerProperty::Transform)) {
         auto computedTransform = computedValues.computedTransformationMatrix(m_bounds);
         [layer setTransform:computedTransform];
+    }
+
+    if (computedValues.transformOperationData) {
+        if (auto path = tryPath(computedValues.clipPath, *computedValues.transformOperationData)) {
+            if (auto mask = dynamic_objc_cast<CAShapeLayer>(layer.mask))
+                mask.path = protect(path->platformPath()).get();
+        }
     }
 }
 


### PR DESCRIPTION
#### 7ea7c5f230d635ff4084103d13cb2ae8ed61f987
<pre>
Run clip-path animations on the compositor
<a href="https://bugs.webkit.org/show_bug.cgi?id=185816">https://bugs.webkit.org/show_bug.cgi?id=185816</a>
<a href="https://rdar.apple.com/97091889">rdar://97091889</a>

Reviewed by NOBODY (OOPS!).

Implement clip-path animations on the compositor for cases where
the size of the animated element is below a certain limit.

This functionality can be tested through the
AcceleratedClipPathAnimationEnabled feature flag.

Note that we only support accelerated clip-path on iOS, on MacOS it is
not supported due to lack of support for the &quot;path&quot; key in CAPresentationModifier.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::acceleratedPropertyDidChange):
(WebCore::allAcceleratedAnimationProperties):
(WebCore::KeyframeEffect::computeAnimationIsAcceleratedAndAffectsAnchorGeometry):
(WebCore::KeyframeEffect::lastStyleChangeEventStyleDidChange):
* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::acceleratedPropertyFromCSSProperty):
(WebCore::cssPropertyFromAcceleratedProperty):
(WebCore::blend):
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::clone const):
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebCore/platform/animation/AcceleratedEffectValues.h:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::requiresCompositingForAnimation const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm:
(WebKit::RemoteAnimationStack::RemoteAnimationStack):
(WebKit::RemoteAnimationStack::initEffectsFromMainThread):
(WebKit::RemoteAnimationStack::applyEffectsFromMainThread const):
* Source/WebCore/style/StyleInterpolation.cpp:
(WebCore::Style::Interpolation::isAccelerated):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ea7c5f230d635ff4084103d13cb2ae8ed61f987

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193838 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147907 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185479 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58885 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143310 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99501 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45773 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44006 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/5702 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/12538 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156166 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43595 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5016 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/44892 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/50195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195776 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/57210 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152842 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57914 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152524 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47068 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/130193 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/126505 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56422 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18605 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55793 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56032 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55860 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->