### PR TITLE
Crash in FetchRequest::initializeWith() when LocalNetworkAccess is enabled

### DIFF
--- a/LayoutTests/fetch/request-clone-without-target-address-space-crash-expected.txt
+++ b/LayoutTests/fetch/request-clone-without-target-address-space-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Cloning a Request without targetAddressSpace in init must not crash
+

--- a/LayoutTests/fetch/request-clone-without-target-address-space-crash.html
+++ b/LayoutTests/fetch/request-clone-without-target-address-space-crash.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LocalNetworkAccessEnabled=true ] -->
+<html>
+<head>
+<title>Cloning a Request without targetAddressSpace in init must not crash</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+test(() => {
+    const original = new Request("http://example.com/");
+    assert_equals(original.targetAddressSpace, "public");
+
+    // Constructing a Request from another Request without specifying
+    // targetAddressSpace in the init dictionary must not crash and must
+    // preserve the original's value.
+    const clone = new Request(original);
+    assert_equals(clone.targetAddressSpace, "public");
+
+    const cloneWithEmptyInit = new Request(original, { });
+    assert_equals(cloneWithEmptyInit.targetAddressSpace, "public");
+
+    const cloneWithOtherInit = new Request(original, { method: "POST" });
+    assert_equals(cloneWithOtherInit.targetAddressSpace, "public");
+}, "Cloning a Request without targetAddressSpace in init must not crash");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -274,7 +274,7 @@ ExceptionOr<void> FetchRequest::initializeWith(FetchRequest& input, Init&& init)
     }
 
     if (RefPtr document = dynamicDowncast<Document>(context); document && document->settings().localNetworkAccessEnabled())
-        m_targetAddressSpace = updateTargetAddressSpaceIfNeeded(*init.targetAddressSpace, m_request.url());
+        m_targetAddressSpace = updateTargetAddressSpaceIfNeeded(init.targetAddressSpace.value_or(input.m_targetAddressSpace), m_request.url());
 
     auto setBodyResult = init.body && init.body.value() ? setBody(WTF::move(*init.body.value())) : setBody(input);
     if (setBodyResult.hasException())


### PR DESCRIPTION
#### a3f3cda54a85059955df2848f0e8ef77a850c2a8
<pre>
Crash in FetchRequest::initializeWith() when LocalNetworkAccess is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=316157">https://bugs.webkit.org/show_bug.cgi?id=316157</a>

Reviewed by Youenn Fablet.

When constructing a Request from another Request without specifying
targetAddressSpace in the init dictionary (e.g. `new Request(other)`),
FetchRequest::initializeWith() dereferenced the empty
std::optional&lt;IPAddressSpace&gt; from FetchRequestInit::targetAddressSpace,
which traps with hardened libc++. The IDL member has no default value, so
the optional is std::nullopt whenever the caller omits it.

Inherit the target address space from the input request when init does
not specify one, mirroring the behavior of FetchRequest::clone().

Test: fetch/request-clone-without-target-address-space-crash.html

* LayoutTests/fetch/request-clone-without-target-address-space-crash-expected.txt: Added.
* LayoutTests/fetch/request-clone-without-target-address-space-crash.html: Added.
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::initializeWith):

Canonical link: <a href="https://commits.webkit.org/314444@main">https://commits.webkit.org/314444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dee945f3fe7ca8afedce554ec3f67bb4e2fd02d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175150 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123358 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129096 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109622 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30446 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29138 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23291 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177683 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30585 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28649 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137443 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39662 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137371 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37019 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40350 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102951 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32660 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25605 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38861 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111935 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38258 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3691 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38503 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->