### PR TITLE
WebGL: RemoteGraphicsContextGLProxy should batch state change commands

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -43,7 +43,7 @@ messages -> RemoteGraphicsContextGL Stream {
 #if !PLATFORM(COCOA) && !USE(GRAPHICS_LAYER_WC) && !USE(GBM)
     void PrepareForDisplay() -> () Synchronous
 #endif
-    void EnsureExtensionEnabled(WebCore::GCGLExtension extension)
+    void EnsureExtensionEnabled(WebCore::GCGLExtension extension) StreamBatched
     void GetErrors() -> (GCGLErrorCodeSet returnValue) Synchronous
     void copyNativeImageYFlipped(enum:bool WebCore::GraphicsContextGLSurfaceBuffer buffer, WebCore::RenderingResourceIdentifier nativeImageIdentifier)
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
@@ -65,8 +65,8 @@ messages -> RemoteGraphicsContextGL Stream {
     void MultiDrawElementsInstancedANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t> countsOffsetsAndInstanceCounts, uint32_t type)
     void MultiDrawArraysInstancedBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, uint32_t> firstsCountsInstanceCountsAndBaseInstances)
     void MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, int32_t, uint32_t> countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, uint32_t type)
-    void DrawBuffers(std::span<const uint32_t> bufs)
-    void DrawBuffersEXT(std::span<const uint32_t> bufs)
+    void DrawBuffers(std::span<const uint32_t> bufs) StreamBatched
+    void DrawBuffersEXT(std::span<const uint32_t> bufs) StreamBatched
     void InvalidateFramebuffer(uint32_t target, std::span<const uint32_t> attachments)
     void InvalidateSubFramebuffer(uint32_t target, std::span<const uint32_t> attachments, int32_t x, int32_t y, int32_t width, int32_t height)
 #if ENABLE(WEBXR)
@@ -74,55 +74,55 @@ messages -> RemoteGraphicsContextGL Stream {
 #endif
     void SetDrawingBufferColorSpace(WebCore::DestinationColorSpace colorSpace)
 
-    void ActiveTexture(uint32_t texture)
-    void AttachShader(uint32_t program, uint32_t shader)
-    void BindAttribLocation(uint32_t arg0, uint32_t index, CString name)
-    void BindBuffer(uint32_t target, uint32_t arg1)
-    void BindFramebuffer(uint32_t target, uint32_t arg1)
-    void BindRenderbuffer(uint32_t target, uint32_t arg1)
-    void BindTexture(uint32_t target, uint32_t arg1)
-    void BlendColor(float red, float green, float blue, float alpha)
-    void BlendEquation(uint32_t mode)
-    void BlendEquationSeparate(uint32_t modeRGB, uint32_t modeAlpha)
-    void BlendFunc(uint32_t sfactor, uint32_t dfactor)
-    void BlendFuncSeparate(uint32_t srcRGB, uint32_t dstRGB, uint32_t srcAlpha, uint32_t dstAlpha)
+    void ActiveTexture(uint32_t texture) StreamBatched
+    void AttachShader(uint32_t program, uint32_t shader) StreamBatched
+    void BindAttribLocation(uint32_t arg0, uint32_t index, CString name) StreamBatched
+    void BindBuffer(uint32_t target, uint32_t arg1) StreamBatched
+    void BindFramebuffer(uint32_t target, uint32_t arg1) StreamBatched
+    void BindRenderbuffer(uint32_t target, uint32_t arg1) StreamBatched
+    void BindTexture(uint32_t target, uint32_t arg1) StreamBatched
+    void BlendColor(float red, float green, float blue, float alpha) StreamBatched
+    void BlendEquation(uint32_t mode) StreamBatched
+    void BlendEquationSeparate(uint32_t modeRGB, uint32_t modeAlpha) StreamBatched
+    void BlendFunc(uint32_t sfactor, uint32_t dfactor) StreamBatched
+    void BlendFuncSeparate(uint32_t srcRGB, uint32_t dstRGB, uint32_t srcAlpha, uint32_t dstAlpha) StreamBatched
     void CheckFramebufferStatus(uint32_t target) -> (uint32_t returnValue) Synchronous
     void Clear(uint32_t mask)
-    void ClearColor(float red, float green, float blue, float alpha)
-    void ClearDepth(float depth)
-    void ClearStencil(int32_t s)
-    void ColorMask(bool red, bool green, bool blue, bool alpha)
+    void ClearColor(float red, float green, float blue, float alpha) StreamBatched
+    void ClearDepth(float depth) StreamBatched
+    void ClearStencil(int32_t s) StreamBatched
+    void ColorMask(bool red, bool green, bool blue, bool alpha) StreamBatched
     void CompileShader(uint32_t arg0)
     void CopyTexImage2D(uint32_t target, int32_t level, uint32_t internalformat, int32_t x, int32_t y, int32_t width, int32_t height, int32_t border)
     void CopyTexSubImage2D(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t x, int32_t y, int32_t width, int32_t height)
-    void CreateBuffer(uint32_t buffer)
-    void CreateFramebuffer(uint32_t framebuffer)
-    void CreateProgram(uint32_t program)
-    void CreateRenderbuffer(uint32_t renderbuffer)
-    void CreateShader(uint32_t shader, uint32_t arg0)
-    void CreateTexture(uint32_t texture)
-    void CullFace(uint32_t mode)
+    void CreateBuffer(uint32_t buffer) StreamBatched
+    void CreateFramebuffer(uint32_t framebuffer) StreamBatched
+    void CreateProgram(uint32_t program) StreamBatched
+    void CreateRenderbuffer(uint32_t renderbuffer) StreamBatched
+    void CreateShader(uint32_t shader, uint32_t arg0) StreamBatched
+    void CreateTexture(uint32_t texture) StreamBatched
+    void CullFace(uint32_t mode) StreamBatched
     void DeleteBuffer(uint32_t arg0)
     void DeleteFramebuffer(uint32_t arg0)
     void DeleteProgram(uint32_t arg0)
     void DeleteRenderbuffer(uint32_t arg0)
     void DeleteShader(uint32_t arg0)
     void DeleteTexture(uint32_t arg0)
-    void DepthFunc(uint32_t func)
-    void DepthMask(bool flag)
-    void DepthRange(float zNear, float zFar)
-    void DetachShader(uint32_t arg0, uint32_t arg1)
-    void Disable(uint32_t cap)
-    void DisableVertexAttribArray(uint32_t index)
+    void DepthFunc(uint32_t func) StreamBatched
+    void DepthMask(bool flag) StreamBatched
+    void DepthRange(float zNear, float zFar) StreamBatched
+    void DetachShader(uint32_t arg0, uint32_t arg1) StreamBatched
+    void Disable(uint32_t cap) StreamBatched
+    void DisableVertexAttribArray(uint32_t index) StreamBatched
     void DrawArrays(uint32_t mode, int32_t first, int32_t count)
     void DrawElements(uint32_t mode, int32_t count, uint32_t type, uint64_t offset)
-    void Enable(uint32_t cap)
-    void EnableVertexAttribArray(uint32_t index)
+    void Enable(uint32_t cap) StreamBatched
+    void EnableVertexAttribArray(uint32_t index) StreamBatched
     void Finish()
     void Flush()
-    void FramebufferRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
-    void FramebufferTexture2D(uint32_t target, uint32_t attachment, uint32_t textarget, uint32_t arg3, int32_t level)
-    void FrontFace(uint32_t mode)
+    void FramebufferRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3) StreamBatched
+    void FramebufferTexture2D(uint32_t target, uint32_t attachment, uint32_t textarget, uint32_t arg3, int32_t level) StreamBatched
+    void FrontFace(uint32_t mode) StreamBatched
     void GenerateMipmap(uint32_t target)
     void ActiveAttribs(uint32_t program) -> (Vector<WebCore::GCGLAttribActiveInfo> returnValue) Synchronous
     void ActiveUniforms(uint32_t program) -> (Vector<WebCore::GCGLUniformActiveInfo> returnValue) Synchronous
@@ -147,7 +147,7 @@ messages -> RemoteGraphicsContextGL Stream {
     void GetUniformiv(uint32_t program, int32_t location, uint64_t valueSize) -> (std::span<const int32_t> value) Synchronous
     void GetUniformuiv(uint32_t program, int32_t location, uint64_t valueSize) -> (std::span<const uint32_t> value) Synchronous
     void GetVertexAttribOffset(uint32_t index, uint32_t pname) -> (uint64_t returnValue) Synchronous
-    void Hint(uint32_t target, uint32_t mode)
+    void Hint(uint32_t target, uint32_t mode) StreamBatched
     void IsBuffer(uint32_t arg0) -> (bool returnValue) Synchronous
     void IsEnabled(uint32_t cap) -> (bool returnValue) Synchronous
     void IsFramebuffer(uint32_t arg0) -> (bool returnValue) Synchronous
@@ -155,53 +155,53 @@ messages -> RemoteGraphicsContextGL Stream {
     void IsRenderbuffer(uint32_t arg0) -> (bool returnValue) Synchronous
     void IsShader(uint32_t arg0) -> (bool returnValue) Synchronous
     void IsTexture(uint32_t arg0) -> (bool returnValue) Synchronous
-    void LineWidth(float arg0)
+    void LineWidth(float arg0) StreamBatched
     void LinkProgram(uint32_t arg0)
-    void PixelStorei(uint32_t pname, int32_t param)
-    void PolygonOffset(float factor, float units)
-    void RenderbufferStorage(uint32_t target, uint32_t internalformat, int32_t width, int32_t height)
-    void SampleCoverage(float value, bool invert)
-    void Scissor(int32_t x, int32_t y, int32_t width, int32_t height)
-    void ShaderSource(uint32_t arg0, CString arg1)
-    void StencilFunc(uint32_t func, int32_t ref, uint32_t mask)
-    void StencilFuncSeparate(uint32_t face, uint32_t func, int32_t ref, uint32_t mask)
-    void StencilMask(uint32_t mask)
-    void StencilMaskSeparate(uint32_t face, uint32_t mask)
-    void StencilOp(uint32_t fail, uint32_t zfail, uint32_t zpass)
-    void StencilOpSeparate(uint32_t face, uint32_t fail, uint32_t zfail, uint32_t zpass)
-    void TexParameterf(uint32_t target, uint32_t pname, float param)
-    void TexParameteri(uint32_t target, uint32_t pname, int32_t param)
-    void Uniform1f(int32_t location, float x)
-    void Uniform1fv(int32_t location, std::span<const float> v)
-    void Uniform1i(int32_t location, int32_t x)
-    void Uniform1iv(int32_t location, std::span<const int32_t> v)
-    void Uniform2f(int32_t location, float x, float y)
-    void Uniform2fv(int32_t location, std::span<const float> v)
-    void Uniform2i(int32_t location, int32_t x, int32_t y)
-    void Uniform2iv(int32_t location, std::span<const int32_t> v)
-    void Uniform3f(int32_t location, float x, float y, float z)
-    void Uniform3fv(int32_t location, std::span<const float> v)
-    void Uniform3i(int32_t location, int32_t x, int32_t y, int32_t z)
-    void Uniform3iv(int32_t location, std::span<const int32_t> v)
-    void Uniform4f(int32_t location, float x, float y, float z, float w)
-    void Uniform4fv(int32_t location, std::span<const float> v)
-    void Uniform4i(int32_t location, int32_t x, int32_t y, int32_t z, int32_t w)
-    void Uniform4iv(int32_t location, std::span<const int32_t> v)
-    void UniformMatrix2fv(int32_t location, bool transpose, std::span<const float> value)
-    void UniformMatrix3fv(int32_t location, bool transpose, std::span<const float> value)
-    void UniformMatrix4fv(int32_t location, bool transpose, std::span<const float> value)
+    void PixelStorei(uint32_t pname, int32_t param) StreamBatched
+    void PolygonOffset(float factor, float units) StreamBatched
+    void RenderbufferStorage(uint32_t target, uint32_t internalformat, int32_t width, int32_t height) StreamBatched
+    void SampleCoverage(float value, bool invert) StreamBatched
+    void Scissor(int32_t x, int32_t y, int32_t width, int32_t height) StreamBatched
+    void ShaderSource(uint32_t arg0, CString arg1) StreamBatched
+    void StencilFunc(uint32_t func, int32_t ref, uint32_t mask) StreamBatched
+    void StencilFuncSeparate(uint32_t face, uint32_t func, int32_t ref, uint32_t mask) StreamBatched
+    void StencilMask(uint32_t mask) StreamBatched
+    void StencilMaskSeparate(uint32_t face, uint32_t mask) StreamBatched
+    void StencilOp(uint32_t fail, uint32_t zfail, uint32_t zpass) StreamBatched
+    void StencilOpSeparate(uint32_t face, uint32_t fail, uint32_t zfail, uint32_t zpass) StreamBatched
+    void TexParameterf(uint32_t target, uint32_t pname, float param) StreamBatched
+    void TexParameteri(uint32_t target, uint32_t pname, int32_t param) StreamBatched
+    void Uniform1f(int32_t location, float x) StreamBatched
+    void Uniform1fv(int32_t location, std::span<const float> v) StreamBatched
+    void Uniform1i(int32_t location, int32_t x) StreamBatched
+    void Uniform1iv(int32_t location, std::span<const int32_t> v) StreamBatched
+    void Uniform2f(int32_t location, float x, float y) StreamBatched
+    void Uniform2fv(int32_t location, std::span<const float> v) StreamBatched
+    void Uniform2i(int32_t location, int32_t x, int32_t y) StreamBatched
+    void Uniform2iv(int32_t location, std::span<const int32_t> v) StreamBatched
+    void Uniform3f(int32_t location, float x, float y, float z) StreamBatched
+    void Uniform3fv(int32_t location, std::span<const float> v) StreamBatched
+    void Uniform3i(int32_t location, int32_t x, int32_t y, int32_t z) StreamBatched
+    void Uniform3iv(int32_t location, std::span<const int32_t> v) StreamBatched
+    void Uniform4f(int32_t location, float x, float y, float z, float w) StreamBatched
+    void Uniform4fv(int32_t location, std::span<const float> v) StreamBatched
+    void Uniform4i(int32_t location, int32_t x, int32_t y, int32_t z, int32_t w) StreamBatched
+    void Uniform4iv(int32_t location, std::span<const int32_t> v) StreamBatched
+    void UniformMatrix2fv(int32_t location, bool transpose, std::span<const float> value) StreamBatched
+    void UniformMatrix3fv(int32_t location, bool transpose, std::span<const float> value) StreamBatched
+    void UniformMatrix4fv(int32_t location, bool transpose, std::span<const float> value) StreamBatched
     void UseProgram(uint32_t arg0)
     void ValidateProgram(uint32_t arg0)
-    void VertexAttrib1f(uint32_t index, float x)
-    void VertexAttrib1fv(uint32_t index, std::span<const float, 1> values)
-    void VertexAttrib2f(uint32_t index, float x, float y)
-    void VertexAttrib2fv(uint32_t index, std::span<const float, 2> values)
-    void VertexAttrib3f(uint32_t index, float x, float y, float z)
-    void VertexAttrib3fv(uint32_t index, std::span<const float, 3> values)
-    void VertexAttrib4f(uint32_t index, float x, float y, float z, float w)
-    void VertexAttrib4fv(uint32_t index, std::span<const float, 4> values)
-    void VertexAttribPointer(uint32_t index, int32_t size, uint32_t type, bool normalized, int32_t stride, uint64_t offset)
-    void Viewport(int32_t x, int32_t y, int32_t width, int32_t height)
+    void VertexAttrib1f(uint32_t index, float x) StreamBatched
+    void VertexAttrib1fv(uint32_t index, std::span<const float, 1> values) StreamBatched
+    void VertexAttrib2f(uint32_t index, float x, float y) StreamBatched
+    void VertexAttrib2fv(uint32_t index, std::span<const float, 2> values) StreamBatched
+    void VertexAttrib3f(uint32_t index, float x, float y, float z) StreamBatched
+    void VertexAttrib3fv(uint32_t index, std::span<const float, 3> values) StreamBatched
+    void VertexAttrib4f(uint32_t index, float x, float y, float z, float w) StreamBatched
+    void VertexAttrib4fv(uint32_t index, std::span<const float, 4> values) StreamBatched
+    void VertexAttribPointer(uint32_t index, int32_t size, uint32_t type, bool normalized, int32_t stride, uint64_t offset) StreamBatched
+    void Viewport(int32_t x, int32_t y, int32_t width, int32_t height) StreamBatched
     void BufferData0(uint32_t target, uint64_t arg1, uint32_t usage)
     void BufferData1(uint32_t target, std::span<const uint8_t> data, uint32_t usage)
     void BufferSubData(uint32_t target, uint64_t offset, std::span<const uint8_t> data)
@@ -216,16 +216,16 @@ messages -> RemoteGraphicsContextGL Stream {
     void CompressedTexSubImage2D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, int32_t imageSize, uint64_t offset)
     void DrawArraysInstanced(uint32_t mode, int32_t first, int32_t count, int32_t primcount)
     void DrawElementsInstanced(uint32_t mode, int32_t count, uint32_t type, uint64_t offset, int32_t primcount)
-    void VertexAttribDivisor(uint32_t index, uint32_t divisor)
-    void CreateVertexArray(uint32_t vertexArray)
+    void VertexAttribDivisor(uint32_t index, uint32_t divisor) StreamBatched
+    void CreateVertexArray(uint32_t vertexArray) StreamBatched
     void DeleteVertexArray(uint32_t arg0)
     void IsVertexArray(uint32_t arg0) -> (bool returnValue) Synchronous
-    void BindVertexArray(uint32_t arg0)
+    void BindVertexArray(uint32_t arg0) StreamBatched
     void CopyBufferSubData(uint32_t readTarget, uint32_t writeTarget, uint64_t readOffset, uint64_t writeOffset, uint64_t arg4)
     void BlitFramebuffer(int32_t srcX0, int32_t srcY0, int32_t srcX1, int32_t srcY1, int32_t dstX0, int32_t dstY0, int32_t dstX1, int32_t dstY1, uint32_t mask, uint32_t filter)
-    void FramebufferTextureLayer(uint32_t target, uint32_t attachment, uint32_t texture, int32_t level, int32_t layer)
-    void ReadBuffer(uint32_t src)
-    void RenderbufferStorageMultisample(uint32_t target, int32_t samples, uint32_t internalformat, int32_t width, int32_t height)
+    void FramebufferTextureLayer(uint32_t target, uint32_t attachment, uint32_t texture, int32_t level, int32_t layer) StreamBatched
+    void ReadBuffer(uint32_t src) StreamBatched
+    void RenderbufferStorageMultisample(uint32_t target, int32_t samples, uint32_t internalformat, int32_t width, int32_t height) StreamBatched
     void TexStorage2D(uint32_t target, int32_t levels, uint32_t internalformat, int32_t width, int32_t height)
     void TexStorage3D(uint32_t target, int32_t levels, uint32_t internalformat, int32_t width, int32_t height, int32_t depth)
     void TexImage3D0(uint32_t target, int32_t level, int32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, uint32_t format, uint32_t type, std::span<const uint8_t> pixels)
@@ -238,43 +238,43 @@ messages -> RemoteGraphicsContextGL Stream {
     void CompressedTexSubImage3D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, std::span<const uint8_t> data)
     void CompressedTexSubImage3D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, int32_t imageSize, uint64_t offset)
     void GetFragDataLocation(uint32_t program, CString name) -> (int32_t returnValue) Synchronous
-    void Uniform1ui(int32_t location, uint32_t v0)
-    void Uniform2ui(int32_t location, uint32_t v0, uint32_t v1)
-    void Uniform3ui(int32_t location, uint32_t v0, uint32_t v1, uint32_t v2)
-    void Uniform4ui(int32_t location, uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3)
-    void Uniform1uiv(int32_t location, std::span<const uint32_t> data)
-    void Uniform2uiv(int32_t location, std::span<const uint32_t> data)
-    void Uniform3uiv(int32_t location, std::span<const uint32_t> data)
-    void Uniform4uiv(int32_t location, std::span<const uint32_t> data)
-    void UniformMatrix2x3fv(int32_t location, bool transpose, std::span<const float> data)
-    void UniformMatrix3x2fv(int32_t location, bool transpose, std::span<const float> data)
-    void UniformMatrix2x4fv(int32_t location, bool transpose, std::span<const float> data)
-    void UniformMatrix4x2fv(int32_t location, bool transpose, std::span<const float> data)
-    void UniformMatrix3x4fv(int32_t location, bool transpose, std::span<const float> data)
-    void UniformMatrix4x3fv(int32_t location, bool transpose, std::span<const float> data)
-    void VertexAttribI4i(uint32_t index, int32_t x, int32_t y, int32_t z, int32_t w)
-    void VertexAttribI4iv(uint32_t index, std::span<const int32_t, 4> values)
-    void VertexAttribI4ui(uint32_t index, uint32_t x, uint32_t y, uint32_t z, uint32_t w)
-    void VertexAttribI4uiv(uint32_t index, std::span<const uint32_t, 4> values)
-    void VertexAttribIPointer(uint32_t index, int32_t size, uint32_t type, int32_t stride, uint64_t offset)
+    void Uniform1ui(int32_t location, uint32_t v0) StreamBatched
+    void Uniform2ui(int32_t location, uint32_t v0, uint32_t v1) StreamBatched
+    void Uniform3ui(int32_t location, uint32_t v0, uint32_t v1, uint32_t v2) StreamBatched
+    void Uniform4ui(int32_t location, uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3) StreamBatched
+    void Uniform1uiv(int32_t location, std::span<const uint32_t> data) StreamBatched
+    void Uniform2uiv(int32_t location, std::span<const uint32_t> data) StreamBatched
+    void Uniform3uiv(int32_t location, std::span<const uint32_t> data) StreamBatched
+    void Uniform4uiv(int32_t location, std::span<const uint32_t> data) StreamBatched
+    void UniformMatrix2x3fv(int32_t location, bool transpose, std::span<const float> data) StreamBatched
+    void UniformMatrix3x2fv(int32_t location, bool transpose, std::span<const float> data) StreamBatched
+    void UniformMatrix2x4fv(int32_t location, bool transpose, std::span<const float> data) StreamBatched
+    void UniformMatrix4x2fv(int32_t location, bool transpose, std::span<const float> data) StreamBatched
+    void UniformMatrix3x4fv(int32_t location, bool transpose, std::span<const float> data) StreamBatched
+    void UniformMatrix4x3fv(int32_t location, bool transpose, std::span<const float> data) StreamBatched
+    void VertexAttribI4i(uint32_t index, int32_t x, int32_t y, int32_t z, int32_t w) StreamBatched
+    void VertexAttribI4iv(uint32_t index, std::span<const int32_t, 4> values) StreamBatched
+    void VertexAttribI4ui(uint32_t index, uint32_t x, uint32_t y, uint32_t z, uint32_t w) StreamBatched
+    void VertexAttribI4uiv(uint32_t index, std::span<const uint32_t, 4> values) StreamBatched
+    void VertexAttribIPointer(uint32_t index, int32_t size, uint32_t type, int32_t stride, uint64_t offset) StreamBatched
     void DrawRangeElements(uint32_t mode, uint32_t start, uint32_t end, int32_t count, uint32_t type, uint64_t offset)
     void ClearBufferiv(uint32_t buffer, int32_t drawbuffer, std::span<const int32_t> values)
     void ClearBufferuiv(uint32_t buffer, int32_t drawbuffer, std::span<const uint32_t> values)
     void ClearBufferfv(uint32_t buffer, int32_t drawbuffer, std::span<const float> values)
     void ClearBufferfi(uint32_t buffer, int32_t drawbuffer, float depth, int32_t stencil)
-    void CreateQuery(uint32_t query)
+    void CreateQuery(uint32_t query) StreamBatched
     void DeleteQuery(uint32_t query)
     void IsQuery(uint32_t query) -> (bool returnValue) Synchronous
     void BeginQuery(uint32_t target, uint32_t query)
     void EndQuery(uint32_t target)
     void GetQuery(uint32_t target, uint32_t pname) -> (int32_t returnValue) Synchronous
     void GetQueryObjectui(uint32_t query, uint32_t pname) -> (uint32_t returnValue) Synchronous
-    void CreateSampler(uint32_t sampler)
+    void CreateSampler(uint32_t sampler) StreamBatched
     void DeleteSampler(uint32_t sampler)
     void IsSampler(uint32_t sampler) -> (bool returnValue) Synchronous
-    void BindSampler(uint32_t unit, uint32_t sampler)
-    void SamplerParameteri(uint32_t sampler, uint32_t pname, int32_t param)
-    void SamplerParameterf(uint32_t sampler, uint32_t pname, float param)
+    void BindSampler(uint32_t unit, uint32_t sampler) StreamBatched
+    void SamplerParameteri(uint32_t sampler, uint32_t pname, int32_t param) StreamBatched
+    void SamplerParameterf(uint32_t sampler, uint32_t pname, float param) StreamBatched
     void GetSamplerParameterf(uint32_t sampler, uint32_t pname) -> (float returnValue) Synchronous
     void GetSamplerParameteri(uint32_t sampler, uint32_t pname) -> (int32_t returnValue) Synchronous
     void FenceSync(uint32_t condition, uint32_t flags) -> (uint64_t returnValue) Synchronous
@@ -283,59 +283,59 @@ messages -> RemoteGraphicsContextGL Stream {
     void ClientWaitSync(uint64_t arg0, uint32_t flags, uint64_t timeout) -> (uint32_t returnValue) Synchronous
     void WaitSync(uint64_t arg0, uint32_t flags, int64_t timeout)
     void GetSynci(uint64_t arg0, uint32_t pname) -> (int32_t returnValue) Synchronous
-    void CreateTransformFeedback(uint32_t transformFeedback)
+    void CreateTransformFeedback(uint32_t transformFeedback) StreamBatched
     void DeleteTransformFeedback(uint32_t id)
     void IsTransformFeedback(uint32_t id) -> (bool returnValue) Synchronous
-    void BindTransformFeedback(uint32_t target, uint32_t id)
+    void BindTransformFeedback(uint32_t target, uint32_t id) StreamBatched
     void BeginTransformFeedback(uint32_t primitiveMode)
     void EndTransformFeedback()
-    void TransformFeedbackVaryings(uint32_t program, Vector<CString> varyings, uint32_t bufferMode)
+    void TransformFeedbackVaryings(uint32_t program, Vector<CString> varyings, uint32_t bufferMode) StreamBatched
     void GetTransformFeedbackVarying(uint32_t program, uint32_t index) -> (std::optional<WebCore::GCGLTransformFeedbackActiveInfo> returnValue) Synchronous
     void PauseTransformFeedback()
     void ResumeTransformFeedback()
-    void BindBufferBase(uint32_t target, uint32_t index, uint32_t buffer)
-    void BindBufferRange(uint32_t target, uint32_t index, uint32_t buffer, uint64_t offset, uint64_t arg4)
+    void BindBufferBase(uint32_t target, uint32_t index, uint32_t buffer) StreamBatched
+    void BindBufferRange(uint32_t target, uint32_t index, uint32_t buffer, uint64_t offset, uint64_t arg4) StreamBatched
     void GetUniformBlockIndex(uint32_t program, CString uniformBlockName) -> (uint32_t returnValue) Synchronous
     void GetActiveUniformBlockName(uint32_t program, uint32_t uniformBlockIndex) -> (CString returnValue) Synchronous
-    void UniformBlockBinding(uint32_t program, uint32_t uniformBlockIndex, uint32_t uniformBlockBinding)
+    void UniformBlockBinding(uint32_t program, uint32_t uniformBlockIndex, uint32_t uniformBlockBinding) StreamBatched
     void GetActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, uint64_t paramsSize) -> (std::span<const int32_t> params) Synchronous
     void GetTranslatedShaderSourceANGLE(uint32_t arg0) -> (CString returnValue) Synchronous
-    void CreateQueryEXT(uint32_t queryEXT)
+    void CreateQueryEXT(uint32_t queryEXT) StreamBatched
     void DeleteQueryEXT(uint32_t query)
     void IsQueryEXT(uint32_t query) -> (bool returnValue) Synchronous
     void BeginQueryEXT(uint32_t target, uint32_t query)
     void EndQueryEXT(uint32_t target)
-    void QueryCounterEXT(uint32_t query, uint32_t target)
+    void QueryCounterEXT(uint32_t query, uint32_t target) StreamBatched
     void GetQueryiEXT(uint32_t target, uint32_t pname) -> (int32_t returnValue) Synchronous
     void GetQueryObjectiEXT(uint32_t query, uint32_t pname) -> (int32_t returnValue) Synchronous
     void GetQueryObjectui64EXT(uint32_t query, uint32_t pname) -> (uint64_t returnValue) Synchronous
     void GetInteger64EXT(uint32_t pname) -> (int64_t returnValue) Synchronous
-    void EnableiOES(uint32_t target, uint32_t index)
-    void DisableiOES(uint32_t target, uint32_t index)
-    void BlendEquationiOES(uint32_t buf, uint32_t mode)
-    void BlendEquationSeparateiOES(uint32_t buf, uint32_t modeRGB, uint32_t modeAlpha)
-    void BlendFunciOES(uint32_t buf, uint32_t src, uint32_t dst)
-    void BlendFuncSeparateiOES(uint32_t buf, uint32_t srcRGB, uint32_t dstRGB, uint32_t srcAlpha, uint32_t dstAlpha)
-    void ColorMaskiOES(uint32_t buf, bool red, bool green, bool blue, bool alpha)
+    void EnableiOES(uint32_t target, uint32_t index) StreamBatched
+    void DisableiOES(uint32_t target, uint32_t index) StreamBatched
+    void BlendEquationiOES(uint32_t buf, uint32_t mode) StreamBatched
+    void BlendEquationSeparateiOES(uint32_t buf, uint32_t modeRGB, uint32_t modeAlpha) StreamBatched
+    void BlendFunciOES(uint32_t buf, uint32_t src, uint32_t dst) StreamBatched
+    void BlendFuncSeparateiOES(uint32_t buf, uint32_t srcRGB, uint32_t dstRGB, uint32_t srcAlpha, uint32_t dstAlpha) StreamBatched
+    void ColorMaskiOES(uint32_t buf, bool red, bool green, bool blue, bool alpha) StreamBatched
     void DrawArraysInstancedBaseInstanceANGLE(uint32_t mode, int32_t first, int32_t count, int32_t instanceCount, uint32_t baseInstance)
     void DrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, int32_t count, uint32_t type, uint64_t offset, int32_t instanceCount, int32_t baseVertex, uint32_t baseInstance)
-    void ClipControlEXT(uint32_t origin, uint32_t depth)
-    void ProvokingVertexANGLE(uint32_t provokeMode)
-    void PolygonModeANGLE(uint32_t face, uint32_t mode)
-    void PolygonOffsetClampEXT(float factor, float units, float clamp)
-    void RenderbufferStorageMultisampleANGLE(uint32_t target, int32_t samples, uint32_t internalformat, int32_t width, int32_t height)
+    void ClipControlEXT(uint32_t origin, uint32_t depth) StreamBatched
+    void ProvokingVertexANGLE(uint32_t provokeMode) StreamBatched
+    void PolygonModeANGLE(uint32_t face, uint32_t mode) StreamBatched
+    void PolygonOffsetClampEXT(float factor, float units, float clamp) StreamBatched
+    void RenderbufferStorageMultisampleANGLE(uint32_t target, int32_t samples, uint32_t internalformat, int32_t width, int32_t height) StreamBatched
     void GetInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, uint64_t paramsSize) -> (std::span<const int32_t> params) Synchronous
 #if ENABLE(WEBXR)
     [EnabledBy=WebXREnabled] void CreateExternalImage(uint32_t externalImage, WebCore::GraphicsContextGL::ExternalImageSource arg0, uint32_t internalFormat, int32_t layer) NotStreamEncodable
     [EnabledBy=WebXREnabled] void DeleteExternalImage(uint32_t handle)
-    [EnabledBy=WebXREnabled] void BindExternalImage(uint32_t target, uint32_t arg1)
+    [EnabledBy=WebXREnabled] void BindExternalImage(uint32_t target, uint32_t arg1) StreamBatched
     [EnabledBy=WebXREnabled] void CreateExternalSync(uint32_t externalSync, WebCore::GraphicsContextGL::ExternalSyncSource arg0) NotStreamEncodable
     [EnabledBy=WebXREnabled] void DeleteExternalSync(uint32_t arg0)
     [EnabledBy=WebXREnabled] void EnableRequiredWebXRExtensions() -> (bool returnValue) Synchronous
     [EnabledBy=WebXREnabled] void AddFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const float> horizontalSamplesLeft, std::span<const float> verticalSamples, std::span<const float> horizontalSamplesRight) -> (bool returnValue) Synchronous
-    [EnabledBy=WebXREnabled] void EnableFoveation(uint32_t arg0)
-    [EnabledBy=WebXREnabled] void DisableFoveation()
-    [EnabledBy=WebXREnabled] void FramebufferResolveRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
+    [EnabledBy=WebXREnabled] void EnableFoveation(uint32_t arg0) StreamBatched
+    [EnabledBy=WebXREnabled] void DisableFoveation() StreamBatched
+    [EnabledBy=WebXREnabled] void FramebufferResolveRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3) StreamBatched
 #endif
 }
 

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -126,12 +126,12 @@ messages -> RemoteGraphicsContextGL Stream {{
     void PrepareForDisplay() -> (std::optional<WebKit::WCContentBufferIdentifier> contentBuffer) Synchronous
 #endif
 #if USE(GBM)
-    void PrepareForDisplay() -> (uint64_t bufferID, struct std::optional<WebCore::DMABufBufferAttributes> dmabufAttributes, UnixFileDescriptor fenceFD) Synchronous NotStreamEncodableReply
+    void PrepareForDisplay() -> (uint64_t bufferID, std::optional<WebCore::DMABufBufferAttributes> dmabufAttributes, UnixFileDescriptor fenceFD) Synchronous NotStreamEncodableReply
 #endif
 #if !PLATFORM(COCOA) && !USE(GRAPHICS_LAYER_WC) && !USE(GBM)
     void PrepareForDisplay() -> () Synchronous
 #endif
-    void EnsureExtensionEnabled(WebCore::GCGLExtension extension)
+    void EnsureExtensionEnabled(WebCore::GCGLExtension extension) StreamBatched
     void GetErrors() -> (GCGLErrorCodeSet returnValue) Synchronous
     void copyNativeImageYFlipped(enum:bool WebCore::GraphicsContextGLSurfaceBuffer buffer, WebCore::RenderingResourceIdentifier nativeImageIdentifier)
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
@@ -153,8 +153,8 @@ messages -> RemoteGraphicsContextGL Stream {{
     void MultiDrawElementsInstancedANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t> countsOffsetsAndInstanceCounts, uint32_t type)
     void MultiDrawArraysInstancedBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, uint32_t> firstsCountsInstanceCountsAndBaseInstances)
     void MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, int32_t, uint32_t> countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, uint32_t type)
-    void DrawBuffers(std::span<const uint32_t> bufs)
-    void DrawBuffersEXT(std::span<const uint32_t> bufs)
+    void DrawBuffers(std::span<const uint32_t> bufs) StreamBatched
+    void DrawBuffersEXT(std::span<const uint32_t> bufs) StreamBatched
     void InvalidateFramebuffer(uint32_t target, std::span<const uint32_t> attachments)
     void InvalidateSubFramebuffer(uint32_t target, std::span<const uint32_t> attachments, int32_t x, int32_t y, int32_t width, int32_t height)
 #if ENABLE(WEBXR)
@@ -674,6 +674,142 @@ def webkit_ipc_msg_arg_type(cpp_type: cpp_type) -> cpp_type:
 # FIXME: these should be removed and IPC should know this.
 non_stream_types = set({"WebCore::GraphicsContextGL::ExternalImageSource&&", "WebCore::GraphicsContextGL::ExternalSyncSource&&"})
 
+stream_batched_msg_names = set([
+    "ActiveTexture",
+    "AttachShader",
+    "BindAttribLocation",
+    "BindBuffer",
+    "BindBufferBase",
+    "BindBufferRange",
+    "BindExternalImage",
+    "BindFramebuffer",
+    "BindRenderbuffer",
+    "BindSampler",
+    "BindTexture",
+    "BindTransformFeedback",
+    "BindVertexArray",
+    "BlendColor",
+    "BlendEquation",
+    "BlendEquationSeparate",
+    "BlendEquationSeparateiOES",
+    "BlendEquationiOES",
+    "BlendFunc",
+    "BlendFuncSeparate",
+    "BlendFuncSeparateiOES",
+    "BlendFunciOES",
+    "ClearColor",
+    "ClearDepth",
+    "ClearStencil",
+    "ClipControlEXT",
+    "ColorMask",
+    "ColorMaskiOES",
+    "CreateBuffer",
+    "CreateFramebuffer",
+    "CreateProgram",
+    "CreateQuery",
+    "CreateQueryEXT",
+    "CreateRenderbuffer",
+    "CreateSampler",
+    "CreateShader",
+    "CreateTexture",
+    "CreateTransformFeedback",
+    "CreateVertexArray",
+    "CullFace",
+    "DepthFunc",
+    "DepthMask",
+    "DepthRange",
+    "DetachShader",
+    "Disable",
+    "DisableFoveation",
+    "DisableVertexAttribArray",
+    "DisableiOES",
+    "Enable",
+    "EnableFoveation",
+    "EnableVertexAttribArray",
+    "EnableiOES",
+    "FramebufferRenderbuffer",
+    "FramebufferResolveRenderbuffer",
+    "FramebufferTexture2D",
+    "FramebufferTextureLayer",
+    "FrontFace",
+    "Hint",
+    "LineWidth",
+    "PixelStorei",
+    "PolygonModeANGLE",
+    "PolygonOffset",
+    "PolygonOffsetClampEXT",
+    "ProvokingVertexANGLE",
+    "QueryCounterEXT",
+    "ReadBuffer",
+    "RenderbufferStorage",
+    "RenderbufferStorageMultisample",
+    "RenderbufferStorageMultisampleANGLE",
+    "SampleCoverage",
+    "SamplerParameterf",
+    "SamplerParameteri",
+    "Scissor",
+    "ShaderSource",
+    "StencilFunc",
+    "StencilFuncSeparate",
+    "StencilMask",
+    "StencilMaskSeparate",
+    "StencilOp",
+    "StencilOpSeparate",
+    "TexParameterf",
+    "TexParameteri",
+    "TransformFeedbackVaryings",
+    "Uniform1f",
+    "Uniform1fv",
+    "Uniform1i",
+    "Uniform1iv",
+    "Uniform1ui",
+    "Uniform1uiv",
+    "Uniform2f",
+    "Uniform2fv",
+    "Uniform2i",
+    "Uniform2iv",
+    "Uniform2ui",
+    "Uniform2uiv",
+    "Uniform3f",
+    "Uniform3fv",
+    "Uniform3i",
+    "Uniform3iv",
+    "Uniform3ui",
+    "Uniform3uiv",
+    "Uniform4f",
+    "Uniform4fv",
+    "Uniform4i",
+    "Uniform4iv",
+    "Uniform4ui",
+    "Uniform4uiv",
+    "UniformBlockBinding",
+    "UniformMatrix2fv",
+    "UniformMatrix2x3fv",
+    "UniformMatrix2x4fv",
+    "UniformMatrix3fv",
+    "UniformMatrix3x2fv",
+    "UniformMatrix3x4fv",
+    "UniformMatrix4fv",
+    "UniformMatrix4x2fv",
+    "UniformMatrix4x3fv",
+    "VertexAttrib1f",
+    "VertexAttrib1fv",
+    "VertexAttrib2f",
+    "VertexAttrib2fv",
+    "VertexAttrib3f",
+    "VertexAttrib3fv",
+    "VertexAttrib4f",
+    "VertexAttrib4fv",
+    "VertexAttribDivisor",
+    "VertexAttribI4i",
+    "VertexAttribI4iv",
+    "VertexAttribI4ui",
+    "VertexAttribI4uiv",
+    "VertexAttribIPointer",
+    "VertexAttribPointer",
+    "Viewport",
+])
+
 
 class webkit_ipc_msg(object):
     cond: str
@@ -703,6 +839,8 @@ class webkit_ipc_msg(object):
         self.tags = []
         if any(arg.type.type_name in non_stream_types for arg in in_args):
             self.tags += ["NotStreamEncodable"]
+        if self.name in stream_batched_msg_names:
+            self.tags += ["StreamBatched"]
 
     def __str__(self):
         tags = f" {' '.join(self.tags)}" if self.tags else ""
@@ -1005,7 +1143,7 @@ class webkit_ipc_cpp_impl(object):
             contained_type = a.type.contained_type.type_name
             self.pre_call_stmts += [f"if (!WTF::isValidCapacityForVector<{contained_type}>({a.name}Size))"]
             self.pre_call_stmts += [f"    {a.name}Size = {inline_capacity};"]
-            self.pre_call_stmts += [f"{str(store_arg.type)} {str(store_arg.name)}({a.name}Size, 0);"]
+            self.pre_call_stmts += [f"{str(store_arg.type)} {str(store_arg.name)}(FillWith {{ }}, {a.name}Size, 0);"]
             self.in_exprs += [cpp_expr(store_arg.type, f"{store_arg.name}")]
             webkit_ipc_type = webkit_ipc_types[a.type]
             self.out_exprs += [webkit_ipc_convert_expr(cpp_expr(store_arg.type, store_arg.name), webkit_ipc_type)]


### PR DESCRIPTION
#### 74b74c4672ee8a942687c52f88700970a78799ef
<pre>
WebGL: RemoteGraphicsContextGLProxy should batch state change commands
<a href="https://bugs.webkit.org/show_bug.cgi?id=316193">https://bugs.webkit.org/show_bug.cgi?id=316193</a>
<a href="https://rdar.apple.com/178607431">rdar://178607431</a>

Reviewed by Dan Glastonbury.

WebGL state change commands and create commands do not do any work.
Batch them to avoid the IPC semaphore signal overhead.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Tools/Scripts/generate-gpup-webgl:
(webkit_ipc_msg.__init__):
(webkit_ipc_cpp_impl.process_out_arg):

Canonical link: <a href="https://commits.webkit.org/314547@main">https://commits.webkit.org/314547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69269ae5a72a77b865625fcb643da81d1efada7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123709 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d22705e2-69d9-40c4-bc2f-8b6d38def70a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129403 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed79dff7-9a99-41d4-a21c-0200dca18404) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169413 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31789 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109928 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5af015dd-3215-404c-85ab-394ecb10566a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30766 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29465 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23642 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178035 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30936 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137759 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137678 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37092 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149057 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103408 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32972 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25923 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39212 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112287 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38609 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4009 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38854 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38752 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->