### PR TITLE
[JSC] Promise jobs must not run with the realm of a cross-realm settle site

### DIFF
--- a/JSTests/stress/cross-realm-await-thenable-resolve-realm.js
+++ b/JSTests/stress/cross-realm-await-thenable-resolve-realm.js
@@ -1,0 +1,115 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ', expected ' + expected);
+}
+
+const results = {};
+
+function setup(label, makePromise) {
+    const other = createGlobalObject();
+    other.MainFunction = Function;
+    other.results = results;
+    other.label = label;
+    const { promise, settle } = makePromise();
+    other.subject = promise;
+    new other.Function(`
+        (async () => {
+            await subject;
+            await { then(f) {
+                results[label] = f.constructor === Function ? "own-realm"
+                    : f.constructor === MainFunction ? "main-realm"
+                    : "unknown";
+                f(0);
+            } };
+            results[label + "-done"] = true;
+        })();
+    `)();
+    return settle;
+}
+
+// An async function awaiting a pending cross-realm vanilla promise must not have
+// its continuation realm poisoned: the resolving functions of a subsequently
+// awaited thenable must belong to the async function's realm.
+const settlePending = setup("pending-vanilla", () => {
+    let resolve;
+    const promise = new Promise((r) => { resolve = r; });
+    return { promise, settle: () => { resolve(1); } };
+});
+
+setup("fulfilled-vanilla", () => ({ promise: Promise.resolve(1), settle: () => {} }));
+
+class SubPromise extends Promise {}
+const settleSubclass = setup("pending-subclass", () => {
+    let resolve;
+    const promise = new SubPromise((r) => { resolve = r; });
+    return { promise, settle: () => { resolve(1); } };
+});
+
+// Adopting a cross-realm promise through a resolving function must not leak the
+// foreign realm into a same-realm promise that an async function is awaiting.
+let settleMainForAdoption;
+{
+    const other = createGlobalObject();
+    other.MainFunction = Function;
+    other.results = results;
+    const mainPending = new Promise((r) => { settleMainForAdoption = () => { r(2); }; });
+    other.subject = mainPending;
+    new other.Function(`
+        let resolveLocal;
+        const local = new Promise((r) => { resolveLocal = r; });
+        (async () => {
+            await local;
+            await { then(f) {
+                results["resolving-function-adoption"] = f.constructor === Function ? "own-realm"
+                    : f.constructor === MainFunction ? "main-realm"
+                    : "unknown";
+                f(0);
+            } };
+            results["resolving-function-adoption-done"] = true;
+        })();
+        resolveLocal(subject);
+    `)();
+}
+
+// Async generators drive awaited values through the same adoption path.
+let settleMainForGenerator;
+{
+    const other = createGlobalObject();
+    other.MainFunction = Function;
+    other.results = results;
+    const mainPending = new Promise((r) => { settleMainForGenerator = () => { r(3); }; });
+    other.subject = mainPending;
+    new other.Function(`
+        async function* generate() {
+            await subject;
+            yield { then(f) {
+                results["async-generator"] = f.constructor === Function ? "own-realm"
+                    : f.constructor === MainFunction ? "main-realm"
+                    : "unknown";
+                f(0);
+            } };
+        }
+        (async () => {
+            for await (const value of generate()) { }
+            results["async-generator-done"] = true;
+        })();
+    `)();
+}
+
+drainMicrotasks();
+settlePending();
+settleSubclass();
+settleMainForAdoption();
+settleMainForGenerator();
+drainMicrotasks();
+
+shouldBe(results["pending-vanilla"], "own-realm");
+shouldBe(results["pending-vanilla-done"], true);
+shouldBe(results["fulfilled-vanilla"], "own-realm");
+shouldBe(results["fulfilled-vanilla-done"], true);
+shouldBe(results["pending-subclass"], "own-realm");
+shouldBe(results["pending-subclass-done"], true);
+shouldBe(results["resolving-function-adoption"], "own-realm");
+shouldBe(results["resolving-function-adoption-done"], true);
+shouldBe(results["async-generator"], "own-realm");
+shouldBe(results["async-generator-done"], true);

--- a/JSTests/stress/cross-realm-promise-internal-reaction-realm.js
+++ b/JSTests/stress/cross-realm-promise-internal-reaction-realm.js
@@ -1,0 +1,163 @@
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error('bad value for ' + label + ': ' + actual + ', expected ' + expected);
+}
+
+const results = {};
+
+// Each case primes an own-realm async function through a promise that is
+// settled by an internal microtask carrying the main realm's globalObject.
+// The realm of the resolving function passed to a subsequently awaited
+// thenable must remain the async function's realm.
+function setup(label, body, makeSubject) {
+    const other = createGlobalObject();
+    other.MainFunction = Function;
+    other.MainObject = Object;
+    other.MainAggregateError = AggregateError;
+    other.results = results;
+    other.label = label;
+    const { subject, settle } = makeSubject();
+    other.subject = subject;
+    new other.Function(`
+        const realmOf = (value) => {
+            const c = value.constructor;
+            return c === Function || c === Object || c === AggregateError ? "own-realm"
+                : c === MainFunction || c === MainObject || c === MainAggregateError ? "main-realm"
+                : "unknown";
+        };
+        const observe = async (promise) => {
+            await promise;
+            await { then(f) { results[label] = realmOf(f); f(0); } };
+            results[label + "-done"] = true;
+        };
+        ${body}
+    `)();
+    return settle;
+}
+
+function makePending() {
+    let resolve;
+    const promise = new Promise((r) => { resolve = r; });
+    return { subject: promise, settle: () => { resolve(1); } };
+}
+
+function makePendingRejection() {
+    let reject;
+    const promise = new Promise((unused, r) => { reject = r; });
+    return { subject: promise, settle: () => { reject(new Error("rejected")); } };
+}
+
+const settles = [];
+
+// PromiseReactionJob: result promise of then() must not be settled with the
+// foreign settle-time realm.
+settles.push(setup("then-fn", `
+    observe(Promise.prototype.then.call(subject, (x) => x));
+`, makePending));
+
+settles.push(setup("then-no-handler", `
+    observe(Promise.prototype.then.call(subject));
+`, makePending));
+
+settles.push(setup("catch-fn", `
+    observe(Promise.prototype.catch.call(subject, () => {}));
+`, makePending));
+
+// PromiseFinallyReactionJob / PromiseFinallyAwaitJob.
+settles.push(setup("finally", `
+    observe(Promise.prototype.finally.call(subject, () => {}));
+`, makePending));
+
+settles.push(setup("finally-promise-result", `
+    observe(Promise.prototype.finally.call(subject, () => Promise.resolve(0)));
+`, makePending));
+
+// Combinator jobs, primed through a then()-poisoned own-realm promise.
+settles.push(setup("all", `
+    observe(Promise.all([Promise.prototype.then.call(subject)]));
+`, makePending));
+
+settles.push(setup("race", `
+    observe(Promise.race([Promise.prototype.then.call(subject)]));
+`, makePending));
+
+settles.push(setup("all-settled", `
+    observe(Promise.allSettled([Promise.prototype.then.call(subject)]));
+`, makePending));
+
+// PromiseAllSettledResolveJob creates the result objects: their realm is
+// directly observable.
+settles.push(setup("all-settled-result-object", `
+    (async () => {
+        const entries = await Promise.allSettled([Promise.prototype.then.call(subject)]);
+        results[label] = realmOf(entries[0]);
+        results[label + "-done"] = true;
+    })();
+`, makePending));
+
+// PromiseAnyResolveJob creates the AggregateError: its realm is directly
+// observable.
+settles.push(setup("any-aggregate-error", `
+    (async () => {
+        try {
+            await Promise.any([Promise.prototype.then.call(subject)]);
+        } catch (error) {
+            results[label] = realmOf(error);
+        }
+        results[label + "-done"] = true;
+    })();
+`, makePendingRejection));
+
+// AsyncFromSyncIteratorContinue: for-await over a sync iterable of a
+// poisoned own-realm promise.
+settles.push(setup("async-from-sync", `
+    (async () => {
+        for await (const value of [Promise.prototype.then.call(subject)]) { }
+        await { then(f) { results[label] = realmOf(f); f(0); } };
+        results[label + "-done"] = true;
+    })();
+`, makePending));
+
+// Async generator driver primed through a poisoned own-realm promise.
+settles.push(setup("async-generator-driver", `
+    async function* generate() {
+        await Promise.prototype.then.call(subject);
+        yield { then(f) { results[label] = realmOf(f); f(0); } };
+    }
+    (async () => {
+        for await (const value of generate()) { }
+        results[label + "-done"] = true;
+    })();
+`, makePending));
+
+// Control: a fully own-realm chain stays own-realm.
+settles.push(setup("own-realm-control", `
+    let resolveLocal;
+    const local = new Promise((r) => { resolveLocal = r; });
+    observe(Promise.prototype.then.call(local, (x) => x));
+    resolveLocal(1);
+`, () => ({ subject: null, settle: () => {} })));
+
+drainMicrotasks();
+for (const settle of settles)
+    settle();
+drainMicrotasks();
+
+for (const label of [
+    "then-fn",
+    "then-no-handler",
+    "catch-fn",
+    "finally",
+    "finally-promise-result",
+    "all",
+    "race",
+    "all-settled",
+    "all-settled-result-object",
+    "any-aggregate-error",
+    "async-from-sync",
+    "async-generator-driver",
+    "own-realm-control",
+]) {
+    shouldBe(results[label], "own-realm", label);
+    shouldBe(results[label + "-done"], true, label + "-done");
+}

--- a/JSTests/stress/cross-realm-promise-microtask-ordering.js
+++ b/JSTests/stress/cross-realm-promise-microtask-ordering.js
@@ -1,0 +1,54 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ', expected ' + expected);
+}
+
+function ticksOf(body, makeSubject) {
+    const log = [];
+    const other = createGlobalObject();
+    other.log = (s) => log.push(s);
+    const { subject, settle } = makeSubject(other);
+    other.subject = subject;
+    new other.Function(body)();
+    drainMicrotasks();
+    settle();
+    let p = Promise.resolve();
+    for (let i = 0; i < 3; i++) {
+        const j = i;
+        p = p.then(() => log.push("c" + j));
+    }
+    drainMicrotasks();
+    return log.join(" ");
+}
+
+function crossRealmPending() {
+    let resolve;
+    const promise = new Promise((r) => { resolve = r; });
+    return { subject: promise, settle: () => { resolve(7); } };
+}
+
+function sameRealmPending(other) {
+    new other.Function(`
+        let r;
+        globalThis.s = new Promise((res) => { r = res; });
+        globalThis.doSettle = () => { r(7); };
+    `)();
+    return { subject: other.s, settle: () => { other.doSettle(); } };
+}
+
+const awaitBody = `(async () => { await subject; log("resumed"); })()`;
+
+// Await performs PromiseResolve, whose SameValue(Get(x, "constructor"), C)
+// check fails for a cross-realm promise: it must be re-wrapped through the
+// thenable path, costing exactly one extra microtask compared to same-realm.
+shouldBe(ticksOf(awaitBody, crossRealmPending), "c0 resumed c1 c2");
+shouldBe(ticksOf(awaitBody, sameRealmPending), "resumed c0 c1 c2");
+
+// Promise Resolve Functions have no such check: adopting a vanilla promise
+// takes the same number of microtasks regardless of its realm.
+const resolveBody = `
+    const outer = new Promise((res) => { res(subject); });
+    outer.then((v) => log("outer:" + v));
+`;
+shouldBe(ticksOf(resolveBody, crossRealmPending), "c0 outer:7 c1 c2");
+shouldBe(ticksOf(resolveBody, sameRealmPending), "c0 outer:7 c1 c2");

--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -147,7 +147,7 @@ JSPromise* JSAPIGlobalObject::moduleLoaderImportModule(JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto reject = [&] (ThrowScope& scope) -> JSPromise* {
         auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        return promise->rejectWithCaughtException(globalObject, scope);
+        return promise->rejectWithCaughtException(vm, scope);
     };
 
     auto specifier = specifierValue->value(globalObject);
@@ -172,11 +172,11 @@ JSPromise* JSAPIGlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject, JS
     JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
 
     Identifier moduleKey = key.toPropertyKey(globalObject);
-    RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
+    RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(vm, scope));
 
     if (![context moduleLoaderDelegate]) [[unlikely]] {
         scope.release();
-        promise->reject(vm, globalObject, createError(globalObject, "No module loader provided."_s));
+        promise->reject(vm, createError(globalObject, "No module loader provided."_s));
         return promise;
     }
 
@@ -187,7 +187,7 @@ JSPromise* JSAPIGlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject, JS
         id script = valueToObject(context, toRef(globalObject, callFrame->argument(0)));
 
         auto rejectPromise = [&] (String message) {
-            promise->reject(vm, globalObject, createTypeError(globalObject, message));
+            promise->reject(vm, createTypeError(globalObject, message));
             return encodedJSUndefined();
         };
 
@@ -210,14 +210,14 @@ JSPromise* JSAPIGlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject, JS
     }, promise);
 
     auto* reject = JSNativeStdFunction::create(vm, globalObject, 1, "reject"_s, [promise] (JSGlobalObject* globalObject, CallFrame* callFrame) {
-        promise->reject(globalObject->vm(), globalObject, callFrame->argument(0));
+        promise->reject(globalObject->vm(), callFrame->argument(0));
         return encodedJSUndefined();
     }, promise);
 
     [[context moduleLoaderDelegate] context:context fetchModuleForIdentifier:[::JSValue valueWithJSValueRef:toRef(globalObject, key) inContext:context] withResolveHandler:[::JSValue valueWithJSValueRef:toRef(globalObject, resolve) inContext:context] andRejectHandler:[::JSValue valueWithJSValueRef:toRef(globalObject, reject) inContext:context]];
     if (context.exception) {
         scope.release();
-        promise->reject(vm, globalObject, toJS(globalObject, [context.exception JSValueRef]));
+        promise->reject(vm, toJS(globalObject, [context.exception JSValueRef]));
         context.exception = nil;
     }
     return promise;

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1867,7 +1867,7 @@ JSC_DEFINE_JIT_OPERATION(operationRejectPromiseFirstResolving, void, (JSGlobalOb
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue argument = JSValue::decode(encodedArgument);
-    promise->reject(vm, globalObject, argument);
+    promise->reject(vm, argument);
     OPERATION_RETURN(scope);
 }
 
@@ -1878,7 +1878,7 @@ JSC_DEFINE_JIT_OPERATION(operationFulfillPromiseFirstResolving, void, (JSGlobalO
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue argument = JSValue::decode(encodedArgument);
-    promise->fulfill(vm, globalObject, argument);
+    promise->fulfill(vm, argument);
     OPERATION_RETURN(scope);
 }
 

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1109,7 +1109,7 @@ JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* globalObject, 
 
     auto rejectWithCaughtException = [&]() -> JSPromise* {
         auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        return promise->rejectWithCaughtException(globalObject, scope);
+        return promise->rejectWithCaughtException(vm, scope);
     };
 
     auto& referrer = sourceOrigin.url();
@@ -1119,7 +1119,7 @@ JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* globalObject, 
 
     if (!referrer.protocolIsFile()) [[unlikely]] {
         auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        promise->reject(vm, globalObject, createError(globalObject, makeString("Could not resolve the referrer's path '"_s, referrer.string(), "', while trying to resolve module '"_s, specifier.data, "'."_s)));
+        promise->reject(vm, createError(globalObject, makeString("Could not resolve the referrer's path '"_s, referrer.string(), "', while trying to resolve module '"_s, specifier.data, "'."_s)));
         return promise;
     }
 
@@ -1472,12 +1472,12 @@ JSPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject, JSModul
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto rejectWithError = [&](JSValue error) {
-        promise->reject(vm, globalObject, error);
+        promise->reject(vm, error);
         return promise;
     };
 
     String moduleKey = key.toWTFString(globalObject);
-    RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
+    RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(vm, scope));
 
     URL moduleURL({ }, moduleKey);
     ASSERT(moduleURL.protocolIsFile());

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -181,7 +181,7 @@ static JSPromise* rejectPromise(ThrowScope& scope, JSGlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
     JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
-    return promise->rejectWithCaughtException(globalObject, scope);
+    return promise->rejectWithCaughtException(vm, scope);
 }
 
 JSPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, const String& moduleName, RefPtr<ScriptFetchParameters> parameters, RefPtr<ScriptFetcher> scriptFetcher)
@@ -239,7 +239,7 @@ JSPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, SourceCode&& sour
 
     JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
     resultPromise->markAsHandled();
-    promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadReturnModuleKey, resultPromise, jsUndefined());
+    promise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleLoadReturnModuleKey, resultPromise, jsUndefined());
 
     return resultPromise;
 }

--- a/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
@@ -417,7 +417,7 @@ JSPromise* CyclicModuleRecord::evaluate(JSGlobalObject* globalObject)
         // 9.c. Assert: module.[[EvaluationError]] and result are the same Completion Record.
         ASSERT(module->evaluationError() == exception->value());
         // 9.d. Perform ! Call(capability.[[Reject]], undefined, « result.[[Value]] »).
-        capability->rejectWithCaughtException(globalObject, scope);
+        capability->rejectWithCaughtException(vm, scope);
     // 10. Else,
     } else {
         // 10.a. Assert: module.[[Status]] is either EVALUATING-ASYNC or EVALUATED.
@@ -430,7 +430,7 @@ JSPromise* CyclicModuleRecord::evaluate(JSGlobalObject* globalObject)
             ASSERT(module->asyncEvaluationOrder().isUnset() || module->asyncEvaluationOrder().isDone());
             // 10.c.ii. NOTE: module.[[AsyncEvaluationOrder]] is DONE if and only if module had already been evaluated and that evaluation was asynchronous.
             // 10.c.iii. Perform ! Call(capability.[[Resolve]], undefined, « undefined »).
-            capability->fulfill(vm, globalObject, jsUndefined());
+            capability->fulfill(vm, jsUndefined());
         }
         // 10.d. Assert: stack is empty.
         ASSERT(stack.isEmpty());
@@ -454,9 +454,9 @@ void CyclicModuleRecord::execute(JSGlobalObject* globalObject, JSPromise* capabi
         if (capability) {
             if (Exception* exception = scope.exception()) {
                 JSModuleLoader::attachErrorInfo(globalObject, exception, wasmModule, wasmModule->moduleKey(), ScriptFetchParameters::WebAssembly, JSModuleLoader::ModuleFailure::Kind::Evaluation);
-                capability->rejectWithCaughtException(globalObject, scope);
+                capability->rejectWithCaughtException(vm, scope);
             } else
-                capability->fulfill(vm, globalObject, result);
+                capability->fulfill(vm, result);
             return;
         }
         RELEASE_AND_RETURN(scope, void());
@@ -490,7 +490,7 @@ void CyclicModuleRecord::executeAsync(JSGlobalObject* globalObject)
     // 7. Let onRejected be CreateBuiltinFunction(rejectedClosure, 0, "", « »).
     // Also handled in JSMicrotask.cpp.
     // 8. Perform PerformPromiseThen(capability.[[Promise]], onFulfilled, onRejected).
-    promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::AsyncModuleExecutionDone, nullptr, this);
+    promise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::AsyncModuleExecutionDone, nullptr, this);
     // 9. Perform ! module.ExecuteModule(capability).
     execute(globalObject, promise);
     RETURN_IF_EXCEPTION(scope, void());
@@ -577,7 +577,7 @@ void CyclicModuleRecord::asyncExecutionRejected(JSGlobalObject* globalObject, JS
         // 9.a. Assert: module.[[CycleRoot]] and module are the same Module Record.
         ASSERT(cycleRoot() == this);
         // 9.b. Perform ! Call(module.[[TopLevelCapability]].[[Reject]], undefined, « error »).
-        topLevel->reject(vm, globalObject, error);
+        topLevel->reject(vm, error);
     }
     // 10. For each Cyclic Module Record m of module.[[AsyncParentModules]], do
     for (const WriteBarrier<AbstractModuleRecord>& m : asyncParentModules()) {
@@ -617,7 +617,7 @@ void CyclicModuleRecord::asyncExecutionFulfilled(JSGlobalObject* globalObject)
         // 7.a. Assert: module.[[CycleRoot]] and module are the same Module Record.
         ASSERT(cycleRoot() == this);
         // 7.b. Perform ! Call(module.[[TopLevelCapability]].[[Resolve]], undefined, « undefined »).
-        capability->fulfill(vm, globalObject, jsUndefined());
+        capability->fulfill(vm, jsUndefined());
     }
     // 8. Let execList be a new empty List.
     // (Note: it's safe to use a Vector instead of a MarkedArgumentsBuffer here because all the contents are accessed through WriteBarriers starting at `this`.)
@@ -672,7 +672,7 @@ void CyclicModuleRecord::asyncExecutionFulfilled(JSGlobalObject* globalObject)
                     // 12.c.iii.3.a. Assert: m.[[CycleRoot]] and m are the same Module Record.
                     ASSERT(m->cycleRoot() == m);
                     // 12.c.iii.3.b. Perform ! Call(m.[[TopLevelCapability]].[[Resolve]], undefined, « undefined »).
-                    capability->fulfill(vm, globalObject, jsUndefined());
+                    capability->fulfill(vm, jsUndefined());
                 }
             }
         }

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -756,7 +756,7 @@ JSC_DEFINE_HOST_FUNCTION(rejectPromise, (JSGlobalObject* globalObject, CallFrame
 {
     auto* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
-    promise->rejectPromise(globalObject->vm(), globalObject, argument);
+    promise->rejectPromise(globalObject->vm(), argument);
     return encodedJSUndefined();
 }
 
@@ -764,7 +764,7 @@ JSC_DEFINE_HOST_FUNCTION(fulfillPromise, (JSGlobalObject* globalObject, CallFram
 {
     auto* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
-    promise->fulfillPromise(globalObject->vm(), globalObject, argument);
+    promise->fulfillPromise(globalObject->vm(), argument);
     return encodedJSUndefined();
 }
 
@@ -793,7 +793,7 @@ JSC_DEFINE_HOST_FUNCTION(rejectPromiseWithFirstResolvingFunctionCallCheck, (JSGl
 {
     auto* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
-    promise->reject(globalObject->vm(), globalObject, argument);
+    promise->reject(globalObject->vm(), argument);
     return encodedJSUndefined();
 }
 
@@ -801,7 +801,7 @@ JSC_DEFINE_HOST_FUNCTION(fulfillPromiseWithFirstResolvingFunctionCallCheck, (JSG
 {
     auto* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
-    promise->fulfill(globalObject->vm(), globalObject, argument);
+    promise->fulfill(globalObject->vm(), argument);
     return encodedJSUndefined();
 }
 
@@ -888,7 +888,7 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorQueueEnqueue, (JSGlobalObject* globalObje
     JSPromise* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(3));
 
     if (!generator) [[unlikely]] {
-        promise->reject(vm, globalObject, createTypeError(globalObject, "|this| should be an async generator"_s));
+        promise->reject(vm, createTypeError(globalObject, "|this| should be an async generator"_s));
         return JSValue::encode(jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorResumeMode::Empty)));
     }
 
@@ -922,7 +922,7 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorQueueDequeueReject, (JSGlobalObject* glob
 
     auto [value, resumeMode, promise] = generator->dequeue(vm);
 
-    promise->reject(vm, globalObject, error);
+    promise->reject(vm, error);
 
     return JSValue::encode(jsNumber(generator->resumeMode()));
 }

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -803,7 +803,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncImportModule, (JSGlobalObject* globalObject, 
 
     auto rejectWithCaughtException = [&]() -> EncodedJSValue {
         auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        return JSValue::encode(promise->rejectWithCaughtException(globalObject, scope));
+        return JSValue::encode(promise->rejectWithCaughtException(vm, scope));
     };
 
     auto sourceOrigin = callFrame->callerSourceOrigin(vm);

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -282,13 +282,11 @@ static void promiseResolveThenableJob(JSGlobalObject* globalObject, JSValue prom
     EXCEPTION_ASSERT(scope.exception() || true);
 }
 
-static void asyncFromSyncIteratorContinueOrDone(JSGlobalObject* globalObject, VM& vm, JSValue context, JSValue result, JSPromise::Status status, bool done)
+static void asyncFromSyncIteratorContinueOrDone(JSGlobalObject* globalObject, VM& vm, JSPromise* promise, JSValue context, JSValue result, JSPromise::Status status, bool done)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* contextObject = asObject(context);
-    JSValue promise = contextObject->getDirect(vm, vm.propertyNames->builtinNames().promisePrivateName());
-    ASSERT(promise.inherits<JSPromise>());
 
     switch (status) {
     case JSPromise::Status::Pending: {
@@ -312,7 +310,7 @@ static void asyncFromSyncIteratorContinueOrDone(JSGlobalObject* globalObject, VM
                 }
             }
             if (error) [[unlikely]] {
-                uncheckedDowncast<JSPromise>(promise)->reject(vm, globalObject, error);
+                promise->reject(vm, error);
                 return;
             }
             if (returnMethod.isCallable()) {
@@ -322,13 +320,13 @@ static void asyncFromSyncIteratorContinueOrDone(JSGlobalObject* globalObject, VM
             }
         }
         scope.release();
-        uncheckedDowncast<JSPromise>(promise)->reject(vm, globalObject, result);
+        promise->reject(vm, result);
         break;
     }
     case JSPromise::Status::Fulfilled: {
         auto* resultObject = createIteratorResultObject(globalObject, result, done);
         scope.release();
-        uncheckedDowncast<JSPromise>(promise)->resolve(globalObject, vm, resultObject);
+        promise->resolve(globalObject, vm, resultObject);
         break;
     }
     }
@@ -353,7 +351,7 @@ static void promiseRaceResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromis
     }
     case JSPromise::Status::Rejected: {
         scope.release();
-        promise->reject(vm, globalObject, resolution);
+        promise->reject(vm, resolution);
         break;
     }
     }
@@ -389,7 +387,7 @@ static void promiseAllResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
     case JSPromise::Status::Rejected: {
         auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
         scope.release();
-        promise->reject(vm, globalObject, resolution);
+        promise->reject(vm, resolution);
         break;
     }
     }
@@ -462,7 +460,7 @@ static void promiseAnyResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
             auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
             auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
             scope.release();
-            promise->reject(vm, globalObject, aggregateError);
+            promise->reject(vm, aggregateError);
         }
         break;
     }
@@ -484,7 +482,7 @@ static void asyncGeneratorReject(JSGlobalObject* globalObject, JSAsyncGenerator*
     auto [value, resumeMode, promise] = generator->dequeue(vm);
     ASSERT(promise);
 
-    promise->reject(vm, globalObject, error);
+    promise->reject(vm, error);
 
     if constexpr (status == IterationStatus::Continue)
         asyncGeneratorResumeNext(globalObject, generator);
@@ -694,14 +692,14 @@ static void promiseFinallyAwaitJob(JSGlobalObject* globalObject, VM& vm, JSValue
     bool wasFulfilled = context->remainingElementsCount().asBoolean();
 
     if (status == JSPromise::Status::Rejected) {
-        resultPromise->rejectPromise(vm, globalObject, settledValue);
+        resultPromise->rejectPromise(vm, settledValue);
         return;
     }
 
     if (wasFulfilled)
         resultPromise->resolvePromise(globalObject, vm, originalValue);
     else
-        resultPromise->rejectPromise(vm, globalObject, originalValue);
+        resultPromise->rejectPromise(vm, originalValue);
 }
 
 static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPromise* resultPromise, JSValue valueOrReason, JSPromiseCombinatorsGlobalContext* context, JSPromise::Status status)
@@ -725,7 +723,7 @@ static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPr
     }
 
     if (error) {
-        resultPromise->rejectPromise(vm, globalObject, error);
+        resultPromise->rejectPromise(vm, error);
         return;
     }
 
@@ -734,9 +732,9 @@ static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPr
 
     if (result.inherits<JSPromise>()) {
         auto* promise = uncheckedDowncast<JSPromise>(result);
-        if (promise->isThenFastAndNonObservable()) {
+        if (promise->realm() == globalObject && promise->isThenFastAndNonObservable()) {
             scope.release();
-            promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseFinallyAwaitJob, resultPromise, context);
+            promise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::PromiseFinallyAwaitJob, resultPromise, context);
             return;
         }
     }
@@ -783,24 +781,19 @@ static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPr
     promiseResolveThenableJob(globalObject, resolutionObject, then, resolve, reject);
 }
 
-static void asyncModuleExecutionDone(JSGlobalObject* globalObject, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
+static void asyncModuleExecutionDone(JSGlobalObject* globalObject, ThrowScope& scope, JSModuleRecord* module, JSValue value, JSPromise::Status status)
 {
     scope.release();
-    auto* module = uncheckedDowncast<JSModuleRecord>(arguments[2]);
-    auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled)
         module->asyncExecutionFulfilled(globalObject);
     else {
         ASSERT(status == JSPromise::Status::Rejected);
-        module->asyncExecutionRejected(globalObject, arguments[1]);
+        module->asyncExecutionRejected(globalObject, value);
     }
 }
 
-static void asyncModuleExecutionResume(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
+static void asyncModuleExecutionResume(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, JSModuleRecord* module, JSValue resolution, JSPromise::Status status)
 {
-    auto* module = uncheckedDowncast<JSModuleRecord>(arguments[2]);
-    JSValue resolution = arguments[1];
-    auto status = static_cast<JSPromise::Status>(payload);
     auto* capability = module->asyncCapability();
 
     JSValue resumeMode = jsNumber(status == JSPromise::Status::Fulfilled
@@ -810,7 +803,7 @@ static void asyncModuleExecutionResume(JSGlobalObject* globalObject, VM& vm, Thr
     JSValue result = module->evaluate(globalObject, resolution, resumeMode);
 
     if (scope.exception())
-        capability->rejectWithCaughtException(globalObject, scope);
+        capability->rejectWithCaughtException(vm, scope);
     else {
         JSValue state = module->internalField(AbstractModuleRecord::Field::State).get();
         if (!state.isNumber() || state.asNumber() == static_cast<int32_t>(JSGenerator::State::Executing))
@@ -832,16 +825,16 @@ static void moduleRegistryFetchSettled(JSGlobalObject* globalObject, VM& vm, Thr
         auto* jsSourceCode = downcast<JSSourceCode>(arguments[1]);
         JSPromise* makeModulePromise = JSModuleLoader::makeModule(globalObject, entry->key(), jsSourceCode);
         if (scope.exception()) {
-            modulePromise->rejectWithCaughtException(globalObject, scope);
+            modulePromise->rejectWithCaughtException(vm, scope);
             return;
         }
-        makeModulePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleRegistryModuleSettled, modulePromise, entry);
+        makeModulePromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleRegistryModuleSettled, modulePromise, entry);
     } else {
         JSValue errorValue = arguments[1];
         if (auto* error = dynamicDowncast<ErrorInstance>(errorValue))
             JSModuleLoader::attachErrorInfo(globalObject, error, nullptr, entry->key(), entry->moduleType(), JSModuleLoader::ModuleFailure::Kind::Instantiation);
         entry->setFetchError(globalObject, errorValue);
-        modulePromise->reject(vm, globalObject, errorValue);
+        modulePromise->reject(vm, errorValue);
     }
 }
 
@@ -856,11 +849,11 @@ static void moduleRegistryModuleSettled(JSGlobalObject* globalObject, VM& vm, st
     if (status == JSPromise::Status::Fulfilled) {
         auto* moduleRecord = downcast<AbstractModuleRecord>(arguments[1]);
         entry->fetchComplete(globalObject, moduleRecord);
-        modulePromise->fulfill(vm, globalObject, moduleRecord);
+        modulePromise->fulfill(vm, moduleRecord);
     } else {
         JSValue errorValue = arguments[1];
         entry->setEvaluationError(globalObject, errorValue);
-        modulePromise->reject(vm, globalObject, errorValue);
+        modulePromise->reject(vm, errorValue);
     }
 }
 
@@ -877,7 +870,7 @@ static void moduleGraphLoadingError(JSGlobalObject* globalObject, VM& vm, ThrowS
             errorValue = JSModuleLoader::maybeDuplicateFetchError(globalObject, error);
             RETURN_IF_EXCEPTION(scope, void());
         }
-        state->promise()->reject(vm, globalObject, errorValue);
+        state->promise()->reject(vm, errorValue);
     }
 }
 
@@ -898,13 +891,13 @@ static void moduleLoadStep(JSGlobalObject* globalObject, VM& vm, ThrowScope& sco
             context->module(vm, module);
             JSPromise* requestedPromise = globalObject->moduleLoader()->loadRequestedModules(globalObject, module, context->scriptFetcher());
             if (scope.exception()) {
-                loadPromise->rejectWithCaughtException(globalObject, scope);
+                loadPromise->rejectWithCaughtException(vm, scope);
                 return;
             }
             context->setStep(ModuleLoadingContext::Step::Requested);
-            requestedPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadStep, loadPromise, context);
+            requestedPromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleLoadStep, loadPromise, context);
         } else
-            loadPromise->reject(vm, globalObject, arguments[1]);
+            loadPromise->reject(vm, arguments[1]);
         return;
     }
     case ModuleLoadingContext::Step::Requested: {
@@ -913,7 +906,7 @@ static void moduleLoadStep(JSGlobalObject* globalObject, VM& vm, ThrowScope& sco
             auto* module = context->module();
             globalObject->moduleLoader()->finishLoadingImportedModule(globalObject, context->referrer(), context->moduleRequest(), context->payload(), module, context->scriptFetcher());
             if (scope.exception()) {
-                loadPromise->rejectWithCaughtException(globalObject, scope);
+                loadPromise->rejectWithCaughtException(vm, scope);
                 return;
             }
 
@@ -921,18 +914,18 @@ static void moduleLoadStep(JSGlobalObject* globalObject, VM& vm, ThrowScope& sco
             auto* entry = context->entry();
             if (auto* cyclic = dynamicDowncast<CyclicModuleRecord>(module); cyclic && cyclic->status() != CyclicModuleRecord::Status::Unlinked) {
                 ASSERT(cyclic->status() != CyclicModuleRecord::Status::Linking);
-                loadPromise->fulfill(vm, globalObject, entry->record());
+                loadPromise->fulfill(vm, entry->record());
             } else {
                 entry->setRecord(vm, module);
                 entry->setStatus(ModuleRegistryEntry::Status::Fetched);
-                loadPromise->fulfill(vm, globalObject, entry->record());
+                loadPromise->fulfill(vm, entry->record());
             }
         } else {
             // onRejected logic: store evaluation error on entry
             auto* entry = context->entry();
             JSValue errorValue = arguments[1];
             entry->setEvaluationError(globalObject, errorValue);
-            loadPromise->reject(vm, globalObject, errorValue);
+            loadPromise->reject(vm, errorValue);
         }
         return;
     }
@@ -942,15 +935,15 @@ static void moduleLoadStep(JSGlobalObject* globalObject, VM& vm, ThrowScope& sco
             auto* module = downcast<AbstractModuleRecord>(arguments[1]);
             globalObject->moduleLoader()->finishLoadingImportedModule(globalObject, context->referrer(), context->moduleRequest(), context->payload(), module, context->scriptFetcher());
             if (scope.exception()) {
-                loadPromise->rejectWithCaughtException(globalObject, scope);
+                loadPromise->rejectWithCaughtException(vm, scope);
                 return;
             }
-            loadPromise->fulfill(vm, globalObject, module);
+            loadPromise->fulfill(vm, module);
         } else {
             auto* entry = context->entry();
             JSValue errorValue = arguments[1];
             entry->setEvaluationError(globalObject, errorValue);
-            loadPromise->reject(vm, globalObject, errorValue);
+            loadPromise->reject(vm, errorValue);
         }
         return;
     }
@@ -977,7 +970,7 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
 
         globalObject->moduleLoader()->provideFetch(globalObject, specifier, type, jsSourceCode);
         if (scope.exception()) {
-            intermediatePromise->rejectWithCaughtException(globalObject, scope);
+            intermediatePromise->rejectWithCaughtException(vm, scope);
             return;
         }
 
@@ -1001,26 +994,26 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
                 innerLoadFlags.add(ModuleLoadFlag::Evaluate);
             loadPromise = globalObject->moduleLoader()->loadModule(globalObject, globalObject, request, combinedCell, scriptFetcher, innerLoadFlags);
             if (scope.exception()) {
-                intermediatePromise->rejectWithCaughtException(globalObject, scope);
+                intermediatePromise->rejectWithCaughtException(vm, scope);
                 return;
             }
             // Specifier transform: instead of creating a closure, use a microtask
             JSPromise* transformedStatePromise = JSPromise::create(vm, globalObject->promiseStructure());
             transformedStatePromise->markAsHandled();
-            statePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadSpecifierTransform, transformedStatePromise, context);
+            statePromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleLoadSpecifierTransform, transformedStatePromise, context);
             statePromise = transformedStatePromise;
         }
 
         if (scope.exception()) {
-            intermediatePromise->rejectWithCaughtException(globalObject, scope);
+            intermediatePromise->rejectWithCaughtException(vm, scope);
             return;
         }
 
         JSPromise* combinedPromise = JSPromise::create(vm, globalObject->promiseStructure());
         combinedPromise->markAsHandled();
 
-        loadPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadCombinedLoadSettled, combinedPromise, combinedCell);
-        statePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadCombinedStateSettled, combinedPromise, combinedCell);
+        loadPromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleLoadCombinedLoadSettled, combinedPromise, combinedCell);
+        statePromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleLoadCombinedStateSettled, combinedPromise, combinedCell);
 
         intermediatePromise->pipeFrom(vm, combinedPromise);
     } else {
@@ -1029,7 +1022,7 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
         auto type = context->moduleRequest().type();
         ModuleRegistryEntry* entry = globalObject->moduleLoader()->ensureRegistered(globalObject, specifier, type);
         if (scope.exception()) {
-            intermediatePromise->rejectWithCaughtException(globalObject, scope);
+            intermediatePromise->rejectWithCaughtException(vm, scope);
             return;
         }
         JSValue errorValue = arguments[1];
@@ -1040,7 +1033,7 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
             else
                 entry->setFetchError(globalObject, error);
         }
-        intermediatePromise->reject(vm, globalObject, errorValue);
+        intermediatePromise->reject(vm, errorValue);
     }
 }
 
@@ -1054,34 +1047,34 @@ static void moduleLoadTopRejected(JSGlobalObject* globalObject, VM& vm, ThrowSco
     auto* resultPromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled)
-        resultPromise->fulfill(vm, globalObject, arguments[1]);
+        resultPromise->fulfill(vm, arguments[1]);
     else {
         const Identifier& specifier = context->moduleRequest().m_specifier;
         auto type = context->moduleRequest().type();
         ModuleRegistryEntry* entry = globalObject->moduleLoader()->ensureRegistered(globalObject, specifier, type);
         if (scope.exception()) {
-            resultPromise->rejectWithCaughtException(globalObject, scope);
+            resultPromise->rejectWithCaughtException(vm, scope);
             return;
         }
         if (JSValue fetchErrorValue = entry->fetchError()) {
             if (ErrorInstance* fetchError = dynamicDowncast<ErrorInstance>(fetchErrorValue)) {
                 ErrorInstance* fetchErrorCopy = JSModuleLoader::maybeDuplicateFetchError(globalObject, fetchError);
                 if (scope.exception()) {
-                    resultPromise->rejectWithCaughtException(globalObject, scope);
+                    resultPromise->rejectWithCaughtException(vm, scope);
                     return;
                 }
-                resultPromise->reject(vm, globalObject, fetchErrorCopy);
+                resultPromise->reject(vm, fetchErrorCopy);
             } else
-                resultPromise->reject(vm, globalObject, fetchErrorValue);
+                resultPromise->reject(vm, fetchErrorValue);
             return;
         }
         JSValue error = arguments[1];
         entry->setEvaluationError(globalObject, error);
-        resultPromise->reject(vm, globalObject, error);
+        resultPromise->reject(vm, error);
     }
 }
 
-static void moduleLoadSpecifierTransform(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
+static void moduleLoadSpecifierTransform(JSGlobalObject*, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
 {
     // Transforms resolution to specifier identifier
     // arguments[0] = pre-created transformedStatePromise
@@ -1092,12 +1085,12 @@ static void moduleLoadSpecifierTransform(JSGlobalObject* globalObject, VM& vm, T
     if (status == JSPromise::Status::Fulfilled) {
         auto* context = uncheckedDowncast<ModuleLoadingContext>(arguments[2]);
         scope.release();
-        transformedPromise->fulfill(vm, globalObject, identifierToJSValue(vm, context->moduleRequest().m_specifier));
+        transformedPromise->fulfill(vm, identifierToJSValue(vm, context->moduleRequest().m_specifier));
     } else
-        transformedPromise->reject(vm, globalObject, arguments[1]);
+        transformedPromise->reject(vm, arguments[1]);
 }
 
-static void moduleLoadCombinedLoadSettled(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
+static void moduleLoadCombinedLoadSettled(JSGlobalObject*, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
 {
     // Combined promise: load side settled
     // arguments[0] = combinedPromise
@@ -1124,9 +1117,9 @@ static void moduleLoadCombinedLoadSettled(JSGlobalObject* globalObject, VM& vm, 
             else
                 fulfillmentValue = uncheckedDowncast<ModuleLoaderPayload>(combinedCell)->fulfillment();
             ASSERT(fulfillmentValue);
-            combinedPromise->fulfill(vm, globalObject, fulfillmentValue);
+            combinedPromise->fulfill(vm, fulfillmentValue);
         } else
-            combinedPromise->reject(vm, globalObject, arguments[1]);
+            combinedPromise->reject(vm, arguments[1]);
         return;
     }
     default:
@@ -1134,7 +1127,7 @@ static void moduleLoadCombinedLoadSettled(JSGlobalObject* globalObject, VM& vm, 
     }
 }
 
-static void moduleLoadCombinedStateSettled(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
+static void moduleLoadCombinedStateSettled(JSGlobalObject*, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
 {
     // Combined promise: state side settled
     // arguments[0] = combinedPromise
@@ -1160,9 +1153,9 @@ static void moduleLoadCombinedStateSettled(JSGlobalObject* globalObject, VM& vm,
     case JSPromise::Status::Pending:
         if (status == JSPromise::Status::Fulfilled) {
             if (fullySettled)
-                combinedPromise->fulfill(vm, globalObject, arguments[1]);
+                combinedPromise->fulfill(vm, arguments[1]);
         } else
-            combinedPromise->reject(vm, globalObject, arguments[1]);
+            combinedPromise->reject(vm, arguments[1]);
         return;
     default:
         return;
@@ -1184,24 +1177,24 @@ static void moduleLoadLinkEvaluateSettled(JSGlobalObject* globalObject, VM& vm, 
             record->link(globalObject, context->scriptFetcher());
             JSModuleLoader::attachErrorInfo(globalObject, scope, record, record->moduleKey(), record->moduleType(), JSModuleLoader::ModuleFailure::Kind::Instantiation);
             if (scope.exception()) {
-                resultPromise->rejectWithCaughtException(globalObject, scope);
+                resultPromise->rejectWithCaughtException(vm, scope);
                 return;
             }
             JSPromise* evaluatePromise = record->evaluate(globalObject);
             JSModuleLoader::attachErrorInfo(globalObject, scope, record, record->moduleKey(), record->moduleType(), JSModuleLoader::ModuleFailure::Kind::Evaluation);
             if (scope.exception()) {
-                resultPromise->rejectWithCaughtException(globalObject, scope);
+                resultPromise->rejectWithCaughtException(vm, scope);
                 return;
             }
             // Chain: when evaluation completes, resolve resultPromise with record
-            evaluatePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadReturnRecord, resultPromise, record);
+            evaluatePromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleLoadReturnRecord, resultPromise, record);
         } else
-            resultPromise->fulfill(vm, globalObject, identifierToJSValue(vm, record->moduleKey()));
+            resultPromise->fulfill(vm, identifierToJSValue(vm, record->moduleKey()));
     } else
-        resultPromise->reject(vm, globalObject, arguments[1]);
+        resultPromise->reject(vm, arguments[1]);
 }
 
-static void moduleLoadReturnRecord(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
+static void moduleLoadReturnRecord(JSGlobalObject*, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
 {
     // Resolves promise with the record after evaluation completes
     // arguments[0] = resultPromise
@@ -1211,9 +1204,9 @@ static void moduleLoadReturnRecord(JSGlobalObject* globalObject, VM& vm, ThrowSc
     auto status = static_cast<JSPromise::Status>(payload);
     scope.release();
     if (status == JSPromise::Status::Fulfilled)
-        resultPromise->fulfill(vm, globalObject, arguments[2]);
+        resultPromise->fulfill(vm, arguments[2]);
     else
-        resultPromise->reject(vm, globalObject, arguments[1]);
+        resultPromise->reject(vm, arguments[1]);
 }
 
 static void moduleLoadStoreError(JSGlobalObject* globalObject, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
@@ -1250,12 +1243,12 @@ static void resolveDeferredImportNamespace(JSGlobalObject* globalObject, VM& vm,
     // Let namespace be GetModuleNamespace(module, phase).
     JSModuleNamespaceObject* moduleNamespace = module->getModuleNamespace(globalObject, AbstractModuleRecord::ModulePhase::Defer);
     if (scope.exception()) [[unlikely]] {
-        capabilityPromise->rejectWithCaughtException(globalObject, scope);
+        capabilityPromise->rejectWithCaughtException(vm, scope);
         return;
     }
     // Perform ! Call(promiseCapability.[[Resolve]], undefined, « namespace »).
     // (See dynamicImportEvaluateSettled for why fulfill is used on this internal promise.)
-    capabilityPromise->fulfill(vm, globalObject, moduleNamespace);
+    capabilityPromise->fulfill(vm, moduleNamespace);
 }
 
 static void dynamicImportLoadSettled(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload, bool deferred)
@@ -1274,7 +1267,7 @@ static void dynamicImportLoadSettled(JSGlobalObject* globalObject, VM& vm, Throw
     if (status != JSPromise::Status::Fulfilled) {
         // Step-4 rejectedClosure
         // 4.a. Perform ! Call(promiseCapability.[[Reject]], undefined, « reason »).
-        capabilityPromise->reject(vm, globalObject, arguments[1]);
+        capabilityPromise->reject(vm, arguments[1]);
         return;
     }
 
@@ -1286,7 +1279,7 @@ static void dynamicImportLoadSettled(JSGlobalObject* globalObject, VM& vm, Throw
     if (Exception* exception = scope.exception()) [[unlikely]] {
         // 6.b.i. Perform ! Call(promiseCapability.[[Reject]], undefined, « link.[[Value]] »).
         JSModuleLoader::attachErrorInfo(globalObject, exception, module, module->moduleKey(), module->moduleType(), JSModuleLoader::ModuleFailure::Kind::Instantiation);
-        capabilityPromise->rejectWithCaughtException(globalObject, scope);
+        capabilityPromise->rejectWithCaughtException(vm, scope);
         return;
     }
 
@@ -1294,12 +1287,12 @@ static void dynamicImportLoadSettled(JSGlobalObject* globalObject, VM& vm, Throw
         // 6.c. Let evaluatePromise be module.Evaluate().
         JSPromise* evaluatePromise = module->evaluate(globalObject);
         if (scope.exception()) [[unlikely]] {
-            capabilityPromise->rejectWithCaughtException(globalObject, scope);
+            capabilityPromise->rejectWithCaughtException(vm, scope);
             return;
         }
 
         // 6.d-f. Perform PerformPromiseThen(evaluatePromise, onFulfilled, onRejected).
-        evaluatePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::DynamicImportEvaluateSettled, capabilityPromise, module);
+        evaluatePromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::DynamicImportEvaluateSettled, capabilityPromise, module);
         return;
     }
 
@@ -1323,7 +1316,7 @@ static void dynamicImportLoadSettled(JSGlobalObject* globalObject, VM& vm, Throw
     for (AbstractModuleRecord* dep : evaluationList) {
         JSPromise* depPromise = dep->evaluate(globalObject);
         if (scope.exception()) [[unlikely]] {
-            capabilityPromise->rejectWithCaughtException(globalObject, scope);
+            capabilityPromise->rejectWithCaughtException(vm, scope);
             return;
         }
         ASSERT(depPromise);
@@ -1331,7 +1324,7 @@ static void dynamicImportLoadSettled(JSGlobalObject* globalObject, VM& vm, Throw
     }
     if (asyncDepsEvaluationPromises.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
-        capabilityPromise->rejectWithCaughtException(globalObject, scope);
+        capabilityPromise->rejectWithCaughtException(vm, scope);
         return;
     }
 
@@ -1342,7 +1335,7 @@ static void dynamicImportLoadSettled(JSGlobalObject* globalObject, VM& vm, Throw
     auto* joinContext = JSPromiseCombinatorsGlobalContext::create(vm, capabilityPromise, module, jsNumber(asyncDepsEvaluationPromises.size()));
     for (unsigned i = 0; i < asyncDepsEvaluationPromises.size(); ++i) {
         auto* depPromise = uncheckedDowncast<JSPromise>(asyncDepsEvaluationPromises.at(i));
-        depPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::DynamicImportDeferDependencySettled, capabilityPromise, joinContext);
+        depPromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::DynamicImportDeferDependencySettled, capabilityPromise, joinContext);
     }
 }
 
@@ -1357,7 +1350,7 @@ static void dynamicImportDeferDependencySettled(JSGlobalObject* globalObject, VM
     auto status = static_cast<JSPromise::Status>(payload);
     if (status != JSPromise::Status::Fulfilled) {
         // First rejection wins; reject() on a settled promise is a no-op.
-        capabilityPromise->reject(vm, globalObject, arguments[1]);
+        capabilityPromise->reject(vm, arguments[1]);
         return;
     }
     int32_t remaining = joinContext->remainingElementsCount().asInt32() - 1;
@@ -1385,7 +1378,7 @@ static void dynamicImportEvaluateSettled(JSGlobalObject* globalObject, VM& vm, T
         // 6.d.i. Let namespace be GetModuleNamespace(module).
         JSModuleNamespaceObject* moduleNamespace = module->getModuleNamespace(globalObject);
         if (scope.exception()) [[unlikely]] {
-            capabilityPromise->rejectWithCaughtException(globalObject, scope);
+            capabilityPromise->rejectWithCaughtException(vm, scope);
             return;
         }
 
@@ -1400,9 +1393,9 @@ static void dynamicImportEvaluateSettled(JSGlobalObject* globalObject, VM& vm, T
         // aligned (as "resolve" will happen in resultPromise side from dynamic import).
         // But ideally, this carried capabilityPromise should be the last user-observable
         // promise and we should do "resolve" here. This requires some clean up.
-        capabilityPromise->fulfill(vm, globalObject, moduleNamespace);
+        capabilityPromise->fulfill(vm, moduleNamespace);
     } else
-        capabilityPromise->reject(vm, globalObject, arguments[1]);
+        capabilityPromise->reject(vm, arguments[1]);
 }
 
 static void importModuleNamespace(JSGlobalObject* globalObject, VM& vm, ThrowScope&, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
@@ -1423,7 +1416,7 @@ static void importModuleNamespace(JSGlobalObject* globalObject, VM& vm, ThrowSco
         auto* moduleNamespace = downcast<JSModuleNamespaceObject>(arguments[1]);
         resultPromise->resolve(globalObject, vm, moduleNamespace);
     } else
-        resultPromise->reject(vm, globalObject, arguments[1]);
+        resultPromise->reject(vm, arguments[1]);
     return;
 }
 
@@ -1461,10 +1454,10 @@ static void promiseResolveWithoutHandlerJob(JSGlobalObject* globalObject, VM& vm
             RELEASE_ASSERT_NOT_REACHED();
             break;
         case JSPromise::Status::Fulfilled:
-            promise->resolvePromise(globalObject, vm, resolution);
+            promise->resolvePromise(promise->realm(), vm, resolution);
             break;
         case JSPromise::Status::Rejected:
-            promise->rejectPromise(vm, globalObject, resolution);
+            promise->rejectPromise(vm, resolution);
             break;
         }
         return;
@@ -1478,7 +1471,7 @@ static void webAssemblyCompileStreaming(JSGlobalObject* globalObject, VM& vm, JS
 {
     JSPromise* outerPromise = context->promise();
     if (status == JSPromise::Status::Rejected) {
-        outerPromise->reject(vm, globalObject, resolution);
+        outerPromise->reject(vm, resolution);
         return;
     }
     ASSERT(globalObject->globalObjectMethodTable()->compileStreaming);
@@ -1489,7 +1482,7 @@ static void webAssemblyInstantiateStreaming(JSGlobalObject* globalObject, VM& vm
 {
     JSPromise* outerPromise = context->promise();
     if (status == JSPromise::Status::Rejected) {
-        outerPromise->reject(vm, globalObject, resolution);
+        outerPromise->reject(vm, resolution);
         return;
     }
 
@@ -1517,7 +1510,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
             RELEASE_AND_RETURN(scope, promiseResolveThenableJobFastSlow(globalObject, promise, promiseToResolve));
 
         scope.release();
-        promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseResolveWithoutHandlerJob, promiseToResolve, jsUndefined());
+        promise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::PromiseResolveWithoutHandlerJob, promiseToResolve, jsUndefined());
         return;
     }
 
@@ -1529,7 +1522,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         if (!promiseSpeciesWatchpointIsValid(vm, promise)) [[unlikely]]
             RELEASE_AND_RETURN(scope, promiseResolveThenableJobWithInternalMicrotaskFastSlow(globalObject, promise, task, context));
 
-        promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, nullptr, context);
+        promise->performPromiseThenWithInternalMicrotask(vm, task, nullptr, context);
         return;
     }
 
@@ -1563,27 +1556,38 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
             break;
         case JSPromise::Status::Fulfilled:
             scope.release();
-            promise->fulfillPromise(vm, globalObject, resolution);
+            promise->fulfillPromise(vm, resolution);
             break;
         case JSPromise::Status::Rejected:
             scope.release();
-            promise->rejectPromise(vm, globalObject, resolution);
+            promise->rejectPromise(vm, resolution);
             break;
         }
         return;
     }
 
-    case InternalMicrotask::PromiseRaceResolveJob:
-        RELEASE_AND_RETURN(scope, promiseRaceResolveJob(globalObject, vm, uncheckedDowncast<JSPromise>(arguments[0]), arguments[1], static_cast<JSPromise::Status>(payload)));
+    case InternalMicrotask::PromiseRaceResolveJob: {
+        auto* promise = uncheckedDowncast<JSPromise>(arguments[0]);
+        RELEASE_AND_RETURN(scope, promiseRaceResolveJob(promise->realm(), vm, promise, arguments[1], static_cast<JSPromise::Status>(payload)));
+    }
 
-    case InternalMicrotask::PromiseAllResolveJob:
-        RELEASE_AND_RETURN(scope, promiseAllResolveJob(globalObject, vm, uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[0]), arguments[1], static_cast<uint64_t>(arguments[2].asAnyInt()), static_cast<JSPromise::Status>(payload)));
+    case InternalMicrotask::PromiseAllResolveJob: {
+        auto* globalContext = uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[0]);
+        auto* resultPromise = uncheckedDowncast<JSPromise>(globalContext->promise());
+        RELEASE_AND_RETURN(scope, promiseAllResolveJob(resultPromise->realm(), vm, globalContext, arguments[1], static_cast<uint64_t>(arguments[2].asAnyInt()), static_cast<JSPromise::Status>(payload)));
+    }
 
-    case InternalMicrotask::PromiseAllSettledResolveJob:
-        RELEASE_AND_RETURN(scope, promiseAllSettledResolveJob(globalObject, vm, uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[0]), arguments[1], static_cast<uint64_t>(arguments[2].asAnyInt()), static_cast<JSPromise::Status>(payload)));
+    case InternalMicrotask::PromiseAllSettledResolveJob: {
+        auto* globalContext = uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[0]);
+        auto* resultPromise = uncheckedDowncast<JSPromise>(globalContext->promise());
+        RELEASE_AND_RETURN(scope, promiseAllSettledResolveJob(resultPromise->realm(), vm, globalContext, arguments[1], static_cast<uint64_t>(arguments[2].asAnyInt()), static_cast<JSPromise::Status>(payload)));
+    }
 
-    case InternalMicrotask::PromiseAnyResolveJob:
-        RELEASE_AND_RETURN(scope, promiseAnyResolveJob(globalObject, vm, uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[0]), arguments[1], static_cast<uint64_t>(arguments[2].asAnyInt()), static_cast<JSPromise::Status>(payload)));
+    case InternalMicrotask::PromiseAnyResolveJob: {
+        auto* globalContext = uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[0]);
+        auto* resultPromise = uncheckedDowncast<JSPromise>(globalContext->promise());
+        RELEASE_AND_RETURN(scope, promiseAnyResolveJob(resultPromise->realm(), vm, globalContext, arguments[1], static_cast<uint64_t>(arguments[2].asAnyInt()), static_cast<JSPromise::Status>(payload)));
+    }
 
     case InternalMicrotask::PromiseReactionJob: {
         JSValue promiseOrCapability = arguments[0];
@@ -1616,7 +1620,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
 
         if (error) {
             if (auto* promise = dynamicDowncast<JSPromise>(promiseOrCapability))
-                RELEASE_AND_RETURN(scope, promise->rejectPromise(vm, globalObject, error));
+                RELEASE_AND_RETURN(scope, promise->rejectPromise(vm, error));
 
             JSValue reject = promiseOrCapability.get(globalObject, vm.propertyNames->reject);
             RETURN_IF_EXCEPTION(scope, void());
@@ -1630,7 +1634,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         }
 
         if (auto* promise = dynamicDowncast<JSPromise>(promiseOrCapability))
-            RELEASE_AND_RETURN(scope, promise->resolvePromise(globalObject, vm, result));
+            RELEASE_AND_RETURN(scope, promise->resolvePromise(promise->realm(), vm, result));
 
         JSValue resolve = promiseOrCapability.get(globalObject, vm.propertyNames->resolve);
         RETURN_IF_EXCEPTION(scope, void());
@@ -1653,6 +1657,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
     case InternalMicrotask::AsyncFunctionResume: {
         JSValue resolution = arguments[1];
         auto* generator = uncheckedDowncast<JSAsyncFunctionGenerator>(arguments[2]);
+        JSGlobalObject* generatorGlobalObject = generator->realm();
         JSGenerator::ResumeMode resumeMode = JSGenerator::ResumeMode::NormalMode;
         switch (static_cast<JSPromise::Status>(payload)) {
         case JSPromise::Status::Pending: {
@@ -1678,7 +1683,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         JSValue error;
         {
             auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            value = callMicrotask(globalObject, next, thisValue, generator, "handler is not a function"_s, microtaskCall,
+            value = callMicrotask(generatorGlobalObject, next, thisValue, generator, "handler is not a function"_s, microtaskCall,
                 generator, jsNumber(state), resolution, jsNumber(static_cast<int32_t>(resumeMode)), frame);
             if (catchScope.exception()) {
                 error = catchScope.exception()->value();
@@ -1692,40 +1697,46 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         if (error) {
             auto* promise = uncheckedDowncast<JSPromise>(generator->context());
             scope.release();
-            promise->reject(vm, globalObject, error);
+            promise->reject(vm, error);
             return;
         }
 
         if (generator->state() == static_cast<int32_t>(JSGenerator::State::Executing)) {
             auto* promise = uncheckedDowncast<JSPromise>(generator->context());
             scope.release();
-            promise->resolve(globalObject, vm, value);
+            promise->resolve(generatorGlobalObject, vm, value);
             return;
         }
 
         scope.release();
-        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, value, InternalMicrotask::AsyncFunctionResume, generator);
+        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(generatorGlobalObject, vm, value, InternalMicrotask::AsyncFunctionResume, generator);
         return;
     }
 
     case InternalMicrotask::AsyncFromSyncIteratorContinue:
-    case InternalMicrotask::AsyncFromSyncIteratorDone:
-        RELEASE_AND_RETURN(scope, asyncFromSyncIteratorContinueOrDone(globalObject, vm, arguments[2], arguments[1], static_cast<JSPromise::Status>(payload), task == InternalMicrotask::AsyncFromSyncIteratorDone));
+    case InternalMicrotask::AsyncFromSyncIteratorDone: {
+        auto* promise = uncheckedDowncast<JSPromise>(asObject(arguments[2])->getDirect(vm, vm.propertyNames->builtinNames().promisePrivateName()));
+        RELEASE_AND_RETURN(scope, asyncFromSyncIteratorContinueOrDone(promise->realm(), vm, promise, arguments[2], arguments[1], static_cast<JSPromise::Status>(payload), task == InternalMicrotask::AsyncFromSyncIteratorDone));
+    }
 
     case InternalMicrotask::AsyncGeneratorYieldAwaited: {
-        RELEASE_AND_RETURN(scope, asyncGeneratorYieldAwaited(globalObject, uncheckedDowncast<JSAsyncGenerator>(arguments[2]), arguments[1], static_cast<JSPromise::Status>(payload)));
+        auto* generator = uncheckedDowncast<JSAsyncGenerator>(arguments[2]);
+        RELEASE_AND_RETURN(scope, asyncGeneratorYieldAwaited(generator->realm(), generator, arguments[1], static_cast<JSPromise::Status>(payload)));
     }
 
     case InternalMicrotask::AsyncGeneratorBodyCallNormal: {
-        RELEASE_AND_RETURN(scope, asyncGeneratorBodyCallNormal(globalObject, uncheckedDowncast<JSAsyncGenerator>(arguments[2]), arguments[1], static_cast<JSPromise::Status>(payload)));
+        auto* generator = uncheckedDowncast<JSAsyncGenerator>(arguments[2]);
+        RELEASE_AND_RETURN(scope, asyncGeneratorBodyCallNormal(generator->realm(), generator, arguments[1], static_cast<JSPromise::Status>(payload)));
     }
 
     case InternalMicrotask::AsyncGeneratorBodyCallReturn: {
-        RELEASE_AND_RETURN(scope, asyncGeneratorBodyCallReturn(globalObject, uncheckedDowncast<JSAsyncGenerator>(arguments[2]), arguments[1], static_cast<JSPromise::Status>(payload)));
+        auto* generator = uncheckedDowncast<JSAsyncGenerator>(arguments[2]);
+        RELEASE_AND_RETURN(scope, asyncGeneratorBodyCallReturn(generator->realm(), generator, arguments[1], static_cast<JSPromise::Status>(payload)));
     }
 
     case InternalMicrotask::AsyncGeneratorResumeNext: {
-        RELEASE_AND_RETURN(scope, asyncGeneratorResumeNextReturn(globalObject, uncheckedDowncast<JSAsyncGenerator>(arguments[2]), arguments[1], static_cast<JSPromise::Status>(payload)));
+        auto* generator = uncheckedDowncast<JSAsyncGenerator>(arguments[2]);
+        RELEASE_AND_RETURN(scope, asyncGeneratorResumeNextReturn(generator->realm(), generator, arguments[1], static_cast<JSPromise::Status>(payload)));
     }
 
     case InternalMicrotask::PromiseFinallyReactionJob: {
@@ -1734,9 +1745,10 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         // arguments[1] = value/reason from original promise
         // arguments[2] = context (JSPromiseCombinatorsGlobalContext: promise=resultPromise, values=onFinally)
         // payload = Fulfilled/Rejected status
+        auto* resultPromise = uncheckedDowncast<JSPromise>(arguments[0]);
         scope.release();
-        promiseFinallyReactionJob(globalObject, vm,
-            uncheckedDowncast<JSPromise>(arguments[0]),
+        promiseFinallyReactionJob(resultPromise->realm(), vm,
+            resultPromise,
             arguments[1],
             uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[2]),
             static_cast<JSPromise::Status>(payload));
@@ -1749,21 +1761,25 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         // arguments[1] = settled value from onFinally's result
         // arguments[2] = context (JSPromiseCombinatorsGlobalContext: promise=resultPromise, values=originalValue, remainingElementsCount=wasFulfilled)
         // payload = status of onFinally's result
+        auto* context = uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[2]);
+        auto* resultPromise = uncheckedDowncast<JSPromise>(context->promise());
         scope.release();
-        promiseFinallyAwaitJob(globalObject, vm,
+        promiseFinallyAwaitJob(resultPromise->realm(), vm,
             arguments[1],
-            uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[2]),
+            context,
             static_cast<JSPromise::Status>(payload));
         return;
     }
 
     case InternalMicrotask::AsyncModuleExecutionDone: {
-        asyncModuleExecutionDone(globalObject, scope, arguments, payload);
+        auto* module = uncheckedDowncast<JSModuleRecord>(arguments[2]);
+        asyncModuleExecutionDone(module->realm(), scope, module, arguments[1], static_cast<JSPromise::Status>(payload));
         return;
     }
 
     case InternalMicrotask::AsyncModuleExecutionResume: {
-        asyncModuleExecutionResume(globalObject, vm, scope, arguments, payload);
+        auto* module = uncheckedDowncast<JSModuleRecord>(arguments[2]);
+        asyncModuleExecutionResume(module->realm(), vm, scope, module, arguments[1], static_cast<JSPromise::Status>(payload));
         return;
     }
 
@@ -1831,9 +1847,9 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         scope.release();
         if (status == JSPromise::Status::Fulfilled) {
             auto* module = downcast<AbstractModuleRecord>(arguments[1]);
-            resultPromise->fulfillPromise(vm, globalObject, identifierToJSValue(vm, module->moduleKey()));
+            resultPromise->fulfillPromise(vm, identifierToJSValue(vm, module->moduleKey()));
         } else
-            resultPromise->rejectPromise(vm, globalObject, arguments[1]);
+            resultPromise->rejectPromise(vm, arguments[1]);
         return;
     }
 

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -374,11 +374,11 @@ JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const Identi
 
     JSPromise* intermediatePromise = JSPromise::create(vm, globalObject->promiseStructure());
     intermediatePromise->markAsHandled();
-    promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadTopSettled, intermediatePromise, context);
+    promise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleLoadTopSettled, intermediatePromise, context);
 
     JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
     resultPromise->markAsHandled();
-    intermediatePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadTopRejected, resultPromise, context);
+    intermediatePromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleLoadTopRejected, resultPromise, context);
 
     return resultPromise;
 }
@@ -443,7 +443,7 @@ JSPromise* JSModuleLoader::requestImportModule(JSGlobalObject* globalObject, con
 
     JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
     resultPromise->markAsHandled();
-    promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ImportModuleNamespace, resultPromise, jsUndefined());
+    promise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ImportModuleNamespace, resultPromise, jsUndefined());
 
     return resultPromise;
 }
@@ -470,10 +470,10 @@ JSPromise* JSModuleLoader::importModule(JSGlobalObject* globalObject, JSString* 
 
     auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
     auto moduleNameString = moduleName->value(globalObject);
-    RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
+    RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(vm, scope));
 
     scope.release();
-    promise->reject(vm, globalObject, createError(globalObject, makeString("Could not import the module '"_s, moduleNameString.data, "'."_s)));
+    promise->reject(vm, createError(globalObject, makeString("Could not import the module '"_s, moduleNameString.data, "'."_s)));
     return promise;
 }
 
@@ -512,10 +512,10 @@ JSPromise* JSModuleLoader::fetch(JSGlobalObject* globalObject, JSValue key, RefP
 
     auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
     String moduleKey = key.toWTFString(globalObject);
-    RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
+    RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(vm, scope));
 
     scope.release();
-    promise->reject(vm, globalObject, createError(globalObject, makeString("Could not open the module '"_s, moduleKey, "'."_s)));
+    promise->reject(vm, createError(globalObject, makeString("Could not open the module '"_s, moduleKey, "'."_s)));
     return promise;
 }
 
@@ -610,7 +610,7 @@ JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, 
         JSValue errorValue = error.get();
         ASSERT(errorValue);
         JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        promise->reject(vm, globalObject, errorValue);
+        promise->reject(vm, errorValue);
         // 9.1. If loadState is not undefined and loadState.[[ErrorToRethrow]] is null, set loadState.[[ErrorToRethrow]] to resolutionError.
         // (Unused.)
         // 9.2. Perform FinishLoadingImportedModule(referrer, moduleRequest, payload, ThrowCompletion(resolutionError)).
@@ -632,7 +632,7 @@ JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, 
             addResolutionFailure(vm, resolutionKey, errorValue);
 
             JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
-            promise->rejectWithCaughtException(globalObject, scope);
+            promise->rejectWithCaughtException(vm, scope);
             // 9.1. If loadState is not undefined and loadState.[[ErrorToRethrow]] is null, set loadState.[[ErrorToRethrow]] to resolutionError.
             // (Unused.)
             // 9.2. Perform FinishLoadingImportedModule(referrer, moduleRequest, payload, ThrowCompletion(resolutionError)).
@@ -674,7 +674,7 @@ JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, 
                 auto* context = ModuleLoadingContext::create(vm, ModuleLoadingContext::Step::Cached, referrer, moduleRequest, payload, mapEntry, scriptFetcher);
                 JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
                 resultPromise->markAsHandled();
-                promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadStep, resultPromise, context);
+                promise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleLoadStep, resultPromise, context);
                 promise = resultPromise;
             }
 
@@ -701,7 +701,7 @@ JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, 
     JSPromise* loadPromise = JSPromise::create(vm, globalObject->promiseStructure());
     loadPromise->markAsHandled();
 
-    modulePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadStep, loadPromise, context);
+    modulePromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleLoadStep, loadPromise, context);
 
     mapEntry->setLoadPromise(vm, loadPromise);
 
@@ -723,8 +723,8 @@ JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const Module
     JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
     resultPromise->markAsHandled();
 
-    promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadLinkEvaluateSettled, resultPromise, context);
-    resultPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadStoreError, nullptr, context);
+    promise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleLoadLinkEvaluateSettled, resultPromise, context);
+    resultPromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleLoadStoreError, nullptr, context);
 
     return resultPromise;
 }
@@ -782,7 +782,7 @@ void JSModuleLoader::innerModuleLoading(JSGlobalObject* globalObject, ModuleGrap
                 ASSERT(module->loadedModules().size() <= loadedModulesCountBefore + 1);
                 ASSERT(needsErrorReaction != module->loadedModules().contains(ModuleMapKey { request.m_specifier.impl(), request.type() }));
                 if (needsErrorReaction)
-                    promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleGraphLoadingError, nullptr, state);
+                    promise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleGraphLoadingError, nullptr, state);
             }
             // 2.d.iv. If state.[[IsLoading]] is false, return UNUSED.
             if (!state->isLoading())
@@ -804,7 +804,7 @@ void JSModuleLoader::innerModuleLoading(JSGlobalObject* globalObject, ModuleGrap
                 loaded->setStatus(CyclicModuleRecord::Status::Unlinked);
         });
         // 5.c. Perform ! Call(state.[[PromiseCapability]].[[Resolve]], undefined, « undefined »).
-        state->promise()->fulfill(vm, globalObject, module);
+        state->promise()->fulfill(vm, module);
     }
     // 6. Return UNUSED.
     scope.release();
@@ -888,7 +888,7 @@ void JSModuleLoader::continueModuleLoading(JSGlobalObject* globalObject, ModuleG
         // 3.a. Set state.[[IsLoading]] to false.
         state->setIsLoading(false);
         // 3.b. Perform ! Call(state.[[PromiseCapability]].[[Reject]], undefined, « moduleCompletion.[[Value]] »).
-        state->promise()->reject(vm, globalObject, std::get<Exception*>(moduleCompletion)->value());
+        state->promise()->reject(vm, std::get<Exception*>(moduleCompletion)->value());
     }
     // 4. Return UNUSED.
     scope.release();
@@ -905,7 +905,7 @@ void JSModuleLoader::continueDynamicImport(JSGlobalObject* globalObject, JSPromi
     // 1. If moduleCompletion is an abrupt completion, then
     if (Exception** exception = std::get_if<Exception*>(&completion)) {
         // 1.a. Perform ! Call(promiseCapability.[[Reject]], undefined, « moduleCompletion.[[Value]] »).
-        promise->reject(vm, globalObject, (*exception)->value());
+        promise->reject(vm, (*exception)->value());
         // 1.b. Return UNUSED.
         scope.assertNoException();
         return;
@@ -916,7 +916,7 @@ void JSModuleLoader::continueDynamicImport(JSGlobalObject* globalObject, JSPromi
     JSPromise* loadPromise = loadRequestedModules(globalObject, module, WTF::move(scriptFetcher));
     RETURN_IF_EXCEPTION(scope, void());
     // 4-8. Link and evaluate using microtask dispatch instead of closures.
-    loadPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, deferred ? InternalMicrotask::DynamicImportDeferLoadSettled : InternalMicrotask::DynamicImportLoadSettled, promise, module);
+    loadPromise->performPromiseThenWithInternalMicrotask(vm, deferred ? InternalMicrotask::DynamicImportDeferLoadSettled : InternalMicrotask::DynamicImportLoadSettled, promise, module);
     // 9. Return UNUSED.
     scope.release();
 }
@@ -1037,9 +1037,9 @@ JSPromise* JSModuleLoader::makeModule(JSGlobalObject* globalObject, const Identi
     if (sourceCode.provider()->sourceType() == SourceProviderSourceType::JSON) {
         auto* moduleRecord = SyntheticModuleRecord::parseJSONModule(globalObject, moduleKey, SourceCode { sourceCode });
         attachErrorInfo(globalObject, scope, moduleRecord, moduleKey, ScriptFetchParameters::JSON, ModuleFailure::Kind::Evaluation);
-        RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
+        RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(vm, scope));
         scope.release();
-        promise->fulfill(vm, globalObject, moduleRecord);
+        promise->fulfill(vm, moduleRecord);
         return promise;
     }
 
@@ -1050,7 +1050,7 @@ JSPromise* JSModuleLoader::makeModule(JSGlobalObject* globalObject, const Identi
     if (error.isValid()) {
         auto* errorInstance = uncheckedDowncast<ErrorInstance>(error.toErrorObject(globalObject, sourceCode));
         attachErrorInfo(globalObject, errorInstance, nullptr, moduleKey, ScriptFetchParameters::JavaScript, ModuleFailure::Kind::Evaluation);
-        promise->reject(vm, globalObject, errorInstance);
+        promise->reject(vm, errorInstance);
         RELEASE_AND_RETURN(scope, promise);
     }
     ASSERT(moduleProgramNode);
@@ -1063,11 +1063,11 @@ JSPromise* JSModuleLoader::makeModule(JSGlobalObject* globalObject, const Identi
         auto [errorType, message] = WTF::move(result.error());
         auto* errorInstance = uncheckedDowncast<ErrorInstance>(createError(globalObject, errorType, message));
         attachErrorInfo(globalObject, errorInstance, nullptr, moduleKey, ScriptFetchParameters::JavaScript, ModuleFailure::Kind::Evaluation);
-        promise->reject(vm, globalObject, errorInstance);
+        promise->reject(vm, errorInstance);
         RELEASE_AND_RETURN(scope, promise);
     }
 
-    promise->fulfill(vm, globalObject, result.value());
+    promise->fulfill(vm, result.value());
     RELEASE_AND_RETURN(scope, promise);
 }
 

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
@@ -146,7 +146,7 @@ void JSModuleRecord::execute(JSGlobalObject* globalObject, JSPromise* capability
         asyncCapability(vm, capability);
         JSValue result = globalObject->moduleLoader()->evaluate(globalObject, identifierToJSValue(vm, moduleKey()), this, nullptr, jsUndefined(), jsNumber(static_cast<int32_t>(ResumeMode::NormalMode)));
         if (scope.exception())
-            capability->rejectWithCaughtException(globalObject, scope);
+            capability->rejectWithCaughtException(vm, scope);
         else if (JSValue state = internalField(Field::State).get(); !state.isNumber() || state.asInt32AsAnyInt() == std::to_underlying(State::Executing))
             capability->resolve(globalObject, vm, result);
         else

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -162,7 +162,7 @@ JSPromise* JSPromise::rejectedPromise(JSGlobalObject* globalObject, JSValue valu
 {
     VM& vm = globalObject->vm();
     JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
-    promise->reject(vm, globalObject, value);
+    promise->reject(vm, value);
     return promise;
 }
 
@@ -175,21 +175,21 @@ void JSPromise::resolve(JSGlobalObject* globalObject, VM& vm, JSValue value)
     }
 }
 
-void JSPromise::reject(VM& vm, JSGlobalObject* globalObject, JSValue value)
+void JSPromise::reject(VM& vm, JSValue value)
 {
     ASSERT(!value.inherits<Exception>());
     if (!isFirstResolvingFunctionCalled()) {
         setFlags(flags() | isFirstResolvingFunctionCalledFlag);
-        rejectPromise(vm, globalObject, value);
+        rejectPromise(vm, value);
     }
 }
 
-void JSPromise::fulfill(VM& vm, JSGlobalObject* globalObject, JSValue value)
+void JSPromise::fulfill(VM& vm, JSValue value)
 {
     ASSERT(!value.inherits<Exception>());
     if (!isFirstResolvingFunctionCalled()) {
         setFlags(flags() | isFirstResolvingFunctionCalledFlag);
-        fulfillPromise(vm, globalObject, value);
+        fulfillPromise(vm, value);
     }
 }
 
@@ -199,8 +199,7 @@ void JSPromise::pipeFrom(VM& vm, JSPromise* from)
         return;
     setFlags(flags() | isFirstResolvingFunctionCalledFlag);
 
-    JSGlobalObject* globalObject = this->realm();
-    from->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseFulfillWithoutHandlerJob, this, jsUndefined());
+    from->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::PromiseFulfillWithoutHandlerJob, this, jsUndefined());
 }
 
 void JSPromise::performPromiseThenExported(VM& vm, JSGlobalObject* globalObject, JSValue onFulfilled, JSValue onRejected, JSValue promiseOrCapability)
@@ -208,33 +207,32 @@ void JSPromise::performPromiseThenExported(VM& vm, JSGlobalObject* globalObject,
     return performPromiseThen(vm, globalObject, onFulfilled, onRejected, promiseOrCapability);
 }
 
-void JSPromise::rejectAsHandled(VM& vm, JSGlobalObject* lexicalGlobalObject, JSValue value)
+void JSPromise::rejectAsHandled(VM& vm, JSValue value)
 {
     // Setting isHandledFlag before calling reject since this removes round-trip between JSC and PromiseRejectionTracker, and it does not show an user-observable behavior.
     if (!isFirstResolvingFunctionCalled()) {
         markAsHandled();
-        reject(vm, lexicalGlobalObject, value);
+        reject(vm, value);
     }
 }
 
-void JSPromise::reject(VM& vm, JSGlobalObject* lexicalGlobalObject, Exception* reason)
+void JSPromise::reject(VM& vm, Exception* reason)
 {
-    reject(vm, lexicalGlobalObject, reason->value());
+    reject(vm, reason->value());
 }
 
-void JSPromise::rejectAsHandled(VM& vm, JSGlobalObject* lexicalGlobalObject, Exception* reason)
+void JSPromise::rejectAsHandled(VM& vm, Exception* reason)
 {
-    rejectAsHandled(vm, lexicalGlobalObject, reason->value());
+    rejectAsHandled(vm, reason->value());
 }
 
-JSPromise* JSPromise::rejectWithCaughtException(JSGlobalObject* globalObject, ThrowScope& scope)
+JSPromise* JSPromise::rejectWithCaughtException(VM& vm, ThrowScope& scope)
 {
-    VM& vm = globalObject->vm();
     Exception* exception = scope.exception();
     ASSERT(exception);
     TRY_CLEAR_EXCEPTION(scope, nullptr);
     scope.release();
-    reject(vm, globalObject, exception->value());
+    reject(vm, exception->value());
     return this;
 }
 
@@ -380,7 +378,7 @@ void JSPromise::performPromiseThen(VM& vm, JSGlobalObject* globalObject, JSValue
     }
 }
 
-void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* globalObject, InternalMicrotask task, JSCell* cell, JSValue context)
+void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, InternalMicrotask task, JSCell* cell, JSValue context)
 {
     JSValue cellValue = cell ? JSValue(cell) : jsUndefined();
     switch (status()) {
@@ -395,6 +393,7 @@ void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* 
         break;
     }
     case JSPromise::Status::Rejected: {
+        JSGlobalObject* globalObject = realm();
         JSValue settled = settlementValue();
         if (!isHandled())
             globalObject->globalObjectMethodTable()->promiseRejectionTracker(globalObject, this, JSPromiseRejectionOperation::Handle);
@@ -403,6 +402,7 @@ void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* 
         break;
     }
     case JSPromise::Status::Fulfilled: {
+        JSGlobalObject* globalObject = realm();
         JSValue settled = settlementValue();
         globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Fulfilled), cellValue, settled, context);
         break;
@@ -491,9 +491,10 @@ ALWAYS_INLINE void JSPromise::settleInlineHandler(VM& vm, JSGlobalObject* global
         globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveWithoutHandlerJob, static_cast<uint8_t>(newStatus), resultPromise, argument, jsUndefined());
 }
 
-void JSPromise::rejectPromise(VM& vm, JSGlobalObject* globalObject, JSValue argument)
+void JSPromise::rejectPromise(VM& vm, JSValue argument)
 {
     ASSERT(status() == Status::Pending);
+    JSGlobalObject* globalObject = realm();
     uint16_t currentFlags = flags();
     auto kind = static_cast<InlineReactionKind>((currentFlags & inlineReactionKindMask) >> inlineReactionKindShift);
     switch (kind) {
@@ -521,9 +522,10 @@ void JSPromise::rejectPromise(VM& vm, JSGlobalObject* globalObject, JSValue argu
     }
 }
 
-void JSPromise::fulfillPromise(VM& vm, JSGlobalObject* globalObject, JSValue argument)
+void JSPromise::fulfillPromise(VM& vm, JSValue argument)
 {
     ASSERT(status() == Status::Pending);
+    JSGlobalObject* globalObject = realm();
     uint16_t currentFlags = flags();
     auto kind = static_cast<InlineReactionKind>((currentFlags & inlineReactionKindMask) >> inlineReactionKindShift);
     switch (kind) {
@@ -553,21 +555,21 @@ void JSPromise::resolvePromise(JSGlobalObject* globalObject, VM& vm, JSValue res
     if (resolution == this) [[unlikely]] {
         Structure* errorStructure = globalObject->errorStructure(ErrorType::TypeError);
         auto* error = ErrorInstance::create(vm, errorStructure, "Cannot resolve a promise with itself"_s, jsUndefined(), nullptr, TypeNothing, ErrorType::TypeError, false);
-        return rejectPromise(vm, globalObject, error);
+        return rejectPromise(vm, error);
     }
 
     if (!resolution.isObject())
-        return fulfillPromise(vm, globalObject, resolution);
+        return fulfillPromise(vm, resolution);
 
     auto* resolutionObject = asObject(resolution);
     if (resolutionObject->inherits<JSPromise>()) {
         auto* promise = uncheckedDowncast<JSPromise>(resolutionObject);
         if (promise->isThenFastAndNonObservable())
-            return globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveThenableJobFast, 0, resolutionObject, this, jsUndefined());
+            return promise->realm()->queueMicrotask(vm, InternalMicrotask::PromiseResolveThenableJobFast, 0, resolutionObject, this, jsUndefined());
     }
 
     if (isDefinitelyNonThenable(resolutionObject, globalObject))
-        return fulfillPromise(vm, globalObject, resolution);
+        return fulfillPromise(vm, resolution);
 
     JSValue then;
     JSValue error;
@@ -581,10 +583,10 @@ void JSPromise::resolvePromise(JSGlobalObject* globalObject, VM& vm, JSValue res
         }
     }
     if (error) [[unlikely]]
-        return rejectPromise(vm, globalObject, error);
+        return rejectPromise(vm, error);
 
     if (!then.isCallable()) [[likely]]
-        return fulfillPromise(vm, globalObject, resolutionObject);
+        return fulfillPromise(vm, resolutionObject);
 
     return globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveThenableJob, 0, resolutionObject, then, this);
 }
@@ -623,7 +625,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionReject, (JSGlobalObject* global
     auto* promise = uncheckedDowncast<JSPromise>(callee->getField(JSFunctionWithFields::Field::ResolvingPromise));
     JSValue argument = callFrame->argument(0);
 
-    promise->rejectPromise(vm, globalObject, argument);
+    promise->rejectPromise(vm, argument);
     return JSValue::encode(jsUndefined());
 }
 
@@ -643,7 +645,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseFirstResolvingFunctionReject, (JSGlobalObject* g
     auto* promise = uncheckedDowncast<JSPromise>(callee->getField(JSFunctionWithFields::Field::FirstResolvingPromise));
     JSValue argument = callFrame->argument(0);
 
-    promise->reject(globalObject->vm(), globalObject, argument);
+    promise->reject(globalObject->vm(), argument);
     return JSValue::encode(jsUndefined());
 }
 
@@ -826,8 +828,8 @@ void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* global
 {
     if (resolution.inherits<JSPromise>()) {
         auto* promise = uncheckedDowncast<JSPromise>(resolution);
-        if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]]
-            return promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, nullptr, context);
+        if (promise->realm() == globalObject && promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]]
+            return promise->performPromiseThenWithInternalMicrotask(vm, task, nullptr, context);
 
         JSValue constructor;
         JSValue error;
@@ -851,7 +853,7 @@ void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* global
         }
 
         if (constructor == globalObject->promiseConstructor())
-            return promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, nullptr, context);
+            return promise->performPromiseThenWithInternalMicrotask(vm, task, nullptr, context);
     }
 
     resolveWithInternalMicrotask(globalObject, vm, resolution, task, context);
@@ -865,7 +867,7 @@ void JSPromise::resolveWithInternalMicrotask(JSGlobalObject* globalObject, VM& v
     auto* resolutionObject = asObject(resolution);
     if (resolutionObject->inherits<JSPromise>()) {
         auto* promise = uncheckedDowncast<JSPromise>(resolutionObject);
-        if (promise->isThenFastAndNonObservable())
+        if (promise->realm() == globalObject && promise->isThenFastAndNonObservable())
             return globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveThenableJobWithInternalMicrotaskFast, static_cast<uint8_t>(task), resolutionObject, context, jsUndefined());
     }
 
@@ -1039,7 +1041,7 @@ JSObject* JSPromise::promiseReject(JSGlobalObject* globalObject, JSObject* const
 
     if (constructor == globalObject->promiseConstructor()) [[likely]] {
         JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        promise->reject(vm, globalObject, argument);
+        promise->reject(vm, argument);
         return promise;
     }
 

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -117,17 +117,17 @@ public:
     JS_EXPORT_PRIVATE static JSPromise* rejectedPromise(JSGlobalObject*, JSValue);
 
     JS_EXPORT_PRIVATE void resolve(JSGlobalObject*, VM&, JSValue);
-    JS_EXPORT_PRIVATE void reject(VM&, JSGlobalObject*, JSValue);
-    JS_EXPORT_PRIVATE void fulfill(VM&, JSGlobalObject*, JSValue);
+    JS_EXPORT_PRIVATE void reject(VM&, JSValue);
+    JS_EXPORT_PRIVATE void fulfill(VM&, JSValue);
     // Pipes its settlement to this promise via internal microtask. Otherwise directly
     // fulfills. Never triggers user-observable behavior.
     JS_EXPORT_PRIVATE void pipeFrom(VM&, JSPromise* from);
-    JS_EXPORT_PRIVATE void rejectAsHandled(VM&, JSGlobalObject*, JSValue);
-    JS_EXPORT_PRIVATE void reject(VM&, JSGlobalObject*, Exception*);
-    JS_EXPORT_PRIVATE void rejectAsHandled(VM&, JSGlobalObject*, Exception*);
+    JS_EXPORT_PRIVATE void rejectAsHandled(VM&, JSValue);
+    JS_EXPORT_PRIVATE void reject(VM&, Exception*);
+    JS_EXPORT_PRIVATE void rejectAsHandled(VM&, Exception*);
     JS_EXPORT_PRIVATE void performPromiseThenExported(VM&, JSGlobalObject*, JSValue onFulfilled, JSValue onRejected, JSValue);
 
-    JS_EXPORT_PRIVATE JSPromise* rejectWithCaughtException(JSGlobalObject*, ThrowScope&);
+    JS_EXPORT_PRIVATE JSPromise* rejectWithCaughtException(VM&, ThrowScope&);
 
     // https://webidl.spec.whatwg.org/#mark-a-promise-as-handled
     void markAsHandled() { m_packed.setType(flags() | isHandledFlag); }
@@ -146,8 +146,8 @@ public:
 
     // This is abstract operations defined in the spec.
     void performPromiseThen(VM&, JSGlobalObject*, JSValue onFulfilled, JSValue onRejected, JSValue);
-    void rejectPromise(VM&, JSGlobalObject*, JSValue);
-    void fulfillPromise(VM&, JSGlobalObject*, JSValue);
+    void rejectPromise(VM&, JSValue);
+    void fulfillPromise(VM&, JSValue);
     void resolvePromise(JSGlobalObject*, VM&, JSValue);
 
     static void resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject*, VM&, JSValue resolution, InternalMicrotask, JSValue context);
@@ -155,7 +155,7 @@ public:
     static void rejectWithInternalMicrotask(VM&, JSGlobalObject*, JSValue argument, InternalMicrotask, JSValue context);
     static void fulfillWithInternalMicrotask(VM&, JSGlobalObject*, JSValue argument, InternalMicrotask, JSValue context);
 
-    void performPromiseThenWithInternalMicrotask(VM&, JSGlobalObject*, InternalMicrotask, JSCell*, JSValue context);
+    void performPromiseThenWithInternalMicrotask(VM&, InternalMicrotask, JSCell*, JSValue context);
 
     bool isThenFastAndNonObservable();
 

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -273,7 +273,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncRace, (JSGlobalObject* globalObje
         ASSERT(exception);
         TRY_CLEAR_EXCEPTION(scope, void());
         scope.release();
-        promise->reject(vm, globalObject, exception);
+        promise->reject(vm, exception);
     };
 
     JSValue iterable = callFrame->argument(0);
@@ -296,7 +296,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncRace, (JSGlobalObject* globalObje
             RETURN_IF_EXCEPTION(scope, void());
             if (constructor == globalObject->promiseConstructor()) [[likely]] {
                 scope.release();
-                nextPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseRaceResolveJob, promise, promise);
+                nextPromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::PromiseRaceResolveJob, promise, promise);
                 return;
             }
         }
@@ -478,7 +478,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
         ASSERT(exception);
         TRY_CLEAR_EXCEPTION(scope, void());
         scope.release();
-        promise->reject(vm, globalObject, exception);
+        promise->reject(vm, exception);
     };
 
     JSArray* values = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), 0);
@@ -522,7 +522,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
             RETURN_IF_EXCEPTION(scope, void());
             if (constructor == globalObject->promiseConstructor()) [[likely]] {
                 scope.release();
-                nextPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseAllResolveJob, globalContext, jsNumber(index));
+                nextPromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::PromiseAllResolveJob, globalContext, jsNumber(index));
                 ++index;
                 return;
             }
@@ -811,7 +811,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
         ASSERT(exception);
         TRY_CLEAR_EXCEPTION(scope, void());
         scope.release();
-        promise->reject(vm, globalObject, exception);
+        promise->reject(vm, exception);
     };
 
     JSArray* values = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), 0);
@@ -854,7 +854,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
             RETURN_IF_EXCEPTION(scope, void());
             if (constructor == globalObject->promiseConstructor()) [[likely]] {
                 scope.release();
-                nextPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseAllSettledResolveJob, globalContext, jsNumber(index));
+                nextPromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::PromiseAllSettledResolveJob, globalContext, jsNumber(index));
                 ++index;
                 return;
             }
@@ -1293,7 +1293,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
         ASSERT(exception);
         TRY_CLEAR_EXCEPTION(scope, void());
         scope.release();
-        promise->reject(vm, globalObject, exception);
+        promise->reject(vm, exception);
     };
 
     JSArray* errors = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), 0);
@@ -1337,7 +1337,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
             RETURN_IF_EXCEPTION(scope, void());
             if (constructor == globalObject->promiseConstructor()) [[likely]] {
                 scope.release();
-                nextPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseAnyResolveJob, globalContext, jsNumber(index));
+                nextPromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::PromiseAnyResolveJob, globalContext, jsNumber(index));
                 ++index;
                 return;
             }
@@ -1384,7 +1384,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
     if (!count) {
         auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
         scope.release();
-        promise->reject(vm, globalObject, aggregateError);
+        promise->reject(vm, aggregateError);
         if (scope.exception()) [[unlikely]] {
             callReject();
             return JSValue::encode(promise);
@@ -1424,7 +1424,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAnyRejectFunction, (JSGlobalObject* globalObject
     if (!count) {
         auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
         scope.release();
-        promise->reject(vm, globalObject, aggregateError);
+        promise->reject(vm, aggregateError);
     }
 
     return JSValue::encode(jsUndefined());

--- a/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
@@ -289,7 +289,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseProtoFuncFinally, (JSGlobalObject* globalObject,
         if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]] {
             JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
             auto* context = JSPromiseCombinatorsGlobalContext::create(vm, resultPromise, onFinally, jsUndefined());
-            promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseFinallyReactionJob, resultPromise, context);
+            promise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::PromiseFinallyReactionJob, resultPromise, context);
             return JSValue::encode(resultPromise);
         }
     }

--- a/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp
@@ -109,7 +109,7 @@ JSPromise* ModuleRegistryEntry::ensureFetchPromise(JSGlobalObject* globalObject)
     promise->markAsHandled();
 
     if (m_status == Status::FetchFailed && m_error)
-        promise->reject(vm, globalObject, m_error.get());
+        promise->reject(vm, m_error.get());
 
     m_fetchPromise.set(vm, this, promise);
     return promise;
@@ -129,7 +129,7 @@ JSPromise* ModuleRegistryEntry::ensureModulePromise(JSGlobalObject* globalObject
     m_modulePromise.set(vm, this, modulePromise);
 
     JSPromise* fetchPromise = ensureFetchPromise(globalObject);
-    fetchPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleRegistryFetchSettled, modulePromise, this);
+    fetchPromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::ModuleRegistryFetchSettled, modulePromise, this);
 
     return modulePromise;
 }
@@ -185,7 +185,7 @@ void ModuleRegistryEntry::setFetchError(JSGlobalObject* globalObject, JSValue er
     VM& vm = globalObject->vm();
     m_error.set(vm, this, error);
     if (m_status == Status::New && m_fetchPromise)
-        m_fetchPromise->reject(vm, globalObject, error);
+        m_fetchPromise->reject(vm, error);
     setStatus(Status::FetchFailed);
 }
 
@@ -231,7 +231,7 @@ void ModuleRegistryEntry::provideFetch(JSGlobalObject* globalObject, JSSourceCod
 
     scope.release();
     m_status = Status::Fetching;
-    m_fetchPromise->fulfill(vm, globalObject, jsSourceCode);
+    m_fetchPromise->fulfill(vm, jsSourceCode);
 }
 
 void ModuleRegistryEntry::fetchComplete(JSGlobalObject* globalObject, AbstractModuleRecord* record)

--- a/Source/JavaScriptCore/runtime/PinballCompletion.cpp
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.cpp
@@ -216,7 +216,7 @@ UCPURegister pinballHandlerFulfillFunctionContinue(PinballHandlerContext* contex
         JSValue arg = JSValue::decode(context->arguments[0]);
         resultPromise->resolve(context->globalObject, vm, arg);
     } else {
-        resultPromise->reject(vm, context->globalObject, scope.exception());
+        resultPromise->reject(vm, scope.exception());
         scope.clearException();
     }
 
@@ -255,7 +255,7 @@ void pinballHandlerFinishReject(PinballHandlerContext* context)
         JSValue arg = JSValue::decode(context->arguments[0]);
         resultPromise->resolve(context->globalObject, vm, arg);
     } else {
-        resultPromise->reject(vm, context->globalObject, scope.exception());
+        resultPromise->reject(vm, scope.exception());
         scope.clearException();
     }
 
@@ -272,7 +272,7 @@ void pinballHandlerRejectWithStackOverflow(PinballHandlerContext* context)
     PinballCompletion* pinball = context->pinball;
     JSPromise* resultPromise = pinball->resultPromise();
 
-    resultPromise->reject(vm, context->globalObject, createStackOverflowError(context->globalObject));
+    resultPromise->reject(vm, createStackOverflowError(context->globalObject));
 
     jspiContext.deactivate(vm);
     context->~PinballHandlerContext();

--- a/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
@@ -78,7 +78,7 @@ JSC_DEFINE_HOST_FUNCTION(importInRealm, (JSGlobalObject* globalObject, CallFrame
 
     JSGlobalObject* realmGlobalObject = thisRealm->globalObject();
     auto* result = realmGlobalObject->moduleLoader()->importModule(realmGlobalObject, specifier, jsUndefined(), sourceOrigin);
-    RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(realmGlobalObject, scope)));
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(vm, scope)));
 
     scope.release();
     promise->resolve(globalObject, vm, result);

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -3987,7 +3987,7 @@ JSC_DEFINE_HOST_FUNCTION(functionRejectPromiseAsHandled, (JSGlobalObject* global
     DollarVMAssertScope assertScope;
     JSPromise* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue reason = callFrame->uncheckedArgument(1);
-    promise->rejectAsHandled(globalObject->vm(), globalObject, reason);
+    promise->rejectAsHandled(globalObject->vm(), reason);
     return JSValue::encode(jsUndefined());
 }
 

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -161,7 +161,7 @@ void StreamingCompiler::didComplete()
 
             if (!result.has_value()) [[unlikely]] {
                 throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, result.error()));
-                promise->rejectWithCaughtException(globalObject, scope);
+                promise->rejectWithCaughtException(vm, scope);
                 return;
             }
 
@@ -169,7 +169,7 @@ void StreamingCompiler::didComplete()
                 auto errorMessage = compileOptions->validateBuiltinsAndImportedStrings(result.value());
                 if (errorMessage.has_value()) {
                     throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, errorMessage.value()));
-                    promise->rejectWithCaughtException(globalObject, scope);
+                    promise->rejectWithCaughtException(vm, scope);
                     return;
                 }
                 result.value()->applyCompileOptions(compileOptions.value());
@@ -194,7 +194,7 @@ void StreamingCompiler::didComplete()
 
             if (!result.has_value()) [[unlikely]] {
                 throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, result.error()));
-                promise->rejectWithCaughtException(globalObject, scope);
+                promise->rejectWithCaughtException(vm, scope);
                 return;
             }
 
@@ -202,7 +202,7 @@ void StreamingCompiler::didComplete()
                 auto errorMessage = compileOptions->validateBuiltinsAndImportedStrings(result.value());
                 if (errorMessage.has_value()) {
                     throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, errorMessage.value()));
-                    promise->rejectWithCaughtException(globalObject, scope);
+                    promise->rejectWithCaughtException(vm, scope);
                     return;
                 }
                 result.value()->applyCompileOptions(compileOptions.value());
@@ -211,7 +211,7 @@ void StreamingCompiler::didComplete()
             JSWebAssemblyModule* module = JSWebAssemblyModule::create(vm, globalObject->webAssemblyModuleStructure(), WTF::move(result.value()));
             JSWebAssembly::instantiateForStreaming(vm, globalObject, promise, module, importObject, WTF::move(provider));
             if (scope.exception()) [[unlikely]] {
-                promise->rejectWithCaughtException(globalObject, scope);
+                promise->rejectWithCaughtException(vm, scope);
                 return;
             }
         });
@@ -234,7 +234,7 @@ void StreamingCompiler::finalize(JSGlobalObject* globalObject)
     }
 }
 
-void StreamingCompiler::fail(JSGlobalObject* globalObject, JSValue error)
+void StreamingCompiler::fail(JSGlobalObject*, JSValue error)
 {
     {
         Locker locker { m_lock };
@@ -251,7 +251,7 @@ void StreamingCompiler::fail(JSGlobalObject* globalObject, JSValue error)
     // scannable by the GC.
     WTF::compilerFence();
     m_vm.deferredWorkTimer->cancelPendingWork(ticket);
-    promise->reject(m_vm, globalObject, error);
+    promise->reject(m_vm, error);
 }
 
 void StreamingCompiler::cancel()

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -149,7 +149,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyCompileFunc, (JSGlobalObject* globalObject, 
     RETURN_IF_EXCEPTION(scope, { });
 
     Vector<uint8_t> source = createSourceBufferFromValue(vm, globalObject, callFrame->argument(0));
-    RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(vm, scope)));
 
     JSObject* compileOptionsObject = nullptr;
     if (Options::useWasmJSStringBuiltins()) {
@@ -182,14 +182,14 @@ void JSWebAssembly::webAssemblyModuleValidateAsync(JSGlobalObject* globalObject,
 
             if (!result.has_value()) [[unlikely]] {
                 throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, result.error()));
-                promise->rejectWithCaughtException(globalObject, scope);
+                promise->rejectWithCaughtException(vm, scope);
                 return;
             }
             if (compileOptions) {
                 auto errorMessage = compileOptions->validateBuiltinsAndImportedStrings(result.value());
                 if (errorMessage.has_value()) {
                     throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, errorMessage.value()));
-                    promise->rejectWithCaughtException(globalObject, scope);
+                    promise->rejectWithCaughtException(vm, scope);
                     return;
                 }
                 result.value()->applyCompileOptions(compileOptions.value());
@@ -211,13 +211,13 @@ static void instantiate(VM& vm, JSGlobalObject* globalObject, JSPromise* promise
     // When called via the module loader, the memory is not available yet at this step, so we skip initializing the memory here.
     JSWebAssemblyInstance* instance = JSWebAssemblyInstance::tryCreate(vm, globalObject->webAssemblyInstanceStructure(), globalObject, moduleKey, module, importObject, creationMode, WTF::move(provider));
     if (scope.exception()) [[unlikely]] {
-        promise->rejectWithCaughtException(globalObject, scope);
+        promise->rejectWithCaughtException(vm, scope);
         return;
     }
 
     instance->initializeImports(globalObject, importObject, creationMode);
     if (scope.exception()) [[unlikely]] {
-        promise->rejectWithCaughtException(globalObject, scope);
+        promise->rejectWithCaughtException(vm, scope);
         return;
     }
 
@@ -234,7 +234,7 @@ static void instantiate(VM& vm, JSGlobalObject* globalObject, JSPromise* promise
             JSGlobalObject* globalObject = instance->realm();
             instance->finalizeCreation(vm, globalObject, WTF::move(calleeGroup), creationMode);
             if (scope.exception()) [[unlikely]] {
-                promise->rejectWithCaughtException(globalObject, scope);
+                promise->rejectWithCaughtException(vm, scope);
                 return;
             }
 
@@ -276,7 +276,7 @@ static void compileAndInstantiate(VM& vm, JSGlobalObject* globalObject, JSPromis
 
     Vector<uint8_t> source = createSourceBufferFromValue(vm, globalObject, buffer);
     if (scope.exception()) [[unlikely]] {
-        promise->rejectWithCaughtException(globalObject, scope);
+        promise->rejectWithCaughtException(vm, scope);
         return;
     }
 
@@ -292,14 +292,14 @@ static void compileAndInstantiate(VM& vm, JSGlobalObject* globalObject, JSPromis
 
             if (!result.has_value()) [[unlikely]] {
                 throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, result.error()));
-                promise->rejectWithCaughtException(globalObject, scope);
+                promise->rejectWithCaughtException(vm, scope);
                 return;
             }
             if (compileOptions) {
                 auto errorMessage = compileOptions->validateBuiltinsAndImportedStrings(result.value());
                 if (errorMessage.has_value()) {
                     throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, errorMessage.value()));
-                    promise->rejectWithCaughtException(globalObject, scope);
+                    promise->rejectWithCaughtException(vm, scope);
                     return;
                 }
                 result.value()->applyCompileOptions(compileOptions.value());
@@ -309,13 +309,13 @@ static void compileAndInstantiate(VM& vm, JSGlobalObject* globalObject, JSPromis
 
             const Identifier moduleKey = JSValue(moduleKeyCell).toPropertyKey(globalObject);
             if (scope.exception()) [[unlikely]] {
-                promise->rejectWithCaughtException(globalObject, scope);
+                promise->rejectWithCaughtException(vm, scope);
                 return;
             }
 
             instantiate(vm, globalObject, promise, module, importObject, WTF::move(sourceProvider), moduleKey, resolveKind, creationMode, /* alwaysAsync */ false);
             if (scope.exception()) [[unlikely]] {
-                promise->rejectWithCaughtException(globalObject, scope);
+                promise->rejectWithCaughtException(vm, scope);
                 return;
             }
         });
@@ -455,20 +455,20 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyCompileStreamingFunc, (JSGlobalObject* globa
         JSValue compileOptionsArgument = callFrame->argument(1);
         JSObject* compileOptionsObject = compileOptionsArgument.getObject();
         if (!compileOptionsArgument.isUndefined() && !compileOptionsObject) [[unlikely]] {
-            promise->reject(vm, globalObject, createTypeError(globalObject, "second argument to WebAssembly.compileStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(compileOptionsArgument)));
+            promise->reject(vm, createTypeError(globalObject, "second argument to WebAssembly.compileStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(compileOptionsArgument)));
             RELEASE_AND_RETURN(scope, JSValue::encode(promise));
         }
         compileOptions = WebAssemblyCompileOptions::tryCreate(globalObject, compileOptionsObject);
         if (scope.exception()) [[unlikely]]
-            RELEASE_AND_RETURN(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
+            RELEASE_AND_RETURN(scope, JSValue::encode(promise->rejectWithCaughtException(vm, scope)));
     }
 
     auto* context = JSWebAssemblyStreamingContext::create(vm, promise, nullptr, WTF::move(compileOptions));
 
     JSPromise* sourcePromise = JSPromise::resolvedPromise(globalObject, callFrame->argument(0));
-    RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(vm, scope)));
 
-    sourcePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::WebAssemblyCompileStreaming, nullptr, context);
+    sourcePromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::WebAssemblyCompileStreaming, nullptr, context);
     return JSValue::encode(promise);
 }
 
@@ -495,7 +495,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyInstantiateStreamingFunc, (JSGlobalObject* g
     JSValue importArgument = callFrame->argument(1);
     JSObject* importObject = importArgument.getObject();
     if (!importArgument.isUndefined() && !importObject) [[unlikely]] {
-        promise->reject(vm, globalObject, createTypeError(globalObject, "second argument to WebAssembly.instantiateStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(importArgument)));
+        promise->reject(vm, createTypeError(globalObject, "second argument to WebAssembly.instantiateStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(importArgument)));
         RELEASE_AND_RETURN(scope, JSValue::encode(promise));
     }
 
@@ -504,20 +504,20 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyInstantiateStreamingFunc, (JSGlobalObject* g
         JSValue compileOptionsArgument = callFrame->argument(2);
         JSObject* compileOptionsObject = compileOptionsArgument.getObject();
         if (!compileOptionsArgument.isUndefined() && !compileOptionsObject) [[unlikely]] {
-            promise->reject(vm, globalObject, createTypeError(globalObject, "third argument to WebAssembly.instantiateStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(compileOptionsArgument)));
+            promise->reject(vm, createTypeError(globalObject, "third argument to WebAssembly.instantiateStreaming must be undefined or an Object"_s, defaultSourceAppender, runtimeTypeForValue(compileOptionsArgument)));
             RELEASE_AND_RETURN(scope, JSValue::encode(promise));
         }
         compileOptions = WebAssemblyCompileOptions::tryCreate(globalObject, compileOptionsObject);
         if (scope.exception()) [[unlikely]]
-            RELEASE_AND_RETURN(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
+            RELEASE_AND_RETURN(scope, JSValue::encode(promise->rejectWithCaughtException(vm, scope)));
     }
 
     auto* context = JSWebAssemblyStreamingContext::create(vm, promise, importObject, WTF::move(compileOptions));
 
     JSPromise* sourcePromise = JSPromise::resolvedPromise(globalObject, callFrame->argument(0));
-    RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(vm, scope)));
 
-    sourcePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::WebAssemblyInstantiateStreaming, nullptr, context);
+    sourcePromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::WebAssemblyInstantiateStreaming, nullptr, context);
     return JSValue::encode(promise);
 }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp
@@ -76,7 +76,7 @@ JSC_DEFINE_HOST_FUNCTION(runWebAssemblyPromisingFunction, (JSGlobalObject* globa
         // An exception was thrown in wasm code
         JSValue exceptionValue = scope.exception()->value();
         TRY_CLEAR_EXCEPTION(scope, { });
-        resultPromise->reject(vm, globalObject, exceptionValue);
+        resultPromise->reject(vm, exceptionValue);
     } else if (!context.completion) [[likely]] {
         // The call returned without suspending, result is the returned value
         resultPromise->resolve(globalObject, vm, result);

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -695,7 +695,7 @@ JSC::JSPromise* JSDOMGlobalObject::moduleLoaderFetch(JSC::JSGlobalObject* global
         RELEASE_AND_RETURN(scope, loader->fetch(globalObject, moduleLoader, moduleKey, WTF::move(parameters), WTF::move(scriptFetcher)));
     JSC::JSPromise* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
     scope.release();
-    promise->reject(vm, globalObject, jsUndefined());
+    promise->reject(vm, jsUndefined());
     return promise;
 }
 
@@ -716,7 +716,7 @@ JSC::JSPromise* JSDOMGlobalObject::moduleLoaderImportModule(JSC::JSGlobalObject*
         RELEASE_AND_RETURN(scope, loader->importModule(globalObject, moduleLoader, moduleName, WTF::move(parameters), sourceOrigin, deferred));
     JSC::JSPromise* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
     scope.release();
-    promise->reject(vm, globalObject, jsUndefined());
+    promise->reject(vm, jsUndefined());
     return promise;
 }
 

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -112,13 +112,13 @@ void DeferredPromise::callFunction(JSGlobalObject& lexicalGlobalObject, ResolveM
         }
         break;
     case ResolveMode::Reject:
-        deferred()->reject(vm, &lexicalGlobalObject, resolution);
+        deferred()->reject(vm, resolution);
         break;
     case ResolveMode::RejectAsHandled:
-        deferred()->rejectAsHandled(vm, &lexicalGlobalObject, resolution);
+        deferred()->rejectAsHandled(vm, resolution);
         break;
     case ResolveMode::Fulfill:
-        deferred()->fulfill(vm, &lexicalGlobalObject, resolution);
+        deferred()->fulfill(vm, resolution);
         break;
     }
 

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -344,7 +344,7 @@ JSC::JSPromise* ScriptModuleLoader::importModule(JSC::JSGlobalObject* jsGlobalOb
 
     auto reject = [&](auto& scope) {
         auto* promise = JSC::JSPromise::create(vm, globalObject.promiseStructure());
-        return promise->rejectWithCaughtException(&globalObject, scope);
+        return promise->rejectWithCaughtException(vm, scope);
     };
 
     auto type = fetchParameters ? fetchParameters->type() : JSC::ScriptFetchParameters::Type::JavaScript;

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -7321,7 +7321,7 @@ sub GenerateCallbackImplementationOperationBody
     push(@$contentRef, "    if (returnedException) {\n");
     if ($codeGenerator->IsPromiseType($operation->type)) {
         push(@$contentRef, "        auto* jsPromise = JSC::JSPromise::create(vm, globalObject.promiseStructure());\n");
-        push(@$contentRef, "        jsPromise->rejectAsHandled(vm, &globalObject, returnedException->value());\n");
+        push(@$contentRef, "        jsPromise->rejectAsHandled(vm, returnedException->value());\n");
         push(@$contentRef, "        return { DOMPromise::create(globalObject, *jsPromise) };\n");
     } elsif ($isForRethrowingHandler) {
         push(@$contentRef, "        auto throwScope = DECLARE_THROW_SCOPE(vm);\n");

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -696,7 +696,7 @@ CallbackResult<typename IDLPromise<IDLUndefined>::CallbackReturnType> JSTestCall
     auto jsResult = m_data->invokeCallback(thisValue, args, JSCallbackData::CallbackType::Object, Identifier::fromString(vm, "callbackThatTreatsExceptionAsRejectedPromise"_s), returnedException);
     if (returnedException) {
         auto* jsPromise = JSC::JSPromise::create(vm, globalObject.promiseStructure());
-        jsPromise->rejectAsHandled(vm, &globalObject, returnedException->value());
+        jsPromise->rejectAsHandled(vm, returnedException->value());
         return { DOMPromise::create(globalObject, *jsPromise) };
      }
 


### PR DESCRIPTION
#### 51cc3feb729804866ae63510d837f4df674bbc59
<pre>
[JSC] Promise jobs must not run with the realm of a cross-realm settle site
<a href="https://bugs.webkit.org/show_bug.cgi?id=316187">https://bugs.webkit.org/show_bug.cgi?id=316187</a>

Reviewed by Yusuke Suzuki.

In a VM with multiple JSGlobalObjects, two defects let a foreign realm leak
into observable objects (e.g. the resolving functions passed to an awaited
thenable&apos;s then(f, j)):

1. The await fast paths in resolveWithInternalMicrotaskForAsyncAwait and
   resolveWithInternalMicrotask adopted cross-realm vanilla promises directly,
   skipping the intermediate promise that PromiseResolve[1] requires for them.
   Now they require the promise&apos;s realm to match the current globalObject, so
   cross-realm promises take the thenable path, whose resolving functions
   re-anchor the realm; cross-realm await now costs one extra microtask,
   matching V8. resolvePromise has no such check in the spec and keeps its
   fast path, but enqueues the thenable job with the promise&apos;s realm.

2. Internal microtask handlers used the queue entry&apos;s globalObject, which is
   the settle site&apos;s realm and can be foreign (e.g. then/catch/finally called
   on a cross-realm promise). Per spec, each job&apos;s realm is fixed at creation
   (e.g. Await[2] step 4), so runInternalMicrotask now derives the realm from
   the object each job drives (the generator, the result promise, or the
   module) and passes it to the handlers, following the precedent of
   JSPromise::pipeFrom. fulfillPromise, rejectPromise, and
   performPromiseThenWithInternalMicrotask now anchor on the promise&apos;s realm
   instead of taking a globalObject.

V8 behaves correctly in all of these cases. Same-realm fast paths only pay
one extra pointer comparison; same-realm microtask ordering is unchanged and
async/promise microbenchmarks are neutral.

    const other = createGlobalObject();
    other.MainFunction = Function;
    other.subject = somePendingMainRealmPromise;
    new other.Function(`
        (async () =&gt; {
            await subject;
            await { then(f) {
                // f.constructor must be this realm&apos;s Function,
                // but was MainFunction before this patch.
            } };
        })();
    `)();

[1]: <a href="https://tc39.es/ecma262/#sec-promise-resolve">https://tc39.es/ecma262/#sec-promise-resolve</a>
[2]: <a href="https://tc39.es/ecma262/#await">https://tc39.es/ecma262/#await</a>

Tests: JSTests/stress/cross-realm-await-thenable-resolve-realm.js
       JSTests/stress/cross-realm-promise-internal-reaction-realm.js

* JSTests/stress/cross-realm-await-thenable-resolve-realm.js: Added.
(shouldBe):
(async return):
* JSTests/stress/cross-realm-promise-internal-reaction-realm.js: Added.
(shouldBe):
(makePending):
(makePendingRejection):
(async settles):
(async return):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::asyncFromSyncIteratorContinueOrDone):
(JSC::promiseFinallyReactionJob):
(JSC::asyncModuleExecutionDone):
(JSC::asyncModuleExecutionResume):
(JSC::promiseResolveWithoutHandlerJob):
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::resolvePromise):
(JSC::JSPromise::resolveWithInternalMicrotaskForAsyncAwait):
(JSC::JSPromise::resolveWithInternalMicrotask):

Canonical link: <a href="https://commits.webkit.org/314528@main">https://commits.webkit.org/314528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c787755bd8d2bfcfaf2ad42cb509c29808dd8a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175424 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129334 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109859 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30695 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29391 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23564 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158533 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177957 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27270 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137689 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137608 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37074 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148986 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103291 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32897 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25852 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199055 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39134 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112209 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/53438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38531 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3938 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38776 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->