### PR TITLE
PlatformTimeRanges::containWithEpsilon checks the wrong delta for inter-range gaps

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -296,7 +296,7 @@ bool PlatformTimeRanges::containWithEpsilon(const PlatformTimeRanges& ranges, co
 
     // Ensure that if we have a gap in the buffered range, it is smaller than the fudge factor;
     for (unsigned i = 1; i < bufferedRanges.length(); i++) {
-        if (bufferedRanges.end(i) - bufferedRanges.start(i-1) > epsilon)
+        if (bufferedRanges.start(i) - bufferedRanges.end(i - 1) > epsilon)
             return false;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/TimeRanges.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TimeRanges.cpp
@@ -317,5 +317,22 @@ TEST(TimeRanges, Add_SmallGaps)
     EXPECT_EQ(1u, ranges->length());
 }
 
+TEST(TimeRanges, ContainWithEpsilon_TolerantOfSmallGap)
+{
+    // PlatformTimeRanges::containWithEpsilon should report containment when
+    // the buffered segments cover the requested range with a gap smaller
+    // than epsilon. Before the fix the gap check used end(i) - start(i-1)
+    // (the span across both segments) instead of start(i) - end(i-1)
+    // (the actual gap), so any multi-segment region was reported as
+    // non-contained.
+    RefPtr<TimeRanges> buffered = TimeRanges::create();
+    buffered->add(0, 5);
+    buffered->add(6, 10);
+
+    RefPtr<TimeRanges> requested = TimeRanges::create(0, 10);
+
+    EXPECT_TRUE(buffered->ranges().containWithEpsilon(requested->ranges(), MediaTime::createWithDouble(2)));
+}
+
 }
 


### PR DESCRIPTION
#### 55c079f8c2adf5e171ab48b59e39054d3ab18fe4
<pre>
PlatformTimeRanges::containWithEpsilon checks the wrong delta for inter-range gaps
<a href="https://bugs.webkit.org/show_bug.cgi?id=316185">https://bugs.webkit.org/show_bug.cgi?id=316185</a>

Reviewed by Jean-Yves Avenard.

When the buffered ranges have more than one segment after intersection
with the requested range, containWithEpsilon() walks the segments to
verify each gap is smaller than the supplied epsilon. The check is
written as:
```
      if (bufferedRanges.end(i) - bufferedRanges.start(i - 1) &gt; epsilon)
          return false;
```
`end(i) - start(i-1)` is the total span across both segments (segment i-1
duration + gap + segment i duration), not the gap, so the check compares
the wrong quantity against epsilon. The intended computation is
`start(i) - end(i-1)`.

In practice the existing MSE callers do not hit this: TrackBuffer merges
any gap smaller than MediaSourcePrivate::timeFudgeFactor() (2002/24000 ~=
83.4ms) before the ranges reach containWithEpsilon, and the requested
interval is always a short single segment, so the loop&apos;s multi-segment
branch is rarely entered with a sub-epsilon gap. The bug is still a
latent correctness issue (e.g. if SourceBuffer.remove() were ever called
with a sub-epsilon interval, or for any future caller that does not go
through TrackBuffer&apos;s coalescing), so switch to the correct subtraction
and add an API test that pins the multi-segment behavior.

Test: TimeRanges.ContainWithEpsilon_TolerantOfSmallGap

* Source/WebCore/platform/graphics/PlatformTimeRanges.cpp:
(WebCore::PlatformTimeRanges::containWithEpsilon const):
* Tools/TestWebKitAPI/Tests/WebCore/TimeRanges.cpp:
(TestWebKitAPI::TEST(TimeRanges, ContainWithEpsilon_TolerantOfSmallGap)):

Canonical link: <a href="https://commits.webkit.org/314592@main">https://commits.webkit.org/314592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b271dc71537afb399d01297b66eacc7f3a13fd85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175496 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123703 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7149aefe-8a36-4b3f-aa5b-256e8a07d32d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129397 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c4119475-8bb0-486e-a8e5-1f4417ab74af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109922 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30759 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29459 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23636 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140728 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178029 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30930 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137752 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137671 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37090 "Found 1 new test failure: fast/block/transparent-outline-with-and-without-border-radius.html (failure)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149052 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103397 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25353 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32966 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25918 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39206 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112281 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38603 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4004 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38848 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38746 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->