### PR TITLE
Sort TestWebKitAPI Xcode project file

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 				"\"${SCRIPT_INPUT_FILE_0}\"",
 				"",
 				"",
+				"",
 			);
 		};
 /* End PBXBuildRule section */
@@ -309,13 +310,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = BC57597F126E74AF006F0F12;
 			remoteInfo = InjectedBundle;
-		};
-		DDF3A83428930475005920CF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DDF3A82928930475005920CF /* gtest.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4539C8FF0EC27F6400A70F4C;
-			remoteInfo = "gtest-framework";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -758,7 +752,6 @@
 				WebCore/RenderStyleChange.cpp,
 				WebCore/RTCRtpSFrameTransformerTests.cpp,
 				WebCore/SampleMap.cpp,
-				WebCore/SharedTimebaseTests.cpp,
 				WebCore/SecurityOrigin.cpp,
 				WebCore/SerializedScriptValue.cpp,
 				WebCore/ServiceWorkerRoutines.cpp,
@@ -766,6 +759,7 @@
 				WebCore/SharedBuffer.cpp,
 				WebCore/SharedBufferTest.cpp,
 				WebCore/SharedMemoryTests.cpp,
+				WebCore/SharedTimebaseTests.cpp,
 				WebCore/StaticRangeValidity.cpp,
 				WebCore/StringUtilities.mm,
 				WebCore/StringWithDirection.cpp,
@@ -944,11 +938,11 @@
 				WebKit/WKWebView/ios/UserInterfaceIdiomUpdate.mm,
 				WebKit/WKWebView/ios/Viewport.mm,
 				WebKit/WKWebView/ios/VisualViewport.mm,
+				WebKit/WKWebView/ios/WindowOrientation.mm,
 				WebKit/WKWebView/ios/WKScrollViewTests.mm,
 				WebKit/WKWebView/ios/WKWebViewAutofillTests.mm,
 				WebKit/WKWebView/ios/WKWebViewOpaque.mm,
 				WebKit/WKWebView/ios/WKWebViewPausePlayingAudioTests.mm,
-				WebKit/WKWebView/ios/WindowOrientation.mm,
 				WebKit/WKWebView/mac/AcceptsFirstMouse.mm,
 				WebKit/WKWebView/mac/AttributedString.mm,
 				WebKit/WKWebView/mac/AttributedSubstringForProposedRange.mm,
@@ -1197,6 +1191,7 @@
 				WTF/ParkingLot.cpp,
 				WTF/PreciseSum.cpp,
 				WTF/PriorityQueue.cpp,
+				WTF/RapidHash.cpp,
 				WTF/RedBlackTree.cpp,
 				WTF/Ref.cpp,
 				WTF/RefCountedFixedVector.cpp,
@@ -1252,7 +1247,6 @@
 				WTF/WorkerPool.cpp,
 				WTF/WorkQueue.cpp,
 				WTF/WTFString.cpp,
-				WTF/RapidHash.cpp,
 			);
 			target = 7C83DE951D0A590C00FEBCF3 /* TestWTFLibrary */;
 		};
@@ -1874,7 +1868,6 @@
 		DDF3A82A28930475005920CF /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				DDF3A83528930475005920CF /* gtest.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2021,8 +2014,6 @@
 			);
 			buildRules = (
 			);
-			dependencies = (
-			);
 			name = WebProcessPlugIn;
 			productName = WebProcessPlugIn;
 			productReference = A13EBB491B87339E00097110 /* TestWebKitAPI.wkbundle */;
@@ -2096,8 +2087,6 @@
 				BC57597E126E74AF006F0F12 /* Frameworks */,
 			);
 			buildRules = (
-			);
-			dependencies = (
 			);
 			name = InjectedBundleTestWebKitAPI;
 			productName = InjectedBundle;
@@ -2189,16 +2178,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		DDF3A83528930475005920CF /* gtest.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = gtest.framework;
-			remoteRef = DDF3A83428930475005920CF /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		A17C582C2C9B3EAD009DD0B5 /* Resources */ = {


### PR DESCRIPTION
#### 9ffb13ba53648d86594fe949e033244a9ef43f4c
<pre>
Sort TestWebKitAPI Xcode project file
<a href="https://bugs.webkit.org/show_bug.cgi?id=316029">https://bugs.webkit.org/show_bug.cgi?id=316029</a>
<a href="https://rdar.apple.com/178459169">rdar://178459169</a>

Reviewed by Richard Robinson.

This is a mechanical application of Xcode&apos;s auto-sorting on the project
file. We&apos;ve seen this in <a href="https://github.com/WebKit/WebKit/pull/66182">https://github.com/WebKit/WebKit/pull/66182</a>
already, so best to just not fight it.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/314378@main">https://commits.webkit.org/314378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f07c248e6bb47d9f2157659cf1e1fd4326a6b45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174824 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123037 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c591852d-5517-44b3-9755-4575d7db97a5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128839 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90741 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e0ef483-6308-4f97-ae31-0b4cfff8b42f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109363 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0fc337e-bdc2-4574-9a69-4694961b2588) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30183 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28856 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22907 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177349 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26675 "Build is in progress. Recent messages:") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137172 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137100 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102560 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25260 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32386 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38540 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37936 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3389 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38182 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38080 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->