### PR TITLE
App Badge origin spoofing from `window` contexts

### DIFF
--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -995,6 +995,11 @@ void WebFrameProxy::updateScrollingMode(WebCore::ScrollbarMode scrollingMode)
 
 void WebFrameProxy::setAppBadge(const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
 {
+    auto firstPartyAccessResult = process().allowsFirstPartyAccess(WebCore::RegistrableDomain { origin });
+    if (firstPartyAccessResult == WebProcessProxy::FirstPartyAccessResult::SilentFailure)
+        return;
+    MESSAGE_CHECK(firstPartyAccessResult == WebProcessProxy::FirstPartyAccessResult::Pass);
+
     if (RefPtr webPageProxy = m_page.get())
         webPageProxy->uiClient().updateAppBadge(*webPageProxy, origin, badge);
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2911,8 +2911,27 @@ void WebProcessProxy::unwrapCryptoKey(WrappedCryptoKey&& wrappedKey, CompletionH
 
 }
 
+WebProcessProxy::FirstPartyAccessResult WebProcessProxy::allowsFirstPartyAccess(const WebCore::RegistrableDomain& domain) const
+{
+    if (m_site)
+        return domain == m_site->domain() ? FirstPartyAccessResult::Pass : FirstPartyAccessResult::HardFailure;
+
+    switch (m_site.error()) {
+    case SiteState::NotYetSpecified:
+        return FirstPartyAccessResult::Pass;
+    case SiteState::MultipleSites:
+        // A web process under the MultipleSites categorization should not be doing things like
+        // sending badge updates.
+        // This is expected sometimes, like right as a new load is starting, so we can silently ignore.
+        return FirstPartyAccessResult::SilentFailure;
+    case SiteState::SharedProcess:
+        return sharedProcessDomains().contains(domain) ? FirstPartyAccessResult::Pass : FirstPartyAccessResult::HardFailure;
+    }
+}
+
 void WebProcessProxy::setAppBadgeFromWorker(const SecurityOriginData& origin, std::optional<uint64_t> badge)
 {
+    MESSAGE_CHECK(allowsFirstPartyAccess(WebCore::RegistrableDomain { origin }) == FirstPartyAccessResult::Pass);
     protect(websiteDataStore())->workerUpdatedAppBadge(origin, badge);
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -623,6 +623,13 @@ public:
     void decrementFrameProcessCount() { --m_frameProcessCount; }
     uint64_t frameProcessCount() const { return m_frameProcessCount; }
 
+    enum class FirstPartyAccessResult {
+        Pass,
+        SilentFailure,
+        HardFailure,
+    };
+    FirstPartyAccessResult allowsFirstPartyAccess(const WebCore::RegistrableDomain&) const;
+
 private:
     Type type() const final { return Type::WebContent; }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Badging.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Badging.mm
@@ -448,7 +448,12 @@ window.navigator.setAppBadge(10);
 </script>
 )SWRESOURCE"_s;
 
-TEST(Badging, Origin)
+// This test verifies that a setAppBadge call from a cross origin iframe passes the correct
+// origin to the delegate.
+// When actually that call should've been rejected down at the DOM level because cross-origin
+// iframes cannot call setAppBadge.
+// Fixing that is for a different day, so for this branch we'll just disable this test.
+TEST(Badging, DISABLED_Origin)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
@@ -538,3 +543,109 @@ TEST(Badging, ServiceWorkerOverride)
 
     EXPECT_EQ(badgeDelegate.get().appBadgeIndex, 2);
 }
+
+#if ENABLE(IPC_TESTING_API)
+
+static constexpr auto badgeAttackFromWorkerBytes = R"TESTRESOURCE(
+<script src="coreipc.js"></script>
+<script>
+async function sendSpoofedBadgeIPC()
+{
+    const CoreIPC = new CoreIPCClass();
+
+    CoreIPC.UI.WebProcessProxy.SetAppBadgeFromWorker(0, {
+        origin: {
+            data: {
+                variantType: 'WebCore::SecurityOriginData::Tuple',
+                variant: {
+                    protocol: 'https',
+                    host: 'apple.com',
+                    port: { }
+                }
+            }
+        },
+        badge: {
+            optionalValue: 1337
+        }
+    });
+}
+</script>
+)TESTRESOURCE"_s;
+
+static void runAppBadgeSpoofTest(const String& attackerHTML)
+{
+    NSURL *coreIPCURL = [NSBundle.test_resourcesBundle URLForResource:@"coreipc" withExtension:@"js"];
+    NSData *coreIPCData = [NSData dataWithContentsOfURL:coreIPCURL];
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { attackerHTML } },
+        { "/coreipc.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, coreIPCData } },
+    });
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+    configuration.get().preferences._appBadgeEnabled = YES;
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+
+    RetainPtr badgeDelegate = adoptNS([BadgeDelegate new]);
+    badgeDelegate.get().expectedAppBadgeSequence = nil;
+
+    webView.get().UIDelegate = badgeDelegate.get();
+    configuration.get().websiteDataStore._delegate = badgeDelegate.get();
+
+    [webView synchronouslyLoadRequest:server.request("/"_s)];
+
+    static bool javascriptDone = false;
+    [webView callAsyncJavaScript:@"sendSpoofedBadgeIPC();" arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        javascriptDone = true;
+    }];
+    TestWebKitAPI::Util::run(&javascriptDone);
+
+    // Give the IPC message time to be processed.
+    TestWebKitAPI::Util::spinRunLoop(30);
+
+    EXPECT_EQ(badgeDelegate.get().appBadgeIndex, 0);
+}
+
+TEST(Badging, SetAppBadgeFromWorkerOriginSpoof)
+{
+    runAppBadgeSpoofTest(badgeAttackFromWorkerBytes);
+}
+
+static constexpr auto badgeAttackFromFrameBytes = R"TESTRESOURCE(
+<script src="coreipc.js"></script>
+<script>
+async function sendSpoofedBadgeIPC()
+{
+    const CoreIPC = new CoreIPCClass();
+
+    CoreIPC.UI.WebFrameProxy.SetAppBadge(IPC.frameID[0], {
+        origin: {
+            data: {
+                variantType: 'WebCore::SecurityOriginData::Tuple',
+                variant: {
+                    protocol: 'https',
+                    host: 'apple.com',
+                    port: { }
+                }
+            }
+        },
+        badge: {
+            optionalValue: 1337
+        }
+    });
+}
+</script>
+)TESTRESOURCE"_s;
+
+TEST(Badging, SetAppBadgeFromFrameOriginSpoof)
+{
+    runAppBadgeSpoofTest(badgeAttackFromFrameBytes);
+}
+
+#endif // ENABLE(IPC_TESTING_API)


### PR DESCRIPTION
#### b0e0375a4da83fc2cb055ddaf84df8532afd49a5
<pre>
App Badge origin spoofing from `window` contexts
<a href="https://rdar.apple.com/173194716">rdar://173194716</a>

Reviewed by Anne van Kesteren.

A compromised web process can send an arbitrary message to the UI process to change
the app badge from page domain.

This is similar to <a href="https://commits.webkit.org/305413.558@safari-7624-branch">305413.558@safari-7624-branch</a> but a different message to spoof the
origin and different code path to receive it.

The fix is basically the same - message check that the requested origin is allowed to
come from both the web process in consideration.

Also comes with a test crafting this attack message.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::setAppBadge):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm:
((Badging, SetAppBadgeFromWorkerOriginSpoof)):
((Badging, SetAppBadgeFromFrameOriginSpoof)):

Originally-landed-as: <a href="https://commits.webkit.org/305413.573@rapid">305413.573@rapid</a>/safari-7624.2.5.110-branch (3654a1bdf8a2). rdar://176062366
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0e0375a4da83fc2cb055ddaf84df8532afd49a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165964 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/39454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33035 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175008 "Hash b0e0375a for PR 66269 does not build (failure)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/388af744-a841-4cac-b576-85343fb3f33d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167830 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39458 "Hash b0e0375a for PR 66269 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/175008 "Hash b0e0375a for PR 66269 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/20f77201-efd7-4fa7-94ad-03094bd68635) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168923 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/175008 "Hash b0e0375a for PR 66269 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83dd3859-9559-4875-b174-329800eb0b96) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/39458 "Hash b0e0375a for PR 66269 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23151 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/26812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/28518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/177543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39523 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/39458 "Hash b0e0375a for PR 66269 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40211 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/148607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/32548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38722 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/111795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38119 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/3557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/38364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38262 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->