### PR TITLE
FetchBody::clone() leaves m_data and m_readableStream desynchronized

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS new Request(clone) preserves a ReadableStream body that came from clone()
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.js
@@ -1,0 +1,22 @@
+// META: global=window,worker
+
+promise_test(async () => {
+    const stream = new ReadableStream({
+        start(controller) {
+            controller.enqueue(new TextEncoder().encode("hello"));
+            controller.close();
+        }
+    });
+
+    const r1 = new Request("https://example.com/", { method: "POST", body: stream, duplex: "half" });
+    const r2 = r1.clone();
+    assert_false(r2.bodyUsed, "clone should not be marked as used");
+    assert_not_equals(r2.body, null, "clone should have a body");
+
+    // Constructing a new Request from the clone should preserve the body.
+    const r3 = new Request(r2);
+    assert_not_equals(r3.body, null, "Request constructed from clone should have a body");
+
+    const text = await r3.text();
+    assert_equals(text, "hello", "body content should be preserved through clone() and new Request()");
+}, "new Request(clone) preserves a ReadableStream body that came from clone()");

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS new Request(clone) preserves a ReadableStream body that came from clone()
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -369,7 +369,9 @@ FetchBody FetchBody::clone(JSDOMGlobalObject& globalObject)
         ASSERT(!clones.hasException());
         if (!clones.hasException()) {
             auto pair = clones.releaseReturnValue();
+            m_data = pair[0];
             m_readableStream = WTF::move(pair[0]);
+            clone.m_data = pair[1];
             clone.m_readableStream = WTF::move(pair[1]);
         }
     }


### PR DESCRIPTION
#### 5d8c7f0a38c9fb57708a347dabd1660b85c51efe
<pre>
FetchBody::clone() leaves m_data and m_readableStream desynchronized
<a href="https://bugs.webkit.org/show_bug.cgi?id=316159">https://bugs.webkit.org/show_bug.cgi?id=316159</a>

Reviewed by Anne van Kesteren.

When cloning a FetchBody whose body is a ReadableStream, only the
m_readableStream field was updated to point at the new tee branches;
m_data still held the original (now disturbed) stream on the source,
and was left as the default nullptr variant on the clone. This broke
the invariant established by FetchBody(Ref&lt;ReadableStream&gt;&amp;&amp;) that
m_data and m_readableStream refer to the same stream, causing
isReadableStream() and hasReadableStream() to disagree.

The visible consequence is that constructing a new Request from a
cloned Request silently dropped the body: FetchBody::createProxy()
keys off isReadableStream(), which returned false on the clone, so
the proxy short-circuited before piping the readable stream through.

Set m_data alongside m_readableStream on both branches of the tee
to keep the two fields in sync.

This aligns our behavior with Chrome.

Tests: imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.html
       imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker.html

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.js: Added.
(promise_test.async const):
(promise_test):
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker.html: Added.
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::clone):

Canonical link: <a href="https://commits.webkit.org/314442@main">https://commits.webkit.org/314442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a0d186307c9c3ce0de793a10a1e9b5d8513b415

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175156 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123364 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c30c71d2-b7e1-4990-b690-94d2b277c969) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129102 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31476 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149240 "Found 7 new API test failures: TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInBackground, TestWebKitAPI.WKWebExtensionContext.CallingMissingBrowserAPIInBackground, TestWebKitAPI.WKWebExtensionContext.ReferenceErrorInBackground, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInServiceWorkerBackground, TestWebKitAPI.WKWebExtension.MultipleContentScriptsInjectedWhenMatched, TestWebKitAPI.WKWebExtensionContext.TopLevelThrowInModuleBackground, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInContentScript (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109628 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67734a74-5246-4f16-bebc-5ff617e3fe3e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30453 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29143 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23297 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177689 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30591 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28645 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137450 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137378 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37015 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148734 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102957 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32666 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25601 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38867 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111941 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38264 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3687 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38509 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->