### PR TITLE
Unreviewed, reverting 314080@main (7d4b9ad5fc39)

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/__init__.py
@@ -20,44 +20,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import importlib
-
-from webkitcorepy.call_by_need import CallByNeed
-
-# ContextStack is a base class for OutputCapture, OutputDuplicate, and PartialProxy, all
-# of which webkitcorepy/__init__.py loads eagerly, so it's effectively never lazy.
 from webkitcorepy.mocks.context_stack import ContextStack
+from webkitcorepy.mocks.time_ import Time
+from webkitcorepy.mocks.subprocess import ProcessCompletion, Subprocess
 
-
-def _lazy(module_path, attr_name):
-    return CallByNeed(lambda: getattr(importlib.import_module(module_path), attr_name))
-
-
-# Other symbols load lazily — see __getattr__ — so callers importing only ContextStack
-# don't pay for time_/subprocess/requests_/etc.
-_LAZY = {
-    'Time': _lazy('webkitcorepy.mocks.time_', 'Time'),
-    'ProcessCompletion': _lazy('webkitcorepy.mocks.subprocess', 'ProcessCompletion'),
-    'Subprocess': _lazy('webkitcorepy.mocks.subprocess', 'Subprocess'),
-    'Response': _lazy('webkitcorepy.mocks.requests_', 'Response'),
-    'Requests': _lazy('webkitcorepy.mocks.requests_', 'Requests'),
-    'Terminal': _lazy('webkitcorepy.mocks.terminal', 'Terminal'),
-    'FileLock': _lazy('webkitcorepy.mocks.file_lock', 'FileLock'),
-    'Environment': _lazy('webkitcorepy.mocks.environment', 'Environment'),
-}
-
-
-def __getattr__(name):
-    proxy = _LAZY.get(name)
-    if proxy is None:
-        raise AttributeError("module 'webkitcorepy.mocks' has no attribute {!r}".format(name))
-    # Resolve through CallByNeed and store the real object in globals(), so future
-    # accesses skip __getattr__ and so pickle/isinstance see the underlying class
-    # rather than the proxy.
-    value = proxy.value
-    globals()[name] = value
-    return value
-
-
-def __dir__():
-    return sorted(set(globals()) | set(_LAZY))
+from webkitcorepy.mocks.requests_ import Response, Requests
+from webkitcorepy.mocks.terminal import Terminal
+from webkitcorepy.mocks.file_lock import FileLock
+from webkitcorepy.mocks.environment import Environment

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py
@@ -20,12 +20,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import importlib
+from unittest import mock
 
 from webkitcorepy import mocks
-from webkitcorepy.call_by_need import CallByNeed
-
-mock = CallByNeed(lambda: importlib.import_module('unittest.mock'))
 
 
 class PartialProxy(mocks.ContextStack):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py
@@ -22,7 +22,6 @@
 
 import bisect
 import collections
-import importlib
 import math
 import os
 import signal
@@ -30,9 +29,6 @@ import threading
 import time
 
 from webkitcorepy import log, string_utils
-from webkitcorepy.call_by_need import CallByNeed
-
-mock = CallByNeed(lambda: importlib.import_module('unittest.mock'))
 
 ORIGINAL_SLEEP = time.sleep
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -68,5 +68,6 @@ from webkitscmpy.pull_request import PullRequest
 from webkitscmpy.scm_base import ScmBase
 
 from webkitscmpy import local
+from webkitscmpy import mocks
 
 name = 'webkitscmpy'

--- a/Tools/Scripts/webkitpy/common/version_name_map.py
+++ b/Tools/Scripts/webkitpy/common/version_name_map.py
@@ -26,12 +26,6 @@ from webkitcorepy import Version
 
 from webkitpy.common.memoized import memoized
 
-# Authoritative CURRENT_VERSION for the Darwin OS family. DarwinPort imports this as its
-# class attribute; IOSPort/WatchPort/VisionOSPort inherit it. The constant lives here so
-# version_name_map can read it without importing the (heavy) port chain. If the WebKit
-# Darwin OSes ever diverge in version, split this into per-OS constants.
-DARWIN_CURRENT_VERSION = Version(26)
-
 
 PUBLIC_TABLE = 'public'
 INTERNAL_TABLE = 'internal'
@@ -54,6 +48,8 @@ class VersionNameMap(object):
             platform = SystemHost.get_default().platform
         self.mapping = {}
 
+        from webkitpy.port import darwin, ios, watch, visionos
+
         self.default_system_platform = platform.os_name
         self.mapping[PUBLIC_TABLE] = {
             'mac': {
@@ -75,10 +71,10 @@ class VersionNameMap(object):
                 'Sequoia': Version(15, 0),
                 'Tahoe': Version(26, 0)
             },
-            'ios': self._automap_to_major_version('iOS', minimum=Version(10), maximum=DARWIN_CURRENT_VERSION),
-            'tvos': self._automap_to_major_version('tvOS', minimum=Version(10), maximum=DARWIN_CURRENT_VERSION),
-            'watchos': self._automap_to_major_version('watchOS', minimum=Version(1), maximum=DARWIN_CURRENT_VERSION),
-            'visionos': self._automap_to_major_version('visionOS', minimum=Version(1), maximum=DARWIN_CURRENT_VERSION),
+            'ios': self._automap_to_major_version('iOS', minimum=Version(10), maximum=ios.IOSPort.CURRENT_VERSION),
+            'tvos': self._automap_to_major_version('tvOS', minimum=Version(10), maximum=darwin.DarwinPort.CURRENT_VERSION),
+            'watchos': self._automap_to_major_version('watchOS', minimum=Version(1), maximum=watch.WatchPort.CURRENT_VERSION),
+            'visionos': self._automap_to_major_version('visionOS', minimum=Version(1), maximum=visionos.VisionOSPort.CURRENT_VERSION),
             'win': {
                 'Win10': Version(10),
                 '8.1': Version(6, 3),

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
@@ -27,7 +27,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import errno
-import functools
 import logging
 import re
 
@@ -61,16 +60,6 @@ class LayoutTestFinder(object):
         self._filesystem = self._port.host.filesystem
         self.LAYOUT_TESTS_DIRECTORY = 'LayoutTests'
         self._test_list_expectations = []
-        # Cache the inner finder per device_type. Bound here, not module-level, so the
-        # cache doesn't outlive this LayoutTestFinder instance.
-        self._inner_finder = functools.cache(self._make_inner_finder)
-
-    def _make_inner_finder(self, device_type=None):
-        return LayoutTestFinder_New(
-            self._port.host.filesystem,
-            self._port.layout_tests_dir(),
-            self._port.baseline_search_path(device_type),
-        )
 
     def find_tests(self, options, args, device_type=None, with_expectations=False):
         paths = self._strip_test_dir_prefixes(args)
@@ -106,16 +95,30 @@ class LayoutTestFinder(object):
 
     def find_tests_by_path(self, paths, device_type=None, with_expectations=False):
         """Return the list of tests found. Both generic and platform-specific tests matching paths should be returned."""
-        return list(self._inner_finder(device_type).get_tests(paths))
+        finder = LayoutTestFinder_New(
+            self._port.host.filesystem,
+            self._port.layout_tests_dir(),
+            self._port.baseline_search_path(device_type),
+        )
+
+        return list(finder.get_tests(paths))
 
     def _is_test_file(self, filesystem, dirname, filename):
-        finder = self._inner_finder()
+        finder = LayoutTestFinder_New(
+            self._port.host.filesystem,
+            self._port.layout_tests_dir(),
+            self._port.baseline_search_path(),
+        )
         return finder.is_test_file(
             dirname, filename
         ) and not self._is_w3c_resource_file(filesystem, dirname, filename)
 
     def _is_w3c_resource_file(self, filesystem, dirname, filename):
-        finder = self._inner_finder()
+        finder = LayoutTestFinder_New(
+            self._port.host.filesystem,
+            self._port.layout_tests_dir(),
+            self._port.baseline_search_path(),
+        )
 
         if dirname:
             dirname = self._filesystem.relpath(dirname, self._port.layout_tests_dir())

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -345,16 +345,12 @@ class Manager(object):
         new_test_inputs = self._multiply_test_inputs(test_inputs, self._options.repeat_each, self._options.iterations)
         worker_count = self._runner.get_worker_count(new_test_inputs, int(self._options.child_processes))
         self._options.child_processes = worker_count
-        # Port has a copy of options (see _create_port_for_driver), so sync the effective
-        # worker count for code paths that read it via self.get_option (mac warmup gate,
-        # embedded port device count).
-        self._port.set_option('child_processes', worker_count)
 
     def _set_up_run(self, test_inputs, device_type):
-        # The helper was kicked off in run() so its ~440 ms warmup overlaps with
-        # _collect_tests; join on it now since check_sys_deps and setup_test_run may use it.
+        # This must be started before we check the system dependencies,
+        # since the helper may do things to make the setup correct.
         self._printer.write_update("Starting helper ...")
-        if not self._port.wait_for_helper_ready():
+        if not self._port.start_helper(pixel_tests=self._options.pixel_tests, prefer_integrated_gpu=self._options.prefer_integrated_gpu):
             return False
 
         self._update_worker_count(test_inputs)
@@ -394,10 +390,6 @@ class Manager(object):
 
             self._results_directory = self._port.results_directory()
             self._finder = LayoutTestFinder(self._port, self._options)
-
-            # Kick the helper off in parallel with test discovery and expectations
-            # parsing; _set_up_run will join on it. Saves ~440 ms on Mac.
-            self._port.start_helper_async(pixel_tests=self._options.pixel_tests, prefer_integrated_gpu=self._options.prefer_integrated_gpu)
 
             device_type_list = self._port.supported_device_types()
             tests_to_run_by_device, aggregate_tests_to_skip = self._collect_tests(args, device_type_list, driver_name)
@@ -525,6 +517,9 @@ class Manager(object):
                 if not self._set_up_run(test_inputs, device_type=device_type):
                     return test_run_results.RunDetails(exit_code=-1)
 
+                configuration = self._port.configuration_for_upload(self._port.target_host(0))
+                if not configuration.get('flavor', None):  # The --result-report-flavor argument should override wk1/wk2
+                    configuration['flavor'] = 'wk1' if self._port.is_webkitlegacy() else 'wk2'
                 temp_initial_results, temp_retry_results, temp_enabled_pixel_tests_in_retry = self._run_test_subset(test_inputs, device_type=device_type)
 
                 skipped_results = TestRunResults(self._expectations[(self._current_driver_name, device_type)], len(aggregate_tests_to_skip))
@@ -535,9 +530,6 @@ class Manager(object):
                 temp_initial_results = temp_initial_results.merge(skipped_results)
 
                 if self._options.report_urls:
-                    configuration = self._port.configuration_for_upload(self._port.target_host(0))
-                    if not configuration.get('flavor', None):  # The --result-report-flavor argument should override wk1/wk2
-                        configuration['flavor'] = 'wk1' if self._port.is_webkitlegacy() else 'wk2'
                     self._printer.writeln('\n')
                     self._printer.write_update('Preparing upload data ...')
 

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py
@@ -40,8 +40,6 @@ from webkitpy.layout_tests.models.test_configuration import (
 )
 from webkitpy.port.base import Port
 
-_BUG_TOKEN_RE = re.compile(r'Bug\((\w+)\)$')
-
 MYPY = False
 if MYPY:
     # MYPY is True when running Mypy; typing is stdlib only in Py3
@@ -319,7 +317,7 @@ class TestExpectationParser(object):
         else:
             expectation_line.comment = expectation_string[comment_index + 1:]
 
-        remaining_string = " ".join(expectation_string[:comment_index].split())
+        remaining_string = re.sub(r"\s+", " ", expectation_string[:comment_index].strip())
         if len(remaining_string) == 0:
             return expectation_line
 
@@ -346,7 +344,7 @@ class TestExpectationParser(object):
                 if token.startswith(WEBKIT_BUG_PREFIX):
                     bugs.append(token.replace(WEBKIT_BUG_PREFIX, 'BUGWK'))
                 else:
-                    match = _BUG_TOKEN_RE.match(token)
+                    match = re.match(r'Bug\((\w+)\)$', token)
                     if not match:
                         warnings.append('unrecognized bug identifier "%s"' % token)
                         break

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -109,13 +109,7 @@ class Port(object):
     # Do test runners support alias hostnames such as web-platform.test
     supports_localhost_aliases = False
 
-    # LayoutTestHelper state. Read/written by start_helper / start_helper_async /
-    # wait_for_helper_ready / stop_helper. _helper_started signals that the spawn was
-    # attempted, so a None _helper_process means spawn failed rather than no spawn.
-    # _helper_ready signals that we've consumed the 'ready' line.
-    _helper_process = None
-    _helper_started = False
-    _helper_ready = False
+    helper = None
     _web_platform_test_server = None
     _websocket_secure_server = None
     _websocket_server = None
@@ -855,16 +849,6 @@ class Port(object):
         method."""
         return True
 
-    def start_helper_async(self, pixel_tests=False, prefer_integrated_gpu=False):
-        """Kick off the helper process without blocking on its readiness.
-        Override along with wait_for_helper_ready to overlap helper warmup
-        with other setup work."""
-        return True
-
-    def wait_for_helper_ready(self):
-        """Block until a previously async-started helper is ready."""
-        return True
-
     def reset_preferences(self):
         """If a port needs to reset platform-specific persistent preference
         storage, it should override this method."""
@@ -982,17 +966,15 @@ class Port(object):
     def stop_helper(self):
         """Shut down the test helper if it is running. Do nothing if
         it isn't, or it isn't available."""
-        if Port._helper_process:
+        if Port.helper:
             _log.debug("Stopping LayoutTestHelper")
             try:
-                Port._helper_process.stdin.write(b"x\n")
-                Port._helper_process.stdin.close()
-                Port._helper_process.wait()
+                Port.helper.stdin.write(b"x\n")
+                Port.helper.stdin.close()
+                Port.helper.wait()
             except IOError as e:
                 _log.debug("IOError raised while stopping helper: %s" % str(e))
-            Port._helper_process = None
-        Port._helper_started = False
-        Port._helper_ready = False
+            Port.helper = None
 
     def stop_http_server(self):
         """Shut down the http server if it is running. Do nothing if it isn't."""

--- a/Tools/Scripts/webkitpy/port/base_unittest.py
+++ b/Tools/Scripts/webkitpy/port/base_unittest.py
@@ -38,7 +38,6 @@ from webkitpy.common.system.executive_mock import MockExecutive2
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.common.host_mock import MockHost
 from webkitpy.port import Port
-from webkitpy.port.config import Config
 from webkitpy.port.test import add_unit_tests_to_mock_filesystem, TestPort
 from webkitpy.thirdparty.mock import patch
 
@@ -50,9 +49,6 @@ def cmp(a, b):
     return (a > b) - (a < b)
 
 class PortTest(unittest.TestCase):
-    def setUp(self):
-        Config._clear_cache_for_testing()
-
     def make_port(self, executive=None, with_tests=False, port_name=None, **kwargs):
         host = MockHost(create_stub_repository_files=True)
         if executive:
@@ -282,7 +278,6 @@ class PortTest(unittest.TestCase):
         )
         self.assertEqual(port._build_path(), '/my-build-directory/Debug')
 
-        Config._clear_cache_for_testing()
         port = self.make_port(
             executive=MockExecutive2(output='/default-build-path/Debug-embedded-port'),
             options=optparse.Values({'build_directory': '/my-build-directory/'}),

--- a/Tools/Scripts/webkitpy/port/config.py
+++ b/Tools/Scripts/webkitpy/port/config.py
@@ -54,50 +54,41 @@ class Config(object):
         "Release": "--release",
     }
 
-    # Shared across all Config instances: webkit-build-directory is a ~110ms
-    # perl invocation whose result is invariant for given inputs within a run.
-    _build_directories = {}
-
     def __init__(self, executive, filesystem, port_implementation=None, use_cmake=False):
         self._executive = executive
         self._filesystem = filesystem
         self._webkit_finder = webkit_finder.WebKitFinder(self._filesystem)
         self._default_configuration = None
+        self._build_directories = {}
         self._port_implementation = port_implementation
         self._use_cmake = use_cmake
 
-    @classmethod
-    def _clear_cache_for_testing(cls):
-        cls._build_directories = {}
-
     def build_directory(self, configuration, for_host=False):
         """Returns the path to the build directory for the configuration."""
-        port_impl = self._port_implementation if not for_host else None
-        cache_key = (port_impl, configuration or "", for_host, self._use_cmake)
-        if self._build_directories.get(cache_key):
-            return self._build_directories[cache_key]
-
         if configuration:
             flags = ["--configuration", self.flag_for_configuration(configuration)]
         else:
+            configuration = ""
             flags = []
-        if port_impl:
-            flags.append('--' + port_impl)
+
+        if self._port_implementation and not for_host:
+            flags.append('--' + self._port_implementation)
+
         if self._use_cmake:
             flags.append('--cmake')
 
-        args = ["perl", self._webkit_finder.path_to_script("webkit-build-directory")] + flags
-        output = self._executive.run_command(args, cwd=self._webkit_finder.webkit_base(), return_stderr=False).rstrip()
-        parts = output.split("\n")
-        self._build_directories[cache_key] = parts[0]
+        cache_key = (configuration, self._use_cmake)
+        if not self._build_directories.get(cache_key):
+            args = ["perl", self._webkit_finder.path_to_script("webkit-build-directory")] + flags
+            output = self._executive.run_command(args, cwd=self._webkit_finder.webkit_base(), return_stderr=False).rstrip()
+            parts = output.split("\n")
+            self._build_directories[cache_key] = parts[0]
 
-        # With no --configuration flag, webkit-build-directory also prints the
-        # default-configuration dir on a second line; cache it for later hits.
-        if len(parts) == 2:
-            default_configuration = parts[1][len(parts[0]):]
-            if default_configuration.startswith("/"):
-                default_configuration = default_configuration[1:]
-            self._build_directories[(port_impl, default_configuration, for_host, self._use_cmake)] = parts[1]
+            if len(parts) == 2:
+                default_configuration = parts[1][len(parts[0]):]
+                if default_configuration.startswith("/"):
+                    default_configuration = default_configuration[1:]
+                self._build_directories[(default_configuration, self._use_cmake)] = parts[1]
 
         return self._build_directories[cache_key]
 

--- a/Tools/Scripts/webkitpy/port/config_unittest.py
+++ b/Tools/Scripts/webkitpy/port/config_unittest.py
@@ -42,9 +42,6 @@ import webkitpy.port.config as config
 
 
 class ConfigTest(unittest.TestCase):
-    def setUp(self):
-        config.Config._clear_cache_for_testing()
-
     def make_config(self, output='', files=None, exit_code=0, exception=None, run_command_fn=None, stderr='', port_implementation=None, use_cmake=False):
         e = MockExecutive2(output=output, exit_code=exit_code, exception=exception, run_command_fn=run_command_fn, stderr=stderr)
         fs = MockFileSystem(files)
@@ -87,7 +84,6 @@ class ConfigTest(unittest.TestCase):
         self.assertRaises(KeyError, c.build_directory, 'Unknown')
 
         # Test that stderr output from webkit-build-directory won't mangle the build dir
-        config.Config._clear_cache_for_testing()
         c = self.make_config(output='/WebKitBuild/', stderr="mock stderr output from webkit-build-directory")
         self.assertEqual(c.build_directory(None), '/WebKitBuild/')
 

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -37,15 +37,13 @@ from webkitcorepy import decorators, Version
 from webkitexpectationspy.parser import ExpectationParser
 from webkitexpectationspy.suites.api_tests import APITestSuite
 
-from webkitpy.common.version_name_map import DARWIN_CURRENT_VERSION
-
 
 _log = logging.getLogger(__name__)
 
 
 class DarwinPort(ApplePort):
 
-    CURRENT_VERSION = DARWIN_CURRENT_VERSION
+    CURRENT_VERSION = Version(26)
     SDK = None
 
     API_TEST_BINARY_NAMES = ['TestWTF', 'TestWebKitAPI', 'TestIPC', 'TestWGSL']

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -31,7 +31,6 @@
 """Factory method to retrieve the appropriate port implementation."""
 
 import fnmatch
-import importlib
 import optparse
 import re
 
@@ -79,7 +78,7 @@ def platform_options(use_globs=False):
 
 def configuration_options():
     return [
-        optparse.make_option("-t", "--target", default=None, dest="configuration", help="(DEPRECATED)"),
+        optparse.make_option("-t", "--target", default=config.Config(executive.Executive(), filesystem.FileSystem()).default_configuration(), dest="configuration", help="(DEPRECATED) (default: %default)"),
         optparse.make_option('--debug', action='store_const', const='Debug', dest="configuration",
             help='Set the configuration to Debug'),
         optparse.make_option('--release', action='store_const', const='Release', dest="configuration",
@@ -100,34 +99,26 @@ def configuration_options():
     ]
 
 
-def _load_port_class(port_class_path):
-    module_name, class_name = port_class_path.rsplit('.', 1)
-    module = importlib.import_module('webkitpy.port.{}'.format(module_name))
-    return getattr(module, class_name)
-
-
 class PortFactory(object):
     # Order matters.  For port classes that have a port_name with a
     # common prefix, the more specific port class should be listed
-    # first. The prefix is duplicated from the class's own port_name
-    # so we can match without importing the (often heavy) port module;
-    # FactoryTest.test_port_classes_table_consistency enforces the two stay in sync.
+    # first.
     PORT_CLASSES = (
-        ('gtk',                 'gtk.GtkPort'),
-        ('ios-simulator',       'ios_simulator.IOSSimulatorPort'),
-        ('iphone-simulator',    'ios_simulator.IPhoneSimulatorPort'),
-        ('ipad-simulator',      'ios_simulator.IPadSimulatorPort'),
-        ('ios-device',          'ios_device.IOSDevicePort'),
-        ('watchos-simulator',   'watch_simulator.WatchSimulatorPort'),
-        ('watchos-device',      'watch_device.WatchDevicePort'),
-        ('visionos-simulator',  'visionos_simulator.VisionOSSimulatorPort'),
-        ('visionos-device',     'visionos_device.VisionOSDevicePort'),
-        ('jsc-only',            'jsc_only.JscOnlyPort'),
-        ('maccatalyst',         'mac.MacCatalystPort'),
-        ('mac',                 'mac.MacPort'),
-        ('test',                'test.TestPort'),
-        ('win',                 'win.WinPort'),
-        ('wpe',                 'wpe.WPEPort'),
+        'gtk.GtkPort',
+        'ios_simulator.IOSSimulatorPort',
+        'ios_simulator.IPhoneSimulatorPort',
+        'ios_simulator.IPadSimulatorPort',
+        'ios_device.IOSDevicePort',
+        'watch_simulator.WatchSimulatorPort',
+        'watch_device.WatchDevicePort',
+        'visionos_simulator.VisionOSSimulatorPort',
+        'visionos_device.VisionOSDevicePort',
+        'jsc_only.JscOnlyPort',
+        'mac.MacCatalystPort',
+        'mac.MacPort',
+        'test.TestPort',
+        'win.WinPort',
+        'wpe.WPEPort',
     )
 
     def __init__(self, host):
@@ -148,26 +139,23 @@ class PortFactory(object):
         port_name is None, this routine attempts to guess at the most
         appropriate port on this platform."""
         port_name = port_name or self._default_port()
-
-        for prefix, port_class_path in self.PORT_CLASSES:
-            if not port_name.startswith(prefix):
-                continue
-            cls = _load_port_class(port_class_path)
-            full_name = cls.determine_full_port_name(self._host, options, port_name)
-            try:
-                return cls(self._host, full_name, options=options, **kwargs)
-            except ValueError:
-                continue
-
+        classes = []
+        for port_class in self.PORT_CLASSES:
+            module_name, class_name = port_class.rsplit('.', 1)
+            module = __import__('webkitpy.port.{}'.format(module_name), globals(), locals(), [], 0)
+            cls = module.__dict__.get('port').__dict__.get(module_name).__dict__.get(class_name)
+            if cls:
+                classes.append(cls)
         if config.apple_additions() and hasattr(config.apple_additions(), 'ports'):
-            for cls in config.apple_additions().ports():
-                if port_name.startswith(cls.port_name):
-                    full_name = cls.determine_full_port_name(self._host, options, port_name)
-                    try:
-                        return cls(self._host, full_name, options=options, **kwargs)
-                    except ValueError:
-                        continue
+            classes += config.apple_additions().ports()
 
+        for cls in classes:
+            if port_name.startswith(cls.port_name):
+                port_name = cls.determine_full_port_name(self._host, options, port_name)
+                try:
+                    return cls(self._host, port_name, options=options, **kwargs)
+                except ValueError:
+                    continue
         raise NotImplementedError('unsupported platform: "%s"' % port_name)
 
     def all_port_names(self, platform=None):

--- a/Tools/Scripts/webkitpy/port/factory_unittest.py
+++ b/Tools/Scripts/webkitpy/port/factory_unittest.py
@@ -74,15 +74,3 @@ class FactoryTest(unittest.TestCase):
 
     def test_unknown_default(self):
         self.assertRaises(NotImplementedError, factory.PortFactory(MockSystemHost(os_name='vms')).get)
-
-    def test_port_classes_table_consistency(self):
-        # The PORT_CLASSES table duplicates each class's port_name so we can
-        # match port names without importing the (often heavy) port module.
-        # If the two ever diverge, prefix matching here would silently behave
-        # differently from the rest of the codebase.
-        for prefix, port_class_path in factory.PortFactory.PORT_CLASSES:
-            cls = factory._load_port_class(port_class_path)
-            self.assertEqual(
-                cls.port_name, prefix,
-                "PORT_CLASSES prefix {!r} doesn't match {}.port_name = {!r}".format(prefix, cls.__name__, cls.port_name),
-            )

--- a/Tools/Scripts/webkitpy/port/mac.py
+++ b/Tools/Scripts/webkitpy/port/mac.py
@@ -293,15 +293,7 @@ class MacPort(DarwinPort):
         return min(supportable_instances, default_count)
 
     def start_helper(self, pixel_tests=False, prefer_integrated_gpu=False):
-        if not self.start_helper_async(pixel_tests=pixel_tests, prefer_integrated_gpu=prefer_integrated_gpu):
-            return False
-        return self.wait_for_helper_ready()
-
-    def start_helper_async(self, pixel_tests=False, prefer_integrated_gpu=False):
         self.stop_helper()
-        # Mark that we *intend* to have a helper so wait_for_helper_ready can distinguish
-        # "never started" from "spawn failed".
-        Port._helper_started = True
 
         helper_path = self._path_to_helper()
         if not helper_path:
@@ -311,22 +303,13 @@ class MacPort(DarwinPort):
         arguments = [helper_path, '--install-color-profile']
         if prefer_integrated_gpu:
             arguments.append('--prefer-integrated-gpu')
-        Port._helper_process = self._executive.popen(arguments,
+        Port.helper = self._executive.popen(arguments,
             stdin=self._executive.PIPE, stdout=self._executive.PIPE, stderr=None)
+        is_ready = Port.helper.stdout.readline()
+        if not is_ready.startswith(b'ready'):
+            _log.error("LayoutTestHelper could not start")
+            return False
         return True
-
-    def wait_for_helper_ready(self):
-        if Port._helper_ready:
-            return True
-        if Port._helper_process:
-            is_ready = Port._helper_process.stdout.readline()
-            if not is_ready.startswith(b'ready'):
-                _log.error("LayoutTestHelper could not start")
-                return False
-            Port._helper_ready = True
-            return True
-        # No helper process: either nobody asked (test ports / non-Mac) or spawn failed.
-        return not Port._helper_started
 
     def reset_preferences(self):
         _log.debug("Resetting persistent preferences")
@@ -393,11 +376,9 @@ class MacPort(DarwinPort):
 
     def setup_test_run(self, device_type=None):
         super(MacPort, self).setup_test_run(device_type)
-        # Warm up only when multiple workers will spawn concurrently (webkit.org/b/242106):
-        # with one worker the first real test does the same first-run binary verification.
-        # Also skipped under --no-timeout so `lldb --wait-for --attach-name ...` doesn't
-        # latch onto the warmup process.
-        if self.get_option('child_processes', 1) > 1 and not self.get_option('no_timeout'):
+        # Warm-up can be disabled with `--no-timeout`. This is useful when trying to avoid debugger
+        # attaching to the warmup process when debugging with `lldb --wait-for --attach-name ...`.
+        if not self.get_option("no_timeout"):
             _log.debug('Warming up the runner ...')
             warmup_driver = self.create_driver(0)
             warmup_driver.run_test(DriverInput('file:///warmup-does-not-exist', 60000., None, should_run_pixel_test=False), stop_when_done=True)


### PR DESCRIPTION
#### 906178ae14f8bc36b30a2444dd1eaf7db670bd45
<pre>
Unreviewed, reverting 314080@main (7d4b9ad5fc39)
<a href="https://bugs.webkit.org/show_bug.cgi?id=316021">https://bugs.webkit.org/show_bug.cgi?id=316021</a>
<a href="https://rdar.apple.com/178452080">rdar://178452080</a>

REGRESSION (314080@main): iOS layout tests failing due to RuntimeError raised: No initialized devices for testing

Reverted change:

    Reduce run-webkit-tests startup overhead for faster iteration
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314459">https://bugs.webkit.org/show_bug.cgi?id=314459</a>
    <a href="https://rdar.apple.com/176618242">rdar://176618242</a>
    314080@main (7d4b9ad5fc39)

Canonical link: <a href="https://commits.webkit.org/314306@main">https://commits.webkit.org/314306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7b981d502fc6aa440a5b60213400ba396d93572

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165765 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39255 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/32836 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167631 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39259 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/174807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168724 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/148932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/174807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/165083 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22890 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/26631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/28337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/177332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/165167 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39324 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40012 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/148426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102541 "Failed to checkout and rebase branch from PR 66189") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25231 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/32374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38523 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37919 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/3375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38165 "Failed to checkout and rebase branch from PR 66189") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38063 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->