### PR TITLE
[YARR] `putRange()` misses Unicode canonical equivalents U+017F and U+212A for ASCII ranges

### DIFF
--- a/JSTests/stress/regexp-unicode-case-insensitive-ascii-range-canonical-set.js
+++ b/JSTests/stress/regexp-unicode-case-insensitive-ascii-range-canonical-set.js
@@ -1,0 +1,50 @@
+// Verify that case-insensitive Unicode-mode character class ranges include the
+// non-ASCII canonical equivalents U+017F (long s) and U+212A (Kelvin sign).
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ', expected: ' + expected);
+}
+
+const longS = "\u017F"; // LATIN SMALL LETTER LONG S, canonicalizes to "s".
+const kelvin = "\u212A"; // KELVIN SIGN, canonicalizes to "k".
+
+shouldBe(/[a-z]/iu.test(longS), true);
+shouldBe(/[A-Z]/iu.test(longS), true);
+shouldBe(/[s]/iu.test(longS), true);
+shouldBe(/[r-t]/iu.test(longS), true);
+shouldBe(/[a-z]/iv.test(longS), true);
+shouldBe(/[a-r]/iu.test(longS), false);
+shouldBe(/[t-z]/iu.test(longS), false);
+
+shouldBe(/[a-z]/iu.test(kelvin), true);
+shouldBe(/[A-Z]/iu.test(kelvin), true);
+shouldBe(/[k]/iu.test(kelvin), true);
+shouldBe(/[j-l]/iu.test(kelvin), true);
+shouldBe(/[a-z]/iv.test(kelvin), true);
+shouldBe(/[a-j]/iu.test(kelvin), false);
+shouldBe(/[l-z]/iu.test(kelvin), false);
+
+// Negated classes must exclude the canonical equivalents.
+shouldBe(/[^a-z]/iu.test(longS), false);
+shouldBe(/[^a-z]/iu.test(kelvin), false);
+
+// Ranges crossing the ASCII boundary.
+shouldBe(/[a-\u00FF]/iu.test(longS), true);
+shouldBe(/[a-\u00FF]/iu.test(kelvin), true);
+
+// Reverse direction: non-ASCII ranges containing the canonical equivalents
+// must keep matching the ASCII characters.
+shouldBe(/[\u0170-\u0180]/iu.test("s"), true);
+shouldBe(/[\u0170-\u0180]/iu.test("S"), true);
+shouldBe(/[\u2120-\u2130]/iu.test("k"), true);
+shouldBe(/[\u2120-\u2130]/iu.test("K"), true);
+
+// Without the i flag, no canonicalization.
+shouldBe(/[a-z]/u.test(longS), false);
+shouldBe(/[a-z]/u.test(kelvin), false);
+
+// Non-Unicode mode (UCS2 canonicalization) must not change: U+017F/U+212A
+// do not canonicalize into ASCII there.
+shouldBe(/[a-z]/i.test(longS), false);
+shouldBe(/[a-z]/i.test(kelvin), false);

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -255,23 +255,28 @@ public:
 
     void putRange(char32_t lo, char32_t hi)
     {
-        // This is ASCII-case-folding fast path. So intentionally using isASCII (not isLatin1).
-        if (isASCII(lo)) {
-            char asciiLo = lo;
-            char asciiHi = std::min<char32_t>(hi, 0x7f);
-            addSortedRange(lo, asciiHi);
+        // The ASCII case-folding fast path is only valid in UCS2 canonical mode. In Unicode
+        // canonical mode, U+212A and U+017F canonicalize into ASCII 'k' and 's', so ASCII
+        // ranges must go through the canonicalization table below.
+        if (!m_isCaseInsensitive || m_canonicalMode == CanonicalMode::UCS2) {
+            // This is ASCII-case-folding fast path. So intentionally using isASCII (not isLatin1).
+            if (isASCII(lo)) {
+                char asciiLo = lo;
+                char asciiHi = std::min<char32_t>(hi, 0x7f);
+                addSortedRange(lo, asciiHi);
 
-            if (m_isCaseInsensitive) {
-                if ((asciiLo <= 'Z') && (asciiHi >= 'A'))
-                    addSortedRange(std::max(asciiLo, 'A')+('a'-'A'), std::min(asciiHi, 'Z')+('a'-'A'));
-                if ((asciiLo <= 'z') && (asciiHi >= 'a'))
-                    addSortedRange(std::max(asciiLo, 'a')+('A'-'a'), std::min(asciiHi, 'z')+('A'-'a'));
+                if (m_isCaseInsensitive) {
+                    if ((asciiLo <= 'Z') && (asciiHi >= 'A'))
+                        addSortedRange(std::max(asciiLo, 'A')+('a'-'A'), std::min(asciiHi, 'Z')+('a'-'A'));
+                    if ((asciiLo <= 'z') && (asciiHi >= 'a'))
+                        addSortedRange(std::max(asciiLo, 'a')+('A'-'a'), std::min(asciiHi, 'z')+('A'-'a'));
+                }
             }
-        }
-        if (isASCII(hi))
-            return;
+            if (isASCII(hi))
+                return;
 
-        lo = std::max<char32_t>(lo, 0x80);
+            lo = std::max<char32_t>(lo, 0x80);
+        }
         addSortedRange(lo, hi);
 
         if (!m_isCaseInsensitive)


### PR DESCRIPTION
#### faf717c136d1e8bf14533462f76179b7831117f7
<pre>
[YARR] `putRange()` misses Unicode canonical equivalents U+017F and U+212A for ASCII ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=316056">https://bugs.webkit.org/show_bug.cgi?id=316056</a>

Reviewed by Yusuke Suzuki.

CharacterClassConstructor::putRange() has an ASCII fast path that only
performs +/-0x20 case folding and returns early when the entire range is
ASCII. This is correct in UCS2 canonical mode, but in Unicode canonical
mode (/iu and /iv flags), U+212A KELVIN SIGN canonicalizes to &apos;k&apos; and
U+017F LATIN SMALL LETTER LONG S canonicalizes to &apos;s&apos;, so character
class ranges covering those ASCII letters must also match the non-ASCII
equivalents. As a result, /[a-z]/iu.test(&quot;ſ&quot;) returned false while
/[s]/iu.test(&quot;ſ&quot;) returned true, and V8 returns true for both.

putChar() already gates its ASCII fast path on
m_canonicalMode == CanonicalMode::UCS2. Apply the same gating to
putRange(): in case-insensitive Unicode canonical mode, skip the fast
path and let the existing canonicalization table walk handle the whole
range. The Unicode range info table fully covers ASCII (including the
CanonicalizeSet entries for k/K and s/S), and addSortedRange() already
splits ranges at the Latin-1 boundary, so the table walk produces the
correct matches for ASCII ranges as well.

Test: JSTests/stress/regexp-unicode-case-insensitive-ascii-range-canonical-set.js

* JSTests/stress/regexp-unicode-case-insensitive-ascii-range-canonical-set.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::putRange):

Canonical link: <a href="https://commits.webkit.org/314416@main">https://commits.webkit.org/314416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01977051e53c9bfeb7096557146547d088c719b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123107 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39346 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128892 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90789 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168811 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31262 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109416 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30238 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28915 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22977 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158009 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177419 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26745 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30334 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137231 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137153 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36997 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148497 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102644 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25364 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111683 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38006 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3446 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->