### PR TITLE
Cherry-pick(s) 1c245d737355. rdar://176061205

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5853,8 +5853,19 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
         m_mainFrameWebsitePolicies = mainFrameWebsitePolicies->copy();
 
     // There is no way we'll be able to return to the page in the previous page so close it.
+<<<<<<< HEAD
     if (!didSuspendPreviousPage && shouldClosePreviousPage(*provisionalPage))
         protect(legacyMainFrameProcess())->sendPageCloseMessage(identifier(), webPageIDInMainFrameProcess());
+=======
+    if (!didSuspendPreviousPage && shouldClosePreviousPage(*provisionalPage)) {
+        auto pageID = identifier();
+        Ref oldProcess = legacyMainFrameProcess();
+        oldProcess->addPagePendingClose(pageID);
+        sendWithAsyncReply(Messages::WebPage::CloseWithReply(), [oldProcess, pageID] {
+            oldProcess->removePagePendingClose(pageID);
+        });
+    }
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     if (m_immersive)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -955,6 +955,7 @@ void WebProcessProxy::removeWebPage(WebPageProxy& webPage, EndsUsingDataStore en
     maybeShutDown();
 }
 
+<<<<<<< HEAD
 void WebProcessProxy::sendPageCloseMessage(std::optional<WebPageProxyIdentifier> pageProxyID, WebCore::PageIdentifier pageID, CompletionHandler<void()>&& completionHandler)
 {
     if (pageProxyID)
@@ -967,6 +968,16 @@ void WebProcessProxy::sendPageCloseMessage(std::optional<WebPageProxyIdentifier>
         if (completionHandler)
             completionHandler();
     }, pageID);
+=======
+void WebProcessProxy::addPagePendingClose(WebPageProxyIdentifier pageID)
+{
+    m_pagesPendingClose.add(pageID);
+}
+
+void WebProcessProxy::removePagePendingClose(WebPageProxyIdentifier pageID)
+{
+    m_pagesPendingClose.remove(pageID);
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
 }
 
 void WebProcessProxy::addVisitedLinkStoreUser(VisitedLinkStore& visitedLinkStore, WebPageProxyIdentifier pageID)
@@ -2373,7 +2384,10 @@ bool WebProcessProxy::isAssociatedWithPage(WebPageProxyIdentifier pageID) const
 {
     if (m_pageMap.contains(pageID))
         return true;
+<<<<<<< HEAD
 
+=======
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
     for (Ref remotePage : m_remotePages) {
         if (remotePage->page() && remotePage->page()->identifier() == pageID)
             return true;

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -275,6 +275,8 @@ public:
 
     enum class EndsUsingDataStore : bool { No, Yes };
     void removeWebPage(WebPageProxy&, EndsUsingDataStore);
+    void addPagePendingClose(WebPageProxyIdentifier);
+    void removePagePendingClose(WebPageProxyIdentifier);
 
     void sendPageCloseMessage(std::optional<WebPageProxyIdentifier>, WebCore::PageIdentifier, CompletionHandler<void()>&& = [] { });
 
@@ -812,7 +814,11 @@ private:
     WeakHashSet<RemotePageProxy> m_remotePages;
     WeakHashSet<ProvisionalPageProxy> m_provisionalPages;
     WeakHashSet<SuspendedPageProxy> m_suspendedPages;
+<<<<<<< HEAD
     HashCountedSet<WebPageProxyIdentifier> m_pagesPendingClose;
+=======
+    HashSet<WebPageProxyIdentifier> m_pagesPendingClose;
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
     UserInitiatedActionMap m_userInitiatedActionMap;
     HashMap<WebCore::PageIdentifier, UserInitiatedActionByAuthorizationTokenMap> m_userInitiatedActionByAuthorizationTokenMap;
     uint64_t m_frameProcessCount { 0 };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2102,7 +2102,17 @@ void WebPage::exitAcceleratedCompositingMode(WebCore::Frame& frame)
     protect(drawingArea())->setRootCompositingLayer(frame, nullptr);
 }
 
+<<<<<<< HEAD
 void WebPage::close(CompletionHandler<void()>&& completionHandler)
+=======
+void WebPage::closeWithReply(CompletionHandler<void()>&& completionHandler)
+{
+    close();
+    completionHandler();
+}
+
+void WebPage::close()
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
 {
     if (m_isClosed) {
         completionHandler();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -623,7 +623,12 @@ public:
     void reinitializeWebPage(WebPageCreationParameters&&);
     void platformReinitializeAccessibilityToken();
 
+<<<<<<< HEAD
     void close(CompletionHandler<void()>&&);
+=======
+    void closeWithReply(CompletionHandler<void()>&&);
+    void close();
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
 
     static WebPage* fromCorePage(WebCore::Page&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -311,7 +311,12 @@ messages -> WebPage WantsAsyncDispatchMessage {
     Suspend() -> (bool success)
     Resume() -> (bool success)
 
+<<<<<<< HEAD
     Close() -> ()
+=======
+    Close()
+    CloseWithReply() -> ()
+>>>>>>> 1c245d737355 (Cross-Process Page Identity Confusion in didPostMessage)
     TryClose() -> (bool shouldClose)
     DispatchCrossOriginBeforeUnloadCheckForFrame(WebCore::FrameIdentifier frameID, WebCore::SecurityOriginData navigatingFrameOrigin)
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176061205 to main. The following sources [1ad0d2a7c3b7] will still need to be cherry-picked once the conflict is resolved.

```Cross-Process Page Identity Confusion in didPostMessage
https://bugs.webkit.org/show_bug.cgi?id=310078
rdar://172392170

Reviewed by Brady Eidson and Ryosuke Niwa.

WebProcessProxy::didPostMessage() may look up a WebPageProxy belonging
to another web process if given a bad WebPageProxyIdentifier from a
compromised WebProcess.

Address the issue by adding a MESSAGE_CHECK that checks that the page
is associated with the current WebProcess, using the pre-existing
WebProcessProxy::isAssociatedWithPage() utility function. Note that I
had to tweak isAssociatedWithPage() to also check m_remotePages to keep
site isolation tests working.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::commitProvisionalPage):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::addPagePendingClose):
(WebKit::WebProcessProxy::removePagePendingClose):
(WebKit::WebProcessProxy::isAssociatedWithPage const):
(WebKit::WebProcessProxy::didPostMessage):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::closeWithReply):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Originally-landed-as: 305413.544@rapid/safari-7624.2.5.110-branch (1c245d737355). rdar://176061205

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f0d0b3ae56d837716678c322d63ac816514b7da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165841 "6 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39331 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32912 "Failed to compile WebKit") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174883 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit; Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123096 "Hash 9f0d0b3a for PR 66219 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39757 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39335 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/174883 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit; Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/123096 "Hash 9f0d0b3a for PR 66219 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168800 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/39757 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/32912 "Failed to compile WebKit") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/174883 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit; Hash 9f0d0b3a for PR 66219 does not build (failure)") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/165159 "Build is in progress. Recent messages:") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/39757 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/39335 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22966 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/39757 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/32912 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177408 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30323 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/32912 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/177408 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39400 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/39335 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/177408 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40088 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/32912 "Failed to compile WebKit") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102632 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/40088 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/32912 "Failed to compile WebKit") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38599 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111672 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37995 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/32912 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38241 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38139 "Hash 9f0d0b3a for PR 66219 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->