### PR TITLE
REGRESSION(314026@main): [JSCOnly] JSC tests no longer running on ARMv7 bot

### DIFF
--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -52,7 +52,7 @@ maybeEnterWebKitContainerSDK();
 setConfiguration();
 my $configuration = configuration();
 
-if (defined $ENV{'WEBKIT_CONTAINER_SDK_INSIDE_MOUNT_NAMESPACE'}) {
+if (isLinux()) {
     portName();
 }
 

--- a/Tools/Scripts/test262-runner
+++ b/Tools/Scripts/test262-runner
@@ -48,7 +48,7 @@ BEGIN {
 
 use Runner;
 
-if (defined $ENV{'WEBKIT_CONTAINER_SDK_INSIDE_MOUNT_NAMESPACE'}) {
+if (isLinux()) {
     portName();
 }
 

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2552,7 +2552,6 @@ sub maybeEnterWebKitContainerSDK()
     # Mirror the cheap opt-out checks from maybe_enter_webkit_container_sdk so
     # that the overwhelmingly common no-op case avoids forking a Python
     # interpreter on every wrapper invocation. Keep in sync with that function.
-    return if ($ENV{'WEBKIT_FLATPAK'} // '') eq '1';
     return if ($ENV{'WEBKIT_JHBUILD'} // '') eq '1';
     return if ($ENV{'WEBKIT_CONTAINER_SDK_INSIDE_MOUNT_NAMESPACE'} // '') eq '1';
     return unless -f File::Spec->catfile(sourceDir(), ".wkdev-sdk-version");


### PR DESCRIPTION
#### 282ac1af71022183325468120d4f862cab6b22e9
<pre>
REGRESSION(<a href="https://commits.webkit.org/314026@main">314026@main</a>): [JSCOnly] JSC tests no longer running on ARMv7 bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=316189">https://bugs.webkit.org/show_bug.cgi?id=316189</a>

Reviewed by NOBODY (OOPS!).

Determine port name within run-javascriptcore-tests and test262-runner otherwise command-line
parsing will fail on Linux platforms.

Driving-by, remove an obsolete check for the WEBKIT_FLATPAK environment variable.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/282ac1af71022183325468120d4f862cab6b22e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166176 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39666 "Failed to checkout and rebase branch from PR 66354") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/33247 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175223 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168042 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40092 "Failed to checkout and rebase branch from PR 66354") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39670 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/129163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169135 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/40092 "Failed to checkout and rebase branch from PR 66354") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/109689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/40092 "Failed to checkout and rebase branch from PR 66354") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23364 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158333 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/40092 "Failed to checkout and rebase branch from PR 66354") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/27006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177756 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/27069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/28712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/137511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39735 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/137439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40423 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/148802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103042 "Failed to checkout and rebase branch from PR 66354") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25290 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/32726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198577 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/38934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/53355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38331 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/3755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38576 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->