### PR TITLE
[WebXR Layers] Lots of flickering rendering https://threejs.org/examples/?q=layers#webgpu_xr_native_layers

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
@@ -50,11 +50,10 @@ WebXRWebGLSwapchain::WebXRWebGLSwapchain(WebGLRenderingContextBase& context, Swa
         m_framebufferForClearing = m_context->createFramebuffer();
 }
 
-void WebXRWebGLSwapchain::clearTextureLayers(GraphicsContextGL& gl, uint32_t layerCount, NOESCAPE const BindAttachmentFunction& bindAttachment)
+void WebXRWebGLSwapchain::clearAttachmentRegion(GraphicsContextGL& gl, const IntRect& viewport, NOESCAPE const BindAttachmentFunction& bindAttachment)
 {
     ASSERT(m_context);
     ASSERT(m_framebufferForClearing);
-    ASSERT(layerCount >= 1);
 
     GCGLenum clearMask = 0;
     if (m_targetFlags.contains(SwapchainTargetFlags::Color))
@@ -77,20 +76,19 @@ void WebXRWebGLSwapchain::clearTextureLayers(GraphicsContextGL& gl, uint32_t lay
     ScopedWebGLRestoreFramebuffer restoreFramebuffer { *m_context };
     ScopedDisableRasterizerDiscard disableRasterizerDiscard { *m_context };
     ScopedEnableBackbuffer enableBackBuffer { *m_context };
-    ScopedDisableScissorTest disableScissorTest { *m_context };
+    ScopedScissorTestForRegion scopedScissor { *m_context, viewport };
     ScopedClearColorAndMask zeroClear { *m_context, 0.f, 0.f, 0.f, 0.f, true, true, true, true };
     ScopedClearDepthAndMask zeroDepth { *m_context, 1.0f, true, m_targetFlags.contains(SwapchainTargetFlags::Depth) };
     ScopedClearStencilAndMask zeroStencil { *m_context, 0, 0xFFFFFFFF, m_targetFlags.contains(SwapchainTargetFlags::Stencil) };
 
     gl.bindFramebuffer(GL::FRAMEBUFFER, m_framebufferForClearing->object());
-    for (GCGLint layer = 0; layer < static_cast<GCGLint>(layerCount); ++layer) {
-        bindAttachment(attachment, layer);
-        gl.clear(clearMask);
-    }
+    bindAttachment(attachment);
+    gl.clear(clearMask);
 }
 
-void WebXRWebGLSwapchain::clearCurrentTexture(GraphicsContextGL& gl)
+void WebXRWebGLSwapchain::clearTextureRegion(GraphicsContextGL& gl, const IntRect& viewport, std::optional<GCGLint> slice)
 {
+    UNUSED_PARAM(slice);
     if (!m_framebufferForClearing)
         return;
 
@@ -98,7 +96,7 @@ void WebXRWebGLSwapchain::clearCurrentTexture(GraphicsContextGL& gl)
     if (!texture)
         return;
 
-    clearTextureLayers(gl, 1, [&](GCGLenum attachment, GCGLint) {
+    clearAttachmentRegion(gl, viewport, [&](GCGLenum attachment) {
         gl.framebufferTexture2D(GL::FRAMEBUFFER, attachment, GL::TEXTURE_2D, texture, 0);
     });
 }
@@ -122,6 +120,16 @@ void WebXRWebGLSwapchain::setupExternalImage(const PlatformXR::FrameData::LayerS
     auto rightPhysicalSize = toIntSize(data.physicalSize[1]);
 
     m_texSize = calcImagePhysicalSize(leftPhysicalSize, rightPhysicalSize);
+}
+
+void WebXRWebGLSwapchain::clearTextureIfNeeded(const IntRect& viewport, std::optional<GCGLint> slice)
+{
+    if (!m_clearOnAccess)
+        return;
+    RefPtr gl = m_context->graphicsContextGL();
+    if (!gl)
+        return;
+    clearTextureRegion(*gl, viewport, slice);
 }
 
 void WebXRWebGLSwapchain::signalEndFrame(GraphicsContextGL& gl, PlatformXR::DeviceLayer& layerData)
@@ -289,9 +297,6 @@ void WebXRWebGLSharedImageSwapchain::startFrame(PlatformXR::FrameData::LayerData
         setupExternalImage(*data.layerSetup);
 
     bindCompositorTexturesForDisplay(*gl, data);
-
-    if (m_clearOnAccess)
-        clearCurrentTexture(*gl);
 }
 
 void WebXRWebGLSharedImageSwapchain::endFrame(PlatformXR::DeviceLayer& layerData)
@@ -394,10 +399,10 @@ void WebXRWebGLStaticImageSwapchain::bindCompositorTexturesForDisplay(GraphicsCo
     m_textures[m_currentImageIndex] = texture;
 }
 
-void WebXRWebGLStaticImageSwapchain::clearCurrentTexture(GraphicsContextGL& gl)
+void WebXRWebGLStaticImageSwapchain::clearTextureRegion(GraphicsContextGL& gl, const IntRect& viewport, std::optional<GCGLint> slice)
 {
     if (m_imageAttributes.textureType != GL::TEXTURE_2D_ARRAY) {
-        WebXRWebGLSwapchain::clearCurrentTexture(gl);
+        WebXRWebGLSwapchain::clearTextureRegion(gl, viewport, slice);
         return;
     }
 
@@ -408,8 +413,9 @@ void WebXRWebGLStaticImageSwapchain::clearCurrentTexture(GraphicsContextGL& gl)
     if (!texture)
         return;
 
-    clearTextureLayers(gl, m_imageAttributes.arrayLength, [&](GCGLenum attachment, GCGLint layer) {
-        gl.framebufferTextureLayer(GL::FRAMEBUFFER, attachment, texture, 0, layer);
+    ASSERT(slice);
+    clearAttachmentRegion(gl, viewport, [&](GCGLenum attachment) {
+        gl.framebufferTextureLayer(GL::FRAMEBUFFER, attachment, texture, 0, *slice);
     });
 }
 
@@ -420,9 +426,6 @@ void WebXRWebGLStaticImageSwapchain::startFrame(PlatformXR::FrameData::LayerData
         return;
 
     bindCompositorTexturesForDisplay(*gl, data);
-
-    if (m_clearOnAccess)
-        clearCurrentTexture(*gl);
 }
 
 void WebXRWebGLStaticImageSwapchain::endFrame(PlatformXR::DeviceLayer&)
@@ -588,7 +591,7 @@ void WebXRWebGLTextureArraySwapchain::blitTextureArrayToSharedImage(GraphicsCont
     gl.bindFramebuffer(GL::FRAMEBUFFER, 0);
 }
 
-void WebXRWebGLTextureArraySwapchain::clearCurrentTexture(GraphicsContextGL& gl)
+void WebXRWebGLTextureArraySwapchain::clearTextureRegion(GraphicsContextGL& gl, const IntRect& viewport, std::optional<GCGLint> slice)
 {
     if (!m_framebufferForClearing)
         return;
@@ -597,8 +600,9 @@ void WebXRWebGLTextureArraySwapchain::clearCurrentTexture(GraphicsContextGL& gl)
     if (!texture)
         return;
 
-    clearTextureLayers(gl, m_arrayLength, [&](GCGLenum attachment, GCGLint layer) {
-        gl.framebufferTextureLayer(GL::FRAMEBUFFER, attachment, texture, 0, layer);
+    ASSERT(slice);
+    clearAttachmentRegion(gl, viewport, [&](GCGLenum attachment) {
+        gl.framebufferTextureLayer(GL::FRAMEBUFFER, attachment, texture, 0, *slice);
     });
 }
 
@@ -612,9 +616,6 @@ void WebXRWebGLTextureArraySwapchain::startFrame(PlatformXR::FrameData::LayerDat
         setupExternalImage(*data.layerSetup);
 
     bindCompositorTexturesForDisplay(*gl, data);
-
-    if (m_clearOnAccess)
-        clearCurrentTexture(*gl);
 }
 
 void WebXRWebGLTextureArraySwapchain::endFrame(PlatformXR::DeviceLayer& layerData)

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
@@ -38,6 +38,7 @@
 
 namespace WebCore {
 
+class IntRect;
 class IntSize;
 class WebGLFramebuffer;
 class WebGLOpaqueTexture;
@@ -92,12 +93,14 @@ public:
 
     virtual GCGLenum textureTarget() const { return GraphicsContextGL::TEXTURE_2D; }
 
+    void clearTextureIfNeeded(const IntRect& viewport, std::optional<GCGLint> slice);
+
 protected:
     WebXRWebGLSwapchain(WebGLRenderingContextBase&, SwapchainTargets, bool clearOnAccess, size_t imageCount);
-    virtual void clearCurrentTexture(GraphicsContextGL&);
+    virtual void clearTextureRegion(GraphicsContextGL&, const IntRect& viewport, std::optional<GCGLint> slice);
 
-    using BindAttachmentFunction = Function<void(GCGLenum attachment, GCGLint layer)>;
-    void clearTextureLayers(GraphicsContextGL&, uint32_t layerCount, NOESCAPE const BindAttachmentFunction&);
+    using BindAttachmentFunction = Function<void(GCGLenum attachment)>;
+    void clearAttachmentRegion(GraphicsContextGL&, const IntRect& viewport, NOESCAPE const BindAttachmentFunction&);
 
     void setupExternalImage(const PlatformXR::FrameData::LayerSetupData&);
     void signalEndFrame(GraphicsContextGL&, PlatformXR::DeviceLayer&);
@@ -174,7 +177,7 @@ private:
     WebXRWebGLStaticImageSwapchain(WebGLRenderingContextBase&, StaticImageAttributes);
     void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&);
     void releaseDisplayImagesAtIndex(size_t);
-    void clearCurrentTexture(GraphicsContextGL&) override;
+    void clearTextureRegion(GraphicsContextGL&, const IntRect& viewport, std::optional<GCGLint> slice) override;
 
     StaticImageAttributes m_imageAttributes;
 #if USE(OPENXR)
@@ -215,7 +218,7 @@ private:
 
     WebXRWebGLTextureArraySwapchain(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength);
 
-    void clearCurrentTexture(GraphicsContextGL&) override;
+    void clearTextureRegion(GraphicsContextGL&, const IntRect& viewport, std::optional<GCGLint> slice) override;
     void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&);
     void blitTextureArrayToSharedImage(GraphicsContextGL&);
     void releaseTexturesAtIndex(size_t);

--- a/Source/WebCore/Modules/webxr/XRCompositionLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRCompositionLayer.cpp
@@ -130,8 +130,7 @@ void XRCompositionLayer::startFrame(PlatformXR::FrameData& frameData)
     if (it == frameData.layers.end())
         return;
 
-    if (needsRedraw())
-        m_backing->startFrame(frameData);
+    m_backing->startFrame(frameData);
 #else
     UNUSED_PARAM(frameData);
 #endif
@@ -172,14 +171,12 @@ PlatformXR::DeviceLayer XRCompositionLayer::endFrame()
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
     PlatformXR::DeviceLayer layerData;
-    if (needsRedraw())
-        m_backing->endFrame(layerData);
+    m_backing->endFrame(layerData);
 
     layerData.handle = m_backing->handle();
     layerData.visible = true;
 
-    if (needsRedraw())
-        recomputePose();
+    recomputePose();
 
     fillInCommonDeviceLayerData(layerData);
     fillInTypeSpecificDeviceLayerData(layerData);

--- a/Source/WebCore/Modules/webxr/XRLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRLayerBacking.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "IntRect.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -63,6 +64,8 @@ public:
     void setHandle(PlatformXR::LayerHandle handle) { m_handle = handle; }
 
     virtual bool allColorTexturesAreBound() const = 0;
+
+    virtual void clearTexturesIfNeeded(const IntRect& viewport, std::optional<uint32_t> slice) { UNUSED_PARAM(viewport); UNUSED_PARAM(slice); }
 
 private:
     PlatformXR::LayerHandle m_handle;

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
@@ -688,6 +688,8 @@ ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLBinding::getSubImage(XRCompositionLayer
                 });
             }
 
+            const auto& vp = subImage->viewport();
+            layer.backing().clearTexturesIfNeeded(IntRect(vp.x(), vp.y(), vp.width(), vp.height()), subImage->imageIndex());
             return subImage;
         },
         [](const auto&) -> ExceptionOr<Ref<XRWebGLSubImage>> {
@@ -741,6 +743,8 @@ ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLBinding::getViewSubImage(XRProjectionLa
 
     Ref subImage = subImageResult.releaseReturnValue();
     subImage->setImageIndex(textureType == XRTextureType::TextureArray && view.eye() == XREye::Right ? 1 : 0);
+    const auto& vp = subImage->viewport();
+    layer.backing().clearTexturesIfNeeded(IntRect(vp.x(), vp.y(), vp.width(), vp.height()), subImage->imageIndex());
     return subImage;
 }
 

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
@@ -290,6 +290,16 @@ bool XRWebGLLayerBacking::allColorTexturesAreBound() const
     return m_colorSwapchain->allTexturesAreBound();
 }
 
+void XRWebGLLayerBacking::clearTexturesIfNeeded(const IntRect& viewport, std::optional<uint32_t> slice)
+{
+    std::optional<GCGLint> glSlice;
+    if (slice)
+        glSlice = static_cast<GCGLint>(*slice);
+    m_colorSwapchain->clearTextureIfNeeded(viewport, glSlice);
+    if (m_depthSwapchain)
+        m_depthSwapchain->clearTextureIfNeeded(viewport, glSlice);
+}
+
 } // namespace WebCore
 
 

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
@@ -81,6 +81,8 @@ public:
 
     bool allColorTexturesAreBound() const final;
 
+    void clearTexturesIfNeeded(const IntRect& viewport, std::optional<uint32_t> slice) final;
+
 protected:
     XRWebGLLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength);
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -531,6 +531,7 @@ protected:
     friend class ScopedDisableScissorTest;
     friend class ScopedEnableBackbuffer;
     friend class ScopedInspectorShaderProgramHighlight;
+    friend class ScopedScissorTestForRegion;
     friend class ScopedWebGLRestoreFramebuffer;
     friend class ScopedWebGLRestoreRenderbuffer;
     friend class ScopedWebGLRestoreTexture;

--- a/Source/WebCore/html/canvas/WebGLUtilities.h
+++ b/Source/WebCore/html/canvas/WebGLUtilities.h
@@ -180,6 +180,37 @@ private:
     WeakPtr<WebGLRenderingContextBase> m_context;
 };
 
+class ScopedScissorTestForRegion {
+    WTF_MAKE_NONCOPYABLE(ScopedScissorTestForRegion);
+public:
+    ScopedScissorTestForRegion(WebGLRenderingContextBase& context, const IntRect& region)
+        : m_context(context)
+        , m_wasEnabled(context.m_scissorEnabled)
+    {
+        if (!m_context)
+            return;
+        RefPtr gl = context.graphicsContextGL();
+        gl->getIntegerv(GraphicsContextGL::SCISSOR_BOX, m_scissorBox);
+        gl->enable(GraphicsContextGL::SCISSOR_TEST);
+        gl->scissor(region.x(), region.y(), region.width(), region.height());
+    }
+
+    ~ScopedScissorTestForRegion()
+    {
+        if (!m_context)
+            return;
+        RefPtr gl = m_context->graphicsContextGL();
+        gl->scissor(m_scissorBox[0], m_scissorBox[1], m_scissorBox[2], m_scissorBox[3]);
+        if (!m_wasEnabled)
+            gl->disable(GraphicsContextGL::SCISSOR_TEST);
+    }
+
+private:
+    WeakPtr<WebGLRenderingContextBase> m_context;
+    std::array<GCGLint, 4> m_scissorBox { };
+    bool m_wasEnabled { false };
+};
+
 class ScopedWebGLRestoreFramebuffer {
     WTF_MAKE_NONCOPYABLE(ScopedWebGLRestoreFramebuffer);
 public:


### PR DESCRIPTION
#### a5033751bee41658f6fcddf4b75ede5c0568799d
<pre>
[WebXR Layers] Lots of flickering rendering <a href="https://threejs.org/examples/?q=layers#webgpu_xr_native_layers">https://threejs.org/examples/?q=layers#webgpu_xr_native_layers</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316080">https://bugs.webkit.org/show_bug.cgi?id=316080</a>

Reviewed by Dan Glastonbury.

The XRCompositionLayer&apos;s needsRedraw attribute signals that the layer
should be rendered in the next animation frame. However we were
incorrectly using it in the code to avoid calling startFrame/endFrame.
Because of that the swapchain was not properly cycling between the
buffers/textures provided by the device (OpenXR in this case) causing a
lot of flickering as we were skipping many frames.

The needsRedraw flag should be used by the app to avoid unnecessary draw
commands (for layers whose contents barely change) and not by the engine
as we must keep submitting frames to the XR compositor.

Removing that gating exposed a latent bug in the way we clear the
textures. When clearOnAccess is set the spec requires each texture to be
cleared at the moment the application accesses it. We were instead
clearing inside the swapchain&apos;s startFrame(), which only appeared
correct because startFrame() was itself gated behind needsRedraw(). It
ran once per frame, on exactly the frames the application was going to
redraw, so the clear happened to line up with the access by coincidence
rather than by design. Once startFrame() runs unconditionally on every
frame (as explained in previous paragraphs) that coincidence no longer
holds; clearing there happens at frame start, before and independently
of the application actually accessing the texture, which is the wrong
place to do it.

The solution is to clear at the real access point. getSubImage()/
getViewSubImage() are exactly where the spec makes the texture available
to the application, so the clear was moved there. Apart from that,
the clear is additionally constrained (via the scissor box) to the subImage&apos;s
viewport (for texture arrays it&apos;s its slice) so that when a single
texture is shared by both eyes, clearing one eye&apos;s region on access does
not wipe the other eye&apos;s already-rendered content.

* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp:
(WebCore::WebXRWebGLSwapchain::clearAttachmentRegion):
(WebCore::WebXRWebGLSwapchain::clearTextureRegion):
(WebCore::WebXRWebGLSwapchain::clearTextureIfNeeded):
(WebCore::WebXRWebGLSharedImageSwapchain::startFrame):
(WebCore::WebXRWebGLStaticImageSwapchain::clearTextureRegion):
(WebCore::WebXRWebGLStaticImageSwapchain::startFrame):
(WebCore::WebXRWebGLTextureArraySwapchain::clearTextureRegion):
(WebCore::WebXRWebGLTextureArraySwapchain::startFrame):
(WebCore::WebXRWebGLSwapchain::clearTextureLayers): Deleted.
(WebCore::WebXRWebGLSwapchain::clearCurrentTexture): Deleted.
(WebCore::WebXRWebGLStaticImageSwapchain::clearCurrentTexture): Deleted.
(WebCore::WebXRWebGLTextureArraySwapchain::clearCurrentTexture): Deleted.
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h:
* Source/WebCore/Modules/webxr/XRCompositionLayer.cpp:
(WebCore::XRCompositionLayer::startFrame):
(WebCore::XRCompositionLayer::endFrame):
* Source/WebCore/Modules/webxr/XRLayerBacking.h:
(WebCore::XRLayerBacking::clearTexturesIfNeeded):
* Source/WebCore/Modules/webxr/XRWebGLBinding.cpp:
(WebCore::XRWebGLBinding::getSubImage):
(WebCore::XRWebGLBinding::getViewSubImage):
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp:
(WebCore::XRWebGLLayerBacking::clearTexturesIfNeeded):
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/html/canvas/WebGLUtilities.h:
(WebCore::ScopedScissorTestForRegion::ScopedScissorTestForRegion):
(WebCore::ScopedScissorTestForRegion::~ScopedScissorTestForRegion):

Canonical link: <a href="https://commits.webkit.org/314441@main">https://commits.webkit.org/314441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d533b3deafe42845141579fb1b2ae13c8735471

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175219 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129159 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31539 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109685 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23360 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177752 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28708 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137507 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39731 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137435 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37011 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148798 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103034 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32723 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38930 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112004 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38327 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3751 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38572 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38470 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->