### PR TITLE
AudioData.copyTo accepts frameOffset == numberOfFrames instead of throwing RangeError

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any-expected.txt
@@ -2,4 +2,5 @@
 PASS Test that AudioData.copyTo copies frameCount amount of mono frames from frameOffset
 PASS Test that AudioData.copyTo copies frameCount amount of stereo frames from frameOffset
 PASS Test that AudioData.copyTo copies frameCount amount of interleaved stereo frames from frameOffset
+PASS AudioData.copyTo throws RangeError when frameOffset >= frameCount
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.js
@@ -88,3 +88,25 @@ test(() => {
     0, 0,
   ], 'only 3 middle elements are copied');
 }, 'Test that AudioData.copyTo copies frameCount amount of interleaved stereo frames from frameOffset');
+
+// Per the "Compute Copy Element Count" algorithm step 7
+// (https://www.w3.org/TR/webcodecs/#compute-copy-element-count):
+// "If options.frameOffset is greater than or equal to frameCount, throw a RangeError."
+test(() => {
+  const data = new AudioData({
+    format: 'f32',
+    sampleRate: 48000,
+    numberOfChannels: 1,
+    numberOfFrames: 5,
+    data: new Float32Array([1, 2, 3, 4, 5]),
+    timestamp: 0,
+  });
+  const output = new Float32Array(5);
+  assert_throws_js(RangeError, () => {
+    data.copyTo(output, { planeIndex: 0, frameOffset: 5 });
+  }, 'frameOffset == numberOfFrames must throw RangeError');
+  assert_throws_js(RangeError, () => {
+    data.copyTo(output, { planeIndex: 0, frameOffset: 6 });
+  }, 'frameOffset > numberOfFrames must throw RangeError');
+  data.close();
+}, 'AudioData.copyTo throws RangeError when frameOffset >= frameCount');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker-expected.txt
@@ -2,4 +2,5 @@
 PASS Test that AudioData.copyTo copies frameCount amount of mono frames from frameOffset
 PASS Test that AudioData.copyTo copies frameCount amount of stereo frames from frameOffset
 PASS Test that AudioData.copyTo copies frameCount amount of interleaved stereo frames from frameOffset
+PASS AudioData.copyTo throws RangeError when frameOffset >= frameCount
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
@@ -120,7 +120,7 @@ ExceptionOr<size_t> computeCopyElementCount(const WebCodecsAudioData& data, cons
     // All planes have the same number of frames, always
     auto frameCount = data.numberOfFrames();
     // 7. If options.frameOffset is greater than or equal to frameCount, throw a RangeError.
-    if (options.frameOffset && *options.frameOffset > frameCount)
+    if (options.frameOffset && *options.frameOffset >= frameCount)
         return Exception { ExceptionCode::RangeError, "frameOffset is too large"_s };
 
     // 8. Let copyFrameCount be the difference of subtracting options.frameOffset from frameCount.


### PR DESCRIPTION
#### 1e4a60e7e40a00a2de58d489c9dbbe3ffc30fb73
<pre>
AudioData.copyTo accepts frameOffset == numberOfFrames instead of throwing RangeError
<a href="https://bugs.webkit.org/show_bug.cgi?id=316175">https://bugs.webkit.org/show_bug.cgi?id=316175</a>

Reviewed by Youenn Fablet.

Step 7 of the WebCodecs &quot;Compute Copy Element Count&quot; algorithm
(<a href="https://www.w3.org/TR/webcodecs/#compute-copy-element-count)">https://www.w3.org/TR/webcodecs/#compute-copy-element-count)</a> requires
throwing a RangeError when options.frameOffset is greater than or equal
to frameCount.

The check used &gt; instead of &gt;=, so frameOffset == numberOfFrames passed
through silently and resulted in a zero-frame copy rather than the
spec-mandated RangeError. The accompanying comment already stated the
correct rule; only the operator was wrong.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp:
(WebCore::computeCopyElementCount):

Canonical link: <a href="https://commits.webkit.org/314451@main">https://commits.webkit.org/314451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dab1699e6a287b62ebe1e25f01bfe16d7dd27afa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175195 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123403 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129137 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3db41df-9803-48a7-9193-f396374276dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109663 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29182 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23336 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177728 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30630 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137484 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137412 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37022 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148773 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102998 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32699 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25640 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38906 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111980 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38303 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3726 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38548 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38446 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->