### PR TITLE
REGRESSION(311380@main): [macOS wk2 ] media/video-concurrent-visible-playback.html is a flaky TEXT failure

### DIFF
--- a/LayoutTests/media/video-invisible-audible-autoplay-not-allowed-expected.txt
+++ b/LayoutTests/media/video-invisible-audible-autoplay-not-allowed-expected.txt
@@ -1,0 +1,11 @@
+
+Test that an audible <video autoplay> element whose renderer attaches outside the viewport does not begin playing.
+
+** loading an audible video with no renderer
+
+EVENT(canplaythrough)
+** making the video renderer attach far below the viewport
+RUN(document.querySelector(".container").style.display = "block")
+EXPECTED (video.paused == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/video-invisible-audible-autoplay-not-allowed.html
+++ b/LayoutTests/media/video-invisible-audible-autoplay-not-allowed.html
@@ -1,0 +1,49 @@
+<html>
+    <head>
+        <script src="media-file.js"></script>
+        <script src="video-test.js"></script>
+        <script>
+            if (window.internals)
+                internals.settings.setInvisibleAutoplayNotPermitted(true);
+
+            function start()
+            {
+                findMediaElement();
+                video.volume = 0.1;
+
+                waitForEventAndFail('playing');
+
+                consoleWrite('** loading an audible video with no renderer');
+                video.src = findMediaFile('video', 'content/test');
+                waitForEventOnce('canplaythrough', onCanPlayThrough);
+                consoleWrite('');
+            }
+
+            function onCanPlayThrough()
+            {
+                consoleWrite('** making the video renderer attach far below the viewport');
+                run('document.querySelector(".container").style.display = "block"');
+                setTimeout(verifyStillPaused, 500);
+            }
+
+            function verifyStillPaused()
+            {
+                testExpected('video.paused', true);
+                endTest();
+            }
+        </script>
+        <style>
+        body { margin: 0; }
+        .spacer { height: 400vh; }
+        .container { display: none; }
+        </style>
+    </head>
+
+    <body onload="start()">
+        <div class="spacer"></div>
+        <div class="container">
+            <video controls autoplay></video>
+        </div>
+        <p>Test that an audible &lt;video autoplay&gt; element whose renderer attaches outside the viewport does not begin playing.</p>
+    </body>
+</html>

--- a/LayoutTests/media/video-invisible-audible-playback-continues-expected.txt
+++ b/LayoutTests/media/video-invisible-audible-playback-continues-expected.txt
@@ -1,0 +1,12 @@
+
+Test that an audible <video> that is already playing continues to play after it is moved outside the viewport.
+
+** setting video.src on a visible audible video
+
+EVENT(playing)
+EXPECTED (video.paused == 'false') OK
+** moving the video outside the viewport
+RUN(video.style.top = "-9999px")
+EXPECTED (video.paused == 'false') OK
+END OF TEST
+

--- a/LayoutTests/media/video-invisible-audible-playback-continues.html
+++ b/LayoutTests/media/video-invisible-audible-playback-continues.html
@@ -1,0 +1,46 @@
+<html>
+    <head>
+        <script src="media-file.js"></script>
+        <script src="video-test.js"></script>
+        <script>
+            if (window.internals)
+                internals.settings.setInvisibleAutoplayNotPermitted(true);
+
+            function start()
+            {
+                findMediaElement();
+                video.volume = 0.1;
+
+                consoleWrite('** setting video.src on a visible audible video');
+                video.src = findMediaFile('video', 'content/test');
+                waitForEventOnce('playing', onPlaying);
+                consoleWrite('');
+            }
+
+            function onPlaying()
+            {
+                testExpected('video.paused', false);
+
+                waitForEventAndFail('pause');
+
+                consoleWrite('** moving the video outside the viewport');
+                run('video.style.top = "-9999px"');
+                setTimeout(checkStillPlaying, 100);
+            }
+
+            function checkStillPlaying()
+            {
+                testExpected('video.paused', false);
+                endTest();
+            }
+        </script>
+        <style>
+        video { position: absolute; top: 0; left: 0; }
+        </style>
+    </head>
+
+    <body onload="start()">
+        <video controls autoplay></video>
+        <p>Test that an audible &lt;video&gt; that is already playing continues to play after it is moved outside the viewport.</p>
+    </body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2325,8 +2325,6 @@ webkit.org/b/315337 [ Sequoia x86_64 ] imported/w3c/web-platform-tests/css/css-v
 webkit.org/b/315337 [ Sequoia x86_64 ] imported/w3c/web-platform-tests/css/css-view-transitions/old-content-root-scrollbar-with-fixed-background.html [ ImageOnlyFailure ]
 webkit.org/b/315337 [ Sequoia x86_64 ] imported/w3c/web-platform-tests/css/filter-effects/root-element-with-opacity-filter-001.html [ ImageOnlyFailure ]
 
-webkit.org/b/315354 media/video-concurrent-visible-playback.html [ Pass Failure ]
-
 webkit.org/b/315398 [ Release ] http/tests/site-isolation/accessibility/client/simple-iframe.html [ Timeout ]
 
 # webkit.org/b/315593 [macOS Release] imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html  is a flaky crash

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -312,6 +312,7 @@ public:
     WEBCORE_EXPORT bool ended() const;
     bool NODELETE autoplay() const;
     bool isAutoplaying() const { return m_autoplaying; }
+    bool wasInterruptedForInvisibleAutoplay() const { return m_wasInterruptedForInvisibleAutoplay; }
     bool NODELETE loop() const;
     void setLoop(bool b);
 

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -504,6 +504,24 @@ Expected<void, MediaPlaybackDenialExplanation> MediaElementSession::playbackStat
     return { };
 }
 
+static bool autoplayPermittedWhileInvisible(const HTMLMediaElement& element)
+{
+    // If the media element is already playing audibly, allow it to continue even when not visible as
+    // pausing it would be observable by the user. Also allow elements that were previously playing
+    // audibly and got interrupted by becoming invisible to resume (e.g. after unmuting), since the
+    // interruption is what made them paused. However, elements that have not yet started playing
+    // should not autoplay while invisible.
+    if (element.paused() && !element.wasInterruptedForInvisibleAutoplay())
+        return false;
+    if (element.isVideo() && !element.hasAudio())
+        return false;
+    if (element.muted())
+        return false;
+    if (!element.volume())
+        return false;
+    return true;
+}
+
 bool MediaElementSession::autoplayPermitted() const
 {
     RefPtr element = m_element.get();
@@ -519,8 +537,7 @@ bool MediaElementSession::autoplayPermitted() const
     if (!hasBehaviorRestriction(MediaElementSession::InvisibleAutoplayNotPermitted))
         return true;
 
-    // If the media element is audible, allow autoplay even when not visible as pausing it would be observable by the user.
-    if ((!element->isVideo() || element->hasAudio()) && !element->muted() && element->volume())
+    if (autoplayPermittedWhileInvisible(*element))
         return true;
 
     CheckedPtr renderer = element->renderer();


### PR DESCRIPTION
#### 19e19acf45b561b9492ed324aa0b55729dda5cba
<pre>
REGRESSION(311380@main): [macOS wk2 ] media/video-concurrent-visible-playback.html is a flaky TEXT failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=315354">https://bugs.webkit.org/show_bug.cgi?id=315354</a>
<a href="https://rdar.apple.com/177711185">rdar://177711185</a>

Reviewed by Eric Carlson and Jer Noble.

MediaElementSession::autoplayPermitted() allowed an audible-but-invisible video to autoplay even
when the InvisibleAutoplayNotPermitted restriction is set, on the grounds that pausing audible
playback would be observable to the user. This bypass was applied unconditionally, including for
elements that had not yet started playing. After 311380@main added an IntersectionObserver-driven
path (LazyLoadVideoObserver) that called updateShouldAutoplay() more eagerly, this caused
audible-but-paused &lt;video autoplay&gt; elements to begin playing while invisible if
autoplayPermitted() happened to be evaluated after metadata had loaded (so that hasAudio() returned
true) but before any earlier evaluation had set up the InvisibleAutoplay interruption.

While 311380@main made this test noticeably flakier, the underlying problem where invisible,
audible elements were allowed to begin playing predates that change (that bug was introduced in
r215120).

Resolved this by gating the audio bypass on !element-&gt;paused() so that it only preserves playback
for videos that are already playing audibly. Paused elements fall through to the existing
renderer-visibility checks and are correctly blocked from autoplaying while invisible.

Un-skipped media/video-concurrent-visible-playback.html, and added two layout tests to verify that:
- invisible, audible videos do not start autoplaying
- audible videos continue playing once no longer visible

* LayoutTests/media/video-invisible-audible-autoplay-not-allowed-expected.txt: Added.
* LayoutTests/media/video-invisible-audible-autoplay-not-allowed.html: Added.
* LayoutTests/media/video-invisible-audible-playback-continues-expected.txt: Added.
* LayoutTests/media/video-invisible-audible-playback-continues.html: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::wasInterruptedForInvisibleAutoplay const):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::autoplayPermittedWhileInvisible):
(WebCore::MediaElementSession::autoplayPermitted const):

Canonical link: <a href="https://commits.webkit.org/314638@main">https://commits.webkit.org/314638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b87d6d1e36fa0aab9f0538d4bd16b4debc233acf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175631 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123839 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129514 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110039 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30885 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29581 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23772 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140856 "Found 1 new API test failure: TestWebKitAPI.HSTS.Preconnect (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178165 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31065 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137874 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137791 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37150 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149175 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103566 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33083 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26040 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39341 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112416 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38738 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4130 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38983 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38881 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->