### PR TITLE
[Tools] linux_get_crash_log: avoid python crashes when the coredumps are auto-deleted with multiple concurrent workers.

### DIFF
--- a/Tools/Scripts/webkitpy/port/linux_get_crash_log.py
+++ b/Tools/Scripts/webkitpy/port/linux_get_crash_log.py
@@ -180,6 +180,12 @@ class CrashLogEnvVars(StrEnum):
 
 class CrashLogUtils:
 
+    # Prefix used for renaming the coredumps when autodeletion is enabled using method Abspath.
+    # The renaming happens before generating the backtrace with gdb, so so no other concurrent
+    # worker selects it meanwhile. The prefix breaks the core_pattern match and is explicitly
+    # skipped by the selection scan. Stale files are cleaned also by clean_old_coredumps().
+    CLAIMED_COREDUMP_PREFIX = '.webkit_cdump_'
+
     @staticmethod
     def get_gdb_concurrent_execution_limit():
         # 0 means no limit
@@ -396,6 +402,24 @@ class CrashLogUtils:
         return f'{fmt(logical)} (sparse, {fmt(actual)} on disk)'
 
     @staticmethod
+    def safe_getmtime(path):
+        # wrapper for os.path.getmtime that tolerates the file disappearing.
+        # With WEBKIT_CORE_DUMPS_AUTODELETE=1 and several workers running a file enumerated
+        # by os.listdir() can be removed by another worker (after processing its own core)
+        # before this worker stats it. Returns None instead of crashing in that case.
+        try:
+            return os.path.getmtime(path)
+        except OSError:
+            return None
+
+    @staticmethod
+    def most_recent_existing(paths):
+        # Most recently modified path that still exists, or None.
+        # Same than max(paths, key=os.path.getmtime), but ignoring paths gone.
+        stamped = [(mtime, p) for p in paths if (mtime := CrashLogUtils.safe_getmtime(p)) is not None]
+        return max(stamped)[1] if stamped else None
+
+    @staticmethod
     def make_temp_path(suffix='', prefix='tmp', dir=None):
         # Safe replacement for the deprecated tempfile.mktemp().
         fd, path = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=dir)
@@ -518,10 +542,15 @@ class ThreadNamesCrashLogCapturer(object):
     def handle_coredump(self, pid):
         # Called in a dedicated thread as soon as the coredump file is created.
         # Reads thread info and writes it to the threadinfo-${pid}.txt
+        pid = str(pid)
         timestamp = datetime.datetime.now().isoformat(timespec='seconds')
         thread_info = self.read_thread_info(pid)
+        # /proc/{pid}/task/{pid}/comm is the same as /proc/{pid}/comm
+        program_name = thread_info.get(pid, '<unknown>') if thread_info else '<unknown>'
+        num_threads = len(thread_info) if thread_info else 0
+        thread_s = 'thread' if num_threads == 1 else 'threads'
         output_path = os.path.join(self._webkit_thread_info_crashlog_dir, CrashLogUtils.get_thread_info_file_name(pid))
-        _log.debug(f'Coredump detected for PID {pid}, saving "/proc/{pid}/task" info to "{output_path}" ...')
+        _log.debug(f'Coredump detected for PID {pid} ({program_name}), saving thread name info for {num_threads} {thread_s} from "/proc/{pid}/task" to "{output_path}" ...')
         try:
             with open(output_path, 'w') as f:
                 f.write(f'# Thread info captured at {timestamp}\n')
@@ -536,8 +565,9 @@ class ThreadNamesCrashLogCapturer(object):
                     # https://www.man7.org/linux/man-pages/man5/proc_pid_task.5.html
                     f.write(f'# WARNING: No threads found under /proc/{pid}/task (maybe main thread exited before the crash).\n')
                 else:
-                    f.write(f'# Number of threads: {len(thread_info)}\n')
+                    f.write(f'# Number of threads: {num_threads}\n')
                     f.write(f'# PID: {pid}\n')
+                    f.write(f'# Program name: {program_name}\n')
                     f.write('\n')
                     f.write(f'{"LWP/TID":<12} {"Thread Name"}\n')
                     f.write(f'{"-"*12} {"-"*20}\n')
@@ -576,10 +606,16 @@ class GDBCrashLogStartupHandler(object):
 
     def _maybe_remove_file_if_old(self, path):
         # Define old as "more than 30 minutes"
-        is_old = (time.time() - os.path.getmtime(path)) > 1800
+        mtime = CrashLogUtils.safe_getmtime(path)
+        if mtime is None:
+            return  # already gone (another worker cleaned it)
+        is_old = (time.time() - mtime) > 1800
         if is_old:
             _log.debug(f'Cleaning old file at: {path}')
-            os.remove(path)
+            try:
+                os.remove(path)
+            except OSError:
+                pass  # likely another worker already removed it
         else:
             _log.debug(f'Skipping non-old file at: {path}')
 
@@ -620,7 +656,7 @@ class GDBCrashLogStartupHandler(object):
     def clean_old_coredumps(self):
         candidate_coredumps = [os.path.join(self._coredump_directory, f) for f in os.listdir(self._coredump_directory) if os.path.isfile(os.path.join(self._coredump_directory, f))]
         pattern_re = re.compile(CrashLogUtils.core_pattern_to_regex(self._coredump_pattern))
-        candidate_coredumps = [f for f in candidate_coredumps if pattern_re.fullmatch(os.path.basename(f))]
+        candidate_coredumps = [f for f in candidate_coredumps if pattern_re.fullmatch(os.path.basename(f)) or os.path.basename(f).startswith(CrashLogUtils.CLAIMED_COREDUMP_PREFIX)]
         for coredump in candidate_coredumps:
             self._maybe_remove_file_if_old(coredump)
 
@@ -734,7 +770,9 @@ class GDBCrashLogGenerator(object):
     def _pick_most_recent(self, candidates, **warning_kwargs):
         if not candidates:
             return None
-        coredump_match_candidate = max(candidates, key=os.path.getmtime)
+        coredump_match_candidate = CrashLogUtils.most_recent_existing(candidates)
+        if coredump_match_candidate is None:
+            return None  # all candidates were deleted by another worker
         m = self._regex_for_core_pattern.fullmatch(os.path.basename(coredump_match_candidate))
         if not m:
             return None
@@ -745,9 +783,9 @@ class GDBCrashLogGenerator(object):
     def _get_coredump_path_with_core_pattern_method(self):
         can_match_by_pid = self._pid_is_valid() and self._coredump_pattern_has_pid_format_string()
         for try_number in range(2):
-            candidate_coredumps = [os.path.join(self._coredump_directory, f) for f in os.listdir(self._coredump_directory) if os.path.isfile(os.path.join(self._coredump_directory, f))]
+            candidate_coredumps = [os.path.join(self._coredump_directory, f) for f in os.listdir(self._coredump_directory) if os.path.isfile(os.path.join(self._coredump_directory, f)) and not f.startswith(CrashLogUtils.CLAIMED_COREDUMP_PREFIX)]
             pattern_re = re.compile(CrashLogUtils.core_pattern_to_regex(self._coredump_pattern))
-            candidate_coredumps = [f for f in candidate_coredumps if pattern_re.fullmatch(os.path.basename(f)) and (not self.newer_than or os.path.getmtime(f) > self.newer_than)]
+            candidate_coredumps = [f for f in candidate_coredumps if pattern_re.fullmatch(os.path.basename(f)) and (not self.newer_than or ((mt := CrashLogUtils.safe_getmtime(f)) is not None and mt > self.newer_than))]
 
             # If we have a pid number then return the last file that matches the pid number ignoring the other format specifiers from core_pattern (if any)
             if can_match_by_pid:
@@ -758,8 +796,10 @@ class GDBCrashLogGenerator(object):
                         pid_matches.append(coredump)
 
                 if pid_matches:
-                    self._effective_coredump_pid = self.pid
-                    return max(pid_matches, key=os.path.getmtime), self._build_warning_msg(pid_found=True)
+                    chosen = CrashLogUtils.most_recent_existing(pid_matches)
+                    if chosen is not None:
+                        self._effective_coredump_pid = self.pid
+                        return chosen, self._build_warning_msg(pid_found=True)
 
                 # If match by pid doesn't happen then sleep and retry once.
                 # This may help if the system is under high stress and this code runs before the kernel starts to write the coredump to disk
@@ -941,17 +981,22 @@ class GDBCrashLogGenerator(object):
             hmsg = hmsg.replace(tip_msg, 'No coredump was generated. Environment seems correctly configured for coredump generation. Cause unknown.\n')
         return hmsg
 
-    def _get_thread_info_for_effective_pid(self):
+    def _get_thread_info_for_effective_pid(self, coredump_found_matches_pid):
         if self._effective_coredump_pid:
             thread_info_file = os.path.join(self._webkit_thread_info_crashlog_dir, CrashLogUtils.get_thread_info_file_name(self._effective_coredump_pid))
-            if os.path.isfile(thread_info_file):
+            try:
                 with open(thread_info_file, 'r') as f:
                     thread_info_content = f.read()
-                # Clean it: we only need it once
-                os.remove(thread_info_file)
-                return thread_info_content
-            return f"Thread names not available: could not find thread naming info for pid {self._effective_coredump_pid}.\n" +\
-                   f"The thread_info_file was not found at {thread_info_file}\n"
+            except OSError as e:
+                # Not written yet, or removed by another worker that selected the same coredump.
+                return f"Thread names not available: could not find thread naming info for pid {self._effective_coredump_pid}.\n" +\
+                       f"Unable to open thread_info_file at {thread_info_file}: {e}\n"
+            try:
+                if coredump_found_matches_pid:
+                    os.remove(thread_info_file)
+            except OSError:
+                pass
+            return thread_info_content
         return f"Thread names not available: could not find the effective pid for the coredump."
 
     def _pid_representation(self):
@@ -1022,17 +1067,43 @@ class GDBCrashLogGenerator(object):
 
         coredump_path, warnings_found = self._get_coredump_path()
         coredump_path_was_found = coredump_path and os.path.isfile(coredump_path)
+        coredump_found_matches_pid = coredump_path_was_found and self._pid_is_valid() and str(self.pid) == str(self._effective_coredump_pid)
         if coredump_path_was_found:
-            coredump_hr_size = CrashLogUtils.human_readable_size(coredump_path)
-            should_delete_coredump = self._coredump_method == CoreDumpMethod.Coredumpctl or os.environ.get(CrashLogEnvVars.core_dumps_autodelete, '0') == '1'
+            coredump_removed_during_processing = False
             try:
-                gdb_backtrace, gdb_stderr, time_output = self._get_gdb_output(coredump_path)
-            finally:
-                if should_delete_coredump:
+                coredump_hr_size = CrashLogUtils.human_readable_size(coredump_path)
+            except OSError:
+                # The core vanished after selection (deleted by another worker that selected
+                # the same name/fallback match, or by the periodic cleanup). We already know
+                # it's gone, so don't claim it by renaming nor spawn gdb on a missing file.
+                coredump_hr_size = "unknown (coredump removed during processing)"
+                coredump_removed_during_processing = True
+            should_delete_coredump = self._coredump_method == CoreDumpMethod.Coredumpctl or (os.environ.get(CrashLogEnvVars.core_dumps_autodelete, '0') == '1' and coredump_found_matches_pid)
+
+            if coredump_removed_during_processing:
+                gdb_backtrace = "Coredump was found during selection but removed (by another worker or the periodic cleanup) before it could be processed.\n"
+            else:
+                gdb_coredump_path = coredump_path
+                if should_delete_coredump and self._coredump_method == CoreDumpMethod.Abspath and coredump_found_matches_pid:
+                    # We are sure this coredump is ours (matched by pid) and we are going to delete it after processing.
+                    # Claim it by renaming it out of the way before the slow gdb run, so no other concurrent worker wastes time selecting it.
+                    # Only for the abspath method (coredumpctl method already dumps to a private temp file).
+                    claimed_path = os.path.join(os.path.dirname(coredump_path), CrashLogUtils.CLAIMED_COREDUMP_PREFIX + os.path.basename(coredump_path))
                     try:
-                        os.remove(coredump_path)
+                        os.rename(coredump_path, claimed_path)
+                        gdb_coredump_path = claimed_path
                     except OSError as e:
-                        _log.error(f'Could not remove {coredump_path}: {e}')
+                        # e.g. the dir spans a different filesystem (EXDEV) or it vanished. Not
+                        # fatal: just process it in place as before.
+                        _log.warning(f'Could not claim coredump {coredump_path} by renaming it to {claimed_path}: {e}. Processing it in place.')
+                try:
+                    gdb_backtrace, gdb_stderr, time_output = self._get_gdb_output(gdb_coredump_path)
+                finally:
+                    if should_delete_coredump:
+                        try:
+                            os.remove(gdb_coredump_path)
+                        except OSError as e:
+                            _log.error(f'Could not remove {gdb_coredump_path}: {e}')
 
         if test_stderr:
             test_stderr = self._filter_with_cppfilt(test_stderr)
@@ -1044,7 +1115,7 @@ class GDBCrashLogGenerator(object):
         if not gdb_backtrace:
             gdb_backtrace = self._get_help_message()
 
-        thread_info_data = self._get_thread_info_for_effective_pid()
+        thread_info_data = self._get_thread_info_for_effective_pid(coredump_found_matches_pid)
 
         seconds_elapsed = time.monotonic() - timestamp_start
         # All data gathered, now print it

--- a/Tools/Scripts/webkitpy/port/linux_get_crash_log_unittest.py
+++ b/Tools/Scripts/webkitpy/port/linux_get_crash_log_unittest.py
@@ -43,7 +43,7 @@ from unittest import mock
 
 from webkitpy.common.system.executive_mock import MockExecutive
 from webkitpy.common.system.filesystem_mock import MockFileSystem
-from webkitpy.port.linux_get_crash_log import CoreDumpMethod, CrashLogEnvVars, CrashLogUtils, GDBCrashLogGenerator, LockFile, ThreadNamesCrashLogCapturer
+from webkitpy.port.linux_get_crash_log import CoreDumpMethod, CrashLogEnvVars, CrashLogUtils, GDBCrashLogGenerator, GDBCrashLogStartupHandler, LockFile, ThreadNamesCrashLogCapturer
 
 
 # GDBCrashLogGenerator with determine_coredump_method_and_dir patched
@@ -190,6 +190,54 @@ class MakeTempPathTest(unittest.TestCase):
         self.addCleanup(os.unlink, p1)
         self.addCleanup(os.unlink, p2)
         self.assertNotEqual(p1, p2)
+
+
+class SafeGetmtimeMostRecentExistingTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+
+    def test_returns_mtime_for_existing_file(self):
+        path = os.path.join(self.tmpdir, 'f')
+        with open(path, 'w') as f:
+            f.write('')
+        os.utime(path, (1234, 1234))
+        self.assertEqual(CrashLogUtils.safe_getmtime(path), 1234)
+
+    def test_returns_none_for_missing_file(self):
+        self.assertIsNone(CrashLogUtils.safe_getmtime(os.path.join(self.tmpdir, 'does-not-exist')))
+
+    def _touch(self, name, mtime):
+        path = os.path.join(self.tmpdir, name)
+        with open(path, 'w') as f:
+            f.write('')
+        os.utime(path, (mtime, mtime))
+        return path
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(CrashLogUtils.most_recent_existing([]))
+
+    def test_picks_newest(self):
+        old = self._touch('a', 1000)
+        new = self._touch('b', 2000)
+        self.assertEqual(CrashLogUtils.most_recent_existing([old, new]), new)
+
+    def test_skips_vanished_path(self):
+        alive = self._touch('a', 1000)
+        ghost = os.path.join(self.tmpdir, 'ghost')  # never created
+        self.assertEqual(CrashLogUtils.most_recent_existing([alive, ghost]), alive)
+
+    def test_newest_vanished_falls_back_to_next(self):
+        alive = self._touch('a', 1000)
+        newer = self._touch('b', 2000)
+        os.remove(newer)  # the candidate we would have picked is gone
+        self.assertEqual(CrashLogUtils.most_recent_existing([alive, newer]), alive)
+
+    def test_all_vanished_returns_none(self):
+        ghost1 = os.path.join(self.tmpdir, 'g1')
+        ghost2 = os.path.join(self.tmpdir, 'g2')
+        self.assertIsNone(CrashLogUtils.most_recent_existing([ghost1, ghost2]))
 
 
 class LockFileTest(unittest.TestCase):
@@ -393,7 +441,7 @@ class GenerateCrashLogTest(unittest.TestCase):
         gen = _make_generator(name='WebKitTestRunner', pid=28529)
         gen._get_coredump_path = lambda: (None, None)
         gen._filter_with_cppfilt = lambda text: text
-        gen._get_thread_info_for_effective_pid = lambda: '(no thread info)\n'
+        gen._get_thread_info_for_effective_pid = lambda coredump_found_matches_pid: '(no thread info)\n'
 
         with mock.patch.object(CrashLogUtils, 'are_coredumps_enabled', return_value=True), \
              mock.patch.object(CrashLogUtils, 'are_coredumps_enabled_and_unlimited', return_value=True):
@@ -421,7 +469,7 @@ class GenerateCrashLogTest(unittest.TestCase):
         gen = _make_generator(name='WebKitWebProcess', pid=42)
         gen._get_coredump_path = lambda: (None, None)
         gen._filter_with_cppfilt = lambda text: text
-        gen._get_thread_info_for_effective_pid = lambda: '(none)\n'
+        gen._get_thread_info_for_effective_pid = lambda coredump_found_matches_pid: '(none)\n'
 
         with mock.patch.object(CrashLogUtils, 'are_coredumps_enabled', return_value=True), \
              mock.patch.object(CrashLogUtils, 'are_coredumps_enabled_and_unlimited', return_value=True):
@@ -429,6 +477,203 @@ class GenerateCrashLogTest(unittest.TestCase):
 
         self.assertIn('TEST STDOUT', log)
         self.assertNotIn('TEST STDERR', log)
+
+
+class CorePatternScanRaceTest(unittest.TestCase):
+    """Regression: a coredump present at os.listdir() time can be deleted by
+    another worker before this one stats it. The scan must skip it instead of
+    raising FileNotFoundError and interrupting the whole test suite."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+
+    def _touch(self, name, mtime):
+        path = os.path.join(self.tmpdir, name)
+        with open(path, 'w') as f:
+            f.write('')
+        os.utime(path, (mtime, mtime))
+        return path
+
+    def test_candidate_deleted_between_listdir_and_stat_does_not_crash(self):
+        gen = _make_generator(
+            name='WebKitWebProcess', pid=222,
+            coredump_pattern='core-%e-pid_%p.dump', coredump_directory=self.tmpdir)
+        # newer_than makes the scan call getmtime on every candidate (the line
+        # that used to crash). Both files are newer than this.
+        gen.newer_than = 500
+        survivor = self._touch('core-WebKitWebProcess-pid_222.dump', mtime=2000)
+        ghost = self._touch('core-WebKitWebProcess-pid_333.dump', mtime=3000)
+
+        real_getmtime = os.path.getmtime
+
+        def flaky_getmtime(path):
+            # Simulate 'ghost' being removed by another worker after listdir().
+            if os.path.basename(path) == os.path.basename(ghost):
+                raise FileNotFoundError(2, 'No such file or directory', path)
+            return real_getmtime(path)
+
+        with mock.patch('os.path.getmtime', side_effect=flaky_getmtime), \
+             mock.patch('time.sleep'):
+            path, warning = gen._get_coredump_path_with_core_pattern_method()
+
+        self.assertEqual(path, survivor)
+        self.assertEqual(gen._effective_coredump_pid, 222)
+
+
+class CoredumpDeletionGatingTest(unittest.TestCase):
+    """With auto-delete on, only a pid-matched coredump (and its thread-info
+    file) is removed. A name/fallback match is left on disk so the rightful
+    owner can still find it; the periodic cleanup reclaims it later."""
+
+    def setUp(self):
+        self.coredir = tempfile.mkdtemp()
+        self.threaddir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.coredir, True)
+        self.addCleanup(shutil.rmtree, self.threaddir, True)
+
+    def _setup(self, pid, effective_pid):
+        gen = _make_generator(name='WebKitWebProcess', pid=pid, coredump_directory=self.coredir)
+        gen._webkit_thread_info_crashlog_dir = self.threaddir
+
+        core_path = os.path.join(self.coredir, f'core-WebKitWebProcess-pid_{effective_pid}.dump')
+        with open(core_path, 'w') as f:
+            f.write('ELF-ish coredump bytes')
+        info_path = os.path.join(self.threaddir, CrashLogUtils.get_thread_info_file_name(effective_pid))
+        with open(info_path, 'w') as f:
+            f.write(f'# PID: {effective_pid}\n')
+
+        # Stub selection so the test drives the deletion logic directly, setting
+        # the effective pid exactly as a pid match (==) or a name match (!=) would.
+        gen._get_coredump_path = lambda: (core_path, None)
+        gen._effective_coredump_pid = effective_pid
+        # Don't run gdb / cppfilt for real. A non-empty backtrace avoids the help-message path.
+        gen._get_gdb_output = lambda path: ('gdb backtrace here\n', '', '')
+        gen._filter_with_cppfilt = lambda text: text
+        return gen, core_path, info_path
+
+    def test_pid_match_deletes_coredump_and_thread_info(self):
+        gen, core_path, info_path = self._setup(pid=222, effective_pid=222)
+        with mock.patch.dict(os.environ, {CrashLogEnvVars.core_dumps_autodelete: '1'}):
+            gen.generate_crash_log('out', 'err')
+        self.assertFalse(os.path.exists(core_path), 'pid-matched coredump should be deleted')
+        self.assertFalse(os.path.exists(info_path), 'pid-matched thread-info should be deleted')
+
+    def test_name_match_keeps_coredump_and_thread_info(self):
+        # effective pid differs from self.pid => matched by name/fallback, not pid.
+        gen, core_path, info_path = self._setup(pid=222, effective_pid=555)
+        with mock.patch.dict(os.environ, {CrashLogEnvVars.core_dumps_autodelete: '1'}):
+            gen.generate_crash_log('out', 'err')
+        self.assertTrue(os.path.exists(core_path), 'non-pid-matched coredump must be left for the owner')
+        self.assertTrue(os.path.exists(info_path), 'non-pid-matched thread-info must be left for the owner')
+
+    def test_no_autodelete_keeps_coredump_even_on_pid_match(self):
+        gen, core_path, info_path = self._setup(pid=222, effective_pid=222)
+        with mock.patch.dict(os.environ, {CrashLogEnvVars.core_dumps_autodelete: '0'}):
+            gen.generate_crash_log('out', 'err')
+        self.assertTrue(os.path.exists(core_path), 'without auto-delete the raw coredump is kept')
+
+    def test_pid_match_claims_coredump_by_rename_before_gdb(self):
+        gen, core_path, info_path = self._setup(pid=222, effective_pid=222)
+
+        # Capture the directory state at the moment gdb runs.
+        observed = {}
+
+        def fake_gdb(path):
+            observed['gdb_path'] = path
+            observed['original_present'] = os.path.exists(core_path)
+            observed['claimed_present'] = any(
+                n.startswith(CrashLogUtils.CLAIMED_COREDUMP_PREFIX) for n in os.listdir(self.coredir))
+            return ('gdb backtrace here\n', '', '')
+
+        gen._get_gdb_output = fake_gdb
+        with mock.patch.dict(os.environ, {CrashLogEnvVars.core_dumps_autodelete: '1'}):
+            gen.generate_crash_log('out', 'err')
+
+        # During gdb the core had already been renamed out of the way.
+        self.assertFalse(observed['original_present'], 'core should be renamed before gdb runs')
+        self.assertTrue(observed['claimed_present'], 'a claimed-prefixed file should exist during gdb')
+        self.assertTrue(os.path.basename(observed['gdb_path']).startswith(CrashLogUtils.CLAIMED_COREDUMP_PREFIX))
+        # Afterwards nothing is left behind (neither the original nor the claimed file).
+        self.assertFalse(os.path.exists(core_path))
+        self.assertFalse(
+            any(n.startswith(CrashLogUtils.CLAIMED_COREDUMP_PREFIX) for n in os.listdir(self.coredir)),
+            'claimed file must be removed after processing')
+
+    def test_name_match_is_not_claimed_by_rename(self):
+        # A non-pid match is left in place (not renamed), so the rightful owner can find it.
+        gen, core_path, info_path = self._setup(pid=222, effective_pid=555)
+        observed = {}
+
+        def fake_gdb(path):
+            observed['original_present'] = os.path.exists(core_path)
+            return ('gdb backtrace here\n', '', '')
+
+        gen._get_gdb_output = fake_gdb
+        with mock.patch.dict(os.environ, {CrashLogEnvVars.core_dumps_autodelete: '1'}):
+            gen.generate_crash_log('out', 'err')
+        self.assertTrue(observed['original_present'], 'name-matched core must not be renamed')
+        self.assertTrue(os.path.exists(core_path))
+
+    def test_coredump_gone_at_stat_time_skips_rename_and_gdb(self):
+        # The core passed the isfile() check but vanished before we could stat its size:
+        # we must not rename it nor spawn gdb on a missing file.
+        gen, core_path, info_path = self._setup(pid=222, effective_pid=222)
+        gdb_called = {'v': False}
+
+        def fake_gdb(path):
+            gdb_called['v'] = True
+            return ('should not be reached\n', '', '')
+
+        gen._get_gdb_output = fake_gdb
+        with mock.patch.object(CrashLogUtils, 'human_readable_size', side_effect=OSError(2, 'No such file or directory')), \
+             mock.patch.dict(os.environ, {CrashLogEnvVars.core_dumps_autodelete: '1'}):
+            _, log = gen.generate_crash_log('out', 'err')
+
+        self.assertFalse(gdb_called['v'], 'gdb must not run when the coredump vanished before stat')
+        self.assertIn('removed', log)
+        self.assertFalse(
+            any(n.startswith(CrashLogUtils.CLAIMED_COREDUMP_PREFIX) for n in os.listdir(self.coredir)),
+            'a vanished coredump must not be renamed/claimed')
+
+
+class CleanOldCoredumpsTest(unittest.TestCase):
+    """clean_old_coredumps() reaps old files matching the core_pattern AND old
+    claimed (being-processed) leftovers, while leaving fresh and unrelated files."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+        # clean_old_coredumps lives on the startup handler; build a bare instance
+        # (its __init__ has heavy side effects) and set only what the method uses.
+        self.handler = GDBCrashLogStartupHandler.__new__(GDBCrashLogStartupHandler)
+        self.handler._coredump_directory = self.tmpdir
+        self.handler._coredump_pattern = 'core-%e-pid_%p.dump'
+
+    def _touch(self, name, age_seconds):
+        path = os.path.join(self.tmpdir, name)
+        with open(path, 'w') as f:
+            f.write('')
+        mtime = time.time() - age_seconds
+        os.utime(path, (mtime, mtime))
+        return path
+
+    def test_reaps_old_pattern_and_claimed_keeps_fresh_and_unrelated(self):
+        old_core = self._touch('core-WebKitWebProcess-pid_111.dump', age_seconds=3600)
+        fresh_core = self._touch('core-WebKitWebProcess-pid_222.dump', age_seconds=5)
+        old_claimed = self._touch(
+            CrashLogUtils.CLAIMED_COREDUMP_PREFIX + 'core-WebKitWebProcess-pid_333.dump', age_seconds=3600)
+        fresh_claimed = self._touch(
+            CrashLogUtils.CLAIMED_COREDUMP_PREFIX + 'core-WebKitWebProcess-pid_444.dump', age_seconds=5)
+        unrelated = self._touch('not-a-coredump.txt', age_seconds=3600)
+
+        self.handler.clean_old_coredumps()
+
+        self.assertFalse(os.path.exists(old_core), 'old pattern-matching core should be reaped')
+        self.assertTrue(os.path.exists(fresh_core), 'fresh core should be kept')
+        self.assertFalse(os.path.exists(old_claimed), 'old claimed leftover should be reaped')
+        self.assertTrue(os.path.exists(fresh_claimed), 'fresh (in-flight) claimed file should be kept')
+        self.assertTrue(os.path.exists(unrelated), 'unrelated file should be left untouched')
 
 
 class DetermineCoredumpMethodAndDirTest(unittest.TestCase):
@@ -686,6 +931,19 @@ class GetCoredumpPathTest(unittest.TestCase):
         self.assertEqual(self.gen._effective_coredump_pid, 222)
         # pid match: no warning
         self.assertIsNone(warning)
+
+    def test_selection_ignores_claimed_prefixed_files(self):
+        # A coredump another worker is processing (renamed with the claimed prefix) must be
+        # invisible to this scan, even though without the prefix it would win by pid+mtime.
+        claimed = self._touch(
+            CrashLogUtils.CLAIMED_COREDUMP_PREFIX + 'core-WebKitWebProcess-pid_222.dump', mtime=3000)
+        expected = self._touch('core-WebKitWebProcess-pid_222.dump', mtime=2000)
+
+        with mock.patch('time.sleep'):
+            path, warning = self.gen._get_coredump_path_with_core_pattern_method()
+
+        self.assertEqual(path, expected)
+        self.assertNotEqual(path, claimed)
 
     def test_matches_by_pid_when_pattern_contains_literal_percent_p(self):
         gen = _make_generator(name='WebKitWebProcess', pid=222, coredump_pattern='core-%%p-pid_%p.dump', coredump_directory=self.tmpdir)


### PR DESCRIPTION
#### 471b695cde8eb37910d73abb4cdaa7d93c7a0fc1
<pre>
[Tools] linux_get_crash_log: avoid python crashes when the coredumps are auto-deleted with multiple concurrent workers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=315195">https://bugs.webkit.org/show_bug.cgi?id=315195</a>

Unreviewed follow-up after 313530@main

With multiple parallel workers and the auto-delete feature enabled (which is enabled on the bots),
it can happen that two workers select the same coredump (one matching by pid and another matching
by program name because it couldn&apos;t match by pid). Then it can happen that one worker deletes the
coredump meanwhile the other is trying to process it. This causes a FileNotFoundError fatal python
crash that interrupts the whole test suite.

Avoid this by guarding against these race conditions. Also do not delete the coredumps when
matching by pid was not possible. This may allow the real owner of that coredump to find it later.
And in the case of matching by pid, when autodeletion is enabled, rename the file as soon as
possible so no other worker matching by name can pick that one.
Those will be cleaned in the next run at clean_old_coredumps() / clean_old_thread_info_files().

On top of that improve a bit the info displayed on the debug logs when capturing the thread names,
which may be useful for checking later issues with the crash log generator not capturing specific
crashes.

This has been observed on the EWS bots:
<a href="https://ews-build.webkit.org/#/builders/1/builds/137321">https://ews-build.webkit.org/#/builders/1/builds/137321</a>
<a href="https://ews-build.webkit.org/#/builders/34/builds/128982">https://ews-build.webkit.org/#/builders/34/builds/128982</a>

* Tools/Scripts/webkitpy/port/linux_get_crash_log.py:
(CrashLogUtils):
(CrashLogUtils.safe_getmtime):
(CrashLogUtils.most_recent_existing):
(ThreadNamesCrashLogCapturer.handle_coredump):
(GDBCrashLogStartupHandler._maybe_remove_file_if_old):
(GDBCrashLogStartupHandler.clean_old_coredumps):
(GDBCrashLogGenerator._pick_most_recent):
(GDBCrashLogGenerator._get_coredump_path_with_core_pattern_method):
(GDBCrashLogGenerator._get_thread_info_for_effective_pid):
(GDBCrashLogGenerator.generate_crash_log):
* Tools/Scripts/webkitpy/port/linux_get_crash_log_unittest.py:
(SafeGetmtimeMostRecentExistingTest):
(SafeGetmtimeMostRecentExistingTest.setUp):
(SafeGetmtimeMostRecentExistingTest.test_returns_mtime_for_existing_file):
(SafeGetmtimeMostRecentExistingTest.test_returns_none_for_missing_file):
(SafeGetmtimeMostRecentExistingTest._touch):
(SafeGetmtimeMostRecentExistingTest.test_empty_returns_none):
(SafeGetmtimeMostRecentExistingTest.test_picks_newest):
(SafeGetmtimeMostRecentExistingTest.test_skips_vanished_path):
(SafeGetmtimeMostRecentExistingTest.test_newest_vanished_falls_back_to_next):
(SafeGetmtimeMostRecentExistingTest.test_all_vanished_returns_none):
(GenerateCrashLogTest.test_no_coredump_emits_help_message_and_sections):
(GenerateCrashLogTest.test_stderr_section_skipped_when_no_stderr):
(CorePatternScanRaceTest):
(CorePatternScanRaceTest.setUp):
(CorePatternScanRaceTest._touch):
(CorePatternScanRaceTest.test_candidate_deleted_between_listdir_and_stat_does_not_crash):
(CorePatternScanRaceTest.test_candidate_deleted_between_listdir_and_stat_does_not_crash.flaky_getmtime):
(CoredumpDeletionGatingTest):
(CoredumpDeletionGatingTest.setUp):
(CoredumpDeletionGatingTest._setup):
(CoredumpDeletionGatingTest.test_pid_match_deletes_coredump_and_thread_info):
(CoredumpDeletionGatingTest.test_name_match_keeps_coredump_and_thread_info):
(CoredumpDeletionGatingTest.test_no_autodelete_keeps_coredump_even_on_pid_match):
(CoredumpDeletionGatingTest.test_pid_match_claims_coredump_by_rename_before_gdb):
(CoredumpDeletionGatingTest.test_pid_match_claims_coredump_by_rename_before_gdb.fake_gdb):
(CoredumpDeletionGatingTest.test_name_match_is_not_claimed_by_rename):
(CoredumpDeletionGatingTest.test_name_match_is_not_claimed_by_rename.fake_gdb):
(CoredumpDeletionGatingTest.test_coredump_gone_at_stat_time_skips_rename_and_gdb):
(CoredumpDeletionGatingTest.test_coredump_gone_at_stat_time_skips_rename_and_gdb.fake_gdb):
(CleanOldCoredumpsTest):
(CleanOldCoredumpsTest.setUp):
(CleanOldCoredumpsTest._touch):
(CleanOldCoredumpsTest.test_reaps_old_pattern_and_claimed_keeps_fresh_and_unrelated):
(GetCoredumpPathTest.test_selection_ignores_claimed_prefixed_files):

Canonical link: <a href="https://commits.webkit.org/314414@main">https://commits.webkit.org/314414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21f1b9422eed9690d0e59063c345638ae15ad6dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166071 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/39561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/33142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175118 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167937 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/129070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169030 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/109596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/165389 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/23259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/26904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177651 "Built successfully") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/28610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/137416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/39630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/39565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/137344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/40318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/148699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25277 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/40318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/38829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/38226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/3652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/38471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/38369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->