### PR TITLE
Fix confusing `String&&` parameter to URLPatternConstructorStringParser()

### DIFF
--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -217,7 +217,7 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
     URLPatternInit init;
 
     if (std::holds_alternative<String>(input) && !std::get<String>(input).isNull()) {
-        auto maybeInit = URLPatternConstructorStringParser(WTF::move(std::get<String>(input))).parse(context);
+        auto maybeInit = URLPatternConstructorStringParser(std::get<String>(input)).parse(context);
         if (maybeInit.hasException())
             return maybeInit.releaseException();
         init = maybeInit.releaseReturnValue();

--- a/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp
@@ -38,8 +38,8 @@
 namespace WebCore {
 using namespace JSC;
 
-URLPatternConstructorStringParser::URLPatternConstructorStringParser(String&& input)
-    : m_input(WTF::move(input))
+URLPatternConstructorStringParser::URLPatternConstructorStringParser(StringView input)
+    : m_input(input)
 {
 }
 

--- a/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.h
@@ -45,7 +45,7 @@ enum class URLPatternConstructorStringParserState : uint8_t { Init, Protocol, Au
 
 class URLPatternConstructorStringParser {
 public:
-    explicit URLPatternConstructorStringParser(String&& input);
+    explicit URLPatternConstructorStringParser(StringView input);
     ExceptionOr<URLPatternInit> parse(ScriptExecutionContext&);
 
 private:


### PR DESCRIPTION
#### b1c46d3f8e26e950472e6105ffa605a5cd04e196
<pre>
Fix confusing `String&amp;&amp;` parameter to URLPatternConstructorStringParser()
<a href="https://bugs.webkit.org/show_bug.cgi?id=316069">https://bugs.webkit.org/show_bug.cgi?id=316069</a>

Reviewed by Anne van Kesteren.

Fix confusing `String&amp;&amp;` parameter to URLPatternConstructorStringParser(),
given that ownership is not transferred and URLPatternConstructorStringParser
only holds a StringView internally.

* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::create):
* Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp:
(WebCore::URLPatternConstructorStringParser::URLPatternConstructorStringParser):
* Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.h:

Canonical link: <a href="https://commits.webkit.org/314402@main">https://commits.webkit.org/314402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87ab7911bfdf0bf9985615e616786547f0743052

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174924 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123136 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167747 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128921 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90807 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109445 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30266 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28945 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23068 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running compile-webkit") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177449 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30363 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137257 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137181 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36993 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148528 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102692 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25395 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38639 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111712 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38035 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3477 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38281 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38179 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->