### PR TITLE
Potential null deref in HIDDevice::uniqueInputElementsInDeviceTreeOrder when an HID collection has no children

### DIFF
--- a/Source/WebCore/platform/mac/HIDDevice.cpp
+++ b/Source/WebCore/platform/mac/HIDDevice.cpp
@@ -94,7 +94,8 @@ Vector<HIDElement> HIDDevice::uniqueInputElementsInDeviceTreeOrder() const
         switch (IOHIDElementGetType(element.get())) {
         case kIOHIDElementTypeCollection: {
             RetainPtr children = IOHIDElementGetChildren(element.get());
-            for (CFIndex i = CFArrayGetCount(children.get()) - 1; i >= 0; --i)
+            CFIndex childCount = children ? CFArrayGetCount(children.get()) : 0;
+            for (CFIndex i = childCount - 1; i >= 0; --i)
                 elementQueue.prepend(checked_cf_cast<IOHIDElementRef>(CFArrayGetValueAtIndex(children.get(), i)));
             continue;
         }


### PR DESCRIPTION
#### dc24f31e117d804296b6b5a1fa56014a6e9fe21a
<pre>
Potential null deref in HIDDevice::uniqueInputElementsInDeviceTreeOrder when an HID collection has no children
<a href="https://bugs.webkit.org/show_bug.cgi?id=316177">https://bugs.webkit.org/show_bug.cgi?id=316177</a>

Reviewed by Basuke Suzuki.

`IOHIDElementGetChildren()` may return NULL for an HID collection
element that has no children, and `CFArrayGetCount(NULL)` is undefined
behavior. The sibling code path that handles `IOHIDDeviceCopyMatchingElements`
(a few lines above) already defends against this:

RetainPtr elements = adoptCF(IOHIDDeviceCopyMatchingElements(...));
CFIndex count = elements ? CFArrayGetCount(elements.get()) : 0;

The collection branch added in 227779@main did not adopt the same
guard:
```
  RetainPtr children = IOHIDElementGetChildren(element.get());
  for (CFIndex i = CFArrayGetCount(children.get()) - 1; i &gt;= 0; --i)
      elementQueue.prepend(checked_cf_cast(CFArrayGetValueAtIndex(children.get(), i)));
```
Apply the same defensive pattern so a childless collection does not
crash.

* Source/WebCore/platform/mac/HIDDevice.cpp:
(WebCore::HIDDevice::uniqueInputElementsInDeviceTreeOrder const):

Canonical link: <a href="https://commits.webkit.org/314593@main">https://commits.webkit.org/314593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/687fe0021470740b92380154fbae34e571edf322

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123406 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129140 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90963 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109666 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91322b42-e0e8-4f9b-b9ae-4f2130439e7d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30493 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29185 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23339 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140462 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177731 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30633 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137488 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33330 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137416 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37120 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148780 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103001 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32701 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25647 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38909 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111983 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38306 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3733 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38551 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38449 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->