### PR TITLE
XRProjectionLayer returns incorrect values for width, height, and layer count

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -536,6 +536,11 @@ void WebXRSession::updateSessionVisibilityState(PlatformXR::VisibilityState visi
     queueTaskToDispatchEvent(*this, TaskSource::WebXR, WTF::move(event));
 }
 
+void WebXRSession::sessionDidInitializeRendering(uint32_t width, uint32_t height, uint32_t arrayLength)
+{
+    m_initialRenderingDimensions = InitialRenderingDimensions { width, height, arrayLength };
+}
+
 void WebXRSession::applyPendingRenderState()
 {
     // https: //immersive-web.github.io/webxr/#apply-the-pending-render-state

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -141,6 +141,13 @@ public:
 
     void initializeTrackingAndRendering(std::optional<XRCanvasConfiguration>&&);
 
+    struct InitialRenderingDimensions {
+        uint32_t width { 0 };
+        uint32_t height { 0 };
+        uint32_t arrayLength { 0 };
+    };
+    std::optional<InitialRenderingDimensions> initialRenderingDimensions() const { return m_initialRenderingDimensions; }
+
 private:
     WebXRSession(Document&, XRSessionMode, PlatformXR::Device&, FeatureList&&);
 
@@ -156,6 +163,7 @@ private:
     void sessionDidInitializeInputSources(Vector<PlatformXR::FrameData::InputSource>&&) final;
     void sessionDidEnd() final;
     void updateSessionVisibilityState(PlatformXR::VisibilityState) final;
+    void sessionDidInitializeRendering(uint32_t width, uint32_t height, uint32_t arrayLength) final;
 
     // VisibilityChangeClient
     void visibilityStateChanged() final;
@@ -199,6 +207,7 @@ private:
     Vector<PlatformXR::Device::ViewData> m_views;
     PlatformXR::FrameData m_frameData;
     std::optional<PlatformXR::RequestData> m_requestData;
+    std::optional<InitialRenderingDimensions> m_initialRenderingDimensions;
 
     double m_minimumInlineFOV { 0.0 };
     double m_maximumInlineFOV { std::numbers::pi };

--- a/Source/WebCore/Modules/webxr/XRProjectionLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRProjectionLayer.cpp
@@ -135,16 +135,42 @@ PlatformXR::DeviceLayer XRProjectionLayer::endFrame()
 
 uint32_t XRProjectionLayer::textureWidth() const
 {
+#if ENABLE(WEBGPU) && PLATFORM(COCOA)
+    if (m_layerData && m_layerData->layerSetup)
+        return m_layerData->layerSetup->actualSize[0][0];
+    if (RefPtr currentSession = session()) {
+        if (auto initial = currentSession->initialRenderingDimensions())
+            return initial->width;
+    }
+#endif
     return m_backing->colorTextureWidth();
 }
 
 uint32_t XRProjectionLayer::textureHeight() const
 {
+#if ENABLE(WEBGPU) && PLATFORM(COCOA)
+    if (m_layerData && m_layerData->layerSetup)
+        return m_layerData->layerSetup->actualSize[0][1];
+    if (RefPtr currentSession = session()) {
+        if (auto initial = currentSession->initialRenderingDimensions())
+            return initial->height;
+    }
+#endif
     return m_backing->colorTextureHeight();
 }
 
 uint32_t XRProjectionLayer::textureArrayLength() const
 {
+#if ENABLE(WEBGPU) && PLATFORM(COCOA)
+    if (m_layerData && m_layerData->layerSetup) {
+        auto& setupData = *m_layerData->layerSetup;
+        return (setupData.physicalSize[1][0] && setupData.physicalSize[1][1]) ? 2 : 1;
+    }
+    if (RefPtr currentSession = session()) {
+        if (auto initial = currentSession->initialRenderingDimensions())
+            return initial->arrayLength;
+    }
+#endif
 #if PLATFORM(IOS_FAMILY_SIMULATOR)
     ASSERT(m_backing->colorTextureArrayLength() == 1);
 #endif

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -633,6 +633,7 @@ public:
     virtual void sessionDidInitializeInputSources(Vector<FrameData::InputSource>&&) = 0;
     virtual void sessionDidEnd() = 0;
     virtual void updateSessionVisibilityState(VisibilityState) = 0;
+    virtual void sessionDidInitializeRendering(uint32_t /* width */, uint32_t /* height */, uint32_t /* arrayLength */) { }
     // FIXME: handle frame update
 };
 

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -81,6 +81,12 @@ void XRDeviceProxy::updateSessionVisibilityState(PlatformXR::VisibilityState vis
         trackingAndRenderingClient()->updateSessionVisibilityState(visibilityState);
 }
 
+void XRDeviceProxy::sessionDidInitializeRendering(uint32_t width, uint32_t height, uint32_t arrayLength)
+{
+    if (trackingAndRenderingClient())
+        trackingAndRenderingClient()->sessionDidInitializeRendering(width, height, arrayLength);
+}
+
 void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOriginData& securityOriginData, PlatformXR::SessionMode sessionMode, const PlatformXR::Device::FeatureList& requestedFeatures, std::optional<WebCore::XRCanvasConfiguration>&& init)
 {
     if (!isImmersive(sessionMode))

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.h
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.h
@@ -52,6 +52,7 @@ public:
 
     void sessionDidEnd();
     void updateSessionVisibilityState(PlatformXR::VisibilityState);
+    void sessionDidInitializeRendering(uint32_t width, uint32_t height, uint32_t arrayLength);
 
 private:
     XRDeviceProxy(XRDeviceInfo&&, PlatformXRSystemProxy&);

--- a/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
@@ -51,6 +51,7 @@ public:
 
     virtual void sessionDidEnd(XRDeviceIdentifier) = 0;
     virtual void sessionDidUpdateVisibilityState(XRDeviceIdentifier, PlatformXR::VisibilityState) = 0;
+    virtual void sessionDidInitializeRendering(XRDeviceIdentifier, uint32_t width, uint32_t height, uint32_t arrayLength) = 0;
 };
 
 class PlatformXRCoordinator {

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -395,6 +395,21 @@ void PlatformXRSystem::sessionDidUpdateVisibilityState(XRDeviceIdentifier device
     });
 }
 
+void PlatformXRSystem::sessionDidInitializeRendering(XRDeviceIdentifier deviceIdentifier, uint32_t width, uint32_t height, uint32_t arrayLength)
+{
+    ensureOnMainRunLoop([weakThis = WeakPtr { *this }, deviceIdentifier, width, height, arrayLength]() mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        RefPtr page = protectedThis->m_page.get();
+        if (!page)
+            return;
+
+        protect(page->legacyMainFrameProcess())->send(Messages::PlatformXRSystemProxy::SessionDidInitializeRendering(deviceIdentifier, width, height, arrayLength), page->webPageIDInMainFrameProcess());
+    });
+}
+
 void PlatformXRSystem::setImmersiveSessionState(ImmersiveSessionState state, CompletionHandler<void(bool)>&& completion)
 {
     m_immersiveSessionState = state;

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -118,6 +118,7 @@ private:
     // PlatformXRCoordinatorSessionEventClient
     void sessionDidEnd(XRDeviceIdentifier) final;
     void sessionDidUpdateVisibilityState(XRDeviceIdentifier, PlatformXR::VisibilityState) final;
+    void sessionDidInitializeRendering(XRDeviceIdentifier, uint32_t width, uint32_t height, uint32_t arrayLength) final;
 
     std::optional<PlatformXR::SessionMode> m_immersiveSessionMode;
     std::optional<WebCore::SecurityOriginData> m_immersiveSessionSecurityOriginData;

--- a/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
+++ b/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
@@ -767,6 +767,26 @@ void CompositorCoordinator::didCompleteSessionSetup(WebPageProxy& page, WebCore:
 
     setUpDepthTextures();
 
+    if (m_sessionEventClient) {
+        uint32_t initialWidth = 0;
+        uint32_t initialHeight = 0;
+        uint32_t initialArrayLength = 0;
+        if (id swapchainObject = (__bridge id)cp_layer_renderer_get_swapchain(m_cpLayer.get()); [swapchainObject isKindOfClass:getCP_OBJECT_cp_swapchainClassSingleton()]) {
+            CP_OBJECT_cp_swapchain *swapchain = (CP_OBJECT_cp_swapchain *)swapchainObject;
+            for (cp_swapchain_link_t swapchainLink in swapchain.swapchainLinks) {
+                id<MTLTexture> referenceTexture = swapchainLink.depthTextures.firstObject;
+                if (!referenceTexture)
+                    continue;
+                initialWidth = static_cast<uint32_t>(referenceTexture.width);
+                initialHeight = static_cast<uint32_t>(referenceTexture.height);
+                initialArrayLength = static_cast<uint32_t>(referenceTexture.arrayLength);
+                break;
+            }
+        }
+        if (initialWidth && initialHeight && initialArrayLength)
+            m_sessionEventClient->sessionDidInitializeRendering(m_headsetIdentifier.value(), initialWidth, initialHeight, initialArrayLength);
+    }
+
     BOOL handTrackingEnabled = NO;
 #if ENABLE(WEBXR_HANDS) && !PLATFORM(IOS_FAMILY_SIMULATOR)
     if (requestedFeatures.contains(PlatformXR::SessionFeature::HandTracking) && m_lastSecurityOriginGrantedHandTracking && securityOriginData == m_lastSecurityOriginGrantedHandTracking.value())

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.cpp
@@ -102,7 +102,7 @@ bool RemoteXRProjectionLayerProxy::ignoreDepthValues() const
 
 std::optional<float> RemoteXRProjectionLayerProxy::fixedFoveation() const
 {
-    return 0.f;
+    return 1.f;
 }
 
 void RemoteXRProjectionLayerProxy::setFixedFoveation(std::optional<float>)

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
@@ -159,6 +159,14 @@ void PlatformXRSystemProxy::sessionDidUpdateVisibilityState(XRDeviceIdentifier d
         device->updateSessionVisibilityState(visibilityState);
 }
 
+void PlatformXRSystemProxy::sessionDidInitializeRendering(XRDeviceIdentifier deviceIdentifier, uint32_t width, uint32_t height, uint32_t arrayLength)
+{
+    RELEASE_ASSERT(webXREnabled());
+
+    if (auto device = deviceByIdentifier(deviceIdentifier))
+        device->sessionDidInitializeRendering(width, height, arrayLength);
+}
+
 RefPtr<XRDeviceProxy> PlatformXRSystemProxy::deviceByIdentifier(XRDeviceIdentifier identifier)
 {
     for (auto& device : m_devices) {

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
@@ -86,6 +86,7 @@ private:
     // Message handlers
     void sessionDidEnd(XRDeviceIdentifier);
     void sessionDidUpdateVisibilityState(XRDeviceIdentifier, PlatformXR::VisibilityState);
+    void sessionDidInitializeRendering(XRDeviceIdentifier, uint32_t width, uint32_t height, uint32_t arrayLength);
 
     PlatformXR::DeviceList m_devices;
     WeakRef<WebPage> m_page;

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.messages.in
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.messages.in
@@ -32,6 +32,7 @@
 messages -> PlatformXRSystemProxy {
     SessionDidEnd(WebKit::XRDeviceIdentifier deviceIdentifier)
     SessionDidUpdateVisibilityState(WebKit::XRDeviceIdentifier deviceIdentifier, PlatformXR::VisibilityState visibilityState)
+    SessionDidInitializeRendering(WebKit::XRDeviceIdentifier deviceIdentifier, uint32_t width, uint32_t height, uint32_t arrayLength)
 }
 
 #endif


### PR DESCRIPTION
#### cab3d2d0f36fb12a72dbd9a57b798c8be347fc8e
<pre>
XRProjectionLayer returns incorrect values for width, height, and layer count
<a href="https://bugs.webkit.org/show_bug.cgi?id=316015">https://bugs.webkit.org/show_bug.cgi?id=316015</a>
<a href="https://rdar.apple.com/178444052">rdar://178444052</a>

Reviewed by Dan Glastonbury.

It&apos;s possible to determine the width and height from the XRGPUSubImage but the
spec requires us to implement the properties on the XRProjectionLayer too and
we had failed to do so.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.cpp:
(WebCore::WebGPU::XRProjectionLayerImpl::colorTextureWidth const):
(WebCore::WebGPU::XRProjectionLayerImpl::colorTextureHeight const):
(WebCore::WebGPU::XRProjectionLayerImpl::colorTextureArrayLength const):
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebGPU/WebGPU/XRProjectionLayer.h:
* Source/WebGPU/WebGPU/XRProjectionLayer.mm:
(WebGPU::XRProjectionLayer::colorTextureWidth const):
(WebGPU::XRProjectionLayer::colorTextureHeight const):
(WebGPU::XRProjectionLayer::colorTextureArrayLength const):
(wgpuXRProjectionLayerColorTextureWidth):
(wgpuXRProjectionLayerColorTextureHeight):
(wgpuXRProjectionLayerColorTextureArrayLength):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp:
(WebKit::RemoteXRProjectionLayer::colorTextureDimensions):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.cpp:
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::startFrame):
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::cachedColorTextureDimensions const const):
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::colorTextureWidth const):
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::colorTextureHeight const):
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::colorTextureArrayLength const):
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::fixedFoveation const):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h:

Canonical link: <a href="https://commits.webkit.org/314658@main">https://commits.webkit.org/314658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac3aadf5497fff811550fefce5af796cb24a1ece

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123384 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129125 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90952 "3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109651 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30473 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29164 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23317 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177709 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30611 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137474 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137402 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37160 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148759 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102978 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32685 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25625 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38887 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111961 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38284 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3711 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38529 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38427 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->