### PR TITLE
GitHub.com: emoji reaction touches code box in comment.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-column-container-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-column-container-with-scrollable-descendant-expected.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: 500px;
+  outline: 1px solid black;
+}
+
+.flex-container {
+  display:flex;
+  flex-direction: column;
+  outline: 1px solid green;
+}
+
+.flex-item {
+  width: 300px;
+  outline: 1px solid magenta;
+}
+
+.content {
+  overflow-x: scroll;
+  white-space: pre;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=flex-container>
+    <div class=flex-item>
+      <div class=content>PASS if always-on scrollbar does not overlap the blue box below</div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-column-container-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-column-container-with-scrollable-descendant-ref.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: 500px;
+  outline: 1px solid black;
+}
+
+.flex-container {
+  display:flex;
+  flex-direction: column;
+  outline: 1px solid green;
+}
+
+.flex-item {
+  width: 300px;
+  outline: 1px solid magenta;
+}
+
+.content {
+  overflow-x: scroll;
+  white-space: pre;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=flex-container>
+    <div class=flex-item>
+      <div class=content>PASS if always-on scrollbar does not overlap the blue box below</div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-column-container-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-column-container-with-scrollable-descendant.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="flex-column-container-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: 500px;
+  outline: 1px solid black;
+}
+
+.flex-container {
+  display:flex;
+  flex-direction: column;
+  outline: 1px solid green;
+}
+
+.flex-item {
+  width: 300px;
+  outline: 1px solid magenta;
+}
+
+.content {
+  overflow: auto;
+  white-space: pre;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=flex-container>
+    <div class=flex-item>
+      <div class=content>PASS if always-on scrollbar does not overlap the blue box below</div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-container-multiple-items-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-container-multiple-items-with-scrollable-descendant-expected.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: 500px;
+}
+.flex-container {
+  display: flex;
+}
+.flex-item {
+  width: 300px;
+}
+.short-item {
+  width: 100px;
+  height: 10px;
+  background-color: magenta;
+}
+.scroller {
+  overflow-x: scroll;
+  white-space: pre;
+}
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=flex-container>
+    <div class=flex-item>
+      <div class=scroller>PASS if always-on scrollbar does not overlap the blue box below</div>
+    </div>
+    <div class=short-item></div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-container-multiple-items-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-container-multiple-items-with-scrollable-descendant-ref.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: 500px;
+}
+.flex-container {
+  display: flex;
+}
+.flex-item {
+  width: 300px;
+}
+.short-item {
+  width: 100px;
+  height: 10px;
+  background-color: magenta;
+}
+.scroller {
+  overflow-x: scroll;
+  white-space: pre;
+}
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=flex-container>
+    <div class=flex-item>
+      <div class=scroller>PASS if always-on scrollbar does not overlap the blue box below</div>
+    </div>
+    <div class=short-item></div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-container-multiple-items-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-container-multiple-items-with-scrollable-descendant.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="flex-container-multiple-items-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: 500px;
+}
+.flex-container {
+  display: flex;
+}
+.flex-item {
+  width: 300px;
+}
+.short-item {
+  width: 100px;
+  height: 10px;
+  background-color: magenta;
+}
+.scroller {
+  overflow: auto;
+  white-space: pre;
+}
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=flex-container>
+    <div class=flex-item>
+      <div class=scroller>PASS if always-on scrollbar does not overlap the blue box below</div>
+    </div>
+    <div class=short-item></div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-container-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-container-with-scrollable-descendant-expected.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: 500px;
+  outline: 1px solid black;
+}
+
+.flex-container {
+  display:flex;
+  outline: 1px solid green;
+}
+
+.flex-item {
+  width: 300px;
+  outline: 1px solid magenta;
+}
+
+.content {
+  overflow-x: scroll;
+  white-space: pre;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=flex-container>
+    <div class=flex-item>
+      <div class=content>PASS if always-on scrollbar does not overlap the blue box below</div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-container-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-container-with-scrollable-descendant-ref.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: 500px;
+  outline: 1px solid black;
+}
+
+.flex-container {
+  display:flex;
+  outline: 1px solid green;
+}
+
+.flex-item {
+  width: 300px;
+  outline: 1px solid magenta;
+}
+
+.content {
+  overflow-x: scroll;
+  white-space: pre;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=flex-container>
+    <div class=flex-item>
+      <div class=content>PASS if always-on scrollbar does not overlap the blue box below</div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-container-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-container-with-scrollable-descendant.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="flex-container-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: 500px;
+  outline: 1px solid black;
+}
+
+.flex-container {
+  display:flex;
+  outline: 1px solid green;
+}
+
+.flex-item {
+  width: 300px;
+  outline: 1px solid magenta;
+}
+
+.content {
+  overflow: auto;
+  white-space: pre;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=flex-container>
+    <div class=flex-item>
+      <div class=content>PASS if always-on scrollbar does not overlap the blue box below</div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-nested-container-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-nested-container-with-scrollable-descendant-expected.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: 500px;
+}
+.outer-flex {
+  display: flex;
+}
+.inner-flex {
+  display: flex;
+  width: 400px;
+}
+.flex-item {
+  width: 300px;
+}
+.scroller {
+  overflow-x: scroll;
+  white-space: pre;
+}
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=outer-flex>
+    <div class=inner-flex>
+      <div class=flex-item>
+        <div class=scroller>PASS if always-on scrollbar does not overlap the blue box below</div>
+      </div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-nested-container-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-nested-container-with-scrollable-descendant-ref.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: 500px;
+}
+.outer-flex {
+  display: flex;
+}
+.inner-flex {
+  display: flex;
+  width: 400px;
+}
+.flex-item {
+  width: 300px;
+}
+.scroller {
+  overflow-x: scroll;
+  white-space: pre;
+}
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=outer-flex>
+    <div class=inner-flex>
+      <div class=flex-item>
+        <div class=scroller>PASS if always-on scrollbar does not overlap the blue box below</div>
+      </div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-nested-container-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-nested-container-with-scrollable-descendant.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="flex-nested-container-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: 500px;
+}
+.outer-flex {
+  display: flex;
+}
+.inner-flex {
+  display: flex;
+  width: 400px;
+}
+.flex-item {
+  width: 300px;
+}
+.scroller {
+  overflow: auto;
+  white-space: pre;
+}
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=outer-flex>
+    <div class=inner-flex>
+      <div class=flex-item>
+        <div class=scroller>PASS if always-on scrollbar does not overlap the blue box below</div>
+      </div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-container-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-container-with-scrollable-descendant-expected.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: 500px;
+  outline: 1px solid black;
+}
+
+.grid-container {
+  display: grid;
+  outline: 1px solid green;
+}
+
+.grid-item {
+  width: 300px;
+  outline: 1px solid magenta;
+}
+
+.content {
+  overflow-x: scroll;
+  white-space: pre;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=grid-container>
+    <div class=grid-item>
+      <div class=content>PASS if always-on scrollbar does not overlap the blue box below</div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-container-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-container-with-scrollable-descendant-ref.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: 500px;
+  outline: 1px solid black;
+}
+
+.grid-container {
+  display: grid;
+  outline: 1px solid green;
+}
+
+.grid-item {
+  width: 300px;
+  outline: 1px solid magenta;
+}
+
+.content {
+  overflow-x: scroll;
+  white-space: pre;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=grid-container>
+    <div class=grid-item>
+      <div class=content>PASS if always-on scrollbar does not overlap the blue box below</div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-container-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-container-with-scrollable-descendant.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="grid-container-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: 500px;
+  outline: 1px solid black;
+}
+
+.grid-container {
+  display: grid;
+  outline: 1px solid green;
+}
+
+.grid-item {
+  width: 300px;
+  outline: 1px solid magenta;
+}
+
+.content {
+  overflow: auto;
+  white-space: pre;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=grid-container>
+    <div class=grid-item>
+      <div class=content>PASS if always-on scrollbar does not overlap the blue box below</div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-nested-container-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-nested-container-with-scrollable-descendant-expected.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: 500px;
+}
+
+.outer-grid {
+  display: grid;
+}
+
+.inner-grid {
+  display: grid;
+  width: 400px;
+}
+
+.grid-item {
+  width: 300px;
+}
+
+.scroller {
+  overflow-x: scroll;
+  white-space: pre;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=outer-grid>
+    <div class=inner-grid>
+      <div class=grid-item>
+        <div class=scroller>PASS if always-on scrollbar does not overlap the blue box below</div>
+      </div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-nested-container-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-nested-container-with-scrollable-descendant-ref.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  width: 500px;
+}
+
+.outer-grid {
+  display: grid;
+}
+
+.inner-grid {
+  display: grid;
+  width: 400px;
+}
+
+.grid-item {
+  width: 300px;
+}
+
+.scroller {
+  overflow-x: scroll;
+  white-space: pre;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=outer-grid>
+    <div class=inner-grid>
+      <div class=grid-item>
+        <div class=scroller>PASS if always-on scrollbar does not overlap the blue box below</div>
+      </div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-nested-container-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-nested-container-with-scrollable-descendant.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="grid-nested-container-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  width: 500px;
+}
+
+.outer-grid {
+  display: grid;
+}
+
+.inner-grid {
+  display: grid;
+  width: 400px;
+}
+
+.grid-item {
+  width: 300px;
+}
+
+.scroller {
+  overflow: auto;
+  white-space: pre;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  border: 4px solid blue;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=outer-grid>
+    <div class=inner-grid>
+      <div class=grid-item>
+        <div class=scroller>PASS if always-on scrollbar does not overlap the blue box below</div>
+      </div>
+    </div>
+  </div>
+  <div class=sibling></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -550,18 +550,22 @@ static EnumSet<LogicalBoxAxis> sizesAffectedByScrollbarsForSubtreeRoot(const Ren
     if (layoutContext.subtreeScrollbarChangesState())
         return { };
 
+    EnumSet<LogicalBoxAxis> sizesAffected;
+
     auto& style = renderBlock.style();
     auto& computedLogicalWidth = style.logicalWidth();
-    if (computedLogicalWidth.isFixed())
-        return { };
+    if (!computedLogicalWidth.isFixed() && (computedLogicalWidth.isIntrinsic() || computedLogicalWidth.isMinIntrinsic() || renderBlock.sizesPreferredLogicalWidthToFitContent()))
+        sizesAffected.add(LogicalBoxAxis::Inline);
 
-    if (computedLogicalWidth.isIntrinsic() || computedLogicalWidth.isMinIntrinsic())
-        return LogicalBoxAxis::Inline;
+    auto& computedLogicalHeight = style.logicalHeight();
 
-    if (renderBlock.sizesPreferredLogicalWidthToFitContent())
-        return LogicalBoxAxis::Inline;
+    if (renderBlock.isRenderFlexibleBox() && renderBlock.isBlockLevelBox() && (computedLogicalHeight.isAuto() || computedLogicalHeight.isIntrinsic()))
+        sizesAffected.add(LogicalBoxAxis::Block);
 
-    return { };
+    if (renderBlock.isRenderGrid() && (computedLogicalHeight.isAuto() || computedLogicalHeight.isIntrinsic()))
+        sizesAffected.add(LogicalBoxAxis::Block);
+
+    return sizesAffected;
 }
 
 static bool canContainDescendantScrollbarChanges(const RenderBlock& renderBlock, const LocalFrameViewLayoutContext& layoutContext)

--- a/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
@@ -147,9 +147,12 @@ SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler()
 
     auto& subtreeRoot = subtreeScrollbarChangesState->subtreeRoot;
     for (auto& rendererScrollbarChange : descendantsWithScrollbarChange) {
-        if (rendererScrollbarChange.sizesAffectedFromScrollbarChanges.containsOnly(LogicalBoxAxis::Block))
-            continue;
-        protect(rendererScrollbarChange.renderer)->invalidateContentLogicalWidths(MarkingBehavior::MarkContainingBlockChain, protect(subtreeRoot->containingBlock()));
+        CheckedRef renderer = rendererScrollbarChange.renderer;
+        ASSERT(renderer->isDescendantOf(subtreeRoot.ptr()));
+        if (rendererScrollbarChange.sizesAffectedFromScrollbarChanges.contains(LogicalBoxAxis::Block))
+            renderer->setNeedsLayout();
+        if (rendererScrollbarChange.sizesAffectedFromScrollbarChanges.contains(LogicalBoxAxis::Inline))
+            renderer->invalidateContentLogicalWidths(MarkingBehavior::MarkContainingBlockChain, protect(subtreeRoot->containingBlock()));
     }
     descendantsWithScrollbarChange.clear();
 


### PR DESCRIPTION
#### a8c7730a75ef911ed99272f87838f12bd99c8c0e
<pre>
GitHub.com: emoji reaction touches code box in comment.
<a href="https://bugs.webkit.org/show_bug.cgi?id=312152">https://bugs.webkit.org/show_bug.cgi?id=312152</a>
<a href="https://rdar.apple.com/174652842">rdar://174652842</a>

Reviewed by Alan Baradlay.

The automatic block size of a block-level flex container is its
max-content size. Similarly, the grid spec states that in both inline
and block formatting contexts, the grid container&apos;s auto block size is
its max-content size. When a descendant within an item gains a scrollbar
that consumes block-axis space (e.g. a horizontal scrollbar), the
container&apos;s block-size must grow to accommodate the taller content.
Without tracking this, the container&apos;s block-size goes stale and
following siblings can overlap the scrollbar.

Consider:

  &lt;div style=&quot;display: flex&quot;&gt; &lt;!-- subtree root --&gt;
    &lt;div class=&quot;flex-item&quot;&gt;
      &lt;div style=&quot;overflow: auto&quot;&gt;
        ...content that overflows horizontally...
      &lt;/div&gt;
    &lt;/div&gt;
  &lt;/div&gt;
  &lt;div class=&quot;sibling&quot;&gt;&lt;/div&gt;

When the overflow div gains a horizontal scrollbar, the flex container
must grow. The subtree root handler calls
subtreeRoot-&gt;layoutBlock(RelayoutChildren::Yes), but RelayoutChildren
only forces direct children to lay out. The scrollbar-gaining renderer
is a grandchild, so it remains clean and never reserves space for the
new scrollbar. We must explicitly call setNeedsLayout() on it so that
the dirty bit propagates up the containing block chain to the subtree
root. When layoutBlock then walks down looking for dirty descendants, it
reaches and relays out the renderer with its new scrollbar geometry.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::sizesAffectedByScrollbarsForSubtreeRoot):
Track LogicalBoxAxis::Block for block-level flex containers and grid
containers with auto or intrinsic logical height.

* Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp:
(WebCore::SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler):
For block-axis changes, call setNeedsLayout() on the descendant. For
inline-axis changes, invalidateContentLogicalWidths(). A renderer with
both gets both.

Tests:
- flex-container-with-scrollable-descendant: row flex, grandchild scroller.
- flex-column-container-with-scrollable-descendant: column flex.
- flex-container-multiple-items-with-scrollable-descendant: multiple items, one with scroller.
- flex-nested-container-with-scrollable-descendant: nested flex containers.
- grid-container-with-scrollable-descendant: grid, grandchild scroller.
- grid-nested-container-with-scrollable-descendant: nested grid containers.

Canonical link: <a href="https://commits.webkit.org/314501@main">https://commits.webkit.org/314501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c6df06c7f9c1b542e0dc49ebb8182ef51c0adab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123128 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128913 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90801 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109437 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30256 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28937 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23060 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140224 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177441 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30355 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28425 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137249 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137174 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37055 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148514 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102675 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32464 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25381 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38631 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111704 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38027 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3463 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38273 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38171 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->