### PR TITLE
REGRESSION (313513@main): Web content is clipped out of right obscured content inset area

### DIFF
--- a/LayoutTests/compositing/geometry/frame-clipping-layer-with-bottom-right-inset-expected.txt
+++ b/LayoutTests/compositing/geometry/frame-clipping-layer-with-bottom-right-inset-expected.txt
@@ -1,5 +1,7 @@
+Layer tree when scrolled to top left
+
 (GraphicsLayer
-  (children 3
+  (children 5
     (GraphicsLayer
       (anchor 0.00 0.00)
       (bounds 800.00 600.00)
@@ -7,7 +9,7 @@
     )
     (GraphicsLayer
       (anchor 0.00 0.00)
-      (bounds 735.00 550.00)
+      (bounds 785.00 585.00)
       (clips 1)
       (children 1
         (GraphicsLayer
@@ -15,10 +17,10 @@
           (children 1
             (GraphicsLayer
               (anchor 0.00 0.00)
-              (bounds 735.00 2000.00)
+              (bounds 2000.00 2000.00)
               (children 1
                 (GraphicsLayer
-                  (bounds 735.00 2000.00)
+                  (bounds 2000.00 2000.00)
                   (contentsOpaque 1)
                   (children 1
                     (GraphicsLayer
@@ -34,8 +36,183 @@
       )
     )
     (GraphicsLayer
-      (position 735.00 0.00)
-      (bounds 15.00 550.00)
+      (position 745.00 0.00)
+      (bounds 15.00 535.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 0.00 535.00)
+      (bounds 745.00 15.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 745.00 535.00)
+      (bounds 15.00 15.00)
+      (drawsContent 1)
+    )
+  )
+)
+Layer tree when scrolled to top right
+
+(GraphicsLayer
+  (children 5
+    (GraphicsLayer
+      (anchor 0.00 0.00)
+      (bounds 800.00 600.00)
+      (backgroundColor #FFFFFF)
+    )
+    (GraphicsLayer
+      (anchor 0.00 0.00)
+      (bounds 745.00 585.00)
+      (clips 1)
+      (children 1
+        (GraphicsLayer
+          (position -1255.00 0.00)
+          (anchor 0.00 0.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (bounds 2000.00 2000.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 2000.00 2000.00)
+                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (GraphicsLayer
+      (position 745.00 0.00)
+      (bounds 15.00 535.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 0.00 535.00)
+      (bounds 745.00 15.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 745.00 535.00)
+      (bounds 15.00 15.00)
+      (drawsContent 1)
+    )
+  )
+)
+Layer tree when scrolled to bottom left
+
+(GraphicsLayer
+  (children 5
+    (GraphicsLayer
+      (anchor 0.00 0.00)
+      (bounds 800.00 600.00)
+      (backgroundColor #FFFFFF)
+    )
+    (GraphicsLayer
+      (anchor 0.00 0.00)
+      (bounds 785.00 535.00)
+      (clips 1)
+      (children 1
+        (GraphicsLayer
+          (position 0.00 -1465.00)
+          (anchor 0.00 0.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (bounds 2000.00 2000.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 2000.00 2000.00)
+                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (GraphicsLayer
+      (position 745.00 0.00)
+      (bounds 15.00 535.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 0.00 535.00)
+      (bounds 745.00 15.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 745.00 535.00)
+      (bounds 15.00 15.00)
+      (drawsContent 1)
+    )
+  )
+)
+Layer tree when scrolled to bottom right
+
+(GraphicsLayer
+  (children 5
+    (GraphicsLayer
+      (anchor 0.00 0.00)
+      (bounds 800.00 600.00)
+      (backgroundColor #FFFFFF)
+    )
+    (GraphicsLayer
+      (anchor 0.00 0.00)
+      (bounds 745.00 535.00)
+      (clips 1)
+      (children 1
+        (GraphicsLayer
+          (position -1255.00 -1465.00)
+          (anchor 0.00 0.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (bounds 2000.00 2000.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 2000.00 2000.00)
+                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (GraphicsLayer
+      (position 745.00 0.00)
+      (bounds 15.00 535.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 0.00 535.00)
+      (bounds 745.00 15.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 745.00 535.00)
+      (bounds 15.00 15.00)
       (drawsContent 1)
     )
   )

--- a/LayoutTests/compositing/geometry/frame-clipping-layer-with-bottom-right-inset.html
+++ b/LayoutTests/compositing/geometry/frame-clipping-layer-with-bottom-right-inset.html
@@ -4,6 +4,7 @@
 <style>
     body {
         height: 2000px;
+        width: 2000px;
         margin: 0;
     }
 
@@ -20,12 +21,38 @@
         testRunner.waitUntilDone();
     }
 
+    function addLayerTreeText(header, layerTreeText) {
+        document.body.insertAdjacentHTML("beforeend", `
+        <div>
+            <h1>${header}</h1>
+            <pre>${layerTreeText}</pre>
+        </div>
+        `);
+    }
+
     async function doTest()
     {
-        await testRunner.setObscuredContentInsets(0, 50, 50, 0);
+        await testRunner.setObscuredContentInsets(0, 40, 50, 0);
         await testRunner.updatePresentation();
+        const topLeftLayerTree = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_ROOT_LAYERS | internals.LAYER_TREE_INCLUDES_CLIPPING);
 
-        document.getElementById("layerTree").innerText = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_ROOT_LAYERS | internals.LAYER_TREE_INCLUDES_CLIPPING);
+        window.scrollTo(document.body.scrollWidth, 0);
+        await testRunner.updatePresentation();
+        const topRightLayerTree = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_ROOT_LAYERS | internals.LAYER_TREE_INCLUDES_CLIPPING);
+
+        window.scrollTo(0, document.body.scrollHeight);
+        await testRunner.updatePresentation();
+        const bottomLeftLayerTree = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_ROOT_LAYERS | internals.LAYER_TREE_INCLUDES_CLIPPING);
+
+        window.scrollTo(document.body.scrollWidth, document.body.scrollHeight);
+        await testRunner.updatePresentation();
+        const bottomRightLayerTree = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_ROOT_LAYERS | internals.LAYER_TREE_INCLUDES_CLIPPING);
+
+        addLayerTreeText("Layer tree when scrolled to top left", topLeftLayerTree);
+        addLayerTreeText("Layer tree when scrolled to top right", topRightLayerTree);
+        addLayerTreeText("Layer tree when scrolled to bottom left", bottomLeftLayerTree);
+        addLayerTreeText("Layer tree when scrolled to bottom right", bottomRightLayerTree);
+
         testRunner.notifyDone();
     }
 
@@ -34,6 +61,5 @@
 </head>
 <body>
 <div class="composited"></div>
-<pre id="layerTree"></pre>
 </body>
 </html>

--- a/LayoutTests/compositing/geometry/frame-clipping-layer-with-top-left-inset-expected.txt
+++ b/LayoutTests/compositing/geometry/frame-clipping-layer-with-top-left-inset-expected.txt
@@ -1,15 +1,17 @@
+Layer tree when scrolled to top left
+
 (GraphicsLayer
-  (children 3
+  (children 5
     (GraphicsLayer
-      (position 50.00 50.00)
+      (position 50.00 40.00)
       (anchor 0.00 0.00)
-      (bounds 750.00 550.00)
+      (bounds 750.00 560.00)
       (backgroundColor #FFFFFF)
     )
     (GraphicsLayer
-      (position 50.00 50.00)
+      (position 50.00 40.00)
       (anchor 0.00 0.00)
-      (bounds 735.00 550.00)
+      (bounds 735.00 545.00)
       (clips 1)
       (children 1
         (GraphicsLayer
@@ -17,10 +19,10 @@
           (children 1
             (GraphicsLayer
               (anchor 0.00 0.00)
-              (bounds 735.00 2000.00)
+              (bounds 2000.00 2000.00)
               (children 1
                 (GraphicsLayer
-                  (bounds 735.00 2000.00)
+                  (bounds 2000.00 2000.00)
                   (contentsOpaque 1)
                   (children 1
                     (GraphicsLayer
@@ -36,8 +38,191 @@
       )
     )
     (GraphicsLayer
-      (position 785.00 50.00)
-      (bounds 15.00 550.00)
+      (position 785.00 40.00)
+      (bounds 15.00 545.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 50.00 585.00)
+      (bounds 735.00 15.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 785.00 585.00)
+      (bounds 15.00 15.00)
+      (drawsContent 1)
+    )
+  )
+)
+Layer tree when scrolled to top right
+
+(GraphicsLayer
+  (children 5
+    (GraphicsLayer
+      (position 50.00 40.00)
+      (anchor 0.00 0.00)
+      (bounds 750.00 560.00)
+      (backgroundColor #FFFFFF)
+    )
+    (GraphicsLayer
+      (position 0.00 40.00)
+      (anchor 0.00 0.00)
+      (bounds 785.00 545.00)
+      (clips 1)
+      (children 1
+        (GraphicsLayer
+          (position -1265.00 0.00)
+          (anchor 0.00 0.00)
+          (children 1
+            (GraphicsLayer
+              (position 50.00 0.00)
+              (anchor 0.00 0.00)
+              (bounds 2000.00 2000.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 2000.00 2000.00)
+                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (GraphicsLayer
+      (position 785.00 40.00)
+      (bounds 15.00 545.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 50.00 585.00)
+      (bounds 735.00 15.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 785.00 585.00)
+      (bounds 15.00 15.00)
+      (drawsContent 1)
+    )
+  )
+)
+Layer tree when scrolled to bottom left
+
+(GraphicsLayer
+  (children 5
+    (GraphicsLayer
+      (position 50.00 40.00)
+      (anchor 0.00 0.00)
+      (bounds 750.00 560.00)
+      (backgroundColor #FFFFFF)
+    )
+    (GraphicsLayer
+      (position 50.00 0.00)
+      (anchor 0.00 0.00)
+      (bounds 735.00 585.00)
+      (clips 1)
+      (children 1
+        (GraphicsLayer
+          (position 0.00 -1455.00)
+          (anchor 0.00 0.00)
+          (children 1
+            (GraphicsLayer
+              (position 0.00 40.00)
+              (anchor 0.00 0.00)
+              (bounds 2000.00 2000.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 2000.00 2000.00)
+                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (GraphicsLayer
+      (position 785.00 40.00)
+      (bounds 15.00 545.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 50.00 585.00)
+      (bounds 735.00 15.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 785.00 585.00)
+      (bounds 15.00 15.00)
+      (drawsContent 1)
+    )
+  )
+)
+Layer tree when scrolled to bottom right
+
+(GraphicsLayer
+  (children 5
+    (GraphicsLayer
+      (position 50.00 40.00)
+      (anchor 0.00 0.00)
+      (bounds 750.00 560.00)
+      (backgroundColor #FFFFFF)
+    )
+    (GraphicsLayer
+      (anchor 0.00 0.00)
+      (bounds 785.00 585.00)
+      (clips 1)
+      (children 1
+        (GraphicsLayer
+          (position -1265.00 -1455.00)
+          (anchor 0.00 0.00)
+          (children 1
+            (GraphicsLayer
+              (position 50.00 40.00)
+              (anchor 0.00 0.00)
+              (bounds 2000.00 2000.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 2000.00 2000.00)
+                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (GraphicsLayer
+      (position 785.00 40.00)
+      (bounds 15.00 545.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 50.00 585.00)
+      (bounds 735.00 15.00)
+      (drawsContent 1)
+    )
+    (GraphicsLayer
+      (position 785.00 585.00)
+      (bounds 15.00 15.00)
       (drawsContent 1)
     )
   )

--- a/LayoutTests/compositing/geometry/frame-clipping-layer-with-top-left-inset.html
+++ b/LayoutTests/compositing/geometry/frame-clipping-layer-with-top-left-inset.html
@@ -4,6 +4,7 @@
 <style>
     body {
         height: 2000px;
+        width: 2000px;
         margin: 0;
     }
 
@@ -20,12 +21,38 @@
         testRunner.waitUntilDone();
     }
 
+    function addLayerTreeText(header, layerTreeText) {
+        document.body.insertAdjacentHTML("beforeend", `
+        <div>
+            <h1>${header}</h1>
+            <pre>${layerTreeText}</pre>
+        </div>
+        `);
+    }
+
     async function doTest()
     {
-        await testRunner.setObscuredContentInsets(50, 0, 0, 50);
+        await testRunner.setObscuredContentInsets(40, 0, 0, 50);
         await testRunner.updatePresentation();
+        const topLeftLayerTree = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_ROOT_LAYERS | internals.LAYER_TREE_INCLUDES_CLIPPING);
 
-        document.getElementById("layerTree").innerText = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_ROOT_LAYERS | internals.LAYER_TREE_INCLUDES_CLIPPING);
+        window.scrollTo(document.body.scrollWidth, 0);
+        await testRunner.updatePresentation();
+        const topRightLayerTree = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_ROOT_LAYERS | internals.LAYER_TREE_INCLUDES_CLIPPING);
+
+        window.scrollTo(0, document.body.scrollHeight);
+        await testRunner.updatePresentation();
+        const bottomLeftLayerTree = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_ROOT_LAYERS | internals.LAYER_TREE_INCLUDES_CLIPPING);
+
+        window.scrollTo(document.body.scrollWidth, document.body.scrollHeight);
+        await testRunner.updatePresentation();
+        const bottomRightLayerTree = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_ROOT_LAYERS | internals.LAYER_TREE_INCLUDES_CLIPPING);
+
+        addLayerTreeText("Layer tree when scrolled to top left", topLeftLayerTree);
+        addLayerTreeText("Layer tree when scrolled to top right", topRightLayerTree);
+        addLayerTreeText("Layer tree when scrolled to bottom left", bottomLeftLayerTree);
+        addLayerTreeText("Layer tree when scrolled to bottom right", bottomRightLayerTree);
+
         testRunner.notifyDone();
     }
 
@@ -34,6 +61,5 @@
 </head>
 <body>
 <div class="composited"></div>
-<pre id="layerTree"></pre>
 </body>
 </html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2670,7 +2670,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
     return { WTF::move(edges), WTF::move(containers) };
 }
 
-FloatRect LocalFrameView::insetClipLayerRect(const FloatPoint& scrollPosition, const FloatBoxExtent& obscuredContentInset, const FloatSize& sizeForVisibleContent)
+FloatRect LocalFrameView::insetClipLayerRect(const FloatPoint& scrollPosition, const FloatSize& totalContentsSize, const FloatBoxExtent& obscuredContentInset, const FloatSize& sizeForVisibleContent)
 {
     auto computeOffset = [](float scrollAmount, float insetAmount) {
         if (!insetAmount)
@@ -2690,14 +2690,26 @@ FloatRect LocalFrameView::insetClipLayerRect(const FloatPoint& scrollPosition, c
     if (obscuredContentInset.top())
         adjustedSize.setHeight(std::max(0.f, adjustedSize.height() - position.y()));
 
-    if (obscuredContentInset.bottom())
-        adjustedSize.setHeight(std::max(0.f, adjustedSize.height() - obscuredContentInset.bottom()));
+    if (obscuredContentInset.bottom()) {
+        float visibleContentTop = std::max(0.f, scrollPosition.y());
+        float visibleContentBottom = visibleContentTop + sizeForVisibleContent.height();
+        // How much of the visible content rect eats into the bottom obscured content inset area.
+        float obscuredInsetOverlap = std::max(0.f, visibleContentBottom - (obscuredContentInset.top() + totalContentsSize.height()));
+
+        adjustedSize.setHeight(std::max(0.f, adjustedSize.height() - obscuredInsetOverlap));
+    }
 
     if (obscuredContentInset.left())
         adjustedSize.setWidth(std::max(0.f, adjustedSize.width() - position.x()));
 
-    if (obscuredContentInset.right())
-        adjustedSize.setWidth(std::max(0.f, adjustedSize.width() - obscuredContentInset.right()));
+    if (obscuredContentInset.right()) {
+        float visibleContentLeft = std::max(0.f, scrollPosition.x());
+        float visibleContentRight = visibleContentLeft + sizeForVisibleContent.width();
+        // How much of the visible content rect eats into the right obscured content inset area.
+        float obscureInsetOverlap = std::max(0.f, visibleContentRight - (obscuredContentInset.left() + totalContentsSize.width()));
+
+        adjustedSize.setWidth(std::max(0.f, adjustedSize.width() - obscureInsetOverlap));
+    }
 
     return { position, adjustedSize };
 }

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -381,7 +381,8 @@ public:
 
     // These layers are positioned differently when there are obscured content insets, a header, or a footer.
     // These value need to be computed on both the main thread and the scrolling thread.
-    static FloatRect insetClipLayerRect(const FloatPoint& scrollPosition, const FloatBoxExtent& obscuredContentInsets, const FloatSize& sizeForVisibleContent);
+    // FIXME (webkit.org/b/316233): this function should take scrollOffset instead of scrollPosition.
+    static FloatRect insetClipLayerRect(const FloatPoint& scrollPosition, const FloatSize& totalContentsSize, const FloatBoxExtent& obscuredContentInsets, const FloatSize& sizeForVisibleContent);
     WEBCORE_EXPORT static FloatPoint positionForRootContentLayer(const FloatPoint& scrollPosition, const FloatPoint& scrollOrigin, const FloatBoxExtent& obscuredContentInsets, float headerHeight);
     WEBCORE_EXPORT FloatPoint positionForRootContentLayer() const;
 

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -910,7 +910,7 @@ void AsyncScrollingCoordinator::reconcileScrollingState(LocalFrameView& frameVie
 
     FloatRect insetClipLayerRect;
     if (insetClipLayer) {
-        insetClipLayerRect = LocalFrameView::insetClipLayerRect(scrollPosition, obscuredContentInsets, frameView.sizeForVisibleContent());
+        insetClipLayerRect = LocalFrameView::insetClipLayerRect(scrollPosition, frameView.totalContentsSize(), obscuredContentInsets, frameView.sizeForVisibleContent());
         insetClipLayerRect.move(frameView.insetForLeftScrollbarSpace(), 0);
         insetClipLayer->setSize(insetClipLayerRect.size());
     }

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp
@@ -132,7 +132,7 @@ void ScrollingTreeFrameScrollingNodeCoordinated::repositionRelatedLayers()
         FloatPoint insetClipPosition;
         {
             Locker locker { m_insetClipLayer->lock() };
-            insetClipPosition = LocalFrameView::insetClipLayerRect(scrollPosition, contentInsets, sizeForVisibleContent()).location();
+            insetClipPosition = LocalFrameView::insetClipLayerRect(scrollPosition, totalContentsSize(), contentInsets, sizeForVisibleContent()).location();
         }
         m_insetClipLayer->setPositionForScrolling(insetClipPosition);
         auto rootContentsPosition = LocalFrameView::positionForRootContentLayer(scrollPosition, scrollOrigin(), contentInsets, headerHeight());

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -216,7 +216,7 @@ void ScrollingTreeFrameScrollingNodeMac::repositionRelatedLayers()
 
     auto obscuredContentInsets = this->obscuredContentInsets();
     if (m_insetClipLayer && m_rootContentsLayer) {
-        auto insetClipLayerRect = LocalFrameView::insetClipLayerRect(scrollPosition, obscuredContentInsets, sizeForVisibleContent());
+        auto insetClipLayerRect = LocalFrameView::insetClipLayerRect(scrollPosition, totalContentsSize(), obscuredContentInsets, sizeForVisibleContent());
         [m_insetClipLayer setPosition:[&] {
             auto position = insetClipLayerRect.location();
             if (!obscuredContentInsets.left())

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2875,7 +2875,7 @@ FloatRect RenderLayerCompositor::insetClipLayerRect() const
 {
     Ref frameView = m_renderView.frameView();
 
-    auto insetClipLayerRect = LocalFrameView::insetClipLayerRect(frameView->scrollPosition(), frameView->obscuredContentInsets(), frameView->sizeForVisibleContent());
+    auto insetClipLayerRect = LocalFrameView::insetClipLayerRect(frameView->scrollPosition(), frameView->totalContentsSize(), frameView->obscuredContentInsets(), frameView->sizeForVisibleContent());
     insetClipLayerRect.move(frameView->insetForLeftScrollbarSpace(), 0);
     return insetClipLayerRect;
 }


### PR DESCRIPTION
#### 3902d9f8c4a790d2754245c7aeb4abd4611525df
<pre>
REGRESSION (313513@main): Web content is clipped out of right obscured content inset area
<a href="https://rdar.apple.com/177728093">rdar://177728093</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316078">https://bugs.webkit.org/show_bug.cgi?id=316078</a>

Reviewed by Lily Spiniolas and Simon Fraser.

LocalFrameView::insetClipLayerRect treats the top/left obscured content insets as expanding
the content area outwards, which is correct, and it should treat the bottom/right insets
similarly. Instead it treats them as narrowing the visible content area. This leads to the
clip layer clipping out the bottom/right obscured content inset area.

When Safari is in RTL mode with its sidebar opened from the right, there&apos;s a right obscured
content inset for it. If the page can scroll horizontally, part of the page should be shown
under the partially transparent side bar. But the clip layer clips out the right obscured
content inset area (area under the side bar) and nothing gets shown.

Fix this by treating the bottom/right insets as expanding the content area outwards
like top/left insets.

Test: compositing/geometry/frame-clipping-layer-with-bottom-right-inset.html
      compositing/geometry/frame-clipping-layer-with-top-left-inset.html

* LayoutTests/compositing/geometry/frame-clipping-layer-with-bottom-right-inset-expected.txt:
* LayoutTests/compositing/geometry/frame-clipping-layer-with-bottom-right-inset.html:
    - Give bottom/right insets different values to ensure we don&apos;t mix them up.
    - Add more cases at different scroll positions (top left, top right, bottom left,
      bottom right.) Print out the layer tree at each position.

* LayoutTests/compositing/geometry/frame-clipping-layer-with-top-left-inset-expected.txt:
* LayoutTests/compositing/geometry/frame-clipping-layer-with-top-left-inset.html:
    - Same changes as compositing/geometry/frame-clipping-layer-with-bottom-right-inset.html.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::insetClipLayerRect):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::reconcileScrollingState):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp:
(WebCore::ScrollingTreeFrameScrollingNodeCoordinated::repositionRelatedLayers):
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
(WebCore::ScrollingTreeFrameScrollingNodeMac::repositionRelatedLayers):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::insetClipLayerRect const):

Canonical link: <a href="https://commits.webkit.org/314526@main">https://commits.webkit.org/314526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bf125a5e5ec1e67e6f9334494a727e385bf156a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123593 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129296 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/70a32af2-bc3d-4996-90f4-60d8cdae4890) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109821 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30657 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29357 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23526 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177918 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30820 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137654 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137576 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37073 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148949 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103232 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25815 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39096 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112171 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38493 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3901 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38738 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38636 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->