### PR TITLE
[WPE] Consistency fixes to the WPE Platform API documentation

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferFormats.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferFormats.cpp
@@ -319,7 +319,7 @@ void wpe_buffer_formats_builder_append_group(WPEBufferFormatsBuilder* builder, W
  * @fourcc: a DRM fourcc
  * @modifier: a DRM modifier
  *
- * Append a new pair of @format and @modifier to the last group added to @builder
+ * Append a new pair of @fourcc and @modifier to the last group added to @builder
  */
 void wpe_buffer_formats_builder_append_format(WPEBufferFormatsBuilder* builder, guint32 fourcc, guint64 modifier)
 {

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferFormats.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferFormats.h
@@ -45,7 +45,7 @@ WPE_API G_DECLARE_FINAL_TYPE (WPEBufferFormats, wpe_buffer_formats, WPE, BUFFER_
  * @WPE_BUFFER_FORMAT_USAGE_MAPPING: format should be used for mapping buffer.
  * @WPE_BUFFER_FORMAT_USAGE_SCANOUT: format should be used for scanout.
  *
- * Enum values to indicate the best usage of a #WPEBufferFormat.
+ * Enum values to indicate the best usage of a buffer format.
  */
 typedef enum {
     WPE_BUFFER_FORMAT_USAGE_RENDERING,

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
@@ -273,8 +273,8 @@ static void wpe_input_method_context_class_init(WPEInputMethodContextClass* klas
     g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 
      /**
-     * WPEInputMethodContextClass::preedit-started:
-     * @context: the #WPEInputMethodContextClass on which the signal is emitted
+     * WPEInputMethodContext::preedit-started:
+     * @context: the #WPEInputMethodContext on which the signal is emitted
      *
      * Emitted when a new preediting sequence starts.
      */
@@ -292,7 +292,7 @@ static void wpe_input_method_context_class_init(WPEInputMethodContextClass* klas
      *
      * Emitted whenever the preedit sequence currently being entered has changed.
      * It is also emitted at the end of a preedit sequence, in which case
-     * wpe_input_method_context_get_preedit() returns the empty string.
+     * wpe_input_method_context_get_preedit_string() returns the empty string.
      */
     signals[PREEDIT_CHANGED] = g_signal_new(
         "preedit-changed",

--- a/Source/WebKit/WPEPlatform/wpe/WPEKeymap.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEKeymap.cpp
@@ -42,7 +42,7 @@ static void wpe_keymap_class_init(WPEKeymapClass*)
 }
 
 /**
- * wpe_keymap_get_entries_for_keycode:
+ * wpe_keymap_get_entries_for_keyval:
  * @keymap: a #WPEKeymap
  * @keyval: a keyval
  * @entries: (out): return location for array of #WPEKeymapEntry

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
@@ -343,7 +343,7 @@ void wpe_toplevel_closed(WPEToplevel* toplevel)
  * wpe_toplevel_get_size:
  * @toplevel: a #WPEToplevel
  * @width: (out) (nullable): return location for width, or %NULL
- * @height: (out) (nullable): return location for width, or %NULL
+ * @height: (out) (nullable): return location for height, or %NULL
  *
  * Get the @toplevel size in logical coordinates
  */

--- a/Source/WebKit/WPEPlatform/wpe/WPEVersion.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEVersion.cpp
@@ -34,8 +34,8 @@
  * Provides convenience functions returning WPE's major, minor and
  * micro versions of the WPE platform library your code is running
  * against. This is not necessarily the same as the
- * #WPE_PLATFORM_MAJOR_VERSION, #WPE_PLATFORM_MINOR_VERSION or
- * #WPE_PLATFORM_MICRO_VERSION, which represent the version of the WPE platform
+ * %WPE_PLATFORM_MAJOR_VERSION, %WPE_PLATFORM_MINOR_VERSION or
+ * %WPE_PLATFORM_MICRO_VERSION, which represent the version of the WPE platform
  * headers included when compiling the code.
  */
 
@@ -46,7 +46,7 @@
  * (e.g. in WPEPlatform version 1.8.3 this is 1.)
  *
  * This function is in the library, so it represents the WPE platform library
- * your code is running against. Contrast with the #WPE_PLATFORM_MAJOR_VERSION
+ * your code is running against. Contrast with the %WPE_PLATFORM_MAJOR_VERSION
  * macro, which represents the major version of the WPE platform headers you
  * have included when compiling your code.
  *
@@ -64,7 +64,7 @@ guint wpe_platform_get_major_version(void)
  * (e.g. in WPEPlatform version 1.8.3 this is 8.)
  *
  * This function is in the library, so it represents the WPE platform library
- * your code is running against. Contrast with the #WPE_PLATFORM_MINOR_VERSION
+ * your code is running against. Contrast with the %WPE_PLATFORM_MINOR_VERSION
  * macro, which represents the minor version of the WPE platform headers you
  * have included when compiling your code.
  *
@@ -82,7 +82,7 @@ guint wpe_platform_get_minor_version(void)
  * (e.g. in WPEPlatform version 1.8.3 this is 3.)
  *
  * This function is in the library, so it represents the WPE platform library
- * your code is running against. Contrast with the #WPE_PLATFORM_MICRO_VERSION
+ * your code is running against. Contrast with the %WPE_PLATFORM_MICRO_VERSION
  * macro, which represents the micro version of the WPE platform headers you
  * have included when compiling your code.
  *

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -951,7 +951,7 @@ gboolean wpe_view_render_buffer(WPEView* view, WPEBuffer* buffer, const WPERecta
  *
  * Notify that the set of graphics buffers used to render the view have changed.
  *
- * The [signal@View::buffers_changed] signal will be emitted.
+ * The [signal@View::buffers-changed] signal will be emitted.
  */
 void wpe_view_buffers_changed(WPEView* view, WPEBuffer** buffers, guint nBuffers)
 {

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -735,7 +735,7 @@ static void wpe_view_wayland_class_init(WPEViewWaylandClass* viewWaylandClass)
  * wpe_view_wayland_get_wl_surface: (skip)
  * @view: a #WPEViewWayland
  *
- * Get the native Wayland view of @view
+ * Get the native Wayland surface of @view
  *
  * Returns: (transfer none) (nullable): a Wayland `wl_surface`
  */


### PR DESCRIPTION
#### c3ed6a5494d65ff9f3e0151c8c86233e81ab3f14
<pre>
[WPE] Consistency fixes to the WPE Platform API documentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=316001">https://bugs.webkit.org/show_bug.cgi?id=316001</a>

Reviewed by Adrian Perez de Castro.

* Source/WebKit/WPEPlatform/wpe/WPEBufferFormats.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEBufferFormats.h:
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp:
(wpe_input_method_context_class_init):
* Source/WebKit/WPEPlatform/wpe/WPEKeymap.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEVersion.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:

Canonical link: <a href="https://commits.webkit.org/314303@main">https://commits.webkit.org/314303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcfd438aaf3a54d1f234759c8844a0548b4a612a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174761 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122974 "Built successfully") 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39640 "Build is in progress. Recent messages:") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128784 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168678 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31127 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109308 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/39640 "Build is in progress. Recent messages:") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28800 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22842 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140055 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177285 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30201 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137114 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137043 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102491 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25229 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32331 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25250 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38477 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111550 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37873 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3331 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->