### PR TITLE
[iOS] Consider visibility endowments when determining if the application is in the background

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -206,6 +206,10 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 
 - (void)_lastPageLoadNetworkActivityCompletionCodeForTesting:(void(^)(NSNumber * _Nullable completionCode))completionHandler;
 
+#if TARGET_OS_IPHONE
++ (void)_setVisibilityEndowmentForTesting:(BOOL)isVisible;
+#endif
+
 @end
 
 typedef NS_ENUM(NSInteger, _WKMediaSessionReadyState) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -28,6 +28,7 @@
 
 #import "AudioSessionRoutingArbitratorProxy.h"
 #import "EditingRange.h"
+#import "EndowmentStateTracker.h"
 #import "GPUProcessProxy.h"
 #import "LogStream.h"
 #import "MediaSessionCoordinatorProxyPrivate.h"
@@ -1333,6 +1334,15 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     return nil;
 #endif
 }
+
+#if PLATFORM(IOS_FAMILY)
++ (void)_setVisibilityEndowmentForTesting:(BOOL)isVisible
+{
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    WebKit::EndowmentStateTracker::singleton().setStateForTesting(isVisible, isVisible);
+#endif
+}
+#endif
 
 @end
 

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.h
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "EndowmentStateTracker.h"
 #import <wtf/Forward.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
 #import <wtf/TZoneMalloc.h>
@@ -48,7 +49,12 @@ enum class ApplicationType : uint8_t {
     Extension,
 };
 
-class ApplicationStateTracker : public RefCountedAndCanMakeWeakPtr<ApplicationStateTracker> {
+class ApplicationStateTracker
+    : public RefCountedAndCanMakeWeakPtr<ApplicationStateTracker>
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    , EndowmentStateTrackerClient
+#endif
+{
     WTF_MAKE_TZONE_ALLOCATED(ApplicationStateTracker);
 public:
     static RefPtr<ApplicationStateTracker> create(UIView *view, SEL didEnterBackgroundSelector, SEL willEnterForegroundSelector, SEL willBeginSnapshotSequenceSelector, SEL didCompleteSnapshotSequenceSelector)
@@ -57,6 +63,14 @@ public:
     }
 
     ~ApplicationStateTracker();
+
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    // EndowmentStateTrackerClient
+    USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<ApplicationStateTracker>);
+    void ref() const final { RefCountedAndCanMakeWeakPtr::ref(); }
+    void deref() const final { RefCountedAndCanMakeWeakPtr::deref(); }
+    void isVisibleChanged(bool) final;
+#endif
 
     bool isInBackground() const { return m_isInBackground; }
 
@@ -70,12 +84,22 @@ private:
 
     void setIsInBackground(bool);
 
+    bool isWindowAndSceneInBackground() const;
+
     void applicationDidEnterBackground();
     void applicationDidFinishSnapshottingAfterEnteringBackground();
     void applicationWillEnterForeground();
     void willBeginSnapshotSequence();
     void didCompleteSnapshotSequence();
     void removeAllObservers();
+
+    enum class SceneState : uint8_t {
+        Unknown,
+        Foreground,
+        Background,
+    };
+    bool shouldBeInBackground(SceneState = SceneState::Unknown) const;
+    void updateIsInBackground(SceneState = SceneState::Unknown);
 
     WeakObjCPtr<UIView> m_view;
     WeakObjCPtr<UIWindow> m_window;

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -172,6 +172,9 @@ ApplicationStateTracker::ApplicationStateTracker(UIView *view, SEL didEnterBackg
     ASSERT([protect(m_view) respondsToSelector:m_didEnterBackgroundSelector]);
     ASSERT([protect(m_view) respondsToSelector:m_willEnterForegroundSelector]);
 
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    EndowmentStateTracker::singleton().addClient(*this);
+#endif
     allApplicationStateTrackers().add(*this);
 }
 
@@ -185,6 +188,9 @@ ApplicationStateTracker::~ApplicationStateTracker()
 
     removeAllObservers();
 
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    EndowmentStateTracker::singleton().removeClient(*this);
+#endif
     allApplicationStateTrackers().remove(*this);
     updateApplicationBackgroundState();
 }
@@ -268,19 +274,8 @@ void ApplicationStateTracker::setWindow(UIWindow *window)
 
 void ApplicationStateTracker::setScene(UIScene *scene)
 {
-    auto isWindowAndSceneInBackground = [] (const auto& window, const auto& scene) {
-        if (!scene) {
-            // TestWebKitAPI will create a WKWebView and place it into a UIWindow that
-            // has no UIWindowScene. For the purposes of keeping tests passing, treat
-            // the combination of a window without a windowScene as not in the background:
-            return !window;
-        }
-
-        return [scene activationState] == UISceneActivationStateBackground || [scene activationState] == UISceneActivationStateUnattached;
-    };
-
     if (m_scene.get() == scene) {
-        setIsInBackground(isWindowAndSceneInBackground(m_window, m_scene));
+        setIsInBackground(shouldBeInBackground());
         return;
     }
 
@@ -292,7 +287,7 @@ void ApplicationStateTracker::setScene(UIScene *scene)
     }
 
     m_scene = scene;
-    setIsInBackground(isWindowAndSceneInBackground(m_window, m_scene));
+    setIsInBackground(shouldBeInBackground());
 
     if (!m_scene)
         return;
@@ -305,7 +300,7 @@ void ApplicationStateTracker::setScene(UIScene *scene)
         if (!protectedThis)
             return;
         RELEASE_LOG(ViewState, "%p - ApplicationStateTracker: UISceneDidEnterBackground", protectedThis.get());
-        protectedThis->applicationDidEnterBackground();
+        protectedThis->updateIsInBackground(SceneState::Background);
     }];
 
     m_willEnterForegroundObserver = [notificationCenter addObserverForName:UISceneWillEnterForegroundNotification object:scene queue:nil usingBlock:[weakThis = WeakPtr { *this }](NSNotification *notification) {
@@ -313,7 +308,7 @@ void ApplicationStateTracker::setScene(UIScene *scene)
         if (!protectedThis)
             return;
         RELEASE_LOG(ViewState, "%p - ApplicationStateTracker: UISceneWillEnterForeground", protectedThis.get());
-        protectedThis->applicationWillEnterForeground();
+        protectedThis->updateIsInBackground(SceneState::Foreground);
     }];
 
     m_willBeginSnapshotSequenceObserver = [notificationCenter addObserverForName:_UISceneWillBeginSystemSnapshotSequence object:scene queue:nil usingBlock:[weakThis = WeakPtr { *this }](NSNotification *notification) {
@@ -386,8 +381,54 @@ void ApplicationStateTracker::setIsInBackground(bool isInBackground)
     m_isInBackground = isInBackground;
 }
 
+bool ApplicationStateTracker::isWindowAndSceneInBackground() const
+{
+    if (RetainPtr scene = m_scene.get()) {
+        auto state = [scene activationState];
+        return state == UISceneActivationStateBackground || state == UISceneActivationStateUnattached;
+    }
+
+    // TestWebKitAPI will create a WKWebView and place it into a UIWindow that
+    // has no UIWindowScene. For the purposes of keeping tests passing, treat
+    // the combination of a window without a windowScene as not in the background:
+    return !m_window;
+}
+
+void ApplicationStateTracker::updateIsInBackground(SceneState sceneState)
+{
+    if (shouldBeInBackground(sceneState))
+        applicationDidEnterBackground();
+    else
+        applicationWillEnterForeground();
+}
+
+bool ApplicationStateTracker::shouldBeInBackground(SceneState sceneState) const
+{
+    bool windowAndSceneInBackground = [&] {
+        switch (sceneState) {
+        case SceneState::Foreground:
+            return false;
+        case SceneState::Background:
+            return true;
+        case SceneState::Unknown:
+            return isWindowAndSceneInBackground();
+        }
+    }();
+
+    if (!windowAndSceneInBackground)
+        return false;
+
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    if (EndowmentStateTracker::singleton().isVisible())
+        return false;
+#endif
+
+    return true;
+}
+
 void ApplicationStateTracker::applicationDidEnterBackground()
 {
+    RELEASE_LOG(ViewState, "%p - ApplicationStateTracker::applicationDidEnterBackground()", this);
     setIsInBackground(true);
     updateApplicationBackgroundState();
 
@@ -397,6 +438,7 @@ void ApplicationStateTracker::applicationDidEnterBackground()
 
 void ApplicationStateTracker::applicationWillEnterForeground()
 {
+    RELEASE_LOG(ViewState, "%p - ApplicationStateTracker::applicationWillEnterForeground()", this);
     setIsInBackground(false);
     updateApplicationBackgroundState();
 
@@ -418,6 +460,13 @@ void ApplicationStateTracker::didCompleteSnapshotSequence()
         wtfObjCMsgSend<void>(view.get(), m_didCompleteSnapshotSequenceSelector);
 }
 
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+void ApplicationStateTracker::isVisibleChanged(bool)
+{
+    updateIsInBackground();
 }
+#endif
+
+} // namespace WebKit
 
 #endif

--- a/Source/WebKit/UIProcess/EndowmentStateTracker.h
+++ b/Source/WebKit/UIProcess/EndowmentStateTracker.h
@@ -59,6 +59,10 @@ public:
 
     static bool isApplicationForeground(pid_t);
 
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    void setStateForTesting(bool isUserFacing, bool isVisible);
+#endif
+
 private:
     friend class NeverDestroyed<EndowmentStateTracker>;
     EndowmentStateTracker() = default;

--- a/Source/WebKit/UIProcess/EndowmentStateTracker.mm
+++ b/Source/WebKit/UIProcess/EndowmentStateTracker.mm
@@ -152,6 +152,13 @@ void EndowmentStateTracker::setState(State&& state)
     });
 }
 
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+void EndowmentStateTracker::setStateForTesting(bool isUserFacing, bool isVisible)
+{
+    setState(State { isUserFacing, isVisible });
+}
+#endif
+
 }
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ApplicationStateTracking.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ApplicationStateTracking.mm
@@ -34,6 +34,7 @@
 #import "Helpers/cocoa/TestProtocol.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "Helpers/cocoa/WKWebViewConfigurationExtras.h"
+#import <WebKit/WKWebViewPrivateForTesting.h>
 
 namespace TestWebKitAPI {
 
@@ -100,6 +101,89 @@ TEST(ApplicationStateTracking, NavigatingFromPDFDoesNotLeaveWebViewInactive)
 }
 
 #endif // HAVE(PDFKIT)
+
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+
+class EndowmentStateTrackingTestHarness {
+public:
+    EndowmentStateTrackingTestHarness()
+    {
+        m_configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+        m_webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:m_configuration.get() addToWindow:NO]);
+        m_window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
+        [m_window addSubview:m_webView.get()];
+        [m_webView synchronouslyLoadHTMLString:@"<body>Foo</body>"];
+        [m_webView waitForNextPresentationUpdate];
+    }
+
+    ~EndowmentStateTrackingTestHarness()
+    {
+        [WKWebView _setVisibilityEndowmentForTesting:YES];
+    }
+
+    void postWithScene(NSNotificationName name)
+    {
+        [NSNotificationCenter.defaultCenter postNotificationName:name object:[m_window windowScene] userInfo:nil];
+    }
+
+    void waitForActivityStateUpdate()
+    {
+        __block bool done = false;
+        [m_webView _doAfterActivityStateUpdate:^{
+            done = true;
+        }];
+        Util::run(&done);
+    }
+
+    bool isPageActive()
+    {
+        return [[m_webView objectByEvaluatingJavaScript:@"internals.isPageActive()"] boolValue];
+    }
+
+private:
+    RetainPtr<WKWebViewConfiguration> m_configuration;
+    RetainPtr<TestWKWebView> m_webView;
+    RetainPtr<UIWindow> m_window;
+};
+
+TEST(ApplicationStateTracking, EndowmentKeepsPageActiveAfterSceneBackgrounds)
+{
+    [WKWebView _setVisibilityEndowmentForTesting:YES];
+    EndowmentStateTrackingTestHarness harness;
+    EXPECT_TRUE(harness.isPageActive());
+
+    harness.postWithScene(UISceneDidEnterBackgroundNotification);
+    harness.waitForActivityStateUpdate();
+    EXPECT_TRUE(harness.isPageActive());
+}
+
+TEST(ApplicationStateTracking, RevokingEndowmentDeactivatesBackgroundedScene)
+{
+    [WKWebView _setVisibilityEndowmentForTesting:YES];
+    EndowmentStateTrackingTestHarness harness;
+    harness.postWithScene(UISceneDidEnterBackgroundNotification);
+    harness.waitForActivityStateUpdate();
+    EXPECT_TRUE(harness.isPageActive());
+
+    [WKWebView _setVisibilityEndowmentForTesting:NO];
+    harness.waitForActivityStateUpdate();
+    EXPECT_FALSE(harness.isPageActive());
+}
+
+TEST(ApplicationStateTracking, SceneForegroundReactivatesEvenWithoutEndowment)
+{
+    [WKWebView _setVisibilityEndowmentForTesting:NO];
+    EndowmentStateTrackingTestHarness harness;
+    harness.postWithScene(UISceneDidEnterBackgroundNotification);
+    harness.waitForActivityStateUpdate();
+    EXPECT_FALSE(harness.isPageActive());
+
+    harness.postWithScene(UISceneWillEnterForegroundNotification);
+    harness.waitForActivityStateUpdate();
+    EXPECT_TRUE(harness.isPageActive());
+}
+
+#endif // ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
 
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### 483d0e85a7aa800e14446d342ff69fe485e0be22
<pre>
[iOS] Consider visibility endowments when determining if the application is in the background
<a href="https://bugs.webkit.org/show_bug.cgi?id=316028">https://bugs.webkit.org/show_bug.cgi?id=316028</a>
<a href="https://rdar.apple.com/178458157">rdar://178458157</a>

Reviewed by Jer Noble.

ApplicationStateTracker currently tracks a web view&apos;s UIWindowScene activationState for determining
whether the web view is in the background or foreground. However, there are cases where the window
scene is in the background but the web view is still responsible for presenting content in another
foreground scene (e.g., via layer hosting). To cover those cases, teach ApplicationStateTracker to
consider itself in the foreground if the application has a visibility endowment.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ApplicationStateTracking.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(+[WKWebView _setVisibilityEndowmentForTesting:]):
* Source/WebKit/UIProcess/ApplicationStateTracker.h:
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(WebKit::m_isInBackground):
(WebKit::ApplicationStateTracker::~ApplicationStateTracker):
(WebKit::ApplicationStateTracker::setScene):
(WebKit::ApplicationStateTracker::isWindowAndSceneInBackground const):
(WebKit::ApplicationStateTracker::updateIsInBackground):
(WebKit::ApplicationStateTracker::shouldBeInBackground const):
(WebKit::ApplicationStateTracker::applicationDidEnterBackground):
(WebKit::ApplicationStateTracker::applicationWillEnterForeground):
(WebKit::ApplicationStateTracker::isVisibleChanged):
* Source/WebKit/UIProcess/EndowmentStateTracker.h:
* Source/WebKit/UIProcess/EndowmentStateTracker.mm:
(WebKit::EndowmentStateTracker::setStateForTesting):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ApplicationStateTracking.mm:
(TestWebKitAPI::EndowmentStateTrackingTestHarness::EndowmentStateTrackingTestHarness):
(TestWebKitAPI::EndowmentStateTrackingTestHarness::~EndowmentStateTrackingTestHarness):
(TestWebKitAPI::EndowmentStateTrackingTestHarness::postWithScene):
(TestWebKitAPI::EndowmentStateTrackingTestHarness::waitForActivityStateUpdate):
(TestWebKitAPI::EndowmentStateTrackingTestHarness::isPageActive):
(TestWebKitAPI::TEST(ApplicationStateTracking, EndowmentKeepsPageActiveAfterSceneBackgrounds)):
(TestWebKitAPI::TEST(ApplicationStateTracking, RevokingEndowmentDeactivatesBackgroundedScene)):
(TestWebKitAPI::TEST(ApplicationStateTracking, SceneForegroundReactivatesEvenWithoutEndowment)):

Canonical link: <a href="https://commits.webkit.org/314329@main">https://commits.webkit.org/314329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/381cf983cf633761658612be4f55bcc9771bf789

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123075 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f201053e-24b4-477e-a21c-8abe11f4fbf5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128872 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c61aea5-d584-45f5-8f6e-2af7f0af5667) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168779 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109396 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1888015-104e-4354-8465-029c031e428e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/28892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22945 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177387 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28388 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137205 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39379 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137132 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36945 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148477 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102606 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32422 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25344 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38578 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111651 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37974 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3426 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38220 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38118 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->