### PR TITLE
REGRESSION (227273@main): ScrollbarThemeMac::hasButtons no longer

### DIFF
--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -276,9 +276,9 @@ inline constexpr unsigned NODELETE scrollbarWidthToIndex(ScrollbarWidth scrollba
 
 bool ScrollbarThemeMac::hasButtons(Scrollbar& scrollbar)
 {
-    if (scrollbar.enabled() && buttonsPlacement() != ScrollbarButtonsNone && (scrollbar.orientation() == ScrollbarOrientation::Horizontal))
-        return scrollbar.width();
-    return scrollbar.height() >= 2 * (cRealButtonLength[scrollbarWidthToIndex(scrollbar.widthStyle())] - cButtonHitInset[scrollbarWidthToIndex(scrollbar.widthStyle())]);
+    return scrollbar.enabled() && buttonsPlacement() != ScrollbarButtonsNone
+        && (scrollbar.orientation() == ScrollbarOrientation::Horizontal ? scrollbar.width() : scrollbar.height())
+            >= 2 * (cRealButtonLength[scrollbarWidthToIndex(scrollbar.widthStyle())] - cButtonHitInset[scrollbarWidthToIndex(scrollbar.widthStyle())]);
 }
 
 bool ScrollbarThemeMac::hasThumb(Scrollbar& scrollbar)


### PR DESCRIPTION
#### f117c616f8c4c41f1f5d19626cd15a7ac1a41dea
<pre>
REGRESSION (<a href="https://commits.webkit.org/227273@main">227273@main</a>): ScrollbarThemeMac::hasButtons no longer
compares scrollbar length to the button-fit threshold
<a href="https://bugs.webkit.org/show_bug.cgi?id=316176">https://bugs.webkit.org/show_bug.cgi?id=316176</a>

Reviewed by NOBODY (OOPS!).

Before <a href="https://commits.webkit.org/227273@main">227273@main</a>, ScrollbarThemeMac::hasButtons() was a single
conditional expression that selected width() for horizontal scrollbars
or height() for vertical scrollbars, then compared the result to
`2 * (cRealButtonLength - cButtonHitInset)`:

```
return scrollbar-&gt;enabled() &amp;&amp; buttonsPlacement() != ScrollbarButtonsNone
         &amp;&amp; (scrollbar-&gt;orientation() == HorizontalScrollbar
         ? scrollbar-&gt;width()
         : scrollbar-&gt;height()) &gt;= 2 * (cRealButtonLength[scrollbar-&gt;controlSize()] - cButtonHitInset[scrollbar-&gt;controlSize()]);
```

<a href="https://commits.webkit.org/227273@main">227273@main</a> refactored it into an if/else form that lost two pieces
of logic:

```
if (scrollbar.enabled() &amp;&amp; buttonsPlacement() != ScrollbarButtonsNone &amp;&amp; (scrollbar.orientation() == HorizontalScrollbar))
    return scrollbar.width();
return scrollbar.height() &gt;= 2 * (cRealButtonLength[scrollbarSizeToIndex(scrollbar.controlSize())] - cButtonHitInset[scrollbarSizeToIndex(scrollbar.controlSize())]);
```

1. For enabled horizontal scrollbars, the function now returns
   `scrollbar.width()` directly (truthy for any non-zero width)
   instead of comparing it to the threshold. hasButtons() therefore
   reports true even when the scrollbar is too short to fit the
   buttons.

2. The fallthrough path (disabled scrollbar, ScrollbarButtonsNone,
   or vertical orientation) unconditionally measures
   `scrollbar.height()` against the threshold, so horizontal
   scrollbars that take this path are measured along the wrong
   axis.

Restore the original conditional axis selection so the threshold is
compared against width() for horizontal and height() for vertical
scrollbars.

No test added: on macOS, gButtonPlacement is initialized to
ScrollbarButtonsNone in the ScrollbarThemeMac constructor and is
never reassigned, so the `buttonsPlacement() != ScrollbarButtonsNone`
guard in hasButtons() always short-circuits to false in production.
The regression therefore has no observable runtime effect on Mac, and
the buggy and fixed versions produce identical behavior for every
reachable scrollbar configuration. Adding a test would require
introducing a test-only hook to override gButtonPlacement purely to
exercise an otherwise unreachable code path. This change is a
correctness fix to dormant code so it behaves correctly if button
placement is ever re-enabled.

* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::hasButtons):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f117c616f8c4c41f1f5d19626cd15a7ac1a41dea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123424 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168035 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129156 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90975 "3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31533 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149299 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 2 api tests failed or timed out; Running re-run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109682 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30510 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29203 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23357 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177749 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30651 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137504 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137432 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148793 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103026 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32720 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25660 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38927 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112001 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38324 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3746 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38569 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38467 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->