### PR TITLE
[JSC] Use in-place JSBigInt for BigInt increment and decrement

### DIFF
--- a/JSTests/microbenchmarks/bigint-heap-dec.js
+++ b/JSTests/microbenchmarks/bigint-heap-dec.js
@@ -1,0 +1,14 @@
+function test(start, count) {
+    let n = start;
+    for (let i = 0; i < count; i++)
+        n--;
+    return n;
+}
+noInline(test);
+
+const start = 0x123456789abcdef0123456789abcdefn;
+let result = 0n;
+for (let i = 0; i < 2000; i++)
+    result = test(start, 2000);
+if (result !== start - 2000n)
+    throw new Error("bad result: " + result);

--- a/JSTests/microbenchmarks/bigint-heap-inc.js
+++ b/JSTests/microbenchmarks/bigint-heap-inc.js
@@ -1,0 +1,14 @@
+function test(start, count) {
+    let n = start;
+    for (let i = 0; i < count; i++)
+        n++;
+    return n;
+}
+noInline(test);
+
+const start = 0x123456789abcdef0123456789abcdefn;
+let result = 0n;
+for (let i = 0; i < 2000; i++)
+    result = test(start, 2000);
+if (result !== start + 2000n)
+    throw new Error("bad result: " + result);

--- a/JSTests/stress/bigint-inc-dec-in-place.js
+++ b/JSTests/stress/bigint-inc-dec-in-place.js
@@ -1,0 +1,124 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+function inc(n) { return ++n; }
+function dec(n) { return --n; }
+noInline(inc);
+noInline(dec);
+
+const oneDigitBits = 64n;
+function pow2(n) { return 1n << n; }
+
+// Zero crossing.
+shouldBe(inc(0n), 1n);
+shouldBe(dec(0n), -1n);
+shouldBe(inc(-1n), 0n);
+shouldBe(dec(1n), 0n);
+shouldBe(inc(-2n), -1n);
+shouldBe(dec(-1n), -2n);
+
+// BigInt32 boundaries (under USE(BIGINT32) these transition to/from heap BigInt).
+shouldBe(inc(2147483647n), 2147483648n);
+shouldBe(dec(2147483648n), 2147483647n);
+shouldBe(inc(-2147483649n), -2147483648n);
+shouldBe(dec(-2147483648n), -2147483649n);
+
+// Carry propagation across digit boundaries: length grows by one digit.
+for (const L of [1, 2, 3, 4, 16, 17, 64]) {
+    const allOnes = pow2(BigInt(L) * oneDigitBits) - 1n; // L digits of all-ones
+    shouldBe(inc(allOnes), pow2(BigInt(L) * oneDigitBits));
+    shouldBe(dec(-allOnes), -pow2(BigInt(L) * oneDigitBits));
+}
+
+// Borrow propagation: length shrinks by one digit.
+for (const L of [2, 3, 4, 16, 17, 64]) {
+    const powerOfDigit = pow2(BigInt(L - 1) * oneDigitBits); // L digits: [0, ..., 0, 1]
+    shouldBe(dec(powerOfDigit), powerOfDigit - 1n);
+    shouldBe(inc(-powerOfDigit), -(powerOfDigit - 1n));
+}
+
+// No carry/borrow out of the top digit: length stays the same.
+for (const L of [1, 2, 3, 16, 64]) {
+    const x = pow2(BigInt(L) * oneDigitBits - 1n) | 12345n;
+    shouldBe(inc(x), x + 1n);
+    shouldBe(dec(x), x - 1n);
+    shouldBe(inc(-x), -(x - 1n));
+    shouldBe(dec(-x), -(x + 1n));
+}
+
+// Carry stops in the middle: low digit all-ones, higher digits not.
+for (const L of [2, 3, 16]) {
+    const x = (pow2(BigInt(L) * oneDigitBits - 1n)) | (pow2(oneDigitBits) - 1n);
+    shouldBe(inc(x), x + 1n);
+    shouldBe(dec(x + 1n), x);
+    shouldBe(dec(-x), -(x + 1n));
+    shouldBe(inc(-(x + 1n)), -x);
+}
+
+// Repeated inc/dec walking across a digit boundary, cross-checked against +/-.
+{
+    let n = pow2(oneDigitBits) - 5n;
+    let m = n;
+    for (let i = 0; i < 10; i++) {
+        n = inc(n);
+        m = m + 1n;
+        shouldBe(n, m);
+    }
+    for (let i = 0; i < 20; i++) {
+        n = dec(n);
+        m = m - 1n;
+        shouldBe(n, m);
+    }
+    shouldBe(n, pow2(oneDigitBits) - 15n);
+}
+
+// Operands must not be mutated (results are fresh cells).
+{
+    const x = pow2(130n) - 1n;
+    const before = x.toString();
+    inc(x);
+    dec(x);
+    shouldBe(x.toString(), before);
+}
+
+// maxLength boundary: maxLengthBits = 1 << 20.
+{
+    const maxLengthBits = 1048576n;
+    // 2^maxLengthBits - 1 (exactly maxLength digits, all-ones), built without
+    // materializing 2^maxLengthBits itself.
+    const max = ((pow2(maxLengthBits - 1n) - 1n) << 1n) | 1n;
+    shouldBe(dec(max), max - 1n);
+    shouldBe(inc(max - 1n), max);
+    shouldBe(inc(-max), -(max - 1n));
+    let caught = null;
+    try {
+        inc(max); // would need maxLength + 1 digits
+    } catch (error) {
+        caught = error;
+    }
+    shouldBe(caught instanceof RangeError, true);
+    caught = null;
+    try {
+        dec(-max);
+    } catch (error) {
+        caught = error;
+    }
+    shouldBe(caught instanceof RangeError, true);
+    // No overflow when the carry does not propagate to a new digit.
+    const nearMax = max - pow2(maxLengthBits - 1n); // still maxLength digits
+    shouldBe(inc(nearMax), nearMax + 1n);
+}
+
+// Stress with tiering: keep inc/dec hot on multi-digit values.
+{
+    const base = pow2(192n) - 2n;
+    let n = base;
+    for (let i = 0; i < 1e4; i++)
+        n = inc(n);
+    shouldBe(n, base + 10000n);
+    for (let i = 0; i < 1e4; i++)
+        n = dec(n);
+    shouldBe(n, base);
+}

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -1916,22 +1916,68 @@ JSValue JSBigInt::remainder(JSGlobalObject* globalObject, int32_t x, JSBigInt* y
 }
 #endif
 
-template <typename BigIntImpl>
-JSBigInt::ImplResult JSBigInt::incImpl(JSGlobalObject* globalObject, BigIntImpl x)
+JSBigInt::ImplResult JSBigInt::absoluteAddOne(JSGlobalObject* globalObject, std::span<const Digit> x, bool resultSign)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto xSpan = x.digits();
-    if (!x.sign()) {
-        Vector<Digit, 16> resultVector(addOneLength(xSpan));
-        auto result = absoluteAddOne(xSpan, resultVector.mutableSpan());
-        RELEASE_AND_RETURN(scope, tryCreateFromImpl(globalObject, vm, false, result));
+    unsigned resultLength = addOneLength(x);
+    if (resultLength > maxLength) [[unlikely]] {
+        Vector<Digit> scratch(resultLength);
+        auto result = absoluteAddOne(x, scratch.mutableSpan());
+        RELEASE_AND_RETURN(scope, tryCreateFromImpl(globalObject, vm, resultSign, result));
     }
 
-    Vector<Digit, 16> resultVector(subOneLength(xSpan));
-    auto result = absoluteSubOne(xSpan, resultVector.mutableSpan());
-    RELEASE_AND_RETURN(scope, tryCreateFromImpl(globalObject, vm, true, result));
+    auto* cell = tryAllocateCell<JSBigInt>(vm, JSBigInt::allocationSize(resultLength));
+    if (!cell) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
+    }
+
+    JSBigInt* bigInt = new (NotNull, cell) JSBigInt(vm, vm.bigIntStructure.get(), resultLength);
+    bigInt->finishCreation(vm);
+    bigInt->setSign(resultSign);
+
+    auto span = absoluteAddOne(x, bigInt->digits());
+    ASSERT(!span.empty());
+    ASSERT(span.back());
+    if (span.size() < resultLength)
+        bigInt->setLength(span.size());
+    return bigInt;
+}
+
+JSBigInt::ImplResult JSBigInt::absoluteSubOne(JSGlobalObject* globalObject, std::span<const Digit> x, bool resultSign)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(!x.empty());
+    unsigned resultLength = subOneLength(x);
+    auto* cell = tryAllocateCell<JSBigInt>(vm, JSBigInt::allocationSize(resultLength));
+    if (!cell) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
+    }
+
+    JSBigInt* bigInt = new (NotNull, cell) JSBigInt(vm, vm.bigIntStructure.get(), resultLength);
+    bigInt->finishCreation(vm);
+    bigInt->setSign(resultSign);
+
+    auto span = normalize(absoluteSubOne(x, bigInt->digits()));
+    if (span.empty())
+        RELEASE_AND_RETURN(scope, zeroImpl(vm));
+    if (span.size() < resultLength)
+        bigInt->setLength(span.size());
+    return bigInt;
+}
+
+template <typename BigIntImpl>
+JSBigInt::ImplResult JSBigInt::incImpl(JSGlobalObject* globalObject, BigIntImpl x)
+{
+    auto xSpan = x.digits();
+    if (!x.sign())
+        return absoluteAddOne(globalObject, xSpan, false);
+    return absoluteSubOne(globalObject, xSpan, true);
 }
 
 JSValue JSBigInt::inc(JSGlobalObject* globalObject, JSBigInt* x)
@@ -1942,27 +1988,18 @@ JSValue JSBigInt::inc(JSGlobalObject* globalObject, JSBigInt* x)
 template <typename BigIntImpl>
 JSBigInt::ImplResult JSBigInt::decImpl(JSGlobalObject* globalObject, BigIntImpl x)
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
     if (x.isZero()) {
 #if USE(BIGINT32)
         return jsBigInt32(-1);
 #else
-        RELEASE_AND_RETURN(scope, createFrom(globalObject, -1));
+        return createFrom(globalObject, -1);
 #endif
     }
 
     auto xSpan = x.digits();
-    if (!x.sign()) {
-        Vector<Digit, 16> resultVector(subOneLength(xSpan));
-        auto result = absoluteSubOne(xSpan, resultVector.mutableSpan());
-        RELEASE_AND_RETURN(scope, tryCreateFromImpl(globalObject, vm, false, result));
-    }
-
-    Vector<Digit, 16> resultVector(addOneLength(xSpan));
-    auto result = absoluteAddOne(xSpan, resultVector.mutableSpan());
-    RELEASE_AND_RETURN(scope, tryCreateFromImpl(globalObject, vm, true, result));
+    if (!x.sign())
+        return absoluteSubOne(globalObject, xSpan, false);
+    return absoluteAddOne(globalObject, xSpan, true);
 }
 
 JSValue JSBigInt::dec(JSGlobalObject* globalObject, JSBigInt* x)

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -571,6 +571,8 @@ private:
     static size_t subOneLength(std::span<const Digit> x) { return x.size(); }
     static std::span<Digit> NODELETE absoluteAddOne(std::span<const Digit> x, std::span<Digit> result);
     static std::span<Digit> NODELETE absoluteSubOne(std::span<const Digit> x, std::span<Digit> result);
+    static ImplResult absoluteAddOne(JSGlobalObject*, std::span<const Digit> x, bool resultSign);
+    static ImplResult absoluteSubOne(JSGlobalObject*, std::span<const Digit> x, bool resultSign);
 
     static Digit NODELETE inplaceAdd(std::span<Digit> z, std::span<const Digit> x);
     static Digit NODELETE inplaceSub(std::span<Digit> z, std::span<const Digit> x);


### PR DESCRIPTION
#### 9923753ca3b36e1c6e13b56858d313c400b2b87a
<pre>
[JSC] Use in-place JSBigInt for BigInt increment and decrement
<a href="https://bugs.webkit.org/show_bug.cgi?id=316155">https://bugs.webkit.org/show_bug.cgi?id=316155</a>

Reviewed by Justin Michaud.

Following 313977@main, this patch makes BigInt increment / decrement
(n++ and n--) write the result directly into the allocated JSBigInt&apos;s
storage instead of computing into a Vector and copying it via
tryCreateFromImpl.

Adding or subtracting one wastes at most one digit after normalization,
so using the JSBigInt storage directly always makes sense in terms of
tradeoff, the same reasoning as the add case in 313977@main. When the
result would exceed maxLength, we fall back to the Vector path, and
when the result normalizes to zero, we return the cached zero BigInt.

                      ToT                     Patched

bigint-heap-inc    35.3500+-0.3672    ^    26.3964+-0.9694    ^ definitely 1.3392x faster
bigint-heap-dec    34.7748+-1.0388    ^    24.2538+-0.7962    ^ definitely 1.4338x faster

&lt;geometric&gt;        35.0597+-0.5210    ^    25.3003+-0.6410    ^ definitely 1.3857x faster

* JSTests/microbenchmarks/bigint-heap-dec.js: Added.
* JSTests/microbenchmarks/bigint-heap-inc.js: Added.
* JSTests/stress/bigint-inc-dec-in-place.js: Added.
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::absoluteAddOne):
(JSC::JSBigInt::absoluteSubOne):
(JSC::JSBigInt::incImpl):
(JSC::JSBigInt::decImpl):
* Source/JavaScriptCore/runtime/JSBigInt.h:

Canonical link: <a href="https://commits.webkit.org/314430@main">https://commits.webkit.org/314430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdfe43042d5d32dff713c6e959f136f629b12859

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175145 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129098 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31471 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109624 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23286 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158255 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177678 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26991 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137445 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137373 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37004 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148729 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102946 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32657 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38856 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111930 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38253 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3682 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38498 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38396 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->