### PR TITLE
Web Locks: request() with already-aborted signal rejects with synthetic AbortError instead of signal.reason

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.https.any-expected.txt
@@ -1,8 +1,8 @@
 
 PASS The signal option must be an AbortSignal
 PASS Passing an already aborted signal aborts
-FAIL Passing an already aborted signal rejects with the custom abort reason. promise_rejects_exactly: Rejection should give the abort reason function "function() { throw e; }" threw object "AbortError: WebLockOptions's signal is aborted" but we expected it to throw "My dog ate it."
-FAIL Passing an already aborted signal rejects with the default abort reason. promise_rejects_exactly: Rejection should give the abort reason function "function() { throw e; }" threw object "AbortError: WebLockOptions's signal is aborted" but we expected it to throw object "AbortError: The operation was aborted."
+PASS Passing an already aborted signal rejects with the custom abort reason.
+PASS Passing an already aborted signal rejects with the default abort reason.
 PASS An aborted request results in AbortError
 PASS Abort after a timeout
 PASS Signal that is not aborted

--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.https.any.serviceworker-expected.txt
@@ -1,8 +1,8 @@
 
 PASS The signal option must be an AbortSignal
 PASS Passing an already aborted signal aborts
-FAIL Passing an already aborted signal rejects with the custom abort reason. promise_rejects_exactly: Rejection should give the abort reason function "function() { throw e; }" threw object "AbortError: WebLockOptions's signal is aborted" but we expected it to throw "My dog ate it."
-FAIL Passing an already aborted signal rejects with the default abort reason. promise_rejects_exactly: Rejection should give the abort reason function "function() { throw e; }" threw object "AbortError: WebLockOptions's signal is aborted" but we expected it to throw object "AbortError: The operation was aborted."
+PASS Passing an already aborted signal rejects with the custom abort reason.
+PASS Passing an already aborted signal rejects with the default abort reason.
 PASS An aborted request results in AbortError
 PASS Abort after a timeout
 PASS Signal that is not aborted

--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.https.any.sharedworker-expected.txt
@@ -1,8 +1,8 @@
 
 PASS The signal option must be an AbortSignal
 PASS Passing an already aborted signal aborts
-FAIL Passing an already aborted signal rejects with the custom abort reason. promise_rejects_exactly: Rejection should give the abort reason function "function() { throw e; }" threw object "AbortError: WebLockOptions's signal is aborted" but we expected it to throw "My dog ate it."
-FAIL Passing an already aborted signal rejects with the default abort reason. promise_rejects_exactly: Rejection should give the abort reason function "function() { throw e; }" threw object "AbortError: WebLockOptions's signal is aborted" but we expected it to throw object "AbortError: The operation was aborted."
+PASS Passing an already aborted signal rejects with the custom abort reason.
+PASS Passing an already aborted signal rejects with the default abort reason.
 PASS An aborted request results in AbortError
 PASS Abort after a timeout
 PASS Signal that is not aborted

--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.https.any.worker-expected.txt
@@ -1,8 +1,8 @@
 
 PASS The signal option must be an AbortSignal
 PASS Passing an already aborted signal aborts
-FAIL Passing an already aborted signal rejects with the custom abort reason. promise_rejects_exactly: Rejection should give the abort reason function "function() { throw e; }" threw object "AbortError: WebLockOptions's signal is aborted" but we expected it to throw "My dog ate it."
-FAIL Passing an already aborted signal rejects with the default abort reason. promise_rejects_exactly: Rejection should give the abort reason function "function() { throw e; }" threw object "AbortError: WebLockOptions's signal is aborted" but we expected it to throw object "AbortError: The operation was aborted."
+PASS Passing an already aborted signal rejects with the custom abort reason.
+PASS Passing an already aborted signal rejects with the default abort reason.
 PASS An aborted request results in AbortError
 PASS Abort after a timeout
 PASS Signal that is not aborted

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -33,6 +33,7 @@
 #include "JSDOMConvertDictionary.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "JSWebLockManagerSnapshot.h"
 #include "NavigatorBase.h"
 #include "Page.h"
@@ -226,7 +227,7 @@ void WebLockManager::request(const String& name, Options&& options, Ref<WebLockG
     }
 
     if (options.signal && options.signal->aborted()) {
-        releasePromise->reject(ExceptionCode::AbortError, "WebLockOptions's signal is aborted"_s);
+        releasePromise->reject<IDLAny>(options.signal->reason().getValue());
         return;
     }
 


### PR DESCRIPTION
#### a8c1d272ba0a7f06ea3cbce59998bde33b206056
<pre>
Web Locks: request() with already-aborted signal rejects with synthetic AbortError instead of signal.reason
<a href="https://bugs.webkit.org/show_bug.cgi?id=316073">https://bugs.webkit.org/show_bug.cgi?id=316073</a>

Reviewed by Anne van Kesteren.

When navigator.locks.request() is called with an AbortSignal that is
already aborted, the spec requires the returned promise to be rejected
with the signal&apos;s abort reason (per &quot;Request a lock&quot;, step 8). WebKit
was instead rejecting with a synthesized AbortError DOMException whose
message was &quot;WebLockOptions&apos;s signal is aborted&quot;, losing the caller&apos;s
custom abort reason and producing a different rejection value than the
default AbortError the platform already attaches to the signal.

The analogous &quot;abort while pending&quot; path (signalToAbortTheRequest) was
already correct: it forwards the reason JSValue via reject&lt;IDLAny&gt;().
Apply the same treatment here.

This makes the following web-platform-tests pass:
* web-locks/signal.https.any.html: Passing an already aborted signal
  rejects with the custom abort reason.
* web-locks/signal.https.any.html: Passing an already aborted signal
  rejects with the default abort reason.
  (plus the worker, sharedworker, and serviceworker variants).

* LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.https.any.worker-expected.txt:
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::request):

Canonical link: <a href="https://commits.webkit.org/314404@main">https://commits.webkit.org/314404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76b8a2874412ce13027236320010385f6dc9884b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174934 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123146 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128930 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90814 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8dec990-a37e-4421-8837-955b4f118564) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109457 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30274 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28954 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23078 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177466 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30373 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137268 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137195 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36992 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148539 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102702 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25406 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38649 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111722 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38045 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3488 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38291 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38189 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->