### PR TITLE
Find in page sometimes finds the first match twice

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -103,8 +103,19 @@ void FindController::countStringMatches(const String& string, OptionSet<FindOpti
 #endif
     {
         RefPtr webPage { m_webPage.get() };
-        matchCount = protect(webPage->corePage())->countFindMatches(string, core(options), maxMatchCount + 1);
-        protect(webPage->corePage())->unmarkAllTextMatches();
+        bool shouldShowOverlay = options.contains(FindOptions::ShowOverlay);
+        bool shouldShowHighlight = options.contains(FindOptions::ShowHighlight);
+        if (shouldShowOverlay || shouldShowHighlight) {
+            auto result = protect(webPage->corePage())->findTextMatches(string, core(options), maxMatchCount);
+            matchCount = result.ranges.size();
+            protect(webPage->corePage())->unmarkAllTextMatches();
+            protect(webPage->corePage())->markAllMatchesForText(string, core(options), shouldShowHighlight, maxMatchCount + 1);
+        } else {
+            matchCount = protect(webPage->corePage())->countFindMatches(string, core(options), maxMatchCount + 1);
+            protect(webPage->corePage())->unmarkAllTextMatches();
+        }
+
+        updateFindPageOverlay(shouldShowOverlay);
     }
 
     if (matchCount > maxMatchCount)
@@ -258,7 +269,6 @@ void FindController::updateFindUIAfterFindingAllMatches(bool found, const String
     RefPtr pluginView = mainFramePlugIn();
 #endif
 
-    bool shouldShowOverlay = found && options.contains(FindOptions::ShowOverlay);
     if (!found) {
         if (selectedFrame && !options.contains(FindOptions::DoNotSetSelection))
             protect(selectedFrame->selection())->clear();
@@ -266,6 +276,7 @@ void FindController::updateFindUIAfterFindingAllMatches(bool found, const String
         return;
     }
 
+    bool shouldShowOverlay = found && options.contains(FindOptions::ShowOverlay);
     bool shouldShowHighlight = options.contains(FindOptions::ShowHighlight);
     if (shouldShowOverlay || shouldShowHighlight) {
         protect(webPage->corePage())->unmarkAllTextMatches();


### PR DESCRIPTION
#### 6df1cac064f436e42dcaca9b07887b7651b4474e
<pre>
Find in page sometimes finds the first match twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=316044">https://bugs.webkit.org/show_bug.cgi?id=316044</a>
<a href="https://rdar.apple.com/177107959">rdar://177107959</a>

Reviewed by Megan Gardner.

There are a three cases when creating a new find session:
1. First find session with nothing in the search box
2. Nth find session without a search term in the search box
3. Nth find session with a search term in the search box

Case 3 is our problem case. When a new session is created, Safari clears
the current selection and performs a search for that string, which marks
all the matches on the page. Many times, WebKit would perform the search
and set the selection, then Safari would clear it as apart of its find
session set up. This seems to be the result of IPC overhead. This causes
the first match to be found twice because findString uses the current
selection to find the next match.

I believe clearing the selection at the beginning of a find session is
the correct thing to do, so I addressed the issue by, removing the first call
to findString. Instead, I have Safari pass _WKFindOptionsShowOverlay to
_countStringMatches, which both highlights all the string matches and reports
the count.

This way, if the user presses cmd-F and a previous search term is in the
search box, all the matches will be marked, but none will be highlighted
until they explicitly search or press the next button.

* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::countStringMatches):
(WebKit::FindController::updateFindUIAfterFindingAllMatches):
* test.html: Added.

Canonical link: <a href="https://commits.webkit.org/314911@main">https://commits.webkit.org/314911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3364337c4285536cf2488aecac99fbe0ba7af199

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124090 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c88a9921-763e-4f28-b091-c4ba870d69c3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129725 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91355 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/518d12a5-4b6e-4aac-bd7a-950ec7b8ee75) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110251 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aff508ba-9283-4270-8c76-3bf59fa329ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31101 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29801 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24616 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141074 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178418 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31315 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138092 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138005 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37336 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149396 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103878 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33283 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26261 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39591 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112665 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38987 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4354 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39232 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39130 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->