### PR TITLE
[visionOS][Quirk] Duplicate YouTube captions after undocking from system environment fullscreen

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
@@ -110,7 +110,7 @@
                     break;
                 default:
                     cue.align = 'center';
-                    cue.positionAlign = = 'center';
+                    cue.positionAlign = 'center';
                 }
                 var topPercent = parseFloat(captionWindow.style.top);
                 var bottomPercent = parseFloat(captionWindow.style.bottom);
@@ -162,8 +162,14 @@
             });
         }
 
+        _getIsInline() {
+            if (typeof this._video.webkitPresentationMode === 'undefined')
+                return !this._video.webkitDisplayingFullscreen;
+            return this._video.webkitPresentationMode == 'inline';
+        }
+
         _handlePresentationModeChanged() {
-            if (this._video.webkitPresentationMode == 'inline') {
+            if (this._getIsInline()) {
                 this._mirrorTrack.mode = 'hidden';
                 return;
             }


### PR DESCRIPTION
#### f1dfb346a714aa891912bb46f1fb3de5fd827bbe
<pre>
[visionOS][Quirk] Duplicate YouTube captions after undocking from system environment fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=316035">https://bugs.webkit.org/show_bug.cgi?id=316035</a>
<a href="https://rdar.apple.com/178235422">rdar://178235422</a>

Reviewed by Jer Noble.

YouTubeCaptionQuirk.js has a strict-mode syntax error (cue.positionAlign = = &apos;center&apos;;) that
prevents the script from loading, so the in-page caption mirror has been inactive in native
fullscreen and PIP on every platform.

On visionOS the script is further hobbled because VideoPresentationModeAPIEnabled is off by
default, so video.webkitPresentationMode reads as undefined. The script never sees the transition
back to inline on undock, leaves the mirror text track showing with stale cues, and those cues
overlap YouTube&apos;s restored in-page captions.

Rather than enable VideoPresentationModeAPIEnabled on visionOS (which would also expose
webkitSetPresentationMode and let pages programmatically request PIP on a platform that doesn&apos;t
support it), feature-detect the property and fall back to the always-exposed read-only
video.webkitDisplayingFullscreen on visionOS.

* Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js:
(CaptionMirror.prototype._syncCues):
(CaptionMirror.prototype._getIsInline):
(CaptionMirror.prototype._handlePresentationModeChanged):

Canonical link: <a href="https://commits.webkit.org/314345@main">https://commits.webkit.org/314345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a8e8abb9ae8376a74789abafa37952409622389

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174855 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123068 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167679 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128866 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109390 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28885 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22938 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177380 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30295 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28381 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137197 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36955 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148470 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102596 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32416 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25337 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38571 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111644 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37967 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3419 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38213 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38111 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->