### PR TITLE
REGRESSION(299621@main): [MacOS Debug] ASSERTION FAILED: m_gamepads[platformGamepad.index] in 'gamepad/gamepad-visibility-1.html' is failing

### DIFF
--- a/LayoutTests/gamepad/gamepad-connect-disconnect-invisible-expected.txt
+++ b/LayoutTests/gamepad/gamepad-connect-disconnect-invisible-expected.txt
@@ -1,0 +1,4 @@
+Connect: 0
+Disconnect: 0
+barrier
+

--- a/LayoutTests/gamepad/gamepad-connect-disconnect-invisible.html
+++ b/LayoutTests/gamepad/gamepad-connect-disconnect-invisible.html
@@ -1,0 +1,42 @@
+<body>
+<div id="logger"></div>
+<script>
+testRunner.dumpAsText();
+testRunner.waitUntilDone();
+function log(msg) {
+    logger.innerHTML += msg + "<br>";
+}
+function timeout(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+async function runTest() {
+    testRunner.setMockGamepadDetails(0, "Test0", "", 2, 2, false, /*was connected*/ true);
+    let connected = new Promise(resolve => {
+        window.ongamepadconnected = (event) => {
+            log(`Connect: ${event.gamepad.index}`);
+            resolve();
+        };
+    });
+    let disconnected = new Promise(resolve => {
+        window.ongamepaddisconnected = (event) => {
+            log(`Disconnect: ${event.gamepad.index}`);
+            resolve();
+        };
+    });
+    testRunner.connectMockGamepad(0);
+    testRunner.setMockGamepadButtonValue(0, 0, 1.0);
+    await connected;
+    testRunner.disconnectMockGamepad(0);
+    await disconnected;
+    log("barrier"); // No Connect:/Disconnect: after barrier.
+    testRunner.connectMockGamepad(0);
+    // This is being tested: at the time of writing, this would assert because
+    // the "[[exposed]]" state of a particular gamepad was being tracked per
+    // navigator, and only once.
+    testRunner.disconnectMockGamepad(0);
+    await timeout(200);
+    testRunner.notifyDone();
+}
+runTest();
+</script>
+</body>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -531,9 +531,6 @@ imported/w3c/web-platform-tests/css/css-flexbox/select-element-zero-height-002.h
 # The test is marked as Timeout for wk2. It has been flaky in GTK and WPE since added.
 crypto/subtle/ecdsa-import-compressed-spki-key-p384.html [ Skip ] # Timeout.
 
-# This test causes subsequent tests to crash with an assertion. Unskip when the referring bug is fixed.
-webkit.org/b/298476 gamepad/gamepad-visibility-1.html [ Skip ]
-
 # Conic gradient. Marked as failure in root expectations
 webkit.org/b/225916 imported/w3c/web-platform-tests/css/css-images/conic-gradient-angle.html [ Pass ]
 

--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -108,8 +108,6 @@ void GamepadManager::platformGamepadConnected(PlatformGamepad& platformGamepad, 
 
 void GamepadManager::platformGamepadDisconnected(PlatformGamepad& platformGamepad)
 {
-    WeakHashSet<Navigator> notifiedNavigators;
-
     // Handle the disconnect for all DOMWindows with event listeners and their Navigators.
     for (auto& window : copyToVectorOf<WeakPtr<LocalDOMWindow, WeakPtrImplWithEventTargetData>>(m_domWindows)) {
         // Event dispatch might have made this window go away.
@@ -120,28 +118,26 @@ void GamepadManager::platformGamepadDisconnected(PlatformGamepad& platformGamepa
         // If this happens the LocalDOMWindow will not get this gamepaddisconnected event.
         Ref navigator = window->navigator();
 
-        // If this Navigator hasn't seen gamepads yet then its Window should not get the disconnect event.
-        if (m_gamepadBlindNavigators.contains(navigator.get()))
-            continue;
-#if PLATFORM(VISION)
-        if (m_gamepadQuarantinedNavigators.contains(navigator.get()))
-            continue;
-#endif
-
         auto& navigatorGamepad = NavigatorGamepad::from(navigator);
 
-        Ref gamepad = navigatorGamepad.gamepadFromPlatformGamepad(platformGamepad);
+        // Only Navigators that actually had this gamepad exposed to them should see the disconnect.
+        // This covers Navigators that were blind (or, on visionOS, quarantined) when the gamepad
+        // connected, as well as gamepads that connected invisibly after a Navigator became visible:
+        // in both cases the gamepad was never added to m_gamepads.
+        RefPtr gamepad = navigatorGamepad.gamepadIfExists(platformGamepad);
+        if (!gamepad)
+            continue;
 
         navigatorGamepad.gamepadDisconnected(platformGamepad);
-        notifiedNavigators.add(navigator.get());
 
-        window->dispatchEvent(GamepadEvent::create(eventNames().gamepaddisconnectedEvent, WTF::move(gamepad)), protect(window->document()).get());
+        window->dispatchEvent(GamepadEvent::create(eventNames().gamepaddisconnectedEvent, gamepad.releaseNonNull()), protect(window->document()).get());
     }
 
-    // Notify all the Navigators that haven't already been notified.
+    // Notify any remaining Navigators that had the gamepad exposed but no listening Window above.
     for (Ref navigator : m_navigators) {
-        if (!notifiedNavigators.contains(navigator.get()))
-            NavigatorGamepad::from(navigator).gamepadDisconnected(platformGamepad);
+        auto& navigatorGamepad = NavigatorGamepad::from(navigator);
+        if (navigatorGamepad.gamepadIfExists(platformGamepad))
+            navigatorGamepad.gamepadDisconnected(platformGamepad);
     }
 }
 

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -79,6 +79,14 @@ Ref<Gamepad> NavigatorGamepad::gamepadFromPlatformGamepad(PlatformGamepad& platf
     return *m_gamepads[index];
 }
 
+RefPtr<Gamepad> NavigatorGamepad::gamepadIfExists(const PlatformGamepad& platformGamepad) const
+{
+    unsigned index = platformGamepad.index();
+    if (index >= m_gamepads.size())
+        return nullptr;
+    return m_gamepads[index];
+}
+
 ExceptionOr<const Vector<RefPtr<Gamepad>>&> NavigatorGamepad::getGamepads(Navigator& navigator)
 {
     RefPtr document = navigator.document() ? navigator.document() : nullptr;

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
@@ -64,6 +64,10 @@ public:
 
     Ref<Gamepad> gamepadFromPlatformGamepad(PlatformGamepad&);
 
+    // Returns the Gamepad this Navigator has exposed for the given platform gamepad, or
+    // null if this Navigator never had it exposed.
+    RefPtr<Gamepad> gamepadIfExists(const PlatformGamepad&) const;
+
     WEBCORE_EXPORT static void NODELETE setGamepadsRecentlyAccessedThreshold(Seconds);
     static Seconds NODELETE gamepadsRecentlyAccessedThreshold();
 


### PR DESCRIPTION
#### fd202c3fce03547cbf98af6e3db4d29754148624
<pre>
REGRESSION(<a href="https://commits.webkit.org/299621@main">299621@main</a>): [MacOS Debug] ASSERTION FAILED: m_gamepads[platformGamepad.index] in &apos;gamepad/gamepad-visibility-1.html&apos; is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=298476">https://bugs.webkit.org/show_bug.cgi?id=298476</a>

Reviewed by NOBODY (OOPS!).

A Navigator is only told about a gamepad once it becomes visible, so gamepads
that connect invisibly, or connect while the Navigator is still blind, are never
added to its m_gamepads. The disconnect path ignored this and notified every
Navigator, calling gamepadDisconnected() for an index absent from m_gamepads and
tripping the assertions (an out-of-bounds write in release-with-asserts builds).

Filter the disconnect like the connect side: dispatch the event and clear the
slot only for Navigators that actually have the gamepad exposed, via
gamepadIfExists(). The blind and visionOS quarantine lists are kept; their
explicit checks here are subsumed by gamepadIfExists().

Based on Kimmo Kinnunen&apos;s patch and reusing his regression test, reduced to the
minimal disconnect-side change.

Test: gamepad/gamepad-connect-disconnect-invisible.html

* LayoutTests/gamepad/gamepad-connect-disconnect-invisible-expected.txt: Added.
* LayoutTests/gamepad/gamepad-connect-disconnect-invisible.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::GamepadManager::platformGamepadDisconnected):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::gamepadIfExists const):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.h:

Co-Authored-By: Kimmo Kinnunen &lt;kkinnunen@apple.com&gt;
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd202c3fce03547cbf98af6e3db4d29754148624

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175206 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129148 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90970 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30500 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29193 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23347 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177739 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30641 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137495 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137423 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148783 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103013 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32710 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25650 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38917 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111991 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38314 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3736 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38559 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->