### PR TITLE
Update makefile in Source/WebKit/Scripts/webkit/tests

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/Makefile
+++ b/Source/WebKit/Scripts/webkit/tests/Makefile
@@ -21,6 +21,8 @@ TESTS = \
     TestWithSuperclass \
     TestWithSuperclassAndWantsAsyncDispatch \
     TestWithSuperclassAndWantsDispatch \
+    TestWithSwift \
+    TestWithSwiftConditionally \
     TestWithValidator \
     TestWithWantsAsyncDispatch \
     TestWithWantsDispatch \

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSwift.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSwift.messages.in
@@ -22,6 +22,8 @@
 
 [
     ExceptionForEnabledBy,
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
     SwiftReceiver
 ]
 messages -> TestWithSwift {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionally.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionally.messages.in
@@ -22,6 +22,8 @@
 
 [
     ExceptionForEnabledBy,
+    ExceptionForDispatchedFrom,
+    ExceptionForDispatchedTo,
     SwiftReceiverBuildEnabledBy=SWIFT_TEST_CONDITION
 ]
 messages -> TestWithSwiftConditionally {


### PR DESCRIPTION
#### 8af33d8c2869ba4ab50ed28682c97f59ac438a32
<pre>
Update makefile in Source/WebKit/Scripts/webkit/tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=316037">https://bugs.webkit.org/show_bug.cgi?id=316037</a>
<a href="https://rdar.apple.com/178468983">rdar://178468983</a>

Reviewed by Brady Eidson.

305567@main added to what is tested by CI, but it didn&apos;t update what happens when
you run make -C Source/WebKit/Scripts/webkit/tests.

* Source/WebKit/Scripts/webkit/tests/Makefile:
* Source/WebKit/Scripts/webkit/tests/TestWithSwift.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionally.messages.in:

Canonical link: <a href="https://commits.webkit.org/315625@main">https://commits.webkit.org/315625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14b723c3f68892ca06959e6ac26a0837172e1ec7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123316 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcd90707-0a91-462c-8353-15d60a98278f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129063 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90913 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36e98ae9-8096-4e9a-a97d-3e07610e13da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109589 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1dd4b352-83da-4ef3-9063-2982a7cdd477) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/165379 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30408 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29100 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23249 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158218 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177641 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26954 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137408 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137335 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40308 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25557 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102906 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25838 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32620 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111893 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198766 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38819 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3643 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53401 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38216 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38461 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38359 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->