### PR TITLE
Anchor positioning: abspos elements can anchor to viewport-fixedpos elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-001-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  height: 2000px;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#anchor {
+  position: fixed;
+  left: 0;
+  top: 0;
+  background: orange;
+}
+
+#anchored {
+  position: fixed;
+  left: 100px;
+  top: 100px;
+  background: green;
+}
+</style>
+
+<div id="anchor"></div>
+<div id="anchored"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-001.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>Abspos element anchored to fixed-positioned anchor: initial scroll position</title>
+<link rel="author" href="mailto:fantasai@inkedblade.net">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/">
+<link rel="match" href="reference/anchor-abspos-to-fixedpos-001-ref.html">
+<style>
+body {
+  margin: 0;
+  height: 2000px;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#anchor {
+  position: fixed;
+  left: 0;
+  top: 0;
+  anchor-name: --a;
+  background: orange;
+}
+
+#anchored {
+  position: absolute;
+  position-anchor: --a;
+  position-area: bottom right;
+  background: green;
+}
+</style>
+
+<div id="anchor"></div>
+<div id="anchored"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-002-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  height: 2000px;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#anchor {
+  position: fixed;
+  left: 0;
+  top: 0;
+  background: orange;
+}
+
+#anchored {
+  position: fixed;
+  left: 100px;
+  top: 100px;
+  background: green;
+}
+</style>
+
+<div id="anchor"></div>
+<div id="anchored"></div>
+
+<script>
+document.documentElement.scrollTop = 200;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-002.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<title>Abspos element anchored to fixed-positioned anchor: scroll position 200px</title>
+<link rel="author" href="mailto:fantasai@inkedblade.net">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/">
+<link rel="match" href="reference/anchor-abspos-to-fixedpos-002-ref.html">
+<style>
+body {
+  margin: 0;
+  height: 2000px;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#anchor {
+  position: fixed;
+  left: 0;
+  top: 0;
+  anchor-name: --a;
+  background: orange;
+}
+
+#anchored {
+  position: absolute;
+  position-anchor: --a;
+  position-area: bottom right;
+  background: green;
+}
+</style>
+
+<div id="anchor"></div>
+<div id="anchored"></div>
+
+<script>
+document.documentElement.scrollTop = 200;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-003-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  height: 2000px;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#anchor {
+  position: fixed;
+  left: 0;
+  top: 0;
+  background: orange;
+}
+
+#anchored {
+  position: fixed;
+  left: 100px;
+  top: 100px;
+  background: green;
+}
+</style>
+
+<div id="anchor"></div>
+<div id="anchored"></div>
+
+<script>
+document.documentElement.scrollTop = 1000;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-003.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<title>Abspos element anchored to fixed-positioned anchor: scroll position 1000px</title>
+<link rel="author" href="mailto:fantasai@inkedblade.net">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/">
+<link rel="match" href="reference/anchor-abspos-to-fixedpos-003-ref.html">
+<style>
+body {
+  margin: 0;
+  height: 2000px;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#anchor {
+  position: fixed;
+  left: 0;
+  top: 0;
+  anchor-name: --a;
+  background: orange;
+}
+
+#anchored {
+  position: absolute;
+  position-anchor: --a;
+  position-area: bottom right;
+  background: green;
+}
+</style>
+
+<div id="anchor"></div>
+<div id="anchored"></div>
+
+<script>
+document.documentElement.scrollTop = 1000;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-abspos-to-fixedpos-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-abspos-to-fixedpos-001-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  height: 2000px;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#anchor {
+  position: fixed;
+  left: 0;
+  top: 0;
+  background: orange;
+}
+
+#anchored {
+  position: fixed;
+  left: 100px;
+  top: 100px;
+  background: green;
+}
+</style>
+
+<div id="anchor"></div>
+<div id="anchored"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-abspos-to-fixedpos-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-abspos-to-fixedpos-002-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  height: 2000px;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#anchor {
+  position: fixed;
+  left: 0;
+  top: 0;
+  background: orange;
+}
+
+#anchored {
+  position: fixed;
+  left: 100px;
+  top: 100px;
+  background: green;
+}
+</style>
+
+<div id="anchor"></div>
+<div id="anchored"></div>
+
+<script>
+document.documentElement.scrollTop = 200;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-abspos-to-fixedpos-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-abspos-to-fixedpos-003-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  height: 2000px;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#anchor {
+  position: fixed;
+  left: 0;
+  top: 0;
+  background: orange;
+}
+
+#anchored {
+  position: fixed;
+  left: 100px;
+  top: 100px;
+  background: green;
+}
+</style>
+
+<div id="anchor"></div>
+<div id="anchored"></div>
+
+<script>
+document.documentElement.scrollTop = 1000;
+</script>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -162,22 +162,24 @@ void AnchorScrollAdjuster::addScrollSnapshot(const RenderBox& scroller)
     m_scrollSnapshots.constructAndAppend(scroller, scroller.constrainedScrollPosition());
 }
 
-void AnchorScrollAdjuster::addViewportSnapshot(const RenderView& renderView)
+void AnchorScrollAdjuster::addViewportSnapshot(const RenderView& renderView, AnchorScrollAdjuster::Direction direction)
 {
     CheckedRef view = renderView.frameView();
     auto position = view->constrainedScrollPosition(ScrollPosition(view->scrollPositionRespectingCustomFixedPosition()));
     m_scrollSnapshots.insert(0, AnchorScrollSnapshot { position });
-    m_adjustForViewport = true;
+    m_adjustmentForViewport = direction;
 }
 
 LayoutSize AnchorScrollAdjuster::adjustmentForViewport(const RenderView& renderView) const
 {
-    if (m_adjustForViewport) {
+    if (m_adjustmentForViewport) {
         // Viewport snapshot is stored in the first slot.
         ASSERT(m_scrollSnapshots.size() && !m_scrollSnapshots.first().m_scroller);
         CheckedRef view = renderView.frameView();
-        return m_scrollSnapshots.first().m_scrollSnapshot
+        auto adjustment = m_scrollSnapshots.first().m_scrollSnapshot
             - view->constrainedScrollPosition(IntPoint(view->scrollPositionRespectingCustomFixedPosition()));
+        adjustment.scale(m_adjustmentForViewport);
+        return adjustment;
     }
     return { };
 }
@@ -300,8 +302,11 @@ void AnchorPositionEvaluator::captureScrollSnapshots(RenderBox& anchored, bool i
         }
     }
 
-    if (isFixed(anchored) && !isFixedAnchor && !isFixed(*containingBlock))
-        adjuster.addViewportSnapshot(anchored.view());
+    bool isFixedAnchored = isFixed(anchored);
+    if (isFixedAnchored != isFixedAnchor && !isFixed(*containingBlock)) {
+        auto direction = isFixedAnchored ? AnchorScrollAdjuster::Direction::Normal : AnchorScrollAdjuster::Direction::Reverse;
+        adjuster.addViewportSnapshot(anchored.view(), direction);
+    }
 
     if (adjuster.isEmpty())
         return clearAnchorScrollSnapshots(anchored);
@@ -544,10 +549,18 @@ LayoutRect AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(C
 
     auto anchorBox = boxBoundingBoxInContainer(anchor, containingBlock);
 
-    // Handle fixed positioning x scrolling anchor.
-    if (&containingBlock == &containingBlock.view() && isFixed(anchoredBox) && !isFixed(anchor)) {
-        CheckedRef view = anchor->view().frameView();
-        anchorBox.moveBy(-view->constrainedScrollPosition(ScrollPosition(view->scrollPositionRespectingCustomFixedPosition())));
+    // Handle fixed positioning x scrolling anchor or vice versa.
+    if (&containingBlock == &containingBlock.view()) {
+        bool anchoredFixed = isFixed(anchoredBox);
+        bool anchorFixed = isFixed(anchor);
+        if (anchoredFixed != anchorFixed) {
+            CheckedRef view = anchor->view().frameView();
+            auto offset = view->constrainedScrollPosition(ScrollPosition(view->scrollPositionRespectingCustomFixedPosition()));
+            if (anchoredFixed)
+                anchorBox.moveBy(-offset);
+            else
+                anchorBox.moveBy(offset);
+        }
     }
 
     if (CheckedPtr containingBox = dynamicDowncast<RenderBox>(containingBlock)) {

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -94,8 +94,9 @@ public:
     void setHidden(bool hide) { m_isHidden = hide; }
 
     inline void addScrollSnapshot(const RenderBox& scroller);
-    inline void addViewportSnapshot(const RenderView&);
-    bool hasViewportSnapshot() const { return m_adjustForViewport; }
+    enum Direction : int8_t { Normal = 1, Reverse = -1 };
+    inline void addViewportSnapshot(const RenderView&, Direction = Reverse);
+    bool hasViewportSnapshot() const { return m_adjustmentForViewport; }
 
     inline void addStickySnapshot(const RenderBoxModelObject& sticky);
 
@@ -115,9 +116,9 @@ private:
     CheckedRef<RenderBox> m_anchored;
     Vector<AnchorScrollSnapshot, 1> m_scrollSnapshots;
     Vector<AnchorStickySnapshot> m_stickySnapshots;
+    int8_t m_adjustmentForViewport { 0 }; /* Boolean and directional multiplier. */
     bool m_needsXAdjustment : 1 { false };
     bool m_needsYAdjustment : 1 { false };
-    bool m_adjustForViewport : 1 { false };
     bool m_hasChainedAnchor : 1 { false };
     bool m_isHidden : 1 { false };
     bool m_hasFallback : 1 { false };


### PR DESCRIPTION
#### fe7bcd9ee8c281bba22ebb9f92c3c845339da4ee
<pre>
Anchor positioning: abspos elements can anchor to viewport-fixedpos elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=307171">https://bugs.webkit.org/show_bug.cgi?id=307171</a>
<a href="https://rdar.apple.com/170323196">rdar://170323196</a>

Reviewed by Kiet Ho.

We didn&apos;t account for non-fixed anchor-positioned boxes anchoring to fixed boxes.
Detect this case and:
a) Calculate the offset in consideration of our scroll position.
b) Create an AnchorScrollAdjuster that compensates correctly.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-abspos-to-fixedpos-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-abspos-to-fixedpos-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-abspos-to-fixedpos-002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-abspos-to-fixedpos-003-ref.html: Added.

Add tests.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::AnchorScrollAdjuster::addViewportSnapshot):
(WebCore::AnchorScrollAdjuster::adjustmentForViewport const):

Implement parameter to track whether we&apos;re inverting the viewport adjustment.

(WebCore::Style::AnchorPositionEvaluator::captureScrollSnapshots):

Detect the case of a non-fixed box attaching to a fixed box, and create an
inverted scroll adjustment for it.

(WebCore::Style::AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock):

Detect the case of a non-fixed box attaching to a fixed box, and make sure
to calculate the scroll compensation for it.

* Source/WebCore/style/AnchorPositionEvaluator.h:
(WebCore::AnchorScrollAdjuster::hasViewportSnapshot const):

Add parameter to track whether we&apos;re inverting the viewport adjustment.

Canonical link: <a href="https://commits.webkit.org/314706@main">https://commits.webkit.org/314706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af2e10d74755ad57d575a301d12fe8d6d8fb7437

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124142 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2a52e03-c183-4462-9112-80b268a40dee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129770 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0e3a9f7-d290-4ad9-9d7a-2aa85edb07bd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110296 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e4b49f0-4fc0-4722-be13-1727f590efe8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31153 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29851 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24668 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178470 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31367 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138141 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138053 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37188 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103949 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33329 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26309 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199563 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39643 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112717 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/199563 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39039 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4403 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39284 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39183 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->