### PR TITLE
[CMake] Use xcrun ninja instead of caching a path

### DIFF
--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -198,12 +198,6 @@ if (CMAKE_GENERATOR STREQUAL "Ninja")
     set(CMAKE_C_ARCHIVE_FINISH true)
 endif ()
 
-WEBKIT_XCRUN(_ninja_path -f ninja)
-if (NOT EXISTS "${_ninja_path}")
-    message(FATAL_ERROR "xcrun could not resolve ninja")
-endif ()
-file(WRITE "${CMAKE_BINARY_DIR}/.webkit-ninja-path" "${_ninja_path}\n")
-
 set(CMAKE_STATIC_LINKER_FLAGS "-no_warning_for_no_symbols")
 
 if (CMAKE_EXPORT_COMPILE_COMMANDS AND NOT EXISTS ${CMAKE_SOURCE_DIR}/compile_commands.json)

--- a/Source/cmake/clang-wrapper
+++ b/Source/cmake/clang-wrapper
@@ -118,7 +118,7 @@ END_OF_NINJA
 
 writeFileIfChanged("$membersFolder/build.ninja", $buildNinja);
 
-exec($ENV{WEBKIT_NINJA_PATH}, '--quiet', '-f', "$membersFolder/build.ninja");
+exec('xcrun', 'ninja', '--quiet', '-f', "$membersFolder/build.ninja");
 die("exec ninja: $!\n");
 
 sub shellQuote {

--- a/Source/cmake/ninja-wrapper
+++ b/Source/cmake/ninja-wrapper
@@ -4,25 +4,20 @@ use warnings;
 use Cwd qw(getcwd);
 use File::Path qw(make_path);
 
-open(my $ninjaPathFile, '<', '.webkit-ninja-path') or die("ninja-wrapper: $!\n");
-chomp(my $ninja = <$ninjaPathFile>);
-close($ninjaPathFile);
-$ENV{WEBKIT_NINJA_PATH} = $ninja;
-
 # CMake configuration
 if (grep({ /^-t/ || /^--version$/ } @ARGV)) {
-    exec($ninja, @ARGV);
+    exec('xcrun', 'ninja', @ARGV);
 }
 
 # CMake try_compile/check_*
 if (getcwd() =~ m{/CMakeFiles/}) {
-    exec($ninja, @ARGV);
+    exec('xcrun', 'ninja', @ARGV);
 }
 
 # Real compilation
 my $bundlePolicy = $ENV{WK_UNIFIED_SOURCES_BUNDLE_POLICY};
 if (!defined($bundlePolicy)) {
-    my $dryRun = `$ninja -n @ARGV 2>&1`;
+    my $dryRun = `xcrun ninja -n @ARGV 2>&1`;
     my ($totalCommands) = $dryRun =~ m{/(\d+)\]};
 
     # No-op build
@@ -49,4 +44,4 @@ if (open(my $fh, '>', "DerivedSources/unified-sources-bundle-policy")) {
     close($fh);
 }
 
-exec('/usr/bin/caffeinate', '-i', $ninja, @ARGV);
+exec('/usr/bin/caffeinate', '-i', 'xcrun', 'ninja', @ARGV);


### PR DESCRIPTION
#### 7eb4e14b5d12b32b5489d426bfc4ed3c671456c8
<pre>
[CMake] Use xcrun ninja instead of caching a path
<a href="https://bugs.webkit.org/show_bug.cgi?id=316146">https://bugs.webkit.org/show_bug.cgi?id=316146</a>
<a href="https://rdar.apple.com/178569070">rdar://178569070</a>

Reviewed by Charlie Wolfe.

This patch reverts 314403@main because it fail to configure a
clean build.

CMake wants to run ninja --version before we&apos;ve cached the path
to ninja.

For now just use xcrun ninja in our wrapper tools. That&apos;s the
simplest solution, and unlike toolchain and SDK, we have yet
to find a case where pinning ninja matters. We can always make
this more complicated if we do find a case.

Canonical link: <a href="https://commits.webkit.org/314424@main">https://commits.webkit.org/314424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff5f127d9b5d77c61ab67a65894e91fdaaadd543

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175124 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129074 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149211 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109600 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23265 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158234 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140391 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177657 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26970 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137420 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137348 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40324 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148705 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102922 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25283 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32633 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25572 "Found 2 new test failures: http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py http/tests/webgpu/webgpu/api/validation/queue/destroyed/buffer.html (failure)") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38835 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38232 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3658 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38477 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38375 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->