### PR TITLE
Cherry-pick(s) 7c715b4eeda1. rdar://176061249

### DIFF
--- a/Source/JavaScriptCore/jit/BaselineJITRegisters.h
+++ b/Source/JavaScriptCore/jit/BaselineJITRegisters.h
@@ -318,8 +318,13 @@ namespace DelById {
     static constexpr GPRReg scratch3GPR { scratchRegisters[2] };
     static constexpr JSValueRegs scratchJSR { JSValueRegs::withTwoAvailableRegs(scratch1GPR, scratch2GPR) };
 
+<<<<<<< HEAD
     static_assert(noOverlap(baseJSR, propertyCacheGPR, scratchJSR, scratch3GPR, GPRInfo::handlerGPR), "Required for call to slow operation");
     static_assert(noOverlap(resultJSR.payloadGPR(), propertyCacheGPR));
+=======
+    static_assert(noOverlap(baseJSR, stubInfoGPR, scratchJSR, scratch3GPR, GPRInfo::handlerGPR), "Required for call to slow operation");
+    static_assert(noOverlap(resultJSR.payloadGPR(), stubInfoGPR));
+>>>>>>> 7c715b4eeda1 (Fix baseline write barrier handling in OpDelBy{Id,Val})
 }
 
 namespace DelByVal {
@@ -335,8 +340,13 @@ namespace DelByVal {
     static constexpr GPRReg scratch3GPR { scratchRegisters[2] };
     static constexpr JSValueRegs scratchJSR { JSValueRegs::withTwoAvailableRegs(scratch1GPR, scratch2GPR) };
 
+<<<<<<< HEAD
     static_assert(noOverlap(baseJSR, propertyJSR, propertyCacheGPR, scratchJSR, scratch3GPR, GPRInfo::handlerGPR), "Required for call to slow operation");
     static_assert(noOverlap(resultJSR.payloadGPR(), propertyCacheGPR));
+=======
+    static_assert(noOverlap(baseJSR, propertyJSR, stubInfoGPR, scratchJSR, scratch3GPR, GPRInfo::handlerGPR), "Required for call to slow operation");
+    static_assert(noOverlap(resultJSR.payloadGPR(), stubInfoGPR));
+>>>>>>> 7c715b4eeda1 (Fix baseline write barrier handling in OpDelBy{Id,Val})
 }
 
 namespace PrivateBrand {

--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -425,7 +425,11 @@ void JIT::emit_op_del_by_id(const JSInstruction* currentInstruction)
 
     using BaselineJITRegisters::DelById::baseJSR;
     using BaselineJITRegisters::DelById::resultJSR;
+<<<<<<< HEAD
     using BaselineJITRegisters::DelById::propertyCacheGPR;
+=======
+    using BaselineJITRegisters::DelById::stubInfoGPR;
+>>>>>>> 7c715b4eeda1 (Fix baseline write barrier handling in OpDelBy{Id,Val})
     using BaselineJITRegisters::DelById::scratchJSR;
 
     emitGetVirtualRegister(base, baseJSR);
@@ -475,7 +479,11 @@ void JIT::emit_op_del_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::DelByVal::baseJSR;
     using BaselineJITRegisters::DelByVal::propertyJSR;
     using BaselineJITRegisters::DelByVal::resultJSR;
+<<<<<<< HEAD
     using BaselineJITRegisters::DelByVal::propertyCacheGPR;
+=======
+    using BaselineJITRegisters::DelByVal::stubInfoGPR;
+>>>>>>> 7c715b4eeda1 (Fix baseline write barrier handling in OpDelBy{Id,Val})
     using BaselineJITRegisters::DelByVal::scratchJSR;
 
     emitGetVirtualRegister(base, baseJSR);


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176061249 to main. The following sources [1cdc540e6ebe] will still need to be cherry-picked once the conflict is resolved.

```Fix baseline write barrier handling in OpDelBy{Id,Val}
https://bugs.webkit.org/show_bug.cgi?id=310139
rdar://172299872

Reviewed by Yusuke Suzuki.

In the baseline implementation of OpDelById, code like `o = delete o.x` can
overwrite the pointer to object o with a boolean value before the write
barrier, meaning the barrier is wrongly invoked on the boolean instead of
the original object. Same problem with OpDelByVal, which can be
replicated with `o = delete o["x"]`.

Tests: JSTests/stress/baseline-op-del-by-id-write-barrier.js
       JSTests/stress/baseline-op-del-by-val-write-barrier.js

* JSTests/stress/baseline-op-del-by-id-write-barrier.js: Added.
(main):
* JSTests/stress/baseline-op-del-by-val-write-barrier.js: Added.
(main):
* Source/JavaScriptCore/jit/BaselineJITRegisters.h:
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::emit_op_del_by_id):
(JSC::JIT::emit_op_del_by_val):
(JSC::JIT::emitWriteBarrier):

Originally-landed-as: 305413.540@rapid/safari-7624.2.5.110-branch (7c715b4eeda1). rdar://176061249

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/759ee511b263fcffc0f2be7d6018f9793b4483cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165985 "20 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39475 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33056 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175031 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123240 "Hash 759ee511 for PR 66276 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39901 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39479 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/175031 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/123240 "Hash 759ee511 for PR 66276 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168944 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/39901 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/33056 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/175031 "Hash 759ee511 for PR 66276 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/39901 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/39479 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23172 "Hash 759ee511 for PR 66276 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158142 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/39901 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/33056 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177565 "Hash 759ee511 for PR 66276 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26878 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30467 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/33056 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/177565 "Hash 759ee511 for PR 66276 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39544 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/39479 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/177565 "Hash 759ee511 for PR 66276 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40232 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/33056 "Hash 759ee511 for PR 66276 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102823 "Built successfully") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/40232 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/33056 "Hash 759ee511 for PR 66276 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198783 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38743 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111817 "Failed to build and analyze WebKit") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53404 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38140 "Hash 759ee511 for PR 66276 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/33056 "Hash 759ee511 for PR 66276 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38385 "Hash 759ee511 for PR 66276 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38283 "Hash 759ee511 for PR 66276 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->