### PR TITLE
Fix the internal build after 314341@main

### DIFF
--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -157,6 +157,8 @@ typedef NS_ENUM(NSInteger, NSScrollPocketEdge) {
 + (_NSCornerRadius *)fixedRadius:(CGFloat)radius;
 @end
 
+// FIXME: Drop these and clean up the call sites once the supported configurations allow it.
+#if !defined(__has_include) || !__has_include(<AppKit/NSViewCornerRadii.h>)
 @interface NSViewCornerRadii : NSObject
 @property CGFloat topLeft;
 @property CGFloat topRight;
@@ -164,11 +166,14 @@ typedef NS_ENUM(NSInteger, NSScrollPocketEdge) {
 @property CGFloat bottomRight;
 @property (copy) CALayerCornerCurve cornerCurve;
 @end
+#endif
 
+#if !defined(__has_include) || !__has_include(<AppKit/NSViewCornerConfiguration.h>)
 @interface NSViewCornerConfiguration : NSObject
 + (NSViewCornerConfiguration *)configurationWithRadius:(_NSCornerRadius *)radius;
 + (instancetype)configurationWithTopLeftRadius:(nullable _NSCornerRadius *)topLeftRadius topRightRadius:(nullable _NSCornerRadius *)topRightRadius bottomLeftRadius:(nullable _NSCornerRadius *)bottomLeftRadius bottomRightRadius:(nullable _NSCornerRadius *)bottomRightRadius;
 @end
+#endif
 
 @interface NSPressGestureRecognizer (SPI)
 @property BOOL cancelPastAllowableMovement;

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -887,7 +887,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (self.enclosingScrollView)
         return [super _cornerConfiguration];
 
-    return [NSViewCornerConfiguration configurationWithRadius:_NSCornerRadius.containerConcentricRadius];
+    return [NSViewCornerConfiguration configurationWithRadius:(id)_NSCornerRadius.containerConcentricRadius];
 }
 
 #endif

--- a/Tools/TestWebKitAPI/Helpers/mac/AppKitSPI.h
+++ b/Tools/TestWebKitAPI/Helpers/mac/AppKitSPI.h
@@ -130,6 +130,8 @@ NSString * const NSInspectorBarTextAlignmentItemIdentifier = @"NSInspectorBarTex
 + (_NSCornerRadius *)fixedRadius:(CGFloat)radius;
 @end
 
+// FIXME: Drop these and clean up the call sites once the supported configurations allow it.
+#if !defined(__has_include) || !__has_include(<AppKit/NSViewCornerRadii.h>)
 @interface NSViewCornerRadii : NSObject
 @property CGFloat topLeft;
 @property CGFloat topRight;
@@ -137,11 +139,14 @@ NSString * const NSInspectorBarTextAlignmentItemIdentifier = @"NSInspectorBarTex
 @property CGFloat bottomRight;
 @property (copy) CALayerCornerCurve cornerCurve;
 @end
+#endif
 
+#if !defined(__has_include) || !__has_include(<AppKit/NSViewCornerConfiguration.h>)
 @interface NSViewCornerConfiguration : NSObject
 + (NSViewCornerConfiguration *)configurationWithRadius:(_NSCornerRadius *)radius;
 + (instancetype)configurationWithTopLeftRadius:(nullable _NSCornerRadius *)topLeftRadius topRightRadius:(nullable _NSCornerRadius *)topRightRadius bottomLeftRadius:(nullable _NSCornerRadius *)bottomLeftRadius bottomRightRadius:(nullable _NSCornerRadius *)bottomRightRadius;
 @end
+#endif
 
 @interface NSView (NSViewCornerConfiguration)
 @property (nullable, readonly) NSViewCornerRadii *_effectiveCornerRadii;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm
@@ -61,10 +61,10 @@
 - (NSViewCornerConfiguration *)_cornerConfiguration
 {
     return [NSViewCornerConfiguration
-        configurationWithTopLeftRadius:[_NSCornerRadius fixedRadius:self.topLeftRadius]
-        topRightRadius:[_NSCornerRadius fixedRadius:self.topRightRadius]
-        bottomLeftRadius:[_NSCornerRadius fixedRadius:self.bottomLeftRadius]
-        bottomRightRadius:[_NSCornerRadius fixedRadius:self.bottomRightRadius]];
+        configurationWithTopLeftRadius:(id)[_NSCornerRadius fixedRadius:self.topLeftRadius]
+        topRightRadius:(id)[_NSCornerRadius fixedRadius:self.topRightRadius]
+        bottomLeftRadius:(id)[_NSCornerRadius fixedRadius:self.bottomLeftRadius]
+        bottomRightRadius:(id)[_NSCornerRadius fixedRadius:self.bottomRightRadius]];
 }
 
 @end


### PR DESCRIPTION
#### 6871d45047a3765581e1a8ba4f272e50c8327729
<pre>
Fix the internal build after 314341@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=316136">https://bugs.webkit.org/show_bug.cgi?id=316136</a>
<a href="https://rdar.apple.com/178561155">rdar://178561155</a>

Reviewed by Abrar Rahman Protyasha.

314341@main reverted `-[WKWebView _cornerConfiguration]` to dispatch on `_NSCornerRadius` because
`+[NSViewCornerRadius containerConcentricRadius]` is undefined at runtime on some internal configs.

Restore the build without altering the runtime path. Casting through `id` keeps `_NSCornerRadius`
as the message receiver and only relaxes the static type so the newer SDK accepts the SPI instance.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _cornerConfiguration]):
* Tools/TestWebKitAPI/Helpers/mac/AppKitSPI.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm:
(-[ContainerView _cornerConfiguration]):

Canonical link: <a href="https://commits.webkit.org/314408@main">https://commits.webkit.org/314408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98f1dab86e5fde31fe78c2127b10a98f6f2a4c5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166053 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/39543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/33124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175100 "Failed to checkout and rebase branch from PR 66298") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167919 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/175100 "Failed to checkout and rebase branch from PR 66298") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169012 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/175100 "Failed to checkout and rebase branch from PR 66298") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23241 "Failed to checkout and rebase branch from PR 66298") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/26884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177633 "Failed to checkout and rebase branch from PR 66298") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/28590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/177633 "Failed to checkout and rebase branch from PR 66298") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39612 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/39547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/177633 "Failed to checkout and rebase branch from PR 66298") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/40300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/148679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25273 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/40300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/38811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111885 "Build is in progress. Recent messages:") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/38208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/3632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/38453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/38351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->