### PR TITLE
CookieStore: use the registration host/jar when removing the cookie change listener

### DIFF
--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -591,18 +591,13 @@ void CookieStore::stop()
     if (!m_hasChangeEventListener)
         return;
 
-    WeakPtr page = document->page();
-    if (!page)
-        return;
-
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-    auto host = document->url().host().toString();
-    if (host.isEmpty())
-        return;
-
-    protect(page->cookieJar())->removeChangeListener(host, *this);
+    if (RefPtr cookieJar = m_cookieJar)
+        cookieJar->removeChangeListener(m_host, *this);
 #endif
     m_hasChangeEventListener = false;
+    m_host = { };
+    m_cookieJar = nullptr;
 }
 
 bool CookieStore::virtualHasPendingActivity() const
@@ -627,26 +622,31 @@ void CookieStore::eventListenersDidChange()
     if (!document)
         return;
 
-    auto host = document->url().host().toString();
-    if (host.isEmpty())
-        return;
-
     bool hadChangeEventListener = m_hasChangeEventListener;
     m_hasChangeEventListener = hasEventListeners(eventNames().changeEvent);
 
     if (hadChangeEventListener == m_hasChangeEventListener)
         return;
 
-    WeakPtr page = document->page();
-    if (!page)
-        return;
-
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-    Ref cookieJar = page->cookieJar();
-    if (m_hasChangeEventListener)
+    if (m_hasChangeEventListener) {
+        auto host = document->url().host().toString();
+        RefPtr page = document->page();
+        if (host.isEmpty() || !page) {
+            m_hasChangeEventListener = false;
+            return;
+        }
+
+        Ref cookieJar = page->cookieJar();
         cookieJar->addChangeListener(*document, *this);
-    else
-        cookieJar->removeChangeListener(host, *this);
+        m_host = WTF::move(host);
+        m_cookieJar = cookieJar;
+    } else {
+        if (RefPtr cookieJar = m_cookieJar)
+            cookieJar->removeChangeListener(m_host, *this);
+        m_host = { };
+        m_cookieJar = nullptr;
+    }
 #endif
 }
 


### PR DESCRIPTION
#### cc35e71c66143f1777eb577bd3b81917356bd514
<pre>
CookieStore: use the registration host/jar when removing the cookie change listener
<a href="https://bugs.webkit.org/show_bug.cgi?id=316153">https://bugs.webkit.org/show_bug.cgi?id=316153</a>

Reviewed by Rupin Mittal.

CookieStore::eventListenersDidChange() and CookieStore::stop() recomputed
the host and cookie jar from the current Document state when removing a
cookie change listener, while WebCookieJar keys its listener map on the
host captured at addChangeListener() time. In practice a Document&apos;s URL
host does not change over its lifetime, so this has not been observed to
cause a leak, but the asymmetry is fragile: any future caller or context
where the host or page reference differs between add and remove time
would silently fail to unregister.

eventListenersDidChange() also returned early when the current host was
empty, before checking the listener-count transition, so a transition
back to &quot;no listener&quot; in an empty-host context would skip the remove
path entirely.

CookieStore already had unused m_host and m_cookieJar members that look
like the start of this fix; this change wires them up.

  - eventListenersDidChange() captures the host and cookie jar when a
    listener is added, and uses those stored values when the listener is
    later removed. The empty-host / no-page check now only short-circuits
    the add path, and resets m_hasChangeEventListener so we don&apos;t claim a
    registration we never made.
  - stop() removes via the stored m_cookieJar/m_host instead of
    re-deriving them.

* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::stop):
(WebCore::CookieStore::eventListenersDidChange):

Canonical link: <a href="https://commits.webkit.org/314601@main">https://commits.webkit.org/314601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88584b27cffd7e1d13478d10344c81a8f4e41f5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123349 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129090 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90933 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149231 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109616 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30439 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29131 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23282 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140408 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177674 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30576 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137437 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137365 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37126 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148725 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102942 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32654 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25592 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111926 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38249 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3678 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38494 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38392 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->