### PR TITLE
[YARR] Fix NonGreedy backtracking

### DIFF
--- a/JSTests/stress/regexp-nongreedy-varcount-content-backtrack.js
+++ b/JSTests/stress/regexp-nongreedy-varcount-content-backtrack.js
@@ -1,0 +1,121 @@
+// Regression test for NonGreedy {m,n}? parentheses backtracking in the YarrJIT.
+//
+// The JIT drives NonGreedy expansion (adding iterations) from END.bt, but when
+// expansion and the latest iteration's content retries are exhausted it must undo
+// the latest iteration and content-backtrack the PREVIOUS iteration, then let
+// forward execution re-expand. Three bugs in that area:
+//
+//   1. min > 0, count >= min: took the Greedy "accept fewer" path instead of
+//      content-retrying earlier iterations -> non-leftmost / missed matches.
+//   2. min > 0 content retry: restoreParenContext clobbered frame.beginIndex with
+//      the popped iteration's begin, so END.bt's progress check refused to
+//      re-expand after shrinking an earlier iteration.
+//   3. min == 0: the NonGreedy backtrack was an empty break, so completed
+//      iterations were never content-backtracked at all.
+//
+// All three produced a wrong result (null or a non-leftmost match) in the JIT
+// while the interpreter and V8 are correct. We run each pattern enough times to
+// tier up so the JIT result is what gets checked.
+
+function run(re, str) {
+    var m = null;
+    for (var i = 0; i < 200; ++i) {
+        re.lastIndex = 0;
+        m = re.exec(str);
+    }
+    return m ? JSON.stringify(Array.prototype.slice.call(m)) + "@" + m.index : "null";
+}
+
+function check(re, str, expected) {
+    var actual = run(re, str);
+    if (actual !== expected)
+        throw new Error("FAILED " + re + " on '" + str + "': expected " + expected + " but got " + actual);
+}
+
+// Bug 1: NonGreedy min>0 must retry earlier iterations' alternatives for a leftmost match.
+check(/(?:aab|ab|a){1,2}?b/, "aaba", '["aab"]@0');
+
+// Bug 2: NonGreedy min>0 must re-expand after shrinking an earlier iteration (3+2+2 split).
+check(/^(?:a{2,3}){1,3}?b$/, "aaaaaaab", '["aaaaaaab"]@0');
+
+// Bug 3: NonGreedy min==0 must content-backtrack completed iterations (3+2+2 split).
+check(/^(?:a{2,3}){0,3}?b$/, "aaaaaaab", '["aaaaaaab"]@0');
+
+// Additional NonGreedy coverage.
+check(/(?:a){0,3}?b/, "aaab", '["aaab"]@0');
+check(/(?:a){1,3}?b/, "b", "null");
+check(/(?:a){2,3}?b/, "aaab", '["aaab"]@0');
+check(/(?:a){2,3}?b/, "aab", '["aab"]@0');
+check(/(?:ab|a){2,4}?c/, "ababc", '["ababc"]@0');
+check(/(?:a|aa|aaa){1,3}?b/, "aaaaaab", '["aaaaaab"]@0');
+check(/(?:a|aa|aaa){0,3}?b/, "aaaaaab", '["aaaaaab"]@0');
+check(/c(?:a{1,2}){1,3}?b/, "caaaaab", '["caaaaab"]@0');
+check(/(?:a{2}){1,3}?b/, "aaaaaab", '["aaaaaab"]@0');
+check(/(foo|foobar){1,2}?baz/, "foofoobarbaz", '["foofoobarbaz","foobar"]@0');
+
+// min==0 NonGreedy total-failure path: BEGIN.bt reaches count==0 after popping the
+// first actual iteration. The empty (zero-iteration) alternative was already tried
+// first via the forward skip, so propagating failure is correct — the parens must
+// return no match here, not silently re-accept empty.
+check(/^(?:a){0,3}?b$/, "aac", "null");
+check(/(?:ab){0,2}?c/, "abx", "null");
+check(/^(?:a{2,3}){0,3}?b$/, "aaaaaaac", "null");
+check(/^(?:a{2,3}){0,3}?$/, "a", "null");
+check(/^(?:aa|a){0,3}?b$/, "aaac", "null");
+// ...and the empty/skip-first alternative still matches when it should:
+check(/^(?:a){0,3}?b$/, "b", '["b"]@0');
+check(/(?:ab){0,2}?c/, "c", '["c"]@0');
+check(/^(?:a{2,3}){0,3}?b$/, "b", '["b"]@0');
+
+// Greedy controls must remain correct after the refactor of the shared path.
+check(/^(?:a{2,3}){1,3}b$/, "aaaaaaab", '["aaaaaaab"]@0');
+check(/(?:aab|ab|a){1,2}b/, "aaba", '["aab"]@0');
+check(/(foo|foobar){1,2}baz/, "foofoobarbaz", '["foofoobarbaz","foobar"]@0');
+
+// Nested variable-count parens must enforce the INNER lazy minimum. The inner
+// (?:a+){2,3}? needs >= 2 iterations; accepting 1 (via a mis-restored outer frame on
+// the JIT, or a missing min-refill on the interpreter content-backtrack) wrongly matches.
+check(/^((?:a+){2,3}?){2,3}ba/, "aaababa", "null");
+
+// Interpreter (also forced here via lookbehind): NonGreedy parens must not accept
+// fewer than quantityMinCount iterations after a content backtrack. {2,3}? needs >= 2.
+check(/(?<=Q)(?:xy|x){2,3}?yxw/, "Qxyxwab", "null");
+
+// Mandatory iterations (count <= min) may match zero-length on backtrack: the {1,3}
+// group's single mandatory iteration must be allowed to retry to the empty alternative
+// so the following "b" can match at index 0.
+check(/^(a|b|){1,3}b/, "bybaaybww", '["b",""]@0');
+check(/^(?:a|b|){1,2}?b/, "b", '["b"]@0');
+
+// Greedy accept-fewer must keep EXACTLY quantityMinCount surviving iterations when it
+// drops down to the minimum (the cannotAcceptFewer test is `Below min`, not `BelowOrEqual`).
+// Here forward overshoots to 3-4 iterations, then must drop back to exactly 2 so the tail
+// matches; with a `BelowOrEqual` threshold these would wrongly content-backtrack to null.
+check(/^(?:(a)|(b)){2,3}ba$/, "abba", '["abba",null,"b"]@0');
+check(/^(?:(a)|(b)){2,4}ba$/, "aabba", '["aabba",null,"b"]@0');
+check(/^(?:(x)|(y)){2,3}yx$/, "xyyx", '["xyyx",null,"y"]@0');
+check(/^(?:(a)|(bb)){2,3}bbc$/, "abbbbc", '["abbbbc",null,"bb"]@0');
+check(/^(?:a{2,3}){2,3}$/, "aaaa", '["aaaa"]@0');   // 2+2, drop to exactly min
+check(/^(?:a{2,3}){2,3}$/, "aaa", "null");          // can't reach min -> fail
+check(/^(?:a{1,2}){2,4}aa$/, "aaaaaa", '["aaaaaa"]@0');
+
+// Greedy accept-zero (min==0, count==0): the group matches zero iterations and the inner
+// captures must reset to undefined via the restored pre-iteration snapshot — even though
+// the greedy forward had set them — without an explicit clear on that success path.
+check(/^(?:(a))*ab$/, "ab", '["ab",null]@0');
+check(/^(?:(a))*(b)$/, "b", '["b",null,"b"]@0');
+check(/^(?:(a)(c))*ac$/, "ac", '["ac",null,null]@0');
+
+// Greedy re-expansion after accept-fewer: backtracking must shrink an earlier iteration
+// and then ADD another to refill (e.g. the 3+2+2 split below). This relies on the
+// accept-fewer path decrementing matchAmount before jumping to End.reentry, so that when
+// the surviving iteration is later re-processed END.forward's re-increment lands on the
+// correct count and its `count < max` check still allows adding the extra iteration.
+// Dropping that decrement makes these return null (END.forward over-counts -> thinks max
+// is reached -> never adds the needed iteration).
+check(/^(?:a{2,3}){1,3}b$/, "aaaaaaab", '["aaaaaaab"]@0');     // 3+2+2
+check(/^(?:a{2,3}){1,4}b$/, "aaaaaaaaab", '["aaaaaaaaab"]@0'); // 3+2+2+2
+check(/^(?:a{2,3}){2,4}c$/, "aaaaaaaac", '["aaaaaaaac"]@0');
+check(/^(?:a{2,4}){2,3}d$/, "aaaaaaad", '["aaaaaaad"]@0');
+check(/^(?:a{1,3}){2,3}x$/, "aaaaax", '["aaaaax"]@0');
+check(/^(?:ab|abc){1,3}d$/, "ababcd", '["ababcd"]@0');

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -1428,31 +1428,13 @@ public:
         ASSERT(term.atom.quantityType != QuantifierType::FixedCount || term.atom.quantityMinCount == term.atom.quantityMaxCount);
 
         unsigned minimumMatchCount = term.atom.quantityMinCount;
-        JSRegExpResult fixedMatchResult;
 
         // Handle fixed matches and the minimum part of a variable length match.
         if (minimumMatchCount) {
-            // While we haven't yet reached our fixed limit,
-            while (backTrack->matchAmount < minimumMatchCount) {
-                // Try to do a match, and it it succeeds, add it to the list.
-                ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                if (!context) [[unlikely]]
-                    return JSRegExpResult::ErrorNoMemory;
-                fixedMatchResult = matchDisjunction(disjunctionBody, context->getDisjunctionContext());
-                if (fixedMatchResult == JSRegExpResult::Match)
-                    appendParenthesesDisjunctionContext(backTrack, context);
-                else {
-                    // The match failed; try to find an alternate point to carry on from.
-                    resetMatches(term, context);
-                    freeParenthesesDisjunctionContext(context);
-                    
-                    if (fixedMatchResult != JSRegExpResult::NoMatch)
-                        return fixedMatchResult;
-                    JSRegExpResult backtrackResult = parenthesesDoBacktrack(term, backTrack);
-                    if (backtrackResult != JSRegExpResult::Match)
-                        return backtrackResult;
-                }
-            }
+            // Match the mandatory iterations, backtracking earlier ones as needed.
+            JSRegExpResult result = refillParenthesesContextsToMinCount(term, backTrack, disjunctionBody);
+            if (result != JSRegExpResult::Match)
+                return result;
 
             ParenthesesDisjunctionContext* context = backTrack->lastContext;
             recordParenthesesMatch(term, context);
@@ -1559,7 +1541,12 @@ public:
                 return JSRegExpResult::NoMatch;
 
             ParenthesesDisjunctionContext* context = backTrack->lastContext;
-            JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(), true);
+            // Per RepeatMatcher, only iterations beyond the mandatory minimum must be
+            // non-empty; a mandatory iteration (count <= min) may match zero-length, so
+            // retry its content allowing an empty match in that case.
+            JSRegExpResult result = (backTrack->matchAmount <= term.atom.quantityMinCount)
+                ? matchDisjunction(disjunctionBody, context->getDisjunctionContext(), true)
+                : matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(), true);
             if (result == JSRegExpResult::Match) {
                 while (backTrack->matchAmount < term.atom.quantityMaxCount) {
                     ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
@@ -1600,25 +1587,10 @@ public:
                     if (result != JSRegExpResult::Match)
                         return result;
 
-                    // Now content-backtracking succeeded. We will try to match up to min-count.
-                    while (backTrack->matchAmount < term.atom.quantityMinCount) {
-                        context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                        if (!context) [[unlikely]]
-                            return JSRegExpResult::ErrorNoMemory;
-                        result = matchDisjunction(disjunctionBody, context->getDisjunctionContext());
-                        if (result == JSRegExpResult::Match)
-                            appendParenthesesDisjunctionContext(backTrack, context);
-                        else {
-                            resetMatches(term, context);
-                            freeParenthesesDisjunctionContext(context);
-
-                            if (result != JSRegExpResult::NoMatch)
-                                return result;
-                            result = parenthesesDoBacktrack(term, backTrack);
-                            if (result != JSRegExpResult::Match)
-                                return result;
-                        }
-                    }
+                    // Now content-backtracking succeeded. Refill back up to min-count.
+                    result = refillParenthesesContextsToMinCount(term, backTrack, disjunctionBody);
+                    if (result != JSRegExpResult::Match)
+                        return result;
                 }
             }
 
@@ -1652,8 +1624,22 @@ public:
             // Nope - okay backtrack looking for an alternative.
             while (backTrack->matchAmount) {
                 ParenthesesDisjunctionContext* context = backTrack->lastContext;
-                JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(), true);
+                // Mandatory iterations (count <= min) may match zero-length; only extra
+                // iterations must be non-empty (RepeatMatcher).
+                JSRegExpResult result = (backTrack->matchAmount <= term.atom.quantityMinCount)
+                    ? matchDisjunction(disjunctionBody, context->getDisjunctionContext(), true)
+                    : matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(), true);
                 if (result == JSRegExpResult::Match) {
+                    // A successful content backtrack may have left us below the mandatory
+                    // minimum (we popped iterations above while searching for an alternative).
+                    // NonGreedy still requires at least min iterations, so refill back up to
+                    // min before accepting — mirroring the Greedy case. Without this the
+                    // interpreter would return a match with fewer than quantityMinCount
+                    // iterations (e.g. /(?:xy|x){2,3}?yxw/ wrongly matching "xyxw").
+                    result = refillParenthesesContextsToMinCount(term, backTrack, disjunctionBody);
+                    if (result != JSRegExpResult::Match)
+                        return result;
+
                     // successful backtrack! we're back in the game!
                     if (backTrack->matchAmount) {
                         context = backTrack->lastContext;
@@ -1677,6 +1663,28 @@ public:
 
         RELEASE_ASSERT_NOT_REACHED();
         return JSRegExpResult::ErrorNoMatch;
+    }
+
+    JSRegExpResult refillParenthesesContextsToMinCount(ByteTerm& term, BackTrackInfoParentheses* backTrack, ByteDisjunction* disjunctionBody)
+    {
+        while (backTrack->matchAmount < term.atom.quantityMinCount) {
+            ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
+            if (!context) [[unlikely]]
+                return JSRegExpResult::ErrorNoMemory;
+            JSRegExpResult result = matchDisjunction(disjunctionBody, context->getDisjunctionContext());
+            if (result == JSRegExpResult::Match) {
+                appendParenthesesDisjunctionContext(backTrack, context);
+                continue;
+            }
+            resetMatches(term, context);
+            freeParenthesesDisjunctionContext(context);
+            if (result != JSRegExpResult::NoMatch)
+                return result;
+            result = parenthesesDoBacktrack(term, backTrack);
+            if (result != JSRegExpResult::Match)
+                return result;
+        }
+        return JSRegExpResult::Match;
     }
 
     bool matchDotStarEnclosure(ByteTerm& term, DisjunctionContext* context)

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -5300,7 +5300,8 @@ class YarrGenerator final : public YarrJITInfo {
                     break;
                 }
 
-                // Greedy/NonGreedy path: restore from context and try fewer iterations.
+                // Greedy/NonGreedy path: pop the latest iteration's context and decide
+                // how to continue backtracking based on the quantifier direction.
                 restoreParenContext(currParenContextReg, m_regs.regT2, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation);
 
                 m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), newParenContextReg);
@@ -5310,81 +5311,87 @@ class YarrGenerator final : public YarrJITInfo {
                 const MacroAssembler::RegisterID countTemporary = m_regs.regT0;
                 loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), countTemporary);
 
-                // We can accept fewer iterations only if count >= min: the next
-                // bt step's restore would land us at "count actual iterations" worth
-                // of position (since restoreParenContext gives state pre-iter (k+1) =
-                // post-iter k where k = count).
-                //
-                // For min == 0 we keep the existing count == 0 branch so the Greedy
-                // "accept zero" / NonGreedy "fail" paths still work and we avoid an
-                // unsigned underflow on the decrement.
-                //
-                // For min > 0 with count < min: we can't accept the current count,
-                // but we may still be able to find a valid match by backtracking into the
-                // latest iter's content (via END.contentBacktrackEntryLabel) — e.g. for
-                // /(?:(?:ab)+){2,}/ against "abab", the outer needs to break iter 1 into
-                // smaller pieces so iter 2 can match.
                 YarrOp& endOp = m_ops[op.m_nextOp];
-                MacroAssembler::Jump cannotAcceptFewer = term->quantityMinCount
-                    ? m_jit.branch32(MacroAssembler::Below, countTemporary, MacroAssembler::Imm32(term->quantityMinCount))
-                    : m_jit.branchTest32(MacroAssembler::Zero, countTemporary);
 
-                // count >= min (or > 0 for min == 0). So mandatory requirement is still passing.
-                // Decrement and try fewer iterations.
+                auto noPreviousIteration = m_jit.branchTest32(MacroAssembler::Zero, countTemporary);
+                m_jit.load32(MacroAssembler::Address(newParenContextReg, ParenContext::beginOffset()), m_regs.regT2);
+                storeToFrame(m_regs.regT2, parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
+
                 m_jit.sub32(MacroAssembler::TrustedImm32(1), countTemporary);
                 storeToFrame(countTemporary, parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
-                m_jit.jump(endOp.m_reentry);
 
-                cannotAcceptFewer.link(&m_jit);
-                if (term->quantityMinCount) {
-                    // count_loaded < min: can't accept this many iterations. If count > 0
-                    // try retrying the latest iter's content via END's content backtrack;
-                    // if count == 0 there's no prior iter to retry, so propagate failure.
-                    MacroAssembler::Jump noIterToRetry = m_jit.branchTest32(MacroAssembler::Zero, countTemporary);
-
-                    // count > 0: decrement count (END.forward will re-increment after a
-                    // successful retry) and jump to content backtrack entry. The earlier
-                    // restoreParenContext already left m_regs.index at the end of iter k.
-                    m_jit.sub32(MacroAssembler::TrustedImm32(1), countTemporary);
-                    storeToFrame(countTemporary, parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
+                switch (term->quantityType) {
+                case QuantifierType::NonGreedy: {
                     ASSERT(endOp.m_op == YarrOpCode::ParenthesesSubpatternEnd);
                     ASSERT(endOp.m_contentBacktrackEntryLabel.isSet());
                     m_jit.jump(endOp.m_contentBacktrackEntryLabel);
 
-                    // Now we are not able to try any backtracking. So parentheses with min-count gets complete failure.
-                    // We need to clear the state, and go back to the further former backtracking.
-                    noIterToRetry.link(&m_jit);
-                    op.m_jumps.link(&m_jit);
+                    // No earlier iteration to retry: the parens fail. Clear captures, mark
+                    // the frame as not-run, and propagate to the previous backtrack point.
+                    //
+                    // Even if quantityMinCount == 0, we should make it a complete failure.
+                    // This is because NonGreedy already tried with count = 0, failing and reaching here.
+                    // So there is no way to proceed further, just propagate a failure.
+                    noPreviousIteration.link(&m_jit);
                     if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
                         for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
                             clearSubpattern(subpattern);
                     }
-                } else {
-                    // Clear the flag in the stackframe indicating we didn't run through the subpattern.
                     storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
+                    m_backtrackingState.fallthrough();
+                    break;
+                }
 
-                    switch (term->quantityType) {
-                    case QuantifierType::Greedy: {
-                        // If Greedy, jump to the end.
+                case QuantifierType::Greedy: {
+                    // Greedy: we took as many iterations as possible, so backtracking reduces
+                    // the count. We can accept fewer iterations only if count >= min: the next
+                    // bt step's restore would land us at "count actual iterations" worth
+                    // of position (since restoreParenContext gives state pre-iter (k+1) =
+                    // post-iter k where k = count).
+                    if (term->quantityMinCount) {
+                        // countTemporary was decremented above, so it now holds
+                        // (surviving count - 1). Accept fewer iterations when the surviving
+                        // count is still >= min, i.e. countTemporary >= min - 1.
+                        m_jit.branch32(MacroAssembler::AboveOrEqual, countTemporary, MacroAssembler::Imm32(term->quantityMinCount - 1)).linkTo(endOp.m_reentry, &m_jit);
+
+                        // Jump to content backtrack entry. The earlier restoreParenContext already left m_regs.index at the end of iter k.
+                        ASSERT(endOp.m_op == YarrOpCode::ParenthesesSubpatternEnd);
+                        ASSERT(endOp.m_contentBacktrackEntryLabel.isSet());
+                        m_jit.jump(endOp.m_contentBacktrackEntryLabel);
+
+                        // Now we are not able to try any backtracking. So parentheses with min-count gets complete failure.
+                        // We need to clear the state, and go back to the further former backtracking.
+                        noPreviousIteration.link(&m_jit);
+                        op.m_jumps.link(&m_jit);
+                        if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
+                            for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
+                                clearSubpattern(subpattern);
+                        }
+                    } else {
+                        // Try fewer iterations.
+                        m_jit.jump(endOp.m_reentry);
+
+                        noPreviousIteration.link(&m_jit);
+                        // Clear the flag in the stackframe indicating we didn't run through the subpattern.
+                        storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
+
+                        // After marking parens as not run, jump to reentry to skip the subpattern.
                         m_jit.jump(endOp.m_reentry);
                         // A backtrack from after the parentheses, when skipping the subpattern,
                         // will jump back to here.
                         op.m_jumps.link(&m_jit);
-                        break;
                     }
-                    case QuantifierType::NonGreedy: {
-                        break;
-                    }
-                    case QuantifierType::FixedCount: {
-                        // This case is handled above with early break
-                        RELEASE_ASSERT_NOT_REACHED();
-                        break;
-                    }
-                    }
+
+                    storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
+                    m_backtrackingState.fallthrough();
+                    break;
                 }
 
-                storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
-                m_backtrackingState.fallthrough();
+                case QuantifierType::FixedCount: {
+                    RELEASE_ASSERT_NOT_REACHED();
+                    break;
+                }
+                }
 #else // !YARR_JIT_ALL_PARENS_EXPRESSIONS
                 RELEASE_ASSERT_NOT_REACHED();
 #endif


### PR DESCRIPTION
#### 95d80761e6761f6c0732628bab19119917c798c7
<pre>
[YARR] Fix NonGreedy backtracking
<a href="https://bugs.webkit.org/show_bug.cgi?id=316180">https://bugs.webkit.org/show_bug.cgi?id=316180</a>
<a href="https://rdar.apple.com/178590766">rdar://178590766</a>

Reviewed by Keith Miller.

This is a pre-existing bug in NonGreedy parentheses handling in
YarrJIT, but since we applied the same mechanism to Variable Count
NonGreedy matching, we now also have the issue for them too.

1. YarrJIT ParenthesesSubpatternBegin.bt

Previously the NonGreedy case shared the Greedy &quot;accept fewer&quot; path and treated
a zero remaining count as a complete failure, so it does not retry the latest
iteration to content-backtrack a previously-completed iteration and re-expand
from there. As a result the JIT missed matches that require redistributing the
iterations.

This patch fixes it so that the NonGreedy case pops the latest iteration and jumps
to the previous iteration&apos;s content-backtrack entry, restoring frame.beginIndex to
that iteration&apos;s begin so END.bt&apos;s progress check can re-expand after the iteration
is shrunk. It propagates a complete failure only when there is no earlier iteration
left.

2. Yarr interpreter backtrackParentheses

NonGreedy did not enforce quantityMinCount after a successful content backtrack:
it returned Match without refilling, so it could accept fewer than min
iterations, e.g. /(?&lt;=Q)(?:xy|x){2,3}?yxw/.exec(&quot;Qxyxwab&quot;) wrongly matched
&quot;xyxw&quot;. It now refills back up to min before accepting, mirroring the Greedy
case.

Retrying an iteration&apos;s content used matchNonZeroDisjunction even for a
mandatory iteration (count &lt;= min). According to RepeatMatcher[1], the empty-match
rejection only applies to iterations beyond the minimum, so a mandatory iteration may
match zero-length. Step 2-b is making zero-length-matching a failure only when min = 0.
Both the Greedy and NonGreedy content-retry sites now use matchDisjunction when
count &lt;= min.

[1]: <a href="https://tc39.es/ecma262/#sec-runtime-semantics-repeatmatcher-abstract-operation">https://tc39.es/ecma262/#sec-runtime-semantics-repeatmatcher-abstract-operation</a>

Test: JSTests/stress/regexp-nongreedy-varcount-content-backtrack.js

* JSTests/stress/regexp-nongreedy-varcount-content-backtrack.js: Added.
(run):
(check):
(check.c):
(check.Q):
(check.a):
(check.x):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::matchParentheses):
(JSC::Yarr::Interpreter::backtrackParentheses):
(JSC::Yarr::Interpreter::refillParenthesesContextsToMinCount):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/314506@main">https://commits.webkit.org/314506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8007b87f008a363255b2b915a4105cc7059cef9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123564 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129270 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109795 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23497 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158466 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177889 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27203 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137623 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137545 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148915 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103201 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25322 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32839 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25781 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198710 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39067 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112141 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/53381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38464 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3867 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38709 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38607 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->