### PR TITLE
[text-wrap: balance] Not applied to content with -webkit-line-clamp: 2

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-line-clamp-1-expected.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-line-clamp-1-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<style>
+    .x1 {
+        width: 750px;
+        outline: 1px solid red;
+    }
+    .x2 {
+        font-family: "Ahem";
+        font-size: 16px;
+        text-wrap: balance;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
+    }
+    .x3 {
+        display: inline-flex;
+    }
+    .x4 {
+        width: 20px;
+        height: 20px;
+        background: red;
+    }
+</style>
+<body>
+    <div class="x1">
+        <h1 class="x2">
+            <span>Lorem ipsum dolor sit amet,<br> consectetur adipiscing.</span>
+            <span class="x3">
+                <span>
+                    <svg class="x4"></svg>
+                </span>
+            </span>
+        </h1>
+    </div>
+</body>

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-line-clamp-1.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-line-clamp-1.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<style>
+    .x1 {
+        width: 750px;
+        outline: 1px solid red;
+    }
+    .x2 {
+        font-family: "Ahem";
+        font-size: 16px;
+        text-wrap: balance;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
+    }
+    .x3 {
+        display: inline-flex;
+    }
+    .x4 {
+        width: 20px;
+        height: 20px;
+        background: red;
+    }
+</style>
+<body>
+    <div class="x1">
+        <h1 class="x2">
+            <span>Lorem ipsum dolor sit amet, consectetur adipiscing.</span>
+            <span class="x3">
+                <span>
+                    <svg class="x4"></svg>
+                </span>
+            </span>
+        </h1>
+    </div>
+</body>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -413,7 +413,6 @@ imported/w3c/web-platform-tests/css/css-text/white-space/hanging-whitespace-001.
 imported/w3c/web-platform-tests/css/css-text/word-break/word-break-break-all-062.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-text/word-break/word-break-keep-all-063.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-text/word-spacing/word-spacing-001.html [ Pass ]
-imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-line-clamp-002.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-line-clamp-005.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-line-clamp-006.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-transforms/scale-transform-overlap.html [ Pass ]

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
@@ -297,7 +297,9 @@ void InlineContentConstrainer::initialize()
 
     // Cache inline item widths after laying out all inline content with LineBuilder.
     updateCachedWidths();
-    m_numberOfLinesInOriginalLayout = lineIndex;
+    // Derive the line count from the actually-recorded lines so the line-clamp early
+    // break path does not under-count by one.
+    m_numberOfLinesInOriginalLayout = m_originalLineConstraints.size();
 
     // Do not adjust single line content.
     if (m_numberOfLinesInOriginalLayout == 1)


### PR DESCRIPTION
#### 2977b592ad531f1886d011484f62f442138f6086
<pre>
[text-wrap: balance] Not applied to content with -webkit-line-clamp: 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=316033">https://bugs.webkit.org/show_bug.cgi?id=316033</a>
<a href="https://rdar.apple.com/172715503">rdar://172715503</a>

Reviewed by Alan Baradlay.

InlineContentConstrainer is essentially disabled when
-webkit-line-clamp: 2 is applied because it causes an off-by-one
error in m_numberOfLinesInOriginalLayout.

InlineContentConstrainer::initialize() uses a greedy layout loop to
get information such as the numebr of lines used, original line widths, etc.
However, this greedy layout has an early break for line-clamp
when incrementing the line index would cause us to reach the line limit.
This would fire before lineIndex++, causing pages with webkit-line-clamp: 2
to set m_numberOfLinesInOriginalLayout to 1. This would trigger the
m_hasSingleLineVisibleContent short-circuit in computeParagraphLevelConstraints
and entirely disable balance.

Derive the count from m_originalLineConstraints.size() instead. The
Vector is appended to once per laid-out line, so its size is the
source-of-truth count regardless of how the loop exits.

Drop the glib [ Pass ] override for WPT text-wrap-balance-line-clamp-002.html
This test was passing due to the text expectation for balance being satisfied
by greedy text wrapping, which is what we fall back to when we short-circuit
computeParagraphLevelConstraints.

* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-line-clamp-1-expected.html: Added.
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-line-clamp-1.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::InlineContentConstrainer::initialize):

Canonical link: <a href="https://commits.webkit.org/314783@main">https://commits.webkit.org/314783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3609cfd883c6333d225ecbc17dcca1f41f72df3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176181 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e20f6f6d-fccb-44b3-9d0f-58f237a1d7c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129992 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41ef32e6-5476-4700-bd38-34d9512a578a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110509 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/815f4d76-79f5-4b6a-9c6c-8e6baa7ac8e7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31374 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30081 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24920 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178722 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31622 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138369 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34234 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138268 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149659 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104348 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25450 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33526 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26534 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39894 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112973 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39291 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4632 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39541 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39435 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->