### PR TITLE
[Site Isolation] CSP upgrade-insecure-requests misses cross-origin iframe-to-top navigations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/link-upgrade.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/link-upgrade.sub.https-expected.txt
@@ -5,6 +5,6 @@ PASS ./link-upgrade/iframe-link-upgrade.sub.html
 PASS ./link-upgrade/iframe-top-navigation-no-upgrade-1.sub.html
 PASS ./link-upgrade/iframe-top-navigation-no-upgrade-2.sub.html
 PASS ./link-upgrade/iframe-top-navigation-upgrade-1.sub.html
-TIMEOUT ./link-upgrade/iframe-top-navigation-upgrade-2.sub.html Test timed out
+PASS ./link-upgrade/iframe-top-navigation-upgrade-2.sub.html
 PASS ./link-upgrade/iframe-top-navigation-upgrade-meta.sub.html
 

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -280,7 +280,6 @@ imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies
 imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.unpartitioned.sub.https.window.html [ Failure ]
 imported/w3c/web-platform-tests/streams/transferable/deserialize-error.window.html [ Failure ]
 imported/w3c/web-platform-tests/svg/animations/svglength-animation-invalid-value-7.html [ Failure ]
-imported/w3c/web-platform-tests/upgrade-insecure-requests/link-upgrade.sub.https.html [ Failure ]
 imported/w3c/web-platform-tests/web-animations/crashtests/color-mix-crashtest.html [ Failure ]
 imported/w3c/web-platform-tests/web-share/disabled-by-permissions-policy-cross-origin.https.sub.html [ Failure ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-not-fully-active.html [ Failure ]

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -541,8 +541,13 @@ void FrameLoader::changeLocation(FrameLoadRequest&& frameRequest, Event* trigger
     if (frameRequest.frameName().isEmpty())
         frameRequest.setFrameName(frame->document()->baseTarget());
 
-    if (RefPtr document = frame->document())
-        protect(document->contentSecurityPolicy())->upgradeInsecureRequestIfNeeded(frameRequest.resourceRequest(), ContentSecurityPolicy::InsecureRequestType::Navigation);
+    if (CheckedPtr requesterCSP = frameRequest.requester().contentSecurityPolicy())
+        requesterCSP->upgradeInsecureRequestIfNeeded(frameRequest.resourceRequest(), ContentSecurityPolicy::InsecureRequestType::Navigation);
+
+    if (RefPtr document = frame->document()) {
+        if (document->contentSecurityPolicy() != frameRequest.requester().contentSecurityPolicy())
+            protect(document->contentSecurityPolicy())->upgradeInsecureRequestIfNeeded(frameRequest.resourceRequest(), ContentSecurityPolicy::InsecureRequestType::Navigation);
+    }
 
     loadFrameRequest(WTF::move(frameRequest), triggeringEvent, { }, WTF::move(privateClickMeasurement));
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5491,8 +5491,17 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
     // Apply CSP upgrade-insecure-requests before computing Site. Only needed for remote-frame
     // navigations. Same-process navigations are already upgraded in the WebProcess.
     if (&processInitiatingNavigation != &frame.process()) {
-        auto& upgradeSet = frame.cspOriginsThatUpgradeInsecureNavigations();
-        if (upgradeSet.contains(WebCore::SecurityOriginData::fromURL(navigation.currentRequest().url())))
+        auto urlOrigin = WebCore::SecurityOriginData::fromURL(navigation.currentRequest().url());
+
+        bool shouldUpgrade = frame.cspOriginsThatUpgradeInsecureNavigations().contains(urlOrigin);
+        if (!shouldUpgrade) {
+            if (const auto& originatingFrameInfo = navigation.originatingFrameInfo()) {
+                if (RefPtr originatingFrame = WebFrameProxy::webFrame(originatingFrameInfo->frameID))
+                    shouldUpgrade = originatingFrame->cspOriginsThatUpgradeInsecureNavigations().contains(urlOrigin);
+            }
+        }
+
+        if (shouldUpgrade)
             navigation.upgradeCurrentInsecureRequest();
     }
 


### PR DESCRIPTION
#### c1ab79ebcc0fff886aad0217b9d1a9b8f20a20cf
<pre>
[Site Isolation] CSP upgrade-insecure-requests misses cross-origin iframe-to-top navigations
<a href="https://bugs.webkit.org/show_bug.cgi?id=316182">https://bugs.webkit.org/show_bug.cgi?id=316182</a>
<a href="https://rdar.apple.com/178591146">rdar://178591146</a>

Reviewed by Sihui Liu.

When a cross-origin sandboxed iframe with upgrade-insecure-requests does
window.top.location = &quot;<a href="http://...&quot">http://...&quot</a>;, the URL should get upgraded to https but doesn&apos;t. The
upgrade logic looks at the target frame&apos;s CSP origin set, which only knows about the target
frame&apos;s own origin. Since the URL points to the iframe&apos;s origin (not the top frame&apos;s),
nothing matches.

Check the requesting document&apos;s CSP for non-site isolation config. For site isolation, look
up the originating frame&apos;s CSP origin set in the UIProcess.

* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/link-upgrade.sub.https-expected.txt:
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::changeLocation):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):

Canonical link: <a href="https://commits.webkit.org/314523@main">https://commits.webkit.org/314523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f88bd3b9c832da7f6151d88f71468053ed63c67b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175365 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123572 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129276 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109801 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30636 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29333 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23505 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177897 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30799 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137628 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137550 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37071 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148924 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103211 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32845 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25790 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39075 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112150 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38472 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3876 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38717 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38615 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->