### PR TITLE
[JSC][Temporal] `Intl.DateTimeFormat` Temporal formatters lose requested era width

### DIFF
--- a/JSTests/stress/intl-datetimeformat-temporal-era-width.js
+++ b/JSTests/stress/intl-datetimeformat-temporal-era-width.js
@@ -1,0 +1,49 @@
+//@ requireOptions("--useTemporal=1")
+// Formatting a Temporal value must preserve the requested era width
+// (era: "long" / "short" / "narrow"), matching an equivalent legacy Date.
+// GetDateTimeFormat used to copy only a single 'G' into the format options,
+// collapsing era:"long" (GGGG) and era:"narrow" (GGGGG) to the short form.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+const plainDate = new Temporal.PlainDate(2026, 6, 2);
+const plainDateTime = new Temporal.PlainDateTime(2026, 6, 2, 10, 30, 45);
+const date = new Date(Date.UTC(2026, 5, 2, 10, 30, 45));
+
+const optionsList = [
+    { era: "long", year: "numeric", month: "long", day: "numeric" },
+    { era: "short", year: "numeric", month: "long", day: "numeric" },
+    { era: "narrow", year: "numeric", month: "long", day: "numeric" },
+    { era: "long", year: "numeric", month: "numeric", day: "numeric" },
+];
+
+const locales = ["ja", "zh", "ko", "en-US", "de"];
+
+for (const locale of locales) {
+    for (const options of optionsList) {
+        const dtf = new Intl.DateTimeFormat(locale, { ...options, timeZone: "UTC" });
+        const label = `${locale} ${JSON.stringify(options)}`;
+
+        // All requested fields are date fields, so PlainDate and PlainDateTime
+        // must format exactly like a legacy Date at the same calendar date.
+        shouldBe(dtf.format(plainDate), dtf.format(date), `${label} format(PlainDate)`);
+        shouldBe(dtf.format(plainDateTime), dtf.format(date), `${label} format(PlainDateTime)`);
+
+        const dateParts = JSON.stringify(dtf.formatToParts(date));
+        shouldBe(JSON.stringify(dtf.formatToParts(plainDate)), dateParts, `${label} formatToParts(PlainDate)`);
+
+        const laterPlainDate = new Temporal.PlainDate(2026, 7, 4);
+        const laterDate = new Date(Date.UTC(2026, 6, 4));
+        shouldBe(dtf.formatRange(plainDate, laterPlainDate), dtf.formatRange(date, laterDate), `${label} formatRange(PlainDate)`);
+    }
+}
+
+// era: "long" must not degrade to the short form ("AD") in ko.
+{
+    const dtf = new Intl.DateTimeFormat("ko", { era: "long", year: "numeric", month: "long", day: "numeric", timeZone: "UTC" });
+    const formatted = dtf.format(plainDate);
+    shouldBe(formatted.includes("서기"), true, `ko era long PlainDate contains 서기: ${formatted}`);
+}

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -2255,8 +2255,10 @@ std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTim
     //     is observably equivalent because ICU's pattern generator respects hour-field length.
     Vector<char16_t, 32> formatOptions;
     if (!inheritAll && allowedFieldsForKind(kind).get('G')) {
-        if (m_impl->m_userSkeleton.contains(u'G'))
-            formatOptions.append(u'G');
+        for (auto ch : m_impl->m_userSkeleton) {
+            if (ch == u'G')
+                formatOptions.append(ch);
+        }
     }
 
     // Steps 13-14: anyPresent — whether the user set any date/time option.


### PR DESCRIPTION
#### 9cd3289437d5a8281c077ddde8da7e137bd6555f
<pre>
[JSC][Temporal] `Intl.DateTimeFormat` Temporal formatters lose requested era width
<a href="https://bugs.webkit.org/show_bug.cgi?id=316048">https://bugs.webkit.org/show_bug.cgi?id=316048</a>

Reviewed by Yijia Huang.

GetDateTimeFormat copies the era option from the user&apos;s requested
skeleton into the format options by appending a single &apos;G&apos; character,
regardless of the width the user requested. In UTS#35 skeletons the
field width is encoded by the character count (era: &quot;short&quot; = GGG,
&quot;long&quot; = GGGG, &quot;narrow&quot; = GGGGG), so era: &quot;long&quot; and era: &quot;narrow&quot;
collapse to the short form: e.g. for ko with era: &quot;long&quot;,
Temporal.PlainDate formatted as &quot;AD 2026년 6월 2일&quot; while an equivalent
legacy Date formatted as &quot;서기 2026년 6월 2일&quot; with the same
DateTimeFormat. Copy every &apos;G&apos; from the user skeleton instead so the
requested width is preserved.

This was introduced in 314541@main.

Test: JSTests/stress/intl-datetimeformat-temporal-era-width.js

* JSTests/stress/intl-datetimeformat-temporal-era-width.js: Added.
(shouldBe):
(const.locale.of.locales.const.options.of.optionsList.dtf.format):
(const.locale.of.locales.const.options.of.optionsList.dtf.formatRange):
(formatRange):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::computeGetDateTimeFormat const):

Canonical link: <a href="https://commits.webkit.org/314711@main">https://commits.webkit.org/314711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/616d74d461d0f393395119e25a5c574442c98501

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40386 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175944 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124154 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129780 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110306 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31157 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29862 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24680 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159053 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178482 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27790 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31379 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138148 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138060 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37190 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41144 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149455 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103968 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33343 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26320 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199575 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112729 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53657 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39051 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4415 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->