### PR TITLE
[build.webkit.org][GTK][WPE] Remove all Debug bots except the ones that run layout tests, also remove the SDK bots and add a Builder for GTK perf.

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -190,18 +190,16 @@
 
                   { "name": "gtk-linux-bot-1", "platform": "gtk" },
                   { "name": "gtk-linux-bot-2", "platform": "gtk" },
-                  { "name": "gtk-linux-bot-3", "platform": "gtk" },
+                  { "name": "gtk-linux-bot-3", "platform": "gtk-perf" },
                   { "name": "gtk-linux-bot-5", "platform": "gtk" },
                   { "name": "gtk-linux-bot-6", "platform": "gtk" },
                   { "name": "gtk-linux-bot-7", "platform": "gtk" },
-                  { "name": "gtk-linux-bot-8", "platform": "gtk" },
+                  { "name": "gtk-linux-bot-8", "platform": "gtk-perf" },
                   { "name": "gtk-linux-bot-9", "platform": "gtk" },
                   { "name": "gtk-linux-bot-10", "platform": "gtk" },
                   { "name": "gtk-linux-bot-11", "platform": "gtk" },
                   { "name": "gtk-linux-bot-12", "platform": "gtk" },
-                  { "name": "gtk-linux-bot-13", "platform": "gtk" },
                   { "name": "gtk-linux-bot-14", "platform": "gtk" },
-                  { "name": "gtk-linux-bot-15", "platform": "gtk" },
                   { "name": "gtk-linux-bot-17", "platform": "gtk" },
                   { "name": "gtk-linux-bot-18", "platform": "gtk-3" },
                   { "name": "gtk-linux-bot-19", "platform": "gtk" },
@@ -209,7 +207,6 @@
                   { "name": "gtk-linux-bot-21", "platform": "gtk" },
                   { "name": "gtk-linux-bot-22", "platform": "gtk" },
                   { "name": "gtk-linux-bot-23", "platform": "gtk" },
-                  { "name": "gtk-linux-bot-24", "platform": "gtk" },
                   { "name": "gtk-linux-bot-25", "platform": "gtk" },
 
                   { "name": "jsconly-linux-igalia-bot-1", "platform": "jsc-only" },
@@ -219,10 +216,8 @@
 
                   { "name": "wpe-linux-bot-1", "platform": "wpe" },
                   { "name": "wpe-linux-bot-2", "platform": "wpe" },
-                  { "name": "wpe-linux-bot-3", "platform": "wpe" },
                   { "name": "wpe-linux-bot-4", "platform": "wpe" },
                   { "name": "wpe-linux-bot-5", "platform": "wpe" },
-                  { "name": "wpe-linux-bot-6", "platform": "wpe" },
                   { "name": "wpe-linux-bot-7", "platform": "wpe" },
                   { "name": "wpe-linux-bot-8", "platform": "wpe" },
                   { "name": "wpe-linux-bot-9", "platform": "wpe" },
@@ -230,7 +225,6 @@
                   { "name": "wpe-linux-bot-11", "platform": "wpe" },
                   { "name": "wpe-linux-bot-12", "platform": "wpe" },
                   { "name": "wpe-linux-bot-13", "platform": "wpe" },
-                  { "name": "wpe-linux-bot-14", "platform": "wpe" },
                   { "name": "wpe-linux-bot-15", "platform": "wpe" },
                   { "name": "wpe-linux-bot-16", "platform": "wpe" },
                   { "name": "wpe-linux-bot-17", "platform": "wpe-rpi4-32bits-mesa" },
@@ -256,13 +250,7 @@
                   { "name": "wpe-linux-bot-37", "platform": "wpe" },
                   { "name": "wpe-linux-bot-38", "platform": "wpe" },
                   { "name": "wpe-linux-bot-39", "platform": "wpe" },
-                  { "name": "wpe-linux-bot-40", "platform": "wpe" },
-
-                  { "name": "wpe-linux-queue-1-bot-1", "platform": "wpe" },
-                  { "name": "wpe-linux-queue-1-bot-2", "platform": "wpe" },
-                  { "name": "wpe-linux-queue-1-bot-3", "platform": "wpe" },
-                  { "name": "wpe-linux-queue-1-bot-4", "platform": "wpe" },
-                  { "name": "wpe-linux-queue-1-bot-5", "platform": "wpe" }
+                  { "name": "wpe-linux-bot-40", "platform": "wpe" }
                 ],
 
   "builders":   [
@@ -529,9 +517,14 @@
                   {
                     "name": "GTK-Linux-64-bit-Release-Build", "factory": "BuildAndGenerateJSCBundleFactory",
                     "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
-                    "triggers": ["gtk-linux-64-release-tests", "gtk-linux-64-release-tests-js", "gtk-linux-64-release-tests-webdriver",
-                                 "gtk-linux-64-release-perf-tests", "gtk-linux-64-release-tests-mvt"],
+                    "triggers": ["gtk-linux-64-release-tests", "gtk-linux-64-release-tests-js", "gtk-linux-64-release-tests-webdriver", "gtk-linux-64-release-tests-mvt"],
                     "workernames": ["gtk-linux-bot-2"]
+                  },
+                  {
+                    "name": "GTK-Linux-64-bit-Release-Perf-Build", "factory": "BuildFactory",
+                    "platform": "gtk-perf", "configuration": "release", "architectures": ["x86_64"],
+                    "triggers": ["gtk-linux-64-release-perf-tests"],
+                    "workernames": ["gtk-linux-bot-3"]
                   },
                   {
                     "name": "GTK-Linux-64-bit-Release-Tests", "factory": "TestAllButJSCFactory",
@@ -549,29 +542,13 @@
                     "workernames": ["gtk-linux-bot-14"]
                   },
                   {
-                    "name": "GTK-Linux-64-bit-Debug-Build", "factory": "BuildFactory",
-                    "platform": "gtk", "configuration": "debug", "architectures": ["x86_64"],
-                    "triggers": ["gtk-linux-64-debug-tests", "gtk-linux-64-debug-tests-js", "gtk-linux-64-debug-tests-webdriver"],
-                    "workernames": ["gtk-linux-bot-3"]
-                  },
-                  {
-                    "name": "GTK-Linux-64-bit-Debug-Tests", "factory": "TestAllButJSCFactory",
+                    "name": "GTK-Linux-64-bit-Debug-Tests", "factory": "BuildAndTestAllButJSCFactory",
                     "platform": "gtk", "configuration": "debug", "architectures": ["x86_64"],
                     "workernames": ["gtk-linux-bot-7"]
                   },
                   {
-                    "name": "GTK-Linux-64-bit-Debug-JS-Tests", "factory": "TestJSFactory",
-                    "platform": "gtk", "configuration": "debug", "architectures": ["x86_64"],
-                    "workernames": ["gtk-linux-bot-13"]
-                  },
-                  {
-                    "name": "GTK-Linux-64-bit-Debug-WebDriver-Tests", "factory": "TestWebDriverFactory",
-                    "platform": "gtk", "configuration": "debug", "architectures": ["x86_64"],
-                    "workernames": ["gtk-linux-bot-15"]
-                  },
-                  {
-                    "name": "GTK-Linux-64-bit-Release-Perf", "factory": "BuildAndPerfTestFactory",
-                    "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
+                    "name": "GTK-Linux-64-bit-Release-Perf-Tests", "factory": "DownloadAndPerfTestFactory",
+                    "platform": "gtk-perf", "configuration": "release", "architectures": ["x86_64"],
                     "workernames": ["gtk-linux-bot-8"]
                   },
                   {
@@ -607,11 +584,6 @@
                     "name": "GTK-Linux-64-bit-Release-Clang-Build", "factory": "BuildFactory",
                     "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
                     "workernames": ["gtk-linux-bot-20"]
-                  },
-                  {
-                    "name": "GTK-Linux-64-bit-Release-SDK-Container", "factory": "BuildAndTestAndArchiveAllButJSCFactory",
-                    "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
-                    "workernames": ["gtk-linux-bot-24"]
                   },
                   {
                     "name": "GTK-Linux-64-bit-Release-MVT-Tests", "factory": "TestMVTFactory",
@@ -677,20 +649,9 @@
                     "workernames": ["wpe-linux-bot-5"]
                   },
                   {
-                    "name": "WPE-Linux-64-bit-Debug-Build", "factory": "BuildFactory",
-                    "platform": "wpe", "configuration": "debug", "architectures": ["x86_64"],
-                    "triggers": ["wpe-linux-64-debug-tests", "wpe-linux-64-debug-tests-js", "wpe-linux-64-debug-tests-webdriver"],
-                    "workernames": ["wpe-linux-bot-3"]
-                  },
-                  {
-                    "name": "WPE-Linux-64-bit-Debug-Tests", "factory": "TestAllButJSCFactory",
+                    "name": "WPE-Linux-64-bit-Debug-Tests", "factory": "BuildAndTestAllButJSCFactory",
                     "platform": "wpe", "configuration": "debug", "architectures": ["x86_64"],
                     "workernames": ["wpe-linux-bot-4"]
-                  },
-                  {
-                    "name": "WPE-Linux-64-bit-Debug-JS-Tests", "factory": "TestJSFactory",
-                    "platform": "wpe", "configuration": "debug", "architectures": ["x86_64"],
-                    "workernames": ["wpe-linux-bot-6"]
                   },
                   {
                     "name": "WPE-Linux-64bit-Release-Packaging-Nightly", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
@@ -725,11 +686,6 @@
                     "name": "WPE-Linux-64-bit-Release-WebDriver-Tests", "factory": "TestWebDriverFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
                     "workernames": ["wpe-linux-bot-13"]
-                  },
-                  {
-                    "name": "WPE-Linux-64-bit-Debug-WebDriver-Tests", "factory": "TestWebDriverFactory",
-                    "platform": "wpe", "configuration": "debug", "architectures": ["x86_64"],
-                    "workernames": ["wpe-linux-bot-14"]
                   },
                   {
                     "name": "WPE-Linux-ARM64-bit-Release-Debian-Stable-Build", "factory": "NoInstallDependenciesBuildFactory",
@@ -773,11 +729,6 @@
                     "workernames": ["wpe-linux-bot-35"]
                   },
                   {
-                    "name": "WPE-Linux-64-bit-Release-SDK-Container", "factory": "BuildAndTestAndArchiveAllButJSCFactory",
-                    "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
-                    "workernames": ["wpe-linux-queue-1-bot-1", "wpe-linux-queue-1-bot-2", "wpe-linux-queue-1-bot-3", "wpe-linux-queue-1-bot-4", "wpe-linux-queue-1-bot-5"]
-                  },
-                  {
                     "name": "WPE-Linux-64-bit-Release-MVT-Tests", "factory": "TestMVTFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
                     "workernames": ["wpe-linux-bot-36"]
@@ -807,23 +758,24 @@
                 ],
 
   "schedulers": [ { "type": "AnyBranchScheduler", "name": "main", "change_filter": "main_filter", "treeStableTimer": 45.0,
-                    "builderNames": ["GTK-Linux-64-bit-Release-Build", "GTK-Linux-64-bit-Debug-Build",
+                    "builderNames": ["GTK-Linux-64-bit-Release-Build",
                                      "GTK-Linux-64-bit-Release-Clang-Build",
                                      "GTK-Linux-64-bit-Release-Debian-Stable-Build",
                                      "GTK-Linux-64-bit-Release-Ubuntu-2204-Build",
                                      "GTK-Linux-64-bit-Release-Ubuntu-LTS-Build",
                                      "GTK-Linux-64-bit-Release-GTK3-Build",
-                                     "GTK-Linux-64-bit-Release-SDK-Container",
+                                     "GTK-Linux-64-bit-Release-Perf-Build",
+                                     "GTK-Linux-64-bit-Debug-Tests",
                                      "WPE-Linux-64-bit-Release-Ubuntu-2204-Build",
                                      "WPE-Linux-64-bit-Release-Ubuntu-LTS-Build",
-                                     "WPE-Linux-64-bit-Release-SDK-Container",
                                      "WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Build",
                                      "WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Build",
+                                     "WPE-Linux-64-bit-Debug-Tests",
                                      "JSCOnly-Linux-AArch64-Release",
                                      "JSCOnly-Linux-ARMv7-Thumb2-Release",
                                      "PlayStation-Release-Build", "PlayStation-Debug-Build",
                                      "Windows-64-bit-Release-Build", "Windows-64-bit-Debug-Build",
-                                     "WPE-Linux-64-bit-Release-Build", "WPE-Linux-64-bit-Debug-Build",
+                                     "WPE-Linux-64-bit-Release-Build",
                                      "WPE-Linux-64-bit-Release-Clang-Build",
                                      "WPE-Linux-64-bit-Release-LibWebRTC-Build",
                                      "WPE-Linux-ARM64-bit-Release-Debian-Stable-Build",
@@ -960,17 +912,8 @@
                   { "type": "Triggerable", "name": "gtk-linux-64-release-tests-webdriver",
                     "builderNames": ["GTK-Linux-64-bit-Release-WebDriver-Tests"]
                   },
-                  { "type": "Triggerable", "name": "gtk-linux-64-debug-tests",
-                    "builderNames": ["GTK-Linux-64-bit-Debug-Tests"]
-                  },
-                  { "type": "Triggerable", "name": "gtk-linux-64-debug-tests-js",
-                    "builderNames": ["GTK-Linux-64-bit-Debug-JS-Tests"]
-                  },
-                  { "type": "Triggerable", "name": "gtk-linux-64-debug-tests-webdriver",
-                    "builderNames": ["GTK-Linux-64-bit-Debug-WebDriver-Tests"]
-                  },
                   { "type": "Triggerable", "name": "gtk-linux-64-release-perf-tests",
-                    "builderNames": ["GTK-Linux-64-bit-Release-Perf"]
+                    "builderNames": ["GTK-Linux-64-bit-Release-Perf-Tests"]
                   },
                   { "type": "Triggerable", "name": "gtk-linux-64-release-tests-mvt",
                     "builderNames": ["GTK-Linux-64-bit-Release-MVT-Tests"]
@@ -992,15 +935,6 @@
                   },
                   { "type": "Triggerable", "name": "wpe-linux-64-release-tests-webdriver",
                     "builderNames": ["WPE-Linux-64-bit-Release-WebDriver-Tests"]
-                  },
-                  { "type": "Triggerable", "name": "wpe-linux-64-debug-tests",
-                    "builderNames": ["WPE-Linux-64-bit-Debug-Tests"]
-                  },
-                  { "type": "Triggerable", "name": "wpe-linux-64-debug-tests-js",
-                    "builderNames": ["WPE-Linux-64-bit-Debug-JS-Tests"]
-                  },
-                  { "type": "Triggerable", "name": "wpe-linux-64-debug-tests-webdriver",
-                    "builderNames": ["WPE-Linux-64-bit-Debug-WebDriver-Tests"]
                   },
                   { "type": "Triggerable", "name": "wpe-linux-rpi4-32-mesa-release-perf-tests",
                     "builderNames": ["WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Tests"]

--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -173,17 +173,8 @@ class TestAllButJSCFactory(TestFactory):
     JSCTestClass = None
 
 
-class BuildAndTestAndArchiveAllButJSCFactory(BuildAndTestFactory):
+class BuildAndTestAllButJSCFactory(BuildAndTestFactory):
     JSCTestClass = None
-
-    def __init__(self, platform, configuration, architectures, triggers=None, additionalArguments=None, device_model=None, **kwargs):
-        BuildAndTestFactory.__init__(self, platform, configuration, architectures, triggers, additionalArguments, device_model, **kwargs)
-        # The parent class will already archive if triggered
-        if not triggers:
-            self.addStep(ArchiveBuiltProduct())
-            self.addStep(UploadBuiltProduct())
-        if platform == "gtk-3":
-            self.addStep(RunWebDriverTests())
 
 
 class BuildAndGenerateJSCBundleFactory(BuildFactory):

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -22,6 +22,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from . import loadConfig
+import json
 import os
 import unittest
 
@@ -1039,19 +1040,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-built-product',
             'webdriver-test'
         ],
-        'GTK-Linux-64-bit-Debug-Build': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'kill-old-processes',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'jhbuild',
-            'compile-webkit',
-            'trigger'
-        ],
         'GTK-Linux-64-bit-Debug-Tests': [
             'configure-build',
             'configuration',
@@ -1062,8 +1050,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-WebKitBuild-directory',
             'delete-stale-build-files',
             'jhbuild',
-            'download-built-product',
-            'extract-built-product',
+            'compile-webkit',
             'layout-test',
             'dashboard-tests',
             'archive-test-results',
@@ -1076,36 +1063,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'bindings-generation-tests',
             'builtins-generator-tests'
         ],
-        'GTK-Linux-64-bit-Debug-JS-Tests': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'kill-old-processes',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'jhbuild',
-            'download-built-product',
-            'extract-built-product',
-            'jscore-test',
-            'test262-test'
-        ],
-        'GTK-Linux-64-bit-Debug-WebDriver-Tests': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'kill-old-processes',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'jhbuild',
-            'download-built-product',
-            'extract-built-product',
-            'webdriver-test'
-        ],
-        'GTK-Linux-64-bit-Release-Perf': [
+        'GTK-Linux-64-bit-Release-Perf-Build': [
             'configure-build',
             'configuration',
             'clean-and-update-working-directory',
@@ -1116,6 +1074,20 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'jhbuild',
             'compile-webkit',
+            'trigger'
+        ],
+        'GTK-Linux-64-bit-Release-Perf-Tests': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'jhbuild',
+            'download-built-product',
+            'extract-built-product',
             'perf-test',
             'benchmark-test'
         ],
@@ -1189,31 +1161,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'jhbuild',
             'compile-webkit'
-        ],
-        'GTK-Linux-64-bit-Release-SDK-Container': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'kill-old-processes',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'jhbuild',
-            'compile-webkit',
-            'layout-test',
-            'dashboard-tests',
-            'archive-test-results',
-            'upload',
-            'extract-test-results',
-            'set-permissions',
-            'run-api-tests',
-            'webkitpy-test',
-            'webkitperl-test',
-            'bindings-generation-tests',
-            'builtins-generator-tests',
-            'archive-built-product',
-            'upload-built-product'
         ],
         'GTK-Linux-64-bit-Release-MVT-Tests': [
             'configure-build',
@@ -1407,19 +1354,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-built-product',
             'webdriver-test'
         ],
-        'WPE-Linux-64-bit-Debug-Build': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'kill-old-processes',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'jhbuild',
-            'compile-webkit',
-            'trigger'
-        ],
         'WPE-Linux-64-bit-Debug-Tests': [
             'configure-build',
             'configuration',
@@ -1430,8 +1364,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-WebKitBuild-directory',
             'delete-stale-build-files',
             'jhbuild',
-            'download-built-product',
-            'extract-built-product',
+            'compile-webkit',
             'layout-test',
             'dashboard-tests',
             'archive-test-results',
@@ -1443,35 +1376,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'webkitperl-test',
             'bindings-generation-tests',
             'builtins-generator-tests'
-        ],
-        'WPE-Linux-64-bit-Debug-JS-Tests': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'kill-old-processes',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'jhbuild',
-            'download-built-product',
-            'extract-built-product',
-            'jscore-test',
-            'test262-test'
-        ],
-        'WPE-Linux-64-bit-Debug-WebDriver-Tests': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'kill-old-processes',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'jhbuild',
-            'download-built-product',
-            'extract-built-product',
-            'webdriver-test'
         ],
         'WPE-Linux-64bit-Release-Packaging-Nightly': [
             'configure-build',
@@ -1620,31 +1524,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'jhbuild',
             'compile-webkit'
         ],
-        'WPE-Linux-64-bit-Release-SDK-Container': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'kill-old-processes',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'jhbuild',
-            'compile-webkit',
-            'layout-test',
-            'dashboard-tests',
-            'archive-test-results',
-            'upload',
-            'extract-test-results',
-            'set-permissions',
-            'run-api-tests',
-            'webkitpy-test',
-            'webkitperl-test',
-            'bindings-generation-tests',
-            'builtins-generator-tests',
-            'archive-built-product',
-            'upload-built-product'
-        ],
         'WPE-Linux-64-bit-Release-MVT-Tests': [
             'configure-build',
             'configuration',
@@ -1753,3 +1632,122 @@ class TestExpectedBuildSteps(unittest.TestCase):
             builders.add(builder['name'])
         for builder in self.expected_steps:
             self.assertTrue(builder in builders, "Builder %s doesn't exist, but has unnecessary expected steps" % builder)
+
+    def test_unique_platform_for_build_product_upload(self):
+        # A builder that compiles WebKit and triggers other builders uploads its build product so the triggered testers can download it.
+        # The upload destination is derived (see CompileWebKit and ConfigureBuild in steps.py) from the build properties as:
+        #   "{fullPlatform}-{archForUpload}-{configuration}"
+        # where fullPlatform is the builder's "platform", archForUpload is the architectures joined with "-", and configuration is "release"/"debug".
+        # The matching testers re-derive that same key to download the product, so if two uploading builders share the key their build products collide
+        # in the same remote directory (see the bug fixed in 308273@main, where two "wpe" builders overwrote each other's release.zip on S3).
+        # Note: the actual upload step is added at runtime by CompileWebKit (addStepsAfterCurrentStep, gated on the "triggers" property), so it is
+        # not present in the static factory step list. We therefore identify the uploading builders by the condition that produces the upload:
+        # they run a compile step and have triggers set.
+        upload_key_to_builder = {}
+        for builder in self.config['builders']:
+            configure_kwargs = None
+            compiles = False
+            for step in builder['factory'].steps:
+                step_name = step.kwargs.get('name', step.step_class.name)
+                if step_name == 'configure-build':
+                    configure_kwargs = step.kwargs
+                if step_name.startswith('compile'):
+                    compiles = True
+            if configure_kwargs is None:
+                continue
+            triggers = configure_kwargs.get('triggers')
+            if not (compiles and triggers):
+                continue
+            arch_for_upload = '-'.join(configure_kwargs['architecture'].split(' '))
+            upload_key = '%s-%s-%s' % (configure_kwargs['platform'], arch_for_upload, configure_kwargs['configuration'])
+            self.assertNotIn(
+                upload_key, upload_key_to_builder,
+                msg='Builders "%s" and "%s" both upload their build product to the same path '
+                    '"%s" (derived from platform-architecture-configuration). Give one of them a '
+                    'unique "platform" suffix so the build products do not collide (see 308273@main).'
+                    % (upload_key_to_builder.get(upload_key), builder['name'], upload_key))
+            upload_key_to_builder[upload_key] = builder['name']
+
+    def test_triggered_testers_share_builder_platform(self):
+        # This is the complement of test_unique_platform_for_build_product_upload:
+        # every bot that gets trigerred should share the same platform keys than the builder,
+        # so the download URI for the built-product matches the builder upload.
+        cwd = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(cwd, 'config.json')) as config_json:
+            raw_config = json.load(config_json)
+        triggerable_builders = {
+            scheduler['name']: scheduler.get('builderNames', [])
+            for scheduler in raw_config['schedulers']
+            if scheduler.get('type') == 'Triggerable'
+        }
+
+        info = {}
+        for builder in self.config['builders']:
+            configure_kwargs = None
+            downloads_product = False
+            for step in builder['factory'].steps:
+                step_name = step.kwargs.get('name', step.step_class.name)
+                if step_name == 'configure-build':
+                    configure_kwargs = step.kwargs
+                if step_name == 'download-built-product':
+                    downloads_product = True
+            if configure_kwargs is None:
+                continue
+            arch_for_upload = '-'.join(configure_kwargs['architecture'].split(' '))
+            info[builder['name']] = {
+                'key': '%s-%s-%s' % (configure_kwargs['platform'], arch_for_upload, configure_kwargs['configuration']),
+                'triggers': configure_kwargs.get('triggers') or [],
+                'downloads_product': downloads_product,
+            }
+
+        for builder_name, data in info.items():
+            for trigger_name in data['triggers']:
+                for triggered_name in triggerable_builders.get(trigger_name, []):
+                    triggered = info.get(triggered_name)
+                    if triggered is None or not triggered['downloads_product']:
+                        continue
+                    self.assertEqual(
+                        triggered['key'], data['key'],
+                        msg='Builder "%s" uploads its build product to "%s" and triggers "%s", but '
+                            '"%s" downloads the build product from "%s". A triggered builder must use '
+                            'the same platform-architecture-configuration as the builder that triggers '
+                            'it, otherwise it cannot find the uploaded product.'
+                            % (builder_name, data['key'], triggered_name, triggered_name, triggered['key']))
+
+    def test_all_builders_are_reachable_by_a_scheduler(self):
+        # Every builder must be able to run automatically: either it is attached to an
+        # automatic scheduler or it is triggered by other bot.
+        cwd = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(cwd, 'config.json')) as config_json:
+            raw_config = json.load(config_json)
+
+        root_scheduler_types = ('AnyBranchScheduler', 'Nightly', 'PlatformSpecificScheduler')
+        directly_scheduled = set()
+        triggerable_builders = {}
+        for scheduler in raw_config['schedulers']:
+            if scheduler.get('type') in root_scheduler_types:
+                directly_scheduled.update(scheduler.get('builderNames', []))
+            elif scheduler.get('type') == 'Triggerable':
+                triggerable_builders[scheduler['name']] = scheduler.get('builderNames', [])
+
+        builder_triggers = {builder['name']: (builder.get('triggers') or []) for builder in raw_config['builders']}
+
+        # Walk the trigger graph outward from the directly-scheduled builders.
+        reachable = set(directly_scheduled)
+        frontier = list(directly_scheduled)
+        while frontier:
+            builder_name = frontier.pop()
+            for trigger_name in builder_triggers.get(builder_name, []):
+                for triggered_name in triggerable_builders.get(trigger_name, []):
+                    if triggered_name not in reachable:
+                        reachable.add(triggered_name)
+                        frontier.append(triggered_name)
+
+        all_builders = set(builder['name'] for builder in self.config['builders'])
+        unreachable = sorted(all_builders - reachable)
+        self.assertEqual(
+            unreachable, [],
+            msg='These builders cannot run automatically: %s. Each is neither attached to a '
+                'scheduler (AnyBranchScheduler / Nightly / PlatformSpecificScheduler) nor triggered '
+                'by a builder that is. Attach each to a scheduler or trigger it from a build bot.'
+                % unreachable)


### PR DESCRIPTION
#### 24c7fd849044cd54b2bba1b20aa93197ee0b2f04
<pre>
[build.webkit.org][GTK][WPE] Remove all Debug bots except the ones that run layout tests, also remove the SDK bots and add a Builder for GTK perf.
<a href="https://bugs.webkit.org/show_bug.cgi?id=316149">https://bugs.webkit.org/show_bug.cgi?id=316149</a>

Reviewed by Nikolas Zimmermann.

Since we enabled assertions on release post-commit bots around 313986@main there is no value in running
tests in Debug unless the test suite is able to generate backtraces (because Debug builds are less
optimized so the backtraces read better).

And currently the only test suite that is able to generate backtraces is layout tests (run-webkit-tests).
All the other test suites just ignore any crash if it happens (they may report that webkit crashed, but
they are not able to generate or report any info about backtraces or any crash log).

So given that status quo, it makes sense that we drop all testing in Debug but layout tests.
Release tests already cover assertions (we enable those now by default), and Debug tests can&apos;t generate
backtraces: so no value on running debug tests.

This means we can optimize this further and merge the Debug build with the Debug layout test bot, so we
don&apos;t longer need to pass 5GB built products all over internet (Amazon S3) and we can keep everything
local. This also will help to avoid issues related to webkit.org/b/304213

This patch removes all the WPE and GTK Debug bots except two (one for each port), and that remaining bot
is set to build and run layout tests. To avoid disrupting external tools (webkit-testhunter, etc) the
name and the bot-id of the bot remains the one of the previous bot that was running the layout tests for
Debug.

This patch also seizes this to remove the deprecated SDK bots (we stopped running those quite ago), and
adds a GTK perf build bot for the GTK perf bot: We tried to switch the machine to build its own built
products on 312685@main but the machine is not powerful enough to build webkit and keeps having issues.
So add a builder that doesn&apos;t enable assertions for it.
Important: use a unique platform suffix (&quot;gtk-perf&quot;) so the build products from this builder have a unique
path and don&apos;t collide with the built-products from default release gtk bot that enables assertions
(so do not repeat the mistake fixed on 308273@main).
Add also some unit tests for this to catch the issue early next time.

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories.py:
(BuildAndTestAllButJSCFactory):
(BuildAndTestAndArchiveAllButJSCFactory): Deleted.
(BuildAndTestAndArchiveAllButJSCFactory.__init__): Deleted.
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):
(TestExpectedBuildSteps.test_unnecessary_expected_steps):
(TestExpectedBuildSteps.test_unique_platform_for_build_product_upload):
(TestExpectedBuildSteps.test_triggered_testers_share_builder_platform):
(TestExpectedBuildSteps.test_all_builders_are_reachable_by_a_scheduler):

Canonical link: <a href="https://commits.webkit.org/314466@main">https://commits.webkit.org/314466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97ecf11d78641d5acea7cd04969a3b912193b2a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175253 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123461 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129186 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109711 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23394 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177786 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137539 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/165608 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137460 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103087 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25298 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32753 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25698 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38964 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38361 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3784 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38606 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->