### PR TITLE
Web Locks: AbortSignal abort algorithm is never removed after a lock request settles

### DIFF
--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -68,8 +68,15 @@ struct WebLockManager::LockRequest {
     WebLockMode mode { WebLockMode::Exclusive };
     RefPtr<WebLockGrantedCallback> grantedCallback;
     RefPtr<AbortSignal> signal;
+    std::optional<uint32_t> signalAlgorithmIdentifier;
 
     bool NODELETE isValid() const { return !!lockIdentifier; }
+
+    void removeSignalAlgorithm()
+    {
+        if (signal && signalAlgorithmIdentifier)
+            protect(signal)->removeAlgorithm(*signalAlgorithmIdentifier);
+    }
 };
 
 class WebLockManager::MainThreadBridge : public ThreadSafeRefCounted<MainThreadBridge, WTF::DestructionThread::Main> {
@@ -234,14 +241,15 @@ void WebLockManager::request(const String& name, Options&& options, Ref<WebLockG
     WebLockIdentifier lockIdentifier = WebLockIdentifier::generate();
     m_releasePromises.add(lockIdentifier, WTF::move(releasePromise));
 
+    std::optional<uint32_t> signalAlgorithmIdentifier;
     if (RefPtr signal = options.signal) {
-        signal->addAlgorithm([weakThis = WeakPtr { *this }, lockIdentifier](JSC::JSValue reason) mutable {
+        signalAlgorithmIdentifier = signal->addAlgorithm([weakThis = WeakPtr { *this }, lockIdentifier](JSC::JSValue reason) mutable {
             if (weakThis)
                 weakThis->signalToAbortTheRequest(lockIdentifier, reason);
         });
     }
 
-    m_pendingRequests.add(lockIdentifier, LockRequest { lockIdentifier, name, options.mode, WTF::move(grantedCallback), WTF::move(options.signal) });
+    m_pendingRequests.add(lockIdentifier, LockRequest { lockIdentifier, name, options.mode, WTF::move(grantedCallback), WTF::move(options.signal), signalAlgorithmIdentifier });
 
     m_mainThreadBridge->requestLock(lockIdentifier, name, options, [weakThis = WeakPtr { *this }, lockIdentifier](bool success) mutable {
         if (weakThis)
@@ -258,6 +266,8 @@ void WebLockManager::didCompleteLockRequest(WebLockIdentifier lockIdentifier, bo
         auto request = manager.m_pendingRequests.take(lockIdentifier);
         if (!request.isValid())
             return;
+
+        request.removeSignalAlgorithm();
 
         if (success) {
             if (request.signal && request.signal->aborted()) {
@@ -335,8 +345,10 @@ void WebLockManager::signalToAbortTheRequest(WebLockIdentifier lockIdentifier, J
     auto& request = requestsIterator->value;
 
     m_mainThreadBridge->abortLockRequest(*request.lockIdentifier, request.name, [weakThis = WeakPtr { *this }, lockIdentifier](bool wasAborted) {
-        if (wasAborted && weakThis)
-            weakThis->m_pendingRequests.remove(lockIdentifier);
+        if (wasAborted && weakThis) {
+            if (auto request = weakThis->m_pendingRequests.take(lockIdentifier); request.isValid())
+                request.removeSignalAlgorithm();
+        }
     });
     if (RefPtr releasePromise = m_releasePromises.take(lockIdentifier))
         releasePromise->reject<IDLAny>(reason);
@@ -363,6 +375,9 @@ void WebLockManager::clientIsGoingAway()
 {
     if (m_pendingRequests.isEmpty() && m_releasePromises.isEmpty())
         return;
+
+    for (auto& request : m_pendingRequests.values())
+        request.removeSignalAlgorithm();
 
     // Reject all pending promises before clearing
     for (Ref promise : m_releasePromises.values())


### PR DESCRIPTION
#### d2e1ba996937a0c34b77df58f38a891786531318
<pre>
Web Locks: AbortSignal abort algorithm is never removed after a lock request settles
<a href="https://bugs.webkit.org/show_bug.cgi?id=316072">https://bugs.webkit.org/show_bug.cgi?id=316072</a>

Reviewed by Anne van Kesteren.

When WebLockManager::request() was called with an AbortSignal, the abort
algorithm registered via AbortSignal::addAlgorithm() was never removed
once the request settled (lock granted, callback returned, or release
promise resolved). The signal would keep the algorithm — and through it
a WeakPtr to the manager — for the lifetime of the signal, and aborting
the signal long after the request had completed would still walk into
signalToAbortTheRequest() unnecessarily.

Per the Web Locks spec, the abort steps must be removed once the request
is no longer pending.

Capture the identifier returned by addAlgorithm() in LockRequest, and
call removeAlgorithm() on every path that takes the request out of
m_pendingRequests: when the request completes in didCompleteLockRequest(),
when an abort succeeds in signalToAbortTheRequest()&apos;s completion handler,
and when the client goes away.

* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::LockRequest::removeSignalAlgorithm): Added.
(WebCore::WebLockManager::request): Store the algorithm identifier
returned by AbortSignal::addAlgorithm() in the LockRequest.

(WebCore::WebLockManager::didCompleteLockRequest): Remove the abort
algorithm from the signal once the request is taken out of the pending
map.

(WebCore::WebLockManager::signalToAbortTheRequest): Remove the abort
algorithm when the abort completes successfully and the request is
removed from the pending map.

(WebCore::WebLockManager::clientIsGoingAway): Remove the abort algorithm
from each pending request before clearing the map.

Canonical link: <a href="https://commits.webkit.org/314433@main">https://commits.webkit.org/314433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09c8bcb8afada594261d48cd259dfe9c3a3dd237

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123175 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ed41ff3-b0f9-4735-b4c3-c3b233bf2b0f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128956 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90839 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3476f556-dce2-46d4-94ac-4254340f8595) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109483 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7fd14869-1c19-4142-a32b-15bcfba90b8e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30306 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28982 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23107 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177496 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30402 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137296 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37007 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148569 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102750 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25436 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111751 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38075 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3518 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38320 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38218 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->