### PR TITLE
[JSC] Fix undefined behavior in double-to-int conversions

### DIFF
--- a/JSTests/stress/get-by-val-double-subscript-out-of-uint32-range.js
+++ b/JSTests/stress/get-by-val-double-subscript-out-of-uint32-range.js
@@ -1,0 +1,33 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function get(object, key) {
+    return object[key];
+}
+noInline(get);
+
+function put(object, key, value) {
+    object[key] = value;
+}
+noInline(put);
+
+const object = {};
+object["4294967295"] = "max-uint32";
+object["4294967296"] = "two-to-the-32";
+object["-1"] = "minus-one";
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(get(object, 4294967296), "two-to-the-32");
+    shouldBe(get(object, 4294967295), "max-uint32");
+    shouldBe(get(object, -1), "minus-one");
+    shouldBe(get(object, 4294967296.5), undefined);
+    shouldBe(get(object, -0.5), undefined);
+}
+
+const array = [];
+for (let i = 0; i < testLoopCount; ++i)
+    put(array, 4294967296, i);
+shouldBe(array.length, 0);
+shouldBe(array["4294967296"], testLoopCount - 1);

--- a/JSTests/stress/jsonp-large-array-index.js
+++ b/JSTests/stress/jsonp-large-array-index.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+globalThis.foo = {};
+loadString('foo[4294967296]={"a":1};');
+shouldBe(JSON.stringify(foo["4294967296"]), '{"a":1}');
+shouldBe(foo[0], undefined);
+
+globalThis.bar = {};
+loadString('bar[2147483648]=5;');
+shouldBe(bar["2147483648"], 5);
+shouldBe(bar[0], undefined);
+
+globalThis.baz = [];
+loadString('baz[0]=1;baz[1]=2;');
+shouldBe(baz[0], 1);
+shouldBe(baz[1], 2);
+shouldBe(baz.length, 2);

--- a/JSTests/stress/number-tostring-methods-out-of-range-arguments.js
+++ b/JSTests/stress/number-tostring-methods-out-of-range-arguments.js
@@ -1,0 +1,39 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function shouldThrowRangeError(func) {
+    let threw = false;
+    try {
+        func();
+    } catch (error) {
+        threw = true;
+        if (!(error instanceof RangeError))
+            throw new Error(`bad error: ${error}`);
+    }
+    if (!threw)
+        throw new Error("did not throw");
+}
+
+const outOfRangeArguments = [Infinity, -Infinity, 1e100, -1e100, 2147483648, -2147483648, 4294967296, 1e21, 101, -1];
+for (const argument of outOfRangeArguments) {
+    shouldThrowRangeError(() => (1.5).toExponential(argument));
+    shouldThrowRangeError(() => (1.5).toFixed(argument));
+    shouldThrowRangeError(() => (1.5).toPrecision(argument));
+}
+shouldThrowRangeError(() => (1.5).toPrecision(0));
+
+shouldBe((1.5).toExponential(100), "1.5000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e+0");
+shouldBe((1.5).toFixed(100), "1.5000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+shouldBe((1.5).toPrecision(100), "1.500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+shouldBe((1.5).toPrecision(1), "2");
+
+// NaN/Infinity receivers are handled before the range check for toExponential/toPrecision, after it for toFixed.
+shouldBe((NaN).toExponential(Infinity), "NaN");
+shouldBe((Infinity).toExponential(1e100), "Infinity");
+shouldBe((-Infinity).toExponential(-Infinity), "-Infinity");
+shouldBe((NaN).toPrecision(Infinity), "NaN");
+shouldBe((Infinity).toPrecision(1e100), "Infinity");
+shouldThrowRangeError(() => (NaN).toFixed(Infinity));
+shouldThrowRangeError(() => (Infinity).toFixed(1e100));

--- a/JSTests/stress/parseint-large-result-int32-boxing.js
+++ b/JSTests/stress/parseint-large-result-int32-boxing.js
@@ -1,0 +1,30 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function parseIntHex(string) {
+    return parseInt(string, 16);
+}
+noInline(parseIntHex);
+
+function parseIntNoRadix(string) {
+    return parseInt(string);
+}
+noInline(parseIntNoRadix);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(parseIntHex("7fffffff"), 0x7fffffff);
+    shouldBe(parseIntNoRadix("123"), 123);
+}
+
+shouldBe(parseIntHex("80000000"), 2147483648);
+shouldBe(parseIntHex("ffffffff"), 4294967295);
+shouldBe(parseIntHex("100000000"), 4294967296);
+shouldBe(parseIntHex("-80000000"), -2147483648);
+shouldBe(parseIntHex("-80000001"), -2147483649);
+shouldBe(parseIntNoRadix("2147483648"), 2147483648);
+shouldBe(parseIntNoRadix("4294967296"), 4294967296);
+shouldBe(parseIntNoRadix("-2147483649"), -2147483649);
+shouldBe(1 / parseIntNoRadix("-0"), -Infinity);
+shouldBe(1 / parseIntHex("-0"), -Infinity);

--- a/JSTests/stress/string-from-code-point-out-of-range.js
+++ b/JSTests/stress/string-from-code-point-out-of-range.js
@@ -1,0 +1,28 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function shouldThrowRangeError(func) {
+    let threw = false;
+    try {
+        func();
+    } catch (error) {
+        threw = true;
+        if (!(error instanceof RangeError))
+            throw new Error(`bad error: ${error}`);
+    }
+    if (!threw)
+        throw new Error("did not throw");
+}
+
+const invalidCodePoints = [-1, -0.5, 0.5, NaN, Infinity, -Infinity, 0x110000, 4294967296, 4294967296 + 65, 1e100, -1e100, 65.5];
+for (const codePoint of invalidCodePoints) {
+    shouldThrowRangeError(() => String.fromCodePoint(codePoint));
+    shouldThrowRangeError(() => String.fromCodePoint(65, codePoint));
+}
+
+shouldBe(String.fromCodePoint(0), "\0");
+shouldBe(String.fromCodePoint(-0), "\0");
+shouldBe(String.fromCodePoint(65), "A");
+shouldBe(String.fromCodePoint(0x10FFFF).codePointAt(0), 0x10FFFF);

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -178,9 +178,6 @@ static ALWAYS_INLINE void putWithThis(JSGlobalObject* globalObject, EncodedJSVal
 
 static ALWAYS_INLINE EncodedJSValue parseIntResult(double input)
 {
-    int asInt = static_cast<int>(input);
-    if (static_cast<double>(asInt) == input && (asInt || !std::signbit(input))) [[likely]]
-        return JSValue::encode(jsNumber(asInt));
     return JSValue::encode(jsNumber(input));
 }
 

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -70,6 +70,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
+#include <wtf/MathExtras.h>
 #include <wtf/PrintStream.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -613,7 +614,7 @@ JSValue JSInjectedScriptHost::weakMapEntries(JSGlobalObject* globalObject, CallF
 
     MarkedArgumentBuffer buffer;
     auto fetchCount = callFrame->argument(1).toIntegerOrInfinity(globalObject);
-    weakMap->takeSnapshot(buffer, fetchCount >= 0 ? static_cast<unsigned>(fetchCount) : 0);
+    weakMap->takeSnapshot(buffer, clampTo<unsigned>(fetchCount));
     ASSERT(!buffer.hasOverflowed());
 
     JSArray* array = constructEmptyArray(globalObject, nullptr);
@@ -656,7 +657,7 @@ JSValue JSInjectedScriptHost::weakSetEntries(JSGlobalObject* globalObject, CallF
 
     MarkedArgumentBuffer buffer;
     auto fetchCount = callFrame->argument(1).toIntegerOrInfinity(globalObject);
-    weakSet->takeSnapshot(buffer, fetchCount >= 0 ? static_cast<unsigned>(fetchCount) : 0);
+    weakSet->takeSnapshot(buffer, clampTo<unsigned>(fetchCount));
     ASSERT(!buffer.hasOverflowed());
 
     JSArray* array = constructEmptyArray(globalObject, nullptr);
@@ -740,7 +741,7 @@ JSValue JSInjectedScriptHost::iteratorEntries(JSGlobalObject* globalObject, Call
     double fetchDouble = numberToFetchArg.toIntegerOrInfinity(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     if (fetchDouble >= 0)
-        numberToFetch = static_cast<unsigned>(fetchDouble);
+        numberToFetch = clampTo<unsigned>(fetchDouble);
 
     JSArray* array = constructEmptyArray(globalObject, nullptr);
     RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -30,6 +30,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/HashTraits.h>
+#include <wtf/MathExtras.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Nonmovable.h>
 #include <wtf/TriState.h>
@@ -1384,7 +1385,7 @@ ALWAYS_INLINE bool JSValue::getUInt32(uint32_t& v) const
     }
     if (isDouble()) {
         double d = asDouble();
-        v = static_cast<uint32_t>(d);
+        v = truncateDoubleToUint32(d);
         return v == d;
     }
     return false;

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -97,7 +97,7 @@ bool LiteralParser<CharType, reviverMode>::tryJSONPParse(Vector<JSONPData>& resu
                 if (m_lexer.next() != TokNumber)
                     return false;
                 double doubleIndex = m_lexer.currentToken()->numberToken;
-                int index = (int)doubleIndex;
+                int index = truncateDoubleToInt32(doubleIndex);
                 if (index != doubleIndex || index < 0)
                     return false;
                 entry.m_pathIndex = index;

--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -401,15 +401,16 @@ JSC_DEFINE_HOST_FUNCTION(numberProtoFuncToExponential, (JSGlobalObject* globalOb
 
     JSValue arg = callFrame->argument(0);
     // Perform ToInteger on the argument before remaining steps.
-    int decimalPlaces = static_cast<int>(arg.toIntegerOrInfinity(globalObject));
+    double decimalPlacesDouble = arg.toIntegerOrInfinity(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Handle NaN and Infinity.
     if (!std::isfinite(x))
         return JSValue::encode(jsNontrivialString(vm, String::number(x)));
 
-    if (decimalPlaces < 0 || decimalPlaces > 100)
+    if (decimalPlacesDouble < 0 || decimalPlacesDouble > 100)
         return throwVMRangeError(globalObject, scope, "toExponential() argument must be between 0 and 100"_s);
+    int decimalPlaces = static_cast<int>(decimalPlacesDouble);
 
     // Round if the argument is not undefined, always format as exponential.
     NumberToStringBuffer buffer;
@@ -437,10 +438,11 @@ JSC_DEFINE_HOST_FUNCTION(numberProtoFuncToFixed, (JSGlobalObject* globalObject, 
     if (!toThisNumber(callFrame->thisValue(), x))
         return throwVMToThisNumberError(globalObject, scope, callFrame->thisValue());
 
-    int decimalPlaces = static_cast<int>(callFrame->argument(0).toIntegerOrInfinity(globalObject));
+    double decimalPlacesDouble = callFrame->argument(0).toIntegerOrInfinity(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
-    if (decimalPlaces < 0 || decimalPlaces > 100)
+    if (decimalPlacesDouble < 0 || decimalPlacesDouble > 100)
         return throwVMRangeError(globalObject, scope, "toFixed() argument must be between 0 and 100"_s);
+    int decimalPlaces = static_cast<int>(decimalPlacesDouble);
 
     // 15.7.4.5.7 states "If x >= 10^21, then let m = ToString(x)"
     // This also covers Ininity, and structure the check so that NaN
@@ -477,15 +479,16 @@ JSC_DEFINE_HOST_FUNCTION(numberProtoFuncToPrecision, (JSGlobalObject* globalObje
         return JSValue::encode(jsString(vm, String::number(x)));
 
     // Perform ToInteger on the argument before remaining steps.
-    int significantFigures = static_cast<int>(arg.toIntegerOrInfinity(globalObject));
+    double significantFiguresDouble = arg.toIntegerOrInfinity(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Handle NaN and Infinity.
     if (!std::isfinite(x))
         return JSValue::encode(jsNontrivialString(vm, String::number(x)));
 
-    if (significantFigures < 1 || significantFigures > 100)
+    if (significantFiguresDouble < 1 || significantFiguresDouble > 100)
         return throwVMRangeError(globalObject, scope, "toPrecision() argument must be between 1 and 100"_s);
+    int significantFigures = static_cast<int>(significantFiguresDouble);
 
     return JSValue::encode(jsString(vm, String::numberToStringFixedPrecision(x, significantFigures, TrailingZerosPolicy::Keep)));
 }

--- a/Source/JavaScriptCore/runtime/StringConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/StringConstructor.cpp
@@ -129,7 +129,7 @@ JSC_DEFINE_HOST_FUNCTION(stringFromCodePoint, (JSGlobalObject* globalObject, Cal
         double codePointAsDouble = callFrame->uncheckedArgument(i).toNumber(globalObject);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-        uint32_t codePoint = static_cast<uint32_t>(codePointAsDouble);
+        uint32_t codePoint = truncateDoubleToUint32(codePointAsDouble);
 
         if (codePoint != codePointAsDouble || codePoint > UCHAR_MAX_VALUE)
             return throwVMError(globalObject, scope, createRangeError(globalObject, "Arguments contain a value that is out of range of code points"_s));


### PR DESCRIPTION
#### 3825a1a93bbf70dba2406c75919f5d5049a18607
<pre>
[JSC] Fix undefined behavior in double-to-int conversions
<a href="https://bugs.webkit.org/show_bug.cgi?id=316051">https://bugs.webkit.org/show_bug.cgi?id=316051</a>

Reviewed by Yusuke Suzuki.

Several call sites convert unbounded, caller-controlled doubles to narrow
integer types with a plain cast, which is undefined behavior when the
truncated value is not representable ([conv.fpint]). With inputs reachable
from JS (e.g. parseInt(&quot;80000000&quot;, 16), (1.5).toExponential(Infinity),
String.fromCodePoint(-1), o[2 ** 32]), every conversion fixed here trips
UBSan&apos;s float-cast-overflow check.

This is not purely theoretical: in Bun, this UB caused user-observable
bugs, e.g. parseInt(&quot;80000000&quot;, 16) returning a negative int32.

Make the conversions defined via truncateDoubleToInt32() /
truncateDoubleToUint32() / clampTo&lt;unsigned&gt;(), or by range-checking the
double before narrowing. No behavior change on current WebKit toolchains.

Tests: JSTests/stress/get-by-val-double-subscript-out-of-uint32-range.js
       JSTests/stress/jsonp-large-array-index.js
       JSTests/stress/number-tostring-methods-out-of-range-arguments.js
       JSTests/stress/parseint-large-result-int32-boxing.js
       JSTests/stress/string-from-code-point-out-of-range.js

* JSTests/stress/get-by-val-double-subscript-out-of-uint32-range.js: Added.
(shouldBe):
(get put):
* JSTests/stress/jsonp-large-array-index.js: Added.
(shouldBe):
* JSTests/stress/number-tostring-methods-out-of-range-arguments.js: Added.
(shouldBe):
* JSTests/stress/parseint-large-result-int32-boxing.js: Added.
(shouldBe):
(parseIntNoRadix):
* JSTests/stress/string-from-code-point-out-of-range.js: Added.
(shouldBe):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::parseIntResult):
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::weakMapEntries):
(Inspector::JSInjectedScriptHost::weakSetEntries):
(Inspector::JSInjectedScriptHost::iteratorEntries):
* Source/JavaScriptCore/runtime/JSCJSValue.h:
(JSC::JSValue::getUInt32 const):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::requires):
* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/314356@main">https://commits.webkit.org/314356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc6e2a8e76753f4bea8c16b2d4990bc2108fa939

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174886 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123099 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128890 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109414 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28911 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22969 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158001 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177411 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26737 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30326 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137224 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137151 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36963 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Reviewed by Yusuke Suzuki; Compiled WebKit (warnings); Skipped layout-tests; Running canonicalize-commit; Pushed commit to WebKit repository") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102635 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25362 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38602 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111675 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37998 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3444 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->