### PR TITLE
[Skia] Restrict Skia compositing to the frame damage

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8766,7 +8766,6 @@ UnifyDamagedRegions:
      WebKitLegacy:
        default: false
      WebKit:
-       "PLATFORM(GTK)": true
        default: false
      WebCore:
        default: false
@@ -8866,6 +8865,7 @@ UseDamagingInformationForCompositing:
     WebKitLegacy:
       default: false
     WebKit:
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
       default: false

--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -21,6 +21,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/SkiaCompositingLayerFilters.h
     platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
     platform/graphics/skia/SkiaCompositingLayerOverlapRegions.h
+    platform/graphics/skia/SkiaDamageRestriction.h
     platform/graphics/skia/SkiaGPUAtlas.h
     platform/graphics/skia/SkiaHarfBuzzFont.h
     platform/graphics/skia/SkiaHarfBuzzFontCache.h

--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -307,6 +307,27 @@ public:
         return result;
     }
 
+    // Rects to paint that never overlap, unlike rects(). At most one bounding rect per grid cell,
+    // clipped to its cell.
+    Rects rectsForPainting() const
+    {
+        if (size() <= 1 || m_mode != Mode::Rectangles)
+            return rects();
+
+        Rects result;
+        for (int row = 0; row < m_rects.gridCells.height(); ++row) {
+            for (int col = 0; col < m_rects.gridCells.width(); ++col) {
+                const IntRect cellRect = { { m_rect.x() + col * m_rects.cellSize.width(), m_rect.y() + row * m_rects.cellSize.height() }, m_rects.cellSize };
+                IntRect cellBounds;
+                for (const auto& rect : *this)
+                    cellBounds.unite(intersection(cellRect, rect));
+                if (!cellBounds.isEmpty())
+                    result.append(cellBounds);
+            }
+        }
+        return result;
+    }
+
     void makeFull()
     {
         if (m_mode == Mode::Full)

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -31,6 +31,7 @@
 #include "CoordinatedTileBuffer.h"
 #include "FontRenderOptions.h"
 #include "PlatformDisplay.h"
+#include "SkiaDamageRestriction.h"
 #include "SkiaPaintingEngine.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
@@ -90,6 +91,7 @@ void SkiaBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint)
 
     FloatRect layerRect = { { }, m_size };
 
+    const auto sampling = SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone);
     auto tilePaint = paint;
     for (auto& tile : m_tiles.values()) {
         if (canvas.quickReject(tile.rect()))
@@ -100,16 +102,19 @@ void SkiaBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint)
             continue;
 
         tilePaint.setAntiAlias(paint.isAntiAlias() && allTileEdgesExposed(layerRect, tile.rect()));
-        canvas.drawImageRect(image, SkRect::MakeWH(image->width(), image->height()), tile.rect(), SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), &tilePaint, SkCanvas::kFast_SrcRectConstraint);
+        canvas.drawImageRect(image, SkRect::MakeWH(image->width(), image->height()), tile.rect(), sampling, &tilePaint, SkCanvas::kFast_SrcRectConstraint);
     }
 }
 
-Vector<SkCanvas::ImageSetEntry> SkiaBackingStore::buildImageSet(SkCanvas& canvas, const SkMatrix& ctm, size_t matrixIndex, float opacity, bool enableAntialias) const
+Vector<SkCanvas::ImageSetEntry> SkiaBackingStore::buildImageSet(SkCanvas& canvas, const SkMatrix& ctm, size_t matrixIndex, float opacity, bool enableAntialias, std::optional<TilingDamageRestriction> restrictedToDamage) const
 {
     if (m_tiles.isEmpty())
         return { };
 
     FloatRect layerRect = { { }, m_size };
+
+    // Restricting to single rects needs an axis-aligned CTM, which turns antialiasing off.
+    ASSERT(!restrictedToDamage || !enableAntialias);
 
     SkAutoCanvasRestore autoRestore(&canvas, true);
     canvas.concat(ctm);
@@ -124,8 +129,24 @@ Vector<SkCanvas::ImageSetEntry> SkiaBackingStore::buildImageSet(SkCanvas& canvas
             continue;
 
         // FIXME: implement per edge antialiasing.
-        unsigned aaFlags = enableAntialias && allTileEdgesExposed(layerRect, tile.rect()) ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
-        images.append(SkCanvas::ImageSetEntry(image, SkRect::MakeWH(image->width(), image->height()), SkRect(tile.rect()), matrixIndex, opacity, aaFlags, false));
+        const unsigned aaFlags = enableAntialias && allTileEdgesExposed(layerRect, tile.rect()) ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
+        const SkRect srcRectFull = SkRect::MakeWH(image->width(), image->height());
+        const SkRect dstRectFull = tile.rect();
+
+        if (!restrictedToDamage) {
+            images.append(SkCanvas::ImageSetEntry(image, srcRectFull, dstRectFull, matrixIndex, opacity, aaFlags, false));
+            continue;
+        }
+
+        SkRect deviceRect;
+        restrictedToDamage->ctm.mapRect(&deviceRect, dstRectFull);
+
+        // Emit one entry per damaged part of the tile, so the batch draws only those parts. The damage
+        // rects never overlap, so the parts don't overlap either - translucent tiles composite once, and
+        // a tile fully outside the damage draws nothing.
+        forEachDamagedSubRect(deviceRect, dstRectFull, srcRectFull, restrictedToDamage->inverse, restrictedToDamage->rects, [&](const SkRect& srcSubRect, const SkRect& dstSubRect) {
+            images.append(SkCanvas::ImageSetEntry(image, srcSubRect, dstSubRect, matrixIndex, opacity, aaFlags, false));
+        });
     }
     return images;
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -28,6 +28,7 @@
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
 #include "CoordinatedBackingStoreProxy.h"
 #include "FloatRect.h"
+#include "SkiaDamageRestriction.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkCanvas.h>
 #include <skia/core/SkSurface.h>
@@ -47,12 +48,21 @@ public:
 
     float scale() const { return m_scale; }
     bool hasPendingTileUpdates() const { return m_hasPendingTileUpdates; }
+    const FloatSize& size() const LIFETIME_BOUND { return m_size; }
+
+    // Limits a tile set to its layer's damage rects. rects are the damage rects that touch the layer,
+    // inverse maps device rects back to layer coordinates.
+    struct TilingDamageRestriction {
+        const SkMatrix& ctm;
+        const SkMatrix& inverse;
+        std::span<const IntRect> rects;
+    };
 
     void update(const FloatSize&, float scale, CoordinatedBackingStoreProxy::Update&&);
     void processPendingTileUpdates();
 
     void paintToCanvas(SkCanvas&, const SkPaint&);
-    Vector<SkCanvas::ImageSetEntry> buildImageSet(SkCanvas&, const SkMatrix&, size_t matrixIndex, float opacity, bool enableAntialias) const;
+    Vector<SkCanvas::ImageSetEntry> buildImageSet(SkCanvas&, const SkMatrix&, size_t matrixIndex, float opacity, bool enableAntialias, std::optional<TilingDamageRestriction> restrictedToDamage = std::nullopt) const;
     void drawDebugBorders(SkCanvas&, const SkPaint&);
 
 private:

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -41,6 +41,7 @@
 #include "SkiaCompositingLayer3DRenderingContext.h"
 #include "SkiaCompositingLayerFilters.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
+#include "SkiaDamageRestriction.h"
 #include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkFont.h>
@@ -51,6 +52,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 #include <skia/gpu/ganesh/gl/GrGLDirectContext.h>
+#include <skia/utils/SkNoDrawCanvas.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
@@ -89,12 +91,8 @@ void SkiaCompositingLayer::invalidate()
 void SkiaCompositingLayer::setSize(const FloatSize& size)
 {
 #if ENABLE(DAMAGE_TRACKING)
-    if (frameDamagePropagationEnabled() && m_size != size) {
-        m_size = size;
+    if (frameDamagePropagationEnabled() && m_size != size)
         damageWholeLayer();
-        addPreviousRectToSharedFrameDamage();
-        return;
-    }
 #endif
     m_size = size;
 }
@@ -146,8 +144,14 @@ void SkiaCompositingLayer::removeFromParent()
     });
 
 #if ENABLE(DAMAGE_TRACKING)
-    if (parent->frameDamagePropagationEnabled())
-        recursiveAddPreviousRectToSharedFrameDamage(Ref { *this });
+    if (parent->frameDamagePropagationEnabled()) {
+        // This subtree won't be walked again, so hand its layers' old positions to the root. The
+        // next collect repaints them.
+        RefPtr root = parent;
+        while (root->m_parent)
+            root = root->m_parent.get();
+        recursiveMoveOrphanedPreviousLayerRects(root->m_orphanedPreviousLayerRects);
+    }
 #endif
 }
 
@@ -258,24 +262,19 @@ void SkiaCompositingLayer::addDamage(Damage&& damage)
         m_layerDamage = WTF::move(damage);
 }
 
-void SkiaCompositingLayer::addPreviousRectToSharedFrameDamage()
+void SkiaCompositingLayer::recursiveConsumePreviousLayerRects(Damage& frameDamage)
 {
-    if (m_previousLayerRectInFrameCoordinates.isEmpty())
-        return;
-
-    // In many cases, damaging the whole layer in the "new" state is not enough.
-    // When e.g. changing size, transform, etc. the layer (or its parts) effectively disappears from one place
-    // and re-appears in another. Therefore the damaging of a layer in the "old" state is required as well.
-    ASSERT(m_sharedFrameDamage);
-    m_sharedFrameDamage->add(std::exchange(m_previousLayerRectInFrameCoordinates, { }));
+    consumePreviousLayerRect(frameDamage);
+    for (auto& child : m_children)
+        child->recursiveConsumePreviousLayerRects(frameDamage);
 }
 
-void SkiaCompositingLayer::recursiveAddPreviousRectToSharedFrameDamage(Ref<SkiaCompositingLayer> layer)
+void SkiaCompositingLayer::recursiveMoveOrphanedPreviousLayerRects(Vector<FloatRect, 1>& orphanedRects)
 {
-    layer->addPreviousRectToSharedFrameDamage();
-
-    for (auto& child : layer->m_children)
-        recursiveAddPreviousRectToSharedFrameDamage(child);
+    if (!m_previousLayerRectInFrameCoordinates.isEmpty())
+        orphanedRects.append(std::exchange(m_previousLayerRectInFrameCoordinates, { }));
+    for (auto& child : m_children)
+        child->recursiveMoveOrphanedPreviousLayerRects(orphanedRects);
 }
 #endif
 
@@ -398,10 +397,8 @@ bool SkiaCompositingLayer::computeTransformsAndAnimations(const TransformationMa
         futureCombinedForChildren.translate3d(-origin.x(), -origin.y(), -m_anchorPoint.z());
 
 #if ENABLE(DAMAGE_TRACKING)
-        if (frameDamagePropagationEnabled() && previousTransform != m_transforms.combined) {
+        if (frameDamagePropagationEnabled() && previousTransform != m_transforms.combined)
             damageWholeLayer();
-            addPreviousRectToSharedFrameDamage();
-        }
 #endif
 
         m_visible = m_backfaceVisibility || !m_transforms.combined.isBackFaceVisible();
@@ -431,25 +428,58 @@ bool SkiaCompositingLayer::computeTransformsAndAnimations(const TransformationMa
     return hasRunningAnimations;
 }
 
-bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& damage)
+void SkiaCompositingLayer::ensurePrepared()
 {
-    bool hasRunningAnimations = computeTransformsAndAnimations({ }, { }, MonotonicTime::now());
-    PaintContext context(damage);
+    if (m_preparedThisFrame)
+        return;
+    m_hadRunningAnimations = computeTransformsAndAnimations({ }, { }, MonotonicTime::now());
+    m_preparedThisFrame = true;
+}
 
-    context.mode = PaintMode::Paint;
-    recursivePaint(canvas, context);
-    context.imageSetBatch.flushIfNeeded(canvas);
+#if ENABLE(DAMAGE_TRACKING)
+void SkiaCompositingLayer::collectDamage(const IntSize& surfaceSize, Damage& frameDamage)
+{
+    ensurePrepared();
+
+    // Walk the whole tree without drawing. Each layer's damage stays until paint() clears it.
+    PaintContext context;
+    context.mode = PaintMode::CollectDamage;
+    context.frameDamage = std::ref(frameDamage);
+
+    SkNoDrawCanvas noDrawCanvas(surfaceSize.width(), surfaceSize.height());
+    recursivePaint(noDrawCanvas, context);
+
+    for (const auto& rect : std::exchange(m_orphanedPreviousLayerRects, { }))
+        frameDamage.add(rect);
+}
+#endif
+
+void SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<DamageRegion>&& damageRegion)
+{
+    ensurePrepared();
+
+    PaintContext context;
+
+    // An empty region means the buffer is already current, so draw nothing.
+    bool skipDraw = false;
+#if ENABLE(DAMAGE_TRACKING)
+    if (damageRegion && damageRegion->rects.isEmpty())
+        skipDraw = true;
+    else if (damageRegion)
+        context.compositingDamageRegion = WTF::move(*damageRegion);
+#else
+    UNUSED_PARAM(damageRegion);
+#endif
+
+    if (!skipDraw) {
+        recursivePaint(canvas, context);
+        context.imageSetBatch.flushIfNeeded(canvas);
+    }
 
     recursiveCleanUpAfterPaint();
 
-#if ENABLE(DAMAGE_TRACKING)
-    if (damage && frameDamagePropagationEnabled()) {
-        damage->add(*m_sharedFrameDamage);
-        *m_sharedFrameDamage = Damage(m_size);
-    }
-#endif
-
-    return hasRunningAnimations;
+    // This is the frame's last walk, so re-arm preparation for the next frame.
+    m_preparedThisFrame = false;
 }
 
 void SkiaCompositingLayer::clipRect(SkCanvas& canvas, const FloatRoundedRect& rect, const TransformationMatrix& transform)
@@ -473,21 +503,51 @@ void SkiaCompositingLayer::clipRect(SkCanvas& canvas, const FloatRoundedRect& re
 
 void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
 {
-    if (m_size.isEmpty() || !m_visible || !m_contentsVisible || !hasVisualContent())
-        return;
+#if ENABLE(DAMAGE_TRACKING)
+    // m_layerDamage isn't cleared here. An opacity, blend or filter layer paints once per region rect,
+    // each taking its share. recursiveCleanUpAfterPaint() clears it after the frame.
+    const bool collectsDamage = context.collectsDamage();
+#endif
 
-    if (context.mode == PaintMode::Paint) {
+    if (!hasVisiblePaintableContent()) {
+#if ENABLE(DAMAGE_TRACKING)
+        if (collectsDamage && frameDamagePropagationEnabled() && context.frameDamage)
+            consumePreviousLayerRect(context.frameDamage->get());
+#endif
+        return;
+    }
+
+    if (context.shouldDraw())
         paintContents(canvas, context);
 #if ENABLE(DAMAGE_TRACKING)
+    if (collectsDamage)
         collectFrameDamage(canvas, context);
 #endif
-    }
+
+    // Drawn in the content stream so content above hides the border and it shares the group's
+    // opacity, filter and mask, like Viz's DebugBorderDrawQuad.
+    if (context.shouldDraw() && m_debugBorder)
+        paintDebugBorder(canvas, context);
+}
+
+TransformationMatrix SkiaCompositingLayer::combinedTransform(const PaintContext& context) const
+{
+    TransformationMatrix transform(context.accumulatedReplicaTransform);
+    transform.multiply(m_transforms.combined);
+    return transform;
 }
 
 void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context)
 {
-    TransformationMatrix transform(context.accumulatedReplicaTransform);
-    transform.multiply(m_transforms.combined);
+#if ENABLE(DAMAGE_TRACKING)
+    // The draw walk doesn't clip the canvas to the damage, so every content draw below must limit
+    // itself with a *RestrictedToDamage helper (or clipToDamageInDeviceSpace). Otherwise it draws over
+    // undamaged pixels and composites translucent content twice. Any new content type added here must
+    // do the same. A set region is never empty, because paint() turns an empty one into a no-op first.
+    ASSERT(!context.compositingDamageRegion || !context.compositingDamageRegion->rects.isEmpty());
+#endif
+
+    auto transform = combinedTransform(context);
 
     auto ctm = SkM44(transform).asM33();
     bool enableAntialias = !ctm.preservesAxisAlignment() && !ctm.preservesRightAngles();
@@ -506,15 +566,28 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
         return paint;
     };
 
-    if (m_backingStore)
-        context.imageSetBatch.addImageSet(canvas, *m_backingStore, ctm, context.opacity, enableAntialias);
+    if (m_backingStore) {
+#if ENABLE(DAMAGE_TRACKING)
+        if (context.compositingDamageRegion) {
+            // Split each tile into its damaged parts and keep the batched draw. A rotated or skewed
+            // transform (or too many rects) can't, so flush and draw the tiles under a damage clip.
+            if (!context.imageSetBatch.addImageSetRestrictedToDamage(canvas, *m_backingStore, ctm, context.opacity, context.compositingDamageRegion->rects)) {
+                ScopedFlush autoFlush(canvas, context.imageSetBatch, ScopedFlush::Mode::FlushBefore);
+                canvas.concat(SkM44(transform));
+                clipToDamageInDeviceSpace(canvas, *context.compositingDamageRegion);
+                m_backingStore->paintToCanvas(canvas, setupPaint());
+            }
+        } else
+#endif
+            context.imageSetBatch.addImageSet(canvas, *m_backingStore, ctm, context.opacity, enableAntialias);
+    }
 
     if (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()) {
         ScopedFlush autoFlush(canvas, context.imageSetBatch, ScopedFlush::Mode::FlushBefore);
         canvas.concat(SkM44(transform));
         SkPaint paint = setupPaint();
         paint.setColor(SkColor(m_contentsSolidColor.colorWithAlphaMultipliedBy(context.opacity)));
-        canvas.drawRect(m_contentsRect, paint);
+        drawRectRestrictedToDamage(canvas, context.compositingDamageRegion, SkRect(m_contentsRect), paint);
     } else if (m_contentsBuffer || m_imageBackingStore) {
         bool shouldPaintNow = [&] {
             if (m_contentsClippingRect.hasNonZeroRadii())
@@ -554,7 +627,7 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
 #endif
                 SkPaint paint = setupPaint();
                 paint.setBlendMode(SkBlendMode::kClear);
-                canvas.drawRect(SkRect(m_contentsRect), paint);
+                drawRectRestrictedToDamage(canvas, context.compositingDamageRegion, SkRect(m_contentsRect), paint);
             } else
 #endif // ENABLE(VIDEO)
                 image = m_contentsBuffer->skiaImage();
@@ -567,20 +640,33 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
                 matrix.postTranslate(m_contentsRect.x() - m_contentsTiling.phase.width(), m_contentsRect.y() - m_contentsTiling.phase.height());
                 SkPaint paint = setupPaint();
                 paint.setShader(tileImage->makeShader(SkTileMode::kRepeat, SkTileMode::kRepeat, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), matrix));
-                canvas.drawRect(m_contentsRect, paint);
+                drawRectRestrictedToDamage(canvas, context.compositingDamageRegion, SkRect(m_contentsRect), paint);
             }
         }
 
         if (image) {
-            if (shouldPaintNow) {
+            auto paintImageDirectly = [&] {
                 SkPaint paint = setupPaint();
-                canvas.drawImageRect(image, SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(m_contentsRect),
-                    SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
-            } else {
+                drawImageRectRestrictedToDamage(canvas, image.get(), SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(m_contentsRect),
+                    SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, context.compositingDamageRegion);
+            };
+
+            if (shouldPaintNow)
+                paintImageDirectly();
+            else {
                 auto clippingRect = m_contentsClippingRect.rect();
                 if (clippingRect.contains(m_contentsRect))
                     clippingRect = { };
-                context.imageSetBatch.addImage(canvas, image, m_contentsRect, clippingRect, ctm, context.opacity, enableAntialias);
+#if ENABLE(DAMAGE_TRACKING)
+                if (context.compositingDamageRegion) {
+                    if (!context.imageSetBatch.addImageRestrictedToDamage(canvas, image, m_contentsRect, ctm, context.opacity, context.compositingDamageRegion->rects)) {
+                        ScopedFlush fallbackFlush(canvas, context.imageSetBatch, ScopedFlush::Mode::FlushBefore);
+                        canvas.concat(SkM44(transform));
+                        paintImageDirectly();
+                    }
+                } else
+#endif
+                    context.imageSetBatch.addImage(canvas, image, m_contentsRect, clippingRect, ctm, context.opacity, enableAntialias);
             }
         }
     }
@@ -592,53 +678,64 @@ void SkiaCompositingLayer::collectFrameDamage(SkCanvas& canvas, PaintContext& co
     if (!frameDamagePropagationEnabled() || !context.frameDamage)
         return;
 
-    TransformationMatrix transform(context.accumulatedReplicaTransform);
-    transform.multiply(m_transforms.combined);
-    auto frameDamage = transform.mapRect(effectiveLayerRect());
+    auto transform = combinedTransform(context);
+    auto layerRectInFrame = transform.mapRect(effectiveLayerRect());
     auto clipBounds = FloatRect(this->clipBounds(canvas, context));
     if (!clipBounds.isEmpty())
-        frameDamage.intersect(clipBounds);
+        layerRectInFrame.intersect(clipBounds);
 
-    m_previousLayerRectInFrameCoordinates.unite(frameDamage);
+    // The rect moved, so repaint both its old and new positions.
+    if (m_previousLayerRectInFrameCoordinates != layerRectInFrame) {
+        context.frameDamage->get().add(std::exchange(m_previousLayerRectInFrameCoordinates, layerRectInFrame));
+        context.frameDamage->get().add(layerRectInFrame);
+    }
 
     if (m_layerDamage) {
         for (const auto& rect : *m_layerDamage) {
             auto damageRect = transform.mapRect(FloatRect(rect));
             if (!clipBounds.isEmpty())
                 damageRect.intersect(clipBounds);
-            context.frameDamage->add(damageRect);
+            context.frameDamage->get().add(damageRect);
         }
     }
 }
 
 #endif
 
-void SkiaCompositingLayer::paintDebugIndicators(SkCanvas& canvas, PaintContext& context)
+void SkiaCompositingLayer::paintDebugBorder(SkCanvas& canvas, PaintContext& context)
 {
-    if (m_size.isEmpty() || !m_visible || !m_contentsVisible || !hasVisualContent())
+    ASSERT(m_debugBorder);
+
+    context.imageSetBatch.flushIfNeeded(canvas);
+
+    auto transform = combinedTransform(context);
+    SkAutoCanvasRestore autoRestore(&canvas, true);
+    canvas.concat(SkM44(transform));
+
+    SkPaint borderPaint;
+    borderPaint.setStyle(SkPaint::kStroke_Style);
+    borderPaint.setColor(SkColor(m_debugBorder->color));
+    borderPaint.setStrokeWidth(m_debugBorder->width);
+    borderPaint.setAntiAlias(true);
+
+    if (m_backingStore)
+        m_backingStore->drawDebugBorders(canvas, borderPaint);
+    if (m_contentsBuffer || m_imageBackingStore || (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()))
+        canvas.drawRect(SkRect(m_contentsRect), borderPaint);
+}
+
+void SkiaCompositingLayer::paintRepaintCounter(SkCanvas& canvas, PaintContext& context)
+{
+    ASSERT(m_repaintCount);
+
+    if (!hasVisiblePaintableContent())
         return;
 
-    TransformationMatrix transform(context.accumulatedReplicaTransform);
-    transform.multiply(m_transforms.combined);
+    context.imageSetBatch.flushIfNeeded(canvas);
 
-    if (m_debugBorder) {
-        SkAutoCanvasRestore autoRestore(&canvas, true);
-        canvas.concat(SkM44(transform));
-
-        SkPaint borderPaint;
-        borderPaint.setStyle(SkPaint::kStroke_Style);
-        borderPaint.setColor(SkColor(m_debugBorder->color));
-        borderPaint.setStrokeWidth(m_debugBorder->width);
-        borderPaint.setAntiAlias(true);
-
-        if (m_backingStore)
-            m_backingStore->drawDebugBorders(canvas, borderPaint);
-        if (m_contentsBuffer || m_imageBackingStore || (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()))
-            canvas.drawRect(SkRect(m_contentsRect), borderPaint);
-    }
-
-    if (!m_repaintCount)
-        return;
+    auto transform = combinedTransform(context);
+    SkAutoCanvasRestore autoRestore(&canvas, true);
+    canvas.concat(SkM44(transform));
 
     // Capture the full canvas-to-device position while the layer transform is still active.
     SkPoint deviceOrigin { 0, 0 };
@@ -669,7 +766,8 @@ void SkiaCompositingLayer::paintDebugIndicators(SkCanvas& canvas, PaintContext& 
         m_repaintCountOverlay.baselineOffset = -textBounds.fTop + padding;
     }
 
-    SkAutoCanvasRestore autoRestore(&canvas, true);
+    SkAutoCanvasRestore overlayRestore(&canvas, true);
+    canvas.resetMatrix();
 
     SkPaint backgroundPaint;
     backgroundPaint.setColor(m_debugBorder ? SkColor(m_debugBorder->color) : SK_ColorBLACK);
@@ -821,7 +919,7 @@ void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintC
     if (surfaceRect.isEmpty())
         return;
 
-    if (context.mode != PaintMode::Paint) {
+    if (!context.shouldDraw()) {
         paintFunction(canvas, context);
         return;
     }
@@ -841,11 +939,23 @@ void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintC
     surfaceCanvas->clear(SK_ColorTRANSPARENT);
     surfaceCanvas->translate(-surfaceRect.x(), -surfaceRect.y());
     SetForScope scopedOffset(context.offset, toIntSize(surfaceRect.location()));
-    paintFunction(*surfaceCanvas, context);
-    context.imageSetBatch.flushIfNeeded(*surfaceCanvas);
+
+    {
+        // The filter may sample outside the damage, so paint the whole subtree. Only the composite
+        // below is limited. SetForScope puts the restriction back afterwards.
+        SetForScope scopedNoDamageRestriction(context.compositingDamageRegion, std::optional<DamageRegion> { std::nullopt });
+        paintFunction(*surfaceCanvas, context);
+        context.imageSetBatch.flushIfNeeded(*surfaceCanvas);
+    }
     grContext->flushAndSubmit(surface.get(), GrSyncCpu::kNo);
 
-    canvas.drawImageRect(surface->makeImageSnapshot(), SkRect::MakeWH(surfaceRect.width(), surfaceRect.height()), SkRect::Make(surfaceRect), SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), paint, SkCanvas::kFast_SrcRectConstraint);
+    auto snapshot = surface->makeImageSnapshot();
+    const auto sampling = SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone);
+
+    SkAutoCanvasRestore autoRestore(&canvas, context.compositingDamageRegion.has_value());
+    if (context.compositingDamageRegion)
+        clipToDamageInDeviceSpace(canvas, *context.compositingDamageRegion);
+    canvas.drawImageRect(snapshot, SkRect::MakeWH(surfaceRect.width(), surfaceRect.height()), SkRect::Make(surfaceRect), sampling, paint, SkCanvas::kFast_SrcRectConstraint);
 }
 
 void SkiaCompositingLayer::paintBackdrop(SkCanvas& canvas, PaintContext& context)
@@ -881,18 +991,15 @@ void SkiaCompositingLayer::paintBackdrop(SkCanvas& canvas, PaintContext& context
 
 void SkiaCompositingLayer::paintWithMaskAndBackdrop(SkCanvas& canvas, PaintContext& context)
 {
-    // An empty clip path fully clips the layer out, so it isn't painted at all.
-    // Skip it in every mode: there's nothing to paint, to collect damage for, or
-    // to annotate with debug indicators.
+    // An empty clip path clips the whole layer away, so skip it in every mode.
     if (m_mask && m_mask->m_clipPath && m_mask->m_clipPath->isEmpty())
         return;
 
-    // Otherwise the mask only affects the painted result, so apply it (clip path
-    // or mask image) only in PaintMode::Paint. Damage collection and debug
-    // indicators walk the tree unmasked.
+    // The mask only affects the drawn result, so apply it in the draw pass only. Damage collection
+    // and debug indicators walk the tree unmasked.
     bool shouldClipPath = false;
     sk_sp<SkImage> maskImage;
-    if (context.mode == PaintMode::Paint && m_mask) {
+    if (context.shouldDraw() && m_mask) {
         shouldClipPath = m_mask->m_clipPath.has_value();
         if (!shouldClipPath)
             maskImage = m_mask->maskImage();
@@ -943,11 +1050,11 @@ void SkiaCompositingLayer::paintWithFilterAndMask(SkCanvas& canvas, PaintContext
 
 #if ENABLE(DAMAGE_TRACKING)
     auto clipBounds = FloatRect(this->clipBounds(canvas, context));
-    const bool collectsDamage = context.mode == PaintMode::Paint;
+    const bool collectsDamage = context.collectsDamage();
     const bool needToProcessFrameDamage = collectsDamage && frameDamagePropagationEnabled() && context.frameDamage;
 #endif
 
-    if (context.mode != PaintMode::Paint) {
+    if (!context.shouldDraw()) {
 #if ENABLE(DAMAGE_TRACKING)
         if (needToProcessFrameDamage) {
             for (const auto& rect : overlapRects) {
@@ -957,7 +1064,7 @@ void SkiaCompositingLayer::paintWithFilterAndMask(SkCanvas& canvas, PaintContext
                 m_accumulatedOverlapRegionFrameDamage.unite(damageRect);
             }
             if (!m_accumulatedOverlapRegionFrameDamage.isEmpty())
-                context.frameDamage->add(m_accumulatedOverlapRegionFrameDamage);
+                context.frameDamage->get().add(m_accumulatedOverlapRegionFrameDamage);
         }
 #endif
         paintSelfAndChildren(canvas, context);
@@ -994,7 +1101,7 @@ void SkiaCompositingLayer::paintWithFilterAndMask(SkCanvas& canvas, PaintContext
 
 #if ENABLE(DAMAGE_TRACKING)
     if (needToProcessFrameDamage && !m_accumulatedOverlapRegionFrameDamage.isEmpty())
-        context.frameDamage->add(m_accumulatedOverlapRegionFrameDamage);
+        context.frameDamage->get().add(m_accumulatedOverlapRegionFrameDamage);
 #endif
 }
 
@@ -1032,8 +1139,13 @@ void SkiaCompositingLayer::recursivePaint(SkCanvas& canvas, PaintContext& contex
 {
     if (context.skipAfterBackdrop)
         return;
-    if (!isVisible())
+    if (!isVisible()) {
+#if ENABLE(DAMAGE_TRACKING)
+        if (context.collectsDamage() && frameDamagePropagationEnabled() && context.frameDamage)
+            recursiveConsumePreviousLayerRects(context.frameDamage->get());
+#endif
         return;
+    }
 
     SetForScope scopedOpacity(context.opacity, context.opacity * opacity());
 
@@ -1042,11 +1154,8 @@ void SkiaCompositingLayer::recursivePaint(SkCanvas& canvas, PaintContext& contex
     else
         paintWithOpacity(canvas, context);
 
-    // Drawn after the layer's own content, filters and masks have been composited
-    // into the parent, but still in tree order, so layers painted on top (e.g. a
-    // modal) occlude the indicators of the layers they cover.
-    if (context.mode == PaintMode::Paint && hasDebugIndicators())
-        paintDebugIndicators(canvas, context);
+    if (context.shouldDraw() && m_repaintCount)
+        paintRepaintCounter(canvas, context);
 }
 
 void SkiaCompositingLayer::computeOverlapRegions(ComputeOverlapRegionData& data, const TransformationMatrix& accumulatedReplicaTransform, IncludesReplica includesReplica)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -34,10 +34,13 @@
 #include "FloatPoint3D.h"
 #include "FloatRect.h"
 #include "FloatRoundedRect.h"
+#include "IntSize.h"
 #include "SkiaCompositingLayerImageSetBatch.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
+#include "SkiaDamageRestriction.h"
 #include "TextureMapperAnimation.h"
 #include "TransformationMatrix.h"
+#include <functional>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkCanvas.h>
 #include <skia/core/SkColorFilter.h>
@@ -45,6 +48,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkPath.h>
 #include <skia/effects/SkImageFilters.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/Function.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -92,7 +96,7 @@ public:
     void setChildren(Vector<Ref<SkiaCompositingLayer>>&&);
 
 #if ENABLE(DAMAGE_TRACKING)
-    void setSharedFrameDamage(std::shared_ptr<Damage> frameDamage) { m_sharedFrameDamage = WTF::move(frameDamage); }
+    void setDamagePropagationEnabled(bool enabled) { m_damagePropagationEnabled = enabled; }
     void addDamage(Damage&&);
 #endif
 
@@ -110,9 +114,18 @@ public:
     const TransformationMatrix& toSurfaceTransform() const { return m_transforms.combined; }
     FloatRect effectiveLayerRect() const { return FloatRect({ }, m_size); }
 
-    bool paint(SkCanvas&, std::optional<Damage>&);
+#if ENABLE(DAMAGE_TRACKING)
+    // Walks the tree without drawing to gather the frame damage that paint() limits itself to. Being
+    // the frame's first walk, it also applies animations and computes transforms.
+    void collectDamage(const IntSize& surfaceSize, Damage& frameDamage);
+#endif
 
-    bool hasDebugIndicators() const { return m_debugBorder.has_value() || m_repaintCount.has_value(); }
+    // No region paints everything. An empty region paints nothing, since the buffer is already current.
+    // Otherwise draw only the region's rects. Prepares transforms first unless collectDamage() did.
+    void paint(SkCanvas&, std::optional<DamageRegion>&& = std::nullopt);
+
+    // Whether the scene had running animations this frame. Valid after collectDamage() or paint().
+    bool hasRunningAnimations() const { return m_hadRunningAnimations; }
 
 private:
     using ScopedFlush = SkiaCompositingLayerImageSetBatch::ScopedFlush;
@@ -124,21 +137,26 @@ private:
     bool isLeafOf3DRenderingContext() const { return !m_preserves3D && (m_parent && m_parent->m_preserves3D); }
     bool isReplica() const { return !!m_replicatedLayer; }
     bool hasVisualContent() const;
+    bool hasVisiblePaintableContent() const { return !m_size.isEmpty() && m_visible && m_contentsVisible && hasVisualContent(); }
     Ref<SkiaCompositingLayer> backdropRoot();
 
     bool computeTransformsAndAnimations(const TransformationMatrix& parentTransform, const TransformationMatrix& futureParentTransform, MonotonicTime);
 
-    enum class PaintMode : bool {
-        Paint,
+    // Applies animations and computes transforms. The frame's first walk does the work, later ones
+    // do nothing. paint() clears the flag when it ends.
+    void ensurePrepared();
+
+    enum class PaintMode : uint8_t {
+        CollectDamage,
+        Paint
     };
 
     struct PaintContext {
-        explicit PaintContext(std::optional<Damage>& damage)
-            : frameDamage(damage)
-        {
-        }
+        bool shouldDraw() const { return mode == PaintMode::Paint; }
+        bool collectsDamage() const { return mode == PaintMode::CollectDamage; }
 
         PaintMode mode { PaintMode::Paint };
+        std::optional<DamageRegion> compositingDamageRegion;
         float opacity { 1 };
         std::optional<SkBlendMode> blendMode;
         IntSize offset;
@@ -146,7 +164,7 @@ private:
         TransformationMatrix accumulatedReplicaTransform;
         RefPtr<SkiaCompositingLayer> paintingBackdropForLayer;
         bool skipAfterBackdrop { false };
-        std::optional<Damage>& frameDamage;
+        std::optional<std::reference_wrapper<Damage>> frameDamage; // Set for the CollectDamage walk only.
         SkiaCompositingLayerImageSetBatch imageSetBatch;
     };
 
@@ -164,7 +182,9 @@ private:
     void paintWithFilterAndMask(SkCanvas&, PaintContext&);
     void paintSelf(SkCanvas&, PaintContext&);
     void paintContents(SkCanvas&, PaintContext&);
-    void paintDebugIndicators(SkCanvas&, PaintContext&);
+    void paintDebugBorder(SkCanvas&, PaintContext&);
+    void paintRepaintCounter(SkCanvas&, PaintContext&);
+    TransformationMatrix combinedTransform(const PaintContext&) const;
 #if ENABLE(DAMAGE_TRACKING)
     void collectFrameDamage(SkCanvas&, PaintContext&);
 #endif
@@ -185,7 +205,7 @@ private:
     void computeOverlapRegions(ComputeOverlapRegionData&, const TransformationMatrix& accumulatedReplicaTransform, IncludesReplica = IncludesReplica::Yes);
 
 #if ENABLE(DAMAGE_TRACKING)
-    bool frameDamagePropagationEnabled() const { return !!m_sharedFrameDamage; }
+    bool frameDamagePropagationEnabled() const { return m_damagePropagationEnabled; }
     void damageWholeLayer()
     {
         m_accumulatedOverlapRegionFrameDamage = { };
@@ -197,8 +217,10 @@ private:
         else
             m_layerDamage->makeFull();
     }
-    void addPreviousRectToSharedFrameDamage();
-    void recursiveAddPreviousRectToSharedFrameDamage(Ref<SkiaCompositingLayer>);
+    // Repaint the layer's last painted position once it moves, hides, or leaves the tree.
+    void consumePreviousLayerRect(Damage& frameDamage) { frameDamage.add(std::exchange(m_previousLayerRectInFrameCoordinates, { })); }
+    void recursiveConsumePreviousLayerRects(Damage&);
+    void recursiveMoveOrphanedPreviousLayerRects(Vector<FloatRect, 1>&);
 #endif
 
     struct AnimationsState {
@@ -275,12 +297,17 @@ private:
     bool m_shouldBlend { false };
     TextureMapperAnimations m_animations;
     std::optional<AnimationsState> m_animationsState;
+    bool m_preparedThisFrame { false };
+    bool m_hadRunningAnimations { false };
     struct {
         TransformationMatrix combined;
         TransformationMatrix futureCombined;
     } m_transforms;
 #if ENABLE(DAMAGE_TRACKING)
-    std::shared_ptr<Damage> m_sharedFrameDamage;
+    bool m_damagePropagationEnabled { false };
+    // Last positions of layers removed since the last collect. They still need a repaint even though
+    // the walk no longer visits them.
+    Vector<FloatRect, 1> m_orphanedPreviousLayerRects;
     std::optional<Damage> m_layerDamage;
     FloatRect m_previousLayerRectInFrameCoordinates;
     FloatRect m_accumulatedOverlapRegionFrameDamage;

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
@@ -30,7 +30,9 @@
 #include "BitmapTexture.h"
 #include "CoordinatedTileBuffer.h"
 #include "FloatRect.h"
+#include "IntRect.h"
 #include "SkiaBackingStore.h"
+#include "SkiaDamageRestriction.h"
 
 namespace WebCore {
 
@@ -51,26 +53,57 @@ void SkiaCompositingLayerImageSetBatch::updateSamplingOptions(SkCanvas& canvas, 
     m_samplingOptions = samplingOptions;
 }
 
-void SkiaCompositingLayerImageSetBatch::addImageSet(SkCanvas& canvas, SkiaBackingStore& backingStore, const SkMatrix& ctm, float opacity, bool enableAntialias)
+void SkiaCompositingLayerImageSetBatch::appendImageSet(Vector<SkCanvas::ImageSetEntry>&& imageSet)
 {
-    updateSamplingOptions(canvas, SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone));
-
-    if (m_preViewMatrices.isEmpty() || m_preViewMatrices.last() != ctm)
-        m_preViewMatrices.append(ctm);
-
-    auto imageSet = backingStore.buildImageSet(canvas, ctm, m_preViewMatrices.size() - 1, opacity, enableAntialias);
     if (m_imageSet.isEmpty())
         m_imageSet = WTF::move(imageSet);
     else
         m_imageSet.appendVector(WTF::move(imageSet));
 }
 
-void SkiaCompositingLayerImageSetBatch::addImage(SkCanvas& canvas, const sk_sp<SkImage>& image, const FloatRect& rect, const FloatRect& clip, const SkMatrix& ctm, float opacity, bool enableAntialias)
+size_t SkiaCompositingLayerImageSetBatch::matrixIndexForDraw(SkCanvas& canvas, const SkMatrix& ctm, const SkSamplingOptions& sampling)
 {
-    updateSamplingOptions(canvas, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone));
+    updateSamplingOptions(canvas, sampling);
 
     if (m_preViewMatrices.isEmpty() || m_preViewMatrices.last() != ctm)
         m_preViewMatrices.append(ctm);
+
+    return m_preViewMatrices.size() - 1;
+}
+
+void SkiaCompositingLayerImageSetBatch::addImageSet(SkCanvas& canvas, SkiaBackingStore& backingStore, const SkMatrix& ctm, float opacity, bool enableAntialias)
+{
+    const auto matrixIndex = matrixIndexForDraw(canvas, ctm, SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone));
+    appendImageSet(backingStore.buildImageSet(canvas, ctm, matrixIndex, opacity, enableAntialias));
+}
+
+bool SkiaCompositingLayerImageSetBatch::addImageSetRestrictedToDamage(SkCanvas& canvas, SkiaBackingStore& backingStore, const SkMatrix& ctm, float opacity, const Vector<IntRect>& damageRects)
+{
+    ASSERT(!damageRects.isEmpty());
+
+    SkRect layerDeviceRect;
+    ctm.mapRect(&layerDeviceRect, SkRect(FloatRect { { }, backingStore.size() }));
+
+    const auto plan = planDrawRestriction(ctm, layerDeviceRect, damageRects.span());
+    switch (plan.kind) {
+    case DrawRestrictionPlan::Kind::SkipDraw:
+        // Fully outside the damage, so it draws nothing and stays batched.
+        return true;
+    case DrawRestrictionPlan::Kind::ClipFallback:
+        // Can't narrow this to single rects, so let the caller flush and draw the tiles under a damage clip.
+        return false;
+    case DrawRestrictionPlan::Kind::PerRect:
+        break;
+    }
+
+    const auto matrixIndex = matrixIndexForDraw(canvas, ctm, SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone));
+    appendImageSet(backingStore.buildImageSet(canvas, ctm, matrixIndex, opacity, false, SkiaBackingStore::TilingDamageRestriction { ctm, plan.inverse, plan.rects.span() }));
+    return true;
+}
+
+void SkiaCompositingLayerImageSetBatch::addImage(SkCanvas& canvas, const sk_sp<SkImage>& image, const FloatRect& rect, const FloatRect& clip, const SkMatrix& ctm, float opacity, bool enableAntialias)
+{
+    const size_t matrixIndex = matrixIndexForDraw(canvas, ctm, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone));
 
     if (!clip.isEmpty()) {
         auto quad = SkRect(clip).toQuad();
@@ -78,9 +111,36 @@ void SkiaCompositingLayerImageSetBatch::addImage(SkCanvas& canvas, const sk_sp<S
             m_dstClips.append(point);
     }
 
-    size_t matrixIndex = m_preViewMatrices.size() - 1;
     unsigned aaFlags = enableAntialias ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
     m_imageSet.append(SkCanvas::ImageSetEntry(image, SkRect::MakeWH(image->width(), image->height()), SkRect(rect), matrixIndex, opacity, aaFlags, !clip.isEmpty()));
+}
+
+bool SkiaCompositingLayerImageSetBatch::addImageRestrictedToDamage(SkCanvas& canvas, const sk_sp<SkImage>& image, const FloatRect& rect, const SkMatrix& ctm, float opacity, const Vector<IntRect>& damageRects)
+{
+    ASSERT(!damageRects.isEmpty());
+
+    const SkRect srcRectFull = SkRect::MakeWH(image->width(), image->height());
+    const SkRect dstRectFull = SkRect(rect);
+    SkRect deviceRect;
+    ctm.mapRect(&deviceRect, dstRectFull);
+
+    const auto plan = planDrawRestriction(ctm, deviceRect, damageRects.span());
+    switch (plan.kind) {
+    case DrawRestrictionPlan::Kind::SkipDraw:
+        // Fully outside the damage, so it draws nothing and stays batched.
+        return true;
+    case DrawRestrictionPlan::Kind::ClipFallback:
+        // Can't narrow this to single rects, so let the caller flush and draw the image under a damage clip.
+        return false;
+    case DrawRestrictionPlan::Kind::PerRect:
+        break;
+    }
+
+    const auto matrixIndex = matrixIndexForDraw(canvas, ctm, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone));
+    forEachDamagedSubRect(deviceRect, dstRectFull, srcRectFull, plan.inverse, plan.rects.span(), [&](const SkRect& srcSubRect, const SkRect& dstSubRect) {
+        m_imageSet.append(SkCanvas::ImageSetEntry(image, srcSubRect, dstSubRect, matrixIndex, opacity, SkCanvas::kNone_QuadAAFlags, false));
+    });
+    return true;
 }
 
 void SkiaCompositingLayerImageSetBatch::flushIfNeeded(SkCanvas& canvas)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
@@ -38,6 +38,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 class FloatRect;
+class IntRect;
 class SkiaBackingStore;
 
 class SkiaCompositingLayerImageSetBatch {
@@ -50,7 +51,9 @@ public:
     void updatePaintProperties(SkCanvas&, const sk_sp<SkColorFilter>&, const std::optional<SkBlendMode>&);
     void updateSamplingOptions(SkCanvas&, SkSamplingOptions);
     void addImageSet(SkCanvas&, SkiaBackingStore&, const SkMatrix&, float opacity, bool enableAntialias);
+    bool addImageSetRestrictedToDamage(SkCanvas&, SkiaBackingStore&, const SkMatrix&, float opacity, const Vector<IntRect>& damageRects);
     void addImage(SkCanvas&, const sk_sp<SkImage>&, const FloatRect&, const FloatRect& clip, const SkMatrix&, float opacity, bool enableAntialias);
+    bool addImageRestrictedToDamage(SkCanvas&, const sk_sp<SkImage>&, const FloatRect&, const SkMatrix&, float opacity, const Vector<IntRect>& damageRects);
     void flushIfNeeded(SkCanvas&);
 
     class ScopedFlush {
@@ -72,6 +75,9 @@ public:
     };
 
 private:
+    size_t matrixIndexForDraw(SkCanvas&, const SkMatrix& ctm, const SkSamplingOptions&);
+    void appendImageSet(Vector<SkCanvas::ImageSetEntry>&&);
+
     Vector<SkCanvas::ImageSetEntry> m_imageSet;
     Vector<SkPoint> m_dstClips;
     Vector<SkMatrix> m_preViewMatrices;

--- a/Source/WebCore/platform/graphics/skia/SkiaDamageRestriction.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaDamageRestriction.h
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Damage.h"
+#include "FloatRect.h"
+#include "GeometryUtilities.h"
+#include "IntRect.h"
+
+#include <optional>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkCanvas.h>
+#include <skia/core/SkMatrix.h>
+#include <skia/core/SkRect.h>
+#include <skia/core/SkRegion.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+#include <span>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+// Above this many damage rects touching a draw, use one clipped draw instead of one draw per rect.
+// Only rects that touch the draw count, not the whole frame.
+static constexpr unsigned cMaxDamageRectsForPerRectDraw = 4;
+
+inline SkRect mapDamageSourceSubRect(const SkRect& dstSubRect, const SkRect& dstRectFull, const SkRect& srcRectFull)
+{
+    return mapRect(FloatRect(dstSubRect), FloatRect(dstRectFull), FloatRect(srcRectFull));
+}
+
+// The frame's damage rects in surface space and the same rects as an SkRegion. The rects never
+// overlap. Built once per frame.
+struct DamageRegion {
+    Vector<IntRect> rects;
+    SkRegion region;
+};
+
+// How to paint this frame, decided from the render target's repaint region.
+// FullRepaint - the region is unknown or covers the whole surface, so clear and repaint everything.
+// SkipPaint - the buffer is already current, so there is nothing to do.
+// RestrictToDamage - clear and composite only the damage region.
+struct FrameRestrictionPlan {
+    enum class Kind : uint8_t {
+        FullRepaint,
+        SkipPaint,
+        RestrictToDamage
+    };
+
+    Kind kind { Kind::FullRepaint };
+    std::optional<DamageRegion> damageRegion; // Set only for RestrictToDamage.
+};
+
+inline FrameRestrictionPlan planFrameRestriction(const std::optional<Damage>& repaintRegion, const IntSize& surfaceSize)
+{
+    FrameRestrictionPlan plan;
+    if (!repaintRegion)
+        return plan;
+
+    if (repaintRegion->isEmpty()) {
+        plan.kind = FrameRestrictionPlan::Kind::SkipPaint;
+        return plan;
+    }
+
+    if (repaintRegion->bounds().contains(IntRect { { }, surfaceSize }))
+        return plan;
+
+    // Damage::rectsForPainting() returns rects that never overlap, which the restriction relies on.
+    // Build the SkRegion here too so clip sites don't have to rebuild it from the rects.
+    plan.kind = FrameRestrictionPlan::Kind::RestrictToDamage;
+    DamageRegion damageRegion;
+    damageRegion.rects = repaintRegion->rectsForPainting();
+    Vector<SkIRect> skiaRects;
+    skiaRects.reserveInitialCapacity(damageRegion.rects.size());
+    for (const auto& rect : damageRegion.rects)
+        skiaRects.append(rect);
+    damageRegion.region.setRects(skiaRects.span().data(), skiaRects.size());
+    plan.damageRegion = WTF::move(damageRegion);
+    return plan;
+}
+
+// How to limit one draw (a layer's tiles, an image or a rect) to the damage.
+// SkipDraw - nothing touches the damage.
+// PerRect - one draw per touched rect, narrowed in local coords (this also narrows the image source).
+//           Needs a rect-preserving CTM and few rects. Inverse and rects are set only then.
+// ClipFallback - rotated or skewed CTM, or too many rects, so use one draw under a device-space clip.
+struct DrawRestrictionPlan {
+    enum class Kind : uint8_t {
+        SkipDraw,
+        PerRect,
+        ClipFallback
+    };
+
+    Kind kind { Kind::SkipDraw };
+    SkMatrix inverse;
+    Vector<IntRect, cMaxDamageRectsForPerRectDraw> rects;
+};
+
+inline DrawRestrictionPlan planDrawRestriction(const SkMatrix& ctm, const SkRect& deviceRect, std::span<const IntRect> damageRects)
+{
+    DrawRestrictionPlan plan;
+    bool tooManyRects = false;
+    for (const auto& rect : damageRects) {
+        if (!SkRect::Make(rect).intersects(deviceRect))
+            continue;
+        if (plan.rects.size() == cMaxDamageRectsForPerRectDraw) {
+            tooManyRects = true;
+            break;
+        }
+        plan.rects.append(rect);
+    }
+
+    if (plan.rects.isEmpty())
+        return plan;
+
+    if (tooManyRects || !ctm.rectStaysRect() || !ctm.invert(&plan.inverse)) {
+        plan.rects.clear();
+        plan.kind = DrawRestrictionPlan::Kind::ClipFallback;
+        return plan;
+    }
+
+    plan.kind = DrawRestrictionPlan::Kind::PerRect;
+    return plan;
+}
+
+// Calls emit(srcSubRect, dstSubRect) once per damage rect that touches deviceRect, narrowing the source
+// to the damaged sub-rect. deviceRect is dstRectFull under the rectilinear ctm, and inverseCtm maps
+// device rects back. A tile fully covered by one rect emits a single full entry. The rects never overlap.
+template<typename EmitFunction>
+void forEachDamagedSubRect(const SkRect& deviceRect, const SkRect& dstRectFull, const SkRect& srcRectFull, const SkMatrix& inverseCtm, std::span<const IntRect> damageRects, NOESCAPE const EmitFunction& emit)
+{
+    for (const auto& rect : damageRects) {
+        SkRect damaged = SkRect::Make(rect);
+        if (!damaged.intersect(deviceRect))
+            continue;
+        if (damaged == deviceRect) {
+            emit(srcRectFull, dstRectFull);
+            return;
+        }
+        SkRect dstSubRect;
+        inverseCtm.mapRect(&dstSubRect, damaged);
+        emit(mapDamageSourceSubRect(dstSubRect, dstRectFull, srcRectFull), dstSubRect);
+    }
+}
+
+inline void clipToDamageInDeviceSpace(SkCanvas& canvas, const DamageRegion& damageRegion)
+{
+    // An empty region would clip everything out, which no caller wants.
+    ASSERT(!damageRegion.rects.isEmpty());
+
+    // The region is in device space, so clip with it directly - no CTM inversion or path building.
+    canvas.clipRegion(damageRegion.region, SkClipOp::kIntersect);
+}
+
+// Replays draw(srcSubRect, dstSubRect) limited to the damage region's rects. The rects never overlap,
+// because overlapping rects would composite translucent content more than once.
+template<typename DrawFunction>
+void drawRestrictedToDamage(SkCanvas& canvas, const std::optional<DamageRegion>& damageRegion, const SkRect& srcRectFull, const SkRect& dstRectFull, NOESCAPE const DrawFunction& draw)
+{
+    if (!damageRegion) {
+        draw(srcRectFull, dstRectFull);
+        return;
+    }
+
+    ASSERT(!damageRegion->rects.isEmpty());
+
+    const auto ctm = canvas.getLocalToDeviceAs3x3();
+    SkRect deviceRect;
+    ctm.mapRect(&deviceRect, dstRectFull);
+
+    const auto plan = planDrawRestriction(ctm, deviceRect, damageRegion->rects.span());
+    switch (plan.kind) {
+    case DrawRestrictionPlan::Kind::SkipDraw:
+        return;
+    case DrawRestrictionPlan::Kind::PerRect:
+        forEachDamagedSubRect(deviceRect, dstRectFull, srcRectFull, plan.inverse, plan.rects.span(), draw);
+        return;
+    case DrawRestrictionPlan::Kind::ClipFallback: {
+        SkAutoCanvasRestore autoRestore(&canvas, true);
+        clipToDamageInDeviceSpace(canvas, *damageRegion);
+        draw(srcRectFull, dstRectFull);
+        return;
+    }
+    }
+}
+
+inline void drawRectRestrictedToDamage(SkCanvas& canvas, const std::optional<DamageRegion>& damageRegion, const SkRect& localRect, const SkPaint& paint)
+{
+    drawRestrictedToDamage(canvas, damageRegion, localRect, localRect, [&](const SkRect&, const SkRect& dstSubRect) {
+        canvas.drawRect(dstSubRect, paint);
+    });
+}
+
+inline void drawImageRectRestrictedToDamage(SkCanvas& canvas, const SkImage* image, const SkRect& srcRectFull, const SkRect& dstRectFull, const SkSamplingOptions& sampling, const SkPaint* paint, const std::optional<DamageRegion>& damageRegion)
+{
+    drawRestrictedToDamage(canvas, damageRegion, srcRectFull, dstRectFull, [&](const SkRect& srcSubRect, const SkRect& dstSubRect) {
+        canvas.drawImageRect(image, srcSubRect, dstSubRect, sampling, paint, SkCanvas::kFast_SrcRectConstraint);
+    });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -119,8 +119,7 @@ SkiaCompositingLayer& CoordinatedPlatformLayer::ensureSkiaTarget()
     if (!m_skiaTarget)
         m_skiaTarget = SkiaCompositingLayer::create();
 #if ENABLE(DAMAGE_TRACKING)
-    if (m_damagePropagationEnabled)
-        m_skiaTarget->setSharedFrameDamage(m_damageInGlobalCoordinateSpace);
+    m_skiaTarget->setDamagePropagationEnabled(m_damagePropagationEnabled);
 #endif
     return *m_skiaTarget;
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -147,18 +147,6 @@ AcceleratedSurface::RenderTarget::RenderTarget(AcceleratedSurface& surface)
 
 AcceleratedSurface::RenderTarget::~RenderTarget() = default;
 
-#if ENABLE(DAMAGE_TRACKING)
-void AcceleratedSurface::RenderTarget::addDamage(const std::optional<Damage>& damage)
-{
-    if (!m_damage)
-        return;
-
-    if (damage)
-        m_damage->add(*damage);
-    else
-        m_damage = std::nullopt;
-}
-#endif
 
 void AcceleratedSurface::RenderTarget::createSkiaSurfaceForTexture(const BitmapTexture& texture)
 {
@@ -899,6 +887,17 @@ uint64_t AcceleratedSurface::SwapChain::window()
 #endif
 
 #if ENABLE(DAMAGE_TRACKING)
+void AcceleratedSurface::SwapChainDamageTracker::recordFrameDamage(Damage&& damage, AccumulateIntoSwapChain accumulate)
+{
+    m_frameDamage = WTF::move(damage);
+    m_frameDamageAccumulatedIntoSwapChain = false;
+
+    // When the caller drives compositing from damage, accumulate right away so a later frame that
+    // reuses a buffer without reading renderTargetDamage still repaints what changed this frame.
+    if (accumulate == AccumulateIntoSwapChain::Yes)
+        accumulateFrameDamageIntoSwapChain();
+}
+
 Vector<IntRect, 1> AcceleratedSurface::SwapChainDamageTracker::takeFrameDamageRects()
 {
     if (!m_frameDamage)
@@ -907,12 +906,40 @@ Vector<IntRect, 1> AcceleratedSurface::SwapChainDamageTracker::takeFrameDamageRe
     return std::exchange(m_frameDamage, std::nullopt)->rects();
 }
 
+void AcceleratedSurface::SwapChainDamageTracker::accumulateFrameDamageIntoSwapChain()
+{
+    // Add this frame's damage to every buffer so each repaints what changed since it was last
+    // rendered. The flag makes this run at most once per frame. No m_frameDamage means nothing changed.
+    if (m_frameDamageAccumulatedIntoSwapChain || !m_frameDamage)
+        return;
+
+    m_swapChain.forEachTarget([&](RenderTarget& target) {
+        target.addDamage(*m_frameDamage);
+    });
+    m_frameDamageAccumulatedIntoSwapChain = true;
+}
+
 const std::optional<Damage>& AcceleratedSurface::SwapChainDamageTracker::damageForTarget(RenderTarget& target)
 {
-    m_swapChain.forEachTarget([&](RenderTarget& candidate) {
-        candidate.addDamage(m_frameDamage);
-    });
+    // Accumulate on read so the result always includes this frame's damage, whatever the caller order.
+    accumulateFrameDamageIntoSwapChain();
     return target.damage();
+}
+
+void AcceleratedSurface::SwapChainDamageTracker::didPresent(RenderTarget& target, FramePainted framePainted, FineGrainedDamage fineGrainedDamage)
+{
+    if (framePainted == FramePainted::No) {
+        // Nothing was drawn, so drop the record and let the buffer's next use repaint it fully.
+        target.setDamage(std::nullopt);
+        return;
+    }
+
+    // The buffer is now current, so start a fresh, empty record. This damage drives compositing
+    // restriction, so it must stay small. Use Damage's default fine-grained grid (NoMaxRectangles)
+    // rather than the rectangle threshold, which on a wide, short surface would collapse into a few
+    // full-height cells. The threshold only bounds how many rects reach the platform, and is applied
+    // in takeFrameDamageRects().
+    target.setDamage(Damage(m_swapChain.size(), fineGrainedDamage == FineGrainedDamage::Yes ? Damage::Mode::Rectangles : Damage::Mode::BoundingBox, Damage::NoMaxRectangles));
 }
 #endif
 
@@ -1099,7 +1126,7 @@ void AcceleratedSurface::clear(const OptionSet<WebCore::CompositionReason>& reas
     }
 }
 
-void AcceleratedSurface::didRenderFrame()
+void AcceleratedSurface::didRenderFrame(FramePainted framePainted, DamageUsedForCompositing damageUsedForCompositing)
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
     TraceScope traceScope(WaitForCompositionCompletionStart, WaitForCompositionCompletionEnd);
@@ -1113,11 +1140,10 @@ void AcceleratedSurface::didRenderFrame()
 
     Vector<IntRect, 1> damageRects;
 #if ENABLE(DAMAGE_TRACKING)
-    // For GL targets we use bounding box damage for render target damage, as its only 2 consumers so far
-    // (CoordinatedBackingStore & ThreadedCompositor) only fetch bounds. Thus having damage with
-    // better resolution is pointless as the bounds are the same in such case.
-    // FIXME: If we start to consume fine-grained damage in the Skia compositor, we will need to relax the usesGL condition.
-    m_target->setDamage(Damage(m_swapChain.size(), usesGL() ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles, m_damageTracker.rectangleThreshold()));
+    // GL consumers only read the damage bounds, so a bounding box is enough. Rectangles are needed
+    // when the Skia compositor draws only the rects, and for CPU rendering to limit GPU uploads.
+    const bool needsFineGrainedDamage = damageUsedForCompositing == DamageUsedForCompositing::Yes || !usesGL();
+    m_damageTracker.didPresent(*m_target, framePainted, needsFineGrainedDamage ? SwapChainDamageTracker::FineGrainedDamage::Yes : SwapChainDamageTracker::FineGrainedDamage::No);
     damageRects = m_damageTracker.takeFrameDamageRects();
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -98,6 +98,9 @@ public:
         NonComposited,
     };
 
+    enum class FramePainted : bool { No, Yes };
+    enum class DamageUsedForCompositing : bool { No, Yes };
+
     static Ref<AcceleratedSurface> create(WebPage&, Function<void()>&& frameCompleteHandler, RenderingPurpose, bool useSkia);
     ~AcceleratedSurface();
 
@@ -127,12 +130,13 @@ public:
 
     void willDestroyGLContext();
     void willRenderFrame(const WebCore::IntSize&);
-    void didRenderFrame();
+    void didRenderFrame(FramePainted = FramePainted::Yes, DamageUsedForCompositing = DamageUsedForCompositing::No);
     void sendFrame();
     void clear(const OptionSet<WebCore::CompositionReason>&);
 
 #if ENABLE(DAMAGE_TRACKING)
-    void setFrameDamage(WebCore::Damage&& damage) { m_damageTracker.recordFrameDamage(WTF::move(damage)); }
+    enum class AccumulateIntoSwapChain : bool { No, Yes };
+    void setFrameDamage(WebCore::Damage&& damage, AccumulateIntoSwapChain accumulate = AccumulateIntoSwapChain::No) { m_damageTracker.recordFrameDamage(WTF::move(damage), accumulate); }
     void setFrameDamageRectangleThreshold(unsigned threshold) { m_damageTracker.setRectangleThreshold(threshold); }
     const std::optional<WebCore::Damage>& frameDamage() const LIFETIME_BOUND { return m_damageTracker.frameDamage(); }
     const std::optional<WebCore::Damage>& renderTargetDamage();
@@ -184,9 +188,13 @@ private:
         SkSurface* skiaSurface() const { return m_skiaSurface.get(); }
 
 #if ENABLE(DAMAGE_TRACKING)
-        void setDamage(WebCore::Damage&& damage) { m_damage = WTF::move(damage); }
+        void setDamage(std::optional<WebCore::Damage>&& damage) { m_damage = WTF::move(damage); }
         const std::optional<WebCore::Damage>& damage() LIFETIME_BOUND { return m_damage; }
-        void addDamage(const std::optional<WebCore::Damage>&);
+        void addDamage(const WebCore::Damage& damage)
+        {
+            if (m_damage)
+                m_damage->add(damage);
+        }
 #endif
 
     protected:
@@ -417,23 +425,32 @@ private:
         }
 
         void setRectangleThreshold(unsigned threshold) { m_rectangleThreshold = threshold; }
-        unsigned rectangleThreshold() const { return m_rectangleThreshold; }
 
-        // This frame's content change vs the last presented frame - propagated to the platform.
-        void recordFrameDamage(WebCore::Damage&& damage) { m_frameDamage = WTF::move(damage); }
+        // What changed in this frame compared to the last presented frame, sent to the platform.
+        // Accumulate adds the damage to every buffer right away, for callers that drive compositing
+        // from damage but never read renderTargetDamage this frame.
+        void recordFrameDamage(WebCore::Damage&&, AccumulateIntoSwapChain = AccumulateIntoSwapChain::No);
         const std::optional<WebCore::Damage>& frameDamage() const LIFETIME_BOUND { return m_frameDamage; }
         Vector<WebCore::IntRect, 1> takeFrameDamageRects();
 
-        // Propagates this frame's damage into every buffer and returns the given buffer's accumulated damage.
+        // What the given buffer must redraw to become current, including this frame's damage.
         const std::optional<WebCore::Damage>& damageForTarget(RenderTarget&);
+
+        enum class FineGrainedDamage : bool { No, Yes };
+        void didPresent(RenderTarget&, FramePainted, FineGrainedDamage);
 
         // Discards the pending frame damage, e.g. when the swap chain is resized.
         void reset() { m_frameDamage = std::nullopt; }
 
     private:
+        void accumulateFrameDamageIntoSwapChain();
+
         SwapChain& m_swapChain;
         std::optional<WebCore::Damage> m_frameDamage;
+        // Most rects sent to the platform before they merge into their bounding box. This bounds only
+        // takeFrameDamageRects(). The per-buffer compositing damage stays fine-grained.
         unsigned m_rectangleThreshold { 4 };
+        bool m_frameDamageAccumulatedIntoSwapChain { false };
     };
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -191,6 +191,11 @@ void LayerTreeHost::updateRendering()
     if (RefPtr drawingArea = page->drawingArea())
         drawingArea->dispatchPendingCallbacksAfterEnsuringDrawing();
 
+#if ENABLE(DAMAGE_TRACKING)
+    const auto& settings = page->corePage()->settings();
+    m_compositor->setDebugIndicatorsEnabled(settings.showDebugBorders() || settings.showRepaintCounter());
+#endif
+
     bool didChangeSceneState = m_sceneState->flush();
     if (m_compositionRequired || m_pendingResize || m_forceFrameSync || didChangeSceneState)
         requestCompositionForRenderingUpdate();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -36,10 +36,12 @@
 #include <WebCore/CoordinatedPlatformLayer.h>
 #include <WebCore/Damage.h>
 #include <WebCore/FontCache.h>
+#include <WebCore/IntRect.h>
 #include <WebCore/Page.h>
 #include <WebCore/PlatformDisplay.h>
 #include <WebCore/Settings.h>
 #include <WebCore/SkiaCompositingLayer.h>
+#include <WebCore/SkiaDamageRestriction.h>
 #include <WebCore/TextureMapperLayer.h>
 #include <WebCore/TransformationMatrix.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -51,6 +53,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/SetForScope.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Vector.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 #if USE(GLIB_EVENT_LOOP)
@@ -82,6 +85,9 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
     , m_sceneState(&sceneState)
     , m_flipY(m_surface->shouldPaintMirrored())
     , m_renderTimer(m_workQueue->runLoop(), "ThreadedCompositor::RenderTimer"_s, this, &ThreadedCompositor::renderLayerTree)
+#if ENABLE(DAMAGE_TRACKING)
+    , m_damageStatsTimer(m_workQueue->runLoop(), "ThreadedCompositor::DamageStatsTimer"_s, this, &ThreadedCompositor::dumpDamageStats)
+#endif
 {
     ASSERT(RunLoop::isMain());
 
@@ -92,14 +98,18 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
     initializeFPSCounter();
 #if ENABLE(DAMAGE_TRACKING)
     if (m_useSkia) {
-        // WEBKIT_SHOW_DAMAGE=N renders the frame damage rects, insetting them
-        // by N-1 pixels (mirrors TextureMapperDamageVisualizer's behavior).
-        if (const auto* showDamageVariable = getenv("WEBKIT_SHOW_DAMAGE")) {
-            if (auto value = parseInteger<unsigned>(StringView::fromLatin1(showDamageVariable)); value && *value) {
-                m_damage.showSkiaDamage = true;
-                m_damage.skiaDamageMargin = *value - 1;
-            }
+        // WEBKIT_DAMAGE_DEBUG shows Skia frame damage.
+        //   1: this frame's damage as a translucent blue overlay
+        //   2: the buffer's whole accumulated damage as a translucent green overlay
+        //   3: clear the scene to black and redraw only the damaged region
+        if (const auto* damageDebugVariable = getenv("WEBKIT_DAMAGE_DEBUG")) {
+            if (auto value = parseInteger<unsigned>(StringView::fromLatin1(damageDebugVariable)); value && *value <= 3)
+                m_damage.debugMode = static_cast<DamageDebugMode>(*value);
         }
+
+        // WEBKIT_DAMAGE_STATS logs rolling averages of how fine-grained the damage is (see recordDamageStats).
+        if (getenv("WEBKIT_DAMAGE_STATS"))
+            m_damageStats.enabled = true;
     } else
         m_damage.visualizer = TextureMapperDamageVisualizer::create();
 #endif
@@ -132,6 +142,15 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
             if (!nativeSurfaceHandle)
                 m_flipY = !m_flipY;
         }
+
+#if ENABLE(DAMAGE_TRACKING)
+        // Dump stats on a wall clock from the compositor thread, so a window is reported even when
+        // the page is idle and no frame is drawn.
+        if (m_damageStats.enabled) {
+            m_damageStats.lastDump = MonotonicTime::now();
+            m_damageStatsTimer.startRepeating(m_damageStats.window);
+        }
+#endif
     });
 }
 
@@ -156,6 +175,9 @@ void ThreadedCompositor::invalidate()
 
     m_didCompositeRunLoopObserver->invalidate();
     m_workQueue->dispatchSync([this] {
+#if ENABLE(DAMAGE_TRACKING)
+        m_damageStatsTimer.stop();
+#endif
         if (!m_useSkia && (!m_context || !m_context->makeContextCurrent()))
             return;
 
@@ -289,11 +311,14 @@ void ThreadedCompositor::setSize(const IntSize& size, float deviceScaleFactor)
 void ThreadedCompositor::setDamagePropagationSettings(std::optional<OptionSet<DamagePropagationFlags>> flags, unsigned rectangleThreshold)
 {
     m_damage.flags = flags;
-    if ((m_damage.visualizer || m_damage.showSkiaDamage) && m_damage.flags) {
-        // We don't use damage when rendering layers if the visualizer is enabled, because we need to make sure the whole
-        // frame is invalidated in the next paint so that previous damage rects are cleared.
+    if (m_damage.visualizer && m_damage.flags) {
+        // The TextureMapper damage visualizer needs the whole frame invalidated each paint to clear
+        // the previous frame's overlay, so don't drive compositing from damage.
         m_damage.flags->remove(DamagePropagationFlags::UseForCompositing);
     }
+    // WEBKIT_DAMAGE_DEBUG (Skia) keeps UseForCompositing so the damage pipeline runs unchanged. The
+    // restriction is just not applied while overlays show (see paintToSkiaCanvas), so the whole frame
+    // repaints to erase the previous overlay.
 
     rectangleThreshold = Damage::clampRectangleThreshold(rectangleThreshold);
     m_damage.rectangleThreshold = rectangleThreshold;
@@ -322,12 +347,13 @@ void ThreadedCompositor::flushCompositingState(const OptionSet<CompositionReason
     m_sceneState->flushCompositingState(reasons, m_useSkia);
 }
 
-void ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
+bool ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
 {
     if (m_useSkia)
-        paintToSkiaCanvas(matrix, size, reasons);
-    else
-        paintToTextureMapper(matrix, size, reasons);
+        return paintToSkiaCanvas(matrix, size, reasons);
+
+    paintToTextureMapper(matrix, size, reasons);
+    return true;
 }
 
 void ThreadedCompositor::paintToTextureMapper(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
@@ -352,18 +378,21 @@ void ThreadedCompositor::paintToTextureMapper(const TransformationMatrix& matrix
         currentRootLayer.collectDamage(*m_textureMapper, frameDamage);
         WTFEndSignpost(this, CollectDamage);
 
-        if (m_damage.shouldNotifyFrameDamageForTesting && m_layerTreeHost)
-            m_layerTreeHost->notifyFrameDamageForTesting(frameDamage.regionForTesting());
+        const bool debugIndicatorsEnabled = m_damage.debugIndicatorsEnabled;
+        const bool useForCompositing = m_damage.flags->contains(DamagePropagationFlags::UseForCompositing);
+        recordFrameDamage(WTF::move(frameDamage), debugIndicatorsEnabled ? DebugOverlays::Yes : DebugOverlays::No, useForCompositing ? AcceleratedSurface::AccumulateIntoSwapChain::Yes : AcceleratedSurface::AccumulateIntoSwapChain::No);
 
-        if (!frameDamage.isEmpty())
-            m_surface->setFrameDamage(WTF::move(frameDamage));
+        if (useForCompositing) {
+            if (debugIndicatorsEnabled) {
+                // Repaint the whole frame while indicators show. Damage is unknown, so skip the scissor below.
+                m_textureMapper->setDamage(std::nullopt);
+            } else {
+                const auto& damageSinceLastSurfaceUse = m_surface->renderTargetDamage();
+                if (damageSinceLastSurfaceUse && !FloatRect(damageSinceLastSurfaceUse->bounds()).contains(clipRect))
+                    rectContainingRegionThatActuallyChanged = FloatRoundedRect(damageSinceLastSurfaceUse->bounds());
 
-        if (m_damage.flags->contains(DamagePropagationFlags::UseForCompositing)) {
-            const auto& damageSinceLastSurfaceUse = m_surface->renderTargetDamage();
-            if (damageSinceLastSurfaceUse && !FloatRect(damageSinceLastSurfaceUse->bounds()).contains(clipRect))
-                rectContainingRegionThatActuallyChanged = FloatRoundedRect(damageSinceLastSurfaceUse->bounds());
-
-            m_textureMapper->setDamage(damageSinceLastSurfaceUse);
+                m_textureMapper->setDamage(damageSinceLastSurfaceUse);
+            }
         }
     }
 
@@ -398,47 +427,215 @@ void ThreadedCompositor::paintToTextureMapper(const TransformationMatrix& matrix
         requestComposition(CompositionReason::Animation);
 }
 
-void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
+#if ENABLE(DAMAGE_TRACKING)
+void ThreadedCompositor::recordFrameDamage(Damage&& damage, DebugOverlays debugOverlays, AcceleratedSurface::AccumulateIntoSwapChain accumulate)
+{
+    // Debug overlays aren't part of the layer-tree damage and can move anywhere, so record full-frame
+    // damage. This makes them present, and makes buffers repaint fully once the overlays are turned off.
+    if (debugOverlays == DebugOverlays::Yes)
+        damage.makeFull();
+
+    if (m_damage.shouldNotifyFrameDamageForTesting && m_layerTreeHost)
+        m_layerTreeHost->notifyFrameDamageForTesting(damage.regionForTesting());
+
+    // Skip empty damage, because accumulating it would mark every swap-chain buffer fully damaged.
+    if (damage.isEmpty())
+        return;
+
+    m_surface->setFrameDamage(WTF::move(damage), accumulate);
+}
+
+static void drawDamageOverlay(SkCanvas& canvas, const Damage& damage, SkColor color)
+{
+    SkPaint paint;
+    paint.setStyle(SkPaint::kFill_Style);
+    paint.setColor(color);
+
+    for (const auto& rect : damage.rectsForPainting())
+        canvas.drawRect(SkRect::MakeXYWH(rect.x(), rect.y(), rect.width(), rect.height()), paint);
+}
+
+static std::pair<unsigned, uint64_t> damageMetrics(const std::optional<Damage>& damage)
+{
+    if (!damage)
+        return { 0, 0 };
+
+    // rects() may return overlapping rectangles (see Damage::rects()), so simply adding their areas
+    // would count shared pixels twice and can exceed the viewport area. Unite them into a Region to
+    // measure the real coverage without overlaps.
+    const auto rects = damage->rects();
+    Region region;
+    for (const auto& rect : rects)
+        region.unite(Region { rect });
+    return { static_cast<unsigned>(rects.size()), region.totalArea() };
+}
+
+void ThreadedCompositor::recordDamageStats(const IntSize& viewport, bool compositingUsesDamage)
+{
+    if (!m_damageStats.enabled)
+        return;
+
+    const uint64_t viewportArea = static_cast<uint64_t>(viewport.width()) * viewport.height();
+
+    const auto [frameRects, frameArea] = damageMetrics(m_surface->frameDamage());
+    m_damageStats.frames++;
+    m_damageStats.frameRects += frameRects;
+    m_damageStats.frameArea += frameArea;
+    m_damageStats.viewportArea += viewportArea;
+
+    if (compositingUsesDamage) {
+        // renderTargetDamage() was already read on the restriction path this frame, so this adds no
+        // work. It returns the buffer's accumulated repaint region.
+        const auto [repaintRects, repaintArea] = damageMetrics(m_surface->renderTargetDamage());
+        m_damageStats.repaintFrames++;
+        m_damageStats.repaintRects += repaintRects;
+        m_damageStats.repaintArea += repaintArea;
+        m_damageStats.repaintViewportArea += viewportArea;
+    }
+}
+
+void ThreadedCompositor::dumpDamageStats()
+{
+    const auto now = MonotonicTime::now();
+    const Seconds elapsed = now - m_damageStats.lastDump;
+    m_damageStats.lastDump = now;
+
+    const unsigned frames = m_damageStats.frames;
+    if (!frames)
+        WTFLogAlways("[DamageStats] %.0f ms, no frame composited", elapsed.milliseconds()); // NOLINT
+    else {
+        const double fps = elapsed.seconds() > 0 ? frames / elapsed.seconds() : 0.0;
+        const double avgFrameRects = m_damageStats.frameRects / static_cast<double>(frames);
+        const double frameAreaPercent = m_damageStats.viewportArea ? 100.0 * m_damageStats.frameArea / m_damageStats.viewportArea : 0.0;
+        if (m_damageStats.repaintFrames) {
+            const double avgRepaintRects = m_damageStats.repaintRects / static_cast<double>(m_damageStats.repaintFrames);
+            const double repaintAreaPercent = m_damageStats.repaintViewportArea ? 100.0 * m_damageStats.repaintArea / m_damageStats.repaintViewportArea : 0.0;
+            WTFLogAlways("[DamageStats] %.0f ms, %u frames (%.1f fps) | frame-damage: %.1f rects, %.2f%% of viewport | repaint-region: %.1f rects, %.2f%% of viewport", // NOLINT
+                elapsed.milliseconds(), frames, fps, avgFrameRects, frameAreaPercent, avgRepaintRects, repaintAreaPercent);
+        } else {
+            WTFLogAlways("[DamageStats] %.0f ms, %u frames (%.1f fps) | frame-damage: %.1f rects, %.2f%% of viewport | repaint-region: n/a (damage compositing off)", // NOLINT
+                elapsed.milliseconds(), frames, fps, avgFrameRects, frameAreaPercent);
+        }
+    }
+
+    m_damageStats.frames = 0;
+    m_damageStats.frameRects = 0;
+    m_damageStats.frameArea = 0;
+    m_damageStats.viewportArea = 0;
+    m_damageStats.repaintFrames = 0;
+    m_damageStats.repaintRects = 0;
+    m_damageStats.repaintArea = 0;
+    m_damageStats.repaintViewportArea = 0;
+}
+#endif
+
+bool ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
 {
     auto* canvas = m_surface->canvas();
     if (!canvas)
-        return;
+        return false;
 
     auto& rootLayer = m_sceneState->rootLayer().ensureSkiaTarget();
     rootLayer.setTransform(matrix);
 
-    m_surface->clear(reasons);
-
     canvas->save();
 
-    std::optional<Damage> frameDamage;
+    // No damage region paints the whole frame (see SkiaCompositingLayer::paint()).
+    std::optional<DamageRegion> damageRegion;
 #if ENABLE(DAMAGE_TRACKING)
-    if (m_damage.flags)
-        frameDamage = Damage(size, m_damage.flags->contains(DamagePropagationFlags::Unified) ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles);
+    // Read the state once so the restriction decision and swap-chain accumulation below agree even if
+    // the main thread changes it mid-frame. The FPS counter is a debug overlay too.
+    const bool debugOverlaysEnabled = m_damage.debugIndicatorsEnabled || m_fpsCounter.drawsFPS;
+    const bool useDamageForCompositing = m_damage.flags && m_damage.flags->contains(DamagePropagationFlags::UseForCompositing);
+    // Overlay debug modes (1, 2) draw on top of the composited frame, and so do the layer indicators
+    // and FPS counter. All of them need the whole frame repainted each paint to erase the previous
+    // overlay. The rest of the damage pipeline stays intact, only the restriction is not applied.
+    const bool overlayNeedsFullRepaint = debugOverlaysEnabled
+        || m_damage.debugMode == DamageDebugMode::CurrentFrame
+        || m_damage.debugMode == DamageDebugMode::Accumulated;
+    // Also collect when a WEBKIT_DAMAGE_DEBUG mode or WEBKIT_DAMAGE_STATS is on, so the overlay and
+    // statistics work even with the compositing feature disabled.
+    if (m_damage.flags || m_damage.debugMode != DamageDebugMode::None || m_damageStats.enabled) {
+        Damage frameDamage(size, m_damage.flags && m_damage.flags->contains(DamagePropagationFlags::Unified) ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles);
+        rootLayer.collectDamage(size, frameDamage);
+
+        // Accumulate into the swap chain when damage drives compositing, so a later frame that reuses
+        // a buffer still repaints what changed this frame.
+        recordFrameDamage(WTF::move(frameDamage), debugOverlaysEnabled ? DebugOverlays::Yes : DebugOverlays::No,
+            useDamageForCompositing ? AcceleratedSurface::AccumulateIntoSwapChain::Yes : AcceleratedSurface::AccumulateIntoSwapChain::No);
+    }
+
+    if (m_damage.debugMode == DamageDebugMode::RedrawDamagedOnly) {
+        // Clear the whole scene to black and redraw only what changed this frame, so the damage shows
+        // up against black.
+        canvas->clear(SK_ColorBLACK);
+        auto plan = planFrameRestriction(m_surface->frameDamage(), size);
+        if (plan.kind == FrameRestrictionPlan::Kind::SkipPaint)
+            damageRegion = DamageRegion { };
+        else if (plan.kind == FrameRestrictionPlan::Kind::RestrictToDamage)
+            damageRegion = WTF::move(plan.damageRegion);
+        // FullRepaint leaves damageRegion unset, so the whole frame paints over the black clear.
+    } else if (useDamageForCompositing && !overlayNeedsFullRepaint) {
+        // Restriction is off while overlays show, so the whole frame repaints and they refresh.
+        // recordFrameDamage above told the platform what changed this frame. The region planned against
+        // here is what this buffer must redraw to become current. The two differ when an older buffer
+        // is reused.
+        auto plan = planFrameRestriction(m_surface->renderTargetDamage(), size);
+        switch (plan.kind) {
+        case FrameRestrictionPlan::Kind::FullRepaint:
+            m_surface->clear(reasons);
+            break;
+        case FrameRestrictionPlan::Kind::SkipPaint:
+            // Buffer already current, so hand paint() an empty region and it draws nothing.
+            damageRegion = DamageRegion { };
+            break;
+        case FrameRestrictionPlan::Kind::RestrictToDamage: {
+            // Clip the clear to the damage region so undamaged content stays and translucent content
+            // composites once.
+            SkAutoCanvasRestore autoRestore(canvas, true);
+            clipToDamageInDeviceSpace(*canvas, *plan.damageRegion);
+            m_surface->clear(reasons);
+            damageRegion = WTF::move(plan.damageRegion);
+            break;
+        }
+        }
+    } else
+        m_surface->clear(reasons);
+
+    // renderTargetDamage() is read above only on the restriction path, so read the repaint region
+    // only there to keep this free of side effects.
+    recordDamageStats(size, useDamageForCompositing && !overlayNeedsFullRepaint);
+#else
+    m_surface->clear(reasons);
 #endif
 
-    bool sceneHasRunningAnimations = rootLayer.paint(*canvas, frameDamage);
+    rootLayer.paint(*canvas, WTF::move(damageRegion));
     canvas->restore();
 
 #if ENABLE(DAMAGE_TRACKING)
-    if (frameDamage) {
-        if (m_damage.shouldNotifyFrameDamageForTesting && m_layerTreeHost)
-            m_layerTreeHost->notifyFrameDamageForTesting(frameDamage->regionForTesting());
-
-        if (!frameDamage->isEmpty())
-            m_surface->setFrameDamage(WTF::move(*frameDamage));
+    // Overlay modes draw the damage rects on top of the finished frame.
+    bool didDrawOverlay = false;
+    if (m_damage.debugMode == DamageDebugMode::CurrentFrame) {
+        if (const auto& damage = m_surface->frameDamage(); damage && !damage->isEmpty()) {
+            drawDamageOverlay(*canvas, *damage, SkColorSetARGB(128, 0, 0, 255));
+            didDrawOverlay = true;
+        }
+    } else if (m_damage.debugMode == DamageDebugMode::Accumulated) {
+        if (const auto& damage = m_surface->renderTargetDamage(); damage && !damage->isEmpty()) {
+            drawDamageOverlay(*canvas, *damage, SkColorSetARGB(128, 0, 255, 0));
+            didDrawOverlay = true;
+        }
     }
-#endif
 
-#if ENABLE(DAMAGE_TRACKING)
-    if (m_damage.showSkiaDamage) {
-        if (auto damage = m_surface->frameDamage())
-            drawSkiaDamage(*canvas, damage);
-
-        // When the damage visualizer is active we cannot send the original damage to the platform, as the
-        // damage rects visualized in the previous frame may not get erased if the platform uses damage.
+    // Every debug mode repaints or clears the whole surface each frame, so report full damage to the
+    // platform. Otherwise the previous frame's overlay (or black fill) may not get erased.
+    if (m_damage.debugMode != DamageDebugMode::None)
         m_surface->setFrameDamage(Damage(size, Damage::Mode::Full));
-    }
+
+    // An overlay was drawn into this buffer. Schedule one more composition so that once damage stops,
+    // the next frame repaints the overlay away instead of leaving it frozen on screen on an idle page.
+    if (didDrawOverlay)
+        requestComposition(CompositionReason::Animation);
 #endif
 
     if (m_fpsCounter.drawsFPS)
@@ -447,8 +644,10 @@ void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, c
     if (auto* surface = canvas->getSurface())
         PlatformDisplay::sharedDisplay().skiaGrContext()->flushAndSubmit(surface, GrSyncCpu::kNo);
 
-    if (sceneHasRunningAnimations)
+    if (rootLayer.hasRunningAnimations())
         requestComposition(CompositionReason::Animation);
+
+    return true;
 }
 
 #if HAVE(OS_SIGNPOST) || USE(SYSPROF_CAPTURE)
@@ -531,7 +730,7 @@ void ThreadedCompositor::renderLayerTree()
     WTFEndSignpost(this, FlushCompositingState);
 
     WTFBeginSignpost(this, PaintToGLContext);
-    paintToCurrentGLContext(viewportTransform, viewportSize, reasons);
+    bool framePainted = paintToCurrentGLContext(viewportTransform, viewportSize, reasons);
     WTFEndSignpost(this, PaintToGLContext);
 
     updateFPSCounter();
@@ -546,7 +745,16 @@ void ThreadedCompositor::renderLayerTree()
     else
         PlatformDisplay::sharedDisplay().skiaGLContext()->swapBuffers();
 
-    m_surface->didRenderFrame();
+#if ENABLE(DAMAGE_TRACKING)
+    // Fine-grained target damage only matters when the Skia compositor draws only the rects.
+    // TextureMapper consumers only read bounds. A WEBKIT_DAMAGE_DEBUG mode keeps UseForCompositing, so
+    // the records stay fine-grained and the overlay shows the real rects.
+    const bool damageUsedForCompositing = m_useSkia && m_damage.flags && m_damage.flags->contains(DamagePropagationFlags::UseForCompositing);
+#else
+    const bool damageUsedForCompositing = false;
+#endif
+    m_surface->didRenderFrame(framePainted ? AcceleratedSurface::FramePainted::Yes : AcceleratedSurface::FramePainted::No,
+        damageUsedForCompositing ? AcceleratedSurface::DamageUsedForCompositing::Yes : AcceleratedSurface::DamageUsedForCompositing::No);
     m_surface->sendFrame();
 
     RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }] {
@@ -755,19 +963,6 @@ void ThreadedCompositor::drawFPSCounter(SkCanvas& canvas)
     textPaint.setAntiAlias(true);
     canvas.drawString(m_fpsCounter.fpsString.data(), padding, m_fpsCounter.textBaseline, font, textPaint);
 }
-
-#if ENABLE(DAMAGE_TRACKING)
-void ThreadedCompositor::drawSkiaDamage(SkCanvas& canvas, const std::optional<WebCore::Damage>& damage)
-{
-    SkPaint paint;
-    paint.setStyle(SkPaint::kFill_Style);
-    paint.setColor(SkColorSetARGB(200, 255, 0, 0));
-
-    const auto margin = static_cast<SkScalar>(m_damage.skiaDamageMargin);
-    for (const auto& rect : *damage)
-        canvas.drawRect(SkRect::MakeXYWH(rect.x() - margin, rect.y() - margin, rect.width() + margin * 2, rect.height() + margin * 2), paint);
-}
-#endif
 
 void ThreadedCompositor::fillGLInformation(RenderProcessInfo&& info, CompletionHandler<void(RenderProcessInfo&&)>&& completionHandler)
 {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS)
+#include "AcceleratedSurface.h"
 #include <WebCore/CoordinatedCompositionReason.h>
 #include <WebCore/Damage.h>
 #include <WebCore/DisplayUpdate.h>
@@ -60,7 +61,6 @@ enum class Critical : bool;
 }
 
 namespace WebKit {
-class AcceleratedSurface;
 class CoordinatedSceneState;
 class LayerTreeHost;
 class WebPage;
@@ -102,6 +102,7 @@ public:
         UseForCompositing = 1 << 1
     };
     void setDamagePropagationSettings(std::optional<OptionSet<DamagePropagationFlags>>, unsigned rectangleThreshold);
+    void setDebugIndicatorsEnabled(bool enabled) { m_damage.debugIndicatorsEnabled = enabled; }
     void enableFrameDamageNotificationForTesting();
 #endif
 
@@ -122,9 +123,9 @@ private:
     void scheduleUpdateLocked();
     void flushCompositingState(const OptionSet<WebCore::CompositionReason>&);
     void renderLayerTree();
-    void paintToCurrentGLContext(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
+    bool paintToCurrentGLContext(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
     void paintToTextureMapper(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
-    void paintToSkiaCanvas(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
+    bool paintToSkiaCanvas(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
     void frameComplete();
 
     void didCompositeRunLoopObserverFired();
@@ -135,7 +136,10 @@ private:
     void updateFPSCounter();
     void drawFPSCounter(SkCanvas&);
 #if ENABLE(DAMAGE_TRACKING)
-    void drawSkiaDamage(SkCanvas&, const std::optional<WebCore::Damage>&);
+    enum class DebugOverlays : bool { No, Yes };
+    void recordFrameDamage(WebCore::Damage&&, DebugOverlays, AcceleratedSurface::AccumulateIntoSwapChain);
+    void recordDamageStats(const WebCore::IntSize& viewport, bool compositingUsesDamage);
+    void dumpDamageStats();
 #endif
 
     const Ref<WorkQueue> m_workQueue;
@@ -175,6 +179,9 @@ private:
     } m_attributes;
 
     RunLoop::Timer m_renderTimer;
+#if ENABLE(DAMAGE_TRACKING)
+    RunLoop::Timer m_damageStatsTimer;
+#endif
     std::unique_ptr<WebCore::TextureMapper> m_textureMapper;
 
     struct {
@@ -195,16 +202,40 @@ private:
     } m_fpsCounter;
 
 #if ENABLE(DAMAGE_TRACKING)
+    // WEBKIT_DAMAGE_DEBUG modes that show Skia frame damage.
+    enum class DamageDebugMode : uint8_t {
+        None, // 0: nothing shown
+        CurrentFrame, // 1: this frame's damage as a translucent blue overlay
+        Accumulated, // 2: the buffer's whole accumulated damage as a translucent green overlay
+        RedrawDamagedOnly, // 3: clear the scene to black and redraw only the current damage
+    };
+
     struct {
         std::optional<OptionSet<DamagePropagationFlags>> flags;
         unsigned rectangleThreshold { 4 };
         std::unique_ptr<WebCore::TextureMapperDamageVisualizer> visualizer;
 
-        bool showSkiaDamage { false };
-        unsigned skiaDamageMargin { 0 };
+        DamageDebugMode debugMode { DamageDebugMode::None };
 
         std::atomic<bool> shouldNotifyFrameDamageForTesting { false };
+        std::atomic<bool> debugIndicatorsEnabled { false };
     } m_damage;
+
+    // WEBKIT_DAMAGE_STATS. recordDamageStats() sums per-frame metrics and m_damageStatsTimer dumps the
+    // averages every window, on a wall clock so a window is reported even when no frame is drawn.
+    struct {
+        bool enabled { false };
+        Seconds window { 1_s };
+        MonotonicTime lastDump;
+        unsigned frames { 0 };
+        uint64_t frameRects { 0 };
+        uint64_t frameArea { 0 };
+        uint64_t viewportArea { 0 };
+        unsigned repaintFrames { 0 };
+        uint64_t repaintRects { 0 };
+        uint64_t repaintArea { 0 };
+        uint64_t repaintViewportArea { 0 };
+    } m_damageStats;
 #endif
 
     std::unique_ptr<WebCore::RunLoopObserver> m_didCompositeRunLoopObserver;

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -601,6 +601,82 @@ TEST(Damage, Unite)
     EXPECT_EQ(damage.rectsForTesting().size(), 1);
 }
 
+TEST(Damage, RectsForPainting)
+{
+    // The function should return the original rect when there is only a single one.
+    Damage damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 250, 250, 12, 12 }));
+    ASSERT_EQ(damage.rectsForPainting().size(), 1);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(250, 250, 12, 12));
+
+    // The function should remove overlaps.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 100, 100 }));
+    EXPECT_TRUE(damage.add(IntRect { 50, 50, 100, 100 }));
+    ASSERT_EQ(damage.rectsForPainting().size(), 1);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 150, 150));
+
+    // The function should remove empty rects.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 10, 10, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 20, 20, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 30, 30, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 40, 40, 10, 10 }));
+    EXPECT_EQ(damage.rects().size(), 1);
+    ASSERT_EQ(damage.rectsForPainting().size(), 1);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 50, 50));
+
+    // The function should clip the rects.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { -2, -2, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 504, 504, 10, 10 }));
+    ASSERT_EQ(damage.rectsForPainting().size(), 2);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(0, 0, 8, 8));
+    EXPECT_EQ(damage.rectsForPainting()[1], IntRect(504, 504, 8, 8));
+
+    // The function should preserve the layout of cells when unification is enabled.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 0, 0, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 10, 10, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 0, 256, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256, 0, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256, 256, 10, 10 }));
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+
+    // The function should preserve the layout of cells when unification is enabled
+    // and the grid does not start at { 0, 0 }.
+    damage = Damage(IntRect { 256, 256, 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 256, 256, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256 + 10, 256 + 10, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256, 256 + 256, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256 + 256, 256, 10, 10 }));
+    EXPECT_TRUE(damage.add(IntRect { 256 + 256, 256 + 256, 10, 10 }));
+    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+
+    // The function should split a rect spanning multiple cells.
+    damage = Damage(IntSize { 512, 512 });
+    EXPECT_TRUE(damage.add(IntRect { 250, 250, 12, 12 }));
+    EXPECT_TRUE(damage.add(IntRect { 249, 249, 1, 1 }));
+    ASSERT_EQ(damage.rectsForPainting().size(), 4);
+    EXPECT_EQ(damage.rectsForPainting()[0], IntRect(249, 249, 7, 7));
+    EXPECT_EQ(damage.rectsForPainting()[1], IntRect(256, 250, 6, 6));
+    EXPECT_EQ(damage.rectsForPainting()[2], IntRect(250, 256, 6, 6));
+    EXPECT_EQ(damage.rectsForPainting()[3], IntRect(256, 256, 6, 6));
+
+    // The function should just return original rects when mode != Mode::Rectangles.
+    damage = Damage(IntRect { 1024, 512, 512, 512 }, Damage::Mode::BoundingBox);
+    EXPECT_TRUE(damage.add(IntRect { 1278, 678, 9, 341 }));
+    EXPECT_TRUE(damage.add(IntRect { 1285, 678, 5, 341 }));
+    EXPECT_FALSE(damage.add(IntRect { 1279, 678, 9, 341 }));
+    EXPECT_TRUE(damage.add(IntRect { 1286, 678, 5, 341 }));
+    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+    damage = Damage(IntRect { 1024, 512, 512, 512 }, Damage::Mode::Full);
+    EXPECT_EQ(damage.rects(), damage.rectsForPainting());
+}
+
 TEST(Damage, MaxRectangles)
 {
     Damage damage(IntSize { 512, 512 }, Damage::Mode::Rectangles, 2);


### PR DESCRIPTION
#### d0dcbc469bfa7c2ddd95cdff53dbf919041dd63f
<pre>
[Skia] Restrict Skia compositing to the frame damage
<a href="https://bugs.webkit.org/show_bug.cgi?id=315990">https://bugs.webkit.org/show_bug.cgi?id=315990</a>

Reviewed by NOBODY (OOPS!).

Make the Skia compositor repaint only what changed each frame instead of redrawing
the whole viewport. It uses the frame damage already collected for the platform.

The layer-tree walk splits into a collectDamage() pass that draws nothing and a
paint() pass that draws, both sharing a once-per-frame ensurePrepared(). Each frame&apos;s
damage becomes a set of paint rects that never overlap, built by the restored
Damage::rectsForPainting(), which returns at most one cell-clipped bounding rect per
damage grid cell. The restriction relies on those rects not overlapping. The rects are
passed through PaintContext down to the per-tile and image-set draws, which split each
tile into its damaged parts so only the changed part is repainted.

To make buffer reuse correct, SwapChainDamageTracker adds each frame&apos;s damage to every
swap-chain buffer and resets a buffer&apos;s record once it was presented, so a frame that
reuses a buffer repaints everything that changed since that buffer was last current.
ThreadedCompositor asks planFrameRestriction() for the acquired buffer&apos;s repaint region
and then either repaints everything, skips painting when the buffer is already current,
or clips the clear and limits every draw to the damage region.

The feature is enabled by default for GTK and WPE (UseDamagingInformationForCompositing),
with GTK no longer merging damage into a bounding box. It falls back to full-frame
repaints while debug indicators are shown, sent to the compositor thread via
setDebugIndicatorsEnabled().

Two test and debug environment variables are added:

  WEBKIT_DAMAGE_DEBUG shows the damage:
    1: this frame&apos;s damage as a translucent blue overlay
    2: the buffer&apos;s whole accumulated damage as a translucent green overlay
    3: clear the scene to black and redraw only the damaged region
  Other or out-of-range values are ignored. Any mode keeps the damage pipeline
  running with full-frame repaints, so it is only useful for debugging.

  WEBKIT_DAMAGE_STATS, set to any value, logs rolling averages of how fine-grained
  the damage is once a second without disturbing the pipeline.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/graphics/Damage.h:
(WebCore::Damage::rectsForPainting const):
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::paintToCanvas):
(WebCore::SkiaBackingStore::buildImageSet const):
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.h:
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::setSize):
(WebCore::SkiaCompositingLayer::removeFromParent):
(WebCore::SkiaCompositingLayer::recursiveConsumePreviousLayerRects):
(WebCore::SkiaCompositingLayer::recursiveMoveOrphanedPreviousLayerRects):
(WebCore::SkiaCompositingLayer::computeTransformsAndAnimations):
(WebCore::SkiaCompositingLayer::ensurePrepared):
(WebCore::SkiaCompositingLayer::collectDamage):
(WebCore::SkiaCompositingLayer::paint):
(WebCore::SkiaCompositingLayer::paintSelf):
(WebCore::SkiaCompositingLayer::combinedTransform const):
(WebCore::SkiaCompositingLayer::paintContents):
(WebCore::SkiaCompositingLayer::collectFrameDamage):
(WebCore::SkiaCompositingLayer::paintDebugBorder):
(WebCore::SkiaCompositingLayer::paintRepaintCounter):
(WebCore::SkiaCompositingLayer::paintWithIntermediateSurface):
(WebCore::SkiaCompositingLayer::paintWithMaskAndBackdrop):
(WebCore::SkiaCompositingLayer::paintWithFilterAndMask):
(WebCore::SkiaCompositingLayer::recursivePaint):
(WebCore::SkiaCompositingLayer::addPreviousRectToSharedFrameDamage): Deleted.
(WebCore::SkiaCompositingLayer::recursiveAddPreviousRectToSharedFrameDamage): Deleted.
(WebCore::SkiaCompositingLayer::paintDebugIndicators): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp:
(WebCore::SkiaCompositingLayerImageSetBatch::appendImageSet):
(WebCore::SkiaCompositingLayerImageSetBatch::matrixIndexForDraw):
(WebCore::SkiaCompositingLayerImageSetBatch::addImageSet):
(WebCore::SkiaCompositingLayerImageSetBatch::addImageSetRestrictedToDamage):
(WebCore::SkiaCompositingLayerImageSetBatch::addImage):
(WebCore::SkiaCompositingLayerImageSetBatch::addImageRestrictedToDamage):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h:
* Source/WebCore/platform/graphics/skia/SkiaDamageRestriction.h: Added.
(WebCore::mapDamageSourceSubRect):
(WebCore::planFrameRestriction):
(WebCore::planDrawRestriction):
(WebCore::forEachDamagedSubRect):
(WebCore::clipToDamageInDeviceSpace):
(WebCore::drawRestrictedToDamage):
(WebCore::drawRectRestrictedToDamage):
(WebCore::drawImageRectRestrictedToDamage):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::ensureSkiaTarget):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::SwapChainDamageTracker::recordFrameDamage):
(WebKit::AcceleratedSurface::SwapChainDamageTracker::accumulateFrameDamageIntoSwapChain):
(WebKit::AcceleratedSurface::SwapChainDamageTracker::damageForTarget):
(WebKit::AcceleratedSurface::SwapChainDamageTracker::didPresent):
(WebKit::AcceleratedSurface::didRenderFrame):
(WebKit::AcceleratedSurface::RenderTarget::addDamage): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::updateRendering):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::m_damageStatsTimer):
(WebKit::ThreadedCompositor::invalidate):
(WebKit::ThreadedCompositor::setDamagePropagationSettings):
(WebKit::ThreadedCompositor::paintToCurrentGLContext):
(WebKit::ThreadedCompositor::paintToTextureMapper):
(WebKit::ThreadedCompositor::recordFrameDamage):
(WebKit::drawDamageOverlay):
(WebKit::damageMetrics):
(WebKit::ThreadedCompositor::recordDamageStats):
(WebKit::ThreadedCompositor::dumpDamageStats):
(WebKit::ThreadedCompositor::paintToSkiaCanvas):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::m_renderTimer): Deleted.
(WebKit::ThreadedCompositor::drawSkiaDamage): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
(WebKit::ThreadedCompositor::setDebugIndicatorsEnabled):
* Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp:
(TestWebKitAPI::TEST(Damage, RectsForPainting)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0dcbc469bfa7c2ddd95cdff53dbf919041dd63f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173304 "Failed to checkout and rebase branch from PR 66164") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47236 "Failed to checkout and rebase branch from PR 66164") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40777 "Failed to checkout and rebase branch from PR 66164") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182877 "Failed to checkout and rebase branch from PR 66164") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130860 "Failed to checkout and rebase branch from PR 66164") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175169 "Failed to checkout and rebase branch from PR 66164") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48529 "Failed to checkout and rebase branch from PR 66164") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46918 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/182877 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/130860 "Failed to checkout and rebase branch from PR 66164") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176262 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/48529 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/40777 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/182877 "Failed to checkout and rebase branch from PR 66164") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/48529 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/46918 "Failed to checkout and rebase branch from PR 66164") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31362 "Failed to checkout and rebase branch from PR 66164") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/40777 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/48529 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/40777 "Failed to checkout and rebase branch from PR 66164") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185300 "Failed to checkout and rebase branch from PR 66164") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34566 "Failed to checkout and rebase branch from PR 66164") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38157 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/46918 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/185300 "Failed to checkout and rebase branch from PR 66164") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46904 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/40777 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/185300 "Failed to checkout and rebase branch from PR 66164") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47583 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/40777 "Failed to checkout and rebase branch from PR 66164") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112684 "Failed to checkout and rebase branch from PR 66164") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/47583 "Failed to checkout and rebase branch from PR 66164") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119332 "Failed to checkout and rebase branch from PR 66164") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46089 "Failed to checkout and rebase branch from PR 66164") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/40777 "Failed to checkout and rebase branch from PR 66164") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45491 "Failed to checkout and rebase branch from PR 66164") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45722 "Failed to checkout and rebase branch from PR 66164") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45548 "Failed to checkout and rebase branch from PR 66164") | | | 
<!--EWS-Status-Bubble-End-->