### PR TITLE
URLPattern fails to accept non-BMP code points in named groups

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpatterntestdata.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpatterntestdata.json
@@ -3154,5 +3154,12 @@
         "groups": {"0": "barbaz"}
       }
     }
+  },
+  {
+    "pattern": [{ "pathname": "/:𠀀" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "𠀀": "foo" } }
+    }
   }
 ]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -366,4 +366,5 @@ PASS Pattern: ["((?R)):"] Inputs: undefined
 PASS Pattern: ["(\\H):"] Inputs: undefined
 PASS Pattern: [{"pathname":"/:foo((?<x>a))"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/foo/(bar(?<x>baz))"}] Inputs: [{"pathname":"/foo/barbaz"}]
+PASS Pattern: [{"pathname":"/:𠀀"}] Inputs: [{"pathname":"/foo"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -366,4 +366,5 @@ PASS Pattern: ["((?R)):"] Inputs: undefined
 PASS Pattern: ["(\\H):"] Inputs: undefined
 PASS Pattern: [{"pathname":"/:foo((?<x>a))"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/foo/(bar(?<x>baz))"}] Inputs: [{"pathname":"/foo/barbaz"}]
+PASS Pattern: [{"pathname":"/:𠀀"}] Inputs: [{"pathname":"/foo"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -366,4 +366,5 @@ PASS Pattern: ["((?R)):"] Inputs: undefined
 PASS Pattern: ["(\\H):"] Inputs: undefined
 PASS Pattern: [{"pathname":"/:foo((?<x>a))"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/foo/(bar(?<x>baz))"}] Inputs: [{"pathname":"/foo/barbaz"}]
+PASS Pattern: [{"pathname":"/:𠀀"}] Inputs: [{"pathname":"/foo"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -366,4 +366,5 @@ PASS Pattern: ["((?R)):"] Inputs: undefined
 PASS Pattern: ["(\\H):"] Inputs: undefined
 PASS Pattern: [{"pathname":"/:foo((?<x>a))"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/foo/(bar(?<x>baz))"}] Inputs: [{"pathname":"/foo/barbaz"}]
+PASS Pattern: [{"pathname":"/:𠀀"}] Inputs: [{"pathname":"/foo"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -366,4 +366,5 @@ PASS Pattern: ["((?R)):"] Inputs: undefined
 PASS Pattern: ["(\\H):"] Inputs: undefined
 PASS Pattern: [{"pathname":"/:foo((?<x>a))"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/foo/(bar(?<x>baz))"}] Inputs: [{"pathname":"/foo/barbaz"}]
+PASS Pattern: [{"pathname":"/:𠀀"}] Inputs: [{"pathname":"/foo"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -366,4 +366,5 @@ PASS Pattern: ["((?R)):"] Inputs: undefined
 PASS Pattern: ["(\\H):"] Inputs: undefined
 PASS Pattern: [{"pathname":"/:foo((?<x>a))"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/foo/(bar(?<x>baz))"}] Inputs: [{"pathname":"/foo/barbaz"}]
+PASS Pattern: [{"pathname":"/:𠀀"}] Inputs: [{"pathname":"/foo"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -366,4 +366,5 @@ PASS Pattern: ["((?R)):"] Inputs: undefined
 PASS Pattern: ["(\\H):"] Inputs: undefined
 PASS Pattern: [{"pathname":"/:foo((?<x>a))"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/foo/(bar(?<x>baz))"}] Inputs: [{"pathname":"/foo/barbaz"}]
+PASS Pattern: [{"pathname":"/:𠀀"}] Inputs: [{"pathname":"/foo"}]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -366,4 +366,5 @@ PASS Pattern: ["((?R)):"] Inputs: undefined
 PASS Pattern: ["(\\H):"] Inputs: undefined
 PASS Pattern: [{"pathname":"/:foo((?<x>a))"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/foo/(bar(?<x>baz))"}] Inputs: [{"pathname":"/foo/barbaz"}]
+PASS Pattern: [{"pathname":"/:𠀀"}] Inputs: [{"pathname":"/foo"}]
 

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
@@ -535,7 +535,7 @@ String escapePatternString(StringView input)
 }
 
 // https://urlpattern.spec.whatwg.org/#is-a-valid-name-code-point
-bool isValidNameCodepoint(char16_t codepoint, URLPatternUtilities::IsFirst first)
+bool isValidNameCodepoint(char32_t codepoint, URLPatternUtilities::IsFirst first)
 {
     if (first == URLPatternUtilities::IsFirst::Yes)
         return u_hasBinaryProperty(codepoint, UCHAR_ID_START) || codepoint == '_' || codepoint == '$';

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.h
@@ -97,7 +97,7 @@ ASCIILiteral convertModifierToString(Modifier);
 std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& partList, const URLPatternStringOptions&);
 String generatePatternString(const Vector<Part>& partList, const URLPatternStringOptions&);
 String escapePatternString(StringView input);
-bool isValidNameCodepoint(char16_t codepoint, URLPatternUtilities::IsFirst);
+bool isValidNameCodepoint(char32_t codepoint, URLPatternUtilities::IsFirst);
 
 
 } // namespace URLPatternUtilities


### PR DESCRIPTION
#### c6cc7c6ea52a3ff6d9b94e0d5e8353afc7473d9b
<pre>
URLPattern fails to accept non-BMP code points in named groups
<a href="https://bugs.webkit.org/show_bug.cgi?id=316067">https://bugs.webkit.org/show_bug.cgi?id=316067</a>

Reviewed by Anne van Kesteren.

isValidNameCodepoint() declared its `codepoint` parameter as char16_t,
silently narrowing supplementary-plane code points before the
ID_Start / ID_Continue check. As a result, a named group like `:𠀀`
(U+20000, a CJK Unified Ideograph that is ID_Start) was rejected by
the strict tokenizer with &quot;Name position equals name start&quot;, so
`new URLPattern({ pathname: &quot;/:𠀀&quot; })` threw TypeError instead of
producing a pattern with a `𠀀` named group. The same narrowing
affected generatePatternString()&apos;s grouping decision in two spots.

The three call sites already pass char32_t (Tokenizer::m_codepoint and
the StringView code-point iterator), so widening the parameter is the
only change needed.

This aligns our behavior with both Blink and Gecko.

No new tests, updated existing WPT test.

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpatterntestdata.json:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPatternParser.cpp:
(WebCore::URLPatternUtilities::isValidNameCodepoint):
* Source/WebCore/Modules/url-pattern/URLPatternParser.h:

Canonical link: <a href="https://commits.webkit.org/314360@main">https://commits.webkit.org/314360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c45de2b89611980d3ec136374e3fb040644480af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174941 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123153 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128936 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149050 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109463 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28961 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23085 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140250 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177474 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30380 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137279 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137205 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36967 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148544 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102711 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32489 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25411 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38656 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111729 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38053 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3493 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38298 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38196 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->