### PR TITLE
PannerNode produces non-finite samples for edge-case distance parameters

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params-expected.txt
@@ -1,0 +1,4 @@
+
+PASS linear distance model with refDistance == maxDistance must not produce NaN/Inf samples
+PASS exponential distance model with refDistance == 0 must not produce NaN/Inf samples
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>PannerNode must not produce non-finite samples for edge-case distance parameters</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+// Linear distance model: gain = 1 - rolloff * (d - ref) / (max - ref).
+// When refDistance == maxDistance the denominator is 0, producing NaN/Inf
+// gain that bleeds into the rendered audio.
+promise_test(async () => {
+  const sampleRate = 48000;
+  const frames = 1024;
+  const ctx = new OfflineAudioContext(2, frames, sampleRate);
+
+  const buf = ctx.createBuffer(1, frames, sampleRate);
+  buf.getChannelData(0).fill(0.25);
+  const src = ctx.createBufferSource();
+  src.buffer = buf;
+  src.loop = true;
+
+  const panner = ctx.createPanner();
+  panner.distanceModel = "linear";
+  panner.refDistance = 1;
+  panner.maxDistance = 1;
+  panner.rolloffFactor = 1;
+  panner.positionX.value = 10;
+
+  src.connect(panner).connect(ctx.destination);
+  src.start();
+
+  const rendered = await ctx.startRendering();
+  for (let ch = 0; ch < rendered.numberOfChannels; ++ch) {
+    const data = rendered.getChannelData(ch);
+    for (let i = 0; i < data.length; ++i) {
+      assert_true(Number.isFinite(data[i]),
+        `channel ${ch} frame ${i} is ${data[i]} (expected finite)`);
+    }
+  }
+}, "linear distance model with refDistance == maxDistance must not produce NaN/Inf samples");
+
+// Exponential distance model: gain = (distance / refDistance)^(-rolloff).
+// When refDistance == 0 the division produces Inf, and when distance is also
+// 0 the result is NaN.
+promise_test(async () => {
+  const ctx = new OfflineAudioContext(2, 1024, 48000);
+  const buf = ctx.createBuffer(1, 1024, 48000);
+  buf.getChannelData(0).fill(0.25);
+  const src = ctx.createBufferSource();
+  src.buffer = buf;
+  src.loop = true;
+
+  const panner = ctx.createPanner();
+  panner.distanceModel = "exponential";
+  panner.refDistance = 0;
+  panner.rolloffFactor = 1;
+
+  src.connect(panner).connect(ctx.destination);
+  src.start();
+
+  const rendered = await ctx.startRendering();
+  for (let ch = 0; ch < rendered.numberOfChannels; ++ch) {
+    const data = rendered.getChannelData(ch);
+    for (let i = 0; i < data.length; ++i) {
+      assert_true(Number.isFinite(data[i]),
+        `channel ${ch} frame ${i} is ${data[i]} (expected finite)`);
+    }
+  }
+}, "exponential distance model with refDistance == 0 must not produce NaN/Inf samples");
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/audio/Distance.cpp
+++ b/Source/WebCore/platform/audio/Distance.cpp
@@ -66,6 +66,9 @@ double DistanceEffect::gain(double distance) const
 double DistanceEffect::linearGain(double distance) const
 {
     auto clampedRolloffFactor = std::clamp(m_rolloffFactor, 0.0, 1.0);
+    // The spec permits refDistance == maxDistance; avoid the resulting division by zero.
+    if (m_refDistance == m_maxDistance)
+        return 1.0 - clampedRolloffFactor;
     // We want a gain that decreases linearly from m_refDistance to
     // m_maxDistance. The gain is 1 at m_refDistance.
     return (1.0 - clampedRolloffFactor * (distance - m_refDistance) / (m_maxDistance - m_refDistance));
@@ -73,11 +76,15 @@ double DistanceEffect::linearGain(double distance) const
 
 double DistanceEffect::inverseGain(double distance) const
 {
+    if (!m_refDistance)
+        return 0;
     return m_refDistance / (m_refDistance + m_rolloffFactor * (distance - m_refDistance));
 }
 
 double DistanceEffect::exponentialGain(double distance) const
 {
+    if (!m_refDistance)
+        return 0;
     return pow(distance / m_refDistance, -m_rolloffFactor);
 }
 

--- a/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
+++ b/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
@@ -122,10 +122,7 @@ RetainPtr<NSDictionary> SerializedPlatformDataCueValue::toNSDictionary() const
 
 bool SerializedPlatformDataCueValue::operator==(const SerializedPlatformDataCueValue& other) const
 {
-    if (!m_data || !other.m_data)
-        return false;
-
-    return *m_data == *other.m_data;
+    return m_data == other.m_data;
 }
 
 bool SerializedPlatformDataCueValue::Data::operator==(const Data& other) const


### PR DESCRIPTION
#### 24f1c91b75334dd093f32ac65d9a69991696a689
<pre>
PannerNode produces non-finite samples for edge-case distance parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=316174">https://bugs.webkit.org/show_bug.cgi?id=316174</a>

Reviewed by NOBODY (OOPS!).

The Web Audio specification permits configurations that make the distance
gain formulas degenerate:
- Linear model with refDistance == maxDistance: divides by zero in
  1 - rolloff * (d - ref) / (max - ref).
- Inverse and exponential models with refDistance == 0: divide by zero
  in ref / (ref + ...) and pow(d / ref, ...) respectively.

These produced NaN / Inf gains that propagated into the rendered audio.
Guard each formula by returning the well-defined limit, matching the
behavior of Blink and Gecko:
- linearGain() returns 1 - rolloffFactor when refDistance == maxDistance.
- inverseGain() and exponentialGain() return 0 when refDistance == 0.

Test: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params.html
This test is passing in Chrome and Firefox, but failing in shipping Safari.

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params.html: Added.
* Source/WebCore/platform/audio/Distance.cpp:
(WebCore::DistanceEffect::linearGain const):
(WebCore::DistanceEffect::inverseGain const):
(WebCore::DistanceEffect::exponentialGain const):
</pre>
----------------------------------------------------------------------
#### d65933f2654c488edb65ef4148f2475624d7dc83
<pre>
SerializedPlatformDataCueValue::operator== is non-reflexive for default-constructed values
<a href="https://bugs.webkit.org/show_bug.cgi?id=316170">https://bugs.webkit.org/show_bug.cgi?id=316170</a>

Reviewed by NOBODY (OOPS!).

SerializedPlatformDataCueValue::operator== returned false whenever either
operand had no underlying Data (i.e. was constructed from a nil
AVMetadataItem or default-constructed). As a result, two empty cue values
compared unequal — including a value compared against itself — violating
the basic reflexivity invariant of equality and breaking any change
detection that relied on operator== for the empty case.

Defer to std::optional&lt;Data&gt;&apos;s built-in operator==, which correctly
returns true when both sides are nullopt, false when exactly one is, and
otherwise compares the wrapped Data via Data::operator==.

* Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm:
(WebCore::SerializedPlatformDataCueValue::operator== const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24f1c91b75334dd093f32ac65d9a69991696a689

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33211 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39634 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/175187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169099 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/23328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/26971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/28677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/177720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39699 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40387 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148767 "Build is in progress. Recent messages:") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/32695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38898 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/111972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38295 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/3720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38540 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38438 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->