### PR TITLE
Non-unified build fixes

### DIFF
--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -372,11 +372,6 @@ void LibWebRTCPeerConnectionBackend::setSenderSourceFromTrack(LibWebRTCRtpSender
     m_endpoint->setSenderSourceFromTrack(sender, track);
 }
 
-static inline LibWebRTCRtpTransceiverBackend& NODELETE backendFromRTPTransceiver(RTCRtpTransceiver& transceiver)
-{
-    return downcast<LibWebRTCRtpTransceiverBackend>(transceiver.backend());
-}
-
 void LibWebRTCPeerConnectionBackend::addInternalTransceiver(UniqueRef<LibWebRTCRtpTransceiverBackend>&& transceiverBackend, RealtimeMediaSource::Type type)
 {
     Ref peerConnection = m_peerConnection;

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -28,6 +28,7 @@
 
 #if USE(CG)
 
+#include "ColorSpaceCG.h"
 #include "FourCC.h"
 #include "ImageFrame.h"
 #include "Logging.h"
@@ -63,7 +64,9 @@ const CFStringRef WebCoreCGImagePropertyUnclampedDelayTime = CFSTR("UnclampedDel
 const CFStringRef WebCoreCGImagePropertyDelayTime = CFSTR("DelayTime");
 const CFStringRef WebCoreCGImagePropertyLoopCount = CFSTR("LoopCount");
 
+#if HAVE(IMAGE_RESTRICTED_DECODING) && USE(APPLE_INTERNAL_SDK)
 const CFStringRef kCGImageSourceEnableRestrictedDecoding = CFSTR("kCGImageSourceEnableRestrictedDecoding");
+#endif
 
 #if HAVE(IMAGEIO_CREATE_UNPREMULTIPLIED_PNG)
 const CFStringRef kCGImageSourceCreateUnpremultipliedPNG = CFSTR("kCGImageSourceCreateUnpremultipliedPNG");

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -1350,25 +1350,6 @@ String RenderThemeCocoa::youTubeQuirkScript()
 
 #endif // ENABLE(VIDEO)
 
-static inline FontSelectionValue cssWeightOfSystemFont(CTFontRef font)
-{
-    auto resultRef = adoptCF(static_cast<CFNumberRef>(CTFontCopyAttribute(font, kCTFontCSSWeightAttribute)));
-    float result = 0;
-    if (resultRef && CFNumberGetValue(resultRef.get(), kCFNumberFloatType, &result))
-        return FontSelectionValue(result);
-
-    auto traits = adoptCF(CTFontCopyTraits(font));
-    resultRef = static_cast<CFNumberRef>(CFDictionaryGetValue(traits.get(), kCTFontWeightTrait));
-    CFNumberGetValue(resultRef.get(), kCFNumberFloatType, &result);
-    // These numbers were experimentally gathered from weights of the system font.
-    static constexpr std::array weightThresholds { -0.6f, -0.365f, -0.115f, 0.130f, 0.235f, 0.350f, 0.5f, 0.7f };
-    for (unsigned i = 0; i < weightThresholds.size(); ++i) {
-        if (result < weightThresholds[i])
-            return FontSelectionValue((static_cast<int>(i) + 1) * 100);
-    }
-    return FontSelectionValue(900);
-}
-
 #if ENABLE(ATTACHMENT_ELEMENT)
 
 int RenderThemeCocoa::attachmentBaseline(const RenderAttachment& attachment) const
@@ -3878,9 +3859,7 @@ constexpr auto trackThicknessForVectorBasedControls = 8.0;
 #else
 constexpr auto trackThicknessForVectorBasedControls = 4.0;
 #endif
-constexpr auto trackRadiusForVectorBasedControls = trackThicknessForVectorBasedControls / 2.0;
 constexpr auto tickLengthForVectorBasedControls = trackThicknessForVectorBasedControls / 4.0;
-constexpr auto defaultSliderTickRadius = trackThicknessForVectorBasedControls / 8.0;
 constexpr FloatSize sliderThumbSize = { 24.f, 16.f };
 
 static void paintSliderTicksForVectorBasedControls(const RenderElement& box, const PaintInfo& paintInfo, const FloatRect& rect, bool isThumbVisible, const Color& tickColorOn, const Color& tickColorOff)

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -158,20 +158,6 @@ static LayoutUnit logicalTopOffset(const RenderBox& renderer)
     return 0_lu;
 }
 
-static inline LayoutUnit borderStartWithStyleForWritingMode(const RenderBox& renderer, const WritingMode writingMode)
-{
-    if (writingMode.isHorizontal()) {
-        if (writingMode.isInlineLeftToRight())
-            return renderer.borderLeft();
-        
-        return renderer.borderRight();
-    }
-    if (writingMode.isInlineTopToBottom())
-        return renderer.borderTop();
-    
-    return renderer.borderBottom();
-}
-
 static inline LayoutUnit borderAndPaddingStartWithStyleForWritingMode(const RenderBox& renderer, const WritingMode writingMode)
 {
     if (writingMode.isHorizontal()) {

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #import "config.h"
 #import "GPUProcess.h"
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
@@ -32,6 +32,7 @@
 #include "IPCUtilities.h"
 #include "RemoteSharedResourceCache.h"
 #include <WebCore/ProcessIdentity.h>
+#include <WebCore/SharedMemory.h>
 #include <wtf/MachSendRight.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -69,7 +70,7 @@ void RemoteGraphicsContextGL::setSharedVideoFrameSemaphore(IPC::Semaphore&& sema
     m_sharedVideoFrameReader.setSemaphore(WTF::move(semaphore));
 }
 
-void RemoteGraphicsContextGL::setSharedVideoFrameMemory(SharedMemory::Handle&& handle)
+void RemoteGraphicsContextGL::setSharedVideoFrameMemory(WebCore::SharedMemory::Handle&& handle)
 {
     m_sharedVideoFrameReader.setSharedMemory(WTF::move(handle));
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -35,6 +35,7 @@
 #include "StreamServerConnection.h"
 #include "WebGPUObjectHeap.h"
 #include <WebCore/WebGPUCompositorIntegration.h>
+#include <WebCore/WebGPUDevice.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #define MESSAGE_CHECK_COMPLETION(assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, m_streamConnection, completion)

--- a/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
@@ -30,6 +30,7 @@
 
 #import "LayerHostingContext.h"
 #import "LayerHostingContextManager.h"
+#import "Logging.h"
 #import "MediaPlayerPrivateRemoteMessages.h"
 #import "RemoteVideoFrameObjectHeap.h"
 #import <QuartzCore/QuartzCore.h>

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessCocoa.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessCocoa.mm
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #import "config.h"
 #import "ModelProcess.h"
 

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
@@ -29,6 +29,7 @@
 
 #include "LegacyCustomProtocolManagerMessages.h"
 #include "LegacyCustomProtocolManagerProxyMessages.h"
+#include "MessageSenderInlines.h"
 #include "NetworkProcess.h"
 #include "NetworkProcessCreationParameters.h"
 #include <WebCore/ResourceRequest.h>

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
@@ -34,6 +34,10 @@
 #include "WebSocketTask.h"
 #include <wtf/TZoneMallocInlines.h>
 
+#if PLATFORM(COCOA)
+#include "NetworkSessionCocoa.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -31,6 +31,8 @@
 #include "DaemonDecoder.h"
 #include "DaemonEncoder.h"
 #include "Logging.h"
+#include "MessageSenderInlines.h"
+#include "NetworkConnectionToWebProcess.h"
 #include "NetworkProcess.h"
 #include "NetworkSession.h"
 #include "PushClientConnectionMessages.h"

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
@@ -27,6 +27,8 @@
 #import "PrivateClickMeasurementConnection.h"
 
 #import "DaemonEncoder.h"
+#import "NetworkProcess.h"
+#import "NetworkSession.h"
 #import "PrivateClickMeasurementXPCUtilities.h"
 #import <wtf/NeverDestroyed.h>
 #import <wtf/darwin/XPCExtras.h>
@@ -57,7 +59,7 @@ void Connection::connectionReceivedEvent(xpc_object_t request)
     CheckedPtr networkSession = m_networkSession.get();
     if (!networkSession)
         return;
-    m_networkSession->networkProcess().broadcastConsoleMessage(m_networkSession->sessionID(), MessageSource::PrivateClickMeasurement, messageLevel, debugMessage);
+    m_networkSession->networkProcess().broadcastConsoleMessage(m_networkSession->sessionID(), JSC::MessageSource::PrivateClickMeasurement, messageLevel, debugMessage);
 }
 
 OSObjectPtr<xpc_object_t> Connection::dictionaryFromMessage(MessageType messageType, EncodedMessage&& message) const

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitorCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitorCocoa.mm
@@ -28,6 +28,7 @@
 #if USE(LIBWEBRTC)
 #import "NetworkRTCSharedMonitor.h"
 
+#import "Logging.h"
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/darwin/DispatchExtras.h>

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -27,6 +27,7 @@
 #import "DaemonConnection.h"
 
 #import "DaemonEncoder.h"
+#import "Logging.h"
 #import "PrivateClickMeasurementConnection.h"
 #import "WebPushDaemonConnection.h"
 #import <wtf/BlockPtr.h>

--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
@@ -36,7 +36,9 @@
 #import <WebCore/TextRecognitionResult.h>
 #import <pal/spi/cocoa/FeatureFlagsSPI.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/MonotonicTime.h>
 #import <wtf/RobinHoodHashSet.h>
+#import <wtf/RunLoop.h>
 #import <wtf/WorkQueue.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "LayerHostingContextManager.h"
 
+#import <QuartzCore/QuartzCore.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/IntRect.h>
 #include <wtf/MachSendRightAnnotated.h>

--- a/Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandleInternal.h
+++ b/Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandleInternal.h
@@ -26,6 +26,7 @@
 #import "WKBrowsingContextHandlePrivate.h"
 #import "WebPageProxyIdentifier.h"
 #import <WebCore/PageIdentifier.h>
+#import <wtf/Markable.h>
 
 namespace WebKit {
 class WebPage;

--- a/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
+++ b/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
@@ -29,12 +29,16 @@
 #if PLATFORM(MAC) && ENABLE(APPLE_PAY)
 
 #import "AppKitSPI.h"
+#import "DisbursementRequest.h"
 #import "PaymentAuthorizationViewController.h"
 #import "WebPageProxy.h"
+#import <WebCore/ApplePayDisbursementRequest.h>
 #import <pal/cocoa/PassKitSoftLink.h>
 #import <wtf/BlockPtr.h>
 
 namespace WebKit {
+
+using namespace WebCore;
 
 void WebPaymentCoordinatorProxy::platformCanMakePayments(CompletionHandler<void(bool)>&& completionHandler)
 {

--- a/Source/WebKit/Shared/IPCTesterReceiver.cpp
+++ b/Source/WebKit/Shared/IPCTesterReceiver.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "IPCTesterReceiver.h"
 
+#include <wtf/CompletionHandler.h>
+
 #if ENABLE(IPC_TESTING_API) && !ENABLE(IPC_TESTING_SWIFT)
 
 #include <wtf/CompletionHandler.h>

--- a/Source/WebKit/UIProcess/API/C/mac/WKNotificationPrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKNotificationPrivateMac.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "WKNotificationPrivateMac.h"
 
+#import "WKAPICast.h"
 #import "WebNotification.h"
 #import <WebCore/NotificationData.h>
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
@@ -27,6 +27,7 @@
 #include "WKContentWorldConfigurationInternal.h"
 
 #include "_WKContentWorldConfiguration.h"
+#include <WebCore/WebCoreObjCExtras.h>
 
 @implementation WKContentWorldConfiguration
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -38,6 +38,7 @@
 #import <WebCore/ElementTargetingTypes.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <wtf/cocoa/Entitlements.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
@@ -39,7 +39,6 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #endif
 
-static const NSInteger UnspecifiedAttachmentErrorCode = 1;
 static const NSInteger InvalidAttachmentErrorCode = 2;
 
 @implementation _WKAttachmentDisplayOptions : NSObject

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
@@ -33,11 +33,6 @@
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-static NSString *iconURLKey = @"iconURL";
-static NSString *tagKey = @"tag";
-static NSString *languageKey = @"language";
-static NSString *dataKey = @"data";
-
 @interface _WKNotificationData()
 - (instancetype)_init;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
@@ -34,7 +34,9 @@
 #import <pal/cocoa/LockdownModeCocoa.h>
 #endif
 
+#if PLATFORM(IOS_FAMILY)
 constexpr auto CaptivePortalConfigurationIgnoreFileName = @"com.apple.WebKit.cpmconfig_ignore";
+#endif
 
 @implementation _WKSystemPreferences
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -106,17 +106,6 @@ static inline void updateCredentialIfNecessary(NSMutableDictionary *credential, 
 #endif // ENABLE(ONGOING_CREDENTIAL_SHARING_WEBKIT_SPI)
 }
 
-static inline String groupForAttributes(NSDictionary *attributes)
-{
-#if ENABLE(ONGOING_CREDENTIAL_SHARING_WEBKIT_SPI)
-    if ([[attributes allKeys] containsObject:kSecAttrSharingGroup]) {
-        if (auto *nsString = dynamic_objc_cast<NSString>(attributes[kSecAttrSharingGroup]))
-            return nsString;
-    }
-#endif // ENABLE(ONGOING_CREDENTIAL_SHARING_WEBKIT_SPI)
-    return nullString();
-}
-
 static inline void updateQueryForGroupIfNecessary(NSMutableDictionary *dictionary, NSString *group)
 {
 #if ENABLE(ONGOING_CREDENTIAL_SHARING_WEBKIT_SPI)

--- a/Source/WebKit/UIProcess/Cocoa/UIProcessLogInitializationCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIProcessLogInitializationCocoa.mm
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #import "config.h"
 #import "UIProcessLogInitialization.h"
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #include "config.h"
 #include "WebPagePreferencesLockdownModeObserver.h"
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -159,8 +159,6 @@
 #import <WebKitAdditions/WebProcessPoolAdditions.h>
 #endif
 
-static NSString * const WebServiceWorkerRegistrationDirectoryDefaultsKey = @"WebServiceWorkerRegistrationDirectory";
-static NSString * const WebKitLocalCacheDefaultsKey = @"WebKitLocalCache";
 static NSString * const WebKitJSCJITEnabledDefaultsKey = @"WebKitJSCJITEnabledDefaultsKey";
 static NSString * const WebKitJSCFTLJITEnabledDefaultsKey = @"WebKitJSCFTLJITEnabledDefaultsKey";
 
@@ -170,8 +168,6 @@ static CFStringRef AppleColorPreferencesChangedNotification = CFSTR("AppleColorP
 #endif
 
 static NSString * const WebKitSuppressMemoryPressureHandlerDefaultsKey = @"WebKitSuppressMemoryPressureHandler";
-
-static NSString * const WebKitMediaStreamingActivity = @"WebKitMediaStreamingActivity";
 
 #if !RELEASE_LOG_DISABLED
 static NSString * const WebKitLogCookieInformationDefaultsKey = @"WebKitLogCookieInformation";

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -87,8 +87,6 @@
 
 namespace WebKit {
 
-static const Seconds unexpectedActivityDuration = 10_s;
-
 void WebProcessProxy::registerNotifyObservers()
 {
     PAL::registerNotifyCallback("com.apple.WebKit.logFrameTrees"_s, [] {

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
 
+#include "MessageSenderInlines.h"
 #include "RemoteMediaSessionClientProxy.h"
 #include "RemoteMediaSessionManagerMessages.h"
 #include "RemoteMediaSessionManagerProxy.h"

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -67,6 +67,11 @@
 #include "VideoPresentationManagerProxy.h"
 #endif
 
+#if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
+#include "PlaybackSessionManagerProxy.h"
+#include "RemotePagePlaybackSessionManagerProxy.h"
+#endif
+
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
 #include "WebDeviceOrientationUpdateProviderProxy.h"
 #endif

--- a/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
+++ b/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
@@ -41,10 +41,14 @@ namespace WebKit {
 static const ASCIILiteral audioExtensionPath { "com.apple.webkit.microphone"_s };
 static const ASCIILiteral videoExtensionPath { "com.apple.webkit.camera"_s };
 static const ASCIILiteral appleCameraServicePath { "com.apple.applecamerad"_s };
+#if USE(APPLE_INTERNAL_SDK) && HAVE(ADDITIONAL_APPLE_CAMERA_SERVICE)
 static const ASCIILiteral additionalAppleCameraServicePath { "com.apple.appleh13camerad"_s };
+#endif
+#if USE(APPLE_INTERNAL_SDK) && HAVE(APPLE_CAMERA_USER_CLIENT)
 static const ASCIILiteral appleCameraUserClientPath { "com.apple.aneuserd"_s };
 static const ASCIILiteral appleCameraUserClientIOKitClientClass { "H11ANEInDirectPathClient"_s };
 static const ASCIILiteral appleCameraUserClientIOKitServiceClass { "H11ANEIn"_s };
+#endif
 #endif
 
 UserMediaProcessManager& UserMediaProcessManager::singleton()

--- a/Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm
+++ b/Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #import "config.h"
 #import "WKRevealItemPresenter.h"
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -34,6 +34,7 @@
 
 #import "CocoaHelpers.h"
 #import "JSWebExtensionWrapper.h"
+#import "MessageSenderInlines.h"
 #import "WebExtensionAPINamespace.h"
 #import "WebExtensionContextMessages.h"
 #import "WebExtensionContextProxyMessages.h"

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
@@ -31,6 +31,9 @@
 #include "GPUProcessConnection.h"
 #include "Logging.h"
 #include "RemoteAudioSourceProviderManager.h"
+#include <WebCore/MediaPlayer.h>
+
+// Include after MediaPlayer.h: the generated header uses WebCore::MediaPlayer.
 #include "RemoteMediaPlayerProxyMessages.h"
 
 namespace WebCore {

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
@@ -32,13 +32,13 @@
 #import "VideoLayerRemote.h"
 #import <WebCore/FloatRect.h>
 #import <WebCore/GeometryUtilities.h>
+#import <WebCore/IntSize.h>
+#import <WebCore/MediaPlayer.h>
 #import <WebCore/Timer.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/MachSendRight.h>
-#if ENABLE(MACH_PORT_LAYER_HOSTING)
 #import <wtf/MachSendRightAnnotated.h>
-#endif
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
 
@@ -213,7 +213,7 @@ static const Seconds PostAnimationDelay { 100_ms };
 
 namespace WebKit {
 
-PlatformLayerContainer createVideoLayerRemote(VideoLayerRemoteParent& parent, LayerHostingContextID contextId, WebCore::MediaPlayerEnums::VideoGravity videoGravity, IntSize contentSize)
+PlatformLayerContainer createVideoLayerRemote(VideoLayerRemoteParent& parent, LayerHostingContextID contextId, WebCore::MediaPlayerEnums::VideoGravity videoGravity, WebCore::IntSize contentSize)
 {
     // Initially, all the layers will be empty (both width and height are 0) and invisible.
     // The renderer will change the sizes of WKVideoLayerRemote to trigger layout of sublayers and make them visible.

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(PDF_PLUGIN)
 
+#import "PDFPluginBase.h"
 #import <WebCore/EnterKeyHint.h>
 #import <WebCore/Event.h>
 #import <WebCore/EventNames.h>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(PDF_PLUGIN)
 
+#import "PDFPluginBase.h"
 #import <WebCore/ElementInlines.h>
 #import <WebCore/HTMLElement.h>
 #import <WebCore/LocalizedStrings.h>

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -31,6 +31,7 @@
 #include "DocumentEditingContext.h"
 #include "FrameInfoData.h"
 #include "Logging.h"
+#include "MessageSenderInlines.h"
 #include "PDFPlugin.h"
 #include "UnifiedPDFPlugin.h"
 #include "WebFrame.h"

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -28,6 +28,7 @@
 
 #include "FormDataReference.h"
 #include "Logging.h"
+#include "MessageSenderInlines.h"
 #include "NetworkConnectionToWebProcessMessages.h"
 #include "NetworkProcessMessages.h"
 #include "RemoteWebLockRegistry.h"

--- a/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
@@ -30,6 +30,7 @@
 
 #include "DefaultWebBrowserChecks.h"
 #include "FrameInfoData.h"
+#include "MessageSenderInlines.h"
 #include "WebAuthenticatorCoordinatorProxyMessages.h"
 #include "WebFrame.h"
 #include "WebPage.h"
@@ -60,13 +61,6 @@ namespace WebKit {
 using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebAuthenticatorCoordinator);
-
-namespace {
-inline bool isWebBrowser()
-{
-    return isParentProcessAFullWebBrowser(WebProcess::singleton());
-}
-}
 
 WebAuthenticatorCoordinator::WebAuthenticatorCoordinator(WebPage& webPage)
     : m_webPage(webPage)

--- a/Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebLocalFrameLoaderClientCocoa.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebLocalFrameLoaderClientCocoa.mm
@@ -32,6 +32,7 @@
 #import <WebCore/AXIsolatedTree.h>
 
 namespace WebKit {
+using namespace WebCore;
 
 WebCore::IntPoint WebLocalFrameLoaderClient::accessibilityRemoteFrameOffset()
 {

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -36,6 +36,7 @@
 #import "InjectedBundlePageContextMenuClient.h"
 #import "LaunchServicesDatabaseManager.h"
 #import "Logging.h"
+#import "MessageSenderInlines.h"
 #import "PDFPluginBase.h"
 #import "PageBanner.h"
 #import "PlatformFontInfo.h"

--- a/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
+++ b/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
@@ -23,7 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
 #import "config.h"
 #import "DigitalCredentialsRequestValidatorBridge.h"
 

--- a/Source/WebKitLegacy/mac/DOM/DOMDocumentFragment.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMDocumentFragment.mm
@@ -31,7 +31,9 @@
 #import "DOMNodeListInternal.h"
 #import "ExceptionHandlers.h"
 #import <WebCore/DocumentFragment.h>
+#import <WebCore/HTMLCollection.h>
 #import <WebCore/JSExecState.h>
+#import <WebCore/NodeList.h>
 #import <WebCore/ThreadCheck.h>
 
 #define IMPL static_cast<WebCore::DocumentFragment*>(reinterpret_cast<WebCore::Node*>(_internal))

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -569,10 +569,6 @@ static Class s_pdfRepresentationClass;
 static Class s_pdfViewClass;
 #endif
 
-#ifndef NDEBUG
-static const char webViewIsOpen[] = "At least one WebView is still open.";
-#endif
-
 #if PLATFORM(IOS_FAMILY)
 @interface WebView(WebViewPrivate)
 - (void)_preferencesChanged:(WebPreferences *)preferences;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestProtocol.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestProtocol.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "Helpers/cocoa/TestProtocol.h"
 
+#import "Helpers/cocoa/TestNSBundleExtras.h"
 #import <WebKit/WKBrowsingContextController.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RetainPtr.h>

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
@@ -36,6 +36,7 @@
 #import "Helpers/Test.h"
 #import "Helpers/cocoa/TestCocoa.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
+#import "Helpers/cocoa/TestUIDelegate.h"
 #import "Helpers/Utilities.h"
 
 #import <WebCore/Color.h>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdditionalReadAccessAllowedURLs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdditionalReadAccessAllowedURLs.mm
@@ -31,6 +31,7 @@
 #import "AdditionalReadAccessAllowedURLsProtocol.h"
 #import "Helpers/DeprecatedGlobalValues.h"
 #import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
 #import "Helpers/Utilities.h"
 #import "Helpers/cocoa/WKWebViewConfigurationExtras.h"
 #import <WebKit/NSAttributedStringPrivate.h>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdditionalSupportedImageTypes.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdditionalSupportedImageTypes.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(COCOA)
 
+#import "Helpers/DeprecatedGlobalValues.h"
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/WKWebViewConfigurationExtras.h"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AttrStyle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AttrStyle.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 
 #import "Helpers/cocoa/TestNavigationDelegate.h"
+#import "Helpers/cocoa/TestNSBundleExtras.h"
 #import "Helpers/Utilities.h"
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentSecurityPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentSecurityPolicy.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 
 #import "Helpers/cocoa/HTTPServer.h"
+#import "Helpers/cocoa/TestNSBundleExtras.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import <WebKit/WKWebViewConfigurationPrivate.h>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EditorStateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EditorStateTests.mm
@@ -32,6 +32,7 @@
 #import "TestInputDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "Helpers/ios/UserInterfaceSwizzler.h"
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/_WKFeature.h>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MessagePortProviders.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MessagePortProviders.mm
@@ -30,6 +30,7 @@
 #import "Helpers/DeprecatedGlobalValues.h"
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/cocoa/TestWKWebView.h"
+#import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WebFrame.h>
 #import <wtf/RetainPtr.h>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkActivityTrackerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkActivityTrackerTests.mm
@@ -27,6 +27,7 @@
 
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/Utilities.h"
 #import <WebKit/WKWebView.h>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm
@@ -440,29 +440,6 @@ onload = () => {
 </body>
 )PSONRESOURCE"_s;
 
-static constexpr auto navigationWithLockedHistoryBytes = R"PSONRESOURCE(
-<script>
-let shouldNavigate = true;
-window.addEventListener('pageshow', function(event) {
-    if (event.persisted) {
-        window.webkit.messageHandlers.pson.postMessage("Was persisted");
-        shouldNavigate = false;
-    }
-});
-
-onload = function()
-{
-    if (!shouldNavigate)
-        return;
-
-    // JS navigation via window.location
-    setTimeout(() => {
-        location = "pson://www.apple.com/main.html";
-    }, 10);
-}
-</script>
-)PSONRESOURCE"_s;
-
 static constexpr auto pageCache1Bytes = R"PSONRESOURCE(
 <script>
 window.addEventListener('pageshow', function(event) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -248,18 +248,6 @@ self.addEventListener("message", (event) => {
 
 )SWRESOURCE"_s;
 
-static constexpr auto scriptWithEvalBytes = R"SWRESOURCE(
-
-self.addEventListener("message", (event) => {
-    if (event.data == "Hello from the web page") {
-        event.source.postMessage("ServiceWorker received: " + event.data);
-        return;
-    }
-    event.source.postMessage("Evaluation result: " + eval(event.data));
-});
-
-)SWRESOURCE"_s;
-
 static constexpr auto mainForFetchTestBytes = R"SWRESOURCE(
 <html>
 <body>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TLSDeprecation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TLSDeprecation.mm
@@ -138,8 +138,6 @@
 
 namespace TestWebKitAPI {
 
-const uint16_t tls1_1 = 0x0302;
-
 TEST(TLSVersion, DefaultBehavior)
 {
     HTTPServer server(HTTPServer::respondWithOK, HTTPServer::Protocol::HttpsWithLegacyTLS);


### PR DESCRIPTION
#### 395ba7a392a281c5e54989138fa0bbbe073af36f
<pre>
Non-unified build fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=316019">https://bugs.webkit.org/show_bug.cgi?id=316019</a>
<a href="https://rdar.apple.com/178451370">rdar://178451370</a>

Reviewed by Mike Wyrzykowski and Zak Ridouh.

This is important to correctness in CMake incremental builds now that CMake
does adaptive un-bundling of unified sources.

Added missing #includes.

Removed unused code (since clang warns in standalone mode).

Removed #pragma once from .cpp/.mm files.

* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
* Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
* Source/WebKit/ModelProcess/cocoa/ModelProcessCocoa.mm
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
* Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitorCocoa.mm
* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
* Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
* Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandleInternal.h
* Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
* Source/WebKit/Shared/IPCTesterReceiver.cpp
* Source/WebKit/UIProcess/API/C/mac/WKNotificationPrivateMac.mm
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
* Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
* Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
* Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
* Source/WebKit/UIProcess/Cocoa/UIProcessLogInitializationCocoa.mm
* Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
* Source/WebKit/UIProcess/RemotePageProxy.cpp
* Source/WebKit/UIProcess/UserMediaProcessManager.cpp
* Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
* Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm
* Source/WebKit/WebProcess/Plugins/PluginView.cpp
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
* Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
* Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebLocalFrameLoaderClientCocoa.mm
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
* Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
* Source/WebKitLegacy/mac/DOM/DOMDocumentFragment.mm
* Source/WebKitLegacy/mac/WebView/WebView.mm
* Tools/TestWebKitAPI/Helpers/cocoa/TestProtocol.mm
* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdditionalReadAccessAllowedURLs.mm
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdditionalSupportedImageTypes.mm
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AttrStyle.mm
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentSecurityPolicy.mm
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EditorStateTests.mm
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MessagePortProviders.mm
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkActivityTrackerTests.mm
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TLSDeprecation.mm

Canonical link: <a href="https://commits.webkit.org/314312@main">https://commits.webkit.org/314312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d0b09e0b9a7f22181853426754fda5a87062290

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165763 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174805 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123018 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/935d107e-61f8-405b-8f84-5c9ad7ad0281) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128823 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19c4ad2f-3f6d-4c6b-9b5d-74a459dcb197) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168722 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109347 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8169c889-e3c1-49c5-8ed3-5909bcc38c36) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/165081 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30133 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22888 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26627 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Passed layout tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177330 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30245 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137158 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137086 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148422 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102538 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25235 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32372 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25289 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38521 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111594 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37917 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3371 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38163 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38061 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->