### PR TITLE
Fix internal build

### DIFF
--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -157,6 +157,7 @@ typedef NS_ENUM(NSInteger, NSScrollPocketEdge) {
 + (_NSCornerRadius *)fixedRadius:(CGFloat)radius;
 @end
 
+#if !defined(__has_include) || !__has_include(<AppKit/NSViewCornerRadii.h>)
 @interface NSViewCornerRadii : NSObject
 @property CGFloat topLeft;
 @property CGFloat topRight;
@@ -164,11 +165,14 @@ typedef NS_ENUM(NSInteger, NSScrollPocketEdge) {
 @property CGFloat bottomRight;
 @property (copy) CALayerCornerCurve cornerCurve;
 @end
+#endif
 
+#if !defined(__has_include) || !__has_include(<AppKit/NSViewCornerConfiguration.h>)
 @interface NSViewCornerConfiguration : NSObject
 + (NSViewCornerConfiguration *)configurationWithRadius:(_NSCornerRadius *)radius;
 + (instancetype)configurationWithTopLeftRadius:(nullable _NSCornerRadius *)topLeftRadius topRightRadius:(nullable _NSCornerRadius *)topRightRadius bottomLeftRadius:(nullable _NSCornerRadius *)bottomLeftRadius bottomRightRadius:(nullable _NSCornerRadius *)bottomRightRadius;
 @end
+#endif
 
 @interface NSPressGestureRecognizer (SPI)
 @property BOOL cancelPastAllowableMovement;

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -887,7 +887,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (self.enclosingScrollView)
         return [super _cornerConfiguration];
 
+#if defined(__has_include) && __has_include(<AppKit/NSViewCornerRadius.h>)
+    return [NSViewCornerConfiguration configurationWithRadius:NSViewCornerRadius.containerConcentricRadius];
+#else
     return [NSViewCornerConfiguration configurationWithRadius:_NSCornerRadius.containerConcentricRadius];
+#endif
 }
 
 #endif

--- a/Tools/TestWebKitAPI/Helpers/mac/AppKitSPI.h
+++ b/Tools/TestWebKitAPI/Helpers/mac/AppKitSPI.h
@@ -130,6 +130,7 @@ NSString * const NSInspectorBarTextAlignmentItemIdentifier = @"NSInspectorBarTex
 + (_NSCornerRadius *)fixedRadius:(CGFloat)radius;
 @end
 
+#if !defined(__has_include) || !__has_include(<AppKit/NSViewCornerRadii.h>)
 @interface NSViewCornerRadii : NSObject
 @property CGFloat topLeft;
 @property CGFloat topRight;
@@ -137,11 +138,14 @@ NSString * const NSInspectorBarTextAlignmentItemIdentifier = @"NSInspectorBarTex
 @property CGFloat bottomRight;
 @property (copy) CALayerCornerCurve cornerCurve;
 @end
+#endif
 
+#if !defined(__has_include) || !__has_include(<AppKit/NSViewCornerConfiguration.h>)
 @interface NSViewCornerConfiguration : NSObject
 + (NSViewCornerConfiguration *)configurationWithRadius:(_NSCornerRadius *)radius;
 + (instancetype)configurationWithTopLeftRadius:(nullable _NSCornerRadius *)topLeftRadius topRightRadius:(nullable _NSCornerRadius *)topRightRadius bottomLeftRadius:(nullable _NSCornerRadius *)bottomLeftRadius bottomRightRadius:(nullable _NSCornerRadius *)bottomRightRadius;
 @end
+#endif
 
 @interface NSView (NSViewCornerConfiguration)
 @property (nullable, readonly) NSViewCornerRadii *_effectiveCornerRadii;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm
@@ -60,11 +60,19 @@
 
 - (NSViewCornerConfiguration *)_cornerConfiguration
 {
+#if defined(__has_include) && __has_include(<AppKit/NSViewCornerRadius.h>)
+    return [NSViewCornerConfiguration
+        configurationWithTopLeftRadius:[NSViewCornerRadius fixedRadius:self.topLeftRadius]
+        topRightRadius:[NSViewCornerRadius fixedRadius:self.topRightRadius]
+        bottomLeftRadius:[NSViewCornerRadius fixedRadius:self.bottomLeftRadius]
+        bottomRightRadius:[NSViewCornerRadius fixedRadius:self.bottomRightRadius]];
+#else
     return [NSViewCornerConfiguration
         configurationWithTopLeftRadius:[_NSCornerRadius fixedRadius:self.topLeftRadius]
         topRightRadius:[_NSCornerRadius fixedRadius:self.topRightRadius]
         bottomLeftRadius:[_NSCornerRadius fixedRadius:self.bottomLeftRadius]
         bottomRightRadius:[_NSCornerRadius fixedRadius:self.bottomRightRadius]];
+#endif
 }
 
 @end


### PR DESCRIPTION
#### 4334c0464d376d9db37bac98175c68814e9797ed
<pre>
Fix internal build
<a href="https://bugs.webkit.org/show_bug.cgi?id=316024">https://bugs.webkit.org/show_bug.cgi?id=316024</a>
<a href="https://rdar.apple.com/178454663">rdar://178454663</a>

Unreviewed.

Tests: Tools/TestWebKitAPI/Helpers/mac/AppKitSPI.h
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _cornerConfiguration]):
* Tools/TestWebKitAPI/Helpers/mac/AppKitSPI.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm:
(-[ContainerView _cornerConfiguration]):

Canonical link: <a href="https://commits.webkit.org/314310@main">https://commits.webkit.org/314310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e94b83d2a25bd20bf2836ab2224491c59caca3ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174812 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f587b0b2-6f30-457b-808e-ad5f9d61b0a4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167636 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39264 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/128827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bf2955f-1d51-4e9e-aa7b-7999ef56feab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168729 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/148936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109351 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56b4c416-ce77-40d7-b79d-573891950762) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28845 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22895 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177337 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/28341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/137161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39329 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137089 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148430 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102546 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25234 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32376 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Passed layout tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38528 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/111601 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37924 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3379 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38170 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38068 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->