### PR TITLE
Use-after-free of Node in Range::createContextualFragment

### DIFF
--- a/LayoutTests/fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash-expected.txt
+++ b/LayoutTests/fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash-expected.txt
@@ -1,0 +1,4 @@
+This tests calling createContextualFragment with trusted types createHTML callback which clears range's endpoints.
+WebKit should not crash or hit any assertions under ASAN and you should see PASS below:
+
+PASS

--- a/LayoutTests/fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash.html
+++ b/LayoutTests/fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+</head>
+<body>
+<p>This tests calling createContextualFragment with trusted types createHTML callback which clears range's endpoints.<br>
+WebKit should not crash or hit any assertions under ASAN and you should see PASS below:</p>
+<div id="result"></div>
+<script src="../../../resources/gc.js"></script>
+<script>
+globalThis?.testRunner.dumpAsText();
+
+const range = document.createRange();
+let div = document.createElement('div');
+range.setStart(div, 0);
+range.setEnd(div, 0);
+
+let didRun = false;
+trustedTypes.createPolicy('default', {
+  createHTML(string) {
+    if (didRun)
+      return;
+    didRun = true;
+
+    range.setEnd(document, 0); // drops range references to 'v'
+    div = null; // drops JS wrapper reference to 'v'
+    gc(); // wrapper GC'd -> C++ object GC'd
+
+    return string;
+  }
+});
+
+range.createContextualFragment('x');
+
+result.textContent = 'PASS';
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 1e11f2a39863c6d044bf2f09308c7869ff51c145
<pre>
Use-after-free of Node in Range::createContextualFragment
<a href="https://bugs.webkit.org/show_bug.cgi?id=312244">https://bugs.webkit.org/show_bug.cgi?id=312244</a>
<a href="https://rdar.apple.com/174489535">rdar://174489535</a>

Reviewed by Chris Dumez.

Fixed the bug by deploying more smart pointers.

Test: fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash.html

* LayoutTests/fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash-expected.txt: Added.
* LayoutTests/fast/dom/Range/range-create-contextual-fragment-trsuted-types-crash.html: Added.
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::createContextualFragment):

Originally-landed-as: 305413.665@safari-7624-branch (4966a0d102e7). <a href="https://rdar.apple.com/176058780">rdar://176058780</a>
Canonical link: <a href="https://commits.webkit.org/314415@main">https://commits.webkit.org/314415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2e69700fb5ac4fee0beaff2268852e1dfc67365

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123284 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129038 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109564 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29072 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23216 "Hash a2e69700 for PR 66294 does not build (failure)") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177609 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26922 "Build is in progress. Recent messages:") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137386 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137309 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148658 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102868 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25278 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32592 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25525 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38787 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38184 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3611 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38429 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38327 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->