### PR TITLE
Use `WTF::toArray()` instead of C-style arrays in JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/assembler/JITOperationList.cpp
+++ b/Source/JavaScriptCore/assembler/JITOperationList.cpp
@@ -177,18 +177,12 @@ FOR_EACH_WASM_BUILTIN(DECLARE_WASM_BUILTIN_ENTRY)
         LLINT_OP_EXTRAS(BUILTIN_WASM_ENTRY_VALIDATE_NAME(setName, builtinName)) \
     },
 
-struct LLIntOperations {
-    const JITOperationAnnotation* operations;
-    size_t numberOfOperations;
-};
-
-static LLIntOperations llintOperations()
+static std::span<const JITOperationAnnotation> llintOperations()
 {
-    static const JITOperationAnnotation* operations = nullptr;
-    static size_t numberOfOperations = 0;
+    static std::span<const JITOperationAnnotation> operations;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
-        static const JITOperationAnnotation operationsStorage[] = {
+        static const auto operationsStorage = WTF::toArray<JITOperationAnnotation>({
             LLINT_ROUTINE(llint_function_for_call_prologue)
             LLINT_ROUTINE(llint_function_for_construct_prologue)
             LLINT_ROUTINE(llint_function_for_call_arity_check)
@@ -224,11 +218,10 @@ static LLIntOperations llintOperations()
 
             JSC_JS_GATE_OPCODES(LLINT_RETURN_LOCATION)
             JSC_WASM_GATE_OPCODES(LLINT_RETURN_LOCATION)
-        };
+        });
         operations = operationsStorage;
-        numberOfOperations = std::size(operationsStorage);
     });
-    return { operations, numberOfOperations };
+    return operations;
 }
 
 #undef LLINT_ROUTINE
@@ -245,7 +238,7 @@ void JITOperationList::populatePointersInJavaScriptCoreForLLInt()
     std::call_once(onceKey, [] {
         if (Options::useJIT()) {
             auto list = llintOperations();
-            jitOperationList->addPointers(list.operations, list.operations + list.numberOfOperations);
+            jitOperationList->addPointers(list.data(), list.data() + list.size());
         }
 #if ENABLE(JIT_OPERATION_DISASSEMBLY)
         if (Options::needDisassemblySupport()) [[unlikely]]
@@ -296,7 +289,7 @@ void JITOperationList::populateDisassemblyLabelsInJavaScriptCoreForLLInt()
     std::call_once(onceKey, [] {
         if (Options::useJIT()) {
             auto list = llintOperations();
-            addDisassemblyLabels(list.operations, list.operations + list.numberOfOperations);
+            addDisassemblyLabels(list.data(), list.data() + list.size());
         }
     });
 }

--- a/Source/JavaScriptCore/runtime/GetPutInfo.h
+++ b/Source/JavaScriptCore/runtime/GetPutInfo.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/ECMAMode.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/UniquedStringImpl.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -91,16 +92,16 @@ enum class InitializationMode : unsigned {
 
 ALWAYS_INLINE const char* resolveModeName(ResolveMode resolveMode)
 {
-    static const char* const names[] = {
+    static constexpr auto names = WTF::toArray<const char*>({
         "ThrowIfNotFound",
         "DoNotThrowIfNotFound"
-    };
+    });
     return names[resolveMode];
 }
 
 ALWAYS_INLINE const char* resolveTypeName(ResolveType type)
 {
-    static const char* const names[] = {
+    static constexpr auto names = WTF::toArray<const char*>({
         "GlobalProperty",
         "GlobalVar",
         "GlobalLexicalVar",
@@ -114,18 +115,18 @@ ALWAYS_INLINE const char* resolveTypeName(ResolveType type)
         "UnresolvedProperty",
         "UnresolvedPropertyWithVarInjectionChecks",
         "Dynamic"
-    };
+    });
     return names[type];
 }
 
 ALWAYS_INLINE const char* initializationModeName(InitializationMode initializationMode)
 {
-    static const char* const names[] = {
+    static constexpr auto names = WTF::toArray<const char*>({
         "Initialization",
         "ConstInitialization",
         "NotInitialization",
         "ScopedArgumentInitialization"
-    };
+    });
     return names[static_cast<unsigned>(initializationMode)];
 }
 

--- a/Source/JavaScriptCore/runtime/IntlCollator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollator.cpp
@@ -385,7 +385,7 @@ void IntlCollator::setBoundCompare(VM& vm, JSBoundFunction* format)
 static bool canDoASCIIUCADUCETComparisonWithUCollator(UCollator& collator)
 {
     // Attributes are default ones unless we set. So, non-configured attributes are default ones.
-    static constexpr std::pair<UColAttribute, UColAttributeValue> attributes[] = {
+    static constexpr auto attributes = WTF::toArray<std::pair<UColAttribute, UColAttributeValue>>({
         { UCOL_FRENCH_COLLATION, UCOL_OFF },
         { UCOL_ALTERNATE_HANDLING, UCOL_NON_IGNORABLE },
         { UCOL_STRENGTH, UCOL_TERTIARY },
@@ -393,7 +393,7 @@ static bool canDoASCIIUCADUCETComparisonWithUCollator(UCollator& collator)
         { UCOL_CASE_FIRST, UCOL_OFF },
         { UCOL_NUMERIC_COLLATION, UCOL_OFF },
         // We do not check UCOL_NORMALIZATION_MODE status since FCD normalization does nothing for ASCII strings.
-    };
+    });
 
     for (auto& pair : attributes) {
         UErrorCode status = U_ZERO_ERROR;

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
@@ -34,6 +34,7 @@
 #include "JSGlobalObjectFunctions.h"
 #include "JSObjectInlines.h"
 #include <wtf/Range.h>
+#include <wtf/StdLibExtras.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -70,9 +71,9 @@ void setNumberFormatDigitOptions(JSGlobalObject* globalObject, IntlType* intlIns
 
     unsigned roundingIncrement = intlNumberOption(globalObject, options, vm.propertyNames->roundingIncrement, 1, 5000, 1);
     RETURN_IF_EXCEPTION(scope, void());
-    static constexpr const unsigned roundingIncrementCandidates[] = {
+    static constexpr auto roundingIncrementCandidates = WTF::toArray<unsigned>({
         1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000
-    };
+    });
     if (std::ranges::none_of(roundingIncrementCandidates, [&](auto candidate) {
         return candidate == roundingIncrement;
     })) {

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -3057,13 +3057,13 @@ JSBigInt::ImplResult JSBigInt::rightShiftByMaximum(JSGlobalObject* globalObject,
 // base-N string representation of a number. To increase accuracy, the array
 // value is the actual value multiplied by 32. To generate this table:
 // for (var i = 0; i <= 36; i++) { print(Math.ceil(Math.log2(i) * 32) + ","); }
-constexpr uint8_t maxBitsPerCharTable[] = {
+constexpr auto maxBitsPerCharTable = WTF::toArray<uint8_t>({
     0,   0,   32,  51,  64,  75,  83,  90,  96, // 0..8
     102, 107, 111, 115, 119, 122, 126, 128,     // 9..16
     131, 134, 136, 139, 141, 143, 145, 147,     // 17..24
     149, 151, 153, 154, 156, 158, 159, 160,     // 25..32
     162, 163, 165, 166,                         // 33..36
-};
+});
 
 static constexpr unsigned bitsPerCharTableShift = 5;
 static constexpr size_t bitsPerCharTableMultiplier = 1u << bitsPerCharTableShift;

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -152,13 +152,13 @@ struct JapaneseEra {
     int32_t startYear;
     ASCIILiteral name;
 };
-static constexpr JapaneseEra japaneseEras[] = {
+static constexpr auto japaneseEras = WTF::toArray<JapaneseEra>({
     { 2019, "reiwa"_s },
     { 1989, "heisei"_s },
     { 1926, "showa"_s },
     { 1912, "taisho"_s },
     { 1868, "meiji"_s },
-};
+});
 
 // japaneseEraStartYear — no spec AO, no ICU4X equivalent (ICU4X keys on EraStartDate directly).
 // Bridges ICU4C's UCAL_ERA integer to a Gregorian start year for lookup in japaneseEras[].


### PR DESCRIPTION
#### f582e488dbf421ca55a28afe456b9d8c18c68ad5
<pre>
Use `WTF::toArray()` instead of C-style arrays in JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=316055">https://bugs.webkit.org/show_bug.cgi?id=316055</a>
<a href="https://rdar.apple.com/178483184">rdar://178483184</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/assembler/JITOperationList.cpp:
(JSC::llintOperations):
* Source/JavaScriptCore/runtime/GetPutInfo.h:
(JSC::resolveModeName):
(JSC::resolveTypeName):
(JSC::initializationModeName):
* Source/JavaScriptCore/runtime/IntlCollator.cpp:
(JSC::canDoASCIIUCADUCETComparisonWithUCollator):
* Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h:
(JSC::setNumberFormatDigitOptions):
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::WTF::toArray&lt;uint8_t&gt;):
* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
(JSC::TemporalCore::WTF::toArray&lt;JapaneseEra&gt;):

Canonical link: <a href="https://commits.webkit.org/314600@main">https://commits.webkit.org/314600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7714bafd59b9e3639d5511b42497ed04e69f6028

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175143 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123351 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129092 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30443 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29133 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23284 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158253 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140412 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177676 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26989 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30578 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137439 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137367 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37125 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148726 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102944 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32655 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25593 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198759 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111928 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53398 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38251 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3679 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38496 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38394 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->