### PR TITLE
[macOS] Higher floor memory usage from unreleased video decoders during stress testing

### DIFF
--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -192,6 +192,7 @@ public:
 class WEBCORE_EXPORT AudioVideoRenderer : public AudioInterface, public VideoInterface, public VideoFullscreenInterface, public SynchronizerInterface, public TracksRendererManager, public AbstractThreadSafeRefCountedAndCanMakeWeakPtr {
 public:
     virtual ~AudioVideoRenderer() = default;
+    virtual void invalidate() = 0;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -70,6 +70,8 @@ public:
     ~AudioVideoRendererAVFObjC();
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
+    void invalidate() final;
+
     WEBCORE_EXPORT void setPreferences(VideoRendererPreferences) final;
     void setHasProtectedVideoContent(bool) final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -103,6 +103,7 @@ AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC(const Logger& originalLogge
     }))
 #endif
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     // addPeriodicTimeObserverForInterval: throws an exception if you pass a non-numeric CMTime, so just use
     // an arbitrarily large time value of once an hour:
     __block ThreadSafeWeakPtr weakThis { *this };
@@ -125,6 +126,12 @@ AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC(const Logger& originalLogge
 
 AudioVideoRendererAVFObjC::~AudioVideoRendererAVFObjC()
 {
+    invalidate();
+}
+
+void AudioVideoRendererAVFObjC::invalidate()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
     if (RefPtr rateChangeListener = std::exchange(m_effectiveRateChangedListener, { }))
         rateChangeListener->stop();
     cancelStartupGateObserver();
@@ -132,10 +139,14 @@ AudioVideoRendererAVFObjC::~AudioVideoRendererAVFObjC()
     cancelTimeReachedAction();
     cancelTimeObserver();
     cancelPerformTaskAtTimeObserverIfNeeded();
-    if (m_timeJumpedObserver)
+    if (m_timeJumpedObserver) {
         [m_synchronizer removeTimeObserver:m_timeJumpedObserver.get()];
-    if (m_videoFrameMetadataGatheringObserver)
+        m_timeJumpedObserver = nil;
+    }
+    if (m_videoFrameMetadataGatheringObserver) {
         [m_synchronizer removeTimeObserver:m_videoFrameMetadataGatheringObserver.get()];
+        m_videoFrameMetadataGatheringObserver = nil;
+    }
 
     destroyVideoTrack();
     destroyAudioRenderers();

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -436,6 +436,8 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
 #if ENABLE(VIDEO)
     protect(videoFrameObjectHeap())->close();
     protect(remoteMediaPlayerManagerProxy())->connectionToWebProcessClosed();
+    if (m_remoteAudioVideoRendererProxyManager)
+        m_remoteAudioVideoRendererProxyManager->close();
 #endif
     // RemoteRenderingBackend objects ref their GPUConnectionToWebProcess so we need to make sure
     // to break the reference cycle by destroying them.

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -89,10 +89,10 @@ void RemoteAudioVideoRendererProxyManager::publishAndSend(RemoteAudioVideoRender
     m_gpuConnectionToWebProcess.get()->connection().send(std::forward<Message>(message), identifier);
 }
 
-RefPtr<AudioVideoRenderer> RemoteAudioVideoRendererProxyManager::createRenderer()
+RefPtr<AudioVideoRenderer> RemoteAudioVideoRendererProxyManager::createRenderer(uint64_t logSiteIdentifier)
 {
 #if USE(AVFOUNDATION)
-    return AudioVideoRendererAVFObjC::create(Ref { m_gpuConnectionToWebProcess.get()->logger() }, LoggerHelper::uniqueLogIdentifier());
+    return AudioVideoRendererAVFObjC::create(Ref { m_gpuConnectionToWebProcess.get()->logger() }, logSiteIdentifier);
 #else
     ASSERT_NOT_REACHED();
     return nullptr;
@@ -110,6 +110,17 @@ RemoteAudioVideoRendererProxyManager::RemoteAudioVideoRendererProxyManager(GPUCo
 }
 
 RemoteAudioVideoRendererProxyManager::~RemoteAudioVideoRendererProxyManager() = default;
+
+void RemoteAudioVideoRendererProxyManager::close()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    auto renderers = std::exchange(m_renderers, { });
+    for (auto& renderContext : renderers.values()) {
+        if (RefPtr renderer = renderContext.renderer)
+            renderer->invalidate();
+    }
+    m_videoFrameObjectHeap->close();
+}
 
 void RemoteAudioVideoRendererProxyManager::ref() const
 {
@@ -129,11 +140,11 @@ std::optional<SharedPreferencesForWebProcess> RemoteAudioVideoRendererProxyManag
     return std::nullopt;
 }
 
-void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdentifier identifier, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier, CompletionHandler<void(std::optional<WebCore::SharedTimebaseHandle>)>&& completionHandler)
+void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdentifier identifier, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier, uint64_t logSiteIdentifier, CompletionHandler<void(std::optional<WebCore::SharedTimebaseHandle>)>&& completionHandler)
 {
     MESSAGE_CHECK(!m_renderers.contains(identifier));
 
-    RefPtr renderer = createRenderer();
+    RefPtr renderer = createRenderer(logSiteIdentifier);
     ASSERT(renderer);
     if (!renderer) {
         completionHandler(std::nullopt);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -71,6 +71,8 @@ public:
     RemoteAudioVideoRendererProxyManager(GPUConnectionToWebProcess&);
     ~RemoteAudioVideoRendererProxyManager();
 
+    void close();
+
     void ref() const final;
     void deref() const final;
 
@@ -86,7 +88,7 @@ public:
 
 private:
     // Messages
-    void create(RemoteAudioVideoRendererIdentifier, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier, CompletionHandler<void(std::optional<WebCore::SharedTimebaseHandle>)>&&);
+    void create(RemoteAudioVideoRendererIdentifier, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier, uint64_t logSiteIdentifier,  CompletionHandler<void(std::optional<WebCore::SharedTimebaseHandle>)>&&);
     void shutdown(RemoteAudioVideoRendererIdentifier);
 
     void setPreferences(RemoteAudioVideoRendererIdentifier, WebCore::VideoRendererPreferences);
@@ -178,7 +180,7 @@ private:
         MonotonicTime nextPlaybackQualityMetricsUpdateTime { };
         bool isGatheringVideoFrameMetadata { false };
     };
-    RefPtr<WebCore::AudioVideoRenderer> createRenderer();
+    RefPtr<WebCore::AudioVideoRenderer> createRenderer(uint64_t logSiteIdentifier);
     RefPtr<WebCore::AudioVideoRenderer> rendererFor(RemoteAudioVideoRendererIdentifier) const;
     RemoteAudioVideoRendererState stateFor(RemoteAudioVideoRendererIdentifier) const;
     RendererContext& NODELETE contextFor(RemoteAudioVideoRendererIdentifier);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -31,7 +31,7 @@
     DispatchedTo=GPU
 ]
 messages -> RemoteAudioVideoRendererProxyManager {
-    Create(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::MediaPlayerClientIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier) -> (std::optional<WebCore::SharedTimebaseHandle> handle)
+    Create(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::MediaPlayerClientIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier, uint64_t logSiteIdentifier) -> (std::optional<WebCore::SharedTimebaseHandle> handle)
     Shutdown(WebKit::RemoteAudioVideoRendererIdentifier identifier)
 
     SetPreferences(WebKit::RemoteAudioVideoRendererIdentifier identifier, OptionSet<WebCore::VideoRendererPreference> preferences)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -105,7 +105,7 @@ AudioVideoRendererRemote::AudioVideoRendererRemote(LoggerHelper* loggerHelper, G
     connection.connection().addWorkQueueMessageReceiver(Messages::AudioVideoRendererRemoteMessageReceiver::messageReceiverName(), queueSingleton(), m_receiver, m_identifier.toUInt64());
     connection.addClient(*this);
 
-    connection.connection().sendWithAsyncReply(Messages::RemoteAudioVideoRendererProxyManager::Create(identifier, mediaElementIdentifier, playerIdentifier), [weakThis = ThreadSafeWeakPtr { *this }](auto&& handle) {
+    connection.connection().sendWithAsyncReply(Messages::RemoteAudioVideoRendererProxyManager::Create(identifier, mediaElementIdentifier, playerIdentifier, m_logIdentifier), [weakThis = ThreadSafeWeakPtr { *this }](auto&& handle) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -131,34 +131,40 @@ AudioVideoRendererRemote::AudioVideoRendererRemote(LoggerHelper* loggerHelper, G
     }, 0);
 }
 
-AudioVideoRendererRemote::~AudioVideoRendererRemote() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+AudioVideoRendererRemote::~AudioVideoRendererRemote()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+    invalidate();
+}
+
+void AudioVideoRendererRemote::invalidate()
+{
+    ensureOnDispatcherSync([&] {
+        Locker locker { m_lock };
+        assertIsCurrent(queueSingleton());
 
 #if PLATFORM(COCOA)
-    m_videoLayerManager->didDestroyVideoLayer();
+        m_videoLayerManager->didDestroyVideoLayer();
 #endif
 
-    ensureOnDispatcher([prepareSeekRequest = WTF::move(m_prepareSeekRequest), prepareSeekPromise = WTF::move(m_prepareSeekPromise), finishSeekRequest = WTF::move(m_finishSeekRequest), finishSeekPromise = WTF::move(m_finishSeekPromise)]() mutable {
-        if (prepareSeekRequest->hasCallback())
-            prepareSeekRequest->disconnect();
-        if (auto promise = std::exchange(prepareSeekPromise, std::nullopt))
+        if (m_prepareSeekRequest->hasCallback())
+            protect(m_prepareSeekRequest)->disconnect();
+        if (auto promise = std::exchange(m_prepareSeekPromise, std::nullopt))
             promise->reject(PlatformMediaError::Cancelled);
-        if (finishSeekRequest->hasCallback())
-            finishSeekRequest->disconnect();
-        if (auto promise = std::exchange(finishSeekPromise, std::nullopt))
+
+        if (m_finishSeekRequest->hasCallback())
+            protect(m_finishSeekRequest)->disconnect();
+        if (auto promise = std::exchange(m_finishSeekPromise, std::nullopt))
             promise->reject();
+
+        if (RefPtr gpuProcessConnection = m_gpuProcessConnection.get(); gpuProcessConnection && !m_shutdown) {
+            gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::Shutdown(m_identifier), 0);
+            gpuProcessConnection->connection().removeWorkQueueMessageReceiver(Messages::AudioVideoRendererRemoteMessageReceiver::messageReceiverName(), m_identifier.toUInt64());
+        }
+
+        for (auto& request : std::exchange(m_layerHostingContextRequests, { }))
+            request({ });
     });
-
-    if (RefPtr gpuProcessConnection = m_gpuProcessConnection.get(); gpuProcessConnection && !m_shutdown) {
-        ensureOnDispatcher([gpuProcessConnection, identifier = m_identifier] {
-            gpuProcessConnection->connection().send(Messages::RemoteAudioVideoRendererProxyManager::Shutdown(identifier), 0);
-            gpuProcessConnection->connection().removeWorkQueueMessageReceiver(Messages::AudioVideoRendererRemoteMessageReceiver::messageReceiverName(), identifier.toUInt64());
-        });
-    }
-
-    for (auto& request : std::exchange(m_layerHostingContextRequests, { }))
-        request({ });
 }
 
 void AudioVideoRendererRemote::setVolume(float volume)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -109,6 +109,8 @@ private:
 
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;
 
+    void invalidate() final;
+    void invalidateSync();
     void setVolume(float) final;
     void setMuted(bool) final;
     void setPreservesPitchAndCorrectionAlgorithm(bool, std::optional<PitchCorrectionAlgorithm>) final;


### PR DESCRIPTION
#### 66ce2a58e076514714c6adda8ad186cc34bc1cce
<pre>
[macOS] Higher floor memory usage from unreleased video decoders during stress testing
<a href="https://rdar.apple.com/175768182">rdar://175768182</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316107">https://bugs.webkit.org/show_bug.cgi?id=316107</a>

Reviewed by NOBODY (OOPS!).

Stress testing revealed a higher baseline level of memory after opening a few web pages
and then closing the tab; logging of these runs revealed that the WebContent process
could be killed without tearing down DOM objects first (which is normal) and that in
this path some system resources were not explicitly freed. Add an explicit step when
the GPUConnectionToWebProcess detects the WebProcess has closed that will tear down and
invalidate all AudioVideoRenderers which were created by that connection.

Drive-by fix: pass the log identifier used in the WebContent process for a renderer
down to the GPU process to make identification of those renderers more straightforward.

* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::~AudioVideoRendererAVFObjC):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::didClose):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::createRenderer):
(WebKit::RemoteAudioVideoRendererProxyManager::close):
(WebKit::RemoteAudioVideoRendererProxyManager::create):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::AudioVideoRendererRemote):
(WebKit::AudioVideoRendererRemote::~AudioVideoRendererRemote):
(WebKit::AudioVideoRendererRemote::invalidate):
(): Deleted.
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66ce2a58e076514714c6adda8ad186cc34bc1cce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123378 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129116 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90948 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109642 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30467 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29158 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23311 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177703 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30605 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28661 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137462 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137390 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148750 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102972 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32678 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25617 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38881 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111955 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38278 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3703 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38523 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->