### PR TITLE
[WPE] Fix typos in the WPE Platform API documentation

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
@@ -371,7 +371,7 @@ guint32 wpe_buffer_dma_buf_get_n_planes(WPEBufferDMABuf* buffer)
  *
  * Get the @buffer file descriptor of @plane
  *
- * Return: a file descriptor, or -1
+ * Returns: a file descriptor, or -1
  */
 int wpe_buffer_dma_buf_get_fd(WPEBufferDMABuf* buffer, guint32 plane)
 {
@@ -388,7 +388,7 @@ int wpe_buffer_dma_buf_get_fd(WPEBufferDMABuf* buffer, guint32 plane)
  *
  * Get the @buffer offset of @plane
  *
- * Return: the buffer offset
+ * Returns: the buffer offset
  */
 guint32 wpe_buffer_dma_buf_get_offset(WPEBufferDMABuf* buffer, guint32 plane)
 {
@@ -405,7 +405,7 @@ guint32 wpe_buffer_dma_buf_get_offset(WPEBufferDMABuf* buffer, guint32 plane)
  *
  * Get the @buffer stride of @plane
  *
- * Return: the buffer stride
+ * Returns: the buffer stride
  */
 guint32 wpe_buffer_dma_buf_get_stride(WPEBufferDMABuf* buffer, guint32 plane)
 {
@@ -421,7 +421,7 @@ guint32 wpe_buffer_dma_buf_get_stride(WPEBufferDMABuf* buffer, guint32 plane)
  *
  * Get the @buffer modifier
  *
- * Return: the buffer modifier
+ * Returns: the buffer modifier
  */
 guint64 wpe_buffer_dma_buf_get_modifier(WPEBufferDMABuf* buffer)
 {

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp
@@ -154,7 +154,7 @@ static void wpe_buffer_shm_class_init(WPEBufferSHMClass* bufferSHMClass)
  * @data: the buffer data
  * @stride: the buffer stride
  *
- * Crerate a new #WPEBufferSHM for the given parameters.
+ * Create a new #WPEBufferSHM for the given parameters.
  *
  * Returns: (transfer full): a #WPEBufferSHM
  */

--- a/Source/WebKit/WPEPlatform/wpe/WPEClipboard.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEClipboard.cpp
@@ -161,7 +161,7 @@ WPEClipboard* wpe_clipboard_new(WPEDisplay* display)
 
 /**
  * wpe_clipboard_get_display:
- * @clipboard: a #WPEClipoard
+ * @clipboard: a #WPEClipboard
  *
  * Get the #WPEDisplay of @clipboard
  *
@@ -176,7 +176,7 @@ WPEDisplay* wpe_clipboard_get_display(WPEClipboard* clipboard)
 
 /**
  * wpe_clipboard_get_change_count:
- * @clipboard: a #WPEClipoard
+ * @clipboard: a #WPEClipboard
  *
  * Get the amount of times @clipboard changed since it was created.
  *
@@ -191,7 +191,7 @@ gint64 wpe_clipboard_get_change_count(WPEClipboard* clipboard)
 
 /**
  * wpe_clipboard_get_formats:
- * @clipboard: a #WPEClipoard
+ * @clipboard: a #WPEClipboard
  *
  * Get the MIME type formats that clipboard can provide
  *
@@ -208,7 +208,7 @@ const char* const* wpe_clipboard_get_formats(WPEClipboard* clipboard)
 
 /**
  * wpe_clipboard_set_content:
- * @clipboard: a #WPEClipoard
+ * @clipboard: a #WPEClipboard
  * @content: (transfer none) (nullable): a #WPEClipboardContent, or %NULL to clear the clipboard
  *
  * Set @content on @clipboard. Passing a %NULL @content will clear the @clipboard.
@@ -239,7 +239,7 @@ void wpe_clipboard_set_content(WPEClipboard* clipboard, WPEClipboardContent* con
 
 /**
  * wpe_clipboard_get_content:
- * @clipboard: a #WPEClipoard
+ * @clipboard: a #WPEClipboard
  *
  * Get the #WPEClipboardContent previously set with wpe_clipboard_set_content().
  * This function returns %NULL if @clipboard is empty or its contents are owned
@@ -256,7 +256,7 @@ WPEClipboardContent* wpe_clipboard_get_content(WPEClipboard* clipboard)
 
 /**
  * wpe_clipboard_read_bytes:
- * @clipboard: a #WPEClipoard
+ * @clipboard: a #WPEClipboard
  * @format: the MIME type format of the text to read
  *
  * Get the contents of @clipboard for the given MIME type @format as bytes.
@@ -294,7 +294,7 @@ GBytes* wpe_clipboard_read_bytes(WPEClipboard* clipboard, const char* format)
 
 /**
  * wpe_clipboard_read_text:
- * @clipboard: a #WPEClipoard
+ * @clipboard: a #WPEClipboard
  * @format: the MIME type format of the text to read
  * @size: (out) (optional): location to return size of returned text.
  *

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -329,7 +329,7 @@ void wpe_display_set_primary(WPEDisplay* display)
 }
 
 /**
- * wpe_display_connect
+ * wpe_display_connect:
  * @display: a #WPEDisplay
  * @error: return location for error or %NULL to ignore
  *
@@ -369,7 +369,7 @@ void wpe_display_disconnected(WPEDisplay* display, GError* error)
  *
  * Get the `EGLDisplay` of @display
  *
- * Retrurns: (transfer none) (nullable): a `EGLDisplay` or %NULL
+ * Returns: (transfer none) (nullable): a `EGLDisplay` or %NULL
  */
 gpointer wpe_display_get_egl_display(WPEDisplay* display, GError** error)
 {

--- a/Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp
@@ -261,7 +261,7 @@ WPEModifiers wpe_event_get_modifiers(WPEEvent* event)
  * a position, %FALSE is returned.
  *
  * Returns: %TRUE if position is returned in @x and @y,
- *    or %FALSE if @event doesn't have a positon
+ *    or %FALSE if @event doesn't have a position
  */
 gboolean wpe_event_get_position(WPEEvent* event, double* x, double* y)
 {
@@ -346,7 +346,7 @@ guint wpe_event_pointer_button_get_button(WPEEvent* event)
  * wpe_event_pointer_button_get_press_count:
  * @event: a #WPEEvent
  *
- * Get the numbbr of button presses for @event
+ * Get the number of button presses for @event
  * Note that @event must be a pointer button press event (%WPE_EVENT_POINTER_DOWN).
  *
  * Returns: the press count of @event
@@ -368,7 +368,7 @@ guint wpe_event_pointer_button_get_press_count(WPEEvent* event)
  * @modifiers: a #WPEModifiers
  * @x: the x coordinate of the pointer
  * @y: the y coordinate of the pointer
- * @delta_x: the x coordainte movement delta
+ * @delta_x: the x coordinate movement delta
  * @delta_y: the y coordinate movement delta
  *
  * Create a #WPEEvent for a pointer move.
@@ -540,7 +540,7 @@ guint wpe_event_keyboard_get_keyval(WPEEvent* event)
 
 /**
  * wpe_event_touch_new:
- * @type: a #WPEEventType (%WPE_EVENT_TOUCH_DOWN, %WPE_EVENT_TOUCH_UP, %WPE_EVENT_TOUCH_MOVER or %WPE_EVENT_TOUCH_CANCEL)
+ * @type: a #WPEEventType (%WPE_EVENT_TOUCH_DOWN, %WPE_EVENT_TOUCH_UP, %WPE_EVENT_TOUCH_MOVE or %WPE_EVENT_TOUCH_CANCEL)
  * @view: a #WPEView
  * @source: a #WPEInputSource
  * @time: the event timestamp
@@ -566,7 +566,7 @@ WPEEvent* wpe_event_touch_new(WPEEventType type, WPEView* view, WPEInputSource s
  * @event: a #WPEEvent
  *
  * Get the sequence identifier of @event.
- * Note that @event must be a touch event (%WPE_EVENT_TOUCH_DOWN, %WPE_EVENT_TOUCH_UP, %WPE_EVENT_TOUCH_MOVER or %WPE_EVENT_TOUCH_CANCEL)
+ * Note that @event must be a touch event (%WPE_EVENT_TOUCH_DOWN, %WPE_EVENT_TOUCH_UP, %WPE_EVENT_TOUCH_MOVE or %WPE_EVENT_TOUCH_CANCEL)
  *
  * Returns: the event sequence identifier
  */

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepadManager.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepadManager.cpp
@@ -72,7 +72,7 @@ static void wpe_gamepad_manager_class_init(WPEGamepadManagerClass* gamepadManage
      * @manager: a #WPEGamepadManager
      * @gamepad: the #WPEGamepad removed
      *
-     * Emitted after a gaempad device is removed.
+     * Emitted after a gamepad device is removed.
      */
     signals[DEVICE_REMOVED] = g_signal_new(
         "device-removed",

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureController.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureController.cpp
@@ -100,7 +100,7 @@ WPEGesture wpe_gesture_controller_get_gesture(WPEGestureController* controller)
  * a position, %FALSE is returned.
  *
  * Returns: %TRUE if position is returned in @x and @y,
- *    or %FALSE if currently detected gesture doesn't have a positon
+ *    or %FALSE if currently detected gesture doesn't have a position
  */
 gboolean wpe_gesture_controller_get_gesture_position(WPEGestureController* controller, double* x, double* y)
 {

--- a/Source/WebKit/WPEPlatform/wpe/WPEKeymap.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEKeymap.h
@@ -55,7 +55,7 @@ typedef struct _WPEKeymapEntry WPEKeymapEntry;
  *   letter at level 0, and an uppercase letter at level 1, though only the
  *   uppercase letter is printed.
  *
- * A WPEKeymapEntry is a map entry retrurned by wpe_keymap_get_entries_for_keyval().
+ * A WPEKeymapEntry is a map entry returned by wpe_keymap_get_entries_for_keyval().
  */
 struct _WPEKeymapEntry
 {

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
@@ -374,7 +374,7 @@ static void wpe_screen_class_init(WPEScreenClass* screenClass)
  * @screen: a #WPEScreen
  *
  * Get the @screen identifier.
- * The idenifier is a non-zero value to uniquely identify a #WPEScreen.
+ * The identifier is a non-zero value to uniquely identify a #WPEScreen.
  *
  * Returns: the screen identifier
  */

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.h
@@ -248,7 +248,7 @@ typedef enum {
  *
  * By default, when a #WPEView is created, a #WPEToplevel is also created and set
  * as the toplevel of the newly created view. This setting allows to create
- * views wihtout a toplevel set, for applications that want to handle the toplevels
+ * views without a toplevel set, for applications that want to handle the toplevels
  * themselves, for example to create a multiview toplevel.
  *
  * VariantType: boolean

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
@@ -345,7 +345,7 @@ void wpe_toplevel_closed(WPEToplevel* toplevel)
  * @width: (out) (nullable): return location for width, or %NULL
  * @height: (out) (nullable): return location for width, or %NULL
  *
- * Get the @vtoplevel size in logical coordinates
+ * Get the @toplevel size in logical coordinates
  */
 void wpe_toplevel_get_size(WPEToplevel* toplevel, int* width, int* height)
 {

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -303,7 +303,7 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
      * Whether the view should be visible or not. This property
      * can be used to show or hide a view, but setting to %TRUE (which
      * is the default) doesn't mean it will always be shown, because
-     * the visbility also depends on the status of its toplevel (for
+     * the visibility also depends on the status of its toplevel (for
      * example if the toplevel is minimized the view will be hidden).
      * To know whether the view is actually visible, you can check
      * #WPEView:mapped property.
@@ -439,7 +439,7 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
         WPE_TYPE_BUFFER);
 
     /**
-     * WPEView::event
+     * WPEView::event:
      * @view: a #WPEView
      * @event: a #WPEEvent
      *
@@ -748,7 +748,7 @@ void wpe_view_set_visible(WPEView* view, gboolean visible)
  * wpe_view_get_mapped:
  * @view: a #WPEView
  *
- * Get whether @view is mapped. A #WPEView isa mapped if
+ * Get whether @view is mapped. A #WPEView is mapped if
  * #WPEView:visible is %TRUE and it's not hidden for other
  * reasons, like for example when its toplevel is minimized.
  * You can connect to notify::mapped signal of @view to


### PR DESCRIPTION
#### 4c0d42479057b5a145b5308a97781878b35774d7
<pre>
[WPE] Fix typos in the WPE Platform API documentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=315996">https://bugs.webkit.org/show_bug.cgi?id=315996</a>

Reviewed by Patrick Griffis.

* Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEClipboard.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEEvent.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEGamepadManager.cpp:
(wpe_gamepad_manager_class_init):
* Source/WebKit/WPEPlatform/wpe/WPEGestureController.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEKeymap.h:
* Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp:
* Source/WebKit/WPEPlatform/wpe/WPESettings.h:
* Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_class_init):

Canonical link: <a href="https://commits.webkit.org/314289@main">https://commits.webkit.org/314289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f548ef49885cef478da4bde84e48ef97a3ae839

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39201 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32782 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122966 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39205 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/128777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168670 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/148882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109301 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28792 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22834 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140048 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177277 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/28286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/137107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39270 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32938 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137036 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39958 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/148376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102476 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25218 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32325 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111542 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37865 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/3324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->