### PR TITLE
Fix the build after 314338@main and 314377@main

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -7668,46 +7668,7 @@ void WebViewImpl::didUpdateTransientZoomStateForScrollPocket(std::optional<Trans
     }
 
     m_transientZoomStateForScrollPocket = state;
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     updateWebContentDistancesFromEdges();
-#endif
-}
-
-#endif
-
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-
-void WebViewImpl::setClientImplicitlyRequestedTopScrollPocket()
-{
-    if (m_clientImplicitlyRequestedTopScrollPocket)
-        return;
-
-    m_clientImplicitlyRequestedTopScrollPocket = true;
-    updateScrollPocket();
-}
-
-void WebViewImpl::updatePrefersSolidColorHardPocket()
-{
-    static bool canSetPrefersSolidColorHardPocket = [NSScrollPocket instancesRespondToSelector:@selector(setPrefersSolidColorHardPocket:)];
-    if (!canSetPrefersSolidColorHardPocket)
-        return;
-
-    RetainPtr view = m_view.get();
-    if (!view)
-        return;
-
-    [m_topScrollPocket setPrefersSolidColorHardPocket:^{
-        if ([view _hasVisibleColorExtensionView:BoxSide::Top])
-            return YES;
-
-        if (pageIsScrolledToTop())
-            return YES;
-
-        if (view->_preferSolidColorHardPocketReasons)
-            return YES;
-
-        return NO;
-    }()];
 }
 
 void WebViewImpl::updateWebContentDistancesFromEdges()
@@ -7746,8 +7707,47 @@ void WebViewImpl::updateWebContentDistancesFromEdges()
 
     m_webContentDistanceFromLeftEdge = leftDistance;
     m_webContentDistanceFromRightEdge = rightDistance;
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     updateScrollPocket();
     [view _updateFixedColorExtensionViewFrames];
+#endif
+}
+
+#endif
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
+void WebViewImpl::setClientImplicitlyRequestedTopScrollPocket()
+{
+    if (m_clientImplicitlyRequestedTopScrollPocket)
+        return;
+
+    m_clientImplicitlyRequestedTopScrollPocket = true;
+    updateScrollPocket();
+}
+
+void WebViewImpl::updatePrefersSolidColorHardPocket()
+{
+    static bool canSetPrefersSolidColorHardPocket = [NSScrollPocket instancesRespondToSelector:@selector(setPrefersSolidColorHardPocket:)];
+    if (!canSetPrefersSolidColorHardPocket)
+        return;
+
+    RetainPtr view = m_view.get();
+    if (!view)
+        return;
+
+    [m_topScrollPocket setPrefersSolidColorHardPocket:^{
+        if ([view _hasVisibleColorExtensionView:BoxSide::Top])
+            return YES;
+
+        if (pageIsScrolledToTop())
+            return YES;
+
+        if (view->_preferSolidColorHardPocketReasons)
+            return YES;
+
+        return NO;
+    }()];
 }
 
 void WebViewImpl::updateScrollPocket()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ObscuredContentInsets.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ObscuredContentInsets.mm
@@ -556,7 +556,7 @@ struct PageState {
     double minScrollXCSS;
     double scrollWidthCSS;
     double scale;
-    bool isRTL;
+    BOOL isRTL;
 };
 
 static PageState capturePageState(TestWKWebView *webView)


### PR DESCRIPTION
#### 5f208e139068bd2ad09a6ed957eaa18ecffd442f
<pre>
Fix the build after 314338@main and 314377@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=316141">https://bugs.webkit.org/show_bug.cgi?id=316141</a>
<a href="https://rdar.apple.com/178536494">rdar://178536494</a>

Unreviewed build fix.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::didUpdateTransientZoomStateForScrollPocket):
(WebKit::WebViewImpl::updateWebContentDistancesFromEdges):

`updateWebContentDistancesFromEdges` is only declared `ENABLE(HORIZONTAL_BANNER_VIEW_OVERLAYS)`.

(WebKit::WebViewImpl::setClientImplicitlyRequestedTopScrollPocket):
(WebKit::WebViewImpl::updatePrefersSolidColorHardPocket):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ObscuredContentInsets.mm:

Use `BOOL` to align with the use of `boolValue`.

Canonical link: <a href="https://commits.webkit.org/314409@main">https://commits.webkit.org/314409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24429aef8c01b65712ad283fe43d417da86b4011

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166052 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/39542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/33123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175099 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167918 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39968 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129054 "Build is in progress. Recent messages:") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169011 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39968 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/109580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39968 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23240 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39968 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/26887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177632 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26945 "Build is in progress. Recent messages:") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/28593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/137398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39611 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/39546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/137325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/40299 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/148682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25274 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/40299 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38810 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/111884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/38207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/3635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/38452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/38350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->