### PR TITLE
Out-of-bounds read in WebM MIME sniffer when iter reaches length()

### DIFF
--- a/Source/WebCore/platform/graphics/MIMESniffer.cpp
+++ b/Source/WebCore/platform/graphics/MIMESniffer.cpp
@@ -156,7 +156,7 @@ static bool NODELETE hasSignatureForWebM(std::span<const uint8_t> sequence)
             //  5. If iter is less than length - 4, abort these steps.
             // TODO: this is a spec error. It will always be less than length - 4 unless an error occurred.
             //  6. Let matched be the result of matching a padded sequence 0x77 0x65 0x62 0x6D ("webm") on sequence at offset iter.
-            while (!sequence[iter] && iter < length)
+            while (iter < length && !sequence[iter])
                 iter++;
             if (iter >= length - 4)
                 break;

--- a/Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp
@@ -49,4 +49,14 @@ TEST(MIMESniffer, MIMETypes)
     ASSERT_EQ(MIMESniffer::getMIMETypeFromContent({ wavedata.data(), wavedata.size() }), String("audio/wave"_s));
 }
 
+TEST(MIMESniffer, WebMSnifferDoesNotReadPastEnd)
+{
+    // Truncated WebM-style header crafted so hasSignatureForWebM() advances
+    // iter exactly to length(): EBML magic (4 bytes) + 0x42 0x82 (2 bytes) +
+    // a 1-byte vint with the high bit set. Catches a 1-byte out-of-bounds
+    // read in MIMESniffer.cpp under ASan / libc++ hardened mode.
+    constexpr std::array<const uint8_t, 7> truncatedWebM = { 0x1A, 0x45, 0xDF, 0xA3, 0x42, 0x82, 0x80 };
+    MIMESniffer::getMIMETypeFromContent(std::span { truncatedWebM });
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 1c9e3e8e8bcdd1531787cbf782fbf8020f3340d6
<pre>
Out-of-bounds read in WebM MIME sniffer when iter reaches length()
<a href="https://bugs.webkit.org/show_bug.cgi?id=316181">https://bugs.webkit.org/show_bug.cgi?id=316181</a>

Reviewed by Jean-Yves Avenard.

In hasSignatureForWebM(), the inner skip-NUL loop reads sequence[iter]
before testing iter &lt; length:
```
      while (!sequence[iter] &amp;&amp; iter &lt; length)
          iter++;
```
After the preceding parseWebMVint() call and the iter += numberSize
update, iter can equal length, in which case the left operand of &amp;&amp; is
evaluated first and reads one byte past the end of the span. A 7-byte
input crafted as EBML magic + 0x42 0x82 + a 1-byte vint reaches this
code path. WebKit builds with hardened libc++, so std::span&apos;s bounds
check turns this into a safe crash on every build, but it&apos;s still a
reachable crash on attacker-controlled input.

Swap the operands so the bounds check short-circuits the dereference,
and add an API test that exercises the truncated input.

Test: MIMESniffer.WebMSnifferDoesNotReadPastEnd

* Source/WebCore/platform/graphics/MIMESniffer.cpp:
(WebCore::MIMESniffer::hasSignatureForWebM):
* Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp:
(TestWebKitAPI::TEST(MIMESniffer, WebMSnifferDoesNotReadPastEnd)):

Canonical link: <a href="https://commits.webkit.org/314498@main">https://commits.webkit.org/314498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4c6f3e39ba989fb465632785ea6e06dbac20254

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175203 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123411 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129145 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8eabd5f0-ed02-4c09-bd4a-08799a074396) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31521 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149287 "Found 10 new API test failures: TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInBackground, TestWebKitAPI.WKWebExtensionContext.ReferenceErrorInBackground, TestWebKitAPI.WKWebExtensionContext.SyntaxErrorInBackground, TestWebKitAPI.WKWebExtensionContext.UnhandledPromiseRejectionInBackground, TestWebKitAPI.WKWebExtensionContext.UnhandledPromiseRejectionInServiceWorkerBackground, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInMainWorldContentScript, TestWebKitAPI.WKWebExtensionContext.CallingMissingBrowserAPIInBackground, TestWebKitAPI.WKWebExtensionContext.TopLevelThrowInModuleBackground, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInContentScript, TestWebKitAPI.WKWebExtensionContext.LoadNonExistentImage (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109671 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30498 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29190 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23344 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140467 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177736 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30638 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137492 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137420 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37053 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148781 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103010 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32708 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25648 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38914 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111988 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38311 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3734 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38556 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38454 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->