### PR TITLE
Add new IntegerRangeOptimization testing helpers

### DIFF
--- a/JSTests/stress/iro-fact-dump-after-osr-recompile.js
+++ b/JSTests/stress/iro-fact-dump-after-osr-recompile.js
@@ -1,0 +1,47 @@
+//@ skip if !$isFTLPlatform
+//@ runDefault("--useTestingHelpers=1", "--useDollarVM=1", "--useConcurrentJIT=0", "--useLoopUnrolling=0")
+
+// The dump map is keyed by CodeBlock*, so after a recompile $vm.iroFactDump
+// must follow fn->replacement() to the current CodeBlock. We pin the probed
+// value at a single source location; across the recompile the same probe id
+// must keep getting a fresh, non-empty dump, not the stale one.
+
+load("./resources/iro-test-helpers.js", "caller relative");
+
+function fn(arr) {
+    return $vm.probe("p", arr.length - 1);
+}
+noInline(fn);
+
+for (let i = 0; i < testLoopCount; ++i) fn([1, 2, 3]);
+
+const dumpA = $vm.iroFactDump(fn);
+if (!dumpA || typeof dumpA !== "object")
+    throw new Error("monomorphic warm-up produced an empty IRO dump");
+
+const compilesA = numberOfDFGCompiles(fn);
+
+// Force an OSR exit by feeding a non-array shape, then re-monomorphize.
+for (let i = 0; i < 1000; ++i) fn({ length: i });
+for (let i = 0; i < testLoopCount * 10; ++i) fn([1, 2, 3]);
+
+const compilesB = numberOfDFGCompiles(fn);
+if (compilesB <= compilesA)
+    throw new Error("expected at least one re-DFG-compile after shape variation; "
+        + "before=" + compilesA + " after=" + compilesB);
+
+const dumpB = $vm.iroFactDump(fn);
+if (!dumpB || typeof dumpB !== "object")
+    throw new Error("re-compile produced an empty IRO dump (FTL may not have caught up — reheat insufficient?)");
+
+// The graph dump embeds the CodeBlock's pointers, so a fresh CodeBlock yields
+// different text. If they match, iroFactDump is reading the stale CodeBlock.
+if (dumpA.graph === dumpB.graph)
+    throw new Error("dump did not change across re-compile — $vm.iroFactDump may be reading a stale CodeBlock");
+
+// Both dumps should expose probe id="p" as the (arr.length - 1) value.
+for (const [label, obj] of [["dumpA", dumpA], ["dumpB", dumpB]]) {
+    const got = obj.probes && obj.probes.find(p => p.id === "p");
+    if (!got)
+        throw new Error(label + " is missing probe id=\"p\": " + JSON.stringify(obj));
+}

--- a/JSTests/stress/iro-probe-arithmetic.js
+++ b/JSTests/stress/iro-probe-arithmetic.js
@@ -1,0 +1,33 @@
+//@ skip if !$isFTLPlatform
+//@ runDefault("--useTestingHelpers=1", "--useDollarVM=1", "--useConcurrentJIT=0")
+
+// IRO forms offset relationships (e.g. `x > y + 1`) on the int32 values it
+// tracks. This checks one is observable through probes, at either operand's
+// anchor, in the weaker and orientation-flipped forms it implies.
+//
+// Note: probe the operands, not `probe(y) + 1` — an add fed by a probe result
+// is a ValueAdd, which IRO does not track.
+
+load("./resources/iro-test-helpers.js", "caller relative");
+
+function fn(x, y) {
+    if (x > y + 1) {
+        const px = $vm.probe("x", x);
+        const py = $vm.probe("y", y);
+        return px - py;
+    }
+    return 0;
+}
+noInline(fn);
+
+for (let i = 0; i < testLoopCount; i++) fn(100, 1);
+const iro = makeIROHelper(fn);
+
+// The exact recorded relation, from either operand's anchor.
+iro.assertRel({ at: "x", lhs: "x", rel: ">", rhs: "y", offset: 1 });
+iro.assertRel({ at: "y", lhs: "x", rel: ">", rhs: "y", offset: 1 });
+
+// Weaker / equivalent / flipped forms it implies.
+iro.assertRel({ at: "y", lhs: "x", rel: ">", rhs: "y" });             // x > y
+iro.assertRel({ at: "y", lhs: "x", rel: ">=", rhs: "y", offset: 2 }); // x >= y + 2  ⇔  x > y + 1
+iro.assertRel({ at: "y", lhs: "y", rel: "<", rhs: "x", offset: -1 }); // y < x - 1

--- a/JSTests/stress/iro-probe-check-removal.js
+++ b/JSTests/stress/iro-probe-check-removal.js
@@ -1,0 +1,30 @@
+//@ skip if !$isFTLPlatform
+//@ runDefault("--useTestingHelpers=1", "--useDollarVM=1", "--useConcurrentJIT=0")
+
+// The dump keys each eliminated op by the probe pinning the value it acted on,
+// so asserting on that per-probe record is robust to node renumbering and
+// unrelated ops, unlike a graph-wide op count or an IR-text grep.
+//
+// Pin the index with a probe but index with the raw value: using a DebugProbe
+// directly as an array subscript destabilizes the access and blocks FTL.
+
+load("./resources/iro-test-helpers.js", "caller relative");
+
+function fn(arr, i) {
+    let s = 0;
+    if (i >= 0 && i < arr.length) {
+        $vm.probe("guarded", i);     // IRO proves arr[i] in-bounds -> check eliminated
+        s += arr[i] | 0;
+    }
+    $vm.probe("unguarded", i & 7);   // valid at runtime, unprovable < length -> check kept
+    s += arr[i & 7] | 0;
+    return s;
+}
+noInline(fn);
+
+const a = [1, 2, 3, 4, 5, 6, 7, 8];
+for (let k = 0; k < testLoopCount; k++) fn(a, k & 7);
+const iro = makeIROHelper(fn);
+
+iro.assertEliminated("CheckInBounds", "guarded");
+iro.assertNotEliminated("CheckInBounds", "unguarded");

--- a/JSTests/stress/iro-probe-debug-print.js
+++ b/JSTests/stress/iro-probe-debug-print.js
@@ -1,0 +1,45 @@
+//@ skip if !$isFTLPlatform
+//@ runDefault("--useTestingHelpers=1", "--useDollarVM=1", "--useConcurrentJIT=0")
+
+// Exercises the debug-printing helpers range(id).toString() and
+// relsAt(id).toString(). When writing a new test, call
+//   print(iro.relsAt("y").toString());
+// to see, at a probe's IR position, its recorded facts and the range of every
+// probe those facts mention — the quickest way to find out what IRO proved
+// before deciding what to assert. Here two probes are related (x > y + 1); the
+// rendering at "y" should report the cross-probe fact and both probes' ranges.
+
+load("./resources/iro-test-helpers.js", "caller relative");
+
+function fn(x, y) {
+    if (x > y + 1) {
+        const px = $vm.probe("x", x);
+        const py = $vm.probe("y", y);
+        return px - py;
+    }
+    return 0;
+}
+noInline(fn);
+
+for (let i = 0; i < testLoopCount; i++) fn(100, 1);
+const iro = makeIROHelper(fn);
+
+// Fact order within a probe is not stable, so check for substrings rather than
+// an exact rendering.
+function expectContains(text, needle, what) {
+    if (!text.includes(needle))
+        throw new Error(what + ": expected output to contain " + JSON.stringify(needle)
+            + ", got:\n" + text);
+}
+
+const rels = iro.relsAt("y").toString();
+expectContains(rels, 'Relations at "y"', "relsAt header");
+expectContains(rels, "ranges:", "relsAt ranges section");
+expectContains(rels, '"y":', "relsAt y range line");
+expectContains(rels, '"x":', "relsAt x range line");      // x shown because a fact mentions it
+expectContains(rels, "facts:", "relsAt facts section");
+expectContains(rels, '"y"<"x"-1', "relsAt cross-probe fact");
+
+const r = iro.range("y").toString();
+expectContains(r, "range ", "range header");
+expectContains(r, '("y")', "range label");

--- a/JSTests/stress/iro-probe-loop-bounds.js
+++ b/JSTests/stress/iro-probe-loop-bounds.js
@@ -1,0 +1,35 @@
+//@ skip if !$isFTLPlatform
+//@ runDefault("--useTestingHelpers=1", "--useDollarVM=1", "--useConcurrentJIT=0", "--useLoopUnrolling=0")
+
+// Probing arr.length at the loop top and the induction variable inside lets us
+// assert `i < len`: CSE makes the in-loop arr.length the same node the probe
+// wraps, so the relation is named on both sides.
+//
+// IRO widens loop bounds, so the tight offset form (`i < len - 1`, e.g. from
+// `i + 1 < arr.length`) is not derived; it keeps only `i < len` / `i <= len`
+// for the induction variable. That is a limit of the analysis, not the dump,
+// so the test asserts only the bounds IRO actually produces.
+
+load("./resources/iro-test-helpers.js", "caller relative");
+
+function fn(arr) {
+    const len = $vm.probe("len", arr.length);
+    let sum = 0;
+    for (let i = 0; i < arr.length; i++) {
+        const pi = $vm.probe("i", i);
+        sum += arr[i] | 0;
+    }
+    return sum;
+}
+noInline(fn);
+
+const a = [1, 2, 3, 4, 5, 6, 7, 8];
+for (let k = 0; k < testLoopCount; k++) fn(a);
+const iro = makeIROHelper(fn);
+
+// The induction variable is bounded by the probed length and non-negative.
+// These hold at the "i" point (inside the loop); the "len" probe sits at the
+// loop top, before i exists, so the relation is anchored at "i".
+iro.assertRel({ at: "i", lhs: "i", rel: "<", rhs: "len" });
+iro.assertRel({ at: "i", lhs: "i", rel: ">=", rhs: { const: 0 } });
+iro.assertRel({ at: "i", lhs: "len", rel: ">", rhs: "i" });

--- a/JSTests/stress/iro-probe-no-relation.js
+++ b/JSTests/stress/iro-probe-no-relation.js
@@ -1,0 +1,37 @@
+//@ skip if !$isFTLPlatform
+//@ runDefault("--useTestingHelpers=1", "--useDollarVM=1", "--useConcurrentJIT=0")
+
+// Exercises assertNoRel and the ANY wildcard. assertNoRel proves IRO did NOT
+// relate two probes; ANY matches "anything" — as an assertRel operand it means
+// "related to some value in this direction", and as assertNoRel's `with` it
+// means "not related to anything" (its trivial self == self echo aside).
+//
+// x and y are related by `x > y + 1`; z is compared to nothing, so it carries
+// only its identity self-fact.
+
+load("./resources/iro-test-helpers.js", "caller relative");
+
+function fn(x, y, z) {
+    if (x > y + 1) {
+        const px = $vm.probe("x", x);
+        const py = $vm.probe("y", y);
+        const pz = $vm.probe("z", z);
+        return px - py + pz;
+    }
+    return 0;
+}
+noInline(fn);
+
+for (let i = 0; i < testLoopCount; i++) fn(100, 1, 42);
+const iro = makeIROHelper(fn);
+
+// ANY as an assertRel operand: x is greater than *something*.
+iro.assertRel({ at: "x", lhs: "x", rel: ">", rhs: iro.ANY });
+// Omitting rhs defaults it to ANY, so this is the same assertion.
+iro.assertRel({ at: "x", lhs: "x", rel: ">" });
+
+// assertNoRel with a specific probe: x and z were never related.
+iro.assertNoRel({ at: "x", with: "z" });
+
+// assertNoRel with ANY: z has no relations at all beyond its identity fact.
+iro.assertNoRel({ at: "z", with: iro.ANY });

--- a/JSTests/stress/iro-probe-range.js
+++ b/JSTests/stress/iro-probe-range.js
@@ -1,0 +1,42 @@
+//@ skip if !$isFTLPlatform
+//@ runDefault("--useTestingHelpers=1", "--useDollarVM=1", "--useConcurrentJIT=0", "--useLoopUnrolling=0")
+
+// Exercises range(id) and rangeOf(atId, ofId): the value range IRO proves for a
+// probe, and the range of one probe as seen at another probe's IR position.
+// Nested loops give two induction variables with constant bounds, so IRO proves
+// exact ranges; both are probed at the inner point, so the outer variable also
+// shows up in the inner probe's per-anchor ranges.
+
+load("./resources/iro-test-helpers.js", "caller relative");
+
+function fn() {
+    let sum = 0;
+    for (let i = 0; i < 10; i++) {
+        for (let j = 0; j < 5; j++) {
+            const pi = $vm.probe("i", i);
+            const pj = $vm.probe("j", j);
+            sum += pi + pj;
+        }
+    }
+    return sum;
+}
+noInline(fn);
+
+for (let k = 0; k < testLoopCount; k++) fn();
+const iro = makeIROHelper(fn);
+
+function expectRange(r, min, max, what) {
+    if (!r || r.min !== min || r.max !== max)
+        throw new Error(what + ": expected " + min + ".." + max
+            + ", got " + (r ? r.min + ".." + r.max : "null"));
+}
+
+expectRange(iro.range("i"), 0, 9, 'range("i")');
+expectRange(iro.range("j"), 0, 4, 'range("j")');
+
+// At "j"'s anchor (inner loop), the outer induction variable "i" is in scope,
+// so its range is visible there.
+expectRange(iro.rangeOf("j", "i"), 0, 9, 'rangeOf("j","i")');
+
+// rangeOf(id, id) is the probe's own range.
+expectRange(iro.rangeOf("i", "i"), 0, 9, 'rangeOf("i","i")');

--- a/JSTests/stress/iro-probe-relation-forms.js
+++ b/JSTests/stress/iro-probe-relation-forms.js
@@ -1,0 +1,55 @@
+//@ skip if !$isFTLPlatform
+//@ runDefault("--useTestingHelpers=1", "--useDollarVM=1", "--useConcurrentJIT=0")
+
+// Covers the relation-matching logic in iro-test-helpers (canonicalRelation /
+// impliedBy): the <= and != query forms, and the weaker relations an == or an
+// inequality fact implies. This exercises the helper, not new IRO behavior, so
+// the function just needs a fact of each kind in scope at one point:
+//   if (x)         -> p != 0                          (NotEqual)
+//   if (a > b + 1) -> a > b + 1  and  b < a - 1       (GreaterThan / LessThan)
+//   every probe    -> self == self                    (Equal)
+
+load("./resources/iro-test-helpers.js", "caller relative");
+
+function fn(x, a, b) {
+    if (x) {
+        if (a > b + 1) {
+            const p = $vm.probe("p", x);
+            const pa = $vm.probe("a", a);
+            const pb = $vm.probe("b", b);
+            return p + pa - pb;
+        }
+    }
+    return 0;
+}
+noInline(fn);
+
+for (let i = 0; i < testLoopCount; i++) fn((i & 7) + 1, 100, 1);
+const iro = makeIROHelper(fn);
+
+function expectThrow(thunk, what) {
+    try { thunk(); } catch { return; }
+    throw new Error(what + ": expected assertRel to throw, but it did not");
+}
+
+// != query implied by a > fact and a < fact.
+iro.assertRel({ at: "a", lhs: "a", rel: "!=", rhs: "b" });   // a > b+1  => a != b
+iro.assertRel({ at: "b", lhs: "b", rel: "!=", rhs: "a" });   // b < a-1  => b != a
+
+// != fact matched by a != query (lhs omitted defaults to `at`).
+iro.assertRel({ at: "p", rel: "!=", rhs: { const: 0 } });    // p != 0
+
+// <= / >= queries canonicalized to < / > and matched against the offset facts.
+iro.assertRel({ at: "b", lhs: "b", rel: "<=", rhs: "a", offset: -2 }); // b <= a-2 <=> b < a-1
+iro.assertRel({ at: "a", lhs: "a", rel: ">=", rhs: "b", offset: 2 });  // a >= b+2 <=> a > b+1
+
+// An == fact implies the trivially-true weaker forms.
+iro.assertRel({ at: "a", lhs: "a", rel: ">", rhs: "a", offset: -1 });  // a > a-1
+iro.assertRel({ at: "a", lhs: "a", rel: "<", rhs: "a", offset: 1 });   // a < a+1
+iro.assertRel({ at: "a", lhs: "a", rel: "!=", rhs: "a", offset: 5 });  // a != a+5
+
+// An unsupported relation is rejected.
+expectThrow(() => iro.assertRel({ at: "a", lhs: "a", rel: "<>", rhs: "b" }), "unsupported relation");
+
+// A relation IRO did not record is not invented (a > b+1 does not imply a < b).
+expectThrow(() => iro.assertRel({ at: "a", lhs: "a", rel: "<", rhs: "b" }), "a < b not implied");

--- a/JSTests/stress/probe-iro.js
+++ b/JSTests/stress/probe-iro.js
@@ -1,0 +1,27 @@
+//@ skip if !$isFTLPlatform
+//@ runDefault("--useTestingHelpers=1", "--useDollarVM=1", "--useConcurrentJIT=0")
+
+// Sanity-check the $vm.probe → DebugProbe → IRO dump plumbing: the dump should
+// report each probe id and IRO's identity fact for it.
+load("./resources/iro-test-helpers.js", "caller relative");
+
+function fn(idxBoost, x) {
+    if (x > -100 && x < 0) {
+        const r = $vm.probe("bitor", idxBoost | x);
+        const z = $vm.probe("add", r + 100);
+        return z;
+    }
+    return 0;
+}
+noInline(fn);
+
+for (let i = 0; i < testLoopCount; i++) fn(7, -5);
+const iro = makeIROHelper(fn);
+
+if (!iro.probes.has("bitor")) throw new Error('probe "bitor" missing from dump');
+if (!iro.probes.has("add")) throw new Error('probe "add" missing from dump');
+
+// IRO models each DebugProbe with an identity relationship to itself, so a
+// recorded self-fact confirms the probed node reached IRO and was tracked.
+iro.assertRel({ at: "bitor", lhs: "bitor", rel: "==", rhs: "bitor" });
+iro.assertRel({ at: "add", lhs: "add", rel: "==", rhs: "add" });

--- a/JSTests/stress/resources/iro-test-helpers.js
+++ b/JSTests/stress/resources/iro-test-helpers.js
@@ -1,0 +1,362 @@
+// Helpers for asserting facts produced by the DFG IntegerRangeOptimization
+// phase (IRO). Tests pin a specific DFG node by wrapping its JS value in a
+// `$vm.probe(id, value)` call: in DFG/FTL the call becomes a DebugProbe DFG
+// node carrying that string id, and IRO emits a dump entry keyed by id.
+//
+// Requires --useTestingHelpers=1 --useDollarVM=1 --useConcurrentJIT=0
+// ($vm.iroFactDump release-asserts concurrent JIT is off).
+//
+// ---- API ------------------------------------------------------------------
+//
+//   makeIROHelper(fn) → {
+//       probes,                              // Map<id, probeEntry>
+//       range(id),                           // { min, max } | null
+//       rangeOf(atId, ofId),                 // range of probe `ofId` at probe `atId`'s point
+//       relsAt(id),                          // relations recorded at probe `id`
+//       assertRel({ at, lhs, rel, rhs, offset }),
+//       assertNoRel({ at, with }),
+//       assertEliminated(op, probeId),      // IRO removed `op` on that probe
+//       assertNotEliminated(op, probeId),
+//       opCount(op),                         // # of nodes with `op` IRO left
+//       dfgGraph,                            // textual DFG dump (string)
+//   }
+//
+// A probe entry has shape:
+//   { id, range: {min,max}|null,
+//     lineRanges: Map<otherProbeId, {min,max}|null>,
+//     rels:       [ factEntry ] }   // facts that mention the probe
+//
+// A factEntry is:
+//   { lhs, rhs, rel, offset }   // lhs/rhs is a probe id (string) or int constant (number)
+//
+// Relations: `lhs` / `rhs` for `assertRel` and `assertNoRel` accept a probe
+// id (string), an integer constant (use { const: N }), or ANY (the Symbol).
+// `rel` is one of "<", ">", "==", "!=", "<=", ">=". `<=` and `>=` are
+// normalized to `<` / `>` with an adjusted offset.
+//
+// Matching is logical, not textual: a recorded `lhs > rhs + 5` matches a
+// query for `lhs > rhs + 0`; `lhs == rhs + 3` matches `lhs > rhs + 2`; and a
+// recorded `rhs < lhs - 5` matches a query for `lhs > rhs + 4` (orientation
+// reversal). Constants on the RHS of a recorded fact match constant queries
+// too.
+
+const ANY = Symbol("IRO.ANY");
+
+function makeIROHelper(fn) {
+    // $vm.iroFactDump returns the fact object directly (probes + graph, with the
+    // accumulated probe-pinned eliminations stitched on by $vm), or an empty
+    // string if the function isn't FTL-compiled.
+    const parsed = $vm.iroFactDump(fn);
+    if (!parsed || typeof parsed !== "object")
+        throw new Error("makeIROHelper: $vm.iroFactDump returned no fact object — was the function FTL-compiled?");
+
+    // IR modifications IRO made to a probed value, e.g. eliminating a
+    // CheckInBounds whose index is a probe. Keyed "op|probeId" so a test can
+    // assert a specific removal happened (or didn't) on a specific probe,
+    // independent of graph-wide op counts.
+    const elimSet = new Set((parsed.eliminations || []).map(e => e.op + "|" + e.on));
+
+    // opCount(op) counts `Op(` node headers in the dump. The trailing `(` makes
+    // it exact (operands are printed as D@N, and it won't match a longer op).
+    const dfgGraph = typeof parsed.graph === "string" ? parsed.graph : "";
+    function opCount(op) {
+        if (!dfgGraph)
+            return 0;
+        const escaped = op.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const matches = dfgGraph.match(new RegExp("\\b" + escaped + "\\(", "g"));
+        return matches ? matches.length : 0;
+    }
+
+    // IRO emits each fact in canonical form (anchor on the left) but may repeat
+    // it: a probe's id is shared by the DebugProbe node and the value it wraps,
+    // and IRO stores every relationship in both orientations. Canonical form
+    // means equal facts stringify identically, so a textual key dedupes them.
+    function dedupeFacts(rels) {
+        const seen = new Set();
+        return rels.filter(f => {
+            const key = [f.lhs, f.rel, f.rhs, f.offset].join("|");
+            return seen.has(key) ? false : (seen.add(key), true);
+        });
+    }
+
+    const probes = new Map();
+    for (const raw of (parsed.probes || [])) {
+        const lineRanges = new Map();
+        for (const lr of (raw.lineRanges || [])) {
+            lineRanges.set(lr.id, lr.range ? { min: lr.range[0], max: lr.range[1] } : null);
+        }
+        probes.set(raw.id, {
+            id: raw.id,
+            range: raw.range ? { min: raw.range[0], max: raw.range[1] } : null,
+            lineRanges,
+            rels: dedupeFacts(raw.rels || []),
+        });
+    }
+
+    function getProbe(id, role) {
+        if (typeof id !== "string")
+            throw new Error("makeIROHelper: " + role + " must be a probe id (string); got " + typeof id);
+        const p = probes.get(id);
+        if (!p)
+            throw new Error("makeIROHelper: no probe with id " + JSON.stringify(id)
+                + " found in dump (known ids: "
+                + [...probes.keys()].map(JSON.stringify).join(", ") + ")");
+        return p;
+    }
+
+    function labelOf(id) {
+        return JSON.stringify(id);
+    }
+
+    function formatRange(r) {
+        return r ? (r.min + ".." + r.max) : "none";
+    }
+
+    function wrapRange(raw, label) {
+        if (raw == null) return null;
+        const r = { min: raw.min, max: raw.max };
+        r.toString = function() {
+            return "range " + formatRange(this) + " (" + label + ")";
+        };
+        return r;
+    }
+
+    // The relsAt(id) result carries its facts plus the per-probe ranges that
+    // are visible at this anchor, so the printout shows the range of every
+    // probe mentioned in the facts (it's confusing to read a fact like
+    //   x-inside < bitor-inside + 1
+    // without seeing x-inside's range at the same point).
+    function wrapRels(probe) {
+        const arr = probe.rels.slice();
+        arr.toString = function() {
+            const lines = [];
+            lines.push("Relations at " + labelOf(probe.id) + " (" + this.length + "):");
+
+            // Collect ranges for every probe mentioned in any fact (plus the
+            // anchor itself). The anchor's own range comes from `probe.range`;
+            // the other probes' ranges live in `probe.lineRanges` (a map of
+            // probeId → range as recorded at this anchor's IR position).
+            const referenced = new Set();
+            referenced.add(probe.id);
+            for (const f of this) {
+                if (typeof f.lhs === "string") referenced.add(f.lhs);
+                if (typeof f.rhs === "string") referenced.add(f.rhs);
+            }
+            const rangesForLabel = new Map();
+            rangesForLabel.set(probe.id, probe.range);
+            for (const otherId of referenced) {
+                if (otherId === probe.id) continue;
+                if (probe.lineRanges.has(otherId))
+                    rangesForLabel.set(otherId, probe.lineRanges.get(otherId));
+            }
+            if (rangesForLabel.size > 0) {
+                lines.push("  ranges:");
+                for (const [id, r] of rangesForLabel)
+                    lines.push("    " + labelOf(id) + ": " + formatRange(r));
+            }
+
+            if (this.length === 0)
+                lines.push("  facts: (no relations recorded)");
+            else {
+                lines.push("  facts:");
+                for (const f of this)
+                    lines.push("    " + describeFact(f));
+            }
+            return lines.join("\n");
+        };
+        return arr;
+    }
+
+    function range(id) {
+        return wrapRange(getProbe(id, "id").range, labelOf(id));
+    }
+
+    function rangeOf(atId, ofId) {
+        const at = getProbe(atId, "atId");
+        if (atId === ofId)
+            return wrapRange(at.range, labelOf(ofId) + " at " + labelOf(atId));
+        const raw = at.lineRanges.has(ofId) ? at.lineRanges.get(ofId) : null;
+        return wrapRange(raw, labelOf(ofId) + " at " + labelOf(atId));
+    }
+
+    function relsAt(id) {
+        return wrapRels(getProbe(id, "id"));
+    }
+
+    // Canonicalize a query relation. IRO records only `<`, `>`, `==`, `!=`;
+    // `<=` and `>=` are expressed via an off-by-one in the offset.
+    function canonicalRelation(rel, offset) {
+        if (rel === ">=") return { rel: ">", offset: offset - 1 };
+        if (rel === "<=") return { rel: "<", offset: offset + 1 };
+        if (rel === ">" || rel === "<" || rel === "==" || rel === "!=")
+            return { rel, offset };
+        throw new Error("makeIROHelper: unsupported relation '" + rel + "'");
+    }
+    function flipRel(rel) {
+        if (rel === "<") return ">";
+        if (rel === ">") return "<";
+        return rel;
+    }
+
+    // Normalize a user-supplied operand to a triple { probeId?, constant?, any }.
+    function normalizeOperand(operand, role) {
+        if (operand === ANY)
+            return { any: true };
+        if (typeof operand === "string")
+            return { probeId: operand };
+        if (operand && typeof operand === "object" && typeof operand.const === "number")
+            return { constant: operand.const };
+        throw new Error("makeIROHelper: " + role + " must be a probe id (string), "
+            + "{ const: N }, or iro.ANY");
+    }
+
+    // For a recorded fact's side, normalize to the same shape so we can
+    // compare.
+    function recordedSide(facta, prefix) {
+        const v = facta[prefix];
+        if (typeof v === "string") return { probeId: v };
+        if (typeof v === "number") return { constant: v };
+        return {};
+    }
+    function sideMatches(recorded, query) {
+        if (query.any) return true;
+        if (query.probeId != null) return recorded.probeId === query.probeId;
+        if (query.constant != null) return recorded.constant === query.constant;
+        return false;
+    }
+
+    function impliedBy(fRel, fOffset, qRel, qOffset) {
+        if (fRel === ">") {
+            if (qRel === ">")  return fOffset >= qOffset;
+            if (qRel === "!=") return fOffset >= qOffset;
+            return false;
+        }
+        if (fRel === "<") {
+            if (qRel === "<")  return fOffset <= qOffset;
+            if (qRel === "!=") return fOffset <= qOffset;
+            return false;
+        }
+        if (fRel === "==") {
+            if (qRel === "==") return fOffset === qOffset;
+            if (qRel === ">")  return fOffset > qOffset;
+            if (qRel === "<")  return fOffset < qOffset;
+            if (qRel === "!=") return fOffset !== qOffset;
+            return false;
+        }
+        if (fRel === "!=") {
+            return qRel === "!=" && fOffset === qOffset;
+        }
+        return false;
+    }
+    function factImplies(f, q) {
+        const fLhs = recordedSide(f, "lhs");
+        const fRhs = recordedSide(f, "rhs");
+        if (sideMatches(fLhs, q.lhs) && sideMatches(fRhs, q.rhs)
+                && impliedBy(f.rel, f.offset, q.rel, q.offset))
+            return true;
+        if (sideMatches(fLhs, q.rhs) && sideMatches(fRhs, q.lhs)
+                && impliedBy(flipRel(f.rel), -f.offset, q.rel, q.offset))
+            return true;
+        return false;
+    }
+
+    function describeFact(f) {
+        const fmt = (prefix) => {
+            const v = f[prefix];
+            if (typeof v === "string") return JSON.stringify(v);
+            if (typeof v === "number") return String(v);
+            return "?";
+        };
+        let s = fmt("lhs") + f.rel + fmt("rhs");
+        if (f.offset > 0) s += "+" + f.offset;
+        else if (f.offset < 0) s += "-" + (-f.offset);
+        return s;
+    }
+    function describeSide(s) {
+        if (s.any) return "ANY";
+        if (s.probeId != null) return JSON.stringify(s.probeId);
+        if (s.constant != null) return String(s.constant);
+        return "?";
+    }
+
+    function assertRel(spec) {
+        if (typeof spec.at !== "string")
+            throw new Error("assertRel: { at } must be a probe id (string)");
+        if (spec.rel == null)
+            throw new Error("assertRel: { rel } is required");
+        const anchor = getProbe(spec.at, "at");
+        const lhs = normalizeOperand(spec.lhs == null ? spec.at : spec.lhs, "lhs");
+        const rhs = normalizeOperand(spec.rhs == null ? ANY : spec.rhs, "rhs");
+        const rawOffset = spec.offset == null ? 0 : spec.offset;
+        const { rel: qRel, offset: qOffset } = canonicalRelation(spec.rel, rawOffset);
+        const q = { lhs, rhs, rel: qRel, offset: qOffset };
+        for (const f of anchor.rels) {
+            if (factImplies(f, q))
+                return f;
+        }
+        const recorded = anchor.rels.length === 0
+            ? "    (no relations recorded at this probe)"
+            : anchor.rels.map(f => "    " + describeFact(f)).join("\n");
+        throw new Error("assertRel: no recorded fact implies "
+            + describeSide(lhs) + spec.rel + describeSide(rhs)
+            + (rawOffset ? (rawOffset > 0 ? "+" + rawOffset : String(rawOffset)) : "")
+            + " at " + labelOf(spec.at) + "\n  recorded facts:\n" + recorded);
+    }
+
+    function assertNoRel(spec) {
+        if (typeof spec.at !== "string")
+            throw new Error("assertNoRel: { at } must be a probe id (string)");
+        if (spec.with === undefined)
+            throw new Error("assertNoRel: { with } is required (probe id, { const: N }, or iro.ANY)");
+        const anchor = getProbe(spec.at, "at");
+        const selfQ = { probeId: spec.at };
+        const otherQ = normalizeOperand(spec.with, "with");
+        for (const f of anchor.rels) {
+            const lhs = recordedSide(f, "lhs");
+            const rhs = recordedSide(f, "rhs");
+            const involvesSelf = sideMatches(lhs, selfQ) || sideMatches(rhs, selfQ);
+            if (!involvesSelf) continue;
+            if (otherQ.any) {
+                // Filter out the trivial self==self echo (probe == probe + 0).
+                const isSelfEcho =
+                    sideMatches(lhs, selfQ) && sideMatches(rhs, selfQ)
+                    && f.rel === "==" && f.offset === 0;
+                if (isSelfEcho) continue;
+                throw new Error("assertNoRel: recorded relation " + describeFact(f)
+                    + " involves " + labelOf(spec.at));
+            }
+            const involvesOther = sideMatches(lhs, otherQ) || sideMatches(rhs, otherQ);
+            if (involvesOther)
+                throw new Error("assertNoRel: recorded relation " + describeFact(f)
+                    + " links " + labelOf(spec.at) + " with " + describeSide(otherQ));
+        }
+    }
+
+    // Assert IRO recorded (or did not record) applying `op` to the value
+    // pinned by probe `probeId` — e.g. assertEliminated("CheckInBounds", "i").
+    function assertEliminated(op, probeId) {
+        if (!elimSet.has(op + "|" + probeId))
+            throw new Error("assertEliminated: IRO did not eliminate " + op
+                + " on probe " + JSON.stringify(probeId) + " (recorded: ["
+                + [...elimSet].join(", ") + "])");
+    }
+    function assertNotEliminated(op, probeId) {
+        if (elimSet.has(op + "|" + probeId))
+            throw new Error("assertNotEliminated: IRO eliminated " + op
+                + " on probe " + JSON.stringify(probeId) + ", but the test expected it kept");
+    }
+
+    return {
+        ANY,
+        probes,
+        range,
+        rangeOf,
+        relsAt,
+        assertRel,
+        assertNoRel,
+        assertEliminated,
+        assertNotEliminated,
+        opCount,
+        dfgGraph,
+    };
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -447,6 +447,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case IdentityWithProfile:
+    case DebugProbe:
     case Identity: {
         setForNode(node, forNode(node->child1()));
         break;

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -662,6 +662,10 @@ private:
             node->child1()->mergeFlags(flags);
             break;
 
+        case DebugProbe:
+            node->child1()->mergeFlags(flags);
+            break;
+
         case Int52Rep: {
             ASSERT(m_graph.afterFixup());
             auto& edge = node->child1();

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -4018,6 +4018,18 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case DebugProbeIntrinsic: {
+            RELEASE_ASSERT(argumentCountIncludingThis >= 3, "$vm.probe requires an id and a value: $vm.probe(id, x)");
+            Node* idNode = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            FrozenValue* idConstant = idNode->hasConstant() ? idNode->constant() : nullptr;
+            JSValue idValue = idConstant ? idConstant->value() : JSValue();
+            RELEASE_ASSERT(idValue && idValue.isString(), "$vm.probe id must be a constant string");
+            insertChecks();
+            Node* value = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
+            setResult(addToGraph(DebugProbe, OpInfo(idConstant), value));
+            return CallOptimizationResult::Inlined;
+        }
+
         case JSMapGetIntrinsic: {
             if (argumentCountIncludingThis < 2 || !is64Bit())
                 return CallOptimizationResult::DidNothing;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -205,6 +205,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
 
     case Identity:
     case IdentityWithProfile:
+    case DebugProbe:
     case Phantom:
     case Check:
     case CheckVarargs:

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -2154,6 +2154,7 @@ private:
             case PhantomNewArrayBuffer:
             case PhantomNewRegExp:
             case BottomValue:
+            case DebugProbe:
                 alreadyHandled = true;
                 break;
 

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -61,6 +61,7 @@ bool doesGC(Graph& graph, Node* node)
     case LazyJSConstant:
     case Identity:
     case IdentityWithProfile:
+    case DebugProbe:
     case GetCallee:
     case SetCallee:
     case GetArgumentCountIncludingThis:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2772,6 +2772,11 @@ private:
             break;
         }
 
+        case DebugProbe: {
+            fixEdge<UntypedUse>(node->child1());
+            break;
+        }
+
         case GetArrayLength: {
             ArrayMode arrayMode = node->arrayMode().refine(m_graph, node, node->child1()->prediction(), ArrayMode::unusedIndexSpeculatedType);
             // We don't know how to handle generic and we only emit this in the Parser when we have checked the value is an Array/TypedArray.

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1913,6 +1913,7 @@ MethodOfGettingAValueProfile Graph::methodOfGettingAValueProfileFor(Node* curren
         switch (node->op()) {
         case BooleanToNumber:
         case Identity:
+        case DebugProbe:
         case ValueRep:
         case DoubleRep:
         case Int52Rep:

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -35,6 +35,9 @@
 #include "DFGNodeFlowProjection.h"
 #include "DFGPhase.h"
 #include "JSCJSValueInlines.h"
+#include "VMInspector.h"
+#include <wtf/JSONValues.h>
+#include <wtf/StringPrintStream.h>
 
 namespace JSC { namespace DFG {
 
@@ -1293,13 +1296,14 @@ public:
         }
         
         // Now we transform the code based on the results computed in the previous loop.
+        dumpFactsHeader();
         changed = false;
         for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
             m_relationships = m_relationshipsAtHead[block];
             for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
                 Node* node = block->at(nodeIndex);
                 dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "Transformation: at ", node, ": ", listDump(sortedRelationships()));
-                
+
                 // This ends up being pretty awkward to write because we need to decide if we
                 // optimize by using the relationships before the operation, but we need to
                 // call executeNode() before we optimize.
@@ -1491,6 +1495,7 @@ public:
                             if (node->op() == CheckInBounds)
                                 m_insertionSet.insertNode(nodeIndex, SpecNone, AssertInBounds, node->origin, node->child1(), node->child2());
                         }
+                        recordProbeTransform(node->child1().node(), "CheckInBounds"_s);
                         // We just need to make sure we are a value-producing node.
                         node->convertToIdentityOn(node->child1().node());
                         changed = true;
@@ -1524,15 +1529,171 @@ public:
                 default:
                     break;
                 }
-                
+
                 executeNode(block->at(nodeIndex));
+                dumpNodeFacts(node);
             }
         }
-        
+        commitFactDump();
+
         return changed;
     }
 
 private:
+    // Helpers $vm.iroFactDump (see JSTests/stress/resources/iro-test-helpers.js).
+    static Ref<JSON::Value> rangeJSON(std::optional<std::tuple<int32_t, int32_t>> range)
+    {
+        if (!range)
+            return JSON::Value::null();
+        auto [lo, hi] = *range;
+        auto arr = JSON::Array::create();
+        arr->pushInteger(lo);
+        arr->pushInteger(hi);
+        return arr;
+    }
+
+    static ASCIILiteral relationKindName(Relationship::Kind kind)
+    {
+        switch (kind) {
+        case Relationship::LessThan:    return "<"_s;
+        case Relationship::GreaterThan: return ">"_s;
+        case Relationship::Equal:       return "=="_s;
+        case Relationship::NotEqual:    return "!="_s;
+        }
+        return "?"_s;
+    }
+
+    void dumpFactsHeader()
+    {
+        if (!Options::useTestingHelpers()) [[likely]]
+            return;
+        m_factProbes = JSON::Array::create();
+        m_probeIds.clear();
+        for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
+            for (Node* node : *block) {
+                if (node->op() != DebugProbe)
+                    continue;
+                String id = probeIdOf(node);
+                if (id.isNull())
+                    continue;
+                m_probeIds.add(node, id);
+                if (node->child1())
+                    m_probeIds.add(node->child1().node(), id);
+            }
+        }
+    }
+
+    // Record that IRO applied a transform, if operand is a probe.
+    void recordProbeTransform(Node* operand, ASCIILiteral op)
+    {
+        if (!m_factProbes) [[likely]]
+            return;
+        auto it = m_probeIds.find(operand);
+        if (it == m_probeIds.end())
+            return;
+        VMInspector::addIROProbeElimination(m_graph.m_codeBlock, op, it->value);
+    }
+
+    void commitFactDump()
+    {
+        if (!m_factProbes) [[likely]]
+            return;
+        auto factRoot = JSON::Object::create();
+        factRoot->setArray("probes"_s, m_factProbes.releaseNonNull());
+        StringPrintStream graphStream;
+        m_graph.dump(graphStream);
+        factRoot->setString("graph"_s, graphStream.toString());
+
+        VMInspector::storeIROFactDump(m_graph.m_codeBlock, factRoot->toJSONString());
+    }
+
+    static String probeIdOf(Node* n)
+    {
+        if (!n || n->op() != DebugProbe)
+            return String();
+        FrozenValue* frozen = n->debugProbeId();
+        JSValue value = frozen->value();
+        if (!value || !value.isString())
+            return String();
+        return String(asString(value)->tryGetValue().data);
+    }
+
+    // The probe id naming this relationship side, or null if it isn't a probe.
+    String probeIdForSide(NodeFlowProjection proj)
+    {
+        if (!proj || !proj.node() || proj.kind() != NodeFlowProjection::Primary)
+            return String();
+        auto it = m_probeIds.find(proj.node());
+        return it != m_probeIds.end() ? it->value : String();
+    }
+
+    bool writeSide(JSON::Object& obj, ASCIILiteral key, NodeFlowProjection proj)
+    {
+        if (!proj || !proj.node() || proj.kind() != NodeFlowProjection::Primary)
+            return false;
+        Node* n = proj.node();
+        if (auto it = m_probeIds.find(n); it != m_probeIds.end())
+            obj.setString(key, it->value);
+        else if (n->isInt32Constant())
+            obj.setInteger(key, n->asInt32());
+        else
+            return false;
+        return true;
+    }
+
+    void dumpNodeFacts(Node* node)
+    {
+        if (!Options::useTestingHelpers()) [[likely]]
+            return;
+        if (!m_factProbes || node->op() != DebugProbe)
+            return;
+        String selfId = probeIdOf(node);
+        if (selfId.isNull())
+            return;
+
+        auto entry = JSON::Object::create();
+        entry->setString("id"_s, selfId);
+        entry->setValue("range"_s, rangeJSON(rangeFor(node)));
+
+        auto lineRanges = JSON::Array::create();
+        HashSet<Node*> seen;
+        for (auto& relEntry : m_relationships) {
+            Node* otherNode = relEntry.key.node();
+            if (!seen.add(otherNode).isNewEntry)
+                continue;
+            String otherId = probeIdOf(otherNode);
+            if (otherId.isNull())
+                continue;
+            auto pair = JSON::Object::create();
+            pair->setString("id"_s, otherId);
+            pair->setValue("range"_s, rangeJSON(rangeFor(otherNode)));
+            lineRanges->pushObject(WTF::move(pair));
+        }
+        entry->setArray("lineRanges"_s, WTF::move(lineRanges));
+
+        auto rels = JSON::Array::create();
+        for (auto& stored : sortedRelationships()) {
+            if (!stored)
+                continue;
+            // IRO stores each relationship in both orientations; pick the one
+            // with the anchor on the left.
+            Relationship rel = probeIdForSide(stored.right()) == selfId
+                ? stored.flipped() : stored;
+            if (probeIdForSide(rel.left()) != selfId)
+                continue;
+            auto r = JSON::Object::create();
+            if (!writeSide(r.get(), "rhs"_s, rel.right()))
+                continue;
+            r->setString("lhs"_s, selfId);
+            r->setString("rel"_s, StringView(relationKindName(rel.kind())).toString());
+            r->setInteger("offset"_s, rel.offset());
+            rels->pushObject(WTF::move(r));
+        }
+        entry->setArray("rels"_s, WTF::move(rels));
+
+        protect(m_factProbes)->pushObject(WTF::move(entry));
+    }
+
     void executeNode(Node* node)
     {
         switch (node->op()) {
@@ -1540,6 +1701,12 @@ private:
         case CheckInBounds: {
             setRelationship(Relationship::safeCreate(node->child1().node(), node->child2().node(), Relationship::LessThan));
             setRelationship(Relationship::safeCreate(node->child1().node(), m_zero, Relationship::GreaterThan, -1));
+            break;
+        }
+
+        case Identity:
+        case DebugProbe: {
+            setEquivalence(node->child1().node(), node);
             break;
         }
 
@@ -2144,6 +2311,12 @@ private:
     BlockMap<RelationshipMap> m_relationshipsAtHead;
     InsertionSet m_insertionSet;
 
+    // State for the IRO fact dump consumed by JS tests
+    RefPtr<JSON::Array> m_factProbes;
+    RefPtr<JSON::Array> m_factEliminations;
+    HashSet<String> m_seenEliminations;
+    UncheckedKeyHashMap<Node*, String> m_probeIds;
+
     unsigned m_iterations { 0 };
 };
     
@@ -2152,6 +2325,36 @@ private:
 bool performIntegerRangeOptimization(Graph& graph)
 {
     return runPhase<IntegerRangeOptimizationPhase>(graph);
+}
+
+class DebugProbeEliminationPhase : public Phase {
+public:
+    DebugProbeEliminationPhase(Graph& graph)
+        : Phase(graph, "debug probe elimination"_s)
+    {
+    }
+
+    bool run()
+    {
+        if (!Options::useTestingHelpers()) [[likely]]
+            return false;
+
+        bool changed = false;
+        for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
+            for (Node* node : *block) {
+                if (node->op() == DebugProbe) {
+                    node->convertToIdentityOn(node->child1().node());
+                    changed = true;
+                }
+            }
+        }
+        return changed;
+    }
+};
+
+bool performDebugProbeElimination(Graph& graph)
+{
+    return runPhase<DebugProbeEliminationPhase>(graph);
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.h
@@ -38,6 +38,8 @@ class Graph;
 
 bool performIntegerRangeOptimization(Graph&);
 
+bool performDebugProbeElimination(Graph&);
+
 } } // namespace JSC::DFG
 
 #endif // ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -62,6 +62,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case CheckVarargs:
     case Identity:
     case IdentityWithProfile:
+    case DebugProbe:
     case GetLocal:
     case LoopHint:
     case Phi:

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1618,6 +1618,17 @@ public:
         return op() == GetInternalField || op() == PutInternalField;
     }
 
+    bool hasDebugProbeId() const
+    {
+        return op() == DebugProbe;
+    }
+
+    FrozenValue* debugProbeId() const
+    {
+        ASSERT(hasDebugProbeId());
+        return m_opInfo.as<FrozenValue*>();
+    }
+
     unsigned internalFieldIndex()
     {
         ASSERT(hasInternalFieldIndex());

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -49,6 +49,7 @@ namespace JSC { namespace DFG {
     macro(Identity, NodeResultJS) \
     /* Used for debugging to force a profile to appear as anything we want. */ \
     macro(IdentityWithProfile, NodeResultJS | NodeMustGenerate) \
+    macro(DebugProbe, NodeResultJS | NodeMustGenerate) /* Used to keep track of a value by id for unit tests in later optimization phases. */ \
     \
     /* Nodes for handling functions (both as call and as construct). */\
     macro(ToThis, NodeResultJS) \

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -428,6 +428,7 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         // Ideally, the dependencies should be explicit. See https://bugs.webkit.org/show_bug.cgi?id=157534.
         RUN_PHASE(performGraphPackingAndLivenessAnalysis);
         RUN_PHASE(performIntegerRangeOptimization);
+        RUN_PHASE(performDebugProbeElimination);
         
         RUN_PHASE(performCleanUp);
         RUN_PHASE(performIntegerCheckCombining);

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1610,6 +1610,12 @@ private:
             break;
         }
 
+        case DebugProbe: {
+            if (m_currentNode->child1())
+                mergePrediction(m_currentNode->child1()->prediction());
+            break;
+        }
+
         case ExtractCatchLocal: {
             setPrediction(m_currentNode->catchLocalPrediction());
             break;

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -196,6 +196,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case LazyJSConstant:
     case Identity:
     case IdentityWithProfile:
+    case DebugProbe:
     case GetCallee:
     case GetArgumentCountIncludingThis:
     case GetLocal:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2174,7 +2174,8 @@ void SpeculativeJIT::compile(Node* node)
         compileLazyJSConstant(node);
         break;
 
-    case Identity: {
+    case Identity:
+    case DebugProbe: {
         compileIdentity(node);
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3286,7 +3286,8 @@ void SpeculativeJIT::compile(Node* node)
         compileLazyJSConstant(node);
         break;
 
-    case Identity: {
+    case Identity:
+    case DebugProbe: {
         compileIdentity(node);
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -258,6 +258,7 @@ public:
                 switch (node->op()) {
                 case Identity:
                 case IdentityWithProfile:
+                case DebugProbe:
                     VALIDATE((node), canonicalResultRepresentation(node->result()) == canonicalResultRepresentation(node->child1()->result()));
                     break;
                 case SetLocal:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -535,6 +535,7 @@ inline CapabilityLevel canCompile(DFG::Node* node)
         break;
 
     case DFG::Identity:
+    case DFG::DebugProbe:
         // No backend handles this because it will be optimized out. But we may check
         // for capabilities before optimization. It would be a deep error to remove this
         // case because it would prevent us from catching bugs where the FTL backend

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -259,6 +259,7 @@ namespace JSC {
     macro(SetInt32HeapPredictionIntrinsic) \
     macro(CheckInt32Intrinsic) \
     macro(FiatInt52Intrinsic) \
+    macro(DebugProbeIntrinsic) \
     \
     /* These are used for $vm performance debugging features. */ \
     macro(CPUMfenceIntrinsic) \

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -640,6 +640,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, dumpWasmOpcodeStatistics, false, Normal, nullptr) \
     v(Bool, dumpWasmWarnings, false, Normal, nullptr) \
     v(Bool, useRecursiveJSONParse, true, Normal, nullptr) \
+    v(Bool, useTestingHelpers, false, Restricted, "Helpers for writing unit tests, e.g. $vm.iroFactDump"_s) \
     v(Unsigned, thresholdForStringReplaceCache, 0x1000, Normal, nullptr) \
     v(Bool, useWasmIPInt, ipintEnabledByDefault(), Normal, "Use the in-place interpereter for WASM instead of LLInt."_s) \
     v(Bool, useWasmIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues"_s) \

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -54,6 +54,7 @@
 #include "JSString.h"
 #include "LinkBuffer.h"
 #include "NativeCallee.h"
+#include "ObjectConstructor.h"
 #include "OperationResult.h"
 #include "Options.h"
 #include "Parser.h"
@@ -2116,6 +2117,7 @@ static NO_RETURN_DUE_TO_CRASH JSC_DECLARE_HOST_FUNCTION(functionCrash);
 static JSC_DECLARE_HOST_FUNCTION(functionBreakpoint);
 static JSC_DECLARE_HOST_FUNCTION(functionExit);
 static JSC_DECLARE_HOST_FUNCTION(functionDFGTrue);
+static JSC_DECLARE_HOST_FUNCTION(functionProbe);
 static JSC_DECLARE_HOST_FUNCTION(functionFTLTrue);
 static JSC_DECLARE_HOST_FUNCTION(functionOMGTrue);
 static JSC_DECLARE_HOST_FUNCTION(functionCpuMfence);
@@ -2255,6 +2257,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionCallFromCPP);
 static JSC_DECLARE_HOST_FUNCTION(functionCachedCallFromCPP);
 static JSC_DECLARE_HOST_FUNCTION(functionDumpLineBreakData);
 static JSC_DECLARE_HOST_FUNCTION(functionWeakCreate);
+static JSC_DECLARE_HOST_FUNCTION(functionIROFactDump);
 
 const ClassInfo JSDollarVM::s_info = { "DollarVM"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDollarVM) };
 
@@ -2331,6 +2334,19 @@ JSC_DEFINE_HOST_FUNCTION(functionDFGTrue, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
     return JSValue::encode(jsBoolean(false));
+}
+
+// Identity-like marker for IRO tests. In LLInt/baseline this just returns
+// the second argument; in DFG/FTL the bytecode parser swaps the call for a
+// DebugProbe DFG node carrying the constant string id so tests can pin a
+// specific DFG node by id.
+// Usage: $vm.probe(id, x)
+JSC_DEFINE_HOST_FUNCTION(functionProbe, (JSGlobalObject*, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    if (callFrame->argumentCount() < 2)
+        return JSValue::encode(jsUndefined());
+    return JSValue::encode(callFrame->uncheckedArgument(1));
 }
 
 // Returns true if the current frame is a FTL frame.
@@ -4395,6 +4411,55 @@ JSC_DEFINE_HOST_FUNCTION(functionWeakCreate, (JSGlobalObject* globalObject, Call
     return JSValue::encode(jsUndefined());
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionIROFactDump, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    RELEASE_ASSERT(!Options::useConcurrentJIT(), "$vm.iroFactDump requires --useConcurrentJIT=0");
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSFunction* fn = dynamicDowncast<JSFunction>(callFrame->argument(0));
+    if (!fn)
+        return throwVMTypeError(globalObject, scope, "First argument is not a JS function"_s);
+    CodeBlock* codeBlock = fn->jsExecutable()->codeBlockForCall();
+    if (!codeBlock)
+        return JSValue::encode(jsEmptyString(vm));
+    // The IRO dump is keyed under the top-tier CodeBlock; codeBlockForCall
+    // returns baseline, so walk replacement() up to FTL.
+    while (codeBlock && codeBlock->jitType() != JITType::FTLJIT) {
+        CodeBlock* next = codeBlock->replacement();
+        if (next == codeBlock || !next)
+            break;
+        codeBlock = next;
+    }
+    if (!codeBlock)
+        return JSValue::encode(jsEmptyString(vm));
+    if (codeBlock->jitType() != JITType::FTLJIT)
+        return throwVMTypeError(globalObject, scope, "Function has not been FTL-compiled"_s);
+
+    String dump = VMInspector::getIROFactDump(codeBlock);
+    if (dump.isEmpty())
+        return JSValue::encode(jsEmptyString(vm));
+
+    // This is stored as json to avoid allocating js cells on the compiler thread.
+    JSValue parsed = JSONParse(globalObject, dump);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!parsed.isObject())
+        return JSValue::encode(jsEmptyString(vm));
+    JSObject* root = asObject(parsed);
+
+    JSArray* eliminations = constructEmptyArray(globalObject, nullptr);
+    RETURN_IF_EXCEPTION(scope, { });
+    for (auto& [op, on] : VMInspector::iroProbeEliminations(codeBlock)) {
+        JSObject* entry = constructEmptyObject(globalObject);
+        entry->putDirect(vm, Identifier::fromString(vm, "op"_s), jsString(vm, op));
+        entry->putDirect(vm, Identifier::fromString(vm, "on"_s), jsString(vm, on));
+        eliminations->push(globalObject, entry);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+    root->putDirect(vm, Identifier::fromString(vm, "eliminations"_s), eliminations);
+    return JSValue::encode(root);
+}
+
 constexpr unsigned jsDollarVMPropertyAttributes = PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | PropertyAttribute::DontDelete;
 
 void JSDollarVM::finishCreation(VM& vm)
@@ -4609,6 +4674,8 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, alwaysAllow, "cachedCallFromCPP"_s, functionCachedCallFromCPP, 2);
     addFunction(vm, alwaysAllow, "dumpLineBreakData"_s, functionDumpLineBreakData, 0);
     addFunction(vm, alwaysAllow, "weakCreate"_s, functionWeakCreate, 0);
+    addFunction(vm, alwaysAllow, "iroFactDump"_s, functionIROFactDump, 1);
+    putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "probe"_s), 2, functionProbe, ImplementationVisibility::Public, DebugProbeIntrinsic, jsDollarVMPropertyAttributes);
 
     if (allowIfNotFuzz)
         m_objectDoingSideEffectPutWithoutCorrectSlotStatusStructureID.set(vm, this, ObjectDoingSideEffectPutWithoutCorrectSlotStatus::createStructure(vm, globalObject, jsNull()));

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -639,4 +639,56 @@ void VMInspector::dumpSubspaceHashes(VM* vm)
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
+static Lock iroFactDumpLock;
+
+static HashMap<const void*, String>& iroFactDumpMap() WTF_REQUIRES_LOCK(iroFactDumpLock)
+{
+    static NeverDestroyed<HashMap<const void*, String>> map;
+    return map.get();
+}
+
+void VMInspector::storeIROFactDump(const void* key, String dump)
+{
+    if (!Options::useTestingHelpers())
+        return;
+    Locker locker { iroFactDumpLock };
+    iroFactDumpMap().set(key, dump);
+}
+
+String VMInspector::getIROFactDump(const void* key)
+{
+    if (!Options::useTestingHelpers())
+        return { };
+    Locker locker { iroFactDumpLock };
+    return iroFactDumpMap().get(key);
+}
+
+static HashMap<const void*, Vector<std::pair<String, String>>>& iroProbeEliminationMap() WTF_REQUIRES_LOCK(iroFactDumpLock)
+{
+    static NeverDestroyed<HashMap<const void*, Vector<std::pair<String, String>>>> map;
+    return map.get();
+}
+
+void VMInspector::addIROProbeElimination(const void* key, ASCIILiteral op, const String& probeId)
+{
+    if (!Options::useTestingHelpers())
+        return;
+    Locker locker { iroFactDumpLock };
+    auto& list = iroProbeEliminationMap().add(key, Vector<std::pair<String, String>> { }).iterator->value;
+    for (auto& entry : list)
+        RELEASE_ASSERT(entry.first != op || entry.second != probeId);
+    list.append({ String { op }, probeId });
+}
+
+Vector<std::pair<String, String>> VMInspector::iroProbeEliminations(const void* key)
+{
+    if (!Options::useTestingHelpers())
+        return { };
+    Locker locker { iroFactDumpLock };
+    auto it = iroProbeEliminationMap().find(key);
+    if (it == iroProbeEliminationMap().end())
+        return { };
+    return it->value;
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/tools/VMInspector.h
+++ b/Source/JavaScriptCore/tools/VMInspector.h
@@ -25,8 +25,11 @@
 
 #pragma once
 
+#include <utility>
 #include <wtf/Expected.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace JSC {
 
@@ -70,6 +73,14 @@ public:
 #if USE(JSVALUE64)
     static bool verifyCell(VM&, JSCell*);
 #endif
+
+    // Testing helpers for DFGFTL Integer Range Optimization JS tests.
+    JS_EXPORT_PRIVATE static void storeIROFactDump(const void* key, String);
+    JS_EXPORT_PRIVATE static String getIROFactDump(const void* key);
+    // Accumulates probe-pinned op eliminations across the pipeline's multiple
+    // IRO runs, so the final dump reflects removals done in any run.
+    JS_EXPORT_PRIVATE static void addIROProbeElimination(const void* key, ASCIILiteral op, const String& probeId);
+    JS_EXPORT_PRIVATE static Vector<std::pair<String, String>> iroProbeEliminations(const void* key);
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### 2419df78248a58b0227c2c5c76884951255079d7
<pre>
Add new IntegerRangeOptimization testing helpers
<a href="https://bugs.webkit.org/show_bug.cgi?id=316042">https://bugs.webkit.org/show_bug.cgi?id=316042</a>

Reviewed by NOBODY (OOPS!).

This patch introduces no new runtime changes, and adds some new
testing machinery:

```
function fn(arr) {
    const len = $vm.probe(&quot;len&quot;, arr.length);
    let sum = 0;
    for (let i = 0; i &lt; arr.length; i++) {
        const pi = $vm.probe(&quot;i&quot;, i);
        sum += arr[i] | 0;
    }
    return sum;
}
iro.assertRel({ at: &quot;i&quot;, lhs: &quot;i&quot;, rel: &quot;&lt;&quot;, rhs: &quot;len&quot; });
```

1) DebugProbe

This anchors a value with a readable id.

2) $vm.iroFactDump

This gives us some json that dumps every fact and computed range known
to the IRO phase, re-written in terms of DebugProbes

3) iro-test-helpers.js

This is a generated test helper. I have also included some generated
tests that test each different testing helper.

This also genenrates some nice pretty printing to make it easier to
hand-craft new tests.

A follow-up patch has some hand-written tests that rely on these
helpers, as well as some new IRO rules.

These tests should hopefully be able to be very thorough; there is a
risk that they will be too fragile though. I have tried my best to strike
a reasonable compromise here, but one example of breakage is a pass like
loop unrolling, which would have broken all of these tests. On the other
hand, this exposes a new optimization opportunity, so I think we should
include these kinds of tests going forward.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f42f7e8327a4115239b1084c73af99963242d262

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175814 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124024 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129673 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91329 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149846 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110199 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31044 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29746 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24550 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158923 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141015 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178359 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27660 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31248 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138046 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137959 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149341 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103811 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33237 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26206 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199445 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39525 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112599 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53612 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38921 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4297 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39166 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->