### PR TITLE
[AppKit Gestures] Scrolling sometimes removes text selection

### DIFF
--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -150,7 +150,7 @@ public:
     bool NODELETE isCheckbox() const;
     bool NODELETE isSwitch() const;
     bool NODELETE isCheckable() const;
-    bool NODELETE isRangeControl() const;
+    WEBCORE_EXPORT bool NODELETE isRangeControl() const;
     WEBCORE_EXPORT bool NODELETE isColorControl() const;
     // FIXME: It's highly likely that any call site calling this function should instead
     // be using a different one. Many input elements behave like text fields, and in addition

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
@@ -70,6 +70,7 @@ struct InteractionInformationAtPosition {
         bool prefersDraggingOverTextSelection,
         bool isDHTMLDraggable,
         bool isColorInput,
+        bool isRangeInput,
         bool isNearMarkedText,
 #if PLATFORM(IOS_FAMILY)
         bool touchCalloutEnabled,
@@ -138,6 +139,8 @@ struct InteractionInformationAtPosition {
     bool prefersDraggingOverTextSelection { false };
     bool isDHTMLDraggable { false };
     bool isColorInput { false };
+    bool isRangeInput { false };
+
     bool isNearMarkedText { false };
 #if PLATFORM(IOS_FAMILY)
     bool touchCalloutEnabled { true };

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
@@ -43,6 +43,7 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
     bool prefersDraggingOverTextSelection,
     bool isDHTMLDraggable,
     bool isColorInput,
+    bool isRangeInput,
     bool isNearMarkedText,
 #if PLATFORM(IOS_FAMILY)
     bool touchCalloutEnabled,
@@ -107,6 +108,7 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
     , prefersDraggingOverTextSelection(prefersDraggingOverTextSelection)
     , isDHTMLDraggable(isDHTMLDraggable)
     , isColorInput(isColorInput)
+    , isRangeInput(isRangeInput)
     , isNearMarkedText(isNearMarkedText)
 #if PLATFORM(IOS_FAMILY)
     , touchCalloutEnabled(touchCalloutEnabled)

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
@@ -41,6 +41,7 @@ struct WebKit::InteractionInformationAtPosition {
     bool prefersDraggingOverTextSelection;
     bool isDHTMLDraggable;
     bool isColorInput;
+    bool isRangeInput;
     bool isNearMarkedText;
 #if PLATFORM(IOS_FAMILY)
     bool touchCalloutEnabled;

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -848,23 +848,62 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     return shouldBegin;
 }
 
-- (BOOL)_dragPressShouldBeginAtLocation:(NSPoint)locationInViewCoordinates
+- (BOOL)_positionInformationRequestIsValidAtLocation:(NSPoint)locationInViewCoordinates withRadius:(NSInteger)radius
 {
     WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInViewCoordinates } };
+    return _hasValidPositionInformation && _positionInformation.request.isApproximatelyValidForRequest(request, radius);
+}
+
+- (BOOL)_dragPressShouldBeginAtLocation:(NSPoint)locationInViewCoordinates
+{
     int radius = static_cast<int>(std::ceil([_dragPressGestureRecognizer allowableMovement]));
+
     // FIXME: Migrate to requestDragStart: IPC for an authoritative decision.
     // The heuristic below approximates DragController::draggableElement() by consulting the same element-type and style signals.
     bool isDraggable = representsDraggableElement(_positionInformation);
-    bool requestIsValid = _hasValidPositionInformation && _positionInformation.request.isApproximatelyValidForRequest(request, radius);
+    bool requestIsValid = [self _positionInformationRequestIsValidAtLocation:locationInViewCoordinates withRadius:radius];
     bool shouldDrag = requestIsValid && isDraggable;
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(),
+
+    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(
+        RefPtr { _page.get() }->logIdentifier(),
         "Drag-press shouldBegin → %d (hasInfo=%d link=%d image=%d attachment=%d dhtml=%d color=%d prefersDrag=%d radius=%d)",
-        shouldDrag, _hasValidPositionInformation,
-        _positionInformation.isLink, _positionInformation.isImage, _positionInformation.isAttachment,
-        _positionInformation.isDHTMLDraggable, _positionInformation.isColorInput, _positionInformation.prefersDraggingOverTextSelection, radius);
+        shouldDrag,
+        _hasValidPositionInformation,
+        _positionInformation.isLink,
+        _positionInformation.isImage,
+        _positionInformation.isAttachment,
+        _positionInformation.isDHTMLDraggable,
+        _positionInformation.isColorInput,
+        _positionInformation.prefersDraggingOverTextSelection,
+        radius
+    );
+
     if (!requestIsValid)
         [self _invalidateCurrentPositionInformation];
+
     return shouldDrag;
+}
+
+- (BOOL)_panShouldBeginAtLocation:(NSPoint)locationInViewCoordinates
+{
+    static constexpr int panPositionInformationToleranceRadius = 15;
+    bool requestIsValid = [self _positionInformationRequestIsValidAtLocation:locationInViewCoordinates withRadius:panPositionInformationToleranceRadius];
+
+    bool isDraggable = representsDraggableElement(_positionInformation);
+    bool prefersInteraction = _positionInformation.isRangeInput;
+    bool yieldToContent = requestIsValid && (isDraggable || prefersInteraction);
+
+    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(
+        RefPtr { _page.get() }->logIdentifier(),
+        "Pan shouldBegin → %d (hasInfo=%d valid=%d draggable=%d prefersInteraction=%d)",
+        !yieldToContent,
+        _hasValidPositionInformation,
+        requestIsValid,
+        isDraggable,
+        prefersInteraction
+    );
+
+    return !yieldToContent;
 }
 
 #pragma mark - Drag Handling
@@ -1320,9 +1359,6 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     if (isSamePair(gestureRecognizer, otherGestureRecognizer, _mouseTrackingGestureRecognizer.get(), _singleClickGestureRecognizer.get()))
         return YES;
 
-    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _mouseTrackingGestureRecognizer.get(), _panGestureRecognizer.get()))
-        return YES;
-
     if (isSamePair(gestureRecognizer, otherGestureRecognizer, _dragPressGestureRecognizer.get(), _singleClickGestureRecognizer.get()))
         return YES;
 
@@ -1382,8 +1418,22 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
 {
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@, Other gesture: %@", gestureRecognizer, otherGestureRecognizer);
 
+    CheckedPtr viewImpl = _viewImpl.get();
+    if (!viewImpl)
+        return NO;
+
+    RetainPtr webView = viewImpl->view();
+    if (!webView)
+        return NO;
+
     if (gestureRecognizer == _singleClickGestureRecognizer && otherGestureRecognizer == _doubleClickGestureRecognizer)
         return YES;
+
+    if (gestureRecognizer == _mouseTrackingGestureRecognizer && otherGestureRecognizer == _panGestureRecognizer) {
+        bool panCanScroll = [self panGestureRecognizerCanScroll];
+        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Mouse tracking requires pan to fail: %d", panCanScroll);
+        return panCanScroll;
+    }
 
     return NO;
 }
@@ -1410,6 +1460,9 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
 
     if (gestureRecognizer == _dragPressGestureRecognizer)
         return [self _dragPressShouldBeginAtLocation:locationInViewCoordinates];
+
+    if (gestureRecognizer == _panGestureRecognizer)
+        return [self _panShouldBeginAtLocation:locationInViewCoordinates];
 
     if (gestureRecognizer == _singleClickGestureRecognizer)
         return !viewImpl->isTextSelectedAtPoint(locationInViewCoordinates);

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -166,12 +166,15 @@ extension WKTextSelectionController {
         let newState = page.editorState
         let newVisualData = Optional(fromCxx: newState.visualData)
 
-        guard let previousVisualData, let newVisualData else {
-            return false
+        return switch (previousVisualData, newVisualData) {
+        case (let previousVisualData?, let newVisualData?):
+            // FIXME: (rdar://170847912) Use the `!=` operator instead when possible.
+            !(previousVisualData.caretRectAtStart == newVisualData.caretRectAtStart)
+        case (nil, nil):
+            false
+        default:
+            true
         }
-
-        // FIXME: (rdar://170847912) Use the `!=` operator instead when possible.
-        return !(previousVisualData.caretRectAtStart == newVisualData.caretRectAtStart)
     }
 
     @objc(showContextMenuAtPoint:)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -416,7 +416,12 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
                 info.isColorInput = true;
         }
 
-        if (info.prefersDraggingOverTextSelection || info.isDHTMLDraggable || info.isColorInput)
+        if (!info.isRangeInput) {
+            if (RefPtr input = dynamicDowncast<WebCore::HTMLInputElement>(currentNode); input && input->isRangeControl() && !input->isDisabledFormControl())
+                info.isRangeInput = true;
+        }
+
+        if (info.prefersDraggingOverTextSelection || info.isDHTMLDraggable || info.isColorInput || info.isRangeInput)
             break;
     }
 #if PLATFORM(MACCATALYST)

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift
@@ -63,13 +63,13 @@ extension WebPage {
     /// An error representing a failure when evaluating JavaScript.
     public enum JavaScriptEvaluationError: Error {
         /// An unexpected error occurred.
-        case unexpectedResult(String)
+        case scriptError(underlyingError: any Error)
 
         /// The JavaScript expression returned a result when none was expected.
         case noResult
 
         /// The expression returned a value of an unexpected type.
-        case mismatchedType(String)
+        case mismatchedType(expected: Any.Type, actual: Any.Type)
 
         /// The JavaScript output type failed to decode.
         case decodingFailure(String)
@@ -83,12 +83,17 @@ extension WebPage {
     /// - Throws: An error if the JavaScript evaluation or decoding fails.
     public func callJavaScript<Expression>(
         _ expression: Expression
-    ) async throws where Expression: JavaScriptExpression, Expression.Output == Void {
+    ) async throws(JavaScriptEvaluationError) where Expression: JavaScriptExpression, Expression.Output == Void {
         let arguments = expression.encoded() as [String: Any]
-        let result = try await self.callJavaScript(Expression.expression, arguments: arguments)
+        let result: Any?
+        do {
+            result = try await self.callJavaScript(Expression.expression, arguments: arguments)
+        } catch {
+            throw .scriptError(underlyingError: error)
+        }
 
         if let result {
-            throw JavaScriptEvaluationError.unexpectedResult("expected no result, got \(result)")
+            throw .mismatchedType(expected: Expression.Output.self, actual: type(of: result))
         }
     }
 
@@ -99,23 +104,84 @@ extension WebPage {
     /// - Throws: An error if the JavaScript evaluation or decoding fails.
     public func callJavaScript<Expression>(
         _ expression: Expression
-    ) async throws -> Expression.Output where Expression: JavaScriptExpression, Expression.Output: JavaScriptDecodable {
+    ) async throws(JavaScriptEvaluationError) -> Expression.Output
+    where Expression: JavaScriptExpression, Expression.Output: JavaScriptDecodable {
         let arguments = expression.encoded() as [String: Any]
-        let result = try await self.callJavaScript(Expression.expression, arguments: arguments)
+        let result: Any?
+        do {
+            result = try await self.callJavaScript(Expression.expression, arguments: arguments)
+        } catch {
+            throw .scriptError(underlyingError: error)
+        }
 
         guard let result else {
-            throw JavaScriptEvaluationError.noResult
+            throw .noResult
         }
 
         guard let dictionaryResult = result as? [String: Any?] else {
-            throw JavaScriptEvaluationError.mismatchedType("expected dictionary JS result")
+            throw .mismatchedType(expected: [String: Any?].self, actual: type(of: result))
         }
 
-        guard let decodedResult = Expression.Output.init(decodedRepresentation: dictionaryResult) else {
-            throw JavaScriptEvaluationError.decodingFailure("failed to decode result")
+        guard let decodedResult = Expression.Output(decodedRepresentation: dictionaryResult) else {
+            throw .decodingFailure("failed to decode result")
         }
 
         return decodedResult
+    }
+
+    /// Executes the specified string as an async JavaScript function.
+    ///
+    /// - Parameters:
+    ///   - returnType: The type the expression returns.
+    ///   - arguments: A dictionary of the arguments to pass to the function call.
+    ///   - script: The JavaScript string to use as the function body.
+    /// - Returns: The result of the script evaluation. If the type of the result is not the type of `returnType`, an error is thrown.
+    /// - Throws: A `JavaScriptEvaluationError` error if there was a problem evaluating the script, or if a serialization failure occurred.
+    public func callJavaScript<Result>(
+        returning returnType: Result.Type,
+        arguments: [String: Any] = [:],
+        script: () -> String
+    ) async throws(JavaScriptEvaluationError) -> Result {
+        let result: Any?
+        do {
+            result = try await callJavaScript(script(), arguments: arguments)
+        } catch {
+            throw .scriptError(underlyingError: error)
+        }
+
+        guard let result else {
+            throw .noResult
+        }
+
+        guard let result = result as? Result else {
+            throw .mismatchedType(expected: Result.self, actual: type(of: result))
+        }
+
+        return result
+    }
+
+    /// Executes the specified string as an async JavaScript function.
+    ///
+    /// - Parameters:
+    ///   - returnType: The type the expression returns.
+    ///   - arguments: A dictionary of the arguments to pass to the function call.
+    ///   - script: The JavaScript string to use as the function body.
+    /// - Throws: A `JavaScriptEvaluationError` error if there was a problem evaluating the script, or if a serialization failure occurred.
+    public func callJavaScript(
+        returning returnType: Void.Type = Void.self,
+        arguments: [String: Any] = [:],
+        script: () -> String
+    ) async throws(JavaScriptEvaluationError) {
+        let result: Any?
+        do {
+            result = try await callJavaScript(script(), arguments: arguments)
+        } catch {
+            throw .scriptError(underlyingError: error)
+        }
+
+        guard result == nil else {
+            throw .mismatchedType(expected: returnType, actual: type(of: result))
+        }
     }
 }
 

--- a/Tools/TestWebKitAPI/Resources/cocoa/custom-slider.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/custom-slider.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    #custom-slider {
+        position: relative;
+        width: 400px;
+        height: 200px;
+        background: #ccc;
+        user-select: none;
+        -webkit-user-select: none;
+    }
+
+    #thumb {
+        position: absolute;
+        top: 0;
+        width: 24px;
+        height: 100%;
+        background: #333;
+    }
+</style>
+</head>
+<body>
+    <input id="native-slider" type="range" min="0" max="10" style="width: 400px; height: 200px" />
+    <div id="custom-slider" role="slider" aria-valuemin="0" aria-valuemax="10" aria-valuenow="5">
+        <div id="thumb"></div>
+    </div>
+
+<script>
+    const customSlider = document.getElementById("custom-slider");
+    const thumb = document.getElementById("thumb");
+    const maxValue = 10;
+
+    window.eventLog = {
+        "custom-slider": new Set(),
+        "native-slider": new Set(),
+    };
+
+    function setValue(value) {
+        value = Math.max(0, Math.min(maxValue, value));
+        customSlider.setAttribute("aria-valuenow", value);
+        window.eventLog["custom-slider"].add(value);
+        thumb.style.left = (value / maxValue) * (customSlider.clientWidth - thumb.offsetWidth) + "px";
+    }
+
+    function setValueFromClientX(clientX) {
+        const rect = customSlider.getBoundingClientRect();
+        setValue(Math.round((clientX - rect.left) / rect.width * maxValue));
+    }
+
+    let dragging = false;
+    customSlider.addEventListener("pointerdown", e => { dragging = true; customSlider.setPointerCapture(e.pointerId); setValueFromClientX(e.clientX); e.preventDefault(); });
+    customSlider.addEventListener("pointermove", e => { if (dragging) setValueFromClientX(e.clientX); });
+    customSlider.addEventListener("pointerup", () => { dragging = false; });
+
+    setValue(5);
+
+    const nativeSlider = document.getElementById("native-slider");
+    window.eventLog["native-slider"].add(Number(nativeSlider.value));
+    nativeSlider.addEventListener("input", e => window.eventLog["native-slider"].add(Number(e.target.value)));
+</script>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -86,16 +86,15 @@ struct AppKitGesturesTests {
 
         let expectedEvents = ["pointerdown", "mousedown", "pointerup", "mouseup", "click"]
 
-        try await page.callJavaScript(
+        try await page.callJavaScript(arguments: ["events": expectedEvents]) {
             """
             window.eventLog = [];
             const target = document.getElementById("div");
             for (const eventType of events) {
                 target.addEventListener(eventType, e => window.eventLog.push(e.type));
             }
-            """,
-            arguments: ["events": expectedEvents]
-        )
+            """
+        }
 
         if contentEditable {
             // FIXME: <rdar://177201499> This workaround establishes a selection first so that the synthetic click does not change insertion point.
@@ -114,7 +113,11 @@ struct AppKitGesturesTests {
         await page.waitForPendingMouseEvents()
         await page.waitForNextPresentationUpdate()
 
-        let eventLog = try await #require(page.callJavaScript("return window.eventLog;") as? [String])
+        let eventLog = try await page.callJavaScript(returning: [String].self) {
+            """
+            return window.eventLog;
+            """
+        }
 
         for eventType in expectedEvents {
             #expect(eventLog.contains(eventType))
@@ -218,6 +221,45 @@ struct AppKitGesturesTests {
         } else {
             #expect(newSelection == .collapsed(.init(in: "div", at: Self.text.count)))
         }
+    }
+
+    @Test
+    func scrollingDoesNotRemoveTextSelection() async throws {
+        try await loadHTML()
+
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        let crazySelection = JavaScriptSelection.range(
+            base: .init(in: "div", at: crazyRange.lowerBound),
+            extent: .init(in: "div", at: crazyRange.upperBound)
+        )
+
+        let crazyBoundsInScreenCoordinates = try await screenBoundsOfText("crazy")
+
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        await recap.play { composer in
+            composer._wk_click(at: crazyBoundsInScreenCoordinates.center, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+            composer._wk_click(at: crazyBoundsInScreenCoordinates.center, for: .seconds(0.1))
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let start = convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: window.frame.center, window: window)
+        let end = CGPoint(x: start.x, y: start.y + 200)
+
+        await recap.play { composer in
+            composer._wk_scroll(withStart: start, end: end, duration: .seconds(1))
+        }
+
+        let newSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        #expect(newSelection == crazySelection)
     }
 
     @Test(arguments: [true, false], [true, false])
@@ -398,23 +440,26 @@ struct AppKitGesturesTests {
 
     // MARK: - Drag Press Disambiguation Tests
 
-    @Test
-    func pressDragOverRangeInputChangesInputValue() async throws {
-        let maximumValue = 10.0
+    @Test(arguments: [true, false])
+    func pressDragOverRangeInputChangesInputValue(useNativeWidget: Bool) async throws {
+        let maximumValue = 10
+        let initialValue = maximumValue / 2
 
-        let html = """
-            <input type="range" id="range" min="0" max="\(maximumValue)" style="width: 400px; height: 200px" />
-            """
+        let elementID = useNativeWidget ? "native-slider" : "custom-slider"
 
-        try await page.load(html: html).wait()
+        let customHTML = try #require(Bundle.testResources.url(forResource: "custom-slider", withExtension: "html"))
+        try await page.load(customHTML).wait()
 
+        await page.waitForNextPresentationUpdate()
+
+        try await page.callJavaScript(arguments: ["elementID": "custom-slider"], script: styleAdjustmentForCustomWidgetScript)
         await page.waitForNextPresentationUpdate()
 
         guard NSApp.isActive else {
             return
         }
 
-        let sliderBounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: "range"))
+        let sliderBounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: elementID))
         let convertedSliderBounds = convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: sliderBounds, window: window)
 
         let start = convertedSliderBounds.center
@@ -426,12 +471,28 @@ struct AppKitGesturesTests {
 
         await page.waitForNextPresentationUpdate()
 
-        let sliderValueScript = """
-            return Number(document.getElementById("range").value);
+        let finalSliderValue = try await page.callJavaScript(
+            returning: Double.self,
+            arguments: ["elementID": elementID, "useNativeWidget": useNativeWidget]
+        ) {
             """
+            if (useNativeWidget) {
+                return Number(document.getElementById(elementID).value);
+            } else {
+                return Number(document.getElementById(elementID).getAttribute("aria-valuenow"));
+            }
+            """
+        }
 
-        let finalSliderValue = try await page.callJavaScript(sliderValueScript) as? Double
-        #expect(finalSliderValue == maximumValue)
+        #expect(finalSliderValue == Double(maximumValue))
+
+        let eventLog = try await page.callJavaScript(returning: [Double].self, arguments: ["elementID": elementID]) {
+            """
+            return [...window.eventLog[elementID]];
+            """
+        }
+
+        #expect(eventLog == (initialValue...maximumValue).map(Double.init))
     }
 
     @Test(
@@ -544,7 +605,7 @@ struct AppKitGesturesTests {
             """
         try await page.load(html: html, baseURL: baseURL).wait()
 
-        try await page.callJavaScript(
+        try await page.callJavaScript {
             """
             const img = document.getElementById("img");
             if (img.complete && img.naturalWidth > 0) {
@@ -552,7 +613,7 @@ struct AppKitGesturesTests {
             }
             await new Promise(resolve => img.addEventListener("load", resolve, { once: true }));
             """
-        )
+        }
 
         let imgViewportBounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: "img"))
         let imgBounds = convertToCoreGraphicsScreenCoordinates(


### PR DESCRIPTION
#### b5e32a9849bc8cd13c9b3f451bf1db742e7d26f5
<pre>
[AppKit Gestures] Scrolling sometimes removes text selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=316013">https://bugs.webkit.org/show_bug.cgi?id=316013</a>
<a href="https://rdar.apple.com/176988227">rdar://176988227</a>

Reviewed by Abrar Rahman Protyasha.

This was happening because the mouse tracking gesture recognizer was being recognized when it should
not have been, resulting in a mouse press happening which then clears the selection.

Fix this by blocking the mouse tracking gesture recognizer on the pan gesture recognizer.
Consequently, the pan gesture recognizer needs to be changed to make its activation conditions more
limited.

This also requires special handling of elements such as range inputs to ensure that they still receive
the proper events instead of scrolling happening instead.

This also fixes a latent issue in WKTextSelectionController that was revealed incidentally with the above
changes; the selection should be considered changed if one of the previous or new visual data&apos;s is nil.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift

* Source/WebCore/html/HTMLInputElement.h:
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h:
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm:
(WebKit::InteractionInformationAtPosition::InteractionInformationAtPosition):
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController _dragPressShouldBeginAtLocation:]):
(-[WKAppKitGestureController _panShouldBeginAtLocation:]):
(-[WKAppKitGestureController gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
(-[WKAppKitGestureController gestureRecognizer:shouldRequireFailureOfGestureRecognizer:]):
(-[WKAppKitGestureController gestureRecognizerShouldBegin:]):
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.moveInsertionCursor(to:placeAtWordBoundary:)):
* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
(WebKit::selectionPositionInformation):
* Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift:
* Tools/TestWebKitAPI/Resources/cocoa/custom-slider.html: Added.
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.singleClickFiresPointerMouseAndClickEvents(_:)):
(AppKitGesturesTests.scrollingDoesNotRemoveTextSelection):
(AppKitGesturesTests.pressDragOverRangeInputChangesInputValue(_:)):
(AppKitGesturesTests.pressDragOnImageInitiatesDragAndDrop):
(AppKitGesturesTests.pressDragOverRangeInputChangesInputValue): Deleted.

Canonical link: <a href="https://commits.webkit.org/314309@main">https://commits.webkit.org/314309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12c1c6c1067b406ff6728e68e53ba7d755128987

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174804 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05dbe655-9899-4d24-9abf-bf82b301709c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39256 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/128824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2fb1604a-3b43-4c58-b232-0dd3b1e5bb48) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168721 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Passed webkitperl tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31152 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109348 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/780cab1f-b41d-45f0-a4eb-8529f1289814) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30131 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28838 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22887 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177329 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28334 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137156 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39321 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137084 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36931 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40009 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148423 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102536 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32371 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25290 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38520 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111593 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37916 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3372 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38162 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38060 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->