### PR TITLE
Partitioned cookies may not be sent on resource requests

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -343,6 +343,7 @@ NetworkProcessProxy& WebsiteDataStore::networkProcess()
         Ref networkProcess = networkProcessForSession(m_sessionID);
         m_networkProcess = networkProcess.copyRef();
         networkProcess->addSession(*this, NetworkProcessProxy::SendParametersToNetworkProcess::Yes);
+        propagateSettingUpdates();
     }
 
     return *m_networkProcess;
@@ -2850,12 +2851,16 @@ void WebsiteDataStore::addPage(WebPageProxy& page)
 {
     m_pages.add(page);
 
+    propagateSettingUpdates();
+
     updateServiceWorkerInspectability();
 }
 
 void WebsiteDataStore::removePage(WebPageProxy& page)
 {
     m_pages.remove(page);
+
+    propagateSettingUpdates();
 
     updateServiceWorkerInspectability();
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm
@@ -5231,6 +5231,245 @@ TEST(Navigation, CookieTransformOnRedirect)
     EXPECT_EQ(transformCallbackCount, 2u);
 }
 
+#if ENABLE(OPT_IN_PARTITIONED_COOKIES)
+TEST(WKNavigation, PartitionedCookieSentOnTopLevelRedirect)
+{
+    using namespace TestWebKitAPI;
+    bool sawCookieOnRedirectTarget { false };
+    bool requestedRedirectTarget { false };
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
+        auto request = co_await connection.awaitableReceiveHTTPRequest();
+        auto path = HTTPServer::parsePath(request);
+        request.append(0);
+        if (path == "/page1"_s) {
+            co_await connection.awaitableSend(
+                "HTTP/1.1 302 Found\r\n"
+                "Location: https://example.com/page2\r\n"
+                "Set-Cookie: PF=value;Secure;HttpOnly;SameSite=None;Partitioned\r\n"
+                "Content-Length: 0\r\n"
+                "\r\n"_s);
+        } else if (path == "/page2"_s) {
+            sawCookieOnRedirectTarget = contains(request.span(), "PF=value"_span);
+            co_await connection.awaitableSend(
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Length: 0\r\n"
+                "\r\n"_s);
+            requestedRedirectTarget = true;
+        }
+    } }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    [dataStore _setResourceLoadStatisticsEnabled:YES];
+
+    // Force the network session to be created while m_pages is empty. After
+    // this returns, the session has isOptInCookiePartitioningEnabled = false.
+    __block bool forcedNetworkProcess = false;
+    [[dataStore httpCookieStore] getAllCookies:^(NSArray<NSHTTPCookie *> *) {
+        forcedNetworkProcess = true;
+    }];
+    Util::run(&forcedNetworkProcess);
+
+    // Sanity check the broken bootstrap state: with no pages added yet, the
+    // data store should still be in the default mode (All) — not the upgraded
+    // AllExceptPartitioned that propagateSettingUpdates produces.
+    EXPECT_WK_STREQ(@"All", [dataStore _thirdPartyCookieBlockingModeForTesting]);
+
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    [viewConfiguration setWebsiteDataStore:dataStore.get()];
+
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    [delegate allowAnyTLSCertificate];
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/page1"]]];
+    Util::run(&requestedRedirectTarget);
+
+    EXPECT_TRUE(sawCookieOnRedirectTarget);
+
+    EXPECT_WK_STREQ(@"AllExceptPartitioned", [dataStore _thirdPartyCookieBlockingModeForTesting]);
+
+    __block bool gotStoredCookies = false;
+    [[dataStore httpCookieStore] getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        EXPECT_EQ(cookies.count, 1u);
+        if (cookies.count) {
+            EXPECT_WK_STREQ(@"PF", cookies[0].name);
+            EXPECT_WK_STREQ(@"https://example.com", cookies[0].properties[@"StoragePartition"]);
+        }
+        gotStoredCookies = true;
+    }];
+    Util::run(&gotStoredCookies);
+}
+
+TEST(WKNavigation, PartitionedCookieSentWhenNetworkProcessExistsBeforePage)
+{
+    using namespace TestWebKitAPI;
+    bool sawCookieOnRedirectTarget { false };
+    bool requestedRedirectTarget { false };
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
+        auto request = co_await connection.awaitableReceiveHTTPRequest();
+        auto path = HTTPServer::parsePath(request);
+        request.append(0);
+        if (path == "/page1"_s) {
+            co_await connection.awaitableSend(
+                "HTTP/1.1 302 Found\r\n"
+                "Location: https://example.com/page2\r\n"
+                "Set-Cookie: PF=value;Secure;HttpOnly;SameSite=None;Partitioned\r\n"
+                "Content-Length: 0\r\n"
+                "\r\n"_s);
+        } else if (path == "/page2"_s) {
+            sawCookieOnRedirectTarget = contains(request.span(), "PF=value"_span);
+            co_await connection.awaitableSend(
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Length: 0\r\n"
+                "\r\n"_s);
+            requestedRedirectTarget = true;
+        }
+    } }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    [dataStore _setResourceLoadStatisticsEnabled:YES];
+
+    // removeDataOfTypes drives WebsiteDataStore::removeData → networkProcess()
+    // lazy creator with empty m_pages. Unlike getAllCookies (which uses
+    // networkProcessIfExists), this genuinely creates the session here.
+    __block bool dataRemoved = false;
+    [dataStore removeDataOfTypes:[NSSet setWithObject:WKWebsiteDataTypeCookies] modifiedSince:[NSDate distantPast] completionHandler:^{
+        dataRemoved = true;
+    }];
+    Util::run(&dataRemoved);
+
+    // Sanity: the session was born with isOpt=false (no pages), and the
+    // post-addSession propagateSettingUpdates inside networkProcess() saw
+    // computeIsOptInCookiePartitioningEnabled() == false too — so the UIProcess
+    // mode is still at the lazy default. If this ever flips early, the test
+    // is no longer modeling the broken-bootstrap scenario.
+    EXPECT_WK_STREQ(@"All", [dataStore _thirdPartyCookieBlockingModeForTesting]);
+
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    [viewConfiguration setWebsiteDataStore:dataStore.get()];
+
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    [delegate allowAnyTLSCertificate];
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/page1"]]];
+    Util::run(&requestedRedirectTarget);
+
+    EXPECT_TRUE(sawCookieOnRedirectTarget);
+    EXPECT_WK_STREQ(@"AllExceptPartitioned", [dataStore _thirdPartyCookieBlockingModeForTesting]);
+
+    __block bool gotStoredCookies = false;
+    [[dataStore httpCookieStore] getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        EXPECT_EQ(cookies.count, 1u);
+        if (cookies.count) {
+            EXPECT_WK_STREQ(@"PF", cookies[0].name);
+            EXPECT_WK_STREQ(@"https://example.com", cookies[0].properties[@"StoragePartition"]);
+        }
+        gotStoredCookies = true;
+    }];
+    Util::run(&gotStoredCookies);
+}
+
+TEST(WKNavigation, PartitionedCookieAfterRedirect)
+{
+    using namespace TestWebKitAPI;
+    bool sawPartitionedCookieOnSubresource { false };
+    bool sawNonPartitionedCookieOnSubresource { false };
+    bool requestedSubresource { false };
+
+    //   (1) example.org/ serves HTML with a JS-driven (client-side) redirect
+    //       to example.com/ — this triggers a top-level cross-site navigation,
+    //       which the client treats as a process swap.
+    //   (2) The redirect target is loaded in a provisional WebProcess
+    //   (3) The Partitioned cookie is set on the first response to example.com,
+    //       which is also the response that commits the provisional page.
+    //   (4) After commit, the original WebProcess is shut down because the swap
+    //       is from a client-side redirect (so the old page is not suspended/cached).
+    //       The bug under investigation is that this termination disables
+    //       setOptInCookiePartitioningEnabled across all NetworkSessions, dropping
+    //       the partition key from in-flight tasks.
+    //   (5) A subresource on example.com/ then loads from the new (committed)
+    //       process.
+    static constexpr auto initialPageHTML =
+        "<script>window.location = \"https://example.com/\";</script>"_s;
+
+    static constexpr auto committedPageBody =
+        "<!DOCTYPE html><img src=\"https://example.com/subresource\">"_s;
+
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
+        auto request = co_await connection.awaitableReceiveHTTPRequest();
+        auto path = HTTPServer::parsePath(request);
+        request.append(0);
+        if (contains(request.span(), "Host: example.org"_span) && path == "/"_s) {
+            co_await connection.awaitableSend(HTTPResponse({ { }, initialPageHTML }).serialize());
+        } else if (contains(request.span(), "Host: example.com"_span) && path == "/"_s) {
+            co_await connection.awaitableSend(makeString(
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: text/html\r\n"
+                "Set-Cookie: testcookie=1; Path=/; Secure; SameSite=None; Max-Age=300\r\n"
+                "Set-Cookie: partitioned_cookie=p1; Path=/; Secure; SameSite=None; Partitioned; Max-Age=300\r\n"
+                "Content-Length: "_s, committedPageBody.length(), "\r\n"
+                "\r\n"_s, committedPageBody));
+        } else if (contains(request.span(), "Host: example.com"_span) && path == "/subresource"_s) {
+            sawNonPartitionedCookieOnSubresource = contains(request.span(), "testcookie=1"_span);
+            sawPartitionedCookieOnSubresource = contains(request.span(), "partitioned_cookie=p1"_span);
+            co_await connection.awaitableSend(
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: image/png\r\n"
+                "Content-Length: 0\r\n"
+                "\r\n"_s);
+            requestedSubresource = true;
+        }
+    } }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    [dataStore _setResourceLoadStatisticsEnabled:YES];
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    [viewConfiguration setWebsiteDataStore:dataStore.get()];
+
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    [delegate allowAnyTLSCertificate];
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.org/"]]];
+    Util::run(&requestedSubresource);
+
+    EXPECT_TRUE(sawNonPartitionedCookieOnSubresource);
+    EXPECT_TRUE(sawPartitionedCookieOnSubresource);
+
+    __block bool gotStoredCookies = false;
+    [[dataStore httpCookieStore] getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        bool foundPartitioned = false;
+        bool foundNonPartitioned = false;
+        for (NSHTTPCookie *cookie in cookies) {
+            if ([cookie.name isEqualToString:@"partitioned_cookie"]) {
+                foundPartitioned = true;
+                EXPECT_WK_STREQ(cookie.properties[@"StoragePartition"], @"https://example.com");
+            } else if ([cookie.name isEqualToString:@"testcookie"]) {
+                foundNonPartitioned = true;
+                EXPECT_NULL(cookie.properties[@"StoragePartition"]);
+            }
+        }
+        EXPECT_TRUE(foundPartitioned);
+        EXPECT_TRUE(foundNonPartitioned);
+        gotStoredCookies = true;
+    }];
+    Util::run(&gotStoredCookies);
+}
+#endif // ENABLE(OPT_IN_PARTITIONED_COOKIES)
+
 TEST(WKNavigation, AllowResourceLoadFromBlockedPortWithCustomScheme)
 {
     using namespace TestWebKitAPI;


### PR DESCRIPTION
#### 39679d6a6e4304b324d919d0e51d712d89e76d9b
<pre>
Partitioned cookies may not be sent on resource requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=316066">https://bugs.webkit.org/show_bug.cgi?id=316066</a>
<a href="https://rdar.apple.com/175507450">rdar://175507450</a>

Reviewed by Charlie Wolfe.

There is a problem with how we compute and synchronize across processes the
preference&apos;s state that controls whether partitioned cookies are enabled. There
is a case where we can erroneously disable partitioned cookies if we are in a
situation where we don&apos;t have any WebPageProxy, but we have an active
provisional load. That gap may result in some resource requests where a
partitioned cookie is absent.

The current behavior relies on a WebPageProxy existing. This patch resolves
that issue, and a couple others, by calling propagateSettingUpdates() when a
page is added or removed from a WebsiteDataStore, and immediately after a
network process is created.

* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::networkProcess):
(WebKit::WebsiteDataStore::addPage):
(WebKit::WebsiteDataStore::removePage):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm:
(TEST(WKNavigation, PartitionedCookieSentOnTopLevelRedirect)):
(TEST(WKNavigation, PartitionedCookieSentWhenNetworkProcessExistsBeforePage)):
(TEST(WKNavigation, PartitionedCookieAfterRedirect)):

Canonical link: <a href="https://commits.webkit.org/315043@main">https://commits.webkit.org/315043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34ddd51b89f363982e53f21dfdcf86df9d33bf3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176655 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125279 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f16aab11-81b6-4263-b567-f7e6d3753744) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130400 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91670 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2132cdc7-9411-4427-a0a0-7b9ff8334d6c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110917 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/830e28b1-355e-469b-9a53-4606c6ed3ea0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31798 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30492 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25388 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141785 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179195 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32338 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138797 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138683 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37417 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41855 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105015 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33940 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26956 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40359 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113702 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39756 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5057 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40007 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39901 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->