### PR TITLE
[Site Isolation] Make RemoteFrameLayoutInfo ref-counted

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2286,6 +2286,7 @@ page/Quirks.cpp @header:RenderStyleGetters
 page/RemoteDOMWindow.cpp
 page/RemoteFrame.cpp
 page/RemoteFrameGeometryTransformer.cpp
+page/RemoteFrameLayoutInfo.cpp
 page/RemoteFrameView.cpp
 page/RenderingUpdateScheduler.cpp
 page/ResizeObservation.cpp @header:RenderStyleGetters

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -356,10 +356,10 @@ void Frame::updateFrameTreeSyncData(const FrameTreeSyncSerializationData& data)
             if (!localChild)
                 continue;
 
-            auto oldFrameInfo = oldMap.getOptional(child->frameID());
-            auto newFrameInfo = newMap.getOptional(child->frameID());
+            RefPtr oldFrameInfo = oldMap.get(child->frameID());
+            RefPtr newFrameInfo = newMap.get(child->frameID());
 
-            if (!oldFrameInfo || !newFrameInfo || oldFrameInfo->ownerElementAppearance.contains(FrameOwnerElementAppearance::IsDark) != newFrameInfo->ownerElementAppearance.contains(FrameOwnerElementAppearance::IsDark)) {
+            if (!oldFrameInfo || !newFrameInfo || oldFrameInfo->ownerElementAppearance().contains(FrameOwnerElementAppearance::IsDark) != newFrameInfo->ownerElementAppearance().contains(FrameOwnerElementAppearance::IsDark)) {
                 RefPtr localChildView = localChild->view();
 
                 localChildView->invalidateForBaseBackgroundOrColorSchemeChange();

--- a/Source/WebCore/page/FrameTreeSyncData.in
+++ b/Source/WebCore/page/FrameTreeSyncData.in
@@ -38,4 +38,4 @@ FrameRect : WebCore::IntRect [Headers=<WebCore/IntRect.h>]
 FrameLayoutViewportRect : WebCore::LayoutRect [Headers=<WebCore/LayoutRect.h>]
 
 # Collection of layout info regarding children frames of this frame.
-ChildrenFrameLayoutInfo : HashMap<WebCore::FrameIdentifier, WebCore::RemoteFrameLayoutInfo> [Headers=<WebCore/FrameIdentifier.h>,<WebCore/RemoteFrameLayoutInfo.h>]
+ChildrenFrameLayoutInfo : HashMap<WebCore::FrameIdentifier, Ref<WebCore::RemoteFrameLayoutInfo>> [Headers=<WebCore/FrameIdentifier.h>,<WebCore/RemoteFrameLayoutInfo.h>]

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2189,25 +2189,17 @@ void Page::syncLocalFrameInfoToRemote()
 
         frameView->updateLayoutViewportRect();
 
-        {
-            HashMap<FrameIdentifier, RemoteFrameLayoutInfo> childrenFrameLayoutInfo;
-
-            for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-                auto visibleRect = frameView->visibleRectOfChild(*child.get());
-                float usedZoom = frame.usedZoomForChild(*child);
-                auto frameOwnerElementAppearance = frameView->appearanceOfOwnerElementOfChildFrame(*child);
-                auto contentBoxLocation = frameView->childFrameOwnerContentBoxLocation(*child);
-
-                childrenFrameLayoutInfo.add(child->frameID(), RemoteFrameLayoutInfo {
-                    .visibleRectInParent = visibleRect,
-                    .usedZoom = usedZoom,
-                    .contentBoxLocation = contentBoxLocation,
-                    .ownerElementAppearance = frameOwnerElementAppearance
-                });
-            }
-
-            frame.loader().client().broadcastChildrenFrameLayoutInfoToOtherProcesses(childrenFrameLayoutInfo);
+        HashMap<FrameIdentifier, Ref<RemoteFrameLayoutInfo>> childrenFrameLayoutInfo;
+        for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+            childrenFrameLayoutInfo.add(child->frameID(), RemoteFrameLayoutInfo::create(
+                frameView->visibleRectOfChild(*child.get()),
+                frame.usedZoomForChild(*child),
+                frameView->childFrameOwnerContentBoxLocation(*child),
+                frameView->appearanceOfOwnerElementOfChildFrame(*child)
+            ));
         }
+
+        frame.loader().client().broadcastChildrenFrameLayoutInfoToOtherProcesses(childrenFrameLayoutInfo);
     });
 }
 

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -232,8 +232,10 @@ AutoplayPolicy RemoteFrame::autoplayPolicy() const
 
 float RemoteFrame::usedZoomForChild(const Frame& child) const
 {
-    auto maybeInfo = frameTreeSyncData().childrenFrameLayoutInfo.getOptional(child.frameID());
-    return maybeInfo.transform([] (auto& info) { return info.usedZoom; }).value_or(1.0);
+    if (RefPtr info = frameTreeSyncData().childrenFrameLayoutInfo.get(child.frameID()))
+        return info->usedZoom();
+
+    return 1.0;
 }
 
 String RemoteFrame::debugDescription() const

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteFrameLayoutInfo.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteFrameLayoutInfo);
+
+Ref<RemoteFrameLayoutInfo> RemoteFrameLayoutInfo::create(std::optional<LayoutRect> visibleRectInParent, float usedZoom, LayoutPoint contentBoxLocation, OptionSet<FrameOwnerElementAppearance> ownerElementAppearance)
+{
+    return adoptRef(*new RemoteFrameLayoutInfo(visibleRectInParent, usedZoom, contentBoxLocation, ownerElementAppearance));
+}
+
+RemoteFrameLayoutInfo::RemoteFrameLayoutInfo(std::optional<LayoutRect> visibleRectInParent, float usedZoom, LayoutPoint contentBoxLocation, OptionSet<FrameOwnerElementAppearance> ownerElementAppearance)
+    : m_visibleRectInParent(visibleRectInParent)
+    , m_usedZoom(usedZoom)
+    , m_contentBoxLocation(contentBoxLocation)
+    , m_ownerElementAppearance(ownerElementAppearance)
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.h
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <WebCore/LayoutRect.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -41,19 +43,32 @@ enum class FrameOwnerElementAppearance : uint8_t {
 // Collection of style/layout info regarding a (potentially remote) frame.
 // This is synchronized from LocalFrame in one process to RemoteFrames
 // in other processes using FrameTreeSyncData.
-struct RemoteFrameLayoutInfo {
+class RemoteFrameLayoutInfo : public RefCounted<RemoteFrameLayoutInfo> {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(RemoteFrameLayoutInfo, WEBCORE_EXPORT);
+
+public:
+    WEBCORE_EXPORT static Ref<RemoteFrameLayoutInfo> create(std::optional<LayoutRect>, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
+
+    std::optional<LayoutRect> visibleRectInParent() const { return m_visibleRectInParent; }
+    float usedZoom() const { return m_usedZoom; }
+    LayoutPoint contentBoxLocation() const { return m_contentBoxLocation; }
+    OptionSet<FrameOwnerElementAppearance> ownerElementAppearance() const { return m_ownerElementAppearance; }
+
+private:
+    RemoteFrameLayoutInfo(std::optional<LayoutRect>, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
+
     // Rectangle of the visible portion of the frame in its parent frame,
     // in the coordinate space of the document of the parent frame.
-    std::optional<LayoutRect> visibleRectInParent;
+    std::optional<LayoutRect> m_visibleRectInParent;
 
     // RenderStyle::usedZoom of the owner renderer of the frame.
-    float usedZoom;
+    float m_usedZoom;
 
     // The offset of the content box of the frame's owner element
     // from its border box.
-    LayoutPoint contentBoxLocation;
+    LayoutPoint m_contentBoxLocation;
 
-    OptionSet<FrameOwnerElementAppearance> ownerElementAppearance;
+    OptionSet<FrameOwnerElementAppearance> m_ownerElementAppearance;
 };
 
 };

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -73,24 +73,24 @@ LayoutRect RemoteFrameView::layoutViewportRect() const
 
 std::optional<LayoutRect> RemoteFrameView::visibleRectOfChild(const Frame& child) const
 {
-    auto maybeInfo = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.getOptional(child.frameID());
-    return maybeInfo.and_then([] (auto& info) {
-        return info.visibleRectInParent;
-    });
+    if (RefPtr info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.get(child.frameID()))
+        return info->visibleRectInParent();
+
+    return std::nullopt;
 }
 
 OptionSet<FrameOwnerElementAppearance> RemoteFrameView::appearanceOfOwnerElementOfChildFrame(const Frame& child) const
 {
-    if (auto info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.getOptional(child.frameID()))
-        return info->ownerElementAppearance;
+    if (RefPtr info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.get(child.frameID()))
+        return info->ownerElementAppearance();
 
     return { };
 }
 
 LayoutPoint RemoteFrameView::childFrameOwnerContentBoxLocation(const Frame& child) const
 {
-    if (auto info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.getOptional(child.frameID()))
-        return info->contentBoxLocation;
+    if (RefPtr info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.get(child.frameID()))
+        return info->contentBoxLocation();
 
     return { };
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2206,11 +2206,11 @@ class WebCore::LayoutRect {
     ExplicitlySet
 };
 
-struct WebCore::RemoteFrameLayoutInfo {
-    std::optional<WebCore::LayoutRect> visibleRectInParent;
-    float usedZoom;
-    WebCore::LayoutPoint contentBoxLocation;
-    OptionSet<WebCore::FrameOwnerElementAppearance> ownerElementAppearance;
+[RefCounted] class WebCore::RemoteFrameLayoutInfo {
+    std::optional<WebCore::LayoutRect> visibleRectInParent();
+    float usedZoom();
+    WebCore::LayoutPoint contentBoxLocation();
+    OptionSet<WebCore::FrameOwnerElementAppearance> ownerElementAppearance();
 };
 
 header: <WebCore/VP9Utilities.h>

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -768,7 +768,7 @@ Ref<FrameTreeSyncData> WebFrameProxy::calculateFrameTreeSyncData() const
     bool isSecureForPaymentSession = false;
 #endif
 
-    return FrameTreeSyncData::create(isSecureForPaymentSession, securityOrigin(), m_documentSecurityPolicy, m_effectiveSandboxFlags.contains(WebCore::SandboxFlag::Origin), url().protocol().toString(), IntRect { }, LayoutRect { }, HashMap<FrameIdentifier, RemoteFrameLayoutInfo> { });
+    return FrameTreeSyncData::create(isSecureForPaymentSession, securityOrigin(), m_documentSecurityPolicy, m_effectiveSandboxFlags.contains(WebCore::SandboxFlag::Origin), url().protocol().toString(), IntRect { }, LayoutRect { }, HashMap<FrameIdentifier, Ref<RemoteFrameLayoutInfo>> { });
 }
 
 Ref<SecurityOrigin> WebFrameProxy::securityOrigin() const


### PR DESCRIPTION
#### 3e82af88174cd6d92a259e777a6305ccb96c9242
<pre>
[Site Isolation] Make RemoteFrameLayoutInfo ref-counted
<a href="https://rdar.apple.com/178482662">rdar://178482662</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316053">https://bugs.webkit.org/show_bug.cgi?id=316053</a>

Reviewed by Megan Gardner.

RemoteFrameLayoutInfo is used as values in the ChildrenFrameLayoutInfo
hashmap in FrameTreeSyncData. HashMap values are limited to 150 bytes in
size, and upcoming patches will exceed this limit by adding 2
TransformationMatrix to the struct. Prepare for it by making
RemoteFrameLayoutInfo ref-counted and store it in the HashMap
as Ref&lt;&gt; instead.

Preferably we should use UniqueRef&lt;&gt;, but the way FrameTreeSyncData
is implemented involves lots of data copies. UniqueRef is not copyable,
so FrameTreeSyncData (more specifically, the code generator in
generate-process-sync-data.py) will have to be changed to avoid copying
stuff around in favor of moving, which is a project on its own.

Refactoring - tested by existing suites.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::updateFrameTreeSyncData):
* Source/WebCore/page/FrameTreeSyncData.in:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::syncLocalFrameInfoToRemote):
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::usedZoomForChild const):
* Source/WebCore/page/RemoteFrameLayoutInfo.cpp: Copied from Source/WebCore/page/RemoteFrameLayoutInfo.h.
(WebCore::RemoteFrameLayoutInfo::create):
(WebCore::RemoteFrameLayoutInfo::RemoteFrameLayoutInfo):
* Source/WebCore/page/RemoteFrameLayoutInfo.h:
(WebCore::RemoteFrameLayoutInfo::visibleRectInParent const):
(WebCore::RemoteFrameLayoutInfo::usedZoom const):
(WebCore::RemoteFrameLayoutInfo::contentBoxLocation const):
(WebCore::RemoteFrameLayoutInfo::ownerElementAppearance const):
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::visibleRectOfChild const):
(WebCore::RemoteFrameView::appearanceOfOwnerElementOfChildFrame const):
(WebCore::RemoteFrameView::childFrameOwnerContentBoxLocation const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::calculateFrameTreeSyncData const):

Canonical link: <a href="https://commits.webkit.org/314488@main">https://commits.webkit.org/314488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb24ab85954d397f6f5a4aaebe5dafbef2d43a17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175114 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123322 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129072 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109598 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30418 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29107 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23255 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177647 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30549 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137419 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137347 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37045 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148702 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102912 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32630 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25569 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38825 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111899 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38222 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3655 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38467 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38365 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->