### PR TITLE
[Cleanup] Remove redundant ScrollbarUpdateScope::scrollbarChange enum.

### DIFF
--- a/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
+++ b/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
@@ -33,16 +33,6 @@
 
 namespace WebCore {
 
-static EnumSet<ScrollbarOrientation> mapScrollbarChangesToOrientations(OptionSet<ScrollbarUpdateScope::ScrollbarChange> scrollbarChanges)
-{
-    EnumSet<ScrollbarOrientation> orientationsForChangedScrollbars;
-    if (scrollbarChanges.contains(ScrollbarUpdateScope::ScrollbarChange::AutoVerticalScrollBarChanged))
-        orientationsForChangedScrollbars.add(ScrollbarOrientation::Vertical);
-    if (scrollbarChanges.contains(ScrollbarUpdateScope::ScrollbarChange::AutoHorizontalScrollbarChanged))
-        orientationsForChangedScrollbars.add(ScrollbarOrientation::Horizontal);
-    return orientationsForChangedScrollbars;
-}
-
 RelayoutScopeForScrollbarChange::RelayoutScopeForScrollbarChange(RenderBlock& renderBlock, InOverflowRelayout inOverflowRelayout)
     : m_renderBlock(renderBlock)
     , m_inOverflowRelayout(inOverflowRelayout)
@@ -55,9 +45,8 @@ RelayoutScopeForScrollbarChange::~RelayoutScopeForScrollbarChange()
     if (!m_scrollbarUpdateScope)
         return;
 
-    using ScrollbarChange = ScrollbarUpdateScope::ScrollbarChange;
-    auto& scrollbarChanges = m_scrollbarUpdateScope->scrollbarChanges();
-    if (scrollbarChanges.isEmpty())
+    auto& autoScrollbarChanges = m_scrollbarUpdateScope->autoScrollbarChanges();
+    if (autoScrollbarChanges.isEmpty())
         return;
 
     // Scrollbars with auto behavior may need to lay out again if scrollbars got added or removed.
@@ -67,13 +56,12 @@ RelayoutScopeForScrollbarChange::~RelayoutScopeForScrollbarChange()
         if (m_inOverflowRelayout == InOverflowRelayout::No) {
             if (auto& subtreeScrollbarChangesState = m_renderBlock->layoutContext().subtreeScrollbarChangesState(); subtreeScrollbarChangesState && subtreeScrollbarChangesState->isEligibleForScrollbarHandlingByAncestor(m_renderBlock.get())) {
                 ASSERT(m_renderBlock.ptr() != subtreeScrollbarChangesState->subtreeRoot.ptr());
-                auto orientationsForChangedScrollbars = mapScrollbarChangesToOrientations(scrollbarChanges);
-                if (auto sizesAffectedFromScrollbarChanges = subtreeScrollbarChangesState->sizesAffectedForSubtreeRootFromScrollbarChanges(m_renderBlock, orientationsForChangedScrollbars)) {
+                if (auto sizesAffectedFromScrollbarChanges = subtreeScrollbarChangesState->sizesAffectedForSubtreeRootFromScrollbarChanges(m_renderBlock, autoScrollbarChanges)) {
                     subtreeScrollbarChangesState->addRendererWithScrollbarChange(m_renderBlock, sizesAffectedFromScrollbarChanges);
                     return;
                 }
             }
-            m_renderBlock->scrollbarsChanged(scrollbarChanges.contains(ScrollbarChange::AutoHorizontalScrollbarChanged), scrollbarChanges.contains(ScrollbarChange::AutoVerticalScrollBarChanged));
+            m_renderBlock->scrollbarsChanged(autoScrollbarChanges.contains(ScrollbarOrientation::Horizontal), autoScrollbarChanges.contains(ScrollbarOrientation::Vertical));
             RenderBlock::relayoutRenderBlockForScrollbarChange(m_renderBlock.get());
         }
     }

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1329,20 +1329,20 @@ std::optional<ScrollbarUpdateScope> RenderLayerScrollableArea::updateScrollInfoA
     updateScrollbarPresenceAndState(hasHorizontalOverflow, hasVerticalOverflow);
 
     // Scrollbars with auto behavior may need to lay out again if scrollbars got added or removed.
-    OptionSet<ScrollbarUpdateScope::ScrollbarChange> scrollbarChanges;
+    EnumSet<ScrollbarOrientation> autoScrollbarChanges;
     if (box->hasAutoScrollbar(ScrollbarOrientation::Horizontal) && (hadHorizontalScrollbar != hasHorizontalScrollbar()))
-        scrollbarChanges.add(ScrollbarUpdateScope::ScrollbarChange::AutoHorizontalScrollbarChanged);
+        autoScrollbarChanges.add(ScrollbarOrientation::Horizontal);
 
     if (box->hasAutoScrollbar(ScrollbarOrientation::Vertical) && (hadVerticalScrollbar != hasVerticalScrollbar()))
-        scrollbarChanges.add(ScrollbarUpdateScope::ScrollbarChange::AutoVerticalScrollBarChanged);
+        autoScrollbarChanges.add(ScrollbarOrientation::Vertical);
 
-    if (!scrollbarChanges.isEmpty()) {
-        if (scrollbarChanges.contains(ScrollbarUpdateScope::ScrollbarChange::AutoVerticalScrollBarChanged) && shouldPlaceVerticalScrollbarOnLeft())
+    if (!autoScrollbarChanges.isEmpty()) {
+        if (autoScrollbarChanges.contains(ScrollbarOrientation::Vertical) && shouldPlaceVerticalScrollbarOnLeft())
             computeScrollOrigin();
         m_layer.updateSelfPaintingLayer();
     }
 
-    return ScrollbarUpdateScope { *this, originalScrollPosition, scrollbarChanges, hasHorizontalOverflow ? HasHorizontalOverflow::Yes : HasHorizontalOverflow::No, hasVerticalOverflow ? HasVerticalOverflow::Yes : HasVerticalOverflow::No };
+    return ScrollbarUpdateScope { *this, originalScrollPosition, autoScrollbarChanges, hasHorizontalOverflow ? HasHorizontalOverflow::Yes : HasHorizontalOverflow::No, hasVerticalOverflow ? HasVerticalOverflow::Yes : HasVerticalOverflow::No };
 }
 
 void RenderLayerScrollableArea::updateScrollbarSteps()

--- a/Source/WebCore/rendering/ScrollbarUpdateScope.cpp
+++ b/Source/WebCore/rendering/ScrollbarUpdateScope.cpp
@@ -35,10 +35,10 @@
 
 namespace WebCore {
 
-ScrollbarUpdateScope::ScrollbarUpdateScope(RenderLayerScrollableArea& scrollableArea, ScrollPosition originalScrollPosition, OptionSet<ScrollbarChange> scrollbarChanges, HasHorizontalOverflow hasHorizontalOverflow, HasVerticalOverflow hasVerticalOverflow)
+ScrollbarUpdateScope::ScrollbarUpdateScope(RenderLayerScrollableArea& scrollableArea, ScrollPosition originalScrollPosition, EnumSet<ScrollbarOrientation> autoScrollbarChanges, HasHorizontalOverflow hasHorizontalOverflow, HasVerticalOverflow hasVerticalOverflow)
     : m_renderLayerScrollableArea(scrollableArea)
     , m_originalScrollPosition(originalScrollPosition)
-    , m_scrollbarChanges(scrollbarChanges)
+    , m_autoScrollbarChanges(autoScrollbarChanges)
     , m_hasHorizontalOverflow(hasHorizontalOverflow)
     , m_hasVerticalOverflow(hasVerticalOverflow)
 {

--- a/Source/WebCore/rendering/ScrollbarUpdateScope.h
+++ b/Source/WebCore/rendering/ScrollbarUpdateScope.h
@@ -28,7 +28,7 @@
 #include <WebCore/ScrollTypes.h>
 
 #include <wtf/CheckedPtr.h>
-#include <wtf/OptionSet.h>
+#include <wtf/EnumSet.h>
 
 namespace WebCore {
 
@@ -42,24 +42,19 @@ enum class HasVerticalOverflow : bool { No, Yes };
 // may need to layout the renderer again.
 class ScrollbarUpdateScope {
 public:
-    enum class ScrollbarChange : uint8_t {
-        AutoHorizontalScrollbarChanged = 1 << 0,
-        AutoVerticalScrollBarChanged = 1 << 1
-    };
-
-    ScrollbarUpdateScope(RenderLayerScrollableArea&, ScrollPosition originalScrollPosition, OptionSet<ScrollbarChange>, HasHorizontalOverflow, HasVerticalOverflow);
+    ScrollbarUpdateScope(RenderLayerScrollableArea&, ScrollPosition originalScrollPosition, EnumSet<ScrollbarOrientation> autoScrollbarChanges, HasHorizontalOverflow, HasVerticalOverflow);
     ~ScrollbarUpdateScope();
 
     ScrollbarUpdateScope(ScrollbarUpdateScope&&) = default;
     ScrollbarUpdateScope(const ScrollbarUpdateScope&) = delete;
     ScrollbarUpdateScope& operator=(const ScrollbarUpdateScope&) = delete;
 
-    const OptionSet<ScrollbarChange>& scrollbarChanges() const { return m_scrollbarChanges; }
+    const EnumSet<ScrollbarOrientation>& autoScrollbarChanges() const { return m_autoScrollbarChanges; }
 
 private:
     const CheckedRef<RenderLayerScrollableArea> m_renderLayerScrollableArea;
     const ScrollPosition m_originalScrollPosition;
-    const OptionSet<ScrollbarChange> m_scrollbarChanges;
+    const EnumSet<ScrollbarOrientation> m_autoScrollbarChanges;
     HasHorizontalOverflow m_hasHorizontalOverflow;
     HasVerticalOverflow m_hasVerticalOverflow;
 };


### PR DESCRIPTION
#### 1695e396e280636e9c23ed2e16367981bb981094
<pre>
[Cleanup] Remove redundant ScrollbarUpdateScope::scrollbarChange enum.
<a href="https://bugs.webkit.org/show_bug.cgi?id=316111">https://bugs.webkit.org/show_bug.cgi?id=316111</a>
<a href="https://rdar.apple.com/problem/178541729">rdar://problem/178541729</a>

Reviewed by Simon Fraser.

The ScrollbarChange enum was a redundant 1:1 mapping of ScrollbarOrientation.
The &quot;auto scrollbar&quot; semantics are now conveyed by the field/accessor name
(m_autoScrollbarChanges / autoScrollbarChanges()) rather than the enum values.
This also removes the mapScrollbarChangesToOrientations() helper which existed
solely to convert between the two equivalent types.

Canonical link: <a href="https://commits.webkit.org/314429@main">https://commits.webkit.org/314429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dd44398ad52bd607665b406009174f412baf296

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175169 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8796f84c-9af9-463a-b82f-6c5e74fe85c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39616 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/129115 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169081 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109641 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23310 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177702 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137461 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39681 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137389 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37001 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148748 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102971 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32677 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38880 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/111954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38277 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3701 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38522 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38420 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->