### PR TITLE
AudioVideoRendererRemote: synchronize m_lastSeekTime and recover the ready-for-more state after a flush

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -233,7 +233,6 @@ private:
     void didProvideMediaDataForTrackId(Ref<MediaSampleAVFObjC>&&, TrackID, const String& mediaType);
     void didUpdateFormatDescriptionForTrackId(Ref<TrackInfo>&&, TrackID);
 
-    void flush();
     void flushTrack(TrackID);
     void flushVideoIfNeeded();
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1545,17 +1545,6 @@ void MediaPlayerPrivateWebM::didProvideMediaDataForTrackId(Ref<MediaSampleAVFObj
     notifyClientWhenReadyForMoreSamples(trackId);
 }
 
-void MediaPlayerPrivateWebM::flush()
-{
-    assertIsCurrent(runningQueue());
-    m_renderer->flush();
-    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->setHasAvailableVideoFrame(false);
-    });
-    setAllTracksForReenqueuing();
-}
-
 void MediaPlayerPrivateWebM::setAllTracksForReenqueuing()
 {
     assertIsCurrent(runningQueue());

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -350,10 +350,15 @@ void RemoteAudioVideoRendererProxyManager::flush(RemoteAudioVideoRendererIdentif
         renderer->flush();
 }
 
-void RemoteAudioVideoRendererProxyManager::flushTrack(RemoteAudioVideoRendererIdentifier identifier, TrackIdentifier trackIdentifier)
+void RemoteAudioVideoRendererProxyManager::flushTrack(RemoteAudioVideoRendererIdentifier identifier, TrackIdentifier trackIdentifier, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (RefPtr renderer = rendererFor(identifier))
-        renderer->flushTrack(trackIdentifier);
+    RefPtr renderer = rendererFor(identifier);
+    if (!renderer) {
+        completionHandler(false);
+        return;
+    }
+    renderer->flushTrack(trackIdentifier);
+    completionHandler(renderer->isReadyForMoreSamples(trackIdentifier));
 }
 
 void RemoteAudioVideoRendererProxyManager::applicationWillResignActive(RemoteAudioVideoRendererIdentifier identifier)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -107,7 +107,7 @@ private:
     void performTaskAtTime(RemoteAudioVideoRendererIdentifier, const MediaTime&);
 
     void flush(RemoteAudioVideoRendererIdentifier);
-    void flushTrack(RemoteAudioVideoRendererIdentifier, TrackIdentifier);
+    void flushTrack(RemoteAudioVideoRendererIdentifier, TrackIdentifier, CompletionHandler<void(bool)>&&);
 
     void applicationWillResignActive(RemoteAudioVideoRendererIdentifier);
     void setSpatialTrackingInfo(RemoteAudioVideoRendererIdentifier, bool, WebCore::MediaPlayerSoundStageSize, const String&, const String&, const String&);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -49,7 +49,7 @@ messages -> RemoteAudioVideoRendererProxyManager {
     PerformTaskAtTime(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime time)
 
     Flush(WebKit::RemoteAudioVideoRendererIdentifier identifier)
-    FlushTrack(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier)
+    FlushTrack(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier) -> (bool isReadyForMoreMediaData)
 
     ApplicationWillResignActive(WebKit::RemoteAudioVideoRendererIdentifier identifier)
     SetSpatialTrackingInfo(WebKit::RemoteAudioVideoRendererIdentifier identifier, bool prefersSpatialAudioExperience, enum:uint8_t WebCore::MediaPlayerSoundStageSize soundStageSize, String sceneIdentifier, String defaultLabel, String label)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -517,9 +517,9 @@ Ref<MediaTimePromise> AudioVideoRendererRemote::prepareToSeek(const MediaTime& t
             if (rate >= 0 ? *m_stallCap < time : *m_stallCap > time)
                 m_stallCap.reset();
         }
+        m_lastSeekTime = time;
     }
     m_seeking = true;
-    m_lastSeekTime = time;
     return invokeAsync(queueSingleton(), [protectedThis = Ref { *this }, this, time] -> Ref<MediaTimePromise> {
         cancelPendingSeek();
 
@@ -734,8 +734,10 @@ void AudioVideoRendererRemote::notifyEffectiveRateChanged(Function<void(double)>
 
 MediaTime AudioVideoRendererRemote::currentTime() const
 {
-    if (m_seeking)
+    if (m_seeking) {
+        Locker locker { m_lock };
         return m_lastSeekTime;
+    }
     Locker locker { m_lock };
     if (!m_sharedTimebaseReader)
         return MediaTime::zeroTime();
@@ -783,23 +785,33 @@ void AudioVideoRendererRemote::performTaskAtTime(const MediaTime& time, Function
 
 void AudioVideoRendererRemote::flush()
 {
-    ALWAYS_LOG(LOGIDENTIFIER, "seeking:", m_seeking.load());
-    m_seeking = false;
-    {
-        Locker locker { m_lock };
-        if (m_sharedTimebaseReader)
-            m_sharedTimebaseReader->resetForTimeDiscontinuity();
-    }
-    ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
-        renderer.m_keyframeNeeded = true;
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::Flush(renderer.m_identifier), 0);
-    });
+    ASSERT_NOT_REACHED();
 }
 
 void AudioVideoRendererRemote::flushTrack(TrackIdentifier identifier)
 {
     ensureOnDispatcherWithConnection([identifier](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::FlushTrack(renderer.m_identifier, identifier), 0);
+        // Wait on the GPU's reply (its post-flush isReadyForMoreSamples) before updating
+        // readiness. IPC ordering guarantees this lands after any in-flight EnqueueSample
+        // replies, so a stale reply can't clobber it. If the GPU is not ready it has armed
+        // its ready-for-more callback, so a ReadyForMoreMediaData will follow.
+        connection.sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::FlushTrack(renderer.m_identifier, identifier), queueSingleton(), [weakThis = ThreadSafeWeakPtr { renderer }, identifier](bool isReadyForMoreMediaData) {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+            {
+                Locker locker { protectedThis->m_lock };
+                protectedThis->readyForMoreDataState(identifier).setRemoteReadyForMoreData(isReadyForMoreMediaData);
+            }
+            if (!isReadyForMoreMediaData) {
+                RefPtr gpuProcessConnection = protectedThis->m_gpuProcessConnection.get();
+                if (!protectedThis->isGPURunning() || !gpuProcessConnection)
+                    return;
+                gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::RequestMediaDataWhenReady(protectedThis->m_identifier, identifier), 0);
+                return;
+            }
+            protectedThis->resolveRequestMediaDataWhenReadyIfNeeded(identifier);
+        }, 0);
     });
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -291,7 +291,7 @@ private:
     Ref<NativePromiseRequest> m_finishSeekRequest WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     std::optional<GenericPromise::Producer> m_finishSeekPromise WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     std::atomic<bool> m_seeking { false };
-    MediaTime m_lastSeekTime; // Always called on the renderer's client thread.
+    MediaTime m_lastSeekTime WTF_GUARDED_BY_LOCK(m_lock);
 
 #if PLATFORM(COCOA)
     const UniqueRef<WebCore::VideoLayerManager> m_videoLayerManager WTF_GUARDED_BY_LOCK(m_lock);


### PR DESCRIPTION
#### baee51550e933f237246b7897512e02d0bf72f5b
<pre>
AudioVideoRendererRemote: synchronize m_lastSeekTime and recover the ready-for-more state after a flush
<a href="https://bugs.webkit.org/show_bug.cgi?id=315993">https://bugs.webkit.org/show_bug.cgi?id=315993</a>
<a href="https://rdar.apple.com/problem/178418023">rdar://problem/178418023</a>

Reviewed by Jer Noble.

Two latent correctness bugs in the remote audio/video renderer

m_lastSeekTime was written on the client thread in prepareToSeek() but read by
currentTime() while seeking, and currentTime() was also called on the
MediaSource worker thread, so those accesses raced. Guard m_lastSeekTime with
m_lock and take the lock on both the write and the seeking-time read.

m_remoteReadyForMoreData was only ever set back to true by an EnqueueSample
reply or a ReadyForMoreMediaData message. When the renderer had last reported
not-ready and was then flushed, neither happened: nothing was enqueued while
not-ready (so no reply arrived), and the GPU side was not re-armed, so the
state stayed false and the data pump never resumed. Make FlushTrack an async
message that replies with the renderer&apos;s isReadyForMoreSamples once the flush
has run. The WebProcess sets readiness from that reply -- which IPC ordering
places after any in-flight EnqueueSample replies, so a stale reply cannot
clobber it -- and, when the reply is false, sends RequestMediaDataWhenReady so
the subsequent ReadyForMoreMediaData resumes the pump.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::flush): Deleted.
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::flushTrack):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::prepareToSeek):
(WebKit::AudioVideoRendererRemote::currentTime const):
(WebKit::AudioVideoRendererRemote::flush): Assert method is not reached as neither MediaPlayerPrivateWebM nor MSE player are using it.
(WebKit::AudioVideoRendererRemote::flushTrack):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:

Canonical link: <a href="https://commits.webkit.org/314325@main">https://commits.webkit.org/314325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2972a5cf10fc5a8b722826c085167f06225c433a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122956 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea750325-e204-4ba9-9e7c-7fccad14314f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128767 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90691 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2307180-de03-485c-bb91-4440ab6655e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168660 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109291 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2fee32a-9006-42ab-a54f-24641bce82e5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28783 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22824 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177267 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30182 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137097 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137026 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36944 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148367 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102459 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32316 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25234 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38459 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111532 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37855 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3315 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38101 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37999 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->