### PR TITLE
[JSC] `matchAll` fast path should not skip `SpeciesConstructor` when RegExp species watchpoint is invalidated

### DIFF
--- a/JSTests/stress/string-prototype-matchall-species-constructor.js
+++ b/JSTests/stress/string-prototype-matchall-species-constructor.js
@@ -1,0 +1,64 @@
+// Verifies that String.prototype.matchAll and RegExp.prototype[@@matchAll] observe
+// SpeciesConstructor(R, %RegExp%): a custom species constructor must be called, and a
+// non-object RegExp.prototype.constructor must cause a TypeError, even after the C++
+// fast path has been warmed up.
+
+function shouldBe(actual, expected) {
+    var a = JSON.stringify(actual);
+    var e = JSON.stringify(expected);
+    if (a !== e)
+        throw new Error("expected " + e + " but got " + a);
+}
+
+function shouldThrow(func, errorMessage) {
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!error)
+        throw new Error("not thrown");
+    if (String(error) !== errorMessage)
+        throw new Error("bad error: " + String(error));
+}
+
+function matchAllToArray(str, re) {
+    return [...str.matchAll(re)];
+}
+noInline(matchAllToArray);
+
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(matchAllToArray("a1b2", /[0-9]/g), [["1"], ["2"]]);
+
+// 1. A custom species constructor must be observed: its return value becomes the matcher.
+(function () {
+    var calls = [];
+    var savedConstructor = RegExp.prototype.constructor;
+    RegExp.prototype.constructor = {
+        [Symbol.species]: function (re, flags) {
+            calls.push(flags);
+            return new RegExp("b", flags);
+        }
+    };
+    try {
+        shouldBe(matchAllToArray("ab", /a/g), [["b"]]);
+        shouldBe(calls, ["g"]);
+
+        calls.length = 0;
+        shouldBe([.../a/g[Symbol.matchAll]("ab")], [["b"]]);
+        shouldBe(calls, ["g"]);
+    } finally {
+        RegExp.prototype.constructor = savedConstructor;
+    }
+})();
+
+// 2. A non-object constructor must cause SpeciesConstructor to throw a TypeError.
+(function () {
+    RegExp.prototype.constructor = 5;
+    shouldThrow(() => "x".matchAll(/y/g), "TypeError: |this|.constructor is not an Object or undefined");
+    shouldThrow(() => /y/g[Symbol.matchAll]("x"), "TypeError: |this|.constructor is not an Object or undefined");
+    // Primitive pattern: matchAll creates a fresh global RegExp internally, which still
+    // inherits the poisoned constructor.
+    shouldThrow(() => "x".matchAll("y"), "TypeError: |this|.constructor is not an Object or undefined");
+})();

--- a/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
@@ -105,6 +105,9 @@ ALWAYS_INLINE bool RegExpObject::isSymbolMatchAllFastAndNonObservable()
     if (!globalObject->stringSymbolMatchAllWatchpointSet().isStillValid())
         return false;
 
+    if (!globalObject->regExpSpeciesWatchpointSet().isStillValid())
+        return false;
+
     if (!getLastIndex().isNumber())
         return false;
 


### PR DESCRIPTION
#### 66b61320dbd7f563dc08e6c83ed9c78bd7be69ef
<pre>
[JSC] `matchAll` fast path should not skip `SpeciesConstructor` when RegExp species watchpoint is invalidated
<a href="https://bugs.webkit.org/show_bug.cgi?id=316047">https://bugs.webkit.org/show_bug.cgi?id=316047</a>

Reviewed by Yusuke Suzuki.

RegExp.prototype[@@matchAll] is required to call SpeciesConstructor(R, %RegExp%),
which reads R.constructor (and C[@@species]) observably. However,
RegExpObject::isSymbolMatchAllFastAndNonObservable() only checked
regExpPrimordialPropertiesWatchpointSet and stringSymbolMatchAllWatchpointSet,
and did not check regExpSpeciesWatchpointSet, unlike the neighboring
isSymbolSplitFastAndNonObservable(). As a result, after replacing
RegExp.prototype.constructor, the C++ fast paths for String.prototype.matchAll
and RegExp.prototype[@@matchAll] kept ignoring the override: a custom species
constructor was never invoked, and a non-object constructor did not throw the
spec-required TypeError.

    RegExp.prototype.constructor = 5;
    &quot;x&quot;.matchAll(/y/g); // Should throw TypeError, but did not.

This patch adds the missing regExpSpeciesWatchpointSet check to the predicate,
following the precedent of isSymbolSplitFastAndNonObservable(). This guards all
fast-path call sites: stringProtoFuncMatchAll, stringMatchAllSlow, and
regExpProtoFuncMatchAll.

Test: JSTests/stress/string-prototype-matchall-species-constructor.js

* JSTests/stress/string-prototype-matchall-species-constructor.js: Added.
(shouldBe):
(shouldThrow):
(matchAllToArray):
(RegExp.prototype.Symbol.species):
* Source/JavaScriptCore/runtime/RegExpObjectInlines.h:
(JSC::RegExpObject::isSymbolMatchAllFastAndNonObservable):

Canonical link: <a href="https://commits.webkit.org/314355@main">https://commits.webkit.org/314355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc409bc912545bc61bdd3f35073da3000097413d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174879 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123092 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128883 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148993 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109407 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30224 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28904 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22962 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157994 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177404 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26730 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30319 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137217 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137144 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36964 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148487 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102626 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32434 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25354 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38595 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111668 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37991 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3436 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38237 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->