### PR TITLE
[CMake] Resolve ninja path via xcrun at configure time

### DIFF
--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -198,6 +198,12 @@ if (CMAKE_GENERATOR STREQUAL "Ninja")
     set(CMAKE_C_ARCHIVE_FINISH true)
 endif ()
 
+WEBKIT_XCRUN(_ninja_path -f ninja)
+if (NOT EXISTS "${_ninja_path}")
+    message(FATAL_ERROR "xcrun could not resolve ninja")
+endif ()
+file(WRITE "${CMAKE_BINARY_DIR}/.webkit-ninja-path" "${_ninja_path}\n")
+
 set(CMAKE_STATIC_LINKER_FLAGS "-no_warning_for_no_symbols")
 
 if (CMAKE_EXPORT_COMPILE_COMMANDS AND NOT EXISTS ${CMAKE_SOURCE_DIR}/compile_commands.json)

--- a/Source/cmake/clang-wrapper
+++ b/Source/cmake/clang-wrapper
@@ -118,7 +118,7 @@ END_OF_NINJA
 
 writeFileIfChanged("$membersFolder/build.ninja", $buildNinja);
 
-exec('ninja', '--quiet', '-f', "$membersFolder/build.ninja");
+exec($ENV{WEBKIT_NINJA_PATH}, '--quiet', '-f', "$membersFolder/build.ninja");
 die("exec ninja: $!\n");
 
 sub shellQuote {

--- a/Source/cmake/ninja-wrapper
+++ b/Source/cmake/ninja-wrapper
@@ -4,20 +4,25 @@ use warnings;
 use Cwd qw(getcwd);
 use File::Path qw(make_path);
 
+open(my $ninjaPathFile, '<', '.webkit-ninja-path') or die("ninja-wrapper: $!\n");
+chomp(my $ninja = <$ninjaPathFile>);
+close($ninjaPathFile);
+$ENV{WEBKIT_NINJA_PATH} = $ninja;
+
 # CMake configuration
 if (grep({ /^-t/ || /^--version$/ } @ARGV)) {
-    exec('ninja', @ARGV);
+    exec($ninja, @ARGV);
 }
 
 # CMake try_compile/check_*
 if (getcwd() =~ m{/CMakeFiles/}) {
-    exec('ninja', @ARGV);
+    exec($ninja, @ARGV);
 }
 
 # Real compilation
 my $bundlePolicy = $ENV{WK_UNIFIED_SOURCES_BUNDLE_POLICY};
 if (!defined($bundlePolicy)) {
-    my $dryRun = `ninja -n @ARGV 2>&1`;
+    my $dryRun = `$ninja -n @ARGV 2>&1`;
     my ($totalCommands) = $dryRun =~ m{/(\d+)\]};
 
     # No-op build
@@ -44,4 +49,4 @@ if (open(my $fh, '>', "DerivedSources/unified-sources-bundle-policy")) {
     close($fh);
 }
 
-exec('/usr/bin/caffeinate', '-i', 'ninja', @ARGV);
+exec('/usr/bin/caffeinate', '-i', $ninja, @ARGV);


### PR DESCRIPTION
#### e8791090c2e8abab64ef6be9fbc9d342d09cdd08
<pre>
[CMake] Resolve ninja path via xcrun at configure time
<a href="https://bugs.webkit.org/show_bug.cgi?id=316122">https://bugs.webkit.org/show_bug.cgi?id=316122</a>
<a href="https://rdar.apple.com/178548259">rdar://178548259</a>

Reviewed by Elliott Williams and Pascoe.

By default on Darwin installs, &apos;ninja&apos; does not actually exist
in any $PATH, but &apos;xcrun ninja&apos; can still find it.

Use xcrun to resolve the ninja path at configure time and save
it, like we do for clang/swiftc/etc.

Then use the resolved / cached path at build time.

Canonical link: <a href="https://commits.webkit.org/314403@main">https://commits.webkit.org/314403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dbbcdad4dbccd0e740c568584d56aa335416b6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175047 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123256 "Build is in progress. Recent messages:") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02fc07e8-d044-4835-960f-41c6447e1aa3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129017 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/123256 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4baba6d2-17e0-4f3a-b5e5-81264d4643e6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109543 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e29e5b45-86e0-4581-839f-6f88314b8e4d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29051 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23188 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158158 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177581 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26894 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30483 "Build is in progress. Recent messages:") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28545 "Found 1 new test failure: fast/webgpu/nocrash/fuzz-298315.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137359 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137286 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148634 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102839 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25271 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32576 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25501 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38759 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38156 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3584 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38401 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38299 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->