### PR TITLE
[Site Isolation] Implement Page.getResourceTree on the UIProcess ProxyingPageAgent

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-cross-origin-iframe-expected.txt
@@ -1,0 +1,15 @@
+Test that Page.getResourceTree returns the cross-origin frame tree under site isolation.
+
+
+== Running test suite: SiteIsolation.Page.GetResourceTreeCrossOriginIFrame
+-- Running test case: SiteIsolation.Page.GetResourceTreeCrossOriginIFrame.MainFrameAndChild
+PASS: Main frame should have a non-empty id.
+PASS: Main frame should have no parentId.
+PASS: Main frame URL should be on the test host.
+PASS: Main frame security origin should be on the test host.
+PASS: Should have exactly one child frame in the tree.
+PASS: Child frame should have a non-empty id.
+PASS: Child frame id should differ from main frame id.
+PASS: Child frame's parentId should match main frame's id.
+PASS: Child frame's name attribute should be reported.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-cross-origin-iframe.html
@@ -1,0 +1,64 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "child-frame";
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/resource-tree-frame.html`;
+    return new Promise(resolve => {
+        iframe.addEventListener("load", () => resolve(), { once: true });
+        document.body.appendChild(iframe);
+    });
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.GetResourceTreeCrossOriginIFrame");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.GetResourceTreeCrossOriginIFrame.MainFrameAndChild",
+        description: "getResourceTree should return the main frame plus a cross-origin child frame with parentId/name/origin populated.",
+        async test() {
+            let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+            // Add the cross-origin iframe from within the test so we can await the
+            // frame target it spawns in a separate WebContent process. The child
+            // commits in its own process, so the inspectedPage's WebFrameProxy never
+            // observes its didCommitLoadForFrame; the frame target appearing is the
+            // reliable signal that the cross-process frame exists.
+            await InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+            await targetAddedPromise;
+
+            // Under Site Isolation, use the multiplexing backendTarget because
+            // its PageAgent is the UIProcess proxy that sees every WebContent
+            // process. The per-page target's PageAgent (== window.PageAgent)
+            // would only return the local frame's view.
+            let { frameTree } = await WI.backendTarget.PageAgent.getResourceTree();
+
+            InspectorTest.expectThat(!!frameTree.frame.id, "Main frame should have a non-empty id.");
+            InspectorTest.expectEqual(frameTree.frame.parentId, undefined, "Main frame should have no parentId.");
+            InspectorTest.expectThat(/127\.0\.0\.1|localhost/.test(frameTree.frame.url), "Main frame URL should be on the test host.");
+            InspectorTest.expectThat(/127\.0\.0\.1|localhost/.test(frameTree.frame.securityOrigin), "Main frame security origin should be on the test host.");
+
+            InspectorTest.expectEqual(frameTree.childFrames?.length, 1, "Should have exactly one child frame in the tree.");
+
+            let child = frameTree.childFrames[0];
+            InspectorTest.expectThat(!!child.frame.id, "Child frame should have a non-empty id.");
+            InspectorTest.expectThat(child.frame.id !== frameTree.frame.id, "Child frame id should differ from main frame id.");
+            InspectorTest.expectEqual(child.frame.parentId, frameTree.frame.id, "Child frame's parentId should match main frame's id.");
+            InspectorTest.expectEqual(child.frame.name, "child-frame", "Child frame's name attribute should be reported.");
+            // FIXME: <https://webkit.org/b/308896> The inspectedPage's WebFrameProxy never
+            // observes the cross-origin child's didCommitLoadForFrame, so its url() and
+            // documentSecurityOriginData() remain stale. Re-enable these once cross-process
+            // WebFrameProxy state propagation lands.
+            // InspectorTest.expectThat(child.frame.url.endsWith("/resource-tree-frame.html"), "Child frame URL should point at the iframe document.");
+            // InspectorTest.expectThat(child.frame.securityOrigin !== frameTree.frame.securityOrigin, "Child frame should have a different (cross-origin) security origin from the main frame.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that Page.getResourceTree returns the cross-origin frame tree under site isolation.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-tree-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-tree-frame.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<title>Cross-origin frame</title>
+<p>Cross-origin frame for getResourceTree test.</p>

--- a/Source/JavaScriptCore/inspector/protocol/Page.json
+++ b/Source/JavaScriptCore/inspector/protocol/Page.json
@@ -2,7 +2,7 @@
     "domain": "Page",
     "description": "Actions and events related to the inspected page belong to the page domain.",
     "debuggableTypes": ["itml", "web-page"],
-    "targetTypes": ["itml", "page"],
+    "targetTypes": ["itml", "page", "web-page"],
     "types": [
         {
             "id": "Setting",

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -197,7 +197,15 @@ WI.NetworkManager = class NetworkManager extends WI.Object
 
     initializeTarget(target)
     {
-        if (target.hasDomain("Page")) {
+        // In the frontend, enabling the Page domain on the Page target is the first
+        // step to bootstrap the page resource tree. However, under Site Isolation, the
+        // Page domain on the WebPage (multiplexing) target is initialized prior to
+        // committing any load, so enabling it here would clobber the actual resource
+        // tree that arrives later with an empty snapshot. We therefore skip the WebPage
+        // target and bootstrap from the per-page target, as it always has been; the
+        // aggregated cross-origin tree is fetched on demand via
+        // WI.backendTarget.PageAgent.getResourceTree().
+        if (target.hasDomain("Page") && target.type !== WI.TargetType.WebPage) {
             target.PageAgent.enable();
 
             if (!target.isProvisional)

--- a/Source/WebInspectorUI/UserInterface/Protocol/MultiplexingBackendTarget.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/MultiplexingBackendTarget.js
@@ -33,7 +33,13 @@ WI.MultiplexingBackendTarget = class MultiplexingBackendTarget extends WI.Target
         const targetId = "multi";
         super(parentTarget, targetId, WI.UIString("Web Page"), WI.TargetType.WebPage, InspectorBackend.backendConnection);
 
-        console.assert(Array.shallowEqual(Object.keys(this._agents).sort(), ["Browser", "Network", "Target"]));
+        // Browser and Target are the only domains always present on the multiplexing
+        // target. Network and Page are optional: Network only appears under Site
+        // Isolation (ProxyingNetworkAgent), and both may be absent when inspecting an
+        // older device whose protocol predates them. The proxying Page domain, when
+        // present, lets the UIProcess PageAgent aggregate the frame tree across
+        // WebContent processes under Site Isolation. See NetworkManager.initializeTarget().
+        console.assert(Array.shallowEqual(Object.keys(this._agents).sort(), ["Browser", "Target"]));
     }
 
     // Target

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
@@ -28,11 +28,13 @@
 
 #include "HandleMessage.h"
 #include "ProxyingPageAgentMessages.h"
+#include "WebFrameProxy.h"
 #include "WebInspectorBackendMessages.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <WebCore/InspectorIdentifierRegistry.h>
+#include <WebCore/SecurityOriginData.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
@@ -214,10 +216,62 @@ CommandResult<void> ProxyingPageAgent::disable()
 
 // MARK: - Stubbed command handlers
 
-// FIXME: <https://webkit.org/b/308896> Merge remote frame subtrees into page resource tree.
+Ref<Protocol::Page::FrameResourceTree> ProxyingPageAgent::buildFrameTree(const WebFrameProxy& frame, const String* parentProtocolId) const
+{
+    auto protocolId = IdentifierRegistry::protocolFrameId(frame.frameID());
+
+    // The UIProcess WebFrameProxy tree is the authoritative cross-process frame
+    // tree under Site Isolation: childFrames() spans every WebContent process, so
+    // walking it yields the full structure (frame ids, parent linkage, name)
+    // regardless of which process hosts each frame.
+    //
+    // FIXME: <https://webkit.org/b/308896> url()/documentSecurityOriginData() are
+    // still stale for cross-origin children because the inspectedPage's
+    // WebFrameProxy never observes their owning process's didCommitLoadForFrame.
+    // WebFrameProxy state propagation across processes is the remaining follow-up.
+    SecurityOriginData securityOrigin = frame.documentSecurityOriginData();
+    String mimeType = frame.mimeType();
+    String name = frame.frameName();
+
+    auto frameObject = Protocol::Page::Frame::create()
+        .setId(protocolId)
+        .setLoaderId(emptyString()) // FIXME: <https://webkit.org/b/308895> get loaderId from document identifier
+        .setUrl(frame.url().string())
+        .setMimeType(mimeType.isEmpty() ? "text/html"_s : mimeType)
+        .setSecurityOrigin(securityOrigin.toString())
+        .release();
+
+    if (parentProtocolId)
+        frameObject->setParentId(*parentProtocolId);
+    if (!name.isEmpty())
+        frameObject->setName(name);
+
+    auto result = Protocol::Page::FrameResourceTree::create()
+        .setFrame(WTF::move(frameObject))
+        .setResources(JSON::ArrayOf<Protocol::Page::FrameResource>::create())
+        .release();
+
+    if (!frame.childFrames().isEmpty()) {
+        auto childrenArray = JSON::ArrayOf<Protocol::Page::FrameResourceTree>::create();
+        for (auto& child : frame.childFrames())
+            childrenArray->addItem(buildFrameTree(child, &protocolId));
+        result->setChildFrames(WTF::move(childrenArray));
+    }
+
+    return result;
+}
+
 CommandResult<Ref<Protocol::Page::FrameResourceTree>> ProxyingPageAgent::getResourceTree()
 {
-    return makeUnexpected("Not yet implemented under Site Isolation"_s);
+    if (!m_enabled)
+        return makeUnexpected("Not supported without Site Isolation"_s);
+
+    Ref inspectedPage = m_inspectedPage.get();
+    RefPtr mainFrame = inspectedPage->mainFrame();
+    if (!mainFrame)
+        return makeUnexpected("Missing main frame"_s);
+
+    return buildFrameTree(*mainFrame, nullptr);
 }
 
 // FIXME: <https://webkit.org/b/308898> Forward emulation overrides to all WebContent processes.

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
@@ -41,6 +41,7 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
+class WebFrameProxy;
 class WebProcessProxy;
 }
 
@@ -106,6 +107,8 @@ private:
     void frameDetached(WebCore::FrameIdentifier);
 
     void removeAllRegisteredReceivers();
+
+    Ref<Protocol::Page::FrameResourceTree> buildFrameTree(const WebKit::WebFrameProxy&, const String* parentProtocolId) const;
 
     const UniqueRef<PageFrontendDispatcher> m_frontendDispatcher;
     const Ref<PageBackendDispatcher> m_backendDispatcher;

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -68,6 +68,7 @@
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/NavigationScheduler.h>
 #include <WebCore/RemoteFrameLayoutInfo.h>
+#include <WebCore/SecurityOriginData.h>
 #include <WebCore/SecurityPolicy.h>
 #include <WebCore/ShareableBitmapHandle.h>
 #include <WebCore/WebKitJSHandle.h>
@@ -779,6 +780,13 @@ Ref<SecurityOrigin> WebFrameProxy::securityOrigin() const
 {
     ASSERT(m_documentSecurityOrigin);
     return *m_documentSecurityOrigin;
+}
+
+SecurityOriginData WebFrameProxy::documentSecurityOriginData() const
+{
+    if (RefPtr origin = m_documentSecurityOrigin)
+        return origin->data();
+    return SecurityOriginData::fromURL(url());
 }
 
 bool WebFrameProxy::isSameOriginAs(const WebFrameProxy& frame) const

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -177,6 +177,9 @@ public:
     const String& title() const LIFETIME_BOUND { return m_title; }
 
     void setSpecifiedName(const String& name) { m_frameName = name; }
+    const String& frameName() const LIFETIME_BOUND { return m_frameName; }
+    const ListHashSet<Ref<WebFrameProxy>>& childFrames() const LIFETIME_BOUND { return m_childFrames; }
+    WebCore::SecurityOriginData documentSecurityOriginData() const;
 
     const WebCore::CertificateInfo& certificateInfo() const LIFETIME_BOUND { return m_certificateInfo; }
 


### PR DESCRIPTION
#### 1c2a6d971d3224a13e8d2ae80cc0c1b269816ce5
<pre>
[Site Isolation] Implement Page.getResourceTree on the UIProcess ProxyingPageAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=308896">https://bugs.webkit.org/show_bug.cgi?id=308896</a>
<a href="https://rdar.apple.com/170094580">rdar://170094580</a>

Reviewed by BJ Burg.

Implement Page.getResourceTree on the UIProcess ProxyingPageAgent by
walking WebFrameProxy::childFrames(), which under Site Isolation is the
authoritative cross-process frame tree: it spans every WebContent
process, so a single recursive walk yields the full structure regardless
of which process hosts each frame. The frontend (web-page) target now
exposes the Page domain so the aggregated tree can be requested on demand
via WI.backendTarget.PageAgent.getResourceTree().

Main-frame and tree-structure data (ids, parent linkage, frame name)
return correctly across cross-origin process boundaries. Cross-origin
URL/origin reporting and wiring the aggregated tree into the live
inspector resource sidebar are left as follow-ups (below).

* Source/JavaScriptCore/inspector/protocol/Page.json:
Add &quot;web-page&quot; to targetTypes so the multiplexing backendTarget gets a
PageAgent on the frontend, making getResourceTree reachable on the
UIProcess proxy.

* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::documentSecurityOriginData):
Add public accessors for frameName(), childFrames(), and a safe
documentSecurityOriginData() that null-guards m_documentSecurityOrigin
(securityOrigin() ASSERTs on uncommitted frames).

* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp:
(Inspector::ProxyingPageAgent::buildFrameTree):
(Inspector::ProxyingPageAgent::getResourceTree):
Implement getResourceTree by recursively walking the inspected page&apos;s
WebFrameProxy tree from the main frame. Each Frame is populated directly
from WebFrameProxy state (url, mimeType, documentSecurityOriginData,
frameName); the UIProcess tree already aggregates frames across
processes, so no per-process event cache is needed.

* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.initializeTarget):
The page&apos;s main-frame resource tree continues to be bootstrapped from
the per-page target. Skip the bootstrap for the multiplexing
backendTarget (TargetType.WebPage), which now also exposes a Page
domain: it is initialized before any load has committed, so letting it
call getResourceTree would clobber the per-page target&apos;s tree with an
empty snapshot, and outside Site Isolation it would shadow the per-page
target entirely. The aggregated cross-origin tree is fetched on demand
via WI.backendTarget.PageAgent.getResourceTree().

* Source/WebInspectorUI/UserInterface/Protocol/MultiplexingBackendTarget.js:
Update the agent-set assertion to include the now-present Page domain.

* LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-tree-frame.html: Added.
Layout test exercising getResourceTree via WI.backendTarget.PageAgent on
a page with a cross-origin iframe. Asserts main-frame and structural
properties (frame ids, parent linkage, name); the cross-origin URL/origin
assertions are commented out with a FIXME pointing at the follow-ups below.

Follow-ups, each tracked in its own bug and landing on top of this change
in the order listed (each depends on the previous):

* bug 316663 -- [Site Isolation] Make Web Inspector frame protocol IDs
  collision-free and hosting-process-qualified: encode the full
  FrameIdentifier (its low 32 bits collide for main(A) -&gt; child(B) -&gt;
  grandchild(A)) and qualify each id by the frame&apos;s hosting process.

* bug 316664 -- [Site Isolation] Emit live Page.frameNavigated/frameDetached
  from cross-origin processes: forward frame lifecycle events from each
  WebContent process to the UIProcess ProxyingPageAgent.

* bug 316665 -- [Site Isolation] Report cross-origin frame url/securityOrigin
  in Page.getResourceTree: cache the committed document info from
  frameNavigated, since the inspectedPage&apos;s WebFrameProxy never sees the
  cross-origin child&apos;s commit.

* bug 316666 -- [Site Isolation] Show cross-origin frames in the inspector
  frame model: consume those events into WI.networkManager.frames and the
  resource sidebar.

* bug 316667 -- [Site Isolation] Aggregate cross-process resources and
  loaderId in Page.getResourceTree: gather each frame&apos;s resources from its
  hosting process (the command becomes asynchronous).

* bug 316668 -- [Site Isolation] Report genuine cross-origin frame removal in
  Page.frameDetached: report removal from the authoritative WebFrameProxy
  destruction path.

* bug 316669 -- [Site Isolation] Expand Page.getResourceTree cross-origin
  test coverage: nested grandchild, siblings, dynamic add/remove, and
  cross-domain frame-id consistency.

Canonical link: <a href="https://commits.webkit.org/314825@main">https://commits.webkit.org/314825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10445b3df613a58680495525d95831ab73caeaff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176364 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f32d24b-227c-4035-aa09-b744e08e869c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130152 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02343f08-246a-45b0-8884-1d30ad23444b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110669 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/060b6650-b13e-41df-a721-72f5286f0356) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25103 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159480 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178907 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/28215 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31804 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138543 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138433 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37271 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149817 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104624 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33683 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26693 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199992 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113157 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53760 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39473 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4791 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39723 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39618 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->