### PR TITLE
<input type=date> text color is partially stale after changing the value of a single component

### DIFF
--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-component-set-updates-color-expected.txt
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-component-set-updates-color-expected.txt
@@ -1,0 +1,6 @@
+PASS getComputedStyle(field).color is not "rgb(0, 0, 0)"
+PASS getComputedStyle(field).color is "rgb(0, 0, 0)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-component-set-updates-color.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-component-set-updates-color.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<input id="input" type="date">
+<script>
+jsTestIsAsync = true;
+var field;
+
+internals.allowAutofillForCurrentWorld();
+
+window.addEventListener("webkitbeforefocus", event => {
+    internals.updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks();
+}, true);
+
+addEventListener("load", async () => {
+    // The middle field should be the placeholder color.
+    field = internals.shadowRoot(input).querySelectorAll("[role=spinbutton]")[1];
+    shouldNotBeEqualToString("getComputedStyle(field).color", "rgb(0, 0, 0)");
+
+    await UIHelper.activateElementAndWaitForInputSession(input);
+    await UIHelper.isShowingDateTimePicker();
+    await UIHelper.chooseDateTimePickerValue();
+
+    // The middle field should now be solid black, because the input has a value.
+    field = internals.shadowRoot(input).querySelectorAll("[role=spinbutton]")[1];
+    shouldBeEqualToString("getComputedStyle(field).color", "rgb(0, 0, 0)");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/js-test.js
+++ b/LayoutTests/resources/js-test.js
@@ -533,6 +533,14 @@ function shouldBeEqualToString(a, b)
   shouldBe(a, unevaledString);
 }
 
+function shouldNotBeEqualToString(a, b)
+{
+  if (typeof a !== "string" || typeof b !== "string")
+    debug("WARN: shouldNotBeEqualToString() expects string arguments");
+  var unevaledString = JSON.stringify(b);
+  shouldNotBe(a, unevaledString);
+}
+
 function shouldBeEqualToNumber(a, b)
 {
   if (typeof a !== "string" || typeof b !== "number")

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -202,6 +202,12 @@ void DateTimeFieldElement::updateVisibleValue(EventBehavior eventBehavior)
     if (textNode->wholeText() != newVisibleValue)
         textNode->replaceWholeText(newVisibleValue);
 
+    auto hasValue = this->hasValue();
+    if (m_hadValueAtLastValueUpdate != hasValue) {
+        m_hadValueAtLastValueUpdate = hasValue;
+        invalidateStyle();
+    }
+
     if (eventBehavior == DispatchInputAndChangeEvents && m_fieldOwner)
         m_fieldOwner->fieldValueChanged();
 }

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.h
@@ -113,6 +113,8 @@ private:
     bool isFieldOwnerHorizontal() const;
 
     WeakPtr<DateTimeFieldElementFieldOwner> m_fieldOwner;
+
+    bool m_hadValueAtLastValueUpdate { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -68,6 +68,7 @@
 #include "DOMRectList.h"
 #include "DOMStringList.h"
 #include "DOMURL.h"
+#include "DOMWrapperWorld.h"
 #include "DeprecatedGlobalSettings.h"
 #include "DiagnosticLoggingClient.h"
 #include "DisabledAdaptations.h"
@@ -2704,7 +2705,11 @@ ExceptionOr<String> Internals::autofillFieldName(Element& element)
         return String { formControl->autofillData().fieldName };
 
     return Exception { ExceptionCode::InvalidNodeTypeError };
+}
 
+void Internals::allowAutofillForCurrentWorld(JSC::JSGlobalObject& globalObject)
+{
+    currentWorld(globalObject).setAllowAutofill();
 }
 
 ExceptionOr<void> Internals::invalidateControlTints()

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -444,6 +444,8 @@ public:
 
     ExceptionOr<String> autofillFieldName(Element&);
 
+    void allowAutofillForCurrentWorld(JSC::JSGlobalObject&);
+
     ExceptionOr<void> invalidateControlTints();
 
     RefPtr<Range> rangeFromLocationAndLength(Element& scope, unsigned rangeLocation, unsigned rangeLength);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -673,6 +673,8 @@ enum ContentsFormat {
     DOMString autofillFieldName(Element formControlElement);
     boolean isSpellcheckDisabledExceptTextReplacement(HTMLInputElement inputElement);
 
+    [CallWith=CurrentGlobalObject] undefined allowAutofillForCurrentWorld();
+
     undefined invalidateControlTints();
 
     undefined scrollElementToRect(Element element, long x, long y, long w, long h);


### PR DESCRIPTION
#### cd61a31ca376f746267ba47a0d9b75ac8802ac9a
<pre>
&lt;input type=date&gt; text color is partially stale after changing the value of a single component
<a href="https://bugs.webkit.org/show_bug.cgi?id=316144">https://bugs.webkit.org/show_bug.cgi?id=316144</a>
<a href="https://rdar.apple.com/177266131">rdar://177266131</a>

Reviewed by Lily Spiniolas and Aditya Keerthi.

When updating the value of a single subfield of a date input, we were not invalidating
style of the whole input, resulting in other subfields maintaining the grey placeholder
color, instead of turning black.

Fix by explicitly invalidating style when the placeholder state changes.

Test: fast/forms/date/date-editable-components/date-editable-components-component-set-updates-color.html

* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-component-set-updates-color-expected.txt: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-component-set-updates-color.html: Added.
Add a test that fails before this change (with mismatching text color from stale style) and passes after.
* LayoutTests/resources/js-test.js:
(shouldNotBeEqualToString):
* Source/WebCore/html/shadow/DateTimeFieldElement.cpp:
(WebCore::DateTimeFieldElement::updateVisibleValue):
This is the actual fix; invalidate style when placeholder state changes.

* Source/WebCore/html/shadow/DateTimeFieldElement.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::autofillFieldName):
(WebCore::Internals::allowAutofillForCurrentWorld):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
Add some test infrastructure allowing us to turn on autofill privileges in a given world;
one of the keys to reproducing this is making layout clean in &quot;webkitbeforefocus&quot;,
before the DateTimeFieldElement knows that it has gained a non-placeholder value.

Canonical link: <a href="https://commits.webkit.org/314469@main">https://commits.webkit.org/314469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a8d908f1877e1354542fe749ce5de7a92809d11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123422 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129154 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149297 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109680 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29199 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23355 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177747 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30649 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137503 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137431 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37034 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148791 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103024 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32718 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25658 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111999 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38322 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3744 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38567 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38465 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->