### PR TITLE
Region::totalArea overflows when a single rect's area exceeds INT_MAX

### DIFF
--- a/Source/WebCore/platform/graphics/Region.cpp
+++ b/Source/WebCore/platform/graphics/Region.cpp
@@ -153,7 +153,7 @@ uint64_t Region::totalArea() const
     uint64_t totalArea = 0;
 
     for (auto& rect : rects())
-        totalArea += (rect.width() * rect.height());
+        totalArea += static_cast<uint64_t>(rect.width()) * rect.height();
 
     return totalArea;
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/RegionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/RegionTests.cpp
@@ -267,4 +267,13 @@ TEST(RegionTests, IsValidShape2)
     ASSERT_TRUE(Shape::isValidShape(segments.span(), spans.span())) << r.dataForTesting();
 }
 
+TEST(RegionTests, TotalAreaDoesNotOverflowSignedInt)
+{
+    // 50000 * 50000 == 2,500,000,000, which exceeds INT_MAX (2,147,483,647).
+    // Region::totalArea computes width() * height() in int before promoting
+    // to uint64_t, so the multiplication wraps.
+    Region region(IntRect { 0, 0, 50000, 50000 });
+    EXPECT_EQ(region.totalArea(), 2'500'000'000ULL);
+}
+
 }


### PR DESCRIPTION
#### 5eacd591f79bb8b1ce4097a8afe3e8c1516bb7ba
<pre>
Region::totalArea overflows when a single rect&apos;s area exceeds INT_MAX
<a href="https://bugs.webkit.org/show_bug.cgi?id=316188">https://bugs.webkit.org/show_bug.cgi?id=316188</a>

Reviewed by Kimmo Kinnunen.

Region::totalArea() accumulates rect.width() * rect.height() into a
uint64_t. Both width() and height() return int, so the multiplication
is performed in int and only the result is widened. Any rect whose
area exceeds INT_MAX (e.g. 50000 x 50000 == 2,500,000,000) overflows
the int multiplication before the assignment, then sign-extends into
uint64_t and corrupts the running total.

Cast one operand to uint64_t so the multiplication itself happens in
64 bits. Add an API test that exercises the overflow case.

Test: RegionTests.TotalAreaDoesNotOverflowSignedInt

* Source/WebCore/platform/graphics/Region.cpp:
(WebCore::Region::totalArea const):
* Tools/TestWebKitAPI/Tests/WebCore/RegionTests.cpp:
(TestWebKitAPI::TEST(RegionTests, TotalAreaDoesNotOverflowSignedInt)):

Canonical link: <a href="https://commits.webkit.org/314594@main">https://commits.webkit.org/314594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50471de6fa75ae9278b5ec7966295a3289460074

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175213 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123421 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129155 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90974 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109681 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30506 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29200 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23354 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177746 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30648 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137501 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137429 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37121 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40413 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148795 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103023 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32717 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25662 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38924 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111998 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38321 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3748 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38566 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38464 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->