### PR TITLE
[MSE] TrackBuffer::reenqueueMediaForTime should not enqueue content before the current playback position

### DIFF
--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -314,9 +314,18 @@ bool TrackBuffer::reenqueueMediaForTime(const MediaTime& time, const MediaTime& 
 
     // Fill the decode queue with the remaining samples.
     if (currentSampleDTSIterator != m_samples.decodeOrder().end()) {
-        m_decodeQueue.insert(*currentSampleDTSIterator);
-        m_minimumEnqueuedPresentationTime = Ref { currentSampleDTSIterator->second }->presentationTime();
+        Ref sample = currentSampleDTSIterator->second;
+        if (sample->isDivisable() && sample->presentationTime() < time && time < sample->presentationEndTime()) {
+            // Avoid enqueueing content before the current playback position: split the sample
+            // straddling `time` and keep only the tail (sub-entries ending after `time`).
+            auto [head, tail] = sample->divide(time, MediaSample::UseEndTime::Use);
+            if (tail)
+                sample = tail.releaseNonNull();
+        }
+        DecodeOrderSampleMap::KeyType decodeKey(sample->decodeTime(), sample->presentationTime());
+        m_minimumEnqueuedPresentationTime = sample->presentationTime();
         previousSampleTime = m_minimumEnqueuedPresentationTime;
+        m_decodeQueue.insert(DecodeOrderSampleMap::MapType::value_type(decodeKey, WTF::move(sample)));
     }
     for (auto iter = ++currentSampleDTSIterator; iter != m_samples.decodeOrder().end(); ++iter) {
         Ref sample = iter->second;


### PR DESCRIPTION
#### 34045e1b94345e7802aafa757895fb7aa226a380
<pre>
[MSE] TrackBuffer::reenqueueMediaForTime should not enqueue content before the current playback position
<a href="https://bugs.webkit.org/show_bug.cgi?id=316087">https://bugs.webkit.org/show_bug.cgi?id=316087</a>
<a href="https://rdar.apple.com/problem/178517738">rdar://problem/178517738</a>

Reviewed by Eric Carlson.

When a mutation to the source buffer caused the currently-enqueued samples
to be re-enqueued from the playback position, the sample whose range
contained that position was enqueued whole. For container formats that pack
multiple sub-entries per sample (e.g. a single audio sample buffer covering
many AAC frames), this meant sub-entries with presentation times before the
playback position were re-enqueued for presentation.

Split that sample at `time` when the sample is divisable and strictly
straddles it, and enqueue only the tail (sub-entries that contain or are
after `time`).

* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::reenqueueMediaForTime):

Canonical link: <a href="https://commits.webkit.org/314461@main">https://commits.webkit.org/314461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93972f0c46735676594189fd5c8086e736b6920e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123174 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99add25a-d903-4491-8031-beebaed65199) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128955 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90838 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b84afb8d-f319-44d0-9698-8e16ded63123) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109482 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a0972f5-9904-46f1-86b8-5a99533f930c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30300 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28981 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23106 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177495 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30401 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137295 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137224 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37028 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148568 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102749 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32508 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25435 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Skipped layout-tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38677 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111750 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38074 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3517 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38319 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38217 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->