### PR TITLE
[CMake] Enable -Wunused-parameter on Cocoa to match Xcode

### DIFF
--- a/Source/WebKitLegacy/PlatformCocoa.cmake
+++ b/Source/WebKitLegacy/PlatformCocoa.cmake
@@ -1,5 +1,5 @@
 # FIXME: Remove once source files are fixed. https://bugs.webkit.org/show_bug.cgi?id=312034
-add_compile_options(-Wno-unused-parameter)
+WEBKIT_ADD_TARGET_CXX_FLAGS(WebKitLegacy -Wno-unused-parameter)
 
 WEBKIT_ADD_PREFIX_HEADER(WebKitLegacy WebKitLegacyPrefix.h PREFIX_LANGUAGES CXX OBJC OBJCXX)
 

--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -129,7 +129,6 @@ add_compile_options(
 add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-Wno-cast-align>")
 add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-Wno-undefined-inline>")
 add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-Wno-nonportable-include-path>")
-add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-Wno-unused-parameter>")
 add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-Wno-missing-field-initializers>")
 add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-Wno-null-conversion>")
 add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-fobjc-weak>")

--- a/Tools/DumpRenderTree/PlatformMac.cmake
+++ b/Tools/DumpRenderTree/PlatformMac.cmake
@@ -1,3 +1,6 @@
+# FIXME: Remove once source files are fixed. https://bugs.webkit.org/show_bug.cgi?id=312034
+WEBKIT_ADD_TARGET_CXX_FLAGS(DumpRenderTree -Wno-unused-parameter)
+
 find_library(QUARTZ_LIBRARY Quartz)
 find_library(CARBON_LIBRARY Carbon)
 find_library(CORESERVICES_LIBRARY CoreServices)

--- a/Tools/ImageDiff/PlatformMac.cmake
+++ b/Tools/ImageDiff/PlatformMac.cmake
@@ -9,3 +9,6 @@ list(APPEND ImageDiff_LIBRARIES
 
 # kUTTypePNG deprecated in 12.0; our deployment target is 26.2.
 list(APPEND ImageDiff_COMPILE_OPTIONS -Wno-deprecated-declarations)
+
+# FIXME: Remove once source files are fixed. https://bugs.webkit.org/show_bug.cgi?id=312034
+list(APPEND ImageDiff_COMPILE_OPTIONS -Wno-unused-parameter)

--- a/Tools/MiniBrowser/mac/CMakeLists.txt
+++ b/Tools/MiniBrowser/mac/CMakeLists.txt
@@ -64,6 +64,8 @@ add_custom_target(MiniBrowserNibs ALL DEPENDS
 
 include_directories(${MiniBrowser_INCLUDE_DIRECTORIES})
 add_executable(MiniBrowser MACOSX_BUNDLE ${MiniBrowser_SOURCES})
+# FIXME: Remove once source files are fixed. https://bugs.webkit.org/show_bug.cgi?id=312034
+WEBKIT_ADD_TARGET_CXX_FLAGS(MiniBrowser -Wno-unused-parameter)
 set_target_properties(MiniBrowser PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${MINIBROWSER_DIR}/Info.plist)
 target_link_libraries(MiniBrowser ${MiniBrowser_LIBRARIES})
 add_dependencies(MiniBrowser MiniBrowserNibs WebProcess NetworkProcess GPUProcess)


### PR DESCRIPTION
#### 8d287629f85e4c16e63d102e2b74f66c66f54e67
<pre>
[CMake] Enable -Wunused-parameter on Cocoa to match Xcode
<a href="https://bugs.webkit.org/show_bug.cgi?id=316129">https://bugs.webkit.org/show_bug.cgi?id=316129</a>
<a href="https://rdar.apple.com/178557623">rdar://178557623</a>

Reviewed by Pascoe.

The Cocoa CMake build globally suppressed -Wunused-parameter via
-Wno-unused-parameter in OptionsCocoa.cmake, even though -Wall -Wextra
already enables it. Xcode enables the warning everywhere (-Wextra in
CommonBase.xcconfig, treated as an error) and opts specific projects out
per-target via WK_FIXME_WARNING_CFLAGS.

Drop the blanket suppression so WTF, JavaScriptCore, WebCore, and PAL
warn like they do under Xcode, and add per-target opt-outs mirroring the
projects Xcode still exempts: WebKit (already present), WebKitLegacy,
DumpRenderTree, ImageDiff, and MiniBrowser. TestWebKitAPI and
WebKitTestRunner already opt out; the third-party targets build with -w.

WebKitLegacy&apos;s existing opt-out used add_compile_options(), which runs
after WEBKIT_FRAMEWORK_DECLARE creates the target and so never applied;
switch it to the target-scoped WEBKIT_ADD_TARGET_CXX_FLAGS form.

* Source/WebKitLegacy/PlatformCocoa.cmake:
* Source/cmake/OptionsCocoa.cmake:
* Tools/DumpRenderTree/PlatformMac.cmake:
* Tools/ImageDiff/PlatformMac.cmake:
* Tools/MiniBrowser/mac/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/314510@main">https://commits.webkit.org/314510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f5a5ae3874beed4c161c6cd7eab1c12f706abf2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175075 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123283 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39944 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39522 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129037 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90900 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109563 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30382 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29071 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23215 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158185 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140351 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26870 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Running layout-tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177608 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26921 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30510 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137381 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137308 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37061 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148665 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102867 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25532 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198773 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38786 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111860 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/53403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38183 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3618 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38428 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38326 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->