### PR TITLE
[iOS] Propagate visibility during fullscreen video layer hosting

### DIFF
--- a/Source/WebKit/Platform/spi/ios/BaseBoardSPI.h
+++ b/Source/WebKit/Platform/spi/ios/BaseBoardSPI.h
@@ -31,6 +31,7 @@ DECLARE_SYSTEM_HEADER
 
 #import <BaseBoard/BSAction.h>
 #import <BaseBoard/BSInvalidatable.h>
+#import <BoardServices/BSServiceConnectionEndpointInjector.h>
 
 #else
 
@@ -63,6 +64,22 @@ typedef void(^BSActionResponseHandler)(BSActionResponse *response);
 - (BOOL)canSendResponse;
 - (void)sendResponse:(BSActionResponse *)response;
 @property (nonatomic, copy, readonly) BSSettings *info;
+@end
+
+@class RBSAttribute;
+@class RBSTarget;
+
+@protocol BSServiceConnectionEndpointInjectorConfiguring
+- (void)setTarget:(RBSTarget *)target;
+- (void)setInheritingEnvironment:(NSString *)inheritingEnvironment;
+- (void)setAdditionalAttributes:(NSArray<RBSAttribute *> *)attributes;
+@end
+
+typedef void(^BSServiceConnectionEndpointInjectorConfigurator)(id<BSServiceConnectionEndpointInjectorConfiguring> config);
+
+@interface BSServiceConnectionEndpointInjector : NSObject <BSInvalidatable>
++ (nullable BSServiceConnectionEndpointInjector *)injectorWithConfigurator:(NS_NOESCAPE BSServiceConnectionEndpointInjectorConfigurator)block;
+- (void)invalidate;
 @end
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/Platform/spi/ios/RunningBoardServicesSPI.h
+++ b/Source/WebKit/Platform/spi/ios/RunningBoardServicesSPI.h
@@ -56,6 +56,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)attributeWithDomain:(NSString *)domain name:(NSString *)name;
 @end
 
+@interface RBSGrant : RBSAttribute
+@end
+
+@interface RBSHereditaryGrant : RBSGrant
++ (instancetype)grantWithNamespace:(NSString *)endowmentNamespace sourceEnvironment:(NSString *)sourceEnvironment attributes:(nullable NSArray<RBSAttribute *> *)attributes;
+@end
+
 @interface RBSTarget : NSObject
 + (RBSTarget *)targetWithPid:(pid_t)pid;
 + (RBSTarget *)targetWithPid:(pid_t)pid environmentIdentifier:(NSString *)environment;
@@ -94,9 +101,15 @@ typedef NS_ENUM(uint8_t, RBSTaskState) {
     RBSTaskStateRunningScheduled        = 4,
 };
 
+@interface RBSProcessEndowmentInfo : NSObject
+@property (nonatomic, readonly, copy) NSString *endowmentNamespace;
+@property (nonatomic, readonly, copy, nullable) NSString *environment;
+@end
+
 @interface RBSProcessState : NSObject
 @property (nonatomic, readonly, assign) RBSTaskState taskState;
 @property (nonatomic, readonly, copy) NSSet<NSString *> *endowmentNamespaces;
+@property (nonatomic, readonly, copy, nullable) NSSet<RBSProcessEndowmentInfo *> *endowmentInfos;
 @end
 
 extern const NSTimeInterval RBSProcessTimeLimitationNone;
@@ -152,6 +165,7 @@ typedef NS_OPTIONS(NSUInteger, RBSProcessStateValues) {
     RBSProcessStateValueTerminationResistance   = (1 << 2),
     RBSProcessStateValueLegacyAssertions        = (1 << 3),
     RBSProcessStateValueModernAssertions        = (1 << 4),
+    RBSProcessStateValueEndowmentInfos          = (1 << 5),
 };
 @end
 

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -581,6 +581,7 @@ UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm @nonARC
 UIProcess/ios/CompactContextMenuPresenter.mm @nonARC
 UIProcess/ios/DragDropInteractionState.mm @nonARC
 UIProcess/ios/GestureRecognizerConsistencyEnforcer.mm @nonARC
+UIProcess/ios/LayerHostingVisibilityPropagator.mm @nonARC
 UIProcess/ios/PageClientImplIOS.mm @nonARC
 UIProcess/ios/PointerTouchCompatibilitySimulator.mm @nonARC
 UIProcess/ios/ProcessStateMonitor.mm @nonARC

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -63,6 +63,9 @@ class WebPageProxy;
 class PlaybackSessionManagerProxy;
 class PlaybackSessionModelContext;
 class VideoPresentationManagerProxy;
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+class LayerHostingVisibilityPropagator;
+#endif
 struct SharedPreferencesForWebProcess;
 
 class VideoPresentationModelContext final
@@ -75,6 +78,11 @@ public:
     virtual ~VideoPresentationModelContext();
 
     void requestCloseAllMediaPresentations(bool finishedWithMedia, CompletionHandler<void()>&&);
+
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    LayerHostingVisibilityPropagator* layerHostingVisibilityPropagator() const { return m_layerHostingVisibilityPropagator.get(); }
+    void setLayerHostingVisibilityPropagator(RefPtr<LayerHostingVisibilityPropagator>&&);
+#endif
 
 private:
     friend class VideoPresentationManagerProxy;
@@ -147,6 +155,10 @@ private:
     WebCore::FloatSize m_videoDimensions;
     bool m_hasVideo { false };
     bool m_isChildOfElementFullscreen { false };
+
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    RefPtr<LayerHostingVisibilityPropagator> m_layerHostingVisibilityPropagator;
+#endif
 
 #if !RELEASE_LOG_DISABLED
     mutable uint64_t m_childIdentifierSeed { 0 };

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -33,6 +33,7 @@
 #import "DrawingAreaProxy.h"
 #import "FrameInfoData.h"
 #import "GPUProcessProxy.h"
+#import "LayerHostingVisibilityPropagator.h"
 #import "Logging.h"
 #import "MessageSenderInlines.h"
 #import "PageClient.h"
@@ -345,6 +346,13 @@ void VideoPresentationModelContext::requestCloseAllMediaPresentations(bool finis
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     manager->requestCloseAllMediaPresentations(m_contextId, finishedWithMedia, WTF::move(completionHandler));
 }
+
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+void VideoPresentationModelContext::setLayerHostingVisibilityPropagator(RefPtr<LayerHostingVisibilityPropagator>&& propagator)
+{
+    m_layerHostingVisibilityPropagator = WTF::move(propagator);
+}
+#endif
 
 void VideoPresentationModelContext::requestFullscreenMode(HTMLMediaElementEnums::VideoFullscreenMode mode, bool finishedWithMedia)
 {
@@ -1111,6 +1119,10 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
     RefPtr pageClient = page->pageClient();
     if (RetainPtr visibilityPropagationView = pageClient ? pageClient->createVisibilityPropagationView() : nil)
         setVisibilityPropagationViewForLayerHostView(visibilityPropagationView.get(), view.get());
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    if (RefPtr layerHostingVisibilityPropagator = pageClient ? pageClient->createLayerHostingVisibilityPropagator() : nil)
+        model->setLayerHostingVisibilityPropagator(WTF::move(layerHostingVisibilityPropagator));
+#endif
 #else
     UNUSED_VARIABLE(view);
 #endif
@@ -1548,6 +1560,9 @@ void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextI
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     if (RetainPtr layerHostView = dynamic_objc_cast<WKLayerHostView>(interface->layerHostView()))
         setVisibilityPropagationViewForLayerHostView(nil, layerHostView.get());
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    model->setLayerHostingVisibilityPropagator(nullptr);
+#endif
 #endif
 
     [protect(interface->layerHostView()) removeFromSuperview];

--- a/Source/WebKit/UIProcess/EndowmentStateTracker.h
+++ b/Source/WebKit/UIProcess/EndowmentStateTracker.h
@@ -28,12 +28,15 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
+#import <wtf/Forward.h>
+#import <wtf/HashSet.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakHashSet.h>
 
-OBJC_CLASS NSSet;
+OBJC_CLASS RBSProcessHandle;
 OBJC_CLASS RBSProcessMonitor;
+OBJC_CLASS RBSProcessState;
 
 namespace WebKit {
 
@@ -44,6 +47,7 @@ public:
     virtual ~EndowmentStateTrackerClient() = default;
     virtual void isUserFacingChanged(bool) { }
     virtual void isVisibleChanged(bool) { }
+    virtual void visibilityEndowmentEnvironmentsChanged(const HashSet<String>&) { }
 };
 
 class EndowmentStateTracker {
@@ -53,6 +57,7 @@ public:
 
     bool isVisible() const { return ensureState().isVisible; }
     bool isUserFacing() const { return ensureState().isUserFacing; }
+    const HashSet<String>& visibilityEndowmentEnvironments() const { return ensureState().visibilityEnvironments; }
 
     void addClient(EndowmentStateTrackerClient&);
     void removeClient(EndowmentStateTrackerClient&);
@@ -70,10 +75,12 @@ private:
     void registerMonitorIfNecessary();
 
     struct State {
-        bool isUserFacing;
-        bool isVisible;
+        bool isUserFacing { false };
+        bool isVisible { false };
+        HashSet<String> visibilityEnvironments;
     };
-    static State stateFromEndowments(NSSet *endowments);
+    static State stateFromProcessState(RBSProcessState *);
+    static State stateForHandle(RBSProcessHandle *);
     const State& ensureState() const;
     void setState(State&&);
 

--- a/Source/WebKit/UIProcess/EndowmentStateTracker.mm
+++ b/Source/WebKit/UIProcess/EndowmentStateTracker.mm
@@ -50,43 +50,54 @@ static RBSProcessHandle *handleForPID(pid_t pid)
     NSError *error = nil;
     RBSProcessHandle *processHandle = [RBSProcessHandle handleForIdentifier:processIdentifier error:&error];
     if (!processHandle) {
-        RELEASE_LOG_ERROR(ProcessSuspension, "endowmentsForPid: Failed to get RBSProcessHandle for process with PID %d, error: %{public}@", pid, error);
+        RELEASE_LOG_ERROR(ProcessSuspension, "handleForPID: Failed to get RBSProcessHandle for process with PID %d, error: %{public}@", pid, error);
         return nil;
     }
 
     return processHandle;
 }
 
-static NSSet<NSString *> *endowmentsForHandle(RBSProcessHandle *processHandle)
-{
-    if (!processHandle) {
-        // We assume foreground when unable to determine state to maintain pre-existing behavior and to avoid
-        // not rendering anything when we fail.
-        return [NSSet setWithObjects:protect(visibilityEndowment).get(), protect(userfacingEndowment).get(), nil];
-    }
-
-    RBSProcessState *state = processHandle.currentState;
-    if (state.taskState != RBSTaskStateRunningScheduled) {
-        RELEASE_LOG_ERROR(ProcessSuspension, "endowmentsForHandle: Process with PID %d is not running", processHandle.pid);
-        return nil;
-    }
-
-    return [state endowmentNamespaces];
-}
-
 WTF_MAKE_TZONE_ALLOCATED_IMPL(EndowmentStateTracker);
 
-inline auto EndowmentStateTracker::stateFromEndowments(NSSet *endowments) -> State
+inline auto EndowmentStateTracker::stateFromProcessState(RBSProcessState *processState) -> State
 {
-    return State {
-        !![endowments containsObject:protect(userfacingEndowment).get()],
-        !![endowments containsObject:protect(visibilityEndowment).get()]
-    };
+    State state;
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    for (RBSProcessEndowmentInfo *info in processState.endowmentInfos) {
+        NSString *endowmentNamespace = info.endowmentNamespace;
+        if ([endowmentNamespace isEqualToString:userfacingEndowment])
+            state.isUserFacing = true;
+        else if ([endowmentNamespace isEqualToString:visibilityEndowment]) {
+            state.isVisible = true;
+            if (NSString *environment = info.environment)
+                state.visibilityEnvironments.add(String(environment));
+        }
+    }
+#else
+    NSSet<NSString *> *endowmentNamespaces = processState.endowmentNamespaces;
+    state.isUserFacing = [endowmentNamespaces containsObject:protect(userfacingEndowment)];
+    state.isVisible = [endowmentNamespaces containsObject:protect(visibilityEndowment)];
+#endif
+    return state;
 }
 
 bool EndowmentStateTracker::isApplicationForeground(pid_t pid)
 {
-    return [protect(endowmentsForHandle(protect(handleForPID(pid)).get())) containsObject:protect(visibilityEndowment).get()];
+    return stateForHandle(protect(handleForPID(pid))).isVisible;
+}
+
+auto EndowmentStateTracker::stateForHandle(RBSProcessHandle *processHandle) -> State
+{
+    if (processHandle) {
+        RBSProcessState *processState = processHandle.currentState;
+        if (processState.taskState == RBSTaskStateRunningScheduled)
+            return stateFromProcessState(processState);
+        RELEASE_LOG_ERROR(ProcessSuspension, "stateForHandle: Process with PID %d is not running", processHandle.pid);
+    }
+
+    // Assume foreground when unable to determine state to maintain pre-existing behavior
+    // and to avoid not rendering anything when we fail.
+    return State { true, true, { } };
 }
 
 EndowmentStateTracker& EndowmentStateTracker::singleton()
@@ -105,10 +116,13 @@ void EndowmentStateTracker::registerMonitorIfNecessary()
 
         RBSProcessStateDescriptor *stateDescriptor = [RBSProcessStateDescriptor descriptor];
         stateDescriptor.endowmentNamespaces = @[visibilityEndowment, userfacingEndowment];
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+        stateDescriptor.values = RBSProcessStateValueEndowmentInfos;
+#endif
         [config setStateDescriptor:stateDescriptor];
 
         [config setUpdateHandler:[this] (RBSProcessMonitor * _Nonnull monitor, RBSProcessHandle * _Nonnull process, RBSProcessStateUpdate * _Nonnull update) mutable {
-            RunLoop::mainSingleton().dispatch([this, state = stateFromEndowments(update.state.endowmentNamespaces)]() mutable {
+            RunLoop::mainSingleton().dispatch([this, state = stateFromProcessState(update.state)]() mutable {
                 setState(WTF::move(state));
             });
         }];
@@ -129,7 +143,7 @@ void EndowmentStateTracker::removeClient(EndowmentStateTrackerClient& client)
 auto EndowmentStateTracker::ensureState() const -> const State&
 {
     if (!m_state)
-        m_state = stateFromEndowments(protect(endowmentsForHandle([RBSProcessHandle currentProcess])));
+        m_state = stateForHandle([RBSProcessHandle currentProcess]);
     return *m_state;
 }
 
@@ -137,18 +151,21 @@ void EndowmentStateTracker::setState(State&& state)
 {
     bool isUserFacingChanged = !m_state || m_state->isUserFacing != state.isUserFacing;
     bool isVisibleChanged = !m_state || m_state->isVisible != state.isVisible;
-    if (!isUserFacingChanged && !isVisibleChanged)
+    bool visibilityEnvironmentsChanged = !m_state || m_state->visibilityEnvironments != state.visibilityEnvironments;
+    if (!isUserFacingChanged && !isVisibleChanged && !visibilityEnvironmentsChanged)
         return;
 
     m_state = WTF::move(state);
 
-    RELEASE_LOG(ViewState, "%p - EndowmentStateTracker::setState() isUserFacing: %{public}s isVisible: %{public}s", this, m_state->isUserFacing ? "true" : "false", m_state->isVisible ? "true" : "false");
+    RELEASE_LOG(ViewState, "%p - EndowmentStateTracker::setState() isUserFacing: %{public}s isVisible: %{public}s visibilityEnvironmentCount: %u", this, m_state->isUserFacing ? "true" : "false", m_state->isVisible ? "true" : "false", m_state->visibilityEnvironments.size());
 
     m_clients.forEach([&](auto& client) {
         if (isUserFacingChanged)
             client.isUserFacingChanged(m_state->isUserFacing);
         if (isVisibleChanged)
             client.isVisibleChanged(m_state->isVisible);
+        if (visibilityEnvironmentsChanged)
+            client.visibilityEndowmentEnvironmentsChanged(m_state->visibilityEnvironments);
     });
 }
 

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -190,6 +190,7 @@ enum class TapHandlingResult : uint8_t;
 
 class ContextMenuContextData;
 class DrawingAreaProxy;
+class LayerHostingVisibilityPropagator;
 class NativeWebGestureEvent;
 class NativeWebKeyboardEvent;
 class NativeWebMouseEvent;
@@ -455,6 +456,9 @@ public:
 #endif
     virtual RetainPtr<UIView> createVisibilityPropagationView() { return nullptr; }
     virtual void removeVisibilityPropagationView(UIView *) { }
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    virtual RefPtr<LayerHostingVisibilityPropagator> createLayerHostingVisibilityPropagator() { return nullptr; }
+#endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/ios/LayerHostingVisibilityPropagator.h
+++ b/Source/WebKit/UIProcess/ios/LayerHostingVisibilityPropagator.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+
+#include "EndowmentStateTracker.h"
+#include <wtf/Forward.h>
+#include <wtf/HashMap.h>
+#include <wtf/RefCounted.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
+
+OBJC_CLASS BSServiceConnectionEndpointInjector;
+
+namespace WebKit {
+
+class AuxiliaryProcessProxy;
+class ProcessAssertion;
+
+class LayerHostingVisibilityPropagator final : public RefCounted<LayerHostingVisibilityPropagator>, public EndowmentStateTrackerClient {
+    WTF_MAKE_TZONE_ALLOCATED(LayerHostingVisibilityPropagator);
+public:
+    static Ref<LayerHostingVisibilityPropagator> create();
+    ~LayerHostingVisibilityPropagator();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+    void propagateVisibilityToProcess(AuxiliaryProcessProxy&);
+    void stopPropagatingVisibilityToProcess(AuxiliaryProcessProxy&);
+    void clear();
+
+private:
+    LayerHostingVisibilityPropagator();
+
+    void visibilityEndowmentEnvironmentsChanged(const HashSet<String>&) final;
+    void refreshInjectorsAtIndex(size_t, const HashSet<String>&);
+
+    struct ProcessAndInjectors {
+        WeakPtr<AuxiliaryProcessProxy> process;
+        HashMap<String, RetainPtr<BSServiceConnectionEndpointInjector>> injectorsBySourceEnvironment;
+    };
+    Vector<ProcessAndInjectors> m_processesAndInjectors;
+    RefPtr<ProcessAssertion> m_processAssertion;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)

--- a/Source/WebKit/UIProcess/ios/LayerHostingVisibilityPropagator.mm
+++ b/Source/WebKit/UIProcess/ios/LayerHostingVisibilityPropagator.mm
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "LayerHostingVisibilityPropagator.h"
+
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+
+#import "AuxiliaryProcessProxy.h"
+#import "BaseBoardSPI.h"
+#import "Logging.h"
+#import "ProcessAssertion.h"
+#import "RunningBoardServicesSPI.h"
+#import <wtf/ProcessID.h>
+#import <wtf/TZoneMallocInlines.h>
+#import <wtf/text/MakeString.h>
+#import <wtf/text/StringBuilder.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LayerHostingVisibilityPropagator);
+
+static NSString * const visibilityEndowmentNamespace = @"com.apple.frontboard.visibility";
+static constexpr ASCIILiteral environmentSuffix = "-layerHosting"_s;
+
+static void invalidateInjectors(HashMap<String, RetainPtr<BSServiceConnectionEndpointInjector>>& injectorsBySourceEnvironment)
+{
+    for (auto& injector : injectorsBySourceEnvironment.values())
+        [injector invalidate];
+}
+
+Ref<LayerHostingVisibilityPropagator> LayerHostingVisibilityPropagator::create()
+{
+    return adoptRef(*new LayerHostingVisibilityPropagator());
+}
+
+LayerHostingVisibilityPropagator::LayerHostingVisibilityPropagator()
+{
+    EndowmentStateTracker::singleton().addClient(*this);
+}
+
+LayerHostingVisibilityPropagator::~LayerHostingVisibilityPropagator()
+{
+    for (auto& entry : std::exchange(m_processesAndInjectors, { }))
+        invalidateInjectors(entry.injectorsBySourceEnvironment);
+    EndowmentStateTracker::singleton().removeClient(*this);
+}
+
+void LayerHostingVisibilityPropagator::propagateVisibilityToProcess(AuxiliaryProcessProxy& process)
+{
+    RELEASE_LOG(Process, "LayerHostingVisibilityPropagator %p: propagateVisibilityToProcess pid=%d", this, process.processID());
+
+    auto matchIndex = m_processesAndInjectors.findIf([&](auto& entry) {
+        return entry.process.get() == &process;
+    });
+
+    if (matchIndex == notFound) {
+        ProcessAndInjectors entry;
+        entry.process = WeakPtr(process);
+        m_processesAndInjectors.append(WTF::move(entry));
+        matchIndex = m_processesAndInjectors.size() - 1;
+    }
+
+    if (!m_processAssertion) {
+        RELEASE_LOG(Process, "LayerHostingVisibilityPropagator %p: taking MediaPlayback process assertion on self", this);
+        m_processAssertion = ProcessAssertion::create(getCurrentProcessID(), "WebKit Media Layer Hosting"_s, ProcessAssertionType::MediaPlayback);
+    }
+
+    refreshInjectorsAtIndex(matchIndex, EndowmentStateTracker::singleton().visibilityEndowmentEnvironments());
+}
+
+void LayerHostingVisibilityPropagator::stopPropagatingVisibilityToProcess(AuxiliaryProcessProxy& process)
+{
+    RELEASE_LOG(Process, "LayerHostingVisibilityPropagator %p: stopPropagatingVisibilityToProcess pid=%d", this, process.processID());
+
+    m_processesAndInjectors.removeAllMatching([&](auto& entry) {
+        auto existingProcess = entry.process.get();
+        if (existingProcess && existingProcess != &process)
+            return false;
+
+        RELEASE_LOG(Process, "LayerHostingVisibilityPropagator %p: removing %u visibility propagation injectors for process with PID=%d", this, entry.injectorsBySourceEnvironment.size(), process.processID());
+        invalidateInjectors(entry.injectorsBySourceEnvironment);
+        return true;
+    });
+
+    if (m_processesAndInjectors.isEmpty() && m_processAssertion) {
+        RELEASE_LOG(Process, "LayerHostingVisibilityPropagator %p: releasing MediaPlayback process assertion on self", this);
+        m_processAssertion = nullptr;
+    }
+}
+
+void LayerHostingVisibilityPropagator::clear()
+{
+    RELEASE_LOG(Process, "LayerHostingVisibilityPropagator %p: clearing all visibility propagation injectors", this);
+    for (auto& entry : std::exchange(m_processesAndInjectors, { }))
+        invalidateInjectors(entry.injectorsBySourceEnvironment);
+    if (m_processAssertion) {
+        RELEASE_LOG(Process, "LayerHostingVisibilityPropagator %p: releasing MediaPlayback process assertion on self", this);
+        m_processAssertion = nullptr;
+    }
+}
+
+void LayerHostingVisibilityPropagator::visibilityEndowmentEnvironmentsChanged(const HashSet<String>& environments)
+{
+    RELEASE_LOG(Process, "LayerHostingVisibilityPropagator %p: visibilityEndowmentEnvironmentsChanged: %u environments now active", this, environments.size());
+    for (size_t i = 0; i < m_processesAndInjectors.size(); ++i)
+        refreshInjectorsAtIndex(i, environments);
+}
+
+void LayerHostingVisibilityPropagator::refreshInjectorsAtIndex(size_t index, const HashSet<String>& environments)
+{
+    auto& entry = m_processesAndInjectors[index];
+    RefPtr process = entry.process.get();
+    if (!process)
+        return;
+
+    auto processID = process->processID();
+    if (!processID)
+        return;
+
+    auto environmentIdentifier = makeString(process->environmentIdentifier(), environmentSuffix);
+
+    entry.injectorsBySourceEnvironment.removeIf([&](auto& pair) {
+        if (environments.contains(pair.key))
+            return false;
+        RELEASE_LOG(Process, "LayerHostingVisibilityPropagator %p: releasing visibility endowment for pid=%d (source=%{public}s) — source environment no longer active", this, processID, pair.key.utf8().data());
+        [pair.value invalidate];
+        return true;
+    });
+
+    for (auto& sourceEnvironment : environments) {
+        if (entry.injectorsBySourceEnvironment.contains(sourceEnvironment))
+            continue;
+
+        if (sourceEnvironment.isEmpty())
+            continue;
+
+        RetainPtr targetEnvironmentString = environmentIdentifier.createNSString();
+        RetainPtr sourceEnvironmentString = sourceEnvironment.createNSString();
+        RetainPtr target = [RBSTarget targetWithPid:processID environmentIdentifier:targetEnvironmentString.get()];
+
+        RetainPtr injector = [BSServiceConnectionEndpointInjector injectorWithConfigurator:^(id<BSServiceConnectionEndpointInjectorConfiguring> config) {
+            [config setTarget:target.get()];
+            [config setInheritingEnvironment:sourceEnvironmentString.get()];
+            [config setAdditionalAttributes:@[[RBSHereditaryGrant grantWithNamespace:visibilityEndowmentNamespace sourceEnvironment:sourceEnvironmentString.get() attributes:nil]]];
+        }];
+
+        if (!injector) {
+            RELEASE_LOG_ERROR(Process, "LayerHostingVisibilityPropagator %p: failed to create endpoint injector for pid=%d", this, processID);
+            continue;
+        }
+
+        RELEASE_LOG(Process, "LayerHostingVisibilityPropagator %p: acquired visibility endowment for pid=%d (source=%{public}s)", this, processID, sourceEnvironment.utf8().data());
+        entry.injectorsBySourceEnvironment.set(sourceEnvironment, WTF::move(injector));
+    }
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -101,6 +101,9 @@ private:
 #endif // ENABLE(MODEL_PROCESS)
     RetainPtr<UIView> createVisibilityPropagationView() override;
     void removeVisibilityPropagationView(UIView *) override;
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    RefPtr<LayerHostingVisibilityPropagator> createLayerHostingVisibilityPropagator() override;
+#endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -39,6 +39,7 @@
 #import "FrameInfoData.h"
 #import "InteractionInformationAtPosition.h"
 #import "KeyEventInterpretationContext.h"
+#import "LayerHostingVisibilityPropagator.h"
 #import "Logging.h"
 #import "NativeWebKeyboardEvent.h"
 #import "NavigationState.h"
@@ -307,6 +308,13 @@ void PageClientImpl::removeVisibilityPropagationView(UIView *view)
 {
     [contentView() _removeVisibilityPropagationView:view];
 }
+
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+RefPtr<LayerHostingVisibilityPropagator> PageClientImpl::createLayerHostingVisibilityPropagator()
+{
+    return [contentView() _createLayerHostingVisibilityPropagator];
+}
+#endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -45,6 +45,7 @@ class FloatRect;
 namespace WebKit {
 class DrawingAreaProxy;
 class RemoteLayerTreeTransaction;
+class LayerHostingVisibilityPropagator;
 class VisibleContentRectUpdateInfo;
 class WebFrameProxy;
 class WebPageProxy;
@@ -120,6 +121,9 @@ using LayerHostingContextID = uint32_t;
 #endif // ENABLE(MODEL_PROCESS)
 - (RetainPtr<UIView>)_createVisibilityPropagationView;
 - (void)_removeVisibilityPropagationView:(UIView *)view;
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+- (RefPtr<WebKit::LayerHostingVisibilityPropagator>)_createLayerHostingVisibilityPropagator;
+#endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 - (void)_setAcceleratedCompositingRootView:(UIView *)rootView;

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -33,6 +33,7 @@
 #import "FrameProcess.h"
 #import "FullscreenClient.h"
 #import "GPUProcessProxy.h"
+#import "LayerHostingVisibilityPropagator.h"
 #import "Logging.h"
 #import "ModelProcessProxy.h"
 #import "PDFDisplayMode.h"
@@ -228,6 +229,9 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     RetainPtr<NSMutableSet<WKVisibilityPropagationView *>> _visibilityPropagationViews;
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    WeakHashSet<WebKit::LayerHostingVisibilityPropagator> _layerHostingVisibilityPropagators;
+#endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
     __weak UIScreen *_screen;
@@ -330,12 +334,20 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 {
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
         [visibilityPropagationView propagateVisibilityToProcess:process contextID:contextID];
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    for (auto& propagator : _layerHostingVisibilityPropagators)
+        propagator.propagateVisibilityToProcess(process);
+#endif
 }
 
 - (void)_removeVisibilityPropagationForWebProcess:(WebKit::WebProcessProxy&)process
 {
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
         [visibilityPropagationView stopPropagatingVisibilityToProcess:process];
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    for (auto& propagator : _layerHostingVisibilityPropagators)
+        propagator.stopPropagatingVisibilityToProcess(process);
+#endif
 }
 
 - (void)_setupVisibilityPropagationForAllWebProcesses
@@ -368,6 +380,10 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
         [visibilityPropagationView propagateVisibilityToProcess:*gpuProcess contextID:page->contextIDForVisibilityPropagationInGPUProcess()];
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    for (auto& propagator : _layerHostingVisibilityPropagators)
+        propagator.propagateVisibilityToProcess(*gpuProcess);
+#endif
 }
 #endif // ENABLE(GPU_PROCESS)
 
@@ -384,6 +400,10 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
         [visibilityPropagationView propagateVisibilityToProcess:*modelProcess contextID:page->contextIDForVisibilityPropagationInModelProcess()];
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    for (auto& propagator : _layerHostingVisibilityPropagators)
+        propagator.propagateVisibilityToProcess(*modelProcess);
+#endif
 }
 #endif // ENABLE(MODEL_PROCESS)
 
@@ -413,6 +433,10 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
         [visibilityPropagationView stopPropagatingVisibilityToProcess:*gpuProcess];
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    for (auto& propagator : _layerHostingVisibilityPropagators)
+        propagator.stopPropagatingVisibilityToProcess(*gpuProcess);
+#endif
 }
 
 #if ENABLE(MODEL_PROCESS)
@@ -428,6 +452,10 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
         [visibilityPropagationView stopPropagatingVisibilityToProcess:*modelProcess];
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    for (auto& propagator : _layerHostingVisibilityPropagators)
+        propagator.stopPropagatingVisibilityToProcess(*modelProcess);
+#endif
 }
 #endif // ENABLE(MODEL_PROCESS)
 
@@ -867,6 +895,10 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 {
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
         [visibilityPropagationView clear];
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+    for (auto& propagator : _layerHostingVisibilityPropagators)
+        propagator.clear();
+#endif
 }
 
 - (void)_setupVisibilityPropagation
@@ -939,6 +971,16 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     if (RetainPtr visibilityPropagationView = dynamic_objc_cast<WKVisibilityPropagationView>(view))
         [_visibilityPropagationViews removeObject:visibilityPropagationView.get()];
 }
+
+#if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
+- (RefPtr<WebKit::LayerHostingVisibilityPropagator>)_createLayerHostingVisibilityPropagator
+{
+    Ref propagator = WebKit::LayerHostingVisibilityPropagator::create();
+    _layerHostingVisibilityPropagators.add(propagator.get());
+    [self _setupVisibilityPropagation];
+    return propagator.ptr();
+}
+#endif // ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
 
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2030,6 +2030,7 @@
 		A1A4FE5A18DCE9FA00B5EA8A /* _WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A4FE5718DCE9FA00B5EA8A /* _WKDownload.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1A4FE5C18DCE9FA00B5EA8A /* _WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A4FE5918DCE9FA00B5EA8A /* _WKDownloadInternal.h */; };
 		A1A4FE6118DD54A400B5EA8A /* _WKDownloadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A4FE6018DD54A400B5EA8A /* _WKDownloadDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A1A55D8D2FCE64B5007EA84E /* LayerHostingVisibilityPropagator.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A55D8B2FCE63AD007EA84E /* LayerHostingVisibilityPropagator.h */; };
 		A1AE0EC32B166439008A2563 /* ExtensionCapabilityGranter.h in Headers */ = {isa = PBXBuildFile; fileRef = A1AE0EC12B1663D4008A2563 /* ExtensionCapabilityGranter.h */; };
 		A1B849362F3D9F02004256A1 /* PlaybackSessionInterfaceAVKit.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B849322F3D9F02004256A1 /* PlaybackSessionInterfaceAVKit.h */; };
 		A1B849372F3D9F02004256A1 /* VideoPresentationInterfaceAVKit.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B849342F3D9F02004256A1 /* VideoPresentationInterfaceAVKit.h */; };
@@ -7771,6 +7772,8 @@
 		A1A4FE5918DCE9FA00B5EA8A /* _WKDownloadInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKDownloadInternal.h; sourceTree = "<group>"; };
 		A1A4FE6018DD54A400B5EA8A /* _WKDownloadDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKDownloadDelegate.h; sourceTree = "<group>"; };
 		A1A53A0F2E943B3E002BAD2D /* AVKit_SPI.swiftinterface */ = {isa = PBXFileReference; lastKnownFileType = text; path = AVKit_SPI.swiftinterface; sourceTree = "<group>"; };
+		A1A55D8B2FCE63AD007EA84E /* LayerHostingVisibilityPropagator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LayerHostingVisibilityPropagator.h; sourceTree = "<group>"; };
+		A1A55D8C2FCE63AD007EA84E /* LayerHostingVisibilityPropagator.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LayerHostingVisibilityPropagator.mm; sourceTree = "<group>"; };
 		A1AC99A92ECF0E350011617C /* MediaPlaybackTargetSerialized.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaPlaybackTargetSerialized.h; sourceTree = "<group>"; };
 		A1AC99AA2ECF0E350011617C /* MediaPlaybackTargetSerialized.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaPlaybackTargetSerialized.cpp; sourceTree = "<group>"; };
 		A1AE0EC12B1663D4008A2563 /* ExtensionCapabilityGranter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExtensionCapabilityGranter.h; sourceTree = "<group>"; };
@@ -12530,6 +12533,8 @@
 				F496A4301F58A272004C1757 /* DragDropInteractionState.mm */,
 				F4CF1E9B25E40DCC000F9D73 /* GestureRecognizerConsistencyEnforcer.h */,
 				F4CF1E9C25E40DCC000F9D73 /* GestureRecognizerConsistencyEnforcer.mm */,
+				A1A55D8B2FCE63AD007EA84E /* LayerHostingVisibilityPropagator.h */,
+				A1A55D8C2FCE63AD007EA84E /* LayerHostingVisibilityPropagator.mm */,
 				0FCB4E3618BBE044000FCFC9 /* PageClientImplIOS.h */,
 				0FCB4E3718BBE044000FCFC9 /* PageClientImplIOS.mm */,
 				F41145632CD6F4B7004CDBD1 /* PointerTouchCompatibilitySimulator.h */,
@@ -18449,6 +18454,7 @@
 				51E9049A27BCB9D400929E7E /* LaunchServicesSPI.h in Headers */,
 				BCE0937814FB128C001138D9 /* LayerHostingContext.h in Headers */,
 				515A0C552E8284CF00D0B56C /* LayerHostingContextManager.h in Headers */,
+				A1A55D8D2FCE64B5007EA84E /* LayerHostingVisibilityPropagator.h in Headers */,
 				1A92DC1112F8BA460017AF65 /* LayerTreeContext.h in Headers */,
 				44E936FD2447C2D8009FA3E3 /* LegacyCustomProtocolID.h in Headers */,
 				5C1427181C23F8B700D41183 /* LegacyCustomProtocolManager.h in Headers */,


### PR DESCRIPTION
#### 23a2f28972cb07b98f802ecdb48dcc77e3f35fed
<pre>
[iOS] Propagate visibility during fullscreen video layer hosting
<a href="https://bugs.webkit.org/show_bug.cgi?id=316184">https://bugs.webkit.org/show_bug.cgi?id=316184</a>
<a href="https://rdar.apple.com/175469152">rdar://175469152</a>

Reviewed by Jer Noble.

When WebKit&apos;s fullscreen video layer is hosted in another process, the UI process and
auxiliary processes should be considered visible for the duration of the fullscreen
presentation. The existing mechanism for visibility propagation (WKVisibilityPropagationView)
relies on the web view being in a visible scene, and while the app hosting the video layer does
propagate a visibility endowment to the UI process, WKVisibilityPropagationView does not further
propagate visibility to the auxiliary processes if the web view itself is not visible.

To address this, introduced LayerHostingVisibilityPropagator. It propagates a hereditary visibility
endowment grant to each auxiliary process for every visibility endowment granted to the UI process.
It also takes a MediaPlayback process assertion on the UI process for the duration of the fullscreen
layer presentation (to account for the lack of a visible scene assertion).

To detect which source environments currently hold the endowment, EndowmentStateTracker now
requests RBSProcessStateValueEndowmentInfos and walks RBSProcessEndowmentInfo entries instead of
just namespaces, allowing it to record the source environment per visibility grant and notify
clients via a new visibilityEndowmentEnvironmentsChanged() callback.

VideoPresentationManagerProxy creates a propagator during fullscreen setup, attaches it to the
VideoPresentationModel, and removes it during cleanup. WKContentView keeps a WeakHashSet of active
propagators and updates them alongside the existing WKVisibilityPropagationViews as auxiliary
processes launch and exit.

* Source/WebKit/Platform/spi/ios/BaseBoardSPI.h:
* Source/WebKit/Platform/spi/ios/RunningBoardServicesSPI.h:
(+[RBSProcessPredicate predicateMatchingHandle:]):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::setLayerHostingVisibilityPropagator):
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
* Source/WebKit/UIProcess/EndowmentStateTracker.h:
(WebKit::EndowmentStateTrackerClient::visibilityEndowmentEnvironmentsChanged):
(WebKit::EndowmentStateTracker::visibilityEndowmentEnvironments const):
* Source/WebKit/UIProcess/EndowmentStateTracker.mm:
(WebKit::handleForPID):
(WebKit::EndowmentStateTracker::stateFromProcessState):
(WebKit::EndowmentStateTracker::isApplicationForeground):
(WebKit::EndowmentStateTracker::stateForHandle):
(WebKit::EndowmentStateTracker::registerMonitorIfNecessary):
(WebKit::EndowmentStateTracker::ensureState const const):
(WebKit::EndowmentStateTracker::setState):
(): Deleted.
(WebKit::EndowmentStateTracker::stateFromEndowments): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::createLayerHostingVisibilityPropagator):
* Source/WebKit/UIProcess/ios/LayerHostingVisibilityPropagator.h: Added.
* Source/WebKit/UIProcess/ios/LayerHostingVisibilityPropagator.mm: Added.
(WebKit::invalidateInjectors):
(WebKit::LayerHostingVisibilityPropagator::create):
(WebKit::LayerHostingVisibilityPropagator::LayerHostingVisibilityPropagator):
(WebKit::LayerHostingVisibilityPropagator::~LayerHostingVisibilityPropagator):
(WebKit::LayerHostingVisibilityPropagator::propagateVisibilityToProcess):
(WebKit::LayerHostingVisibilityPropagator::stopPropagatingVisibilityToProcess):
(WebKit::LayerHostingVisibilityPropagator::clear):
(WebKit::LayerHostingVisibilityPropagator::visibilityEndowmentEnvironmentsChanged):
(WebKit::LayerHostingVisibilityPropagator::refreshInjectorsAtIndex):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::createLayerHostingVisibilityPropagator):
* Source/WebKit/UIProcess/ios/WKContentView.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _setupVisibilityPropagationForWebProcess:contextID:]):
(-[WKContentView _removeVisibilityPropagationForWebProcess:]):
(-[WKContentView _setupVisibilityPropagationForGPUProcess]):
(-[WKContentView _setupVisibilityPropagationForModelProcess]):
(-[WKContentView _removeVisibilityPropagationViewForGPUProcess]):
(-[WKContentView _removeVisibilityPropagationViewForModelProcess]):
(-[WKContentView _resetVisibilityPropagation]):
(-[WKContentView _createLayerHostingVisibilityPropagator]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/314516@main">https://commits.webkit.org/314516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6895f50922347aa68351e65f70befa0d60552976

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123570 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f07fa0a-fa1a-4966-bdb4-9bdbec7a2f1a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129278 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b2d52b6-b9e5-43eb-bdaf-72e61229f7e3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109803 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f445dc55-4027-4a3c-be5a-db03488afdf2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29332 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23503 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140606 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177895 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30797 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137630 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137552 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37066 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148927 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103209 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32846 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25793 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112148 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38470 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3879 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38715 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38613 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->