### PR TITLE
[GStreamer] mediaTime from requestVideoFrameCallback is wrong in case of captureCanvas as source

### DIFF
--- a/LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata-expected.txt
+++ b/LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS requestVideoFrameCallback metadata for canvas captureStream (2d context)
+

--- a/LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata.html
+++ b/LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata.html
@@ -1,0 +1,74 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+    <body>
+        <canvas id="canvas" width=100 height=100></canvas>
+        <video id="video" autoplay width=100 height=100></video>
+        <script src="../../../resources/testharness.js"></script>
+        <script src="../../../resources/testharnessreport.js"></script>
+        <script>
+
+const canvas = document.getElementById("canvas");
+const video  = document.getElementById("video");
+
+function drawFrame(color) {
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+function waitForFrame(v) {
+    return new Promise((resolve, reject) => {
+        const id = v.requestVideoFrameCallback((now, metadata) => resolve({ now, metadata }));
+        setTimeout(() => {
+            v.cancelVideoFrameCallback(id);
+            reject("requestVideoFrameCallback timed out after 5s");
+        }, 5000);
+    });
+}
+
+promise_test(async test => {
+    const stream = canvas.captureStream();
+    video.srcObject = stream;
+
+    // Let the pipeline initialize before registering the first callback.
+    await new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve, 0)));
+
+    drawFrame("green");
+    const { metadata: meta1 } = await waitForFrame(video);
+
+    // Dimensions must match the canvas.
+    assert_equals(meta1.width,  canvas.width,  "width matches canvas");
+    assert_equals(meta1.height, canvas.height, "height matches canvas");
+
+    // presentedFrames must be at least 1.
+    assert_greater_than(meta1.presentedFrames, 0, "presentedFrames > 0");
+
+    // presentationTime is a DOMHighResTimeStamp (ms since time origin), must be positive.
+    assert_greater_than(meta1.presentationTime, 0, "presentationTime > 0");
+
+    // expectedDisplayTime must be at or after presentationTime.
+    assert_greater_than_equal(meta1.expectedDisplayTime, meta1.presentationTime,
+        "expectedDisplayTime >= presentationTime");
+
+    // mediaTime is stream-relative (seconds since stream start), must be non-negative
+    // and well below the system uptime, confirming it is not the raw clock value.
+    assert_greater_than_equal(meta1.mediaTime, 0, "mediaTime >= 0");
+    assert_less_than(meta1.mediaTime, 60, "mediaTime is stream-relative, not an absolute clock value");
+
+    // captureTime must be provided for canvas capture frames.
+    assert_not_equals(meta1.captureTime, undefined, "captureTime is set");
+    assert_greater_than(meta1.captureTime, 0, "captureTime > 0");
+
+    // Draw a second frame and verify all monotonically-increasing fields advance.
+    drawFrame("green");
+    const { metadata: meta2 } = await waitForFrame(video);
+
+    assert_greater_than(meta2.presentedFrames, meta1.presentedFrames, "presentedFrames increases");
+    assert_greater_than(meta2.presentationTime, meta1.presentationTime, "presentationTime increases");
+    assert_greater_than(meta2.mediaTime, meta1.mediaTime, "mediaTime increases");
+
+}, "requestVideoFrameCallback metadata for canvas captureStream (2d context)");
+
+        </script>
+    </body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -221,6 +221,7 @@ scrollingcoordinator/non-fast-scrollable-region-scaled-iframe.html [ Skip ]
 scrollingcoordinator/non-fast-scrollable-region-transformed-iframe.html [ Skip ]
 
 imported/w3c/web-platform-tests/video-rvfc [ Pass ]
+fast/mediastream/captureStream/canvas-rvfc-metadata.html [ Failure ]
 fast/mediastream/getUserMedia-rvfc.html [ Pass ]
 webrtc/peerConnection-rvfc.html [ Pass ]
 # Timing out tests until we add XR session.

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -189,6 +189,8 @@ webkit.org/b/61827 fast/events/drag-image-filename.html
 fast/mediastream/microphone-change-while-muted.html [ Pass ]
 
 # Media Stream API is not fully supported.
+fast/mediastream/captureStream/canvas-rvfc-metadata.html [ Failure ]
+
 fast/mediastream/MediaStream-add-ended-tracks.html
 
 fast/mediastream/RTCPeerConnection-ice.html [ Skip ]

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4683,11 +4683,15 @@ std::optional<VideoFrameMetadata> MediaPlayerPrivateGStreamer::videoFrameMetadat
     metadata.presentedFrames = m_sampleCount;
 
     if (GST_BUFFER_PTS_IS_VALID(buffer)) {
-        auto segment = gst_sample_get_segment(m_sample.get());
-        RELEASE_ASSERT(segment);
-        uint64_t streamTime;
-        if (int sign = gst_segment_to_stream_time_full(segment, GST_FORMAT_TIME, GST_BUFFER_PTS(buffer), &streamTime))
-            metadata.mediaTime = sign * fromGstClockTime(streamTime).toDouble();
+        if (isMediaStreamPlayer())
+            metadata.mediaTime = currentTime().toDouble();
+        else {
+            auto segment = gst_sample_get_segment(m_sample.get());
+            RELEASE_ASSERT(segment);
+            uint64_t streamTime;
+            if (int sign = gst_segment_to_stream_time_full(segment, GST_FORMAT_TIME, GST_BUFFER_PTS(buffer), &streamTime))
+                metadata.mediaTime = sign * fromGstClockTime(streamTime).toDouble();
+        }
     }
 
     // FIXME: presentationTime and expectedDisplayTime might not always have the same value, we should try getting more precise values.


### PR DESCRIPTION
#### 82c645da79b52c4a9063580d1bb1ad924087ac57
<pre>
[GStreamer] mediaTime from requestVideoFrameCallback is wrong in case of captureCanvas as source
<a href="https://bugs.webkit.org/show_bug.cgi?id=316190">https://bugs.webkit.org/show_bug.cgi?id=316190</a>

Reviewed by Philippe Normand.

Canvas capture frames have their PTS stamped with the absolute GStreamer
system clock time. Because the default GstSegment has start=0, calling
gst_segment_to_stream_time on such a buffer returns the raw clock value
(system uptime in seconds), not a stream-relative position.
To fix that and set the correct value of mediaTime in VideoFrameMetadata
provided by requestVideoFrameCallback, this change detects canvas frames
via their VideoFrameContentHint and uses currentTime() instead.

A new layout test fast/mediastream/captureStream/canvas-rvfc-metadata.html
validates the metadata fields returned by requestVideoFrameCallback for a
canvas captureStream, including that mediaTime is stream-relative and not
an absolute clock value.

Test: fast/mediastream/captureStream/canvas-rvfc-metadata.html
* LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata-expected.txt: Added.
* LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata.html: Added.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::videoFrameMetadata):

Canonical link: <a href="https://commits.webkit.org/314533@main">https://commits.webkit.org/314533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d606ae41d71783e5b834fde1757dc87ed98f179a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123661 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129360 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109885 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29416 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23594 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140687 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177987 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30888 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137715 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137634 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37082 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149009 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103330 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32925 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39164 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112239 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38561 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3961 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38806 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->