### PR TITLE
REGRESSION(314042@main): Intermittent build failures on CMake+Gtk/Swift builds

### DIFF
--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -923,6 +923,13 @@ function(_webkit_setup_swift_header_deps _target _stamp _header)
             target_compile_options(${_target}_SwiftCompile PRIVATE $<TARGET_PROPERTY:${_target},COMPILE_OPTIONS>)
             target_compile_definitions(${_target}_SwiftCompile PRIVATE $<TARGET_PROPERTY:${_target},COMPILE_DEFINITIONS>)
             target_include_directories(${_target}_SwiftCompile PRIVATE $<TARGET_PROPERTY:${_target},INCLUDE_DIRECTORIES>)
+            # Emit the interop header from the helper only: it is the sole writer
+            # of WebKit-Swift-CPP.h.tmp in the legacy path and produces the
+            # swiftmodule the copy depends on, so the copy is ordered after the
+            # single write. ${_target} deliberately does not emit it here.
+            if (DEFINED ${_target}_SWIFT_EMIT_HEADER_FLAGS)
+                target_compile_options(${_target}_SwiftCompile PRIVATE ${${_target}_SWIFT_EMIT_HEADER_FLAGS})
+            endif ()
             add_dependencies(${_target}_SwiftCompile ${_target}_SwiftGeneratedDeps)
             file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swift-link)
             set_target_properties(${_target} PROPERTIES Swift_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swift-link)
@@ -1157,11 +1164,27 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
             # call populates it with all generated (binary-dir) headers for this target
             # once ${_target}_HEADERS and ${_target}_DERIVED_SOURCES are fully known.
             add_custom_target(${_target}_SwiftGeneratedDeps)
-            target_compile_options(${_target} PRIVATE
+            # WebKit-Swift-CPP.h.tmp must be written by exactly one target: the one
+            # whose ${_module_name}.swiftmodule the copy command below depends on. A
+            # second writer races the copy and fails it sporadically.
+            # https://bugs.webkit.org/show_bug.cgi?id=316000
+            set(_swift_emit_header_flags
                 "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-clang-header-path ${_header_tmp_path}>")
             if (CAN_USE_EMIT_CLANG_HEADER_MIN_ACCESS)
-                target_compile_options(${_target} PRIVATE
+                list(APPEND _swift_emit_header_flags
                     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -emit-clang-header-min-access -Xfrontend ${${_target}_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS}>")
+            endif ()
+            if (POLICY CMP0157)
+                # New Swift support: ${_target} is the only Swift compile, so emit here.
+                target_compile_options(${_target} PRIVATE ${_swift_emit_header_flags})
+            else ()
+                # Legacy support compiles the Swift sources twice: in the throw-away
+                # ${_target}_SwiftCompile helper (which produces the swiftmodule the
+                # copy depends on) and again in ${_target}'s link rule. Emit only from
+                # the helper; emitting from ${_target} too would make its link rule
+                # write the same temp unordered against the copy and race it. Stashed
+                # here, applied to the helper by _webkit_setup_swift_header_deps.
+                set(${_target}_SWIFT_EMIT_HEADER_FLAGS "${_swift_emit_header_flags}")
             endif ()
             add_custom_command(
                 OUTPUT ${_header_stamp_path}


### PR DESCRIPTION
#### 9584faf20f9822331332179303b55a4fcf0c1ede
<pre>
REGRESSION(314042@main): Intermittent build failures on CMake+Gtk/Swift builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=316000">https://bugs.webkit.org/show_bug.cgi?id=316000</a>

Reviewed by Geoffrey Garen.

Since 314042@main the interop header is emitted as a side effect of the Swift
compile, via -emit-clang-header-path on the target&apos;s shared Swift
COMPILE_OPTIONS. In the pre-CMP0157 (legacy) path the throw-away
WebKit_SwiftCompile helper inherits those options, so both the helper and the
real library link write the same WebKit-Swift-CPP.h.tmp. The copy_if_different
step is ordered after only the helper, so the link&apos;s unordered write races the
copy and fails it sporadically (&quot;Error copying file (if different)&quot;).

Emit the header from exactly the target whose swiftmodule the copy depends on:
the real target under CMP0157, the helper otherwise. The real library link no
longer emits the header, leaving a single writer correctly ordered before the
copy.

* Source/cmake/WebKitMacros.cmake:

Canonical link: <a href="https://commits.webkit.org/314322@main">https://commits.webkit.org/314322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6fbaabd7ab6acc55ed0f1ae87bfdc1cb2feb5ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174833 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128845 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168750 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109369 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28864 "Build is in progress. Recent messages:") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22916 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157948 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177358 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26684 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28355 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137179 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 20 flakes 6 failures; Uploaded test results") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39350 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137107 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36942 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102569 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32394 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25311 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38549 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37945 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3393 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->