### PR TITLE
[Site Isolation] Evicting a cross-site page from the back/forward cache crashes the iframe process

### DIFF
--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -163,9 +163,10 @@ void SuspendedPageProxy::startSuspension(std::optional<BackForwardFrameItemIdent
     m_process->addSuspendedPageProxy(*this);
     m_suspensionState = SuspensionState::Suspending;
 
-    if (mainFrameItemID)
+    if (mainFrameItemID) {
+        m_suspendedFrameItemID = *mainFrameItemID;
         suspendSubframeProcesses(*mainFrameItemID);
-    else
+    } else
         m_allSubframesSuspended = true;
 
     m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, *this);
@@ -422,6 +423,15 @@ bool SuspendedPageProxy::hasSubframeInProcess(WebCore::ProcessIdentifier process
             return true;
     }
     return false;
+}
+
+HashSet<Ref<WebProcessProxy>> SuspendedPageProxy::iframeProcesses() const
+{
+    // FIXME: Add WebFrameProxy::forEachDescendant() to avoid manual traverseNext() loops.
+    HashSet<Ref<WebProcessProxy>> processes;
+    for (RefPtr frame = m_mainFrame->traverseNext().frame; frame; frame = frame->traverseNext().frame)
+        processes.add(Ref { frame->process() });
+    return processes;
 }
 
 void SuspendedPageProxy::maybeCompleteSuspension()

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/NavigationIdentifier.h>
+#include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/SwiftBridging.h>
 #include <wtf/TZoneMalloc.h>
@@ -88,6 +89,9 @@ public:
 
     bool hasSubframeInProcess(WebCore::ProcessIdentifier) const;
 
+    std::optional<WebCore::BackForwardFrameItemIdentifier> suspendedFrameItemID() const { return m_suspendedFrameItemID; }
+    HashSet<Ref<WebProcessProxy>> iframeProcesses() const;
+
     void pageDidFirstLayerFlush();
     void closeWithoutFlashing();
 
@@ -134,6 +138,8 @@ private:
     bool m_shouldCloseWhenEnteringAcceleratedCompositingMode { false };
 
     SuspensionState m_suspensionState { SuspensionState::BeforeStart };
+    // Set once in startSuspension; never reset (the entry destructor gates reads on its own frame id).
+    std::optional<WebCore::BackForwardFrameItemIdentifier> m_suspendedFrameItemID;
     CompletionHandler<void(SuspendedPageProxy*)> m_readyToUnsuspendHandler;
     RunLoop::Timer m_suspensionTimeoutTimer;
     bool m_mainFrameSuspended { false };

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
@@ -64,10 +64,9 @@ WebBackForwardCacheEntry::~WebBackForwardCacheEntry()
     // takeForRestoration(), so this skips on the BFCache restore path.
     if (!m_backForwardFrameItemID)
         return;
-    if (RefPtr mainProcess = process())
-        mainProcess->sendWithAsyncReply(Messages::WebProcess::ClearCachedPage(*m_backForwardFrameItemID), [] { });
-    for (auto& iframeProcess : iframeProcesses())
-        iframeProcess->sendWithAsyncReply(Messages::WebProcess::ClearCachedPage(*m_backForwardFrameItemID), [] { });
+
+    for (auto& process : allProcesses())
+        process->sendWithAsyncReply(Messages::WebProcess::ClearCachedPage(*m_backForwardFrameItemID), [] { });
 }
 
 WebBackForwardCache* WebBackForwardCacheEntry::backForwardCache() const
@@ -108,6 +107,18 @@ HashSet<Ref<WebProcessProxy>> WebBackForwardCacheEntry::iframeProcesses() const
         for (RefPtr frame = root->traverseNext().frame; frame; frame = frame->traverseNext().frame)
             result.add(Ref { frame->process() });
     }
+
+    if (RefPtr suspendedPage = m_suspendedPage; suspendedPage && suspendedPage->suspendedFrameItemID() == m_backForwardFrameItemID)
+        result.addAll(suspendedPage->iframeProcesses());
+
+    return result;
+}
+
+HashSet<Ref<WebProcessProxy>> WebBackForwardCacheEntry::allProcesses() const
+{
+    HashSet<Ref<WebProcessProxy>> result = iframeProcesses();
+    if (RefPtr mainProcess = process())
+        result.add(mainProcess.releaseNonNull());
     return result;
 }
 

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -76,6 +76,7 @@ private:
     WebBackForwardCacheEntry(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier, WebCore::ProcessIdentifier, RefPtr<SuspendedPageProxy>&&);
 
     HashSet<Ref<WebProcessProxy>> iframeProcesses() const;
+    HashSet<Ref<WebProcessProxy>> allProcesses() const;
 
     void expirationTimerFired();
     void markAsTakenForRestoration();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8782,6 +8782,51 @@ TEST(SiteIsolation, MultiProcessBFCacheIframeProcessSurvival)
     EXPECT_TRUE(processStillRunning(iframePID));
 }
 
+// DEBUG-assert regression guard: without the fix the iframe process trips
+// ASSERT(m_rootFrames.isEmpty()) (Page.cpp:577) on the eviction Close. Release has no assert,
+// so the process-alive EXPECT below is only a weak secondary signal there.
+TEST(SiteIsolation, MultiProcessBFCacheCrossSiteEvictionDoesNotCrashIframe)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    // The web process cache keeps the b.com process alive past the navigation, so eviction's
+    // Close reaches a live process and runs ~Page() instead of force-killing it.
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    processPoolConfiguration.get().usesWebProcessCache = YES;
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [configuration setProcessPool:processPool.get()];
+    enableFeature(configuration.get(), @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration.get());
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    pid_t iframePID = findFramePID(frameTrees(webView.get()).get(), FrameType::Remote);
+
+    // Cross-site navigation suspends a.com into the BFCache via SuspendedPageProxy; b.com keeps
+    // a CachedPage and stays alive in the web process cache.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(processStillRunning(iframePID));
+
+    [webView _clearBackForwardCache];
+
+    // Let the eviction IPC (ClearCachedPage then Close) drain so a crash, if any, lands in-window.
+    Util::runFor(0.5_s);
+    EXPECT_TRUE(processStillRunning(iframePID));
+}
+
 // FIXME: Use openerAndOpenedViews() once MultiProcessBackForwardCacheEnabled is on by default.
 TEST(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)
 {


### PR DESCRIPTION
#### 5b5081adba8f0891b114ba01a843fbbfdb6b7cd7
<pre>
[Site Isolation] Evicting a cross-site page from the back/forward cache crashes the iframe process
<a href="https://bugs.webkit.org/show_bug.cgi?id=316114">https://bugs.webkit.org/show_bug.cgi?id=316114</a>
<a href="https://rdar.apple.com/178543188">rdar://178543188</a>

Reviewed by Sihui Liu.

When a cross-site Site Isolation page is held in the back/forward cache via a
SuspendedPageProxy, evicting that cache entry never cleared the cached page in the
iframe processes. WebBackForwardCacheEntry only sent ClearCachedPage to the main
process and to the iframe processes tracked in m_cachedChildren, which is empty for
the cross-site SuspendedPageProxy path. The SuspendedPageProxy teardown then sent a
plain Close to the iframe process, so it ran WebPage::close() with its document still
in the back/forward cache and Page::~Page() asserted (m_rootFrames was not empty).

The cached subframe processes live in one of two places depending on the path: the
in-process cache path records them on WebBackForwardCacheEntry::m_cachedChildren, while
the cross-site path leaves them in the frozen frame tree of the SuspendedPageProxy.
Unify both into a single accessor: SuspendedPageProxy now records the frame item it was
suspended under (suspendedFrameItemID) and exposes its iframe processes, and
WebBackForwardCacheEntry::iframeProcesses() folds those into the m_cachedChildren set.
A new WebBackForwardCacheEntry::allProcesses() adds the main frame process, so the
destructor clears every relevant process through one path.

The destructor sends ClearCachedPage to allProcesses() before m_suspendedPage is
released at the end of the destructor; ~SuspendedPageProxy then sends Close, and IPC is
FIFO per connection, so ClearCachedPage arrives first and the iframe leaves the
back/forward cache cleanly. A SuspendedPageProxy can be shared across same-process
entries, so its frame id may differ from ours; only the entry the page was actually
suspended under (suspendedFrameItemID() == m_backForwardFrameItemID) contributes the
suspended page&apos;s iframe processes, other entries do nothing.

This crash is only reachable once MultiProcessBackForwardCacheEnabled is on under Site
Isolation, so the new test enables the preference explicitly.

* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::startSuspension):
(WebKit::SuspendedPageProxy::iframeProcesses):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
(WebKit::SuspendedPageProxy::suspendedFrameItemID const):
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp:
(WebKit::WebBackForwardCacheEntry::~WebBackForwardCacheEntry):
(WebKit::WebBackForwardCacheEntry::iframeProcesses const):
(WebKit::WebBackForwardCacheEntry::allProcesses const):
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TEST(SiteIsolation, MultiProcessBFCacheCrossSiteEvictionDoesNotCrashIframe)):

Canonical link: <a href="https://commits.webkit.org/314507@main">https://commits.webkit.org/314507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72b31ebf2bf11edd212e514e4f32c1637c40645a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175369 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc79d0a5-141c-439b-982e-addcb068642c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129281 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95ab2f1e-2e83-4e05-b772-9441dbd426a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169280 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109806 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23509 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177901 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137633 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39881 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137555 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37054 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148930 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103215 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32848 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39079 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38476 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3882 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38721 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38619 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->