### PR TITLE
[AutoFill Debugging] Scroll interaction summary string sometimes "Scrolled down 0px" even if we scrolled

### DIFF
--- a/LayoutTests/fast/text-extraction/text-extraction-scroll-to-next-page-expected.txt
+++ b/LayoutTests/fast/text-extraction/text-extraction-scroll-to-next-page-expected.txt
@@ -3,15 +3,20 @@ Tests that scroll interactions with no delta scroll by one page and wrap around.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS scrollVerticalError is ""
+PASS scrollVerticalResult.error is ""
+PASS scrollVerticalResult.summary is "Scrolled 200px down"
 PASS verticalScrollTopAfterFirstScroll is 200
-PASS scrollVerticalWrapError is ""
+PASS scrollVerticalWrapResult.error is ""
+PASS scrollVerticalWrapResult.summary is "Scrolled 3800px up (wrapped to start)"
 PASS verticalScrollTopAfterWrap is 0
-PASS scrollHorizontalError is ""
+PASS scrollHorizontalResult.error is ""
+PASS scrollHorizontalResult.summary is "Scrolled 200px right"
 PASS horizontalScrollLeftAfterFirstScroll is 200
-PASS scrollHorizontalWrapError is ""
+PASS scrollHorizontalWrapResult.error is ""
+PASS scrollHorizontalWrapResult.summary is "Scrolled 3800px left (wrapped to start)"
 PASS horizontalScrollLeftAfterWrap is 0
-PASS scrollPageError is ""
+PASS scrollPageResult.error is ""
+PASS /^Scrolled [1-9]\d*px down$/.test(scrollPageResult.summary) is true
 PASS pageScrollTopAfterScroll is > 0
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/text-extraction/text-extraction-scroll-to-next-page.html
+++ b/LayoutTests/fast/text-extraction/text-extraction-scroll-to-next-page.html
@@ -57,7 +57,7 @@
             includeAccessibilityAttributes: true,
         });
 
-        scrollVerticalError = await UIHelper.performTextExtractionInteraction("scroll", {
+        scrollVerticalResult = await UIHelper.performTextExtractionInteractionResult("scroll", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Vertical scroller"),
         });
 
@@ -66,12 +66,13 @@
 
         verticalScrollTopAfterFirstScroll = verticalScroller.scrollTop;
 
-        shouldBeEqualToString("scrollVerticalError", "");
+        shouldBeEqualToString("scrollVerticalResult.error", "");
+        shouldBeEqualToString("scrollVerticalResult.summary", "Scrolled 200px down");
         shouldBe("verticalScrollTopAfterFirstScroll", "200");
 
         verticalScroller.scrollTop = verticalScroller.scrollHeight;
 
-        scrollVerticalWrapError = await UIHelper.performTextExtractionInteraction("scroll", {
+        scrollVerticalWrapResult = await UIHelper.performTextExtractionInteractionResult("scroll", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Vertical scroller"),
         });
 
@@ -80,10 +81,11 @@
 
         verticalScrollTopAfterWrap = verticalScroller.scrollTop;
 
-        shouldBeEqualToString("scrollVerticalWrapError", "");
+        shouldBeEqualToString("scrollVerticalWrapResult.error", "");
+        shouldBeEqualToString("scrollVerticalWrapResult.summary", "Scrolled 3800px up (wrapped to start)");
         shouldBe("verticalScrollTopAfterWrap", "0");
 
-        scrollHorizontalError = await UIHelper.performTextExtractionInteraction("scroll", {
+        scrollHorizontalResult = await UIHelper.performTextExtractionInteractionResult("scroll", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Horizontal scroller"),
         });
 
@@ -92,12 +94,13 @@
 
         horizontalScrollLeftAfterFirstScroll = horizontalScroller.scrollLeft;
 
-        shouldBeEqualToString("scrollHorizontalError", "");
+        shouldBeEqualToString("scrollHorizontalResult.error", "");
+        shouldBeEqualToString("scrollHorizontalResult.summary", "Scrolled 200px right");
         shouldBe("horizontalScrollLeftAfterFirstScroll", "200");
 
         horizontalScroller.scrollLeft = horizontalScroller.scrollWidth;
 
-        scrollHorizontalWrapError = await UIHelper.performTextExtractionInteraction("scroll", {
+        scrollHorizontalWrapResult = await UIHelper.performTextExtractionInteractionResult("scroll", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Horizontal scroller"),
         });
 
@@ -106,20 +109,22 @@
 
         horizontalScrollLeftAfterWrap = horizontalScroller.scrollLeft;
 
-        shouldBeEqualToString("scrollHorizontalWrapError", "");
+        shouldBeEqualToString("scrollHorizontalWrapResult.error", "");
+        shouldBeEqualToString("scrollHorizontalWrapResult.summary", "Scrolled 3800px left (wrapped to start)");
         shouldBe("horizontalScrollLeftAfterWrap", "0");
 
         document.body.style.height = "4000px";
         await UIHelper.ensurePresentationUpdate();
 
-        scrollPageError = await UIHelper.performTextExtractionInteraction("scroll", {});
+        scrollPageResult = await UIHelper.performTextExtractionInteractionResult("scroll", {});
 
         await UIHelper.ensureVisibleContentRectUpdate();
         await UIHelper.ensurePresentationUpdate();
 
         pageScrollTopAfterScroll = document.scrollingElement.scrollTop;
 
-        shouldBeEqualToString("scrollPageError", "");
+        shouldBeEqualToString("scrollPageResult.error", "");
+        shouldBeTrue("/^Scrolled [1-9]\\d*px down$/.test(scrollPageResult.summary)");
         shouldBeGreaterThan("pageScrollTopAfterScroll", "0");
 
         finishJSTest();

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2692,14 +2692,20 @@ window.UIHelper = class UIHelper {
 
     static async performTextExtractionInteraction(action, options)
     {
+        const result = await UIHelper.performTextExtractionInteractionResult(action, options);
+        return result.error;
+    }
+
+    static async performTextExtractionInteractionResult(action, options)
+    {
         if (!this.isWebKit2())
-            return Promise.resolve(false);
+            return Promise.resolve({ error: "", summary: "" });
 
         return new Promise(resolve => {
             const scriptToRun = `uiController.performTextExtractionInteraction("${action}", ${JSON.stringify(options)}, result => {
                 uiController.uiScriptComplete(result)
             })`;
-            testRunner.runUIScript(scriptToRun, resolve);
+            testRunner.runUIScript(scriptToRun, raw => resolve(JSON.parse(raw)));
         });
     }
 }

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -2266,9 +2266,10 @@ static void scrollToNextPage(LocalFrame& frame, std::optional<NodeIdentifier>&& 
         auto visibleSize = scroller->visibleSize();
         auto delta = scrollsHorizontally ? FloatSize { static_cast<float>(visibleSize.width()), 0 } : FloatSize { 0, static_cast<float>(visibleSize.height()) };
         scroller->scrollToOffsetWithoutAnimation(FloatPoint { currentOffset } + delta);
-        auto newOffset = scroller->scrollOffset();
         auto direction = scrollsHorizontally ? (isRTL ? "left"_s : "right"_s) : "down"_s;
-        auto distance = scrollsHorizontally ? roundToInt(newOffset.x() - currentOffset.x()) : roundToInt(newOffset.y() - currentOffset.y());
+        auto distance = scrollsHorizontally
+            ? std::min(roundToInt(visibleSize.width()), roundToInt(maxOffset.x() - currentOffset.x()))
+            : std::min(roundToInt(visibleSize.height()), roundToInt(maxOffset.y() - currentOffset.y()));
         completion(true, buildSummary(distance, direction, ASCIILiteral { }));
     }
 }

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -564,9 +564,18 @@ void UIScriptControllerCocoa::performTextExtractionInteraction(JSStringRef jsAct
         if (!m_context)
             return;
 
-        RetainPtr description = [result.error.userInfo objectForKey:NSDebugDescriptionErrorKey] ?: @"";
-        JSRetainPtr jsDescription = adopt(JSStringCreateWithCFString((__bridge CFStringRef)description.get()));
-        m_context->asyncTaskComplete(callbackID, { JSValueMakeString(m_context->jsContext(), jsDescription.get()) });
+        NSDictionary *resultDict = @{
+            @"error": [result.error.userInfo objectForKey:NSDebugDescriptionErrorKey] ?: @"",
+            @"summary": result.summary ?: @"",
+        };
+
+        RetainPtr data = [NSJSONSerialization dataWithJSONObject:resultDict options:0 error:nil];
+        RetainPtr resultString = data ? adoptNS([[NSString alloc] initWithData:data.get() encoding:NSUTF8StringEncoding]) : nullptr;
+        if (!resultString)
+            resultString = @"{\"error\":\"\",\"summary\":\"\"}";
+
+        JSRetainPtr jsString = adopt(JSStringCreateWithCFString((__bridge CFStringRef)resultString.get()));
+        m_context->asyncTaskComplete(callbackID, { JSValueMakeString(m_context->jsContext(), jsString.get()) });
     }];
 }
 


### PR DESCRIPTION
#### a0246b3f1f71689e63587e2de04e60d8eeed9e1d
<pre>
[AutoFill Debugging] Scroll interaction summary string sometimes &quot;Scrolled down 0px&quot; even if we scrolled
<a href="https://bugs.webkit.org/show_bug.cgi?id=316102">https://bugs.webkit.org/show_bug.cgi?id=316102</a>
<a href="https://rdar.apple.com/178531777">rdar://178531777</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

The new content offset after issuing `scrollToOffsetWithoutAnimation` may still be the same as the
old content offset, due to async scrolling. Instead of computing the final delta, report the amount
by which we attempted to scroll instead.

* LayoutTests/fast/text-extraction/text-extraction-scroll-to-next-page-expected.txt:
* LayoutTests/fast/text-extraction/text-extraction-scroll-to-next-page.html:
* LayoutTests/resources/ui-helper.js:

Add test support for summary strings in text extraction layout tests.

(window.UIHelper.async performTextExtractionInteraction):
(window.UIHelper.async performTextExtractionInteractionResult):
(window.UIHelper):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::scrollToNextPage):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::performTextExtractionInteraction):

Canonical link: <a href="https://commits.webkit.org/314394@main">https://commits.webkit.org/314394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffbaf05661fa5b53bcf86d922f624a91e5f8464f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123214 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c201c626-a68c-4c82-aa33-09ae90487cf7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39453 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128992 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/136d4eb8-c1c3-4e6e-aca3-c678cd1ccb06) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109519 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/219b627f-5e28-4004-8e73-a61dbe232f90) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29018 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23146 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177538 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30441 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137332 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137261 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36986 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148597 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102797 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32543 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25464 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 13 flakes 3 failures; Uploaded test results; 9 flakes 4 failures; 3 failures; Passed layout tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38717 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111790 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38114 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3546 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38359 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->