### PR TITLE
[Build] Use xcrun ninja if needed inside ninja-wrapper

### DIFF
--- a/Source/cmake/ninja-wrapper
+++ b/Source/cmake/ninja-wrapper
@@ -3,21 +3,25 @@ use strict;
 use warnings;
 use Cwd qw(getcwd);
 use File::Path qw(make_path);
+use File::Which qw(which);
+
+# Use Ninja from inside the Xcode toolchain if not otherwise available.
+my @ninja = defined which('ninja') ? 'ninja' : ('xcrun', 'ninja');
 
 # CMake configuration
 if (grep({ /^-t/ || /^--version$/ } @ARGV)) {
-    exec('ninja', @ARGV);
+    exec(@ninja, @ARGV);
 }
 
 # CMake try_compile/check_*
 if (getcwd() =~ m{/CMakeFiles/}) {
-    exec('ninja', @ARGV);
+    exec(@ninja, @ARGV);
 }
 
 # Real compilation
 my $bundlePolicy = $ENV{WK_UNIFIED_SOURCES_BUNDLE_POLICY};
 if (!defined($bundlePolicy)) {
-    my $dryRun = `ninja -n @ARGV 2>&1`;
+    my $dryRun = `@ninja -n @ARGV 2>&1`;
     my ($totalCommands) = $dryRun =~ m{/(\d+)\]};
 
     # No-op build
@@ -44,4 +48,4 @@ if (open(my $fh, '>', "DerivedSources/unified-sources-bundle-policy")) {
     close($fh);
 }
 
-exec('/usr/bin/caffeinate', '-i', 'ninja', @ARGV);
+exec('/usr/bin/caffeinate', '-i', @ninja, @ARGV);


### PR DESCRIPTION
#### 47e4186bb896fe03b42e5773112cca15c3d962e8
<pre>
[Build] Use xcrun ninja if needed inside ninja-wrapper
<a href="https://bugs.webkit.org/show_bug.cgi?id=316112">https://bugs.webkit.org/show_bug.cgi?id=316112</a>

Reviewed by NOBODY (OOPS!).

Change the wrapper script to check for `ninja` on the PATH and fall back
to calling it through xcrun.

* Source/cmake/ninja-wrapper:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47e4186bb896fe03b42e5773112cca15c3d962e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123236 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bbdcdffc-53dd-4705-a835-e30d35be9972) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129006 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a70868a0-2381-4f79-a9cd-460e7570c478) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109532 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/abc772e0-b281-47b0-8226-80d6b19a2aa8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29032 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23168 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158138 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140319 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177561 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26874 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137348 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137275 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148617 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102819 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32562 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25484 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38739 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111813 "Build is in progress. Recent messages:") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38136 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3567 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38279 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->