### PR TITLE
[JSC] Add `emitBytecodeInConditionContext` for nullish coalescing

### DIFF
--- a/JSTests/stress/nullish-coalescing-in-condition-context-edge-cases.js
+++ b/JSTests/stress/nullish-coalescing-in-condition-context-edge-cases.js
@@ -1,0 +1,394 @@
+//@ requireOptions("--validateGraph=true")
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${expected}, got ${actual}`);
+}
+
+function shouldThrow(fn, errorType, msg) {
+    let threw = false;
+    try {
+        fn();
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof errorType))
+            throw new Error(`FAIL: ${msg}: expected ${errorType.name}, got ${e.constructor.name}`);
+    }
+    if (!threw)
+        throw new Error(`FAIL: ${msg}: expected throw, got no throw`);
+}
+
+// =========================================================================
+// Masquerades-as-undefined: non-nullish for ??, but falsy for ToBoolean.
+// The condition-context path tests the same value with both
+// is_undefined_or_null and a truthiness branch — they must disagree here.
+// =========================================================================
+
+const masquerader = makeMasquerader();
+
+function testMasqLhs(a, b) {
+    if (a ?? b)
+        return "T";
+    return "F";
+}
+noInline(testMasqLhs);
+
+function testMasqRhs(a, b) {
+    if (a ?? b)
+        return "T";
+    return "F";
+}
+noInline(testMasqRhs);
+
+function testMasqNot(a, b) {
+    if (!(a ?? b))
+        return "T";
+    return "F";
+}
+noInline(testMasqNot);
+
+function testMasqWhile(state) {
+    let c = 0;
+    while (state.values[state.i++] ?? false)
+        c++;
+    return c;
+}
+noInline(testMasqWhile);
+
+for (let i = 0; i < 1e4; i++) {
+    // Masquerader is NOT nullish: rhs must be skipped, condition is falsy.
+    shouldBe(testMasqLhs(masquerader, 1), "F", "masq lhs: non-nullish but falsy");
+    shouldBe(testMasqRhs(null, masquerader), "F", "masq rhs: falsy");
+    shouldBe(testMasqNot(masquerader, 1), "T", "masq under !");
+    shouldBe(testMasqWhile({ values: [1, 1, masquerader, 1], i: 0 }), 2, "masq stops while");
+}
+
+// Pollute profiling with normal values first, then feed the masquerader to
+// force a speculation failure in the optimizing tiers.
+function testMasqOSR(a, b) {
+    if (a ?? b)
+        return "T";
+    return "F";
+}
+noInline(testMasqOSR);
+
+for (let i = 0; i < 1e4; i++)
+    shouldBe(testMasqOSR({}, 0), "T", "masqOSR warmup");
+for (let i = 0; i < 100; i++)
+    shouldBe(testMasqOSR(masquerader, 1), "F", "masqOSR after tier-up");
+for (let i = 0; i < 100; i++)
+    shouldBe(testMasqOSR(null, masquerader), "F", "masqOSR rhs after tier-up");
+
+// =========================================================================
+// lhs must be evaluated exactly once, even though the condition-context
+// path inspects the resulting value twice (nullish check + truthiness).
+// =========================================================================
+
+let getterCount = 0;
+const counting = {
+    get x() {
+        getterCount++;
+        return this.val;
+    },
+    val: undefined,
+};
+
+function testGetterOnce(o, b) {
+    if (o.x ?? b)
+        return "T";
+    return "F";
+}
+noInline(testGetterOnce);
+
+for (let i = 0; i < 1e4; i++) {
+    getterCount = 0;
+    counting.val = 1;
+    shouldBe(testGetterOnce(counting, 0), "T", "getter: truthy");
+    shouldBe(getterCount, 1, "getter called once (truthy)");
+
+    getterCount = 0;
+    counting.val = 0;
+    shouldBe(testGetterOnce(counting, 1), "F", "getter: falsy non-nullish");
+    shouldBe(getterCount, 1, "getter called once (falsy non-nullish)");
+
+    getterCount = 0;
+    counting.val = undefined;
+    shouldBe(testGetterOnce(counting, 1), "T", "getter: nullish");
+    shouldBe(getterCount, 1, "getter called once (nullish)");
+}
+
+let callCount = 0;
+function testCallOnce(o, b) {
+    if (o?.f() ?? b)
+        return "T";
+    return "F";
+}
+noInline(testCallOnce);
+
+for (let i = 0; i < 1e4; i++) {
+    callCount = 0;
+    shouldBe(testCallOnce({ f() { callCount++; return 0; } }, 1), "F", "call: falsy non-nullish");
+    shouldBe(callCount, 1, "f called once");
+
+    callCount = 0;
+    shouldBe(testCallOnce(null, 1), "T", "call: chain short-circuit");
+    shouldBe(callCount, 0, "f not called on short-circuit");
+}
+
+// =========================================================================
+// rhs must NOT be evaluated when lhs is non-nullish — including every
+// falsy non-nullish value, where a buggy lowering might fall into the
+// rhs path.
+// =========================================================================
+
+let rhsCount = 0;
+function rhsEffect() {
+    rhsCount++;
+    return 1;
+}
+
+function testRhsSkipped(a) {
+    if (a ?? rhsEffect())
+        return "T";
+    return "F";
+}
+noInline(testRhsSkipped);
+
+const falsyNonNullish = [0, -0, "", false, NaN, 0n, masquerader];
+for (let i = 0; i < 1e3; i++) {
+    for (const v of falsyNonNullish) {
+        rhsCount = 0;
+        shouldBe(testRhsSkipped(v), "F", `rhs skipped: ${String(v)} is falsy`);
+        shouldBe(rhsCount, 0, `rhs not evaluated for ${String(v)}`);
+    }
+    rhsCount = 0;
+    shouldBe(testRhsSkipped(1), "T", "rhs skipped: truthy");
+    shouldBe(rhsCount, 0, "rhs not evaluated for truthy");
+
+    rhsCount = 0;
+    shouldBe(testRhsSkipped(null), "T", "rhs evaluated for null");
+    shouldBe(rhsCount, 1, "rhs evaluated once for null");
+
+    rhsCount = 0;
+    shouldBe(testRhsSkipped(undefined), "T", "rhs evaluated for undefined");
+    shouldBe(rhsCount, 1, "rhs evaluated once for undefined");
+}
+
+// =========================================================================
+// ToBoolean must not invoke valueOf / toString / Symbol.toPrimitive.
+// =========================================================================
+
+const trapped = {
+    valueOf() { throw new Error("valueOf must not be called"); },
+    toString() { throw new Error("toString must not be called"); },
+    [Symbol.toPrimitive]() { throw new Error("toPrimitive must not be called"); },
+};
+
+function testNoToPrimitive(a, b) {
+    if (a ?? b)
+        return "T";
+    return "F";
+}
+noInline(testNoToPrimitive);
+
+for (let i = 0; i < 1e3; i++) {
+    shouldBe(testNoToPrimitive(trapped, 0), "T", "object lhs truthy without ToPrimitive");
+    shouldBe(testNoToPrimitive(null, trapped), "T", "object rhs truthy without ToPrimitive");
+}
+
+// =========================================================================
+// Primitive truthiness coverage on both paths
+// =========================================================================
+
+function testPrim(a, b) {
+    if (a ?? b)
+        return "T";
+    return "F";
+}
+noInline(testPrim);
+
+for (let i = 0; i < 1e3; i++) {
+    shouldBe(testPrim(0n, 1), "F", "0n falsy non-nullish");
+    shouldBe(testPrim(1n, 0), "T", "1n truthy");
+    shouldBe(testPrim(null, 0n), "F", "rhs 0n");
+    shouldBe(testPrim(null, 1n), "T", "rhs 1n");
+    shouldBe(testPrim(Symbol(), 0), "T", "symbol truthy");
+    shouldBe(testPrim(null, Symbol()), "T", "rhs symbol truthy");
+    shouldBe(testPrim(-0, 1), "F", "-0 falsy non-nullish");
+    shouldBe(testPrim("0", 0), "T", "'0' truthy");
+}
+
+// =========================================================================
+// Assignment as lhs: side effect must land exactly once, value flows to
+// the condition.
+// =========================================================================
+
+function testAssignLhs(v, b) {
+    let x = "unset";
+    let r;
+    if ((x = v) ?? b)
+        r = "T";
+    else
+        r = "F";
+    return `${r}:${String(x)}`;
+}
+noInline(testAssignLhs);
+
+for (let i = 0; i < 1e3; i++) {
+    shouldBe(testAssignLhs(1, 0), "T:1", "assign lhs truthy");
+    shouldBe(testAssignLhs(0, 1), "F:0", "assign lhs falsy non-nullish");
+    shouldBe(testAssignLhs(null, 1), "T:null", "assign lhs null, rhs truthy");
+    shouldBe(testAssignLhs(null, 0), "F:null", "assign lhs null, rhs falsy");
+}
+
+// =========================================================================
+// Left-associative nesting with absorbed optional chains at each level
+// (chain target stack must stay balanced).
+// =========================================================================
+
+function testNestedChains(p, q, r) {
+    if ((p?.x ?? q?.y) ?? r?.z)
+        return "T";
+    return "F";
+}
+noInline(testNestedChains);
+
+for (let i = 0; i < 1e4; i++) {
+    shouldBe(testNestedChains({ x: 1 }, null, null), "T", "nested chains: p.x");
+    shouldBe(testNestedChains({ x: 0 }, { y: 1 }, { z: 1 }), "F", "nested chains: p.x falsy non-nullish");
+    shouldBe(testNestedChains(null, { y: 1 }, null), "T", "nested chains: q.y");
+    shouldBe(testNestedChains(null, { y: 0 }, { z: 1 }), "F", "nested chains: q.y falsy non-nullish");
+    shouldBe(testNestedChains(null, null, { z: 1 }), "T", "nested chains: r.z");
+    shouldBe(testNestedChains(null, null, { z: 0 }), "F", "nested chains: r.z falsy");
+    shouldBe(testNestedChains(null, null, null), "F", "nested chains: all nullish");
+}
+
+// `this` binding through an absorbed chain call.
+function testThisBinding(o, b) {
+    if (o?.m() ?? b)
+        return "T";
+    return "F";
+}
+noInline(testThisBinding);
+
+const thisObj = {
+    m() {
+        return this === thisObj;
+    },
+};
+
+for (let i = 0; i < 1e3; i++) {
+    shouldBe(testThisBinding(thisObj, 0), "T", "this preserved through absorbed chain");
+    shouldBe(testThisBinding(null, 0), "F", "chain short-circuit to rhs");
+}
+
+// delete inside an optional chain as lhs.
+function testDeleteChain(o, b) {
+    if ((delete o?.x) ?? b)
+        return "T";
+    return "F";
+}
+noInline(testDeleteChain);
+
+for (let i = 0; i < 1e3; i++) {
+    shouldBe(testDeleteChain({ x: 1 }, 0), "T", "delete o?.x is true");
+    shouldBe(testDeleteChain(null, 0), "T", "delete with nullish base is true");
+}
+
+// =========================================================================
+// Exception from lhs evaluation must propagate without touching rhs.
+// =========================================================================
+
+function testThrowingGetter(o) {
+    if (o.x ?? rhsEffect())
+        return "T";
+    return "F";
+}
+noInline(testThrowingGetter);
+
+const throwing = {
+    get x() { throw new TypeError("boom"); },
+};
+
+for (let i = 0; i < 1e3; i++) {
+    rhsCount = 0;
+    shouldThrow(() => testThrowingGetter(throwing), TypeError, "getter throws");
+    shouldBe(rhsCount, 0, "rhs untouched when lhs throws");
+}
+
+// =========================================================================
+// Scope-sensitive lhs: with-scope and direct eval.
+// =========================================================================
+
+function testWithScope(scope, b) {
+    with (scope) {
+        if (x ?? b)
+            return "T";
+        return "F";
+    }
+}
+noInline(testWithScope);
+
+for (let i = 0; i < 1e3; i++) {
+    shouldBe(testWithScope({ x: 1 }, 0), "T", "with: truthy");
+    shouldBe(testWithScope({ x: 0 }, 1), "F", "with: falsy non-nullish");
+    shouldBe(testWithScope({ x: null }, 1), "T", "with: nullish, rhs truthy");
+}
+
+function testDirectEval(a, b) {
+    return eval("if (a ?? b) 'T'; else 'F';");
+}
+noInline(testDirectEval);
+
+for (let i = 0; i < 100; i++) {
+    shouldBe(testDirectEval(0, 1), "F", "eval: falsy non-nullish");
+    shouldBe(testDirectEval(null, 1), "T", "eval: rhs truthy");
+    shouldBe(testDirectEval(masquerader, 1), "F", "eval: masquerader");
+}
+
+// =========================================================================
+// Register pressure: condition emitted while many temporaries are live,
+// rhs call clobbers caller-side temps.
+// =========================================================================
+
+function clobber(a, b, c, d, e, f, g, h) {
+    return a + b + c + d + e + f + g + h;
+}
+noInline(clobber);
+
+function testRegisterPressure(v, w) {
+    const t1 = v + 1, t2 = v + 2, t3 = v + 3, t4 = v + 4;
+    const t5 = v + 5, t6 = v + 6, t7 = v + 7, t8 = v + 8;
+    let r;
+    if (w ?? clobber(t1, t2, t3, t4, t5, t6, t7, t8))
+        r = "T";
+    else
+        r = "F";
+    return `${r}:${t1 + t2 + t3 + t4 + t5 + t6 + t7 + t8}`;
+}
+noInline(testRegisterPressure);
+
+for (let i = 0; i < 1e4; i++) {
+    shouldBe(testRegisterPressure(0, null), "T:36", "pressure: rhs call truthy");
+    shouldBe(testRegisterPressure(0, 0), "F:36", "pressure: lhs falsy non-nullish");
+    shouldBe(testRegisterPressure(0, 1), "T:36", "pressure: lhs truthy");
+}
+
+// =========================================================================
+// Composition with conditional expression in a loop condition.
+// =========================================================================
+
+function testComposed(state) {
+    let n = 0;
+    while ((state.v ?? state.fallback) ? state.count-- > 0 : false)
+        n++;
+    return n;
+}
+noInline(testComposed);
+
+for (let i = 0; i < 1e3; i++) {
+    shouldBe(testComposed({ v: true, fallback: false, count: 3 }), 3, "composed: lhs truthy");
+    shouldBe(testComposed({ v: null, fallback: true, count: 2 }), 2, "composed: rhs truthy");
+    shouldBe(testComposed({ v: null, fallback: false, count: 5 }), 0, "composed: rhs falsy");
+    shouldBe(testComposed({ v: masquerader, fallback: true, count: 5 }), 0, "composed: masquerader falsy");
+}

--- a/JSTests/stress/nullish-coalescing-in-condition-context.js
+++ b/JSTests/stress/nullish-coalescing-in-condition-context.js
@@ -1,0 +1,379 @@
+//@ requireOptions("--validateGraph=true")
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${expected}, got ${actual}`);
+}
+
+function shouldThrow(fn, errorType, msg) {
+    let threw = false;
+    try {
+        fn();
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof errorType))
+            throw new Error(`FAIL: ${msg}: expected ${errorType.name}, got ${e.constructor.name}`);
+    }
+    if (!threw)
+        throw new Error(`FAIL: ${msg}: expected throw, got no throw`);
+}
+
+// =========================================================================
+// Basic patterns
+// =========================================================================
+
+function testIf(a, b) {
+    if (a ?? b)
+        return "T";
+    return "F";
+}
+noInline(testIf);
+
+function testNot(a, b) {
+    if (!(a ?? b))
+        return "T";
+    return "F";
+}
+noInline(testNot);
+
+function testRhsAnd(a, b, c) {
+    if (a ?? (b && c))
+        return "T";
+    return "F";
+}
+noInline(testRhsAnd);
+
+function testRhsOr(a, b, c) {
+    if (a ?? (b || c))
+        return "T";
+    return "F";
+}
+noInline(testRhsOr);
+
+function testRhsNot(a, b) {
+    if (a ?? !b)
+        return "T";
+    return "F";
+}
+noInline(testRhsNot);
+
+function testRhsRel(a, b, c) {
+    if (a ?? b < c)
+        return "T";
+    return "F";
+}
+noInline(testRhsRel);
+
+function testRhsEq(a, b, c) {
+    if (a ?? b === c)
+        return "T";
+    return "F";
+}
+noInline(testRhsEq);
+
+function testNested(a, b, c) {
+    if (a ?? (b ?? c))
+        return "T";
+    return "F";
+}
+noInline(testNested);
+
+function testTernaryCond(a, b) {
+    return (a ?? b) ? "T" : "F";
+}
+noInline(testTernaryCond);
+
+function testOuterAnd(a, b, c) {
+    if ((a ?? b) && c)
+        return "T";
+    return "F";
+}
+noInline(testOuterAnd);
+
+function testOuterOr(a, b, c) {
+    if ((a ?? b) || c)
+        return "T";
+    return "F";
+}
+noInline(testOuterOr);
+
+function testWhile(state) {
+    let c = 0;
+    while (state.v ?? state.next())
+        c++;
+    return c;
+}
+noInline(testWhile);
+
+function testFor(arr) {
+    let log = [];
+    for (let i = 0; arr[i] ?? false; i++)
+        log.push(arr[i]);
+    return log.join(",");
+}
+noInline(testFor);
+
+function testDoWhile(state) {
+    let c = 0;
+    do {
+        c++;
+    } while (state.v ?? --state.n > 0);
+    return c;
+}
+noInline(testDoWhile);
+
+function testCommaLhs(a, b, c) {
+    if ((a, b ?? c))
+        return "T";
+    return "F";
+}
+noInline(testCommaLhs);
+
+// =========================================================================
+// Run basic patterns
+// =========================================================================
+
+for (let i = 0; i < 1e4; i++) {
+    shouldBe(testIf(1, 0), "T", "testIf(1,0): lhs non-nullish truthy");
+    shouldBe(testIf(0, 1), "F", "testIf(0,1): lhs non-nullish falsy");
+    shouldBe(testIf(null, 1), "T", "testIf(null,1): rhs truthy");
+    shouldBe(testIf(null, 0), "F", "testIf(null,0): rhs falsy");
+    shouldBe(testIf(undefined, "x"), "T", "testIf(undef,'x')");
+    shouldBe(testIf(undefined, NaN), "F", "testIf(undef,NaN)");
+    shouldBe(testIf("", 1), "F", "testIf('',1): empty string non-nullish falsy");
+    shouldBe(testIf(false, 1), "F", "testIf(false,1): false non-nullish");
+    shouldBe(testIf(NaN, 1), "F", "testIf(NaN,1): NaN non-nullish falsy");
+
+    shouldBe(testNot(1, 0), "F", "testNot(1,0)");
+    shouldBe(testNot(0, 1), "T", "testNot(0,1)");
+    shouldBe(testNot(null, 0), "T", "testNot(null,0)");
+    shouldBe(testNot(null, 1), "F", "testNot(null,1)");
+
+    shouldBe(testRhsAnd(1, 0, 0), "T", "rhsAnd: lhs truthy");
+    shouldBe(testRhsAnd(0, 1, 1), "F", "rhsAnd: lhs falsy non-nullish");
+    shouldBe(testRhsAnd(null, 1, 1), "T", "rhsAnd: b&&c true");
+    shouldBe(testRhsAnd(null, 0, 1), "F", "rhsAnd: b falsy");
+    shouldBe(testRhsAnd(null, 1, 0), "F", "rhsAnd: c falsy");
+
+    shouldBe(testRhsOr(null, 0, 1), "T", "rhsOr: c truthy");
+    shouldBe(testRhsOr(null, 0, 0), "F", "rhsOr: both falsy");
+    shouldBe(testRhsOr(0, 1, 1), "F", "rhsOr: lhs falsy non-nullish");
+
+    shouldBe(testRhsNot(null, 0), "T", "rhsNot: !0");
+    shouldBe(testRhsNot(null, 1), "F", "rhsNot: !1");
+    shouldBe(testRhsNot(false, 0), "F", "rhsNot: lhs false");
+
+    shouldBe(testRhsRel(null, 1, 2), "T", "rhsRel: 1<2");
+    shouldBe(testRhsRel(null, 2, 1), "F", "rhsRel: 2<1");
+    shouldBe(testRhsEq(null, 1, 1), "T", "rhsEq: 1===1");
+    shouldBe(testRhsEq(null, 1, 2), "F", "rhsEq: 1!==2");
+
+    shouldBe(testNested(null, null, 1), "T", "nested: innermost truthy");
+    shouldBe(testNested(null, null, 0), "F", "nested: innermost falsy");
+    shouldBe(testNested(null, 1, 0), "T", "nested: middle truthy");
+    shouldBe(testNested(0, 1, 1), "F", "nested: outer falsy non-nullish");
+
+    shouldBe(testTernaryCond(1, 0), "T", "ternaryCond lhs truthy");
+    shouldBe(testTernaryCond(null, 1), "T", "ternaryCond rhs truthy");
+    shouldBe(testTernaryCond(null, 0), "F", "ternaryCond rhs falsy");
+
+    shouldBe(testOuterAnd(1, 0, 1), "T", "outerAnd: lhs truthy, c truthy");
+    shouldBe(testOuterAnd(null, 1, 1), "T", "outerAnd: rhs truthy, c truthy");
+    shouldBe(testOuterAnd(null, 1, 0), "F", "outerAnd: c falsy");
+    shouldBe(testOuterAnd(0, 1, 1), "F", "outerAnd: lhs falsy non-nullish");
+
+    shouldBe(testOuterOr(0, 1, 0), "F", "outerOr: lhs falsy non-nullish, c falsy");
+    shouldBe(testOuterOr(null, 0, 1), "T", "outerOr: c truthy");
+    shouldBe(testOuterOr(1, 0, 0), "T", "outerOr: lhs truthy");
+
+    shouldBe(testWhile({ v: null, n: 0, next() { return this.n++ < 3; } }), 3, "testWhile");
+    shouldBe(testFor([1, 2, 3, null]), "1,2,3", "testFor stops at null");
+    shouldBe(testFor([1, 2, 0, 3]), "1,2", "testFor stops at falsy non-nullish");
+    shouldBe(testDoWhile({ v: null, n: 3 }), 3, "testDoWhile");
+    shouldBe(testDoWhile({ v: false, n: 3 }), 1, "testDoWhile lhs false");
+
+    shouldBe(testCommaLhs(99, null, 1), "T", "commaLhs: rhs truthy");
+    shouldBe(testCommaLhs(99, null, 0), "F", "commaLhs: rhs falsy");
+    shouldBe(testCommaLhs(99, 1, 0), "T", "commaLhs: lhs truthy");
+}
+
+// =========================================================================
+// Optional chain absorption: a?.b ?? c in condition context
+// =========================================================================
+
+function testOptChain(o, b) {
+    if (o?.x ?? b)
+        return "T";
+    return "F";
+}
+noInline(testOptChain);
+
+function testOptChainCall(o, b) {
+    if (o?.f() ?? b)
+        return "T";
+    return "F";
+}
+noInline(testOptChainCall);
+
+function testOptChainDeep(o, b) {
+    if (o?.x?.y ?? b)
+        return "T";
+    return "F";
+}
+noInline(testOptChainDeep);
+
+function testOptChainRhsAnd(o, b, c) {
+    if (o?.x ?? (b && c))
+        return "T";
+    return "F";
+}
+noInline(testOptChainRhsAnd);
+
+for (let i = 0; i < 1e4; i++) {
+    shouldBe(testOptChain({ x: 1 }, 0), "T", "optChain: x truthy");
+    shouldBe(testOptChain({ x: 0 }, 1), "F", "optChain: x falsy non-nullish");
+    shouldBe(testOptChain({ x: null }, 1), "T", "optChain: x nullish, b truthy");
+    shouldBe(testOptChain(null, 1), "T", "optChain: o nullish, b truthy");
+    shouldBe(testOptChain(null, 0), "F", "optChain: o nullish, b falsy");
+    shouldBe(testOptChain(undefined, 0), "F", "optChain: o undefined, b falsy");
+    shouldBe(testOptChain({}, 1), "T", "optChain: x undefined, b truthy");
+
+    shouldBe(testOptChainCall({ f() { return 1; } }, 0), "T", "optChainCall: returns truthy");
+    shouldBe(testOptChainCall({ f() { return 0; } }, 1), "F", "optChainCall: returns falsy");
+    shouldBe(testOptChainCall(null, 1), "T", "optChainCall: o nullish");
+    shouldBe(testOptChainCall(null, 0), "F", "optChainCall: o nullish, b falsy");
+
+    shouldBe(testOptChainDeep({ x: { y: 1 } }, 0), "T", "optChainDeep: y truthy");
+    shouldBe(testOptChainDeep({ x: null }, 1), "T", "optChainDeep: x nullish");
+    shouldBe(testOptChainDeep(null, 0), "F", "optChainDeep: o nullish, b falsy");
+
+    shouldBe(testOptChainRhsAnd(null, 1, 1), "T", "optChainRhsAnd: b&&c");
+    shouldBe(testOptChainRhsAnd(null, 1, 0), "F", "optChainRhsAnd: c falsy");
+    shouldBe(testOptChainRhsAnd({ x: 1 }, 0, 0), "T", "optChainRhsAnd: x truthy");
+}
+
+// =========================================================================
+// Side effect ordering
+// =========================================================================
+
+let log = [];
+function s(v, tag) {
+    log.push(tag);
+    return v;
+}
+
+function testOrder(a, b) {
+    if (s(a, "a") ?? s(b, "b"))
+        return "T";
+    return "F";
+}
+noInline(testOrder);
+
+function testOrderShortCircuit(a, b) {
+    if (s(a, "a") ?? s(b, "b"))
+        return "T";
+    return "F";
+}
+noInline(testOrderShortCircuit);
+
+function testOrderInRhsAnd(a, b, c) {
+    if (s(a, "a") ?? (s(b, "b") && s(c, "c")))
+        return "T";
+    return "F";
+}
+noInline(testOrderInRhsAnd);
+
+for (let i = 0; i < 1e3; i++) {
+    log = [];
+    shouldBe(testOrder(null, 1), "T", "order: rhs evaluated");
+    shouldBe(log.join(","), "a,b", "order: a then b");
+
+    log = [];
+    shouldBe(testOrderShortCircuit(0, 1), "F", "order: lhs non-nullish");
+    shouldBe(log.join(","), "a", "order: b skipped when lhs non-nullish");
+
+    log = [];
+    shouldBe(testOrderShortCircuit(1, 1), "T", "order: lhs truthy");
+    shouldBe(log.join(","), "a", "order: b skipped when lhs truthy");
+
+    log = [];
+    shouldBe(testOrderInRhsAnd(null, 1, 1), "T", "orderInRhsAnd: full");
+    shouldBe(log.join(","), "a,b,c", "orderInRhsAnd: a,b,c");
+
+    log = [];
+    shouldBe(testOrderInRhsAnd(null, 0, 1), "F", "orderInRhsAnd: b falsy");
+    shouldBe(log.join(","), "a,b", "orderInRhsAnd: c skipped");
+}
+
+// =========================================================================
+// Throws
+// =========================================================================
+
+function testThrowLhs() {
+    if ((() => { throw new Error("lhs"); })() ?? 1)
+        return "T";
+    return "F";
+}
+function testThrowRhs() {
+    if (null ?? (() => { throw new Error("rhs"); })())
+        return "T";
+    return "F";
+}
+noInline(testThrowLhs);
+noInline(testThrowRhs);
+
+for (let i = 0; i < 1e3; i++) {
+    shouldThrow(() => testThrowLhs(), Error, "throw in lhs");
+    shouldThrow(() => testThrowRhs(), Error, "throw in rhs");
+}
+
+// =========================================================================
+// Generator / async
+// =========================================================================
+
+function* gen(a, b) {
+    if (a ?? b)
+        yield "T";
+    else
+        yield "F";
+}
+
+async function asyncFn(a, b) {
+    if (a ?? b)
+        return "T";
+    return "F";
+}
+
+(async () => {
+    for (let i = 0; i < 100; i++) {
+        shouldBe(gen(1, 0).next().value, "T", "generator lhs truthy");
+        shouldBe(gen(null, 0).next().value, "F", "generator rhs falsy");
+        shouldBe(gen(null, 1).next().value, "T", "generator rhs truthy");
+
+        shouldBe(await asyncFn(0, 1), "F", "async lhs falsy non-nullish");
+        shouldBe(await asyncFn(null, 1), "T", "async rhs truthy");
+    }
+})();
+
+// =========================================================================
+// Switch
+// =========================================================================
+
+function testSwitch(a, b) {
+    switch (true) {
+        case (a ?? b > 5):
+            return "big";
+        case (a ?? b > 0):
+            return "small";
+        default:
+            return "none";
+    }
+}
+noInline(testSwitch);
+
+for (let i = 0; i < 1e3; i++) {
+    shouldBe(testSwitch(null, 10), "big");
+    shouldBe(testSwitch(null, 3), "small");
+    shouldBe(testSwitch(null, -1), "none");
+    shouldBe(testSwitch(true, -1), "big");
+}

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -3800,6 +3800,32 @@ RegisterID* CoalesceNode::emitBytecode(BytecodeGenerator& generator, RegisterID*
     return generator.move(dst, temp.get());
 }
 
+void CoalesceNode::emitBytecodeInConditionContext(BytecodeGenerator& generator, Label& trueTarget, Label& falseTarget, FallThroughMode fallThroughMode)
+{
+    if (needsDebugHook()) [[unlikely]]
+        generator.emitDebugHook(this);
+
+    Ref<Label> nullishTarget = generator.newLabel();
+
+    if (m_hasAbsorbedOptionalChain)
+        generator.pushOptionalChainTarget(nullishTarget.get());
+    RefPtr<RegisterID> value = generator.emitNode(m_expr1);
+    generator.emitJumpIfTrue(generator.emitIsUndefinedOrNull(generator.newTemporary(), value.get()), nullishTarget.get());
+    if (m_hasAbsorbedOptionalChain)
+        generator.discardOptionalChainTarget();
+
+    if (fallThroughMode == FallThroughMeansTrue) {
+        generator.emitJumpIfFalse(value.get(), falseTarget);
+        generator.emitJump(trueTarget);
+    } else {
+        generator.emitJumpIfTrue(value.get(), trueTarget);
+        generator.emitJump(falseTarget);
+    }
+
+    generator.emitLabel(nullishTarget.get());
+    generator.emitNodeInConditionContext(m_expr2, trueTarget, falseTarget, fallThroughMode);
+}
+
 // ------------------------------ OptionalChainNode ----------------------------
 
 RegisterID* OptionalChainNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -1468,6 +1468,7 @@ namespace JSC {
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
+        void emitBytecodeInConditionContext(BytecodeGenerator&, Label& trueTarget, Label& falseTarget, FallThroughMode) final;
 
         ExpressionNode* m_expr1;
         ExpressionNode* m_expr2;


### PR DESCRIPTION
#### 0dde5cddb126e5c9fc51f61d9984a389c19b3c71
<pre>
[JSC] Add `emitBytecodeInConditionContext` for nullish coalescing
<a href="https://bugs.webkit.org/show_bug.cgi?id=316090">https://bugs.webkit.org/show_bug.cgi?id=316090</a>

Reviewed by Yusuke Suzuki.

`if (a ?? b)` materialized the result into a temporary and tested it
with `jfalse`, defeating the condition-context lowering of the
right-hand side (e.g. `&amp;&amp;`, `||`, `!`).

Implement CoalesceNode::emitBytecodeInConditionContext: test the
left-hand side with a fused `jundefined_or_null`, branch directly on
its truthiness when non-nullish, and otherwise emit the right-hand
side in the condition context. When the coalesce has absorbed an
optional chain (`o?.x ?? b`), the nullish label doubles as the chain&apos;s
bail-out target.

Before:
    if (a ?? b)
    [ 0] enter
    [ 1] mov                 loc5, arg1
    [ 4] jnundefined_or_null loc5, -&gt;10
    [ 7] mov                 loc5, arg2
    [10] jfalse              loc5, -&gt;15

After:
    [ 0] enter
    [ 1] jundefined_or_null  arg1, -&gt;9
    [ 4] jfalse              arg1, -&gt;14
    [ 7] jmp                 -&gt;12
    [ 9] jfalse              arg2, -&gt;14

Tests: JSTests/stress/nullish-coalescing-in-condition-context-edge-cases.js
       JSTests/stress/nullish-coalescing-in-condition-context.js

* JSTests/stress/nullish-coalescing-in-condition-context-edge-cases.js: Added.
(shouldBe):
(testMasqLhs):
(testMasqRhs):
(testMasqNot):
(testMasqWhile):
(testMasqOSR):
(const.counting.get x):
(testGetterOnce):
(testCallOnce):
(i.shouldBe.testCallOnce.f):
(rhsEffect):
(testRhsSkipped):
(const.trapped.valueOf):
(const.trapped.toString):
(const.trapped.Symbol.toPrimitive):
(testNoToPrimitive):
(testPrim):
(testAssignLhs):
(testNestedChains):
(testThisBinding):
(const.thisObj.m):
(testDeleteChain):
(testThrowingGetter):
(const.throwing.get x):
(testWithScope):
(testDirectEval):
(clobber):
(testRegisterPressure):
(testComposed):
* JSTests/stress/nullish-coalescing-in-condition-context.js: Added.
(shouldBe):
(testNot):
(testRhsAnd):
(testRhsOr):
(testRhsNot):
(testRhsRel):
(testRhsEq):
(testNested):
(testTernaryCond):
(testOuterAnd):
(testOuterOr):
(testWhile):
(testFor):
(testDoWhile):
(testCommaLhs):
(i.shouldBe.testWhile.next):
(testOptChain):
(testOptChainCall):
(testOptChainDeep):
(testOptChainRhsAnd):
(i.shouldBe.testOptChainCall.f):
(testOrder):
(testOrderShortCircuit):
(testOrderInRhsAnd):
(testThrowLhs):
(testThrowRhs):
(gen):
(async asyncFn):
(async for):
(testSwitch):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::CoalesceNode::emitBytecodeInConditionContext):
* Source/JavaScriptCore/parser/Nodes.h:

Canonical link: <a href="https://commits.webkit.org/315176@main">https://commits.webkit.org/315176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76f3b95ff2546b2b4eaefe77550e02ca06f6bd48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125968 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130950 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111462 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32402 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31103 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26291 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160886 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142388 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180195 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29514 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32918 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139386 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139249 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37501 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42524 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105936 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34537 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27595 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200945 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41028 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114284 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53977 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40425 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5680 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->