### PR TITLE
SerializedPlatformDataCueValue::operator== is non-reflexive for default-constructed values

### DIFF
--- a/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
+++ b/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
@@ -122,10 +122,7 @@ RetainPtr<NSDictionary> SerializedPlatformDataCueValue::toNSDictionary() const
 
 bool SerializedPlatformDataCueValue::operator==(const SerializedPlatformDataCueValue& other) const
 {
-    if (!m_data || !other.m_data)
-        return false;
-
-    return *m_data == *other.m_data;
+    return m_data == other.m_data;
 }
 
 bool SerializedPlatformDataCueValue::Data::operator==(const Data& other) const


### PR DESCRIPTION
#### c4104fee97014ee644f68172798c46248d542115
<pre>
SerializedPlatformDataCueValue::operator== is non-reflexive for default-constructed values
<a href="https://bugs.webkit.org/show_bug.cgi?id=316170">https://bugs.webkit.org/show_bug.cgi?id=316170</a>

Reviewed by Jean-Yves Avenard.

SerializedPlatformDataCueValue::operator== returned false whenever either
operand had no underlying Data (i.e. was constructed from a nil
AVMetadataItem or default-constructed). As a result, two empty cue values
compared unequal — including a value compared against itself — violating
the basic reflexivity invariant of equality and breaking any change
detection that relied on operator== for the empty case.

Defer to std::optional&lt;Data&gt;&apos;s built-in operator==, which correctly
returns true when both sides are nullopt, false when exactly one is, and
otherwise compares the wrapped Data via Data::operator==.

* Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm:
(WebCore::SerializedPlatformDataCueValue::operator== const):

Canonical link: <a href="https://commits.webkit.org/314542@main">https://commits.webkit.org/314542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d65933f2654c488edb65ef4148f2475624d7dc83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175184 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123392 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129129 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90956 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109655 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30479 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29172 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23325 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177717 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30619 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137476 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33317 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137404 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37087 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148761 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102986 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32688 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25627 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111969 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38292 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3717 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38537 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38435 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->