### PR TITLE
Add missing null checks when calling internal stream functions

### DIFF
--- a/LayoutTests/streams/pipeTo-in-worker-terminate-crash-expected.txt
+++ b/LayoutTests/streams/pipeTo-in-worker-terminate-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Terminating a worker while pipeTo is in flight should not crash
+

--- a/LayoutTests/streams/pipeTo-in-worker-terminate-crash.html
+++ b/LayoutTests/streams/pipeTo-in-worker-terminate-crash.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<script src='../resources/testharness.js'></script>
+<script src='../resources/testharnessreport.js'></script>
+<script>
+function startPipeInWorker() {
+    const readable = new ReadableStream({
+        start(controller) {
+            controller.enqueue(new Uint8Array(1));
+        }
+    });
+    const writable = new WritableStream({
+        write() {
+            return new Promise(() => { });
+        }
+    });
+    readable.pipeTo(writable).catch(() => { });
+    self.postMessage("");
+}
+
+function createWorker() {
+    const worker = new Worker('data:application/javascript;charset=utf-8,' + startPipeInWorker.toString() + ';startPipeInWorker()');
+    return new Promise(resolve => {
+        worker.onmessage = () => {
+            worker.terminate();
+            resolve();
+        };
+    });
+}
+
+promise_test(async () => {
+    const pending = [];
+    for (let i = 0; i < 100; ++i)
+        pending.push(createWorker());
+    await Promise.all(pending);
+    await new Promise(resolve => setTimeout(resolve, 100));
+}, "Terminating a worker while pipeTo is in flight should not crash");
+</script>

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
@@ -102,6 +102,8 @@ void ReadableStreamDefaultReader::read(JSDOMGlobalObject& globalObject, Ref<Read
 {
     if (RefPtr internalReader = this->internalDefaultReader()) {
         auto value = internalReader->readForBindings(globalObject);
+        if (!value)
+            return;
         auto* promise = downcast<JSC::JSPromise>(value);
         if (!promise)
             return;

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -302,6 +302,8 @@ void StreamPipeToState::handleSignal()
                     return nullptr;
 
                 auto value = internalWritableStream->abort(*globalObject, signal->reason().getValue());
+                if (!value)
+                    return nullptr;
                 auto* promise = downcast<JSC::JSPromise>(value);
                 if (!promise)
                     return nullptr;
@@ -407,6 +409,8 @@ void StreamPipeToState::errorsMustBePropagatedForward(JSDOMGlobalObject& globalO
 
                 Ref internalWritableStream = protectedThis->m_destination->internalWritableStream();
                 auto value = internalWritableStream->abort(*globalObject, error.get());
+                if (!value)
+                    return nullptr;
                 auto* promise = downcast<JSC::JSPromise>(value);
                 if (!promise) {
                     auto [result, deferred] = createPromiseAndWrapper(*globalObject);

--- a/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
@@ -190,7 +190,7 @@ void InternalWritableStreamWriter::onClosedPromiseResolution(Function<void()>&& 
     });
 }
 
-static int writableStreamDefaultWriterGetDesiredSize(InternalWritableStreamWriter& writer)
+static std::optional<int> writableStreamDefaultWriterGetDesiredSize(InternalWritableStreamWriter& writer)
 {
     auto* globalObject = writer.globalObject();
     if (!globalObject)
@@ -203,12 +203,18 @@ static int writableStreamDefaultWriterGetDesiredSize(InternalWritableStreamWrite
     arguments.append(writer.guardedObject());
 
     auto result = invokeWritableStreamWriterFunction(*globalObject, privateName, arguments);
+    if (result.hasException())
+        return { };
     return result.returnValue().toNumber(globalObject);
 }
 
 void InternalWritableStreamWriter::whenReady(Function<void (bool)>&& callback)
 {
-    if (writableStreamDefaultWriterGetDesiredSize(*this) > 0) {
+    auto size = writableStreamDefaultWriterGetDesiredSize(*this);
+    if (!size)
+        return;
+
+    if (*size > 0) {
         callback(true);
         return;
     }


### PR DESCRIPTION
#### 846badc3c41ca797dd2d5980061ad32c157638f5
<pre>
Add missing null checks when calling internal stream functions
<a href="https://rdar.apple.com/178381545">rdar://178381545</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316085">https://bugs.webkit.org/show_bug.cgi?id=316085</a>

Reviewed by Ryosuke Niwa.

InternalReadableStreamDefaultReader::readForBindings and InternalWritableStream::abort return an empty JSC::JSValue when the underlying JS call throws (e.g. on a termination exception when a
Worker is terminated mid-flight).
The callers were then passing the empty JSValue to downcast&lt;JSC::JSPromise&gt;(), which RELEASE_ASSERTs on !value.isCell() and crashes.
We bail out when the returned JSValue is empty.

* LayoutTests/streams/pipeTo-in-worker-terminate-crash-expected.txt: Added.
* LayoutTests/streams/pipeTo-in-worker-terminate-crash.html: Added.
* Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp:
(WebCore::ReadableStreamDefaultReader::read):
* Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp:
(WebCore::StreamPipeToState::handleSignal):
(WebCore::StreamPipeToState::errorsMustBePropagatedForward):

Canonical link: <a href="https://commits.webkit.org/314435@main">https://commits.webkit.org/314435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d1247affa350e4e39c68596adaeecc2da484cd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174966 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123178 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ae64fcb-d0ac-4657-adcb-b566a160f6c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128959 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90842 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4d3813a-b01b-4f47-a092-3720d25a6493) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109486 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93807d11-f639-48f3-b6c1-63199d08eede) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30303 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28984 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23110 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177499 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30405 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137298 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137227 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37009 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148561 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102753 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32511 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25428 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38681 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111754 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38078 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3510 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38323 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38221 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->