### PR TITLE
[JSC] Optimize the layout of InlineCacheHandler

### DIFF
--- a/Source/JavaScriptCore/assembler/CPU.h
+++ b/Source/JavaScriptCore/assembler/CPU.h
@@ -222,7 +222,7 @@ constexpr size_t prologueStackPointerDelta()
 #endif
 }
 
-
+#define CACHE_LINE_ALIGNED alignas(64)
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/bytecode/InlineCacheHandler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheHandler.cpp
@@ -58,11 +58,11 @@ InlineCacheHandler::InlineCacheHandler()
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 InlineCacheHandler::InlineCacheHandler(bool makesJSCalls, Ref<InlineCacheHandler>&& previous, Ref<PolymorphicAccessJITStubRoutine>&& stubRoutine, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&& watchpoint, CacheType cacheType)
-    : m_callTarget(stubRoutine->code().code().template retagged<JITStubRoutinePtrTag>())
+    : m_next(WTF::move(previous))
+    , m_callTarget(stubRoutine->code().code().template retagged<JITStubRoutinePtrTag>())
     , m_jumpTarget(CodePtr<NoPtrTag> { m_callTarget.retagged<NoPtrTag>().dataLocation<uint8_t*>() + prologueSizeInBytesDataIC }.template retagged<JITStubRoutinePtrTag>())
     , m_cacheType(cacheType)
     , m_makesJSCalls(makesJSCalls)
-    , m_next(WTF::move(previous))
     , m_stubRoutine(WTF::move(stubRoutine))
     , m_watchpoint(WTF::move(watchpoint))
 {

--- a/Source/JavaScriptCore/bytecode/InlineCacheHandler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheHandler.h
@@ -52,7 +52,7 @@ enum class CacheType : int8_t {
     StringLength,
 };
 
-class InlineCacheHandler : public RefCounted<InlineCacheHandler> {
+class CACHE_LINE_ALIGNED InlineCacheHandler : public RefCounted<InlineCacheHandler> {
     WTF_MAKE_NONCOPYABLE(InlineCacheHandler);
     WTF_MAKE_TZONE_ALLOCATED(InlineCacheHandler);
     friend class InlineCacheCompiler;
@@ -138,11 +138,17 @@ protected:
 
     static Ref<InlineCacheHandler> createSlowPath(VM&, AccessType);
 
+    // The selection and ordering of the fields through m_uid is deliberate.
+    // They are are either hot with high affinity, or placed where they are to minimize padding.
+    StructureID m_structureID { };
+    RefPtr<InlineCacheHandler> m_next;
     CodePtr<JITStubRoutinePtrTag> m_callTarget;
     CodePtr<JITStubRoutinePtrTag> m_jumpTarget;
-    StructureID m_structureID { };
     PropertyOffset m_offset { invalidOffset };
+    CacheType m_cacheType { CacheType::Unset };
+    bool m_makesJSCalls { false };
     UniquedStringImpl* m_uid { nullptr };
+
     union {
         struct {
             StructureID m_newStructureID { };
@@ -159,13 +165,14 @@ protected:
             WriteBarrierBase<Unknown>* m_moduleVariableSlot;
         } s3;
     } u;
-    CacheType m_cacheType { CacheType::Unset };
-    bool m_makesJSCalls { false };
-    RefPtr<InlineCacheHandler> m_next;
     RefPtr<PolymorphicAccessJITStubRoutine> m_stubRoutine;
     RefPtr<AccessCase> m_accessCase;
     std::unique_ptr<PropertyInlineCacheClearingWatchpoint> m_watchpoint;
 };
+
+#if !ASSERT_ENABLED && CPU(ARM64) && CPU(ADDRESS64)
+static_assert(InlineCacheHandler::offsetOfUid() == 40, "InlineCacheHandler hot field layout drifted.");
+#endif
 
 class InlineCacheHandlerWithJSCall final : public InlineCacheHandler {
     WTF_MAKE_TZONE_ALLOCATED(InlineCacheHandlerWithJSCall);

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -33,8 +33,6 @@
 #include <wtf/Vector.h>
 #include <wtf/unicode/CharacterNames.h>
 
-#define CACHE_LINE_ALIGNED alignas(64)
-
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {


### PR DESCRIPTION
#### de8227087714d02287b01937b7046c39cb660f12
<pre>
[JSC] Optimize the layout of InlineCacheHandler
<a href="https://bugs.webkit.org/show_bug.cgi?id=316163">https://bugs.webkit.org/show_bug.cgi?id=316163</a>
<a href="https://rdar.apple.com/178579821">rdar://178579821</a>

Reviewed by Yusuke Suzuki and Dan Hecht.

This patch optimizes the layout of InlineCacheHandler to place hot fields within the same
cache line and reduce padding.

Key changes:

- m_next is grouped with other hot fields and the class is made CACHE_LINE_ALIGNED to
ensure hot fields land on one cache line.

- m_structureID is placed as the first field. The instance begins with a hidden 4-byte
refcount, and placing m_structureID first uses the 4 bytes between the refcount and the
first pointer-size field instead of wasting them on padding. Also, m_cacheType and
m_makesJSCalls are placed after the 4-byte m_offset, to use 2 out of 4 bytes of padding
between m_offset and m_uid.

- CACHE_LINE_ALIGNED is moved from Lexer.h to a reusable header CPU.h.

Testing: covered by existing tests.
Canonical link: <a href="https://commits.webkit.org/314513@main">https://commits.webkit.org/314513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/083d6e7cd2d9124eb16e981da3b3c645f2beae71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175349 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123556 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129265 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109790 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29320 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23489 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158458 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177881 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27195 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30783 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137616 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137538 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37060 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40548 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148918 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103193 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32840 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25784 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198702 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39059 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112146 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/53378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38456 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3870 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38701 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38599 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->