### PR TITLE
animation-range shorthand serializes incorrectly when the end value is the default for a different start type

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-expected.txt
@@ -8,7 +8,7 @@ PASS e.style['animation-range'] = "entry-crossing" should set the property value
 PASS e.style['animation-range'] = "exit" should set the property value
 PASS e.style['animation-range'] = "exit-crossing" should set the property value
 PASS e.style['animation-range'] = "entry, exit" should set the property value
-FAIL e.style['animation-range'] = "0% 100%" should set the property value assert_equals: serialization should be canonical expected "0%" but got "0% 100%"
+PASS e.style['animation-range'] = "0% 100%" should set the property value
 PASS e.style['animation-range'] = "entry 0% entry 100%" should set the property value
 PASS e.style['animation-range'] = "entry-crossing 0% entry-crossing 100%" should set the property value
 PASS e.style['animation-range'] = "exit 0% exit 100%" should set the property value
@@ -31,7 +31,7 @@ PASS e.style['animation-range'] = "normal 100px" should set the property value
 PASS e.style['animation-range'] = "100px" should set the property value
 PASS e.style['animation-range'] = "100px normal" should set the property value
 PASS e.style['animation-range'] = "10% normal" should set the property value
-FAIL e.style['animation-range'] = "entry normal" should set the property value assert_equals: serialization should be canonical expected "entry normal" but got "entry"
+PASS e.style['animation-range'] = "entry normal" should set the property value
 PASS Property animation-range value 'normal'
 PASS Property animation-range value 'normal normal'
 PASS Property animation-range value 'cover'
@@ -65,7 +65,7 @@ PASS Property animation-range value 'normal 100px'
 PASS Property animation-range value '100px'
 PASS Property animation-range value '100px normal'
 PASS Property animation-range value '10% normal'
-FAIL Property animation-range value 'entry normal' assert_equals: expected "entry normal" but got "entry"
+PASS Property animation-range value 'entry normal'
 PASS Property animation-range value '10% calc(70% + 10% * sign(100em - 1px))'
 PASS e.style['animation-range'] = "entry 50% 0s" should not set the property value
 PASS e.style['animation-range'] = "0s entry 50%" should not set the property value

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -1545,22 +1545,32 @@ String ShorthandSerializer::serializeSingleAnimationRange(const CSSValue& value,
         return value.isLength() || value.isPercentage() || value.isCalculatedPercentageWithLength();
     };
 
+    bool isStartValue = type == Style::SingleAnimationRangeType::Start;
+    bool startHasNoName = startValueID == CSSValueInvalid || startValueID == CSSValueNormal;
+
     if (RefPtr pair = dynamicDowncast<CSSValuePair>(value)) {
         bool isSameNameAsStart = isValueID(pair->first(), startValueID);
-        bool isStartValue = type == Style::SingleAnimationRangeType::Start;
         bool isDefaultValue = isDefault(dynamicDowncast<CSSPrimitiveValue>(pair->second()), Style::SingleAnimationRangeType::Start);
         if (isDefaultValue && (isStartValue || !isSameNameAsStart))
             return nameLiteral(valueID(pair->first()));
         return pair->cssText(m_serializationContext);
     }
     if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        if (isRangeOffset(*primitiveValue))
+        if (isRangeOffset(*primitiveValue)) {
+            // For a bare length/percentage start, the implicit default end is "normal"; a 100% end
+            // is equivalent and should be elided from the canonical shorthand serialization.
+            if (!isStartValue && startHasNoName && isDefault(primitiveValue, type))
+                return emptyString();
             return primitiveValue->cssText(m_serializationContext);
+        }
     } else if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
         bool isNormal = keywordValue->valueID() == CSSValueNormal;
         bool isSameNameAsStart = keywordValue->valueID() == startValueID;
-        bool isStartValue = type == Style::SingleAnimationRangeType::Start;
-        if (isStartValue || (!isNormal && !isSameNameAsStart))
+        // The default end for a <timeline-range-name> start is the same name (i.e. <name> 100%);
+        // for any other start (length/percentage or "normal") the default end is "normal". Only
+        // elide an end keyword that matches that default.
+        bool isDefaultEnd = isSameNameAsStart || (isNormal && startHasNoName);
+        if (isStartValue || !isDefaultEnd)
             return nameLiteral(keywordValue->valueID());
     }
     return emptyString();

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -2677,7 +2677,12 @@ static Ref<CSSValueList> convertAnimationRange(ExtractorState& state, const Sing
 
     bool isNormal = range.end.isNormal();
     bool isDefaultAndSameNameAsStart = range.start.name() == range.end.name() && range.end.hasDefaultOffset();
-    if (endValue->length() && !endValueEqualsStart && !isNormal && !isDefaultAndSameNameAsStart)
+    // The default end for a length/percentage start (Name::Omitted) or "normal" start is "normal";
+    // for a <timeline-range-name> start the default end is the same name. Only elide an end of
+    // "normal" against starts where it's actually the default.
+    bool startHasNoName = range.start.name() == SingleAnimationRangeName::Normal || range.start.name() == SingleAnimationRangeName::Omitted;
+    bool isDefaultNormalEnd = isNormal && startHasNoName;
+    if (endValue->length() && !endValueEqualsStart && !isDefaultNormalEnd && !isDefaultAndSameNameAsStart)
         list.append(WTF::move(endValue));
 
     return CSSValueList::createSpaceSeparated(WTF::move(list));


### PR DESCRIPTION
#### d53e5c00c6a0f4cf06e7b547b723814629ba30d2
<pre>
animation-range shorthand serializes incorrectly when the end value is the default for a different start type
<a href="https://bugs.webkit.org/show_bug.cgi?id=316064">https://bugs.webkit.org/show_bug.cgi?id=316064</a>
<a href="https://rdar.apple.com/178493102">rdar://178493102</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Two related bugs in animation-range shorthand serialization:

1. An end of `normal` was always elided, even when the start was a
  &lt;timeline-range-name&gt; like `entry`. For a named-range start the
  default end is `&lt;name&gt; 100%`, not `normal`, so `entry normal` should
  serialize as `entry normal`, not `entry`.

2. An end of `100%` was not elided when the start was a bare
  length/percentage. For an unnamed start the default end is `normal`,
  which a 100% offset is equivalent to, so `0% 100%` should serialize
  as `0%`.

Both elisions live in two places that needed the same correction:

* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeSingleAnimationRange):
Only elide a `normal` end when the start has no &lt;timeline-range-name&gt;
(CSSValueInvalid) or is `normal` itself. Elide a 100% offset end when
the start is a bare length/percentage.

* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::convertAnimationRange):
Same correction for the getComputedStyle path: only elide an end of
`normal` against starts where it is actually the default.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-expected.txt: Progressions
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d53e5c00c6a0f4cf06e7b547b723814629ba30d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123130 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128915 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90803 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109439 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30259 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28939 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23062 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177443 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26768 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30357 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137252 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137176 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148520 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102682 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32467 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25387 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38633 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111706 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38029 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3469 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38275 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38173 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->