### PR TITLE
[iOS] WebKit process extensions should have separate temp directories per App

### DIFF
--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -128,10 +128,10 @@ static void checkFrameworkVersion(xpc_object_t message)
 
 static bool s_isWebProcess = false;
 
-static void setUserDirSuffix(ASCIILiteral suffix)
+static void setUserDirSuffix(String&& suffix)
 {
 #if PLATFORM(IOS_FAMILY)
-    if (_set_user_dir_suffix(suffix)) {
+    if (_set_user_dir_suffix(suffix.utf8().data())) {
         RELEASE_LOG(IPC, "Successfully set temp dir");
         confstr(_CS_DARWIN_USER_TEMP_DIR, nullptr, 0);
         return;
@@ -209,10 +209,14 @@ void XPCServiceEventHandler(xpc_connection_t peer)
                 return;
             }
 
+            String uiProcessName = xpcDictionaryGetString(event, "ui-process-name"_s);
+
             CFStringRef entryPointFunctionName = nullptr;
             if (serviceName.startsWith(webContentServiceName)) {
                 s_isWebProcess = true;
-#if !USE(EXTENSIONKIT)
+#if USE(EXTENSIONKIT)
+                setUserDirSuffix(WTF::move(uiProcessName));
+#else
                 setUserDirSuffix(webContentServiceName);
 #endif
                 entryPointFunctionName = CFSTR(STRINGIZE_VALUE_OF(WEBCONTENT_SERVICE_INITIALIZER));
@@ -220,7 +224,9 @@ void XPCServiceEventHandler(xpc_connection_t peer)
                 setUserDirSuffix(networkingServiceName);
                 entryPointFunctionName = CFSTR(STRINGIZE_VALUE_OF(NETWORK_SERVICE_INITIALIZER));
             } else if (serviceName == gpuServiceName) {
-#if !USE(EXTENSIONKIT)
+#if USE(EXTENSIONKIT)
+                setUserDirSuffix(WTF::move(uiProcessName));
+#else
                 setUserDirSuffix(gpuServiceName);
 #endif
                 entryPointFunctionName = CFSTR(STRINGIZE_VALUE_OF(GPU_SERVICE_INITIALIZER));


### PR DESCRIPTION
#### 9682d18068ac9fe96d17f82577f5c3afb803355e
<pre>
[iOS] WebKit process extensions should have separate temp directories per App
<a href="https://bugs.webkit.org/show_bug.cgi?id=315107">https://bugs.webkit.org/show_bug.cgi?id=315107</a>
<a href="https://rdar.apple.com/177441499">rdar://177441499</a>

Reviewed by Sihui Liu.

Each app should have a unique temp directory in the extension&apos;s container. It&apos;s important to
not share temp data between apps.

This was initially landed in <a href="https://commits.webkit.org/313609@main">https://commits.webkit.org/313609@main</a>, but was reverted due to a
layout test failure. See <a href="https://bugs.webkit.org/show_bug.cgi?id=315675.">https://bugs.webkit.org/show_bug.cgi?id=315675.</a>

It can be relanded after <a href="https://commits.webkit.org/314233@main.">https://commits.webkit.org/314233@main.</a>

* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::setUserDirSuffix):
(WebKit::XPCServiceEventHandler):

Canonical link: <a href="https://commits.webkit.org/314314@main">https://commits.webkit.org/314314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18112be5215b10125750fcd3ec5f8592be7eb90c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174777 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122990 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ece3d58-391d-46c2-ad9c-003f3a397454) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128797 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fec34e36-59ee-49c8-8a3c-59e054db776d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168694 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109321 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b341cc89-6f98-46e0-96a1-e53e97854547) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28811 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22858 "Hash 18112be5 for PR 66169 does not build (failure)") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157892 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177301 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30217 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137129 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32957 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137057 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102509 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25237 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32342 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25259 "Passed tests") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38493 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111566 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37889 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3340 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38135 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38033 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->