### PR TITLE
font-style: italic does not slant a variable font whose @font-face uses an oblique angle (no 'ital' axis)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4832,7 +4832,6 @@ webkit.org/b/206882 imported/w3c/web-platform-tests/css/css-fonts/variations/at-
 webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/font-language-override-01.html [ ImageOnlyFailure ]
 webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/test-synthetic-italic-2.html [ ImageOnlyFailure ]
 webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/test-synthetic-italic-3.html [ ImageOnlyFailure ]
-webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/variations/font-slant-1.html [ ImageOnlyFailure ]
 webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/hiragana-katakana-kerning.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-face-local-not-family.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-family-name-000.xht [ ImageOnlyFailure ]

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1319,9 +1319,6 @@ imported/blink/fast/pagination/viewport-y-horizontal-tb-rtl.html [ ImageOnlyFail
 
 webkit.org/b/213114 fast/flexbox/line-clamp-with-anchor-content-only.html [ ImageOnlyFailure ]
 
-webkit.org/b/189483 imported/w3c/web-platform-tests/css/css-fonts/variations/slnt-variable.html [ ImageOnlyFailure ]
-webkit.org/b/189483 imported/w3c/web-platform-tests/css/css-fonts/variations/slnt-backslant-variable.html [ ImageOnlyFailure ]
-
 # fast/gradients are Skip in the top level Expectation. When fixing, change this to
 # Pass instead of removing this line.
 webkit.org/b/234606 fast/gradients/conic-gradient-alpha.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1148,10 +1148,6 @@ fast/text/system-font-japanese-synthetic-italic.html [ Pass ImageOnlyFailure ]
 # we should delete the test.
 fast/text/font-variations-feature-detection.html [ ImageOnlyFailure ]
 
-# These tests fail which are related to browser support of slnt and ital axes in variable fonts and failing due to underlying bug
-webkit.org/b/189483 imported/w3c/web-platform-tests/css/css-fonts/variations/slnt-variable.html [ ImageOnlyFailure ]
-webkit.org/b/189483 imported/w3c/web-platform-tests/css/css-fonts/variations/slnt-backslant-variable.html [ ImageOnlyFailure ]
-
 # webkit.org/b/315568 Image-only failures from css-fonts WPT resync
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-palette-values-relative-colors.html [ ImageOnlyFailure ]
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-synthesis-weight-webfont-bold.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -201,4 +201,20 @@ void FontDescription::setVariantLigatures(FontVariantLigaturesValues values)
     setVariantContextualAlternates(values.contextual);
 }
 
+// Resolves which axis a font's slope is applied to when realizing variations. The slnt variation
+// implements oblique values and ital=1 implements italic values. WebKit treats italic as a synonym
+// for oblique, which css-fonts-4 permits ("User agents may treat italic as a synonym for oblique"),
+// so when italic is requested against a face that exposes its slope on the 'slnt' axis (an
+// oblique-angle @font-face, no 'ital' axis) and no synthetic oblique applies, drive the 'slnt' axis
+// rather than the absent 'ital' axis.
+FontStyleAxis variationStyleAxis(const FontDescription& description, const FontSelectionSpecifiedCapabilities& faceCapabilities)
+{
+    auto axis = description.fontStyleAxis();
+    if (axis != FontStyleAxis::ital || faceCapabilities.faceAxis != FontStyleAxis::slnt)
+        return axis;
+    bool willSynthesizeOblique = description.allowsItalicOrObliqueFontSynthesisStyle()
+        && faceCapabilities.slope && !isItalic(faceCapabilities.slope->maximum);
+    return willSynthesizeOblique ? axis : FontStyleAxis::slnt;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -207,4 +207,6 @@ private:
     PREFERRED_TYPE(bool) unsigned m_evaluationTimeZoomEnabled : 1;
 };
 
+FontStyleAxis variationStyleAxis(const FontDescription&, const FontSelectionSpecifiedCapabilities& faceCapabilities);
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
@@ -213,7 +213,7 @@ void UnrealizedCoreTextFont::applyVariations(CFMutableDictionaryRef attributes, 
 
 void UnrealizedCoreTextFont::modifyFromContext(CFMutableDictionaryRef attributes, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, ApplyTraitsVariations applyTraitsVariations, float weight, float width, float slope, CGFloat size, const OpticalSizingType& opticalSizingType)
 {
-    auto fontStyleAxis = fontDescription.fontStyleAxis();
+    auto fontStyleAxis = variationStyleAxis(fontDescription, fontCreationContext.fontFaceCapabilities());
     const auto& variations = fontDescription.variationSettings();
     const auto& features = fontDescription.featureSettings();
     const auto& variantSettings = fontDescription.variantSettings();
@@ -286,7 +286,7 @@ void UnrealizedCoreTextFont::modifyFromContext(const FontDescription& fontDescri
         m_weight = fontSelectionRequest.weight;
         m_width = fontSelectionRequest.width;
         m_slope = fontSelectionRequest.slope.value_or(normalItalicValue());
-        m_fontStyleAxis = fontDescription.fontStyleAxis();
+        m_fontStyleAxis = variationStyleAxis(fontDescription, fontCreationContext.fontFaceCapabilities());
         if (auto weightValue = fontCreationContext.fontFaceCapabilities().weight)
             m_weight = std::max(std::min(m_weight, static_cast<float>(weightValue->maximum)), static_cast<float>(weightValue->minimum));
         if (auto widthValue = fontCreationContext.fontFaceCapabilities().width)

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -70,7 +70,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
             width = std::max(std::min(width, static_cast<float>(widthValue->maximum)), static_cast<float>(widthValue->minimum));
         applyVariation(FontVariationAxisTag::wdth, width);
 
-        if (description.fontStyleAxis() == FontStyleAxis::ital)
+        if (variationStyleAxis(description, fontCreationContext.fontFaceCapabilities()) == FontStyleAxis::ital)
             applyVariation(FontVariationAxisTag::ital, 1);
         else {
             float slope = description.fontStyleSlope().value_or(normalItalicValue());


### PR DESCRIPTION
#### ff490666c01049e0070000425efa9e3478465b1b
<pre>
font-style: italic does not slant a variable font whose @font-face uses an oblique angle (no &apos;ital&apos; axis)
<a href="https://bugs.webkit.org/show_bug.cgi?id=316143">https://bugs.webkit.org/show_bug.cgi?id=316143</a>
<a href="https://rdar.apple.com/178566326">rdar://178566326</a>

Reviewed by Brent Fulgham.

When font-style: italic is requested, the font realization code always drove
the &apos;ital&apos; axis. A variable font whose @font-face declares its style with an
oblique angle exposes its slope on the &apos;slnt&apos; axis and has no &apos;ital&apos; axis, so
the request had no effect and the text rendered upright.

Add variationStyleAxis(), a shared helper that maps an italic request onto the
&apos;slnt&apos; axis when the matched face&apos;s slope is expressed there (faceAxis == slnt)
and no synthetic oblique will be applied. This is permitted because css-fonts-4
allows treating italic as a synonym for oblique (&quot;User agents may treat italic
as a synonym for oblique&quot;) and specifies that the slnt variation implements
oblique values [1]. The synthesis guard mirrors the syntheticItalic computation
in CSSSegmentedFontFace so a synthesized slant is not doubled. Use it from both
the CoreText and Skia variation paths.

[1] <a href="https://www.w3.org/TR/css-fonts-4/#font-style-prop">https://www.w3.org/TR/css-fonts-4/#font-style-prop</a>

* LayoutTests/TestExpectations:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/platform/graphics/FontDescription.cpp:
(WebCore::variationStyleAxis):
* Source/WebCore/platform/graphics/FontDescription.h:
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp:
(WebCore::UnrealizedCoreTextFont::modifyFromContext):
* Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):

Canonical link: <a href="https://commits.webkit.org/314681@main">https://commits.webkit.org/314681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/752b8f23504e1bb065f2c97afcba8a7153470f77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175878 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124088 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a7a4760-5477-4cb0-9dae-25de9a239644) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129726 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1de4589-f979-4361-825c-c4b0d6ccd5b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110252 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78f27b45-d689-4310-a817-7e75b5561b50) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29802 "Passed tests") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178416 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31313 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29306 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138093 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138006 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37170 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149397 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103876 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33284 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26262 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39589 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112663 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38985 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4355 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39230 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39128 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->