### PR TITLE
Fix use-after-free in ~WebProcessProxy() when replying to pending IPC messages

### DIFF
--- a/LayoutTests/http/tests/site-isolation/remove-iframe-while-process-launching-crash-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/remove-iframe-while-process-launching-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/http/tests/site-isolation/remove-iframe-while-process-launching-crash.html
+++ b/LayoutTests/http/tests/site-isolation/remove-iframe-while-process-launching-crash.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// Regression test for rdar://178478856: tearing down a cross-site iframe
+// while its WebProcess is still launching left a WebPage::Close async-reply
+// handler in AuxiliaryProcessProxy::m_pendingMessages. ~AuxiliaryProcessProxy
+// then cancelled it after ~WebProcessProxy had already destroyed
+// m_pagesPendingClose, and the lambda's still-live WeakPtr read freed memory.
+
+let count = 0;
+function churn() {
+    let f = document.createElement("iframe");
+    f.src = "http://localhost:8000/site-isolation/resources/frame-with-text.html";
+    document.body.appendChild(f);
+    // Remove on a microtask so the provisional frame's process is still
+    // launching when WebPageProxy::didDestroyFrame tears it down.
+    Promise.resolve().then(() => f.remove());
+
+    if (++count < 5)
+        setTimeout(churn, 0);
+    else
+        setTimeout(() => {
+            document.body.textContent = "PASS if no crash";
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 100);
+}
+onload = churn;
+</script>
+</body>

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -360,6 +360,11 @@ WebProcessProxy::~WebProcessProxy()
     ASSERT(m_pageURLRetainCountMap.isEmpty());
     WEBPROCESSPROXY_RELEASE_LOG(Process, "destructor:");
 
+    // ~AuxiliaryProcessProxy() replies to pending messages after our members are gone; a reply
+    // handler that upgrades its still-live WeakPtr<WebProcessProxy> would then touch freed members
+    // (e.g. m_pagesPendingClose). Cancel them now, while our state is intact.
+    replyToPendingMessages();
+
     liveProcessesLRU().remove(*this);
 
     for (auto identifier : m_speechRecognitionServerMap.keys())


### PR DESCRIPTION
#### 9d60567537546eba3b8e490334a06b2fb3ecb0ae
<pre>
Fix use-after-free in ~WebProcessProxy() when replying to pending IPC messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=316154">https://bugs.webkit.org/show_bug.cgi?id=316154</a>
<a href="https://rdar.apple.com/178478856">rdar://178478856</a>

Reviewed by Chris Dumez.

When a WebProcessProxy is torn down while its process is still launching,
~AuxiliaryProcessProxy() calls replyToPendingMessages() after WebProcessProxy&apos;s
own members have already been destroyed. Those reply handlers (e.g. the one queued
by sendPageCloseMessage()) upgrade a WeakPtr&lt;WebProcessProxy&gt; that is still live —
the WeakPtrFactory lives in a base class destroyed later — and read freed members
such as m_pagesPendingClose, causing a heap-use-after-free.

Reply to the pending messages at the top of ~WebProcessProxy(), while our members
are still intact. The later base-class call then finds an empty queue and is a no-op.

* LayoutTests/http/tests/site-isolation/remove-iframe-while-process-launching-crash-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/remove-iframe-while-process-launching-crash.html: Added.
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::~WebProcessProxy):

Canonical link: <a href="https://commits.webkit.org/314426@main">https://commits.webkit.org/314426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/277d24e71ca7156f2781a986051b881af48b0db1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175149 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129094 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31468 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109620 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23290 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177682 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137442 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39661 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137370 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37002 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148736 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102950 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32658 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38860 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111934 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38257 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3689 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38502 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38400 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->