### PR TITLE
Web Inspector: [SI] populate Accessibility sidebar for cross-origin iframe nodes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/accessibility-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/accessibility-frame-target-expected.txt
@@ -1,0 +1,36 @@
+Tests FrameDOMAgent.getAccessibilityPropertiesForNode for nodes inside a cross-origin iframe.
+
+
+
+== Running test suite: SiteIsolation.DOM.FrameDOMAgent.Accessibility
+-- Running test case: Setup
+PASS: Should find a cross-origin frame target.
+PASS: Should find iframe BODY.
+
+-- Running test case: Heading.RoleAndLevel
+PASS: AX object should exist for h1.
+PASS: Role should be 'heading'.
+PASS: headingLevel should be 1.
+
+-- Running test case: Button.RoleAndLabel
+PASS: AX object should exist for button.
+PASS: Role should be 'button'.
+PASS: Label should be the aria-label override.
+
+-- Running test case: Listbox.BusyAndLabel
+PASS: AX object should exist for listbox.
+PASS: Role should be 'listbox'.
+PASS: busy should be true.
+PASS: Label should be the aria-label override.
+
+-- Running test case: Input.Required
+PASS: AX object should exist for input.
+PASS: required should be true.
+
+-- Running test case: DynamicUpdate.AriaBusyReflectsLiveState
+PASS: Listbox starts busy.
+PASS: Listbox no longer reports busy after live mutation.
+
+-- Running test case: InvalidNodeId
+PASS: Unknown nodeId should reject.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/accessibility-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/accessibility-frame-target.html
@@ -1,0 +1,149 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameDOMAgent.Accessibility");
+
+    let frameTarget = null;
+    let frameBody = null;
+
+    function bid(node) { return node.backendNodeId; }
+
+    async function findChildElement(parent, predicate) {
+        await new Promise((resolve) => parent.getChildNodes(resolve));
+        return parent.children.find(predicate);
+    }
+
+    async function axFor(node) {
+        let {properties} = await frameTarget.DOMAgent.getAccessibilityPropertiesForNode(bid(node));
+        return properties;
+    }
+
+    async function findById(id) {
+        let nodeId = await frameBody.querySelector("#" + id);
+        return WI.domManager.nodeForIdInFrameTarget(nodeId, frameTarget);
+    }
+
+    async function evaluateInFrame(expression) {
+        return frameTarget.RuntimeAgent.evaluate.invoke({
+            expression,
+            objectGroup: "test",
+            includeCommandLineAPI: false,
+            contextId: frameTarget.executionContext.id,
+        });
+    }
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Find the cross-origin frame target and walk to its body.",
+        async test() {
+            let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+            let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+            let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+            frameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+            InspectorTest.expectNotNull(frameTarget, "Should find a cross-origin frame target.");
+
+            if (frameTarget.isProvisional) {
+                let committedEvent = await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+                frameTarget = committedEvent.data.target;
+            }
+            await frameTarget.ensureTargetExecutionContext();
+
+            let frameDoc = WI.domManager.frameTargetDocumentForTarget(frameTarget);
+            if (!frameDoc) {
+                let docEvent = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+                frameDoc = docEvent.data.document;
+            }
+            let htmlNode = await findChildElement(frameDoc, (n) => n.nodeName() === "HTML");
+            frameBody = await findChildElement(htmlNode, (n) => n.nodeName() === "BODY");
+            InspectorTest.expectNotNull(frameBody, "Should find iframe BODY.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Heading.RoleAndLevel",
+        description: "h1 should report role 'heading' with headingLevel 1.",
+        async test() {
+            let heading = await findById("heading");
+            let ax = await axFor(heading);
+            InspectorTest.expectThat(ax.exists, "AX object should exist for h1.");
+            InspectorTest.expectEqual(ax.role, "heading", "Role should be 'heading'.");
+            InspectorTest.expectEqual(ax.headingLevel, 1, "headingLevel should be 1.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Button.RoleAndLabel",
+        description: "Button with aria-label should report role 'button' and the override label.",
+        async test() {
+            let button = await findById("action-button");
+            let ax = await axFor(button);
+            InspectorTest.expectThat(ax.exists, "AX object should exist for button.");
+            InspectorTest.expectEqual(ax.role, "button", "Role should be 'button'.");
+            InspectorTest.expectEqual(ax.label, "Submit form", "Label should be the aria-label override.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Listbox.BusyAndLabel",
+        description: "div[role=listbox][aria-busy=true] should report busy.",
+        async test() {
+            let listbox = await findById("busy-region");
+            let ax = await axFor(listbox);
+            InspectorTest.expectThat(ax.exists, "AX object should exist for listbox.");
+            InspectorTest.expectEqual(ax.role, "listbox", "Role should be 'listbox'.");
+            InspectorTest.expectThat(ax.busy, "busy should be true.");
+            InspectorTest.expectEqual(ax.label, "Loading list", "Label should be the aria-label override.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Input.Required",
+        description: "input[required] should report required: true.",
+        async test() {
+            let input = await findById("required-input");
+            let ax = await axFor(input);
+            InspectorTest.expectThat(ax.exists, "AX object should exist for input.");
+            InspectorTest.expectThat(ax.required, "required should be true.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "DynamicUpdate.AriaBusyReflectsLiveState",
+        description: "Mutating aria-busy in the iframe's process should be reflected in the next AX query, proving the AXObjectCache lookup is process-local.",
+        async test() {
+            let listbox = await findById("busy-region");
+
+            let before = await axFor(listbox);
+            InspectorTest.expectThat(before.busy, "Listbox starts busy.");
+
+            await evaluateInFrame(`document.getElementById("busy-region").setAttribute("aria-busy", "false")`);
+
+            let after = await axFor(listbox);
+            InspectorTest.expectThat(!after.busy, "Listbox no longer reports busy after live mutation.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "InvalidNodeId",
+        description: "getAccessibilityPropertiesForNode with a bogus nodeId should reject.",
+        async test() {
+            let threw = false;
+            try {
+                await frameTarget.DOMAgent.getAccessibilityPropertiesForNode(9999999);
+            } catch (e) {
+                threw = true;
+            }
+            InspectorTest.expectThat(threw, "Unknown nodeId should reject.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests FrameDOMAgent.getAccessibilityPropertiesForNode for nodes inside a cross-origin iframe.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/ax-frame.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/resources/ax-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/resources/ax-frame.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cross-Origin AX Frame</title>
+</head>
+<body>
+    <h1 id="heading">Iframe heading</h1>
+    <button id="action-button" aria-label="Submit form">Click me</button>
+    <div id="busy-region" role="listbox" aria-busy="true" aria-label="Loading list"></div>
+    <input id="required-input" required value="hi">
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -483,6 +483,7 @@
         {
             "name": "getAccessibilityPropertiesForNode",
             "description": "Returns a dictionary of accessibility properties for the node.",
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node for which to get accessibility properties." }
             ],

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "FrameDOMAgent.h"
 
+#include "AXObjectCacheInlines.h"
+#include "AccessibilityNodeObject.h"
+#include "AccessibilityObjectInlines.h"
 #include "Attr.h"
 #include "CharacterData.h"
 #include "CommandLineAPIHost.h"
@@ -1560,6 +1563,349 @@ Inspector::CommandResult<void> FrameDOMAgent::setInspectedNode(int nodeId)
         commandLineAPIHost->addInspectedObject(makeUnique<InspectableFrameNode>(node.get()));
 
     return { };
+}
+
+// MARK: - Accessibility
+
+void FrameDOMAgent::processAccessibilityChildren(AXCoreObject& axObject, JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>& childNodeIds)
+{
+    const auto& children = axObject.unignoredChildren();
+    if (!children.size())
+        return;
+
+    for (const auto& childObject : children) {
+        if (RefPtr childNode = childObject->node())
+            childNodeIds.addItem(pushNodePathToFrontend(childNode.get()));
+        else
+            processAccessibilityChildren(childObject.get(), childNodeIds);
+    }
+}
+
+Ref<Inspector::Protocol::DOM::AccessibilityProperties> FrameDOMAgent::buildObjectForAccessibilityProperties(Node& node)
+{
+    AXObjectCache::enableAccessibility();
+
+    RefPtr<Node> activeDescendantNode;
+    bool busy = false;
+    auto checked = Inspector::Protocol::DOM::AccessibilityProperties::Checked::False;
+    auto switchState = Inspector::Protocol::DOM::AccessibilityProperties::SwitchState::Off;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>> childNodeIds;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>> controlledNodeIds;
+    auto currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::False;
+    bool exists = false;
+    bool expanded = false;
+    bool disabled = false;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>> flowedNodeIds;
+    bool focused = false;
+    bool ignored = true;
+    bool ignoredByDefault = false;
+    auto invalid = Inspector::Protocol::DOM::AccessibilityProperties::Invalid::False;
+    bool hidden = false;
+    String label;
+    bool liveRegionAtomic = false;
+    RefPtr<JSON::ArrayOf<String>> liveRegionRelevant;
+    auto liveRegionStatus = Inspector::Protocol::DOM::AccessibilityProperties::LiveRegionStatus::Off;
+    RefPtr<Node> mouseEventNode;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>> ownedNodeIds;
+    RefPtr<Node> parentNode;
+    bool pressed = false;
+    bool readonly = false;
+    bool required = false;
+    String role;
+    bool selected = false;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>> selectedChildNodeIds;
+    bool isSwitch = false;
+    bool supportsChecked = false;
+    bool supportsExpanded = false;
+    bool supportsLiveRegion = false;
+    bool supportsPressed = false;
+    bool supportsRequired = false;
+    bool supportsFocused = false;
+    bool isPopupButton = false;
+    int headingLevel = 0;
+    unsigned hierarchicalLevel = 0;
+    unsigned level = 0;
+
+    if (CheckedPtr axObjectCache = protect(node.document())->axObjectCache()) {
+        if (RefPtr axObject = axObjectCache->getOrCreate(node)) {
+
+            if (RefPtr activeDescendant = axObject->activeDescendant())
+                activeDescendantNode = activeDescendant->node();
+
+            RefPtr current = axObject;
+            while (!busy && current) {
+                busy = current->isBusy();
+                current = current->parentObject();
+            }
+
+            isSwitch = axObject->isSwitch();
+            supportsChecked = axObject->supportsChecked();
+            if (supportsChecked) {
+                AccessibilityButtonState checkValue = axObject->checkboxOrRadioValue();
+                if (checkValue == AccessibilityButtonState::On) {
+                    if (isSwitch)
+                        switchState = Inspector::Protocol::DOM::AccessibilityProperties::SwitchState::On;
+                    else
+                        checked = Inspector::Protocol::DOM::AccessibilityProperties::Checked::True;
+                } else if (checkValue == AccessibilityButtonState::Mixed && !isSwitch)
+                    checked = Inspector::Protocol::DOM::AccessibilityProperties::Checked::Mixed;
+                else if (axObject->isChecked()) {
+                    if (isSwitch)
+                        switchState = Inspector::Protocol::DOM::AccessibilityProperties::SwitchState::On;
+                    else
+                        checked = Inspector::Protocol::DOM::AccessibilityProperties::Checked::True;
+                }
+            }
+
+            if (!axObject->children().isEmpty()) {
+                childNodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
+                processAccessibilityChildren(*axObject, *childNodeIds);
+            }
+
+            auto controlledElements = axObject->elementsFromAttribute(HTMLNames::aria_controlsAttr);
+            if (controlledElements.size()) {
+                controlledNodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
+                for (auto& controlledElement : controlledElements) {
+                    if (auto controlledElementId = pushNodePathToFrontend(controlledElement.ptr()))
+                        controlledNodeIds->addItem(controlledElementId);
+                }
+            }
+
+            switch (axObject->currentState()) {
+            case AccessibilityCurrentState::False:
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::False;
+                break;
+            case AccessibilityCurrentState::Page:
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::Page;
+                break;
+            case AccessibilityCurrentState::Step:
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::Step;
+                break;
+            case AccessibilityCurrentState::Location:
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::Location;
+                break;
+            case AccessibilityCurrentState::Date:
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::Date;
+                break;
+            case AccessibilityCurrentState::Time:
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::Time;
+                break;
+            case AccessibilityCurrentState::True:
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::True;
+                break;
+            }
+
+            disabled = !axObject->isEnabled();
+            exists = true;
+
+            supportsExpanded = axObject->supportsExpanded();
+            if (supportsExpanded)
+                expanded = axObject->isExpanded();
+
+            auto flowedElements = axObject->elementsFromAttribute(HTMLNames::aria_flowtoAttr);
+            if (flowedElements.size()) {
+                flowedNodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
+                for (auto& flowedElement : flowedElements) {
+                    if (auto flowedElementId = pushNodePathToFrontend(flowedElement.ptr()))
+                        flowedNodeIds->addItem(flowedElementId);
+                }
+            }
+
+            if (is<Element>(node)) {
+                supportsFocused = axObject->canSetFocusAttribute();
+                if (supportsFocused)
+                    focused = axObject->isFocused();
+            }
+
+            ignored = axObject->isIgnored();
+            ignoredByDefault = axObject->isIgnoredByDefault();
+
+            String invalidValue = axObject->invalidStatus();
+            if (invalidValue == "false"_s)
+                invalid = Inspector::Protocol::DOM::AccessibilityProperties::Invalid::False;
+            else if (invalidValue == "grammar"_s)
+                invalid = Inspector::Protocol::DOM::AccessibilityProperties::Invalid::Grammar;
+            else if (invalidValue == "spelling"_s)
+                invalid = Inspector::Protocol::DOM::AccessibilityProperties::Invalid::Spelling;
+            else
+                invalid = Inspector::Protocol::DOM::AccessibilityProperties::Invalid::True;
+
+            if (axObject->isHidden())
+                hidden = true;
+
+            label = axObject->computedLabel();
+
+            if (axObject->supportsLiveRegion()) {
+                supportsLiveRegion = true;
+                liveRegionAtomic = axObject->liveRegionAtomic();
+
+                auto ariaRelevantAttrValue = axObject->liveRegionRelevant();
+                if (!ariaRelevantAttrValue.isEmpty()) {
+                    String ariaRelevantAdditions = Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::DOM::LiveRegionRelevant::Additions);
+                    String ariaRelevantRemovals = Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::DOM::LiveRegionRelevant::Removals);
+                    String ariaRelevantText = Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::DOM::LiveRegionRelevant::Text);
+                    liveRegionRelevant = JSON::ArrayOf<String>::create();
+                    SpaceSplitString values(AtomString { ariaRelevantAttrValue }, SpaceSplitString::ShouldFoldCase::Yes);
+                    if (values.contains("all"_s)) {
+                        liveRegionRelevant->addItem(ariaRelevantAdditions);
+                        liveRegionRelevant->addItem(ariaRelevantRemovals);
+                        liveRegionRelevant->addItem(ariaRelevantText);
+                    } else {
+                        if (values.contains(AtomString { ariaRelevantAdditions }))
+                            liveRegionRelevant->addItem(ariaRelevantAdditions);
+                        if (values.contains(AtomString { ariaRelevantRemovals }))
+                            liveRegionRelevant->addItem(ariaRelevantRemovals);
+                        if (values.contains(AtomString { ariaRelevantText }))
+                            liveRegionRelevant->addItem(ariaRelevantText);
+                    }
+                }
+
+                String ariaLive = axObject->liveRegionStatus();
+                if (ariaLive == "assertive"_s)
+                    liveRegionStatus = Inspector::Protocol::DOM::AccessibilityProperties::LiveRegionStatus::Assertive;
+                else if (ariaLive == "polite"_s)
+                    liveRegionStatus = Inspector::Protocol::DOM::AccessibilityProperties::LiveRegionStatus::Polite;
+            }
+
+            if (RefPtr clickableObject = axObject->clickableSelfOrAncestor(ClickHandlerFilter::IncludeBody))
+                mouseEventNode = clickableObject->node();
+
+            if (axObject->supportsARIAOwns()) {
+                auto ownedElements = axObject->elementsFromAttribute(HTMLNames::aria_ownsAttr);
+                if (ownedElements.size()) {
+                    ownedNodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
+                    for (auto& ownedElement : ownedElements) {
+                        if (auto ownedElementId = pushNodePathToFrontend(ownedElement.ptr()))
+                            ownedNodeIds->addItem(ownedElementId);
+                    }
+                }
+            }
+
+            if (RefPtr parentObject = axObject->parentObjectUnignored())
+                parentNode = parentObject->node();
+
+            supportsPressed = axObject->pressedIsPresent();
+            if (supportsPressed)
+                pressed = axObject->isPressed();
+
+            if (axObject->isTextControl())
+                readonly = !axObject->canSetValueAttribute();
+
+            supportsRequired = axObject->supportsRequiredAttribute();
+            if (supportsRequired)
+                required = axObject->isRequired();
+
+            role = axObject->computedRoleString();
+            selected = axObject->isSelected();
+
+            auto selectedChildren = axObject->selectedChildren();
+            if (selectedChildren.size()) {
+                selectedChildNodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
+                for (auto& selectedChildObject : selectedChildren) {
+                    if (RefPtr selectedChildNode = selectedChildObject->node()) {
+                        if (auto selectedChildNodeId = pushNodePathToFrontend(selectedChildNode.get()))
+                            selectedChildNodeIds->addItem(selectedChildNodeId);
+                    }
+                }
+            }
+
+            headingLevel = axObject->headingLevel();
+            hierarchicalLevel = axObject->hierarchicalLevel();
+
+            level = hierarchicalLevel ? hierarchicalLevel : headingLevel;
+            isPopupButton = axObject->isPopUpButton() || axObject->selfOrAncestorLinkHasPopup();
+        }
+    }
+
+    auto value = Inspector::Protocol::DOM::AccessibilityProperties::create()
+        .setExists(exists)
+        .setLabel(label)
+        .setRole(role)
+        .setNodeId(pushNodePathToFrontend(&node))
+        .release();
+
+    if (exists) {
+        if (activeDescendantNode) {
+            if (auto activeDescendantNodeId = pushNodePathToFrontend(activeDescendantNode.get()))
+                value->setActiveDescendantNodeId(activeDescendantNodeId);
+        }
+        if (busy)
+            value->setBusy(busy);
+
+        if (isSwitch)
+            value->setSwitchState(switchState);
+        else if (supportsChecked)
+            value->setChecked(checked);
+
+        if (childNodeIds)
+            value->setChildNodeIds(childNodeIds.releaseNonNull());
+        if (controlledNodeIds)
+            value->setControlledNodeIds(controlledNodeIds.releaseNonNull());
+        if (currentState != Inspector::Protocol::DOM::AccessibilityProperties::Current::False)
+            value->setCurrent(currentState);
+        if (disabled)
+            value->setDisabled(disabled);
+        if (supportsExpanded)
+            value->setExpanded(expanded);
+        if (flowedNodeIds)
+            value->setFlowedNodeIds(flowedNodeIds.releaseNonNull());
+        if (supportsFocused)
+            value->setFocused(focused);
+        if (ignored)
+            value->setIgnored(ignored);
+        if (ignoredByDefault)
+            value->setIgnoredByDefault(ignoredByDefault);
+        if (invalid != Inspector::Protocol::DOM::AccessibilityProperties::Invalid::False)
+            value->setInvalid(invalid);
+        if (hidden)
+            value->setHidden(hidden);
+        if (supportsLiveRegion) {
+            value->setLiveRegionAtomic(liveRegionAtomic);
+            if (liveRegionRelevant && liveRegionRelevant->length())
+                value->setLiveRegionRelevant(liveRegionRelevant.releaseNonNull());
+            value->setLiveRegionStatus(liveRegionStatus);
+        }
+        if (mouseEventNode) {
+            if (auto mouseEventNodeId = pushNodePathToFrontend(mouseEventNode))
+                value->setMouseEventNodeId(mouseEventNodeId);
+        }
+        if (ownedNodeIds)
+            value->setOwnedNodeIds(ownedNodeIds.releaseNonNull());
+        if (parentNode) {
+            if (auto parentNodeId = pushNodePathToFrontend(parentNode.get()))
+                value->setParentNodeId(parentNodeId);
+        }
+        if (supportsPressed)
+            value->setPressed(pressed);
+        if (readonly)
+            value->setReadonly(readonly);
+        if (supportsRequired)
+            value->setRequired(required);
+        if (selected)
+            value->setSelected(selected);
+        if (selectedChildNodeIds)
+            value->setSelectedChildNodeIds(selectedChildNodeIds.releaseNonNull());
+
+        if (headingLevel)
+            value->setHeadingLevel(level);
+        else if (level)
+            value->setHierarchyLevel(level);
+        if (isPopupButton)
+            value->setIsPopUpButton(isPopupButton);
+    }
+
+    return value;
+}
+
+Inspector::CommandResult<Ref<Inspector::Protocol::DOM::AccessibilityProperties>> FrameDOMAgent::getAccessibilityPropertiesForNode(int nodeId)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    return buildObjectForAccessibilityProperties(*node);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
@@ -39,6 +39,7 @@
 
 namespace WebCore {
 
+class AXCoreObject;
 class CharacterData;
 class DOMEditor;
 class Document;
@@ -165,6 +166,9 @@ private:
 
     RefPtr<Node> nodeForObjectId(const Inspector::Protocol::Runtime::RemoteObjectId&);
     RefPtr<Inspector::Protocol::Runtime::RemoteObject> resolveNodeInternal(Node*, const String& objectGroup);
+
+    Ref<Inspector::Protocol::DOM::AccessibilityProperties> buildObjectForAccessibilityProperties(Node&);
+    void processAccessibilityChildren(AXCoreObject&, JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>&);
 
     Ref<Inspector::Protocol::DOM::Node> buildObjectForNode(Node*, int depth);
     Ref<JSON::ArrayOf<String>> buildArrayForElementAttributes(Element*);

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
@@ -52,11 +52,6 @@ Inspector::CommandResult<void> FrameDOMAgent::removeBreakpointForEventListener(i
     return makeUnexpected("Not supported for frame targets"_s);
 }
 
-Inspector::CommandResult<Ref<Inspector::Protocol::DOM::AccessibilityProperties>> FrameDOMAgent::getAccessibilityPropertiesForNode(int)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
 #if PLATFORM(IOS_FAMILY)
 Inspector::CommandResult<void> FrameDOMAgent::setInspectModeEnabled(bool, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&, RefPtr<JSON::Object>&&)
 {

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -969,12 +969,6 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
-        // FIXME: <https://webkit.org/b/298980> Accessibility properties for cross-origin frame nodes are not yet supported.
-        if (this.owningTarget) {
-            callback({});
-            return;
-        }
-
         function accessibilityPropertiesCallback(error, accessibilityProperties)
         {
             if (!error && callback && accessibilityProperties) {
@@ -1018,8 +1012,8 @@ WI.DOMNode = class DOMNode extends WI.Object
             }
         }
 
-        let target = WI.assumingMainTarget();
-        target.DOMAgent.getAccessibilityPropertiesForNode(this.id, accessibilityPropertiesCallback.bind(this));
+        let target = this.owningTarget || WI.assumingMainTarget();
+        target.DOMAgent.getAccessibilityPropertiesForNode(this.backendNodeId, accessibilityPropertiesCallback.bind(this));
     }
 
     path()


### PR DESCRIPTION
#### e33f7f21b67a916374d694d63fb5d6f00c59a65c
<pre>
Web Inspector: [SI] populate Accessibility sidebar for cross-origin iframe nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=316138">https://bugs.webkit.org/show_bug.cgi?id=316138</a>
<a href="https://rdar.apple.com/178562336">rdar://178562336</a>

Reviewed by Qianlang Chen.

Port getAccessibilityPropertiesForNode onto FrameDOMAgent.
Walks the frame&apos;s local AXObjectCache for role, label, busy, checked,
expanded, required, heading level, live region status,
owned/controlled/flowed node references, and the rest of the AccessibilityProperties
shape. Cross-frame AX references (parentNode walking up past the
iframe boundary, controlledNodeIds pointing into the parent
process) resolve to 0 via pushNodePathToFrontend and are silently omitted,
matching the graceful-degradation behavior of the page-level path.

On the frontend, the cross-origin guard on
DOMNode.accessibilityProperties is removed.
The call routes through `owningTarget ||
WI.assumingMainTarget()` with `backendNodeId`.

The Accessibility section of the right-hand sidebar now
populates for nodes inside cross-origin iframes.

Test: http/tests/site-isolation/inspector/dom/accessibility-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/dom/accessibility-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/accessibility-frame-target.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/resources/ax-frame.html: Added.
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp:
(WebCore::FrameDOMAgent::processAccessibilityChildren):
(WebCore::FrameDOMAgent::buildObjectForAccessibilityProperties):
(WebCore::FrameDOMAgent::getAccessibilityPropertiesForNode):
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.h:
* Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp:
(WebCore::FrameDOMAgent::getAccessibilityPropertiesForNode): Deleted.
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.accessibilityProperties):

Canonical link: <a href="https://commits.webkit.org/316399@main">https://commits.webkit.org/316399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecabd0cc0258a8b04bafaca82e654be91d130073

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129771 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e6e50c2-337e-4127-a4cf-65f5772a1cdd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133946 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf54310a-6606-4c62-910f-40133f27026e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37378 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114420 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84f13792-e125-405c-9f2f-f286b3fc5dc8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36009 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30273 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/3040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184201 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33476 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36805 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142705 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45801 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38497 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46481 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111185 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37669 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204895 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44999 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8942 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54708 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44399 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44631 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44458 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->