### PR TITLE
AX iOS: Accessibility search should surface out-of-process iframes as remote element placeholders

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -17,6 +17,8 @@ accessibility/gtk [ Skip ]
 accessibility/mac [ Skip ]
 accessibility/win [ Skip ]
 http/tests/site-isolation/accessibility/client [ Skip ]
+# Exercises iOS-specific remote-frame accessibility search behavior; enabled only on iOS (see platform/ios/TestExpectations).
+http/tests/site-isolation/accessibility/heading-search-returns-remote-frame.html [ Skip ]
 displaylists [ Skip ]
 editing/mac [ Skip ]
 editing/caret/ios [ Skip ]

--- a/LayoutTests/http/tests/site-isolation/accessibility/heading-search-returns-remote-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/heading-search-returns-remote-frame-expected.txt
@@ -1,0 +1,11 @@
+This test ensures the accessibility search used by the VoiceOver rotor returns a remote frame placeholder for an out-of-process iframe on iOS.
+
+PASS: headingSearchReturnsRemoteFrame() === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+start
+Local heading
+
+

--- a/LayoutTests/http/tests/site-isolation/accessibility/heading-search-returns-remote-frame.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/heading-search-returns-remote-frame.html
@@ -1,0 +1,47 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/accessibility-helper.js"></script>
+</head>
+<body id="body">
+
+<button>start</button>
+<h1>Local heading</h1>
+<iframe id="iframe" onload="runTest()" src="http://localhost:8000/site-isolation/resources/iframe.html"></iframe>
+
+<script>
+var output = "This test ensures the accessibility search used by the VoiceOver rotor returns a remote frame placeholder for an out-of-process iframe on iOS.\n\n";
+
+var container;
+var startElement;
+
+// The heading rotor search runs in-process and does not descend into out-of-process iframes; instead it
+// returns the iframe as an AXRemoteElement placeholder (in tree order) for VoiceOver to descend into.
+function headingSearchReturnsRemoteFrame() {
+    var results = container.uiElementsForSearchPredicate(startElement, true, "AXHeadingSearchKey", "", false, false, 10);
+    for (var index = 0; index < results.length; index++) {
+        if (results[index].isRemotePlatformElement)
+            return true;
+    }
+    return false;
+}
+
+function runTest() {
+    if (window.accessibilityController) {
+        window.jsTestIsAsync = true;
+
+        setTimeout(async function() {
+            container = accessibilityController.rootElement;
+            startElement = accessibilityController.focusedElement.childAtIndex(0);
+
+            await waitFor(headingSearchReturnsRemoteFrame);
+            output += expect("headingSearchReturnsRemoteFrame()", "true");
+
+            debug(output);
+            finishJSTest();
+        }, 0);
+    }
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1491,6 +1491,8 @@ imported/w3c/web-platform-tests/css/css-view-transitions/old-content-inline-with
 
 # Site isolation testing infrastructure for accessibility doesn't exist on iOS.
 http/tests/site-isolation/accessibility/ [ Skip ]
+# ...except this test, which verifies the in-process rotor search returns a remote-frame placeholder for an out-of-process iframe.
+http/tests/site-isolation/accessibility/heading-search-returns-remote-frame.html [ Pass ]
 
 ###
 # Known failures

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -2191,12 +2191,21 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::findMatchingObjectsWithi
     criteria.anchorObject = this;
     auto stream = AXSearchManager().findMatchingObjectsAsStream(WTF::move(criteria));
 
-    // Extract local objects from the stream. Remote frame entries are ignored since
-    // callers of this function expect AccessibilityChildrenVector.
     AccessibilityChildrenVector results;
     for (const auto& entry : stream.entries()) {
-        if (RefPtr object = entry.objectIfLocalResult())
+        if (RefPtr object = entry.objectIfLocalResult()) {
             results.append(object.releaseNonNull());
+            continue;
+        }
+#if PLATFORM(IOS_FAMILY)
+        // iOS surfaces the remote frame placeholder inline so makeNSArray() emits its AXRemoteElement and
+        // ATs can descend into the out-of-process iframe. Skip it if there's no platform element.
+        // On other platforms, remote frame entries are ignored since callers expect only local objects.
+        if (RefPtr remoteFrameObject = entry.remoteFrameObject()) {
+            if (remoteFrameObject->remoteFramePlatformElement())
+                results.append(remoteFrameObject.releaseNonNull());
+        }
+#endif
     }
     return results;
 }

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -29,9 +29,11 @@
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
 #include "AXObjectCacheInlines.h"
+#include "AXRemoteFrame.h"
 #include "AXTreeStoreInlines.h"
 #include "AXUtilities.h"
 #include "AccessibilityObject.h"
+#include "AccessibilityScrollView.h"
 #include "FrameDestructionObserverInlines.h"
 #include "LocalFrameInlines.h"
 #include "LocalFrameView.h"
@@ -199,6 +201,24 @@ static void appendAccessibilityObject(Ref<AXCoreObject> object, AccessibilityObj
     else if (RefPtr axObject = dynamicDowncast<AccessibilityObject>(object)) {
         // Find the next descendant of this attachment object so search can continue through frames.
         RefPtr widget = axObject->widgetForAttachmentView();
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+        if (widget && widget->isRemoteFrameView()) {
+            // For an out-of-process (site-isolated) iframe, the content lives in another process, so we can't
+            // descend into it. Append the AXRemoteFrame placeholder instead so the search records the iframe in
+            // tree order; the client descends into it via the placeholder's platform element (AXRemoteElement).
+            CheckedPtr cache = axObject->axObjectCache();
+            if (RefPtr remoteFrameHost = cache ? cache->getOrCreate(*widget) : nullptr) {
+                remoteFrameHost->updateChildrenIfNecessary();
+                if (RefPtr scrollView = dynamicDowncast<AccessibilityScrollView>(*remoteFrameHost)) {
+                    if (RefPtr remoteFrame = scrollView->remoteFrame())
+                        results.append(remoteFrame.releaseNonNull());
+                }
+            }
+            return;
+        }
+#endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+
         RefPtr frameView = dynamicDowncast<LocalFrameView>(widget);
         if (!frameView)
             return;
@@ -396,18 +416,23 @@ AccessibilitySearchResultStream AXSearchManager::findMatchingObjectsInternalAsSt
 
     bool isForward = criteria.searchDirection == AccessibilitySearchDirection::Next;
 
-#if PLATFORM(MAC)
-    // For backward search starting from a remote frame, we need to dispatch to that frame first
-    // so it can search backward from its current focus position. Without this, the backward search
-    // would skip the remote frame entirely and only search elements before it in the parent.
+#if PLATFORM(COCOA)
+    // For backward search starting from a remote frame, we need to handle that frame first so its
+    // content isn't skipped (otherwise the backward search would only see elements before it in the parent).
     if (!isForward && startObject != anchorObject && startObject->isRemoteFrame()) {
-        if (auto frameID = startObject->remoteFrameID(); frameID && startObject->remoteFramePID()) {
+        if (std::optional frameID = startObject->remoteFrameID(); frameID && startObject->remoteFramePID()) {
+#if PLATFORM(IOS_FAMILY)
+            // iOS returns the remote frame's AXRemoteElement placeholder inline; VoiceOver descends into it.
+            stream.appendRemoteFrame(*frameID, startObject);
+#else
+            // macOS forwards the search into the remote frame via IPC.
             stream.appendRemoteFrame(*frameID);
             if (remoteFrameCallback)
                 remoteFrameCallback(*frameID, stream.entryCount(), localResultCount);
+#endif
         }
     }
-#endif // PLATFORM(MAC)
+#endif // PLATFORM(COCOA)
 
     // The first iteration of the outer loop will examine the children of the start object for matches. However, when
     // iterating backwards, the start object children should not be considered, so the loop is skipped ahead. We make an
@@ -434,25 +459,32 @@ AccessibilitySearchResultStream AXSearchManager::findMatchingObjectsInternalAsSt
         while (!searchStack.isEmpty()) {
             Ref searchObject = searchStack.takeLast();
 
-#if PLATFORM(MAC)
-            // Check if this is a remote frame - if so, record it in the stream for cross-process search.
+#if PLATFORM(COCOA)
+            // Check if this is a remote frame - if so, record it in the stream to maintain tree order.
             if (searchObject->isRemoteFrame()) {
-                auto frameID = searchObject->remoteFrameID();
-                auto pid = searchObject->remoteFramePID();
-                if (frameID && pid) {
-                    // Always record remote frames in the stream to maintain tree order.
+                std::optional frameID = searchObject->remoteFrameID();
+#if PLATFORM(IOS_FAMILY)
+                // iOS returns the remote frame's AXRemoteElement placeholder inline and lets VoiceOver
+                // descend into it; there's no in-WebProcess cross-process coordination like on macOS.
+                if (frameID && searchObject->remoteFramePID())
+                    stream.appendRemoteFrame(*frameID, RefPtr { searchObject.ptr() });
+                UNUSED_PARAM(remoteFrameCallback);
+#else // !PLATFORM(IOS_FAMILY)
+                // macOS forwards the search into the remote frame via IPC.
+                if (frameID && searchObject->remoteFramePID()) {
                     stream.appendRemoteFrame(*frameID);
                     // Invoke callback to allow eager IPC dispatch while search continues.
                     if (remoteFrameCallback)
                         remoteFrameCallback(*frameID, stream.entryCount(), localResultCount);
                 }
+#endif // PLATFORM(IOS_FAMILY)
                 // Don't descend into remote frames - we'll forward the search to them
                 // via IPC in |remoteFrameCallback|.
                 continue;
             }
-#else
+#else // !PLATFORM(COCOA)
             UNUSED_PARAM(remoteFrameCallback);
-#endif // PLATFORM(MAC)
+#endif // PLATFORM(COCOA)
 
             if (addMatchToStream(searchObject))
                 break;

--- a/Source/WebCore/accessibility/AXSearchManager.h
+++ b/Source/WebCore/accessibility/AXSearchManager.h
@@ -162,15 +162,20 @@ public:
         return { Type::LocalResult, object.ptr(), std::nullopt, index };
     }
 
-    static SearchResultEntry remoteFrame(FrameIdentifier fid, size_t index)
+    // On iOS, a RemoteFrame entry carries its AXRemoteFrame object so the result can be converted to its
+    // AXRemoteElement platform wrapper (see AXCoreObject::findMatchingObjectsWithin). macOS leaves it null
+    // and resolves the frame via IPC instead.
+    static SearchResultEntry remoteFrame(FrameIdentifier frameID, RefPtr<AXCoreObject> remoteFrameObject, size_t index)
     {
-        return { Type::RemoteFrame, nullptr, fid, index };
+        return { Type::RemoteFrame, WTF::move(remoteFrameObject), frameID, index };
     }
 
     bool isLocalResult() const { return m_type == Type::LocalResult; }
     bool isRemoteFrame() const { return m_type == Type::RemoteFrame; }
 
     RefPtr<AXCoreObject> objectIfLocalResult() const { return isLocalResult() ? m_object : nullptr; }
+    // On iOS, a RemoteFrame entry carries its AXRemoteFrame object. null on macOS / when not provided.
+    RefPtr<AXCoreObject> remoteFrameObject() const { return isRemoteFrame() ? m_object : nullptr; }
     const std::optional<FrameIdentifier>& frameID() const LIFETIME_BOUND { return m_frameID; }
     size_t streamIndex() const { return m_streamIndex; }
 
@@ -181,8 +186,9 @@ private:
         , m_frameID(WTF::move(frameID))
         , m_streamIndex(streamIndex)
     {
-        // A local result must have an object; a remote frame must have a frameID.
-        AX_ASSERT((m_type == Type::LocalResult) == (m_object != nullptr));
+        // A local result must have an object. A remote frame must have a frameID and may optionally
+        // carry its AXRemoteFrame object (used on iOS to emit an inline AXRemoteElement placeholder).
+        AX_ASSERT(m_type != Type::LocalResult || m_object);
         AX_ASSERT((m_type == Type::RemoteFrame) == m_frameID.has_value());
     }
 
@@ -204,9 +210,11 @@ public:
         m_entries.append(SearchResultEntry::localResult(WTF::move(object), nextIndex()));
     }
 
-    void appendRemoteFrame(FrameIdentifier frameID)
+    // remoteFrameObject is non-null only on iOS, where it lets callers emit an inline AXRemoteElement
+    // placeholder. macOS passes none and resolves the frame via IPC.
+    void appendRemoteFrame(FrameIdentifier frameID, RefPtr<AXCoreObject> remoteFrameObject = nullptr)
     {
-        m_entries.append(SearchResultEntry::remoteFrame(frameID, nextIndex()));
+        m_entries.append(SearchResultEntry::remoteFrame(frameID, WTF::move(remoteFrameObject), nextIndex()));
     }
 
     const Vector<SearchResultEntry>& entries() const LIFETIME_BOUND { return m_entries; }

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -2318,19 +2318,6 @@ static RenderObject* rendererForView(WAKView* view)
     return nil;
 }
 
-- (BOOL)_accessibilityShouldUseCustomRotor
-{
-    if (![self _prepareAccessibilityCall])
-        return YES;
-
-    RefPtr<AXCoreObject> backingObject = self.axBackingObject;
-    RefPtr page = backingObject ? backingObject->page() : nullptr;
-    // WebKit's custom rotor implementation can't search across processes, so we shouldn't
-    // use it if it site isolation is enabled. Once site isolation is enabled by default,
-    // this should be removed entirely.
-    return !page || !page->settings().siteIsolationEnabled();
-}
-
 - (NSArray<WebAccessibilityObjectWrapper *> *)accessibilityFindMatchingObjects:(NSDictionary *)parameters
 {
     RefPtr<AXCoreObject> backingObject = self.axBackingObject;

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h
@@ -121,6 +121,7 @@ public:
     bool isOffScreen() const override;
     bool isCollapsed() const override;
     bool isIgnored() const override;
+    bool isRemotePlatformElement() const override;
     bool isSingleLine() const override;
     bool isMultiLine() const override;
     bool hasPopup() const override;

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -876,6 +876,14 @@ bool AccessibilityUIElementIOS::attributedStringRangeIsMisspelled(unsigned locat
     return false;
 }
 
+bool AccessibilityUIElementIOS::isRemotePlatformElement() const
+{
+    // A search that crosses into an out-of-process iframe surfaces that frame as an AXRemoteElement
+    // placeholder (the iOS analog of NSAccessibilityRemoteUIElement on macOS). The class is soft-linked
+    // by WebCore, so it is only present in the process once such a placeholder has been created.
+    return [m_element isKindOfClass:NSClassFromString(@"AXRemoteElement")];
+}
+
 unsigned AccessibilityUIElementIOS::uiElementCountForSearchPredicate(JSContextRef context, AccessibilityUIElement *startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
     return 0;
@@ -906,8 +914,11 @@ JSValueRef AccessibilityUIElementIOS::uiElementsForSearchPredicate(JSContextRef 
         return nullptr;
 
     Vector<RefPtr<AccessibilityUIElement>> elements;
+    Class remoteElementClass = NSClassFromString(@"AXRemoteElement");
     for (id result in searchResults) {
-        if ([result isAccessibilityElement])
+        // Include the remote-frame placeholder (an AXRemoteElement, which is not itself an accessibility
+        // element) so tests can observe that a search crossing an out-of-process iframe returns it.
+        if ([result isAccessibilityElement] || [result isKindOfClass:remoteElementClass])
             elements.append(AccessibilityUIElement::create(result));
     }
     return makeJSArray(context, elements);


### PR DESCRIPTION
#### ed16a756bec625d60e1acf4defaf6b38d61dcfb0
<pre>
AX iOS: Accessibility search should surface out-of-process iframes as remote element placeholders
<a href="https://bugs.webkit.org/show_bug.cgi?id=316040">https://bugs.webkit.org/show_bug.cgi?id=316040</a>
<a href="https://rdar.apple.com/178471548">rdar://178471548</a>

Reviewed by Chris Fleizach.

When VoiceOver navigates by rotor (e.g. headings) on iOS, the in-process accessibility
search run by AXSearchManager silently dropped any out-of-process (site-isolated) iframe
it crossed, so content inside cross-origin iframes was unreachable by rotor.

Now, rather than skipping a remote frame, the search records it in tree order and returns
its AXRemoteElement platform placeholder inline. VoiceOver descends into that placeholder
to reach the iframe&apos;s content.

The obsolete -[WebAccessibilityObjectWrapper _accessibilityShouldUseCustomRotor] hook (which
disabled the custom rotor under site isolation) is removed.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/site-isolation/accessibility/heading-search-returns-remote-frame-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/heading-search-returns-remote-frame.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::findMatchingObjectsWithin):
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::appendAccessibilityObject):
(WebCore::AXSearchManager::findMatchingObjectsInternalAsStream):
* Source/WebCore/accessibility/AXSearchManager.h:
(WebCore::SearchResultEntry::remoteFrame):
(WebCore::SearchResultEntry::remoteFrameObject const):
(WebCore::SearchResultEntry::SearchResultEntry):
(WebCore::AccessibilitySearchResultStream::appendRemoteFrame):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper _accessibilityShouldUseCustomRotor]): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElementIOS::isRemotePlatformElement const):
(WTR::AccessibilityUIElementIOS::uiElementsForSearchPredicate):

Canonical link: <a href="https://commits.webkit.org/314365@main">https://commits.webkit.org/314365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb672e15fe235a5abb4fc77881af113c263c46a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174902 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123115 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128900 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109424 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30242 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28923 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23048 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177427 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30342 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137235 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137161 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36973 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40107 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148507 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102656 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32451 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25374 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38618 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111691 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38014 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3456 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38260 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38158 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->