### PR TITLE
PannerNode produces non-finite samples for edge-case distance parameters

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params-expected.txt
@@ -1,0 +1,4 @@
+
+PASS linear distance model with refDistance == maxDistance must not produce NaN/Inf samples
+PASS exponential distance model with refDistance == 0 must not produce NaN/Inf samples
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>PannerNode must not produce non-finite samples for edge-case distance parameters</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+// Linear distance model: gain = 1 - rolloff * (d - ref) / (max - ref).
+// When refDistance == maxDistance the denominator is 0, producing NaN/Inf
+// gain that bleeds into the rendered audio.
+promise_test(async () => {
+  const sampleRate = 48000;
+  const frames = 1024;
+  const ctx = new OfflineAudioContext(2, frames, sampleRate);
+
+  const buf = ctx.createBuffer(1, frames, sampleRate);
+  buf.getChannelData(0).fill(0.25);
+  const src = ctx.createBufferSource();
+  src.buffer = buf;
+  src.loop = true;
+
+  const panner = ctx.createPanner();
+  panner.distanceModel = "linear";
+  panner.refDistance = 1;
+  panner.maxDistance = 1;
+  panner.rolloffFactor = 1;
+  panner.positionX.value = 10;
+
+  src.connect(panner).connect(ctx.destination);
+  src.start();
+
+  const rendered = await ctx.startRendering();
+  for (let ch = 0; ch < rendered.numberOfChannels; ++ch) {
+    const data = rendered.getChannelData(ch);
+    for (let i = 0; i < data.length; ++i) {
+      assert_true(Number.isFinite(data[i]),
+        `channel ${ch} frame ${i} is ${data[i]} (expected finite)`);
+    }
+  }
+}, "linear distance model with refDistance == maxDistance must not produce NaN/Inf samples");
+
+// Exponential distance model: gain = (distance / refDistance)^(-rolloff).
+// When refDistance == 0 the division produces Inf, and when distance is also
+// 0 the result is NaN.
+promise_test(async () => {
+  const ctx = new OfflineAudioContext(2, 1024, 48000);
+  const buf = ctx.createBuffer(1, 1024, 48000);
+  buf.getChannelData(0).fill(0.25);
+  const src = ctx.createBufferSource();
+  src.buffer = buf;
+  src.loop = true;
+
+  const panner = ctx.createPanner();
+  panner.distanceModel = "exponential";
+  panner.refDistance = 0;
+  panner.rolloffFactor = 1;
+
+  src.connect(panner).connect(ctx.destination);
+  src.start();
+
+  const rendered = await ctx.startRendering();
+  for (let ch = 0; ch < rendered.numberOfChannels; ++ch) {
+    const data = rendered.getChannelData(ch);
+    for (let i = 0; i < data.length; ++i) {
+      assert_true(Number.isFinite(data[i]),
+        `channel ${ch} frame ${i} is ${data[i]} (expected finite)`);
+    }
+  }
+}, "exponential distance model with refDistance == 0 must not produce NaN/Inf samples");
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/audio/Distance.cpp
+++ b/Source/WebCore/platform/audio/Distance.cpp
@@ -66,19 +66,32 @@ double DistanceEffect::gain(double distance) const
 double DistanceEffect::linearGain(double distance) const
 {
     auto clampedRolloffFactor = std::clamp(m_rolloffFactor, 0.0, 1.0);
+    // The spec permits refDistance == maxDistance; avoid the resulting division by zero.
+    if (m_refDistance == m_maxDistance)
+        return 1.0 - clampedRolloffFactor;
     // We want a gain that decreases linearly from m_refDistance to
     // m_maxDistance. The gain is 1 at m_refDistance.
     return (1.0 - clampedRolloffFactor * (distance - m_refDistance) / (m_maxDistance - m_refDistance));
 }
 
-double DistanceEffect::inverseGain(double distance) const
+SUPPRESS_NODELETE double DistanceEffect::inverseGain(double distance) const
 {
-    return m_refDistance / (m_refDistance + m_rolloffFactor * (distance - m_refDistance));
+    // The spec mandates clamping distance to be at least refDistance for the inverse
+    // model. With that clamping in place, the only remaining division by zero is when
+    // refDistance and distance are both 0.
+    if (!m_refDistance && !distance)
+        return 0;
+    return m_refDistance / (m_refDistance + m_rolloffFactor * (std::max(distance, m_refDistance) - m_refDistance));
 }
 
 double DistanceEffect::exponentialGain(double distance) const
 {
-    return pow(distance / m_refDistance, -m_rolloffFactor);
+    // The spec mandates clamping distance to be at least refDistance for the exponential
+    // model. With that clamping in place, the only remaining division by zero is when
+    // refDistance and distance are both 0.
+    if (!m_refDistance && !distance)
+        return 0;
+    return pow(std::max(distance, m_refDistance) / m_refDistance, -m_rolloffFactor);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6ee8c6bb887e95f6523846509a7824c2eeabbcc5
<pre>
PannerNode produces non-finite samples for edge-case distance parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=316174">https://bugs.webkit.org/show_bug.cgi?id=316174</a>

Reviewed by Eric Carlson.

The Web Audio specification permits configurations that make the distance
gain formulas degenerate:
- Linear model with refDistance == maxDistance: divides by zero in
  1 - rolloff * (d - ref) / (max - ref).
- Inverse and exponential models with refDistance == 0 and distance == 0:
  divide by zero in ref / (ref + ...) and pow(d / ref, ...) respectively.

These produced NaN / Inf gains that propagated into the rendered audio.
Guard the formulas by returning the well-defined limit:
- linearGain() returns 1 - rolloffFactor when refDistance == maxDistance.
- inverseGain() and exponentialGain() apply the spec-mandated
  std::max(distance, refDistance) clamping inline (matching Gecko) so the
  only remaining division by zero is when both refDistance and distance
  are 0; that case returns 0.

Test: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params.html
This test is passing in Chrome and Firefox, but failing in shipping Safari.

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-non-finite-distance-params.html: Added.
* Source/WebCore/platform/audio/Distance.cpp:
(WebCore::DistanceEffect::linearGain const):
(WebCore::DistanceEffect::inverseGain const):
(WebCore::DistanceEffect::exponentialGain const):

Canonical link: <a href="https://commits.webkit.org/314608@main">https://commits.webkit.org/314608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c1938499f04e54090bccf2f5abd26885a99d6a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123857 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cfea8782-41db-4b97-8233-a7c8b0c12f05) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129530 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110055 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b5dedc7-2fd5-41ef-92f0-80ce51370b71) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29597 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23790 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178183 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31083 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137892 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137809 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37129 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40849 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149191 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103586 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33097 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26056 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39360 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112434 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38756 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4146 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39001 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38899 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->