### PR TITLE
AX: Atomically transfer pending tree updates from main thread to AX thread

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -274,7 +274,7 @@ WTF_EXPORT_PRIVATE uint64_t WTFCurrentContinuousTime(Seconds deltaFromNow);
 WTF_EXTERN_C_END
 
 #define FOR_EACH_WTF_SIGNPOST_NAME(M) \
-    M(AccessibilityIsolatedTreeApplyPendingChanges) \
+    M(AccessibilityIsolatedTreeApplyCommittedChanges) \
     M(InitialAccessibilityIsolatedTreeBuild) \
     M(DataTask) \
     M(NavigationAndPaintTiming) \

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -322,7 +322,7 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::unignoredChildren(bool u
     // NOTE: The per-object properties read below (role, IsExposableTable, IsIgnored) participate
     // in AXIsolatedTree's cache invalidation for stitchedUnignoredChildren. If a new property
     // becomes a dependency of this walk, update the trigger list in
-    // AXIsolatedTree::applyPendingChangesFromSnapshot.
+    // AXIsolatedTree::applyCommittedChanges.
 
     if (onlyAddsUnignoredChildren())
         return children(updateChildrenIfNeeded);

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -403,7 +403,10 @@ bool AXObjectCache::shouldServeInitialCachedFrame()
     return !clientIsInTestMode() || forceInitialFrameCaching();
 }
 
-static constexpr Seconds updateTreeSnapshotTimerInterval { 100_ms };
+// Just over one frame at 60Hz (16.67ms). The timer is scheduled on demand when the isolated
+// tree first queues work, so this is "publish one frame after the first change in this batch",
+// with any further changes in the window coalescing into the same commit.
+static constexpr Seconds updateTreeSnapshotTimerDuration { 17_ms };
 #endif
 
 AXObjectCache::AXObjectCache(LocalFrame& localFrame, Document* document)
@@ -2125,6 +2128,9 @@ void AXObjectCache::notificationPostTimerFired()
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     updateIsolatedTree(notificationsToPost);
+    // We're going to post platform notifications, so make sure to publish isolated tree
+    // changes so we provide up-to-date information.
+    processQueuedIsolatedNodeUpdates();
 #endif
 
     for (const auto& note : notificationsToPost) {
@@ -3078,7 +3084,6 @@ void AXObjectCache::onAccessibilityPaintFinished()
     }
 
     tree->markMostRecentlyPaintedTextDirty();
-    startUpdateTreeSnapshotTimer();
 }
 
 bool AXObjectCache::onFontChange(Element& element, const Style::ComputedStyle* oldStyle, const Style::ComputedStyle* newStyle)
@@ -4294,7 +4299,6 @@ void AXObjectCache::dirtyIsolatedTreeRelations()
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID))
         tree->markRelationsDirty();
-    startUpdateTreeSnapshotTimer();
 #endif
 }
 
@@ -6294,7 +6298,7 @@ void AXObjectCache::updateIsolatedTree(AccessibilityObject& axObject, AXProperty
 void AXObjectCache::startUpdateTreeSnapshotTimer()
 {
     if (!m_updateTreeSnapshotTimer.isActive())
-        m_updateTreeSnapshotTimer.startOneShot(updateTreeSnapshotTimerInterval);
+        m_updateTreeSnapshotTimer.startOneShot(updateTreeSnapshotTimerDuration);
 }
 
 void AXObjectCache::onPaint(const RenderObject& renderer, IntRect&& paintRect) const
@@ -7302,12 +7306,6 @@ void AXObjectCache::selectedTextRangeTimerFired()
     }
 
     m_lastDebouncedTextRangeObject = std::nullopt;
-}
-
-void AXObjectCache::updateTreeSnapshotTimerFired()
-{
-    m_updateTreeSnapshotTimer.stop();
-    processQueuedIsolatedNodeUpdates();
 }
 
 void AXObjectCache::processQueuedIsolatedNodeUpdates()

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -941,7 +941,7 @@ private:
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void selectedTextRangeTimerFired();
     Seconds NODELETE platformSelectedTextRangeDebounceInterval() const;
-    void updateTreeSnapshotTimerFired();
+    void updateTreeSnapshotTimerFired() { processQueuedIsolatedNodeUpdates(); }
     void processQueuedIsolatedNodeUpdates();
 
     void deferAddUnconnectedNode(AccessibilityObject&);

--- a/Source/WebCore/accessibility/AXTreeStore.cpp
+++ b/Source/WebCore/accessibility/AXTreeStore.cpp
@@ -40,7 +40,7 @@ WEBCORE_EXPORT void AXTreeStore<AXIsolatedTree>::applyPendingChangesForAllIsolat
 
     // Snapshot all live trees while holding the lock, then release it before
     // calling applyPendingChangesOrTearDown. This is necessary because
-    // applyPendingChangesLocked can call attachPlatformWrapper ->
+    // applyCommittedChanges can call attachPlatformWrapper ->
     // crossFrameChildObject -> treeForFrameID, which needs to acquire
     // s_storeLock. Holding s_storeLock across that call would self-deadlock.
     Vector<std::pair<AXTreeID, Ref<AXIsolatedTree>>> trees;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -874,7 +874,7 @@ RefPtr<AXIsolatedObject> AXIsolatedObject::approximateHitTest(const IntPoint& po
             // RemoteFrames don't have this problem since they have a wrapper that points to the remote accessibility
             // object, and the frameworks recursively hit test in the bridged process.
             // This also helps guard against potential frame wrapper issues, like the one noted in
-            // AXIsolatedTree::applyPendingChangesLocked.
+            // AXIsolatedTree::applyCommittedChanges.
             if (RefPtr crossFrameChild = child->crossFrameChildObject()) {
                 if (RefPtr hitChild = crossFrameChild->approximateHitTest(point))
                     return hitChild;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -110,8 +110,18 @@ void AXIsolatedTree::queueForDestruction()
     AX_ASSERT(isMainThread());
 
     Locker locker { m_changeLogLock };
-    m_queuedForDestruction = true;
+    // Publish anything still in the working buffer before the AX thread tears this tree down.
+    // Teardown (clearTreeContentsLocked) only clears m_committedChanges, and every NodeChange
+    // left behind holds a Ref to this tree (IsolatedObjectData::tree), so stranding them would
+    // be a self-reference cycle that keeps the tree alive forever.
+    commitWorkingChangesLocked();
+    // Note that setting m_hasPendingChanges here is deliberately redundant (since commitWorkingChages
+    // also sets it). It's repeated here because teardown depends on it, and would fail silently without
+    // it, since applyPendingChangesOrTearDown early-exits if not set. Setting it here makes queueForDestruction()
+    // correct no matter what commitWorkingChanges() does, now or in the future.
     m_hasPendingChanges.store(true);
+
+    m_queuedForDestruction = true;
     s_anyTreeNeedsTearDown.store(true, std::memory_order_relaxed);
 }
 
@@ -131,12 +141,12 @@ Ref<AXIsolatedTree> AXIsolatedTree::createEmpty(AXObjectCache& axObjectCache)
     tree->updateLoadingProgress(axObjectCache.loadingProgress());
     tree->m_processingProgress = 0;
 
-    // Now that the tree is ready to take client requests, add it to the tree maps so that it can be found.
-    storeTree(axObjectCache, tree);
-
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     tree->updateFrameGeometryAndScrollPositionIfNeeded(axObjectCache);
 #endif
+
+    // Now that the tree is ready to take client requests, add it to the tree maps so that it can be found.
+    storeTree(axObjectCache, tree);
 
     return tree;
 }
@@ -174,11 +184,8 @@ void AXIsolatedTree::createEmptyContent(AccessibilityObject& axRoot)
     m_nodeMap.set(axRoot.objectID(), ParentChildrenIDs { std::nullopt, { axWebArea->objectID() } });
     m_nodeMap.set(axWebArea->objectID(), ParentChildrenIDs { axRoot.objectID(), { } });
 
-    {
-        Locker locker { m_changeLogLock };
-        setPendingRootNodeIDLocked(axRoot.objectID());
-        mutablePendingChanges()->focusedNodeID = axWebArea->objectID();
-    }
+    setPendingRootNodeID(axRoot.objectID());
+    markDirtyAndGetWorkingChanges().focusedNodeID = Markable<AXID> { axWebArea->objectID() };
     Vector<NodeChange> appends;
     appends.reserveInitialCapacity(2);
     appends.append(WTF::move(rootAppend));
@@ -237,12 +244,12 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
         addUnconnectedNodeIfNeeded(targetID);
     tree->updateRelations(WTF::move(relations));
 
-    // Now that the tree is ready to take client requests, add it to the tree maps so that it can be found.
-    storeTree(axObjectCache, tree);
-
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     tree->updateFrameGeometryAndScrollPositionIfNeeded(axObjectCache);
 #endif
+
+    // Now that the tree is ready to take client requests, add it to the tree maps so that it can be found.
+    storeTree(axObjectCache, tree);
 
     if (AXObjectCache::isAppleInternalInstall()) [[unlikely]]
         WTFEndSignpostAlways(tree.ptr(), InitialAccessibilityIsolatedTreeBuild);
@@ -253,14 +260,25 @@ void AXIsolatedTree::storeTree(AXObjectCache& cache, const Ref<AXIsolatedTree>& 
 {
     AX_ASSERT(isMainThread());
 
+    // Atomically publish any working-buffer writes into m_committedChanges before the tree
+    // becomes externally visible.
+    auto shouldEagerlyApply = tree->commitWorkingChanges();
+
     // Once we've added this new tree to the AXTreeStore, clients will be able to use
     // it off the main-thread. Make any final state mutations while we are the only thread
     // that can touch this tree.
     cache.setIsolatedTree(tree);
     AXTreeStore::set(tree->treeID(), tree.ptr());
     tree->m_replacingTree = nullptr;
-    Locker locker { s_storeLock };
-    treeFrameCache().set(cache.frameID(), tree.copyRef());
+
+    {
+        Locker locker { s_storeLock };
+        treeFrameCache().set(cache.frameID(), tree.copyRef());
+    }
+    AX_ASSERT(!tree->m_workingChangesDirty);
+
+    // Now that the tree is reachable off the main thread, hand the initial contents over.
+    tree->dispatchEagerApplyIfNeeded(shouldEagerlyApply);
 }
 
 double AXIsolatedTree::loadingProgress()
@@ -366,13 +384,12 @@ std::optional<AXIsolatedTree::NodeChange> AXIsolatedTree::nodeChangeForObject(Re
 void AXIsolatedTree::queueChange(NodeChange&& nodeChange)
 {
     AX_ASSERT(isMainThread());
-    AX_ASSERT(m_changeLogLock.isLocked());
 
     AXID objectID = nodeChange.data.axID;
     Markable parentID = nodeChange.data.parentID;
     bool isTextControl = AXCoreObject::isTextControl(nodeChange.data.role);
-    auto pending = mutablePendingChanges();
-    pending->appends.append(WTF::move(nodeChange));
+    auto& pending = markDirtyAndGetWorkingChanges();
+    pending.appends.append(WTF::move(nodeChange));
 
     // An append carries a full, fresh copy of the node's properties, so it supersedes a SelectedTextRange
     // update already queued for this object in an earlier cycle. Drop that stale update; without this it
@@ -385,27 +402,27 @@ void AXIsolatedTree::queueChange(NodeChange&& nodeChange)
     // same-cycle dedup in processQueuedNodeUpdates() already assumes), but we limit this to SelectedTextRange
     // for now since other properties may intentionally be pushed as targeted updates. Consider generalizing.
     if (isTextControl) {
-        for (auto& change : pending->propertyChanges) {
+        for (auto& change : pending.propertyChanges) {
             if (change.axID == objectID) {
                 change.properties.removeAllMatching([] (const auto& property) {
                     return property.first == AXProperty::SelectedTextRange;
                 });
             }
         }
-        pending->propertyChanges.removeAllMatching([] (const auto& change) {
+        pending.propertyChanges.removeAllMatching([] (const auto& change) {
             return change.properties.isEmpty();
         });
     }
 
     if (parentID) {
         auto siblingsIDs = m_nodeMap.get(*parentID).childrenIDs;
-        pending->childrenUpdates.append({ *parentID, WTF::move(siblingsIDs) });
+        pending.childrenUpdates.append({ *parentID, WTF::move(siblingsIDs) });
     }
 
     ASSERT_WITH_MESSAGE(objectID != parentID, "object ID was the same as its parent ID (%s) when queueing a node change", objectID.loggingString().utf8().data());
     ASSERT_WITH_MESSAGE(m_nodeMap.contains(objectID), "node map should've contained objectID: %s", objectID.loggingString().utf8().data());
     auto childrenIDs = m_nodeMap.get(objectID).childrenIDs;
-    pending->childrenUpdates.append({ objectID, WTF::move(childrenIDs) });
+    pending.childrenUpdates.append({ objectID, WTF::move(childrenIDs) });
 }
 
 void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
@@ -431,33 +448,27 @@ void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
     m_unconnectedNodes.add(objectID);
 
     // Because we are queuing a change for an object not intended to be connected to the rest of the tree,
-    // we don't need to update m_nodeMap or m_pendingChanges.childrenUpdates for this object or its parent as is
+    // we don't need to update m_nodeMap or m_workingChanges.childrenUpdates for this object or its parent as is
     // done in AXIsolatedTree::nodeChangeForObject and AXIsolatedTree::queueChange.
     //
     // Instead, just directly create and queue the node change so m_readerThreadNodeMap can hold a reference
     // to it. It will be removed from m_readerThreadNodeMap when the corresponding DOM element, renderer, or
     // other entity is removed from the page.
     NodeChange nodeChange { createIsolatedObjectData(axObject, *this), axObject->wrapper(), nextChangeSequence() };
-    Locker locker { m_changeLogLock };
-    mutablePendingChanges()->appends.append(WTF::move(nodeChange));
+    markDirtyAndGetWorkingChanges().appends.append(WTF::move(nodeChange));
 }
 
 void AXIsolatedTree::queueRemovals(Vector<NodeAndParentID>&& subtreeRemovals)
 {
     AX_ASSERT(isMainThread());
 
-    Locker locker { m_changeLogLock };
-    queueRemovalsLocked(WTF::move(subtreeRemovals));
-}
+    // Bail before touching the working buffer when there's nothing to queue.
+    if (subtreeRemovals.isEmpty() && m_protectedFromDeletionIDs.isEmpty())
+        return;
 
-void AXIsolatedTree::queueRemovalsLocked(Vector<NodeAndParentID>&& subtreeRemovals)
-{
-    AX_ASSERT(isMainThread());
-    AX_ASSERT(m_changeLogLock.isLocked());
-
-    auto pending = mutablePendingChanges();
-    pending->subtreeRemovals.appendVector(WTF::move(subtreeRemovals));
-    pending->protectedFromDeletionIDs.addAll(std::exchange(m_protectedFromDeletionIDs, { }));
+    auto& pending = markDirtyAndGetWorkingChanges();
+    pending.subtreeRemovals.appendVector(WTF::move(subtreeRemovals));
+    pending.protectedFromDeletionIDs.addAll(std::exchange(m_protectedFromDeletionIDs, { }));
 }
 
 void AXIsolatedTree::queueRemovalsAndUnresolvedChanges()
@@ -515,16 +526,15 @@ void AXIsolatedTree::queueAppendsAndRemovals(Vector<NodeChange>&& appends, Vecto
     AX_ASSERT(isMainThread());
 
     auto parentUpdateIDs = std::exchange(m_needsParentUpdate, { });
-    Locker locker { m_changeLogLock };
     for (auto&& append : appends)
         queueChange(WTF::move(append));
 
     for (const auto& axID : parentUpdateIDs) {
         ASSERT_WITH_MESSAGE(m_nodeMap.contains(axID), "An object marked as needing a parent update should've had an entry in the node map by now. ID was %s", axID.loggingString().utf8().data());
-        mutablePendingChanges()->parentUpdates.set(axID, *m_nodeMap.get(axID).parentID);
+        markDirtyAndGetWorkingChanges().parentUpdates.set(axID, *m_nodeMap.get(axID).parentID);
     }
 
-    queueRemovalsLocked(WTF::move(subtreeRemovals));
+    queueRemovals(WTF::move(subtreeRemovals));
 }
 
 void AXIsolatedTree::collectNodeChangesForSubtree(AccessibilityObject& axObject)
@@ -609,7 +619,6 @@ void AXIsolatedTree::updateNode(AccessibilityObject& axObject)
     // In both cases, we can't attach the wrapper immediately on the main thread, since the wrapper could be in use
     // on the AX thread (because this function updates an existing node).
     if (auto change = nodeChangeForObject(axObject)) {
-        Locker locker { m_changeLogLock };
         queueChange(WTF::move(*change));
         return;
     }
@@ -622,10 +631,8 @@ void AXIsolatedTree::updateNode(AccessibilityObject& axObject)
     if (!axParent)
         return;
 
-    if (auto change = nodeChangeForObject(downcast<AccessibilityObject>(*axParent))) {
-        Locker locker { m_changeLogLock };
+    if (auto change = nodeChangeForObject(downcast<AccessibilityObject>(*axParent)))
         queueChange(WTF::move(*change));
-    }
 }
 
 void AXIsolatedTree::objectChangedIgnoredState(const AccessibilityObject& object)
@@ -986,8 +993,7 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
     if (properties.isEmpty())
         return;
 
-    Locker locker { m_changeLogLock };
-    mutablePendingChanges()->propertyChanges.append({ axObject.objectID(), WTF::move(properties) });
+    markDirtyAndGetWorkingChanges().propertyChanges.append({ axObject.objectID(), WTF::move(properties) });
 }
 
 void AXIsolatedTree::overrideNodeProperties(AXID axID, AXPropertyVector&& properties)
@@ -997,8 +1003,7 @@ void AXIsolatedTree::overrideNodeProperties(AXID axID, AXPropertyVector&& proper
     if (properties.isEmpty())
         return;
 
-    Locker locker { m_changeLogLock };
-    mutablePendingChanges()->propertyChanges.append({ axID, WTF::move(properties) });
+    markDirtyAndGetWorkingChanges().propertyChanges.append({ axID, WTF::move(properties) });
 }
 
 void AXIsolatedTree::updateDependentProperties(AccessibilityObject& axObject)
@@ -1239,8 +1244,14 @@ bool AXIsolatedTree::unsafeHasObjectForID(AXID axID) const
 
 std::optional<AXID> AXIsolatedTree::pendingRootNodeID()
 {
+    // The root the main thread has published or is about to publish, regardless of which buffer
+    // currently holds it. This should only be used on the main-thread.
+    AX_ASSERT(isMainThread());
+
+    if (m_workingChanges.rootNodeID)
+        return m_workingChanges.rootNodeID;
     Locker locker { m_changeLogLock };
-    return m_pendingChanges.rootNodeID;
+    return m_committedChanges.rootNodeID;
 }
 
 RefPtr<AXIsolatedObject> AXIsolatedTree::rootWebArea()
@@ -1256,17 +1267,10 @@ RefPtr<AXIsolatedObject> AXIsolatedTree::rootWebArea()
 
 void AXIsolatedTree::setPendingRootNodeID(AXID axID)
 {
-    Locker locker { m_changeLogLock };
-    setPendingRootNodeIDLocked(axID);
-}
-
-void AXIsolatedTree::setPendingRootNodeIDLocked(AXID axID)
-{
-    AXTRACE("AXIsolatedTree::setPendingRootNodeIDLocked"_s);
+    AXTRACE("AXIsolatedTree::setPendingRootNodeID"_s);
     AX_ASSERT(isMainThread());
-    AX_ASSERT(m_changeLogLock.isLocked());
 
-    mutablePendingChanges()->rootNodeID = axID;
+    markDirtyAndGetWorkingChanges().rootNodeID = axID;
 }
 
 void AXIsolatedTree::setFocusedNodeID(std::optional<AXID> axID)
@@ -1275,8 +1279,7 @@ void AXIsolatedTree::setFocusedNodeID(std::optional<AXID> axID)
     AXLOG(makeString("axID "_s, axID ? axID->loggingString() : ""_str));
     AX_ASSERT(isMainThread());
 
-    Locker locker { m_changeLogLock };
-    mutablePendingChanges()->focusedNodeID = axID;
+    markDirtyAndGetWorkingChanges().focusedNodeID = Markable<AXID> { axID };
 }
 
 void AXIsolatedTree::updateRelations(HashMap<AXID, AXRelations>&& relations)
@@ -1285,8 +1288,7 @@ void AXIsolatedTree::updateRelations(HashMap<AXID, AXRelations>&& relations)
     AX_ASSERT(isMainThread());
 
     m_relationsNeedUpdate = false;
-    Locker locker { m_changeLogLock };
-    mutablePendingChanges()->relations = WTF::move(relations);
+    markDirtyAndGetWorkingChanges().relations = WTF::move(relations);
 }
 
 void AXIsolatedTree::setSelectedTextMarkerRange(AXTextMarkerRange&& range)
@@ -1294,17 +1296,15 @@ void AXIsolatedTree::setSelectedTextMarkerRange(AXTextMarkerRange&& range)
     AXTRACE("AXIsolatedTree::setSelectedTextMarkerRange"_s);
     AX_ASSERT(isMainThread());
 
-    Locker locker { m_changeLogLock };
-    mutablePendingChanges()->selectedTextMarkerRange = WTF::move(range);
+    markDirtyAndGetWorkingChanges().selectedTextMarkerRange = WTF::move(range);
 }
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 void AXIsolatedTree::setFrameGeometry(AXFrameGeometry&& geometry, IntPoint viewOriginScrollPosition)
 {
-    Locker locker { m_changeLogLock };
-    auto pending = mutablePendingChanges();
-    pending->frameGeometry = WTF::move(geometry);
-    pending->frameViewOriginScrollPosition = viewOriginScrollPosition;
+    auto& pending = markDirtyAndGetWorkingChanges();
+    pending.frameGeometry = WTF::move(geometry);
+    pending.frameViewOriginScrollPosition = viewOriginScrollPosition;
 }
 
 void AXIsolatedTree::updateFrameGeometryAndScrollPositionIfNeeded(AXObjectCache& cache)
@@ -1349,8 +1349,7 @@ void AXIsolatedTree::updateFrame(AXID axID, IntRect&& newFrame)
     properties.append({ AXProperty::RelativeFrame, WTF::move(newFrame) });
     // We can clear the initially-cached rough frame, since the object's frame has been cached.
     properties.append({ AXProperty::InitialLocalRect, FloatRect() });
-    Locker locker { m_changeLogLock };
-    mutablePendingChanges()->propertyChanges.append({ axID, WTF::move(properties) });
+    markDirtyAndGetWorkingChanges().propertyChanges.append({ axID, WTF::move(properties) });
 }
 
 void AXIsolatedTree::updateRootScreenRelativePosition()
@@ -1440,15 +1439,15 @@ void AXIsolatedTree::applyPendingChanges()
     if (!hasPendingChanges())
         return;
 
-    PendingChanges snapshot;
+    PendingChanges committedChanges;
     {
         Locker locker { m_changeLogLock };
-        // Release the lock before applying changes in the snapshot,
-        // since doing so can take time, and we don't want to block
-        // the main-thread unnecessarily.
-        snapshot = takePendingChangesLocked();
+        // Release the lock before applying committedChanges locally, since
+        // doing so can take time, and we don't want to block the main-thread
+        // unnecessarily.
+        committedChanges = takeCommittedChangesLocked();
     }
-    applyPendingChangesFromSnapshot(WTF::move(snapshot));
+    applyCommittedChanges(WTF::move(committedChanges));
 }
 
 void AXIsolatedTree::applyPendingChangesUnlessQueuedForDestruction()
@@ -1458,14 +1457,14 @@ void AXIsolatedTree::applyPendingChangesUnlessQueuedForDestruction()
     if (!hasPendingChanges())
         return;
 
-    PendingChanges snapshot;
+    PendingChanges committedChanges;
     {
         Locker locker { m_changeLogLock };
         if (m_queuedForDestruction) [[unlikely]]
             return;
-        snapshot = takePendingChangesLocked();
+        committedChanges = takeCommittedChangesLocked();
     }
-    applyPendingChangesFromSnapshot(WTF::move(snapshot));
+    applyCommittedChanges(WTF::move(committedChanges));
 }
 
 DidTearDown AXIsolatedTree::applyPendingChangesOrTearDown()
@@ -1475,7 +1474,7 @@ DidTearDown AXIsolatedTree::applyPendingChangesOrTearDown()
     if (!hasPendingChanges())
         return DidTearDown::No;
 
-    PendingChanges snapshot;
+    PendingChanges committedChanges;
     {
         Locker locker { m_changeLogLock };
 
@@ -1484,9 +1483,9 @@ DidTearDown AXIsolatedTree::applyPendingChangesOrTearDown()
             return DidTearDown::Yes;
         }
 
-        snapshot = takePendingChangesLocked();
+        committedChanges = takeCommittedChangesLocked();
     }
-    applyPendingChangesFromSnapshot(WTF::move(snapshot));
+    applyCommittedChanges(WTF::move(committedChanges));
     return DidTearDown::No;
 }
 
@@ -1501,27 +1500,30 @@ void AXIsolatedTree::clearTreeContentsLocked()
 
     // Because each AXIsolatedObject holds a RefPtr to this tree, clear out any member variable
     // that holds an AXIsolatedObject so the ref-cycle is broken and this tree can be destroyed.
+    //
+    // m_workingChanges.appends holds tree-referencing NodeChanges too, but deliberately isn't
+    // cleared here, since that can only used on the main-thread.
     m_readerThreadNodeMap.clear();
-    m_pendingChanges.appends.clear();
+    m_committedChanges.appends.clear();
     // We don't need to bother clearing out any other non-cycle-causing member variables as they
     // will be cleaned up automatically when the tree is destroyed.
 }
 
 // When a node is queued for both subtree removal and appending in the same batch (e.g. when an
 // in-process FrameHost is replaced with an out-of-process one due to site isolation), the old
-// subtree snapshot and the new one can both end up in m_pendingChanges.appends. The removal root
+// subtree snapshot and the new one can both end up in m_committedChanges.appends. The removal root
 // may not yet be in the node map, so deleteSubtree won't encounter it, and removeStaleAppends is what
 // keeps the stale snapshot from being applied.
 //
-// More generally, a batch of pending changes carries appends and subtree removals in two separate
-// vectors, and the same AXID can legitimately appear in both. Two independent guards keep that from
+// More generally, a committed batch carries appends and subtree removals in two separate vectors,
+// and the same AXID can legitimately appear in both. Two independent guards keep that from
 // corrupting the tree, and it's worth being precise about which does what, because they serve
 // different purposes.
 //
 //   m_protectedFromDeletionIDs  "don't destroy a live object"
 //   removeStaleAppends          "don't resurrect a dead one"
 //
-// They also run at different times. applyPendingChanges applies removals first, destroying
+// They also run at different times. applyCommittedChanges applies removals first, destroying
 // objects as it goes, and only then calls removeStaleAppends to filter the appends. So by the
 // time we get here, destruction has already happened (unless m_protectedFromDeletionIDs saved the object).
 //
@@ -1553,7 +1555,7 @@ void AXIsolatedTree::clearTreeContentsLocked()
 // Ref to this tree. The FrameHost replacement described at the top of this comment is an instance
 // of this shape -- a removal root that was never applied, and so is absent from the node map.
 //
-// Scenario 3: The same parent, removed and then re-added. Pending changes accumulate until the
+// Scenario 3: The same parent, removed and then re-added. Committed changes accumulate until the
 // AX thread applies them, so decisions from two main-thread cycles can share one batch.
 //
 //     owner.setAttribute("aria-owns", "child");  // cycle 1: remove child from parent,
@@ -1699,66 +1701,181 @@ void AXIsolatedTree::deleteSubtree(Ref<AXCoreObject>&& coreObjectToDelete, const
     }
 }
 
-AXIsolatedTree::PendingChanges AXIsolatedTree::takePendingChangesLocked()
+void AXIsolatedTree::PendingChanges::merge(PendingChanges&& source)
+{
+    // Vector concatenation: order matters for removeStaleAppends, and for the
+    // last-write-wins semantics that propertyChanges and childrenUpdates rely on
+    // when applyCommittedChanges replays them. When the destination is empty (the
+    // common case immediately after the AX thread takes a snapshot), move the
+    // source vector into place instead of allocating + copying.
+    auto mergeVector = [](auto& destinationVector, auto&& sourceVector) {
+        if (destinationVector.isEmpty())
+            destinationVector = WTF::move(sourceVector);
+        else
+            destinationVector.appendVector(WTF::move(sourceVector));
+    };
+    mergeVector(appends, WTF::move(source.appends));
+    mergeVector(subtreeRemovals, WTF::move(source.subtreeRemovals));
+    mergeVector(propertyChanges, WTF::move(source.propertyChanges));
+    mergeVector(childrenUpdates, WTF::move(source.childrenUpdates));
+
+    // Set/map union: idempotent for protectedFromDeletionIDs; overwrite-by-key for parentUpdates.
+    // As an optimization, when the destination is empty, move-assign instead of element-by-element merge.
+    if (protectedFromDeletionIDs.isEmpty())
+        protectedFromDeletionIDs = WTF::move(source.protectedFromDeletionIDs);
+    else
+        protectedFromDeletionIDs.addAll(source.protectedFromDeletionIDs);
+
+    if (parentUpdates.isEmpty())
+        parentUpdates = WTF::move(source.parentUpdates);
+    else {
+        for (auto& parentUpdate : source.parentUpdates)
+            parentUpdates.set(parentUpdate.key, parentUpdate.value);
+    }
+
+    // Last-write-wins: only overwrite if source wrote a value this cycle. Otherwise the
+    // destination's existing value (which may be persistent state preserved across cycles,
+    // e.g. focusedNodeID and rootNodeID) is left untouched. Works for Markable and
+    // std::optional alike, since both are falsy when unset.
+    auto mergeIfSet = [](auto& destination, auto&& sourceValue) {
+        if (sourceValue)
+            destination = WTF::move(sourceValue);
+    };
+    mergeIfSet(focusedNodeID, WTF::move(source.focusedNodeID));
+    mergeIfSet(rootNodeID, WTF::move(source.rootNodeID));
+    mergeIfSet(selectedTextMarkerRange, WTF::move(source.selectedTextMarkerRange));
+    mergeIfSet(sortedLiveRegionIDs, WTF::move(source.sortedLiveRegionIDs));
+    mergeIfSet(sortedNonRootWebAreaIDs, WTF::move(source.sortedNonRootWebAreaIDs));
+    mergeIfSet(mostRecentlyPaintedText, WTF::move(source.mostRecentlyPaintedText));
+    mergeIfSet(relations, WTF::move(source.relations));
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    mergeIfSet(frameGeometry, WTF::move(source.frameGeometry));
+    mergeIfSet(frameViewOriginScrollPosition, WTF::move(source.frameViewOriginScrollPosition));
+#endif
+}
+
+void AXIsolatedTree::scheduleQueuedNodeUpdateProcessing()
+{
+    AX_ASSERT(isMainThread());
+
+    m_hasQueuedNodeUpdates = true;
+    if (CheckedPtr cache = axObjectCache())
+        cache->startUpdateTreeSnapshotTimer();
+}
+
+void AXIsolatedTree::commitWorkingChangesLocked()
+{
+    AX_ASSERT(isMainThread());
+    AX_ASSERT(m_changeLogLock.isLocked());
+
+    m_committedChanges.merge(std::exchange(m_workingChanges, { }));
+    m_workingChangesDirty = false;
+    // m_hasPendingChanges is only ever written under the lock, from either thread, so that its
+    // state is exactly paired with the merge into / take from m_committedChanges. This isn't
+    // about memory ordering (the atomic covers that), it's mutual exclusion against
+    // takeCommittedChangesLocked. Writing it outside the lock would let the AX thread observe
+    // hasPendingChanges() == false while m_committedChanges actually holds committed changes,
+    // leaving them unapplied until the next commit.
+    m_hasPendingChanges.store(true);
+}
+
+AXIsolatedTree::ShouldEagerlyApply AXIsolatedTree::commitWorkingChanges()
+{
+    AX_ASSERT(isMainThread());
+
+    // Check before taking the lock, so a clean buffer costs nothing.
+    if (!m_workingChangesDirty)
+        return ShouldEagerlyApply::No;
+
+    Locker locker { m_changeLogLock };
+    commitWorkingChangesLocked();
+#if ENABLE(ACCESSIBILITY_THREAD_DISPATCHING)
+    // Claim the eager-apply dispatch if the AX thread isn't already applying, or queued to
+    // apply, the committed changes. Claimed here rather than in commitWorkingChangesLocked()
+    // because only callers that go on to dispatch should take the claim.
+    if (std::exchange(m_appliedOrApplyingCommittedChanges, false))
+        return ShouldEagerlyApply::Yes;
+#endif
+    return ShouldEagerlyApply::No;
+}
+
+void AXIsolatedTree::dispatchEagerApplyIfNeeded(ShouldEagerlyApply shouldEagerlyApply)
+{
+    AX_ASSERT(isMainThread());
+
+#if ENABLE(ACCESSIBILITY_THREAD_DISPATCHING)
+    if (shouldEagerlyApply == ShouldEagerlyApply::No)
+        return;
+
+    std::ignore = callOnAXThread([protectedThis = Ref { *this }] {
+        protectedThis->applyPendingChanges();
+    });
+#else
+    UNUSED_PARAM(shouldEagerlyApply);
+#endif
+}
+
+AXIsolatedTree::PendingChanges AXIsolatedTree::takeCommittedChangesLocked()
 {
     AX_ASSERT(m_changeLogLock.isLocked());
 
-    auto snapshot = std::exchange(m_pendingChanges, { });
+    auto committedChanges = std::exchange(m_committedChanges, { });
 
     // focusedNodeID and rootNodeID represent persistent state (not a queue), so preserve them
-    // across snapshots. Otherwise they get reset to empty and incorrectly clear the focused / root
-    // node on the next apply cycle. Re-sending the root every snapshot also lets the accessibility
+    // across cycles. Otherwise they get reset to empty and incorrectly clear the focused / root
+    // node on the next apply cycle. Re-sending the root every cycle also lets the accessibility
     // thread re-affirm (and, if it ever drifted, repair) the root on every apply.
-    m_pendingChanges.focusedNodeID = snapshot.focusedNodeID;
-    m_pendingChanges.rootNodeID = snapshot.rootNodeID;
+    m_committedChanges.focusedNodeID = committedChanges.focusedNodeID;
+    m_committedChanges.rootNodeID = committedChanges.rootNodeID;
 
     m_hasPendingChanges.store(false);
 #if ENABLE(ACCESSIBILITY_THREAD_DISPATCHING)
-    m_appliedOrApplyingMainThreadSnapshot.store(true, std::memory_order_relaxed);
+    m_appliedOrApplyingCommittedChanges = true;
 #endif
-    return snapshot;
+    return committedChanges;
 }
 
-void AXIsolatedTree::applyPendingChangesFromSnapshot(PendingChanges&& snapshot)
+void AXIsolatedTree::applyCommittedChanges(PendingChanges&& committedChanges)
 {
-    AXTRACE("AXIsolatedTree::applyPendingChanges"_s);
+    AXTRACE("AXIsolatedTree::applyCommittedChanges"_s);
     AX_ASSERT(!isMainThread());
 
     if (AXObjectCache::isAppleInternalInstall()) [[unlikely]]
-        WTFBeginSignpostAlways(this, AccessibilityIsolatedTreeApplyPendingChanges, "tree ID: %" PRIVATE_LOG_STRING "", treeID().loggingString().utf8().data());
+        WTFBeginSignpostAlways(this, AccessibilityIsolatedTreeApplyCommittedChanges, "tree ID: %" PRIVATE_LOG_STRING "", treeID().loggingString().utf8().data());
 
     // Any structural change can affect some ancestor's stitchedUnignoredChildren result.
     // Property changes that could affect the unignored-children result (IsIgnored, StitchGroups, etc.)
     // are detected and cleared later, fused into the property-apply loop.
-    const bool hasTreeStructureChange = !snapshot.appends.isEmpty()
-        || !snapshot.subtreeRemovals.isEmpty()
-        || !snapshot.childrenUpdates.isEmpty()
-        || !snapshot.parentUpdates.isEmpty();
+    const bool hasTreeStructureChange = !committedChanges.appends.isEmpty()
+        || !committedChanges.subtreeRemovals.isEmpty()
+        || !committedChanges.childrenUpdates.isEmpty()
+        || !committedChanges.parentUpdates.isEmpty();
     if (hasTreeStructureChange)
         m_cachedUnignoredChildren.clear();
 
-    if (snapshot.focusedNodeID != m_focusedNodeID) {
-        AXLOG(makeString("focusedNodeID "_s, m_focusedNodeID ? m_focusedNodeID->loggingString() : ""_str, " pendingFocusedNodeID "_s, snapshot.focusedNodeID ? snapshot.focusedNodeID->loggingString() : ""_str));
-        m_focusedNodeID = snapshot.focusedNodeID;
+    if (committedChanges.focusedNodeID && *committedChanges.focusedNodeID != m_focusedNodeID) {
+        AXLOG(makeString("focusedNodeID "_s, m_focusedNodeID ? m_focusedNodeID->loggingString() : ""_str, " pendingFocusedNodeID "_s, *committedChanges.focusedNodeID ? (*committedChanges.focusedNodeID)->loggingString() : ""_str));
+        m_focusedNodeID = *committedChanges.focusedNodeID;
     }
 
-    // Snapshot the IDs pending subtree removal before processing, so we can
-    // use them to filter stale nodes from snapshot.appends afterwards. This is
-    // necessary because a pending removal root may not yet be in the node map
-    // (e.g. when an in-process FrameHost is replaced with an out-of-process
-    // one during site isolation), so deleteSubtree won't encounter it.
-    for (const auto& removal : snapshot.subtreeRemovals) {
-        if (snapshot.protectedFromDeletionIDs.contains(removal.nodeID))
+    // Capture the IDs pending subtree removal before processing, so we can
+    // use them to filter stale nodes from committedChanges.appends afterwards.
+    // This is necessary because a pending removal root may not yet be in the
+    // node map (e.g. when an in-process FrameHost is replaced with an
+    // out-of-process one during site isolation), so deleteSubtree won't
+    // encounter it.
+    for (const auto& removal : committedChanges.subtreeRemovals) {
+        if (committedChanges.protectedFromDeletionIDs.contains(removal.nodeID))
             continue;
 
         if (RefPtr object = m_readerThreadNodeMap.take(removal.nodeID))
-            deleteSubtree(object.releaseNonNull(), snapshot.protectedFromDeletionIDs);
+            deleteSubtree(object.releaseNonNull(), committedChanges.protectedFromDeletionIDs);
     }
 
-    if (!snapshot.subtreeRemovals.isEmpty())
-        removeStaleAppends(snapshot.subtreeRemovals, snapshot.appends);
+    if (!committedChanges.subtreeRemovals.isEmpty())
+        removeStaleAppends(committedChanges.subtreeRemovals, committedChanges.appends);
 
-    for (auto& item : snapshot.appends) {
+    for (auto& item : committedChanges.appends) {
         auto axID = item.data.axID;
         AXLOG(makeString("appending axID "_s, axID.loggingString()));
 
@@ -1783,23 +1900,23 @@ void AXIsolatedTree::applyPendingChangesFromSnapshot(PendingChanges&& snapshot)
         // Can hit this on many tests with ITM + ENABLE_ACCESSIBILITY_LOCAL_FRAME (e.g. accessibility/deleting-iframe-destroys-axcache.html).
         AX_BROKEN_ASSERT(object->wrapper());
         // The reference count of the just added IsolatedObject must be 2
-        // because it is referenced by m_readerThreadNodeMap and the snapshot's appends.
-        // When the snapshot is destroyed, the object will be held only by m_readerThreadNodeMap. The exception is the root node whose reference count is 3.
+        // because it is referenced by m_readerThreadNodeMap and committedChanges.appends.
+        // When committedChanges goes out of scope, the object will be held only by m_readerThreadNodeMap. The exception is the root node whose reference count is 3.
     }
 
-    for (const auto& parentUpdate : snapshot.parentUpdates) {
+    for (const auto& parentUpdate : committedChanges.parentUpdates) {
         if (auto* object = objectForID(parentUpdate.key))
             object->setParent(parentUpdate.value);
     }
 
-    for (auto& update : snapshot.childrenUpdates) {
+    for (auto& update : committedChanges.childrenUpdates) {
         AXLOG(makeString("updating children for axID "_s, update.first.loggingString()));
         if (RefPtr object = objectForID(update.first))
             object->setChildrenIDs(WTF::move(update.second));
     }
 
     bool hasUnignoredChildrenAffectingPropertyChange = false;
-    for (auto& change : snapshot.propertyChanges) {
+    for (auto& change : committedChanges.propertyChanges) {
         if (RefPtr object = objectForID(change.axID)) {
             for (auto& property : change.properties) {
                 if (!hasTreeStructureChange && !hasUnignoredChildrenAffectingPropertyChange) {
@@ -1825,32 +1942,34 @@ void AXIsolatedTree::applyPendingChangesFromSnapshot(PendingChanges&& snapshot)
         m_cachedUnignoredChildren.clear();
     }
 
-    if (snapshot.sortedLiveRegionIDs)
-        m_sortedLiveRegionIDs = WTF::move(*snapshot.sortedLiveRegionIDs);
+    if (committedChanges.sortedLiveRegionIDs)
+        m_sortedLiveRegionIDs = WTF::move(*committedChanges.sortedLiveRegionIDs);
 
-    if (snapshot.sortedNonRootWebAreaIDs)
-        m_sortedNonRootWebAreaIDs = WTF::move(*snapshot.sortedNonRootWebAreaIDs);
+    if (committedChanges.sortedNonRootWebAreaIDs)
+        m_sortedNonRootWebAreaIDs = WTF::move(*committedChanges.sortedNonRootWebAreaIDs);
 
-    if (snapshot.mostRecentlyPaintedText)
-        m_mostRecentlyPaintedText = WTF::move(*snapshot.mostRecentlyPaintedText);
+    if (committedChanges.mostRecentlyPaintedText)
+        m_mostRecentlyPaintedText = WTF::move(*committedChanges.mostRecentlyPaintedText);
 
-    if (snapshot.relations)
-        m_relations = WTF::move(*snapshot.relations);
+    if (committedChanges.relations)
+        m_relations = WTF::move(*committedChanges.relations);
 
-    if (snapshot.selectedTextMarkerRange)
-        m_selectedTextMarkerRange = WTF::move(*snapshot.selectedTextMarkerRange);
+    if (committedChanges.selectedTextMarkerRange)
+        m_selectedTextMarkerRange = WTF::move(*committedChanges.selectedTextMarkerRange);
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    if (snapshot.frameGeometry) {
-        m_frameGeometry = WTF::move(*snapshot.frameGeometry);
+    if (committedChanges.frameGeometry) {
+        m_frameGeometry = WTF::move(*committedChanges.frameGeometry);
         m_hasReceivedFrameGeometry = true;
     }
-    if (snapshot.frameViewOriginScrollPosition)
-        m_frameViewOriginScrollPosition = *snapshot.frameViewOriginScrollPosition;
+    if (committedChanges.frameViewOriginScrollPosition)
+        m_frameViewOriginScrollPosition = *committedChanges.frameViewOriginScrollPosition;
 #endif
 
-    if (snapshot.rootNodeID != m_rootNodeID) {
-        m_rootNodeID = snapshot.rootNodeID;
+    // Do this at the end because it requires looking up the root node by ID (in the assert below),
+    // so doing it at the end ensures all additions to m_readerThreadNodeMap have been made by now.
+    if (committedChanges.rootNodeID != m_rootNodeID) {
+        m_rootNodeID = committedChanges.rootNodeID;
 
 #if ASSERT_ENABLED
         // Check that the applied tree is fully reachable from the root. For performance, only do this
@@ -1873,26 +1992,25 @@ void AXIsolatedTree::applyPendingChangesFromSnapshot(PendingChanges&& snapshot)
     }
 
     if (AXObjectCache::isAppleInternalInstall()) [[unlikely]]
-        WTFEndSignpostAlways(this, AccessibilityIsolatedTreeApplyPendingChanges, "tree ID: %" PRIVATE_LOG_STRING "", treeID().loggingString().utf8().data());
+        WTFEndSignpostAlways(this, AccessibilityIsolatedTreeApplyCommittedChanges, "tree ID: %" PRIVATE_LOG_STRING "", treeID().loggingString().utf8().data());
 }
 
 void AXIsolatedTree::sortedLiveRegionsDidChange(Vector<AXID> liveRegionIDs)
 {
     AX_ASSERT(isMainThread());
 
-    Locker locker { m_changeLogLock };
-    mutablePendingChanges()->sortedLiveRegionIDs = WTF::move(liveRegionIDs);
+    markDirtyAndGetWorkingChanges().sortedLiveRegionIDs = WTF::move(liveRegionIDs);
 }
 
 void AXIsolatedTree::sortedNonRootWebAreasDidChange(Vector<AXID> webAreaIDs)
 {
     AX_ASSERT(isMainThread());
 
-    Locker locker { m_changeLogLock };
-    // FIXME: m_pendingChanges.sortedLiveRegionIDs and m_pendingChanges.sortedNonRootWebAreaIDs should be synced in AXIsolatedTree::processQueuedNodeUpdates(),
-    // not ad-hoc whenever the main-thread changes them. Otherwise we could sync IDs to the accessibility thread that don't have isolated objects
-    // until the next actual tree-update cycle.
-    mutablePendingChanges()->sortedNonRootWebAreaIDs = WTF::move(webAreaIDs);
+    // FIXME: PendingChanges::sortedLiveRegionIDs and PendingChanges::sortedNonRootWebAreaIDs
+    // should be synced in AXIsolatedTree::processQueuedNodeUpdates(), not ad-hoc whenever the
+    // main-thread changes them. Otherwise we could sync IDs to the accessibility thread that don't
+    // have isolated objects until the next actual tree-update cycle.
+    markDirtyAndGetWorkingChanges().sortedNonRootWebAreaIDs = WTF::move(webAreaIDs);
 }
 
 AXTreePtr findAXTree(Function<bool(AXTreePtr)>&& match)
@@ -1950,8 +2068,7 @@ void AXIsolatedTree::queueNodeUpdate(AXID objectID, const NodeUpdateOptions& opt
     if (options.shouldUpdateNode)
         m_needsUpdateNode.add(objectID);
 
-    if (CheckedPtr cache = axObjectCache())
-        cache->startUpdateTreeSnapshotTimer();
+    scheduleQueuedNodeUpdateProcessing();
 }
 
 void AXIsolatedTree::queueNodeRemoval(const AccessibilityObject& axObject)
@@ -1972,17 +2089,26 @@ void AXIsolatedTree::queueNodeRemoval(const AccessibilityObject& axObject)
     std::optional<AXID> parentID = parent ? std::optional { parent->objectID() } : std::nullopt;
 
     m_needsNodeRemoval.add(axObject.objectID(), parentID);
-    if (axObjectCache)
-        axObjectCache->startUpdateTreeSnapshotTimer();
+    scheduleQueuedNodeUpdateProcessing();
 }
 
 void AXIsolatedTree::processQueuedNodeUpdates()
 {
     AX_ASSERT(isMainThread());
 
-    WeakPtr cache = axObjectCache();
-    if (!cache)
+    // Early-out so a scheduled tick does no work in the common case where nothing has been queued.
+    if (!m_hasQueuedNodeUpdates)
         return;
+
+    WeakPtr cache = axObjectCache();
+    if (!cache) {
+        // Leave m_hasQueuedNodeUpdates set so a later tick (with a non-null
+        // cache) processes the queued work instead of stranding it.
+        return;
+    }
+    m_hasQueuedNodeUpdates = false;
+
+    SetForScope processingScope(m_isProcessingQueuedNodeUpdates, true);
 
     if (AXObjectCache::isAppleInternalInstall()) [[unlikely]]
         WTFBeginSignpostAlways(this, UpdateAccessibilityIsolatedTree, "updating isolated tree for AXObjectCache: %" PRIVATE_LOG_STRING "", cache ? CheckedPtr { cache }->debugDescription().utf8().data() : "null");
@@ -2025,37 +2151,12 @@ void AXIsolatedTree::processQueuedNodeUpdates()
 
     if (m_mostRecentlyPaintedTextIsDirty) {
         m_mostRecentlyPaintedTextIsDirty = false;
-        // Resolving `mostRecentlyPaintedText()` can result in this sequence:
-        //   1. AXObjectCache::getOrCreate, which calls AccessibilityObject::recomputeIsIgnored
-        //   2. If the ignored state changes, AXObjectCache::objectBecameUnignored may be called
-        //   3. AXIsolatedTree::treeForFrameID() will be called to try to inform the isolated tree
-        //      of this change, which requires taking AXTreeStore::s_storeLock.
-        //
-        // If we (the main-thread) held the m_changeLogLock when the above sequence happened, we would deadlock
-        // if the accessibility thread was simultaneously running applyPendingChangesForAllIsolatedTrees(), which
-        // holds the s_storeLock for the length of the function. The main-thread would be waiting on the storeLock,
-        // and the accessibility thread would be waiting on the m_changeLogLock to run AXIsolatedTree::applyPendingChanges()
-        // while holding the s_storeLock. Thus, a deadlock.
-        //
-        // So it's crucial to resolve the mostRecentlyPaintedText structure before the m_changeLogLock critical section,
-        // and only perform a move or copy while in the critical section to avoid a deadlock.
-        auto mostRecentlyPaintedText = cache ? cache->mostRecentlyPaintedText() : HashMap<AXID, LineRange> { };
-        Locker lock { m_changeLogLock };
-        mutablePendingChanges()->mostRecentlyPaintedText = WTF::move(mostRecentlyPaintedText);
+        markDirtyAndGetWorkingChanges().mostRecentlyPaintedText = cache ? cache->mostRecentlyPaintedText() : HashMap<AXID, LineRange> { };
     }
 
     queueRemovalsAndUnresolvedChanges();
 
-#if ENABLE(ACCESSIBILITY_THREAD_DISPATCHING)
-    if (hasPendingChanges() && m_appliedOrApplyingMainThreadSnapshot.exchange(false, std::memory_order_relaxed)) {
-        // Eagerly try to applyPendingChanges so we don't have to do it prior to
-        // serving a client request, providing improved responsiveness.
-        // Only queue this up if one isn't already queued up.
-        std::ignore = callOnAXThread([protectedThis = Ref { *this }] {
-            protectedThis->applyPendingChanges();
-        });
-    }
-#endif // ENABLE(ACCESSIBILITY_THREAD_DISPATCHING)
+    dispatchEagerApplyIfNeeded(commitWorkingChanges());
 
     if (AXObjectCache::isAppleInternalInstall()) [[unlikely]]
         WTFEndSignpostAlways(this, UpdateAccessibilityIsolatedTree);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -533,22 +533,30 @@ public:
         objectChangedIgnoredState(object);
     }
 
-    // Both setPendingRootNodeLocked and setFocusedNodeID are called during the generation
-    // of the IsolatedTree.
-    // Focused node updates in AXObjectCache use setFocusNodeID.
+    // Main-thread setters that route writes through m_workingChanges.
+    // Published to the AX thread on the next commitWorkingChanges().
     void setPendingRootNodeID(AXID);
-    void NODELETE setPendingRootNodeIDLocked(AXID) WTF_REQUIRES_LOCK(m_changeLogLock);
     void setFocusedNodeID(std::optional<AXID>);
 
     // Relationships between objects.
     std::optional<ListHashSet<AXID>> relatedObjectIDsFor(const AXIsolatedObject&, AXRelation);
-    void markRelationsDirty() { m_relationsNeedUpdate = true; }
+    void markRelationsDirty()
+    {
+        AX_ASSERT(isMainThread());
+        m_relationsNeedUpdate = true;
+        scheduleQueuedNodeUpdateProcessing();
+    }
     void updateRelations(HashMap<AXID, AXRelations>&&);
 
     AXCoreObject::AccessibilityChildrenVector sortedLiveRegions();
     AXCoreObject::AccessibilityChildrenVector sortedNonRootWebAreas();
 
-    void markMostRecentlyPaintedTextDirty() { m_mostRecentlyPaintedTextIsDirty = true; }
+    void markMostRecentlyPaintedTextDirty()
+    {
+        AX_ASSERT(isMainThread());
+        m_mostRecentlyPaintedTextIsDirty = true;
+        scheduleQueuedNodeUpdateProcessing();
+    }
     const HashMap<AXID, LineRange>& mostRecentlyPaintedText() const LIFETIME_BOUND { return m_mostRecentlyPaintedText; }
 
     // Called on AX thread from WebAccessibilityObjectWrapper methods.
@@ -659,7 +667,14 @@ private:
     };
 
     struct PendingChanges {
-        Markable<AXID> focusedNodeID;
+        // std::nullopt means "focus wasn't written this cycle", so the destination's existing
+        // value is preserved by merge(). A non-std::nullopt + empty Markable means "focus was
+        // explicitly cleared" and propagates the null Markable.
+        std::optional<Markable<AXID>> focusedNodeID;
+        // A plain Markable rather than an optional like focusedNodeID above, because the root is
+        // never cleared. setPendingRootNodeID takes an AXID, not an optional one, so "cleared" is
+        // unrepresentable. If a clearing setter is ever added, this needs the same optional treatment
+        // as focusedNodeID, or the clear would look like "not written" and be dropped by merge().
         Markable<AXID> rootNodeID;
         Vector<NodeChange> appends;
         Vector<AXPropertyChange> propertyChanges;
@@ -676,43 +691,47 @@ private:
         std::optional<AXFrameGeometry> frameGeometry;
         std::optional<IntPoint> frameViewOriginScrollPosition;
 #endif
+
+        // Merges source's per-field state into this one, using field-specific semantics
+        // derived from how applyCommittedChanges consumes each field.
+        void merge(PendingChanges&& source);
     };
 
-    class PendingChangesAccessor {
-        WTF_MAKE_NONCOPYABLE(PendingChangesAccessor);
-    public:
-        PendingChangesAccessor(PendingChanges& data, std::atomic<bool>& flagToSetOnCompletion)
-            : m_data(data), m_flagToSetOnCompletion(flagToSetOnCompletion) { }
-        ~PendingChangesAccessor()
-        {
-            // Don't create a PendingChangesAccessor without using it — the destructor
-            // unconditionally sets m_hasPendingChanges, so unused accessors cause
-            // false-positive dirty flags.
-            AX_ASSERT(m_wasAccessed);
-            m_flagToSetOnCompletion.store(true);
-        }
-        PendingChanges* operator->()
-        {
-#if ASSERT_ENABLED
-            m_wasAccessed = true;
-#endif
-            return &m_data;
-        }
-    private:
-        PendingChanges& m_data;
-        std::atomic<bool>& m_flagToSetOnCompletion;
-#if ASSERT_ENABLED
-        bool m_wasAccessed { false };
-#endif
-    };
-
-    PendingChangesAccessor mutablePendingChanges() WTF_REQUIRES_LOCK(m_changeLogLock)
+    // Returns a direct reference to m_workingChanges, the main-thread-only buffer that
+    // accumulates writes between AX thread handoff points. As the name says, this marks the
+    // buffer dirty, so only call it when you actually intend to write to the buffer.
+    PendingChanges& markDirtyAndGetWorkingChanges()
     {
-        return { m_pendingChanges, m_hasPendingChanges };
+        AX_ASSERT(isMainThread());
+        m_workingChangesDirty = true;
+        // Any change to m_workingChanges needs processing in processQueuedNodeUpdates(), so
+        // make sure a cycle is scheduled if we aren't already in the middle of doing one.
+        // Without this flag, we would reschedule processQueuedNodeUpdates() infinitely.
+        if (!m_isProcessingQueuedNodeUpdates)
+            scheduleQueuedNodeUpdateProcessing();
+        return m_workingChanges;
     }
 
-    PendingChanges takePendingChangesLocked() WTF_REQUIRES_LOCK(m_changeLogLock);
-    void applyPendingChangesFromSnapshot(PendingChanges&&);
+    // Marks that processQueuedNodeUpdates() has work to do and schedules a tick to run it.
+    void scheduleQueuedNodeUpdateProcessing();
+
+    enum class ShouldEagerlyApply : bool { No, Yes };
+    // Atomically publishes m_workingChanges into m_committedChanges so the AX thread sees a
+    // single logical work-cycle as an indivisible state change. Returns whether the caller
+    // should dispatch an eager apply to the AX thread (i.e. whether the AX thread isn't
+    // already applying, or queued to apply, the committed changes). Always No when
+    // ACCESSIBILITY_THREAD_DISPATCHING is disabled.
+    [[nodiscard]] ShouldEagerlyApply commitWorkingChanges();
+
+    // The publish half of commitWorkingChanges(), for callers that already hold the lock.
+    void commitWorkingChangesLocked() WTF_REQUIRES_LOCK(m_changeLogLock);
+
+    // Eagerly applies the committed changes on the AX thread so we don't have to do it prior to
+    // serving a client request, providing improved responsiveness.
+    void dispatchEagerApplyIfNeeded(ShouldEagerlyApply);
+
+    PendingChanges takeCommittedChangesLocked() WTF_REQUIRES_LOCK(m_changeLogLock);
+    void applyCommittedChanges(PendingChanges&&);
     void removeStaleAppends(const Vector<NodeAndParentID>&, Vector<NodeChange>&);
 
     void updateChildren(AccessibilityObject&, ResolveNodeChanges = ResolveNodeChanges::Yes);
@@ -722,9 +741,8 @@ private:
     std::optional<NodeChange> nodeChangeForObject(Ref<AccessibilityObject>, std::optional<uint64_t> sequence = std::nullopt);
     void collectNodeChangesForSubtree(AccessibilityObject&);
     bool isCollectingNodeChanges() const { return m_isCollectingNodeChanges; }
-    void queueChange(NodeChange&&) WTF_REQUIRES_LOCK(m_changeLogLock);
+    void queueChange(NodeChange&&);
     void queueRemovals(Vector<NodeAndParentID>&&);
-    void queueRemovalsLocked(Vector<NodeAndParentID>&&) WTF_REQUIRES_LOCK(m_changeLogLock);
     void queueRemovalsAndUnresolvedChanges();
     Vector<NodeChange> resolveAppends();
     void queueAppendsAndRemovals(Vector<NodeChange>&&, Vector<NodeAndParentID>&&);
@@ -780,10 +798,26 @@ private:
     Markable<AXID> m_rootNodeID;
 
     // Written to by main thread under lock, accessed and applied by AX thread.
-    PendingChanges m_pendingChanges WTF_GUARDED_BY_LOCK(m_changeLogLock);
+    PendingChanges m_committedChanges WTF_GUARDED_BY_LOCK(m_changeLogLock);
+
+    // Main-thread-only buffer that accumulates writes between commit points.
+    // commitWorkingChanges() merges it into m_committedChanges under lock.
+    PendingChanges m_workingChanges;
+
+    // Main thread only. True when m_workingChanges holds writes that haven't been merged into
+    // m_committedChanges yet. Cleared by commitWorkingChanges().
+    bool m_workingChangesDirty { false };
+
+    // Main thread only. True when there is work for processQueuedNodeUpdates() to do, i.e.
+    // a working-buffer write, an entry in one of the m_needs* queues, or a relations /
+    // painted-text dirty mark.
+    bool m_hasQueuedNodeUpdates { false };
+
+    // Main thread only. True while inside processQueuedNodeUpdates().
+    bool m_isProcessingQueuedNodeUpdates { false };
 
     // Main thread only. Marks appends and subtree removals with the order in which the main
-    // thread decided on them. applyPendingChanges replays appends and removals from separate
+    // thread decided on them. applyCommittedChanges replays appends and removals from separate
     // vectors, so their relative order isn't otherwise recoverable, and removeStaleAppends needs
     // it to tell a leftover append apart from a re-add that happened after the removal.
     uint64_t nextChangeSequence()
@@ -793,23 +827,30 @@ private:
     }
     uint64_t m_lastChangeSequence { 0 };
 
-    // These are placed here to fit in padding that would otherwise be between m_pendingSortedLiveRegionIDs and m_pendingSortedNonRootWebAreaIDs.
+    // These small members are grouped here to fit into padding gaps in the layout.
     OptionSet<ActivityState> m_pageActivityState;
     bool m_isEmptyContentTree { false };
     bool m_queuedForDestruction WTF_GUARDED_BY_LOCK(m_changeLogLock) { false };
     bool m_isMainFrame { false };
     bool m_siteIsolationEnabled { false };
+#if ENABLE(ACCESSIBILITY_THREAD_DISPATCHING)
+    // Dispatch-dedup hint for the eager applyPendingChanges in dispatchEagerApplyIfNeeded. True
+    // means no dispatch is outstanding. Claimed (set false) by commitWorkingChanges on the main
+    // thread and released (set true) by takeCommittedChangesLocked on the AX thread, both under
+    // m_changeLogLock. Mutating it under the lock, alongside its accompanying m_hasPendingChanges
+    // state-change, is what keeps the main thread's "commit + claim the dispatch" atomic against
+    // the AX thread's "take + release the dispatch".
+    bool m_appliedOrApplyingCommittedChanges WTF_GUARDED_BY_LOCK(m_changeLogLock) { true };
+#endif
 
     Markable<AXID> m_focusedNodeID;
     std::atomic<double> m_loadingProgress { 0 };
     std::atomic<double> m_processingProgress { 1 };
+    // Written only under m_changeLogLock, but read without it, so it can't be WTF_GUARDED_BY_LOCK.
     std::atomic<bool> m_hasPendingChanges { false };
 #if ENABLE(WRITING_TOOLS)
     std::atomic<bool> m_writingToolsAvailable { false };
 #endif // ENABLE(WRITING_TOOLS)
-#if ENABLE(ACCESSIBILITY_THREAD_DISPATCHING)
-    std::atomic<bool> m_appliedOrApplyingMainThreadSnapshot { true };
-#endif
 
     // Only accessed on the accessibility thread.
     Vector<AXID> m_sortedLiveRegionIDs;
@@ -817,9 +858,9 @@ private:
     HashMap<AXID, LineRange> m_mostRecentlyPaintedText;
     HashMap<AXID, AXRelations> m_relations;
     // Cache of unignoredChildren() results for AXIsolatedObjects. Populated lazily
-    // on cache miss; cleared in applyPendingChangesFromSnapshot when the incoming snapshot
-    // carries a change that could affect any unignored-children list (tree structure change,
-    // or IsIgnored / IsExposableTable / StitchGroups property update).
+    // on cache miss; cleared in applyCommittedChanges when the incoming committed
+    // changes carry a change that could affect any unignored-children list (tree
+    // structure change, or IsIgnored / IsExposableTable / StitchGroups property update).
     HashMap<AXID, CachedUnignoredChildren> m_cachedUnignoredChildren;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     AXFrameGeometry m_frameGeometry;


### PR DESCRIPTION
#### 30446586d80c473d54cc344b85404af37e1f536c
<pre>
AX: Atomically transfer pending tree updates from main thread to AX thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=316148">https://bugs.webkit.org/show_bug.cgi?id=316148</a>
<a href="https://rdar.apple.com/178573374">rdar://178573374</a>

Reviewed by Andres Gonzalez.

Before this change, every main-thread writer acquired m_changeLogLock briefly
to mutate m_pendingChanges directly. Because the lock was acquired and released
per-mutation rather than once per logical work cycle, the AX thread could take
a snapshot mid-update-cycle and observe partial state. As an example,
performDeferredCacheUpdate calls tree-&gt;setFocusedNodeID(X) (publishing focus
immediately), but X&apos;s append into m_pendingChanges-&gt;appends is still queued in
m_unresolvedPendingAppends and only materialized later by
processQueuedNodeUpdates. If the AX thread takes the snapshot between these two writes,
it observes focusedNodeID = X with no corresponding appends entry and reports
focus on a node that isn&apos;t in m_readerThreadNodeMap.

This commit reshapes main-thread writes so the AX thread can never observe a
partial update. Introduce a two-buffer model:

  - m_workingChanges: main-thread-only, no lock. Writes accumulate here via
    markDirtyAndGetWorkingChanges().
  - m_committedChanges: cross-thread, guarded by m_changeLogLock. The AX thread
    reads only this buffer, via takeCommittedChangesLocked().

commitWorkingChanges() merges working into committed in a single critical
section via PendingChanges::merge(), so a logical work cycle becomes one
indivisible state change. Field-specific merge semantics mirror how
applyCommittedChanges consumes each field. Vectors concatenate, sets and maps
union, and last-write-wins fields only overwrite when the source wrote this
cycle.

The one-shot scheduleQueuedNodeUpdateProcessing() timer drops from 100ms to 17ms, so a
batch is processed roughly one frame after its first change.

The eager-apply dedup flag (m_appliedOrApplyingCommittedChanges) becomes a plain bool
guarded by m_changeLogLock, and is modified inside the same lock-section that commits
the working changes.

* Source/WTF/wtf/SystemTracing.h:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::unignoredChildren):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onAccessibilityPaintFinished):
(WebCore::AXObjectCache::dirtyIsolatedTreeRelations):
(WebCore::AXObjectCache::startUpdateTreeSnapshotTimer):
(WebCore::AXObjectCache::updateTreeSnapshotTimerFired):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXTreeStore.cpp:
(WebCore::AXTreeStore&lt;AXIsolatedTree&gt;::applyPendingChangesForAllIsolatedTrees):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::approximateHitTest const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmpty):
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::AXIsolatedTree::create):
(WebCore::AXIsolatedTree::storeTree):
(WebCore::AXIsolatedTree::removeTreeForFrameID):
(WebCore::AXIsolatedTree::queueChange):
(WebCore::AXIsolatedTree::addUnconnectedNode):
(WebCore::AXIsolatedTree::queueRemovals):
(WebCore::AXIsolatedTree::queueAppendsAndRemovals):
(WebCore::AXIsolatedTree::updateNode):
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::AXIsolatedTree::overrideNodeProperties):
(WebCore::AXIsolatedTree::pendingRootNodeID):
(WebCore::AXIsolatedTree::setPendingRootNodeID):
(WebCore::AXIsolatedTree::setFocusedNodeID):
(WebCore::AXIsolatedTree::updateRelations):
(WebCore::AXIsolatedTree::setSelectedTextMarkerRange):
(WebCore::AXIsolatedTree::setFrameGeometry):
(WebCore::AXIsolatedTree::updateFrame):
(WebCore::AXIsolatedTree::applyPendingChanges):
(WebCore::AXIsolatedTree::applyPendingChangesUnlessQueuedForDestruction):
(WebCore::AXIsolatedTree::applyPendingChangesOrTearDown):
(WebCore::AXIsolatedTree::clearTreeContentsLocked):
(WebCore::AXIsolatedTree::commitWorkingChanges):
(WebCore::AXIsolatedTree::takeCommittedChangesLocked):
(WebCore::AXIsolatedTree::applyCommittedChanges):
(WebCore::AXIsolatedTree::sortedLiveRegionsDidChange):
(WebCore::AXIsolatedTree::sortedNonRootWebAreasDidChange):
(WebCore::AXIsolatedTree::queueNodeUpdate):
(WebCore::AXIsolatedTree::queueNodeRemoval):
(WebCore::AXIsolatedTree::processQueuedNodeUpdates):
(WebCore::AXIsolatedTree::queueRemovalsLocked): Deleted.
(WebCore::AXIsolatedTree::setPendingRootNodeIDLocked): Deleted.
(WebCore::AXIsolatedTree::takePendingChangesLocked): Deleted.
(WebCore::AXIsolatedTree::applyPendingChangesFromSnapshot): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::markRelationsDirty):
(WebCore::AXIsolatedTree::markMostRecentlyPaintedTextDirty):
(WebCore::AXIsolatedTree::PendingChanges::setFocusedNodeID):
(WebCore::AXIsolatedTree::markDirtyAndGetWorkingChanges):
(WebCore::AXIsolatedTree::PendingChangesAccessor::PendingChangesAccessor): Deleted.
(WebCore::AXIsolatedTree::PendingChangesAccessor::~PendingChangesAccessor): Deleted.
(WebCore::AXIsolatedTree::PendingChangesAccessor::operator-&gt;): Deleted.
(WebCore::AXIsolatedTree::WTF_REQUIRES_LOCK): Deleted.

Canonical link: <a href="https://commits.webkit.org/319200@main">https://commits.webkit.org/319200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c8fa0de6f40967fc1a32256a5fe67ae6977d8de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190838 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144949 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3252316-50ed-4974-aa91-ce0834ac5368) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140883 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/601810d9-f7e0-4679-8852-df26d15b47cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121335 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d14c070c-dd1d-4dab-8b81-6e6d4ec23afc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43230 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41511 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3302 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10144 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153634 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; 1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41188 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1998 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/41901 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192774 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54238 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150259 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40250 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54926 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37805 "Too many flaky failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/contentextensions/video-element-resource-type.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/javascriptlink-frames.html, http/tests/navigation/post-redirect-get-reload.py, http/tests/resourceLoadStatistics/input-autofilled-user-interaction.html, http/tests/security/cached-cross-origin-shared-css-stylesheet.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/frame-src-about-blank-allowed-by-scheme.html, http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image-UpgradeMixedContent.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149977 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44598 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127191 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122406 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53443 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16181 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52825 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53062 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52890 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->