### PR TITLE
[MSE] notifyTimeReachedAndStall must not arm a stall behind currentTime

### DIFF
--- a/LayoutTests/media/media-source/media-mp4-xhe-aac.html
+++ b/LayoutTests/media/media-source/media-mp4-xhe-aac.html
@@ -34,6 +34,7 @@
             consoleWrite('Append media segment.')
             run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
             await waitFor(sourceBuffer, 'update');
+            source.endOfStream();
 
             run('video.currentTime = video.duration - 0.5');
             await waitFor(video, 'seeked');

--- a/LayoutTests/media/media-source/media-source-small-gap.html
+++ b/LayoutTests/media/media-source/media-source-small-gap.html
@@ -46,6 +46,7 @@
     }
 
     function checkBuffered() {
+        source.endOfStream();
         testExpected('sourceBuffer.buffered.length', 1);
         testExpected('sourceBuffer.buffered.start(0)', 0);
         testExpected('sourceBuffer.buffered.end(0)', 8);

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
@@ -55,6 +55,11 @@ bool MediaSourceInterfaceMainThread::isClosed() const
     return m_mediaSource->isClosed();
 }
 
+bool MediaSourceInterfaceMainThread::isEnded() const
+{
+    return m_mediaSource->isEnded();
+}
+
 MediaTime MediaSourceInterfaceMainThread::duration() const
 {
     return m_mediaSource->duration();

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h
@@ -41,6 +41,7 @@ private:
     RefPtr<MediaSourcePrivateClient> client() const final;
     void monitorSourceBuffers() final;
     bool isClosed() const final;
+    bool isEnded() const final;
     MediaTime duration() const final;
     PlatformTimeRanges buffered() const final;
     PlatformTimeRanges seekable() const final;

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h
@@ -48,6 +48,7 @@ public:
     virtual RefPtr<MediaSourcePrivateClient> client() const = 0;
     virtual void monitorSourceBuffers() = 0;
     virtual bool isClosed() const = 0;
+    virtual bool isEnded() const = 0;
     virtual MediaTime duration() const = 0;
     virtual PlatformTimeRanges buffered() const = 0;
     virtual PlatformTimeRanges seekable() const = 0;

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
@@ -64,6 +64,13 @@ bool MediaSourceInterfaceWorker::isClosed() const
     return true;
 }
 
+bool MediaSourceInterfaceWorker::isEnded() const
+{
+    if (RefPtr mediaSourcePrivate = m_handle->mediaSourcePrivate())
+        return mediaSourcePrivate->readyState() == MediaSource::ReadyState::Ended;
+    return true;
+}
+
 MediaTime MediaSourceInterfaceWorker::duration() const
 {
     if (RefPtr mediaSourcePrivate = m_handle->mediaSourcePrivate(); mediaSourcePrivate && !isClosed())

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h
@@ -41,6 +41,7 @@ private:
     RefPtr<MediaSourcePrivateClient> NODELETE client() const final;
     void monitorSourceBuffers() final;
     bool isClosed() const final;
+    bool isEnded() const final;
     MediaTime duration() const final;
     PlatformTimeRanges buffered() const final;
     PlatformTimeRanges seekable() const final;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5931,6 +5931,17 @@ void HTMLMediaElement::mediaPlayerTimeChanged()
     MediaTime dur = durationMediaTime();
     double playbackRate = requestedPlaybackRate();
 
+    // Reaching the end of the available data only counts as end-of-media once
+    // playback is allowed to end. For a normal (finite) resource that is always the
+    // case; for Media Source it holds only once the MediaSource has transitioned to
+    // 'ended' (via endOfStream()) — until then, reaching the buffered end is a stall
+    // (surfaced as 'waiting'), not 'ended'.
+    bool canReachEnd = true;
+#if ENABLE(MEDIA_SOURCE)
+    if (m_mediaSource)
+        canReachEnd = m_mediaSource->isEnded();
+#endif
+
     // When the current playback position reaches the end of the media resource then the user agent must follow these steps:
     if ((dur || (!dur && !now)) && dur.isValid() && !dur.isPositiveInfinite() && !dur.isNegativeInfinite()) {
 
@@ -5946,7 +5957,7 @@ void HTMLMediaElement::mediaPlayerTimeChanged()
 
                 seekInternal(MediaTime::zeroTime());
             }
-        } else if ((now <= MediaTime::zeroTime() && playbackRate < 0) || (now >= dur && playbackRate > 0)) {
+        } else if ((now <= MediaTime::zeroTime() && playbackRate < 0) || (now >= dur && playbackRate > 0 && canReachEnd)) {
 
             ALWAYS_LOG(LOGIDENTIFIER, "current time (", now, ") is greater then duration (", dur, ") or <= 0, pausing");
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -522,6 +522,14 @@ void AudioVideoRendererAVFObjC::stall()
 void AudioVideoRendererAVFObjC::notifyTimeReachedAndStall(const MediaTime& timeBoundary, Function<void(const MediaTime&)>&& callback)
 {
     cancelTimeReachedAction();
+
+    if (timeBoundary <= currentTime()) {
+        ALWAYS_LOG(LOGIDENTIFIER, "boundary ", timeBoundary, " is behind currentTime ", currentTime(), "; stalling and firing callback immediately");
+        stall();
+        callback(timeBoundary);
+        return;
+    }
+
     RetainPtr<NSArray> times = @[[NSValue valueWithCMTime:PAL::toCMTime(timeBoundary)]];
 
     auto logSiteIdentifier = LOGIDENTIFIER;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -761,29 +761,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::resetStallForTime(const MediaTime& ti
     assertIsMainThread();
     m_renderer->cancelTimeReachedAction();
 
-    auto ranges = protect(m_mediaSourcePrivate)->buffered();
-    if (!protect(m_mediaSourcePrivate)->hasFutureTime(time) && shouldBePlaying()) {
-        ALWAYS_LOG(LOGIDENTIFIER, "Not having data to play at time: ", time, " stalling");
-        stall();
-    }
-
-    auto stallAtTime = duration();
-    size_t index = ranges.find(time);
-    if (index != notFound) {
-        // Find the next gap (or end of media)
-        for (; index < ranges.length(); index++) {
-            if ((index < ranges.length() - 1 && ranges.start(index + 1) - ranges.end(index) > m_mediaSourcePrivate->timeFudgeFactor())
-                || (index == ranges.length() - 1 && ranges.end(index) > time)) {
-                stallAtTime = ranges.end(index);
-                break;
-            }
-        }
-    }
-
-    ALWAYS_LOG(LOGIDENTIFIER, "will stall playback at time: ", stallAtTime);
     auto logSiteIdentifier = LOGIDENTIFIER;
     UNUSED_PARAM(logSiteIdentifier);
-    m_renderer->notifyTimeReachedAndStall(stallAtTime, [weakThis = WeakPtr { *this }, logSiteIdentifier](const MediaTime& stallTime) {
+    auto stallReachedCallback = [weakThis = WeakPtr { *this }, logSiteIdentifier](const MediaTime& stallTime) {
         ensureOnMainThread([weakThis, logSiteIdentifier, stallTime] {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
@@ -804,7 +784,37 @@ void MediaPlayerPrivateMediaSourceAVFObjC::resetStallForTime(const MediaTime& ti
                 protectedThis->pause();
             protectedThis->timeChanged();
         });
-    });
+    };
+
+    if (time >= duration()) {
+        ALWAYS_LOG(LOGIDENTIFIER, "playhead ", time, " is at or past duration ", duration(), "; stalling");
+        if (shouldBePlaying())
+            stall();
+        stallReachedCallback(time);
+        return;
+    }
+
+    auto ranges = protect(m_mediaSourcePrivate)->buffered();
+    if (!protect(m_mediaSourcePrivate)->hasFutureTime(time) && shouldBePlaying()) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Not having data to play at time: ", time, " stalling");
+        stall();
+    }
+
+    auto stallAtTime = duration();
+    size_t index = ranges.find(time);
+    if (index != notFound) {
+        // Find the next gap (or end of media)
+        for (; index < ranges.length(); index++) {
+            if ((index < ranges.length() - 1 && ranges.start(index + 1) - ranges.end(index) > m_mediaSourcePrivate->timeFudgeFactor())
+                || (index == ranges.length() - 1 && ranges.end(index) > time)) {
+                stallAtTime = ranges.end(index);
+                break;
+            }
+        }
+    }
+
+    ALWAYS_LOG(LOGIDENTIFIER, "will stall playback at time: ", stallAtTime);
+    m_renderer->notifyTimeReachedAndStall(stallAtTime, WTF::move(stallReachedCallback));
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::setLayerRequiresFlush()

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -749,6 +749,13 @@ MediaTime AudioVideoRendererRemote::currentTime() const
 
 void AudioVideoRendererRemote::notifyTimeReachedAndStall(const MediaTime& time, Function<void(const MediaTime&)>&& callback)
 {
+    auto now = currentTime();
+    if (time <= now) {
+        ALWAYS_LOG(LOGIDENTIFIER, "boundary ", time, " is behind currentTime ", now, "; stalling and firing callback immediately");
+        stall();
+        callback(time);
+        return;
+    }
     {
         Locker locker { m_lock };
         m_stallCap = time;


### PR DESCRIPTION
#### 6e7720ec70a93041e32a13f0b3f53fc57efe432f
<pre>
[MSE] notifyTimeReachedAndStall must not arm a stall behind currentTime
<a href="https://bugs.webkit.org/show_bug.cgi?id=316082">https://bugs.webkit.org/show_bug.cgi?id=316082</a>
<a href="https://rdar.apple.com/problem/178513965">rdar://problem/178513965</a>

Reviewed by Eric Carlson.

When a SourceBuffer&apos;s duration is truncated to (or below) currentTime while
playback is parked at the end of the buffered data, two things went wrong.

1) resetStallForTime() could ask the renderer to stall at a boundary that
was already behind the playhead. Such a boundary&apos;s observer never fires
naturally, and the rate=0 failsafe in handleEffectiveRateChanged then re-pins
the synchronizer onto that stale boundary, dragging the published time
backwards. A stall boundary must never sit behind currentTime.

2) more fundamentally, end-of-media was decided in the wrong place.
HTMLMediaElement::mediaPlayerTimeChanged() scheduled the &apos;ended&apos; event
whenever the playback position had reached duration with a positive rate,
without regard for whether the media data was actually complete. For Media
Source that is incorrect: reaching the end of the currently buffered data
while the MediaSource is still &apos;open&apos; is a stall (&apos;waiting&apos;), not
end-of-media -- &apos;ended&apos; must not fire until the MediaSource transitions to
&apos;ended&apos; via endOfStream(). The consequence is that the &apos;ended&apos; event could be
fired incorrectly any time MediaPlayer::timeChanged() happened to be called at
or past duration even though the MediaSource had not ended, which is precisely
what the stall-boundary callback does when parked at the truncated duration.

Gate the forward end-of-media transition in mediaPlayerTimeChanged() on the
media data being complete: always true for a finite resource, and for Media
Source only once the MediaSource has ended. End-of-media is then driven solely
off the MediaSource &apos;ended&apos; transition (notifyEndOfMediaIfNeeded()), leaving
the renderer free to stall and report its stall time without that being
mistaken for end-of-media.

* LayoutTests/media/media-source/media-mp4-xhe-aac.html: Test incorrectly assumed that the ended event would fire when the MediaSource wasn&apos;t ended. Revealed by fixing 2) above
* LayoutTests/media/media-source/media-source-small-gap.html: Same as above.
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp:
(WebCore::MediaSourceInterfaceMainThread::isEnded const):
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h:
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h:
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp:
(WebCore::MediaSourceInterfaceWorker::isEnded const):
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerTimeChanged): Only treat reaching
duration as end-of-media once the media data is complete.
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::notifyTimeReachedAndStall):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::resetStallForTime):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::notifyTimeReachedAndStall):

Co-Authored-By: Claude Opus 4.8 (1M context) &lt;noreply@anthropic.com&gt;
Canonical link: <a href="https://commits.webkit.org/314610@main">https://commits.webkit.org/314610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84d1c5ac71dd7a6048b9101c5b42abfd43d5abb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33665 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175642 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123850 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40092 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/175642 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149691 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/175642 "") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29588 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23783 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178176 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31076 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29095 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137880 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137797 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37130 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149186 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103577 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33091 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26051 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39353 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112427 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38749 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4141 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38994 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38892 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->