### PR TITLE
Serialize @font-face descriptor ranges with equal bounds as a single value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors-expected.txt
@@ -20,7 +20,7 @@ PASS font-weight(valid): Valid calc expression: calc(100.5*3 + 50.5)
 PASS font-weight(valid): Valid calc expression with out-of-range value: calc(100.5*3 + 800)
 PASS font-weight(invalid): Valid calc expression with units: calc(100.5px + 50.5px)
 PASS font-weight(valid): Simple range: 100 900
-FAIL font-weight(valid): Simple range with equal upper and lower bounds: 500 500 assert_equals: Unexpected resulting value. expected "500" but got "500 500"
+PASS font-weight(valid): Simple range with equal upper and lower bounds: 500 500
 PASS font-weight(invalid): Lower bound out of range: 0.9 100
 PASS font-weight(invalid): Upper bound out of range: 100 1001
 PASS font-weight(valid): Lower bound calc(): calc(100 + 100) 400
@@ -54,7 +54,7 @@ PASS font-stretch(valid): Negative calc expression (to be clamped): calc(50% - 5
 PASS font-stretch(invalid): Unit-less calc value: calc(100)
 PASS font-stretch(invalid): Calc value with units: calc(100px)
 PASS font-stretch(valid): Simple range: 100% 200%
-FAIL font-stretch(valid): Simple range with equal upper and lower bounds: 100% 100% assert_equals: Unexpected resulting value. expected "100%" but got "100% 100%"
+PASS font-stretch(valid): Simple range with equal upper and lower bounds: 100% 100%
 PASS font-stretch(invalid): Lower bound out of range: -100% 100%
 PASS font-stretch(valid): Lower bound calc(): calc(10% + 10%) 30%
 PASS font-stretch(valid): Upper bound calc(): 10% calc(10% + 10%)
@@ -81,7 +81,7 @@ PASS font-style(invalid): 'oblique' followed by isolated minus: oblique -
 PASS font-style(invalid): 'oblique' followed by minus and angle separated by space: oblique - 20deg
 PASS font-style(invalid): 'oblique' followed by minus and non-number: oblique -a
 PASS font-style(valid): Simple range: oblique 10deg 20deg
-FAIL font-style(valid): Simple range with equal upper and lower bounds: oblique 10deg 10deg assert_equals: Unexpected resulting value. expected "oblique 10deg" but got "oblique 10deg 10deg"
+PASS font-style(valid): Simple range with equal upper and lower bounds: oblique 10deg 10deg
 PASS font-style(valid): Simple range with equal upper and lower bounds: oblique 0deg 0deg
 PASS font-style(valid): Simple range with former default angle for both bounds: oblique 20deg 20deg
 PASS font-style(valid): Bounds out of order: oblique 20deg 10deg

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors.html
@@ -164,7 +164,7 @@
             { value: "oblique 10deg 20deg",         isValid: true,  description: "Simple range" },
             { value: "oblique 10deg 10deg",         isValid: true,  expectedValue: "oblique 10deg", description: "Simple range with equal upper and lower bounds" },
             { value: "oblique 0deg 0deg",           isValid: true,  expectedValue: "normal", description: "Simple range with equal upper and lower bounds" },
-            { value: "oblique 20deg 20deg",         isValid: true,  description: "Simple range with former default angle for both bounds" },
+            { value: "oblique 20deg 20deg",         isValid: true,  expectedValue: "oblique 20deg", description: "Simple range with former default angle for both bounds" },
             { value: "oblique 20deg 10deg",         isValid: true,  expectedValue: "oblique 20deg 10deg", description: "Bounds out of order" },
             { value: "oblique -100deg 20deg",       isValid: false, description: "Lower bound out of range" },
             { value: "oblique 20deg 100deg",        isValid: false, description: "Upper bound out of range" },

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -36,6 +36,7 @@
 #include "CSSUnicodeRangeValue.h"
 #include "CSSValue.h"
 #include "CSSValueList.h"
+#include "CSSValuePair.h"
 #include "CachedFont.h"
 #include "ContextDestructionObserverInlines.h"
 #include "Document.h"
@@ -169,14 +170,9 @@ FontFace* CSSFontFace::existingWrapper()
 
 static FontSelectionRange calculateWeightRange(CSSValue& value)
 {
-    if (auto* valueList = dynamicDowncast<CSSValueList>(value)) {
-        ASSERT(valueList->length() == 2);
-        if (valueList->length() != 2)
-            return { normalWeightValue(), normalWeightValue() };
-        Ref value0 = *valueList->item(0);
-        Ref value1 = *valueList->item(1);
-        auto result0 = Style::fontWeightFromCSSValueDeprecated(value0);
-        auto result1 = Style::fontWeightFromCSSValueDeprecated(value1);
+    if (auto* pair = dynamicDowncast<CSSValuePair>(value)) {
+        auto result0 = Style::fontWeightFromCSSValueDeprecated(pair->first());
+        auto result1 = Style::fontWeightFromCSSValueDeprecated(pair->second());
         return { result0, result1 };
     }
 
@@ -201,14 +197,9 @@ void CSSFontFace::setWeight(CSSValue& weight)
 
 static FontSelectionRange calculateWidthRange(CSSValue& value)
 {
-    if (auto* valueList = dynamicDowncast<CSSValueList>(value)) {
-        ASSERT(valueList->length() == 2);
-        if (valueList->length() != 2)
-            return { normalWidthValue(), normalWidthValue() };
-        Ref value0 = *valueList->item(0);
-        Ref value1 = *valueList->item(1);
-        auto result0 = Style::fontStretchFromCSSValueDeprecated(value0);
-        auto result1 = Style::fontStretchFromCSSValueDeprecated(value1);
+    if (auto* pair = dynamicDowncast<CSSValuePair>(value)) {
+        auto result0 = Style::fontStretchFromCSSValueDeprecated(pair->first());
+        auto result1 = Style::fontStretchFromCSSValueDeprecated(pair->second());
         return { result0, result1 };
     }
 
@@ -261,11 +252,9 @@ static FontFaceStyleInfo calculateFontFaceStyleInfo(CSSValue& value)
                 return FontSelectionValue { narrowPrecisionToFloat(Style::toStyle(angle, NoConversionDataRequiredToken { }).value) };
             };
 
-            if (!oblique.first)
+            if (!oblique.angle)
                 return { FontSelectionRange { italicValue() }, FontStyleAxis::slnt };
-            if (!oblique.second)
-                return { FontSelectionRange { resolveAngle(*oblique.first) }, FontStyleAxis::slnt };
-            return { FontSelectionRange { resolveAngle(*oblique.first), resolveAngle(*oblique.second) }, FontStyleAxis::slnt };
+            return { FontSelectionRange { resolveAngle(oblique.angle->first()), resolveAngle(oblique.angle->second()) }, FontStyleAxis::slnt };
         }
     );
 }

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -13600,7 +13600,7 @@
                     {
                         "enable-if": "ENABLE_VARIATION_FONTS",
                         "aliases": ["font-stretch"],
-                        "parser-grammar": "<font-width-absolute> | <percentage [0,inf]>{1,2}",
+                        "parser-grammar": "<font-width-absolute> | <percentage [0,inf]>{1,2}@(type=CSSValuePair default=previous)",
                         "parser-grammar-comment": "Current spec grammar is 'auto | <'font-width'>{1,2}'",
                         "parser-exported": true
                     },
@@ -13657,7 +13657,7 @@
                 "codegen-properties": [
                     {
                         "enable-if": "ENABLE_VARIATION_FONTS",
-                        "parser-grammar": "normal | bold | <number [1,1000]>{1,2}",
+                        "parser-grammar": "normal | bold | <number [1,1000]>{1,2}@(type=CSSValuePair default=previous)",
                         "parser-grammar-comment": "Current spec grammar is 'auto | <font-weight-absolute>{1,2}'",
                         "parser-exported": true
                     },

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -769,18 +769,20 @@ std::optional<CSS::FontStyleRange> consumeUnresolvedFontFaceFontStyle(CSSParserT
 
         if (rangeCopy.atEnd()) {
             range = rangeCopy;
-            return CSS::FontStyleRange { CSS::FontStyleRange::Oblique { std::nullopt, std::nullopt } };
+            return CSS::FontStyleRange { CSS::FontStyleRange::Oblique { std::nullopt } };
         }
 
         auto firstAngle = consumeFontStyleAngleUnresolved(rangeCopy, state);
         if (!firstAngle)
             return std::nullopt;
 
+        using Oblique = CSS::FontStyleRange::Oblique;
+
         if (rangeCopy.atEnd()) {
             range = rangeCopy;
             if (firstAngle->isKnownZero())
                 return CSS::FontStyleRange { CSS::Keyword::Normal { } };
-            return CSS::FontStyleRange { CSS::FontStyleRange::Oblique { WTF::move(firstAngle), std::nullopt } };
+            return CSS::FontStyleRange { Oblique { Oblique::Angles { *firstAngle, *firstAngle } } };
         }
 
         auto secondAngle = consumeFontStyleAngleUnresolved(rangeCopy, state);
@@ -790,7 +792,7 @@ std::optional<CSS::FontStyleRange> consumeUnresolvedFontFaceFontStyle(CSSParserT
         range = rangeCopy;
         if (firstAngle->isKnownZero() && secondAngle->isKnownZero())
             return CSS::FontStyleRange { CSS::Keyword::Normal { } };
-        return CSS::FontStyleRange { CSS::FontStyleRange::Oblique { WTF::move(firstAngle), WTF::move(secondAngle) } };
+        return CSS::FontStyleRange { Oblique { Oblique::Angles { *firstAngle, *secondAngle } } };
     }
 
     default:

--- a/Source/WebCore/css/values/fonts/CSSFontStyleRange.cpp
+++ b/Source/WebCore/css/values/fonts/CSSFontStyleRange.cpp
@@ -44,7 +44,7 @@ Ref<CSSValue> CSSValueCreation<FontStyleRange>::operator()(CSSValuePool&, const 
 
 void Serialize<FontStyleRange::Oblique>::operator()(StringBuilder& builder, const SerializationContext& context, const FontStyleRange::Oblique& value)
 {
-    CSS::serializationForCSS(builder, context, SpaceSeparatedTuple { Keyword::Oblique { }, value.first, value.second });
+    CSS::serializationForCSS(builder, context, SpaceSeparatedTuple { Keyword::Oblique { }, value.angle });
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/fonts/CSSFontStyleRange.h
+++ b/Source/WebCore/css/values/fonts/CSSFontStyleRange.h
@@ -37,9 +37,11 @@ namespace CSS {
 struct FontStyleRange {
     struct Oblique {
         using Angle = CSS::Angle<Range{-90, 90}>;
+        using Angles = MinimallySerializingSpaceSeparatedPair<Angle>;
 
-        std::optional<Angle> first;
-        std::optional<Angle> second;
+        // Empty represents `oblique` without an explicit angle. A single angle is
+        // stored as an equal-bounds pair, which serializes minimally (`oblique 10deg`).
+        std::optional<Angles> angle;
 
         bool operator==(const Oblique&) const = default;
     };
@@ -54,13 +56,7 @@ struct FontStyleRange {
     bool operator==(const FontStyleRange&) const = default;
 };
 
-template<size_t I> const auto& get(const FontStyleRange::Oblique& value)
-{
-    if constexpr (!I)
-        return value.first;
-    else if constexpr (I == 1)
-        return value.second;
-}
+DEFINE_TYPE_WRAPPER_GET(FontStyleRange::Oblique, angle)
 
 // MARK: - Conversion
 
@@ -73,5 +69,5 @@ template<> struct Serialize<FontStyleRange::Oblique> { void operator()(StringBui
 } // namespace CSS
 } // namespace WebCore
 
-DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::FontStyleRange::Oblique, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE_FOR_TYPE_WRAPPER(WebCore::CSS::FontStyleRange::Oblique)
 DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::CSS::FontStyleRange)


### PR DESCRIPTION
#### 9b487fb860c56c76b34d97cfd7ca3c13e5c35f05
<pre>
Serialize @font-face descriptor ranges with equal bounds as a single value
<a href="https://bugs.webkit.org/show_bug.cgi?id=316086">https://bugs.webkit.org/show_bug.cgi?id=316086</a>
<a href="https://rdar.apple.com/178517226">rdar://178517226</a>

Reviewed by Sam Weinig.

Per CSSOM 6.7.2, equal-bounded &lt;X&gt;{1,2} ranges should collapse to a single
value. font-weight and font-width descriptors now use a @(type=CSSValuePair
default=previous) grammar annotation, which produces a coalescing CSSValuePair
that serializes equal values as one. font-style oblique has a custom parser, so
the collapse is achieved by storing both angles in a
MinimallySerializingSpaceSeparatedPair, which coalesces equal values on
serialization.

Also fix the WPT test to expect oblique 20deg for oblique 20deg 20deg, matching
the same collapse rule the test already asserts for oblique 10deg 10deg.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors.html:
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::calculateFontFaceStyleInfo):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
(WebCore::CSSPropertyParserHelpers::consumeUnresolvedFontFaceFontStyle):
* Source/WebCore/css/values/fonts/CSSFontStyleRange.cpp:
(WebCore::CSS::Serialize&lt;FontStyleRange::Oblique&gt;::operator()):
* Source/WebCore/css/values/fonts/CSSFontStyleRange.h:

Canonical link: <a href="https://commits.webkit.org/314486@main">https://commits.webkit.org/314486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31890da638924a70b17456fb0c68aade9be0f152

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175286 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0eed9f86-7f51-4817-b592-e327c8d47c74) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129213 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109738 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23427 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140544 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177819 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30721 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137567 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137487 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37044 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148861 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103124 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32786 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25728 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38997 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112071 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38394 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3814 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38639 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38537 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->