### PR TITLE
[Swift in WebKit] Set `NoUseUnstructuredThrowingTask` as an error instead of a warning

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -127,7 +127,7 @@ WK_SWIFT_CLANG_DEPLOYMENT_TARGET = $(WK_SWIFT_CLANG_DEPLOYMENT_TARGET_$(WK_PLATF
 WK_SWIFT_CLANG_DEPLOYMENT_TARGET_macosx = -clang-target $(CURRENT_ARCH)-apple-macos$(MACOSX_DEPLOYMENT_TARGET);
 
 // rdar://170129992: remove -track-system-dependencies when resolved
-OTHER_SWIFT_FLAGS = $(inherited) -Xcc -fvisibility=hidden -Werror ExistentialAny -enable-upcoming-feature ExistentialAny $(WK_SWIFT_MEMORY_SAFETY_FLAGS) $(WK_SWIFT_MEMORY_SAFETY_ERROR_FLAGS) $(WK_SWIFT_CLANG_DEPLOYMENT_TARGET) $(WK_SANITIZER_OTHER_SWIFT_FLAGS) -enable-upcoming-feature InternalImportsByDefault -enable-upcoming-feature MemberImportVisibility -track-system-dependencies -enable-experimental-feature ImportCxxMembersLazily;
+OTHER_SWIFT_FLAGS = $(inherited) -Xcc -fvisibility=hidden -Werror ExistentialAny -Werror NoUseUnstructuredThrowingTask -enable-upcoming-feature ExistentialAny $(WK_SWIFT_MEMORY_SAFETY_FLAGS) $(WK_SWIFT_MEMORY_SAFETY_ERROR_FLAGS) $(WK_SWIFT_CLANG_DEPLOYMENT_TARGET) $(WK_SANITIZER_OTHER_SWIFT_FLAGS) -enable-upcoming-feature InternalImportsByDefault -enable-upcoming-feature MemberImportVisibility -track-system-dependencies -enable-experimental-feature ImportCxxMembersLazily;
 // Work around rdar://157581667 on affected toolchains.
 OTHER_SWIFT_FLAGS[sdk=*26.2*] = $(inherited) -Xcc -fno-modulemap-allow-subdirectory-search;
 OTHER_SWIFT_FLAGS[sdk=*26.3*] = $(inherited) -Xcc -fno-modulemap-allow-subdirectory-search;

--- a/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
@@ -173,7 +173,9 @@ final class BrowserViewModel {
 
     func exportAsPDF() {
         Task {
-            let data = try await page.exported(as: .pdf)
+            guard let data = try? await page.exported(as: .pdf) else {
+                return
+            }
             exportedPDF = PDF(data: data, title: !page.title.isEmpty ? page.title : nil)
         }
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift
@@ -100,10 +100,10 @@ struct TestURLSchemeHandler: URLSchemeHandler, Sendable {
 
             case .async:
                 Task {
-                    try await Task.sleep(for: delays.beforeYield)
+                    try? await Task.sleep(for: delays.beforeYield)
                     yieldResponse()
 
-                    try await Task.sleep(for: delays.beforeFinish)
+                    try? await Task.sleep(for: delays.beforeFinish)
                     yieldDataAndFinish()
                 }
             }


### PR DESCRIPTION
#### ab43363ec9c5dc136a909d83c4cccb2d6b39b90e
<pre>
[Swift in WebKit] Set `NoUseUnstructuredThrowingTask` as an error instead of a warning
<a href="https://bugs.webkit.org/show_bug.cgi?id=316173">https://bugs.webkit.org/show_bug.cgi?id=316173</a>
<a href="https://rdar.apple.com/178585668">rdar://178585668</a>

Reviewed by Adrian Taylor.

Set -Werror for this diagnostic (<a href="https://docs.swift.org/compiler/documentation/diagnostics/no-use-throwing-unstructured-task/).">https://docs.swift.org/compiler/documentation/diagnostics/no-use-throwing-unstructured-task/).</a>

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift

* Configurations/CommonBase.xcconfig:
* Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift:
(BrowserViewModel.exportAsPDF):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift:
(reply(for:)):

Canonical link: <a href="https://commits.webkit.org/314485@main">https://commits.webkit.org/314485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/198a14cc4be5d30d2c87e4eb52170b8d7721d811

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175185 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123393 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129130 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109656 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30481 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29173 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23326 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177718 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28674 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137477 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137405 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37043 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148764 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102987 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32691 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25631 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38896 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38293 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3716 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38538 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38436 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->