### PR TITLE
[Cocoa] Video disappears from fullscreen when video element is not visible

### DIFF
--- a/LayoutTests/media/media-visible-in-viewport-in-fullscreen-expected.txt
+++ b/LayoutTests/media/media-visible-in-viewport-in-fullscreen-expected.txt
@@ -1,0 +1,30 @@
+
+RUN(internals.settings.setAllowsPictureInPictureMediaPlayback(true))
+RUN(internals.setMockVideoPresentationModeEnabled(true))
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(canplaythrough)
+EXPECTED (internals.mediaElementViewportVisibility(video) == 'NotVisible') OK
+
+Test viewport visibility in Picture-in-Picture:
+RUN(video.requestPictureInPicture())
+EVENT(enterpictureinpicture)
+EXPECTED (internals.mediaElementViewportVisibility(video) == 'VisibleInPictureInPicture') OK
+EXPECTED (internals.isChangingPresentationMode(video) == 'false') OK
+RUN(document.exitPictureInPicture())
+EVENT(leavepictureinpicture)
+EXPECTED (internals.mediaElementViewportVisibility(video) == 'NotVisible') OK
+
+Test viewport visibility in Fullscreen:
+RUN(video.webkitEnterFullscreen())
+EVENT(webkitpresentationmodechanged)
+EXPECTED (internals.isChangingPresentationMode(video) == 'false') OK
+EXPECTED (internals.mediaElementViewportVisibility(video) == 'VisibleInFullscreen') OK
+RUN(video.webkitExitFullscreen())
+EVENT(webkitpresentationmodechanged)
+EXPECTED (internals.mediaElementViewportVisibility(video) == 'NotVisible') OK
+
+Ensure video becomes visible-in-viewport when scrolled on-screen:
+RUN(video.scrollIntoView())
+EXPECTED (internals.mediaElementViewportVisibility(video) == 'VisibleInViewport') OK
+END OF TEST
+

--- a/LayoutTests/media/media-visible-in-viewport-in-fullscreen.html
+++ b/LayoutTests/media/media-visible-in-viewport-in-fullscreen.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>media-visible-in-viewport-in-fullscreen</title>
+	<style>
+		#spacer { height: 300vh; }
+	</style>
+	<script src="video-test.js"></script>
+	<script src="media-file.js"></script>
+	<script>
+	window.addEventListener('load', event => {
+		runTest().then(endTest).catch(failTest);
+	})
+
+	async function runTest() {
+		if (!window.internals)
+			throw('Requires window.internals');
+
+        run('internals.settings.setAllowsPictureInPictureMediaPlayback(true)');
+        run('internals.setMockVideoPresentationModeEnabled(true)');
+
+		findMediaElement();
+		run('video.src = findMediaFile("video", "content/test")');
+		await waitFor(video, 'canplaythrough');
+		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'NotVisible', '==', 1000);
+
+		consoleWrite('');
+		consoleWrite('Test viewport visibility in Picture-in-Picture:');
+		internals.withUserGesture(() => {
+			return run('video.requestPictureInPicture()');
+		});
+		await waitFor(video, 'enterpictureinpicture');
+		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'VisibleInPictureInPicture', '==', 1000);
+
+        await testExpectedEventually("internals.isChangingPresentationMode(video)", false);
+		internals.withUserGesture(() => {
+			return run('document.exitPictureInPicture()');
+		});
+		await waitFor(video, 'leavepictureinpicture');
+		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'NotVisible', '==', 1000);
+
+		consoleWrite('');
+		consoleWrite('Test viewport visibility in Fullscreen:');
+		internals.withUserGesture(() => {
+			return run('video.webkitEnterFullscreen()');
+		});
+		await waitFor(video, 'webkitpresentationmodechanged');
+        await testExpectedEventually("internals.isChangingPresentationMode(video)", false);
+		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'VisibleInFullscreen', '==', 1000);
+
+		internals.withUserGesture(() => {
+			return run('video.webkitExitFullscreen()');
+		});
+		await waitFor(video, 'webkitpresentationmodechanged');
+		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'NotVisible', '==', 1000);
+
+		consoleWrite('');
+		consoleWrite('Ensure video becomes visible-in-viewport when scrolled on-screen:');
+		run('video.scrollIntoView()');
+		await testExpectedEventually('internals.mediaElementViewportVisibility(video)', 'VisibleInViewport', '==', 1000);
+	}
+	</script>
+</head>
+<body>
+	<div id=spacer></div>
+	<video controls></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5541,6 +5541,9 @@ webkit.org/b/315925 inspector/heap/getRemoteObject.html [ Failure Pass ]
 
 webkit.org/b/315934 fast/dom/lazy-image-loading-document-leak.html [ Crash Pass ]
 
+# Needs picture-in-picture support
+media/media-visible-in-viewport-in-fullscreen.html
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9770,6 +9770,10 @@ bool HTMLMediaElement::isVisibleInViewport() const
 
 WEBCORE_EXPORT auto HTMLMediaElement::viewportVisibility() const -> ViewportVisibility
 {
+    if (fullscreenMode() & VideoFullscreenModePictureInPicture)
+        return ViewportVisibility::VisibleInPictureInPicture;
+    if (fullscreenMode() & VideoFullscreenModeStandard)
+        return ViewportVisibility::VisibleInFullscreen;
     if (isVisibleInViewport())
         return ViewportVisibility::VisibleInViewport;
     if (isIntersectingViewport())

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -2320,14 +2320,18 @@ String convertEnumerationToString(MediaPlayer::BufferingPolicy enumerationValue)
 
 String convertEnumerationToString(MediaPlayer::ViewportVisibility enumerationValue)
 {
-    static const std::array<NeverDestroyed<String>, 4> values {
+    static const std::array<NeverDestroyed<String>, 5> values {
         MAKE_STATIC_STRING_IMPL("NotVisible"),
         MAKE_STATIC_STRING_IMPL("IntersectingViewport"),
         MAKE_STATIC_STRING_IMPL("VisibleInViewport"),
+        MAKE_STATIC_STRING_IMPL("VisibleInFullscreen"),
+        MAKE_STATIC_STRING_IMPL("VisibleInPictureInPicture"),
     };
     static_assert(!static_cast<size_t>(MediaPlayer::ViewportVisibility::NotVisible), "MediaPlayer::NotVisible is not 0 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::ViewportVisibility::IntersectingViewport) == 1, "MediaPlayer::IntersectingViewport is not 1 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::ViewportVisibility::VisibleInViewport) == 2, "MediaPlayer::VisibleInViewport is not 2 as expected");
+    static_assert(static_cast<size_t>(MediaPlayer::ViewportVisibility::VisibleInFullscreen) == 3, "MediaPlayer::VisibleInFullscreen is not 2 as expected");
+    static_assert(static_cast<size_t>(MediaPlayer::ViewportVisibility::VisibleInPictureInPicture) == 4, "MediaPlayer::VisibleInPictureInPicture is not 2 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -125,6 +125,8 @@ enum class MediaPlayerViewportVisibility : uint8_t {
     NotVisible,
     IntersectingViewport,
     VisibleInViewport,
+    VisibleInFullscreen,
+    VisibleInPictureInPicture,
 };
 
 class MediaPlayerEnums {

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -615,6 +615,7 @@ void MediaPlayerPrivateAVFoundation::setViewportVisibility(ViewportVisibility vi
     if (m_viewportVisibility == visibility)
         return;
 
+    ALWAYS_LOG(LOGIDENTIFIER, visibility);
     m_viewportVisibility = visibility;
     platformViewportVisibilityChanged(visibility);
 }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5806,6 +5806,11 @@ void Internals::setMediaElementVolumeLocked(HTMLMediaElement& element, bool volu
     element.setVolumeLocked(volumeLocked);
 }
 
+String Internals::mediaElementViewportVisibility(HTMLMediaElement& element)
+{
+    return convertEnumerationToString(element.viewportVisibility());
+}
+
 #if ENABLE(SPEECH_SYNTHESIS)
 SpeechSynthesisUtterance* Internals::speechSynthesisUtteranceForCue(const VTTCue& cue)
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1321,6 +1321,7 @@ public:
     size_t mediaElementCount() const;
 
     void setMediaElementVolumeLocked(HTMLMediaElement&, bool);
+    String mediaElementViewportVisibility(HTMLMediaElement&);
 
 #if ENABLE(SPEECH_SYNTHESIS)
     SpeechSynthesisUtterance* NODELETE speechSynthesisUtteranceForCue(const VTTCue&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1358,6 +1358,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] boolean elementShouldDisplayPosterImage(HTMLVideoElement element);
     [Conditional=VIDEO] readonly attribute unsigned long mediaElementCount;
     [Conditional=VIDEO] undefined setMediaElementVolumeLocked(HTMLMediaElement element, boolean volumeLocked);
+    [Conditional=VIDEO] DOMString mediaElementViewportVisibility(HTMLMediaElement element);
 
     [Conditional=SPEECH_SYNTHESIS] SpeechSynthesisUtterance? speechSynthesisUtteranceForCue(VTTCue cue);
     [Conditional=SPEECH_SYNTHESIS] VTTCue? mediaElementCurrentlySpokenCue(HTMLMediaElement media);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4299,6 +4299,8 @@ enum class WebCore::MediaPlayerViewportVisibility : uint8_t {
     NotVisible,
     IntersectingViewport,
     VisibleInViewport,
+    VisibleInFullscreen,
+    VisibleInPictureInPicture,
 };
 
 class WebCore::GeolocationPositionData {


### PR DESCRIPTION
#### c58c8180245a031b9209d8718999b6a735ba4c06
<pre>
[Cocoa] Video disappears from fullscreen when video element is not visible
<a href="https://rdar.apple.com/177081214">rdar://177081214</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316010">https://bugs.webkit.org/show_bug.cgi?id=316010</a>

Reviewed by Eric Carlson.

In 311380@main, MediaElements which were scrolled far away from the viewport were sent
a message saying so, but no exception was made for video elemnets playing in fullscreen
or picture-in-picture. This had the side effect, for MediaPlayerPrivates which would tear
down their decoders when not visible, of causing fullscreen or pip playback to show
black frames.

Add the concept of &quot;VisibleInFullscreen&quot; and &quot;VisibleInPictureInPicture&quot; to ViewportVisibility
and send those values when in fullscreen or pip.

* LayoutTests/media/media-visible-in-viewport-in-fullscreen-expected.txt: Added.
* LayoutTests/media/media-visible-in-viewport-in-fullscreen.html: Added.

Canonical link: <a href="https://commits.webkit.org/314324@main">https://commits.webkit.org/314324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d63128935cf3dc54c2eece35a54debf8cdb0295

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174831 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/248b7337-f924-46e0-954e-8bf5a0dee17c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128844 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3615e61d-3430-45ab-bdf7-153958b476b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168748 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/148959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109368 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcb29a1b-db85-45a7-98ee-03b6bd5bb506) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22914 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177356 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137177 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137105 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36938 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148453 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102567 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32392 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38547 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111620 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37943 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3402 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38189 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->