### PR TITLE
Add new ChildChange types for moveBefore

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6232,9 +6232,6 @@ imported/w3c/web-platform-tests/trusted-types/should-trusted-type-policy-creatio
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-preserve-render.html [ Skip ]
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-option-recalc-style.html [ Skip ]
 
-# Flaky crash.
-webkit.org/b/315031 imported/w3c/web-platform-tests/dom/nodes/moveBefore/throws-exception.html [ Skip ]
-
 # Flaky.
 imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-default-style-meta-from-fragment.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Synchronous script execution in HTMLScriptElement during moveBefore should be blocked assert_false: <html:script> does not define moving steps which allow script execution. expected false got true
-FAIL Synchronous script execution in SVGScriptElement during moveBefore should be blocked assert_false: <svg:script> does not define moving steps which allow script execution. expected false got true
+PASS Synchronous script execution in HTMLScriptElement during moveBefore should be blocked
+PASS Synchronous script execution in SVGScriptElement during moveBefore should be blocked
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -312,6 +312,49 @@ static ContainerNode::ChildChange makeChildChangeForInsertion(ContainerNode& con
     };
 }
 
+static ContainerNode::ChildChange makeChildChangeForMoveRemoval(Node& child)
+{
+    auto changeType = [&] {
+        if (is<Element>(child))
+            return ContainerNode::ChildChange::Type::ElementMovedFrom;
+        if (is<Text>(child))
+            return ContainerNode::ChildChange::Type::TextMovedFrom;
+        return ContainerNode::ChildChange::Type::NonContentsChildMovedFrom;
+    }();
+
+    return {
+        changeType,
+        nullptr,
+        dynamicDowncast<Element>(child),
+        ElementTraversal::previousSibling(child),
+        ElementTraversal::nextSibling(child),
+        ContainerNode::ChildChange::Source::API,
+        changeType == ContainerNode::ChildChange::Type::ElementMovedFrom ? ContainerNode::ChildChange::AffectsElements::Yes : ContainerNode::ChildChange::AffectsElements::No
+    };
+}
+
+static ContainerNode::ChildChange makeChildChangeForMoveInsertion(ContainerNode& containerNode, Node& child, Node* beforeChild)
+{
+    auto changeType = [&] {
+        if (is<Element>(child))
+            return ContainerNode::ChildChange::Type::ElementMovedInto;
+        if (is<Text>(child))
+            return ContainerNode::ChildChange::Type::TextMovedInto;
+        return ContainerNode::ChildChange::Type::NonContentsChildMovedInto;
+    }();
+
+    auto* beforeChildElement = dynamicDowncast<Element>(beforeChild);
+    return {
+        changeType,
+        nullptr,
+        dynamicDowncast<Element>(child),
+        beforeChild ? ElementTraversal::previousSibling(*beforeChild) : ElementTraversal::lastChild(containerNode),
+        !beforeChild || beforeChildElement ? beforeChildElement : ElementTraversal::nextSibling(*beforeChild),
+        ContainerNode::ChildChange::Source::API,
+        changeType == ContainerNode::ChildChange::Type::ElementMovedInto ? ContainerNode::ChildChange::AffectsElements::Yes : ContainerNode::ChildChange::AffectsElements::No
+    };
+}
+
 static ContainerNode::ChildChange NODELETE makeChildChangeForInsertion(ContainerNode& containerNode, NodeVector& children, Node* beforeChild, ContainerNode::ChildChange::Source source, ReplacedAllChildren replacedAllChildren)
 {
     using Type = ContainerNode::ChildChange::Type;
@@ -1504,7 +1547,7 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
     RefPtr oldPreviousSibling = node.previousSibling();
     RefPtr oldNextSibling = node.nextSibling();
 
-    auto removalChildChange = makeChildChangeForRemoval(node, ChildChange::Source::API);
+    auto removalChildChange = makeChildChangeForMoveRemoval(node);
 
     {
         Ref nodeDocument = node.document();
@@ -1552,10 +1595,8 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
 
     runMovingStepsForShadowIncludingInclusiveDescendants(node, node, *oldParent, newParentIsConnected);
 
-    // FIXME: Add a new type for ChildChange.
-
     oldParent->childrenChanged(removalChildChange);
-    childrenChanged(makeChildChangeForInsertion(*this, node, refChild, ChildChange::Source::API, ReplacedAllChildren::No));
+    childrenChanged(makeChildChangeForMoveInsertion(*this, node, refChild));
 
     return { };
 }

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -83,7 +83,7 @@ public:
 
     enum class CanDelayNodeDeletion : uint8_t { No, Yes, Unknown };
     struct ChildChange {
-        enum class Type : uint8_t { ElementInserted, ElementRemoved, ElementAndTextInserted, TextInserted, TextRemoved, TextChanged, AllChildrenRemoved, NonContentsChildRemoved, NonContentsChildInserted, AllChildrenReplaced };
+        enum class Type : uint8_t { ElementInserted, ElementRemoved, ElementMovedInto, ElementMovedFrom, ElementAndTextInserted, TextInserted, TextRemoved, TextChanged, TextMovedFrom, TextMovedInto, AllChildrenRemoved, NonContentsChildRemoved, NonContentsChildInserted, NonContentsChildMovedInto, NonContentsChildMovedFrom, AllChildrenReplaced };
         enum class Source : uint8_t { Parser, API, Clone };
         enum class AffectsElements : uint8_t { Unknown, No, Yes };
 
@@ -107,10 +107,16 @@ public:
             case ChildChange::Type::AllChildrenReplaced:
                 return true;
             case ChildChange::Type::ElementRemoved:
+            case ChildChange::Type::ElementMovedFrom:
+            case ChildChange::Type::ElementMovedInto:
             case ChildChange::Type::TextRemoved:
+            case ChildChange::Type::TextMovedFrom:
+            case ChildChange::Type::TextMovedInto:
             case ChildChange::Type::TextChanged:
             case ChildChange::Type::AllChildrenRemoved:
             case ChildChange::Type::NonContentsChildRemoved:
+            case ChildChange::Type::NonContentsChildMovedFrom:
+            case ChildChange::Type::NonContentsChildMovedInto:
                 return false;
             }
             ASSERT_NOT_REACHED();

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3767,7 +3767,10 @@ void Element::childrenChanged(const ChildChange& change)
         switch (change.type) {
         case ChildChange::Type::ElementInserted:
         case ChildChange::Type::ElementRemoved:
+        case ChildChange::Type::ElementMovedFrom:
+        case ChildChange::Type::ElementMovedInto:
             // For elements, we notify shadowRoot in Element::insertionSteps and Element::removingSteps.
+            // FIXME(321178): Need to notify shadowRoot when elements are moved.
             break;
         case ChildChange::Type::AllChildrenRemoved:
         case ChildChange::Type::AllChildrenReplaced:
@@ -3777,10 +3780,14 @@ void Element::childrenChanged(const ChildChange& change)
         case ChildChange::Type::TextInserted:
         case ChildChange::Type::TextRemoved:
         case ChildChange::Type::TextChanged:
+        case ChildChange::Type::TextMovedFrom:
+        case ChildChange::Type::TextMovedInto:
             shadowRoot->didMutateTextNodesOfShadowHost();
             break;
         case ChildChange::Type::NonContentsChildInserted:
         case ChildChange::Type::NonContentsChildRemoved:
+        case ChildChange::Type::NonContentsChildMovedFrom:
+        case ChildChange::Type::NonContentsChildMovedInto:
             break;
         }
     }

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -173,12 +173,18 @@ void ShadowRoot::childrenChanged(const ChildChange& childChange)
     case ChildChange::Type::ElementRemoved:
         protect(m_host)->invalidateStyleForSubtree();
         break;
+    case ChildChange::Type::ElementMovedFrom:
+    case ChildChange::Type::ElementMovedInto:
     case ChildChange::Type::TextInserted:
     case ChildChange::Type::TextRemoved:
     case ChildChange::Type::TextChanged:
+    case ChildChange::Type::TextMovedFrom:
+    case ChildChange::Type::TextMovedInto:
     case ChildChange::Type::AllChildrenRemoved:
     case ChildChange::Type::NonContentsChildRemoved:
     case ChildChange::Type::NonContentsChildInserted:
+    case ChildChange::Type::NonContentsChildMovedFrom:
+    case ChildChange::Type::NonContentsChildMovedInto:
     case ChildChange::Type::AllChildrenReplaced:
         break;
     }

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -696,7 +696,7 @@ CompletionHandlerCallingScope HTMLSelectElement::optionToSelectFromChildChangeSc
     };
 
     RefPtr<HTMLOptionElement> optionToSelect;
-    if (change.type == ChildChange::Type::ElementInserted || change.type == ChildChange::Type::ElementAndTextInserted) {
+    if (change.type == ChildChange::Type::ElementInserted || change.type == ChildChange::Type::ElementAndTextInserted || change.type == ChildChange::Type::ElementMovedInto) {
         auto handleInsertedElement = [&](Element& insertedElement) {
             if (auto* option = dynamicDowncast<HTMLOptionElement>(insertedElement)) {
                 if (option->selectedWithoutUpdate())

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -315,12 +315,18 @@ void SVGAnimateMotionElement::childrenChanged(const ChildChange& change)
         updateAnimationPath();
         break;
     case ChildChange::Type::ElementInserted:
+    case ChildChange::Type::ElementMovedFrom:
+    case ChildChange::Type::ElementMovedInto:
     case ChildChange::Type::ElementAndTextInserted:
     case ChildChange::Type::TextInserted:
     case ChildChange::Type::TextRemoved:
+    case ChildChange::Type::TextMovedFrom:
+    case ChildChange::Type::TextMovedInto:
     case ChildChange::Type::TextChanged:
     case ChildChange::Type::NonContentsChildInserted:
     case ChildChange::Type::NonContentsChildRemoved:
+    case ChildChange::Type::NonContentsChildMovedFrom:
+    case ChildChange::Type::NonContentsChildMovedInto:
         break;
     }
 }


### PR DESCRIPTION
#### 0ac697f1a0640b799851de96337bf5f7e7a997cf
<pre>
Add new ChildChange types for moveBefore
<a href="https://bugs.webkit.org/show_bug.cgi?id=316098">https://bugs.webkit.org/show_bug.cgi?id=316098</a>

Reviewed by Ryosuke Niwa and Darin Adler.

This adds a new ElementMoved, TextMoved, and NonContentsChildMoved ChildChange type.
These are used by moveBefore(), this ensures that children changed steps such as script&apos;s
which runs prepareScript, don&apos;t run when triggered via moveBefore.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before-expected.txt:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::makeChildChangeForMoveRemoval):
(WebCore::makeChildChangeForMoveInsertion):
(WebCore::ContainerNode::moveBefore):
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::ChildChange::isInsertion const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::childrenChanged):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::childrenChanged):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::optionToSelectFromChildChangeScope):
* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::childrenChanged):

Canonical link: <a href="https://commits.webkit.org/320069@main">https://commits.webkit.org/320069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24a004d60cbc784f07966990e44f2f92db388460

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/183391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/57315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/193612 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/185254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/57050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/143159 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99407 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/186346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123578 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45604 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43836 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/43454 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4786 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/48103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/195551 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56985 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152663 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40953 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57689 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/152347 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46896 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129968 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/126267 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/56197 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/18464 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/55568 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/55635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->