### PR TITLE
Import navigation-state-reset-sameorigin WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin-expected.txt
@@ -5,5 +5,5 @@ Tests that navigating a same-origin child frame resets its activation states.
 Click inside the yellow area.
 
 
-PASS Post-navigation state reset.
+FAIL Post-navigation state reset. assert_true: child-two sticky user activation state after loaded expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin.html
@@ -33,29 +33,41 @@
         var child = document.getElementById("child");
         child.src = "./resources/child-one.html";
         const unclickeData = await message("child-one-loaded");
-        assert_false(navigator.userActivation.isActive);
-        assert_false(navigator.userActivation.hasBeenActive);
-        assert_false(unclickeData.isActive);
-        assert_false(unclickeData.hasBeenActive);
+
+        assert_false(navigator.userActivation.isActive,
+              "main page transient user activation state before click");
+        assert_false(navigator.userActivation.hasBeenActive,
+              "main page sticky user activation state before click");
+        assert_false(unclickeData.isActive,
+              "child-one transient user activation state after loaded");
+        assert_false(unclickeData.hasBeenActive,
+              "child-one sticky user activation state after loaded");
 
         const [, child1Data] = await Promise.all([
           test_driver.click(child),
           message("child-one-clicked"),
         ]);
 
-        assert_true(navigator.userActivation.isActive);
-        assert_true(navigator.userActivation.hasBeenActive);
-        assert_true(child1Data.isActive);
-        assert_true(child1Data.hasBeenActive);
+        assert_true(navigator.userActivation.isActive,
+              "main page transient user activation state after click");
+        assert_true(navigator.userActivation.hasBeenActive,
+              "main page sticky user activation state after click");
+        assert_true(child1Data.isActive,
+              "child-one transient user activation state after click");
+        assert_true(child1Data.hasBeenActive,
+              "child-one sticky user activation state after click");
 
         child.src = "./resources/child-two.html";
-
         const child2Data = await message("child-two-loaded");
 
-        assert_true(navigator.userActivation.isActive);
-        assert_true(navigator.userActivation.hasBeenActive);
-        assert_false(child2Data.isActive);
-        assert_false(child2Data.hasBeenActive);
+        assert_true(navigator.userActivation.isActive,
+              "main page transient user activation state after navigation");
+        assert_true(navigator.userActivation.hasBeenActive,
+              "main page sticky user activation state after navigation");
+        assert_false(child2Data.isActive,
+              "child-two transient user activation state after loaded");
+        assert_true(child2Data.hasBeenActive,
+              "child-two sticky user activation state after loaded");
       }, "Post-navigation state reset.");
     </script>
   </body>


### PR DESCRIPTION
#### 5027808b979ca6e5df1953e0da3954a7bbdfd64b
<pre>
Import navigation-state-reset-sameorigin WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=316059">https://bugs.webkit.org/show_bug.cgi?id=316059</a>

Reviewed by Anne van Kesteren.

Update html/user-activation/navigation-state-reset-sameorigin.html to the
latest upstream version, which adds a check that a same-origin child frame
retains its sticky user-activation state after it completes a same-origin
navigation, matching <a href="https://github.com/whatwg/html/pull/11454.">https://github.com/whatwg/html/pull/11454.</a>

WebKit does not yet implement this behavior, so the new subtest fails and
is baselined into the -expected.txt accordingly.

Upstream commit: web-platform-tests/wpt@8187b0a8e3

* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin.html:

Canonical link: <a href="https://commits.webkit.org/314406@main">https://commits.webkit.org/314406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e245cd2d59369de558464a6210bcfabad101086

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123198 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128977 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109504 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30324 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29004 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23130 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177519 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137316 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137245 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36995 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148587 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102777 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32531 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25454 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38701 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38098 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3536 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38343 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->