### PR TITLE
Commit message generator creates "Test" entries for non-test files under Tools/TestWebKitAPI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -36,4 +36,4 @@ objc/*.h diff=objcppheader
 /Source/JavaScriptCore/b3/testb3*.cpp test=1
 /Source/JavaScriptCore/b3/air/testair.cpp test=1
 /Source/JavaScriptCore/dfg/testdfg.cpp test=1
-/Tools/TestWebKitAPI/**/* test=1
+/Tools/TestWebKitAPI/Tests/**/* test=1


### PR DESCRIPTION
#### 8aa310e0db67b98e8520c3b9780208d7786e878f
<pre>
Commit message generator creates &quot;Test&quot; entries for non-test files under Tools/TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=316022">https://bugs.webkit.org/show_bug.cgi?id=316022</a>
<a href="https://rdar.apple.com/178452228">rdar://178452228</a>

Reviewed by Ryan Haddad.

After the TestWebKitAPI project restructure in 310630@main, all test
files are cleanly under Tools/TestWebKitAPI/Tests. In light of this
change, we can improve a current deficiency of the commit message
generator, which suggests _any_ change under Tools/TestWebKitAPI as a
test change.

To fix this, we change the scope of files that receive the `test`
attribute under the TestWebKitAPI project.

* .gitattributes:

Canonical link: <a href="https://commits.webkit.org/314313@main">https://commits.webkit.org/314313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dd005f41bb875092fd56d35628a449d52ececf9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174810 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123023 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65475558-9aa6-4365-ad02-42b51997f82e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128826 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56876015-187e-436b-89b8-78ff1495d39b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168727 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109350 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a9c04d6-558a-4188-86ea-e11c34c6f368) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30127 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28844 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22893 "Hash 6dd005f4 for PR 66192 does not build (failure)") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177335 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137160 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137088 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148428 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102544 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25236 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32375 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25295 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38526 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37922 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3377 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38066 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->