### PR TITLE
[JSC] `GetByStatus::computeFor` should not constant-fold prototype loads when the head structure is a dictionary

### DIFF
--- a/JSTests/stress/get-by-id-constant-fold-dictionary-head-shadow-property.js
+++ b/JSTests/stress/get-by-id-constant-fold-dictionary-head-shadow-property.js
@@ -1,0 +1,48 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+let proto = { protoProperty: "PROTO_VALUE" };
+
+// Create the property-replacement watchpoint set for proto.protoProperty via a self IC on proto.
+function warmProto(p) {
+    return p.protoProperty;
+}
+noInline(warmProto);
+for (let i = 0; i < 1e4; ++i)
+    shouldBe(warmProto(proto), "PROTO_VALUE");
+
+let o = Object.create(proto);
+o.x = 42;
+
+// Transition-count overflow turns the structure into a cacheable dictionary.
+for (let i = 0; i < 200; ++i)
+    o["p" + i] = i;
+
+// A prototype access through an IC flattens the dictionary and sets hasBeenFlattenedBefore.
+for (let i = 0; i < 1e3; ++i)
+    shouldBe(warmProto(o), "PROTO_VALUE");
+
+// Overflow again to get a cacheable dictionary that inherits hasBeenFlattenedBefore,
+// so prototype-access ICs on o give up instead of flattening.
+for (let i = 200; i < 400; ++i)
+    o["p" + i] = i;
+
+function opt(o) {
+    let a = o.x;
+    let b = o.protoProperty;
+    return [a, b];
+}
+noInline(opt);
+
+for (let i = 0; i < 1e5; ++i) {
+    let [a, b] = opt(o);
+    shouldBe(a, 42);
+    shouldBe(b, "PROTO_VALUE");
+}
+
+// Adding a shadowing own property to a dictionary object does not transition the structure.
+o.protoProperty = "OWN_VALUE";
+shouldBe(o.protoProperty, "OWN_VALUE");
+shouldBe(opt(o)[1], "OWN_VALUE");

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -495,6 +495,9 @@ GetByStatus GetByStatus::computeFor(JSGlobalObject* globalObject, const Structur
         if (!structure)
             return std::nullopt;
 
+        if (structure->isDictionary())
+            return std::nullopt;
+
         JSObject* prototype = nullptr;
         auto* currentStructure = structure;
         constexpr unsigned maxPrototypeWalkDepth = 8;


### PR DESCRIPTION
#### 73689f5430825ecffb614dbcce8e6575dfea3d50
<pre>
[JSC] `GetByStatus::computeFor` should not constant-fold prototype loads when the head structure is a dictionary
<a href="https://bugs.webkit.org/show_bug.cgi?id=316046">https://bugs.webkit.org/show_bug.cgi?id=316046</a>

Reviewed by Yusuke Suzuki.

GetByStatus::computeFor(JSGlobalObject*, const StructureSet&amp;, ...) walks the
prototype chain and folds a prototype property hit into a Simple variant with an
ObjectPropertyConditionSet, which DFG AI uses to constant-fold GetById. The
generated conditions only cover the prototype chain objects (generateConditions
rejects dictionary prototypes and the conditions are watched); the absence of a
shadowing own property on the base object is supposed to be guaranteed by the
structure check alone.

That guarantee does not hold for dictionary structures: adding an own property
to a cacheable dictionary does not transition the structure and does not fire
any watchpoint. So when AI proves a finite structure set whose only structure
is a cacheable dictionary (e.g. via a self-access IC on a dictionary structure
that cannot be flattened again due to hasBeenFlattenedBefore), DFG/FTL
constant-folds the prototype value, and adding a shadowing own property
afterwards keeps returning the stale prototype value with no OSR exit.

This change rejects dictionary head structures before the prototype walk,
mirroring the head-structure check that the TryGetById folding path already
performs.

Test: JSTests/stress/get-by-id-constant-fold-dictionary-head-shadow-property.js

* JSTests/stress/get-by-id-constant-fold-dictionary-head-shadow-property.js: Added.
(shouldBe):
(warmProto):
(opt):
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeFor):

Canonical link: <a href="https://commits.webkit.org/314361@main">https://commits.webkit.org/314361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8caaf2b71c5e7061f3d8e95d43acaf269f5ab904

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174873 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123086 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128879 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109403 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30220 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28900 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22956 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157988 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177398 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26724 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30313 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137213 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137140 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36969 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148484 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102620 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32429 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25351 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38589 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111662 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37985 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3433 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->