### PR TITLE
Web Inspector: [SI] implement resolveNode / requestNode / setInspectedNode on FrameDOMAgent

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/js-bridge-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/js-bridge-frame-target-expected.txt
@@ -1,0 +1,37 @@
+Tests FrameDOMAgent's JS bridge: resolveNode (DOM node -> RemoteObject), requestNode (RemoteObject -> DOM node), and setInspectedNode (binds the frame's $0 command-line variable).
+
+
+
+== Running test suite: SiteIsolation.DOM.FrameDOMAgent.JSBridge
+-- Running test case: Setup
+PASS: Should find a cross-origin frame target.
+PASS: Frame target should have an execution context.
+PASS: Should find #container.
+PASS: Should find #heading.
+
+-- Running test case: ResolveNode.Backend
+PASS: Should return a RemoteObject payload.
+PASS: RemoteObject type should be 'object'.
+PASS: RemoteObject subtype should be 'node'.
+PASS: RemoteObject should have an objectId scoped to the frame target.
+
+-- Running test case: ResolveNode.Frontend
+PASS: Should resolve.
+PASS: Resolved RemoteObject should report as a node.
+
+-- Running test case: ResolveNode.InvalidNodeId
+PASS: Should produce an exception.
+Error: Missing node for given nodeId
+
+-- Running test case: RequestNode.Backend
+PASS: requestNode should return the same nodeId we resolved.
+
+-- Running test case: SetInspectedNode.Dollar0InFrameContext
+PASS: $0 should evaluate without error.
+PASS: $0 should resolve as a node.
+PASS: $0 in the frame's context should be the inspected heading node.
+
+-- Running test case: SetInspectedNode.InvalidNodeId
+PASS: Should produce an exception.
+Error: Missing node for given nodeId
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/js-bridge-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/js-bridge-frame-target.html
@@ -1,0 +1,136 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameDOMAgent.JSBridge");
+
+    let frameTarget = null;
+    let frameDoc = null;
+    let containerNode = null;
+    let headingNode = null;
+
+    function bid(node) { return node.backendNodeId; }
+
+    async function findChildElement(parent, predicate) {
+        await new Promise((resolve) => parent.getChildNodes(resolve));
+        return parent.children.find(predicate);
+    }
+
+    async function evaluateInFrame(expression) {
+        let response = await frameTarget.RuntimeAgent.evaluate.invoke({
+            expression,
+            objectGroup: "test",
+            includeCommandLineAPI: true,
+            contextId: frameTarget.executionContext.id,
+        });
+        return response;
+    }
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Find the cross-origin frame target and walk to #container / #heading.",
+        async test() {
+            let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+            let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+            let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+            frameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+            InspectorTest.expectNotNull(frameTarget, "Should find a cross-origin frame target.");
+
+            if (frameTarget.isProvisional) {
+                let committedEvent = await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+                frameTarget = committedEvent.data.target;
+            }
+            await frameTarget.ensureTargetExecutionContext();
+            InspectorTest.expectNotNull(frameTarget.executionContext, "Frame target should have an execution context.");
+
+            frameDoc = WI.domManager.frameTargetDocumentForTarget(frameTarget);
+            if (!frameDoc) {
+                let docEvent = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+                frameDoc = docEvent.data.document;
+            }
+            let htmlNode = await findChildElement(frameDoc, (n) => n.nodeName() === "HTML");
+            let bodyNode = await findChildElement(htmlNode, (n) => n.nodeName() === "BODY");
+            containerNode = await findChildElement(bodyNode, (n) => n.getAttribute && n.getAttribute("id") === "container");
+            InspectorTest.expectNotNull(containerNode, "Should find #container.");
+            await new Promise((resolve) => containerNode.getChildNodes(resolve));
+
+            let headingId = await containerNode.querySelector("#heading");
+            headingNode = WI.domManager.nodeForIdInFrameTarget(headingId, frameTarget);
+            InspectorTest.expectNotNull(headingNode, "Should find #heading.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "ResolveNode.Backend",
+        description: "frameTarget.DOMAgent.resolveNode should return a RemoteObject for a frame-target node.",
+        async test() {
+            let {object} = await frameTarget.DOMAgent.resolveNode(bid(headingNode), "test");
+            InspectorTest.expectNotNull(object, "Should return a RemoteObject payload.");
+            InspectorTest.expectEqual(object.type, "object", "RemoteObject type should be 'object'.");
+            InspectorTest.expectEqual(object.subtype, "node", "RemoteObject subtype should be 'node'.");
+            InspectorTest.expectNotNull(object.objectId, "RemoteObject should have an objectId scoped to the frame target.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "ResolveNode.Frontend",
+        description: "WI.RemoteObject.resolveNode should route through the frame's DOMAgent and resolve.",
+        async test() {
+            let remoteObject = await WI.RemoteObject.resolveNode(headingNode, "test");
+            InspectorTest.expectNotNull(remoteObject, "Should resolve.");
+            InspectorTest.expectThat(remoteObject.isNode(), "Resolved RemoteObject should report as a node.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "ResolveNode.InvalidNodeId",
+        description: "resolveNode with an unknown nodeId should reject.",
+        async test() {
+            await InspectorTest.expectException(() => frameTarget.DOMAgent.resolveNode(9999999, "test"));
+        }
+    });
+
+    suite.addTestCase({
+        name: "RequestNode.Backend",
+        description: "frameTarget.DOMAgent.requestNode given a frame-target objectId should return the matching nodeId.",
+        async test() {
+            // First resolve to get a real objectId scoped to the frame.
+            let {object} = await frameTarget.DOMAgent.resolveNode(bid(headingNode), "test");
+            let {nodeId} = await frameTarget.DOMAgent.requestNode(object.objectId);
+            InspectorTest.expectEqual(nodeId, bid(headingNode), "requestNode should return the same nodeId we resolved.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SetInspectedNode.Dollar0InFrameContext",
+        description: "After setInspectedNode on a frame node, $0 in the frame's runtime context should equal that node.",
+        async test() {
+            await frameTarget.DOMAgent.setInspectedNode(bid(headingNode));
+
+            let response = await evaluateInFrame("$0");
+            InspectorTest.expectNotNull(response.result, "$0 should evaluate without error.");
+            InspectorTest.expectEqual(response.result.subtype, "node", "$0 should resolve as a node.");
+
+            // Use requestNode to verify the objectId maps back to our heading.
+            let {nodeId} = await frameTarget.DOMAgent.requestNode(response.result.objectId);
+            InspectorTest.expectEqual(nodeId, bid(headingNode), "$0 in the frame's context should be the inspected heading node.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SetInspectedNode.InvalidNodeId",
+        description: "setInspectedNode with an unknown nodeId should reject.",
+        async test() {
+            await InspectorTest.expectException(() => frameTarget.DOMAgent.setInspectedNode(9999999));
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests FrameDOMAgent's JS bridge: resolveNode (DOM node -> RemoteObject), requestNode (RemoteObject -> DOM node), and setInspectedNode (binds the frame's $0 command-line variable).</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/dom-frame.html"></iframe>
+</body>

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -553,7 +553,7 @@
         {
             "name": "requestNode",
             "description": "Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of <code>setChildNodes</code> notifications.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "JavaScript object id to convert into node." }
             ],
@@ -746,7 +746,7 @@
         {
             "name": "resolveNode",
             "description": "Resolves JavaScript node object for given node id.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to resolve." },
                 { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
@@ -804,7 +804,7 @@
         {
             "name": "setInspectedNode",
             "description": "Enables console to refer to the node with given id via $0 (see Command Line API for more details).",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "DOM node id to be accessible by means of $0 command line API." }
             ]

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
@@ -28,6 +28,7 @@
 
 #include "Attr.h"
 #include "CharacterData.h"
+#include "CommandLineAPIHost.h"
 #include "ContainerNode.h"
 #include "DOMEditor.h"
 #include "DOMPatchSupport.h"
@@ -51,7 +52,10 @@
 #include "InspectorHistory.h"
 #include "InspectorNodeFinder.h"
 #include "InstrumentingAgents.h"
+#include "JSDOMBindingSecurity.h"
+#include "JSDOMWindowCustom.h"
 #include "JSEventListener.h"
+#include "JSNode.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
@@ -62,8 +66,11 @@
 #include "ShadowRoot.h"
 #include "Text.h"
 #include "TextNodeTraversal.h"
+#include "WebInjectedScriptManager.h"
 #include "markup.h"
 #include <JavaScriptCore/IdentifiersFactory.h>
+#include <JavaScriptCore/InjectedScript.h>
+#include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -151,6 +158,7 @@ FrameDOMAgent::FrameDOMAgent(FrameAgentContext& context)
     , m_backendDispatcher(Inspector::DOMBackendDispatcher::create(Ref { context.backendDispatcher }, this))
     , m_instrumentingAgents(context.instrumentingAgents)
     , m_inspectedFrame(context.inspectedFrame)
+    , m_injectedScriptManager(context.injectedScriptManager)
     , m_destroyedNodesTimer(*this, &FrameDOMAgent::destroyedNodesTimerFired)
 {
 }
@@ -173,6 +181,8 @@ void FrameDOMAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
 {
     m_domEditor.reset();
     m_history.reset();
+
+    m_inspectedNode = nullptr;
 
     Ref { m_instrumentingAgents.get() }->setPersistentFrameDOMAgent(nullptr);
     m_documentRequested = false;
@@ -510,6 +520,12 @@ void FrameDOMAgent::setDocument(Document* document)
 {
     if (document == m_document.get())
         return;
+
+    // Mirror InspectorDOMAgent::didCommitLoad: drop the inspected node if it
+    // belonged to the document being navigated away from, so $0 and the
+    // Properties sidebar don't point at a stale node across a frame load.
+    if (m_inspectedNode && &m_inspectedNode->document() == m_document.get())
+        m_inspectedNode = nullptr;
 
     reset();
     m_document = document;
@@ -1443,6 +1459,105 @@ Inspector::CommandResult<void> FrameDOMAgent::redo()
 Inspector::CommandResult<void> FrameDOMAgent::markUndoableState()
 {
     m_history->markUndoableState();
+
+    return { };
+}
+
+// MARK: - JS Bridge
+
+namespace {
+
+class InspectableFrameNode final : public CommandLineAPIHost::InspectableObject {
+public:
+    explicit InspectableFrameNode(Node* node)
+        : m_node(node)
+    {
+    }
+
+    JSC::JSValue get(JSC::JSGlobalObject& state) final
+    {
+        return InspectorDOMAgent::nodeAsScriptValue(state, m_node.get());
+    }
+
+private:
+    RefPtr<Node> m_node;
+};
+
+} // namespace
+
+RefPtr<Inspector::Protocol::Runtime::RemoteObject> FrameDOMAgent::resolveNodeInternal(Node* node, const String& objectGroup)
+{
+    if (!node)
+        return nullptr;
+
+    RefPtr document = &node->document();
+    if (RefPtr templateHost = document->templateDocumentHost())
+        document = WTF::move(templateHost);
+    RefPtr frame = document->frame();
+    if (!frame)
+        return nullptr;
+
+    auto& globalObject = mainWorldGlobalObject(*frame);
+    auto injectedScript = m_injectedScriptManager->injectedScriptFor(&globalObject);
+    if (injectedScript.hasNoValue())
+        return nullptr;
+
+    return injectedScript.wrapObject(InspectorDOMAgent::nodeAsScriptValue(globalObject, node), objectGroup);
+}
+
+RefPtr<Node> FrameDOMAgent::nodeForObjectId(const Inspector::Protocol::Runtime::RemoteObjectId& objectId)
+{
+    auto injectedScript = m_injectedScriptManager->injectedScriptForObjectId(objectId);
+    if (injectedScript.hasNoValue())
+        return nullptr;
+
+    return InspectorDOMAgent::scriptValueAsNode(injectedScript.findObjectById(objectId));
+}
+
+Inspector::CommandResult<Ref<Inspector::Protocol::Runtime::RemoteObject>> FrameDOMAgent::resolveNode(int nodeId, const String& objectGroup)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    auto object = resolveNodeInternal(node.get(), objectGroup);
+    if (!object)
+        return makeUnexpected("Missing injected script for given nodeId"_s);
+
+    return object.releaseNonNull();
+}
+
+Inspector::CommandResult<int> FrameDOMAgent::requestNode(const String& objectId)
+{
+    RefPtr node = nodeForObjectId(objectId);
+    if (!node)
+        return makeUnexpected("Missing node for given objectId"_s);
+
+    Inspector::Protocol::ErrorString errorString;
+    auto nodeId = pushNodePathToFrontend(errorString, node.get());
+    if (!nodeId)
+        return makeUnexpected(errorString);
+
+    return nodeId;
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setInspectedNode(int nodeId)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    if (node->isInUserAgentShadowTree() && !m_allowEditingUserAgentShadowTrees)
+        return makeUnexpected("Node for given nodeId is in a shadow tree"_s);
+
+    m_inspectedNode = node;
+
+    if (RefPtr commandLineAPIHost = downcast<WebInjectedScriptManager>(m_injectedScriptManager.get()).commandLineAPIHost())
+        commandLineAPIHost->addInspectedObject(makeUnique<InspectableFrameNode>(node.get()));
 
     return { };
 }

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
@@ -163,6 +163,9 @@ private:
     RefPtr<Node> assertEditableNode(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);
     RefPtr<Element> assertEditableElement(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);
 
+    RefPtr<Node> nodeForObjectId(const Inspector::Protocol::Runtime::RemoteObjectId&);
+    RefPtr<Inspector::Protocol::Runtime::RemoteObject> resolveNodeInternal(Node*, const String& objectGroup);
+
     Ref<Inspector::Protocol::DOM::Node> buildObjectForNode(Node*, int depth);
     Ref<JSON::ArrayOf<String>> buildArrayForElementAttributes(Element*);
     Ref<JSON::ArrayOf<Inspector::Protocol::DOM::Node>> buildArrayForContainerChildren(Node* container, int depth);
@@ -215,12 +218,14 @@ private:
     const Ref<Inspector::DOMBackendDispatcher> m_backendDispatcher;
     WeakRef<InstrumentingAgents> m_instrumentingAgents;
     WeakRef<LocalFrame> m_inspectedFrame;
+    const CheckedRef<Inspector::InjectedScriptManager> m_injectedScriptManager;
 
     WeakHashMap<Node, Inspector::Protocol::DOM::NodeId, WeakPtrImplWithEventTargetData> m_nodeToId;
     HashMap<Inspector::Protocol::DOM::NodeId, WeakPtr<Node, WeakPtrImplWithEventTargetData>> m_idToNode;
     HashSet<Inspector::Protocol::DOM::NodeId> m_childrenRequested;
     Inspector::Protocol::DOM::NodeId m_lastNodeId { 1 };
     RefPtr<Document> m_document;
+    RefPtr<Node> m_inspectedNode;
 
     Vector<Inspector::Protocol::DOM::NodeId> m_destroyedDetachedNodeIdentifiers;
     Vector<std::pair<Inspector::Protocol::DOM::NodeId, Inspector::Protocol::DOM::NodeId>> m_destroyedAttachedNodeIdentifiers;

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
@@ -57,11 +57,6 @@ Inspector::CommandResult<Ref<Inspector::Protocol::DOM::AccessibilityProperties>>
     return makeUnexpected("Not yet implemented for frame targets"_s);
 }
 
-Inspector::CommandResult<int> FrameDOMAgent::requestNode(const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
 #if PLATFORM(IOS_FAMILY)
 Inspector::CommandResult<void> FrameDOMAgent::setInspectModeEnabled(bool, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&)
 {
@@ -146,17 +141,7 @@ Inspector::CommandResult<void> FrameDOMAgent::hideFlexOverlay(std::optional<int>
     return makeUnexpected("Not supported for frame targets"_s);
 }
 
-Inspector::CommandResult<Ref<Inspector::Protocol::Runtime::RemoteObject>> FrameDOMAgent::resolveNode(int, const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
 Inspector::CommandResult<void> FrameDOMAgent::focus(int)
-{
-    return makeUnexpected("Not supported for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::setInspectedNode(int)
 {
     return makeUnexpected("Not supported for frame targets"_s);
 }

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -576,11 +576,30 @@ WI.DOMManager = class DOMManager extends WI.Object
         this.requestDocument(function(){});
     }
 
-    pushNodeToFrontend(objectId, callback)
+    pushNodeToFrontend(objectId, callback, target)
     {
-        let target = WI.assumingMainTarget();
-        this._dispatchWhenDocumentAvailable((callbackWrapper) => {
-            target.DOMAgent.requestNode(objectId, callbackWrapper);
+        target ||= WI.assumingMainTarget();
+
+        let callbackWrapper = DOMManager.wrapClientCallback(callback);
+        let dispatch = () => target.DOMAgent.requestNode(objectId, callbackWrapper);
+
+        if (target.type === WI.TargetType.Frame) {
+            if (this._frameTargetDOMData.get(target)?.document) {
+                dispatch();
+                return;
+            }
+            let handler = (event) => {
+                if (event.data.target !== target)
+                    return;
+                this.removeEventListener(WI.DOMManager.Event.FrameDocumentAvailable, handler);
+                dispatch();
+            };
+            this.addEventListener(WI.DOMManager.Event.FrameDocumentAvailable, handler);
+            return;
+        }
+
+        this._dispatchWhenDocumentAvailable((wrapper) => {
+            target.DOMAgent.requestNode(objectId, wrapper);
         }, callback);
     }
 
@@ -1112,17 +1131,8 @@ WI.DOMManager = class DOMManager extends WI.Object
             this.dispatchEventToListeners(WI.DOMManager.Event.InspectedNodeChanged, {lastInspectedNode});
         };
 
-        // FIXME: <https://webkit.org/b/298980> `DOM.setInspectedNode` for cross-origin frame nodes is not yet supported;
-        // `node.id` for frame-owned nodes is a composite "frameId:nodeId" string, not a numeric backend node id.
-        if (node.owningTarget) {
-            let lastInspectedNode = this._inspectedNode;
-            this._inspectedNode = node;
-            this.dispatchEventToListeners(WI.DOMManager.Event.InspectedNodeChanged, {lastInspectedNode});
-            return;
-        }
-
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.setInspectedNode(node.id, callback);
+        let target = node.owningTarget || WI.assumingMainTarget();
+        target.DOMAgent.setInspectedNode(node.backendNodeId, callback);
     }
 
     getSupportedEventNames(callback)

--- a/Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js
@@ -133,9 +133,9 @@ WI.RemoteObject = class RemoteObject
         if (node.destroyed)
             return Promise.reject("ERROR: node is destroyed");
 
-        let target = WI.assumingMainTarget();
-        return target.DOMAgent.resolveNode(node.id, objectGroup)
-            .then(({object}) => WI.RemoteObject.fromPayload(object, WI.mainTarget));
+        let target = node.owningTarget || WI.assumingMainTarget();
+        return target.DOMAgent.resolveNode(node.backendNodeId, objectGroup)
+            .then(({object}) => WI.RemoteObject.fromPayload(object, target));
     }
 
     static resolveWebSocket(webSocketResource, objectGroup, callback)
@@ -409,7 +409,7 @@ WI.RemoteObject = class RemoteObject
     pushNodeToFrontend(callback)
     {
         if (this._objectId && InspectorBackend.hasCommand("DOM.requestNode"))
-            WI.domManager.pushNodeToFrontend(this._objectId, callback);
+            WI.domManager.pushNodeToFrontend(this._objectId, callback, this._target);
         else
             callback(0);
     }


### PR DESCRIPTION
#### d845346ddb6c21f345369b0095da6e519b3c6e8b
<pre>
Web Inspector: [SI] implement resolveNode / requestNode / setInspectedNode on FrameDOMAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=316137">https://bugs.webkit.org/show_bug.cgi?id=316137</a>
<a href="https://rdar.apple.com/178562399">rdar://178562399</a>

Reviewed by Qianlang Chen.

Port the JS bridge commands onto FrameDOMAgent. resolveNode wraps a
frame node in a RemoteObject via the frame&apos;s WebInjectedScriptManager
and main-world global. requestNode walks an objectId back to a Node
through the same manager. setInspectedNode registers the node with
the frame&apos;s CommandLineAPIHost so $0 resolves to it inside that
frame&apos;s console context.

On the frontend, WI.RemoteObject.resolveNode and
WI.DOMManager.setInspectedNode route through `owningTarget ||
WI.assumingMainTarget()` with `backendNodeId`. pushNodeToFrontend
takes an optional target threaded from the originating RemoteObject
so the requestNode lookup hits the agent that owns the objectId.

Selecting a cross-origin iframe node in Elements no longer logs
&quot;Cannot resolve node&quot; errors, the Properties sidebar populates, and
$0 in the iframe&apos;s console context resolves to the inspected node.

Test: http/tests/site-isolation/inspector/dom/js-bridge-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/dom/js-bridge-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/js-bridge-frame-target.html: Added.
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp:
(WebCore::FrameDOMAgent::willDestroyFrontendAndBackend):
(WebCore::FrameDOMAgent::setDocument):
(WebCore::FrameDOMAgent::resolveNodeInternal):
(WebCore::FrameDOMAgent::nodeForObjectId):
(WebCore::FrameDOMAgent::resolveNode):
(WebCore::FrameDOMAgent::requestNode):
(WebCore::FrameDOMAgent::setInspectedNode):
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.h:
* Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp:
(WebCore::FrameDOMAgent::requestNode): Deleted.
(WebCore::FrameDOMAgent::resolveNode): Deleted.
(WebCore::FrameDOMAgent::setInspectedNode): Deleted.
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.prototype.pushNodeToFrontend):
(WI.DOMManager.prototype.setInspectedNode):
* Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js:
(WI.RemoteObject.resolveNode):
(WI.RemoteObject.prototype.pushNodeToFrontend):

Canonical link: <a href="https://commits.webkit.org/316367@main">https://commits.webkit.org/316367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94731f13ffb30dabb21633e624ae1b06d0f81650

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127586 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e71c827-bd7d-4afc-9c4c-1a9c74ea8ac4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132394 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61d4247f-c663-47ac-8082-888c7dfa477d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172833 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37218 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-in-report-only-ignored.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112896 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b478131-2a7a-4d5f-b2df-ae07823ef093) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34243 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32534 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27931 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1295 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145161 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181832 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31129 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36700 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140845 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140676 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44141 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108436 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26117 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35943 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115906 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202553 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42652 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7358 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Uploaded test results") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54288 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42044 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42299 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42187 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->