### PR TITLE
Regression: Canvas textAlign center/right ignored for complex text (Thai) because cached shaped-text width is computed as 0

### DIFF
--- a/LayoutTests/fast/canvas/canvas-text-align-complex-text-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-text-align-complex-text-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Complex text is measured and painted
+PASS textAlign 'center' is honored for complex text
+PASS textAlign 'right' is honored for complex text
+

--- a/LayoutTests/fast/canvas/canvas-text-align-complex-text.html
+++ b/LayoutTests/fast/canvas/canvas-text-align-complex-text.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Canvas textAlign center/right applies to complex-script (Thai) text</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="800" height="80"></canvas>
+<script>
+// Regression test: the cached shaped-text width was computed as 0 for complex
+// (e.g. Thai) text, so canvas textAlign "center"/"right" collapsed to "left" and
+// the text was mis-positioned / clipped. https://bugs.webkit.org/show_bug.cgi?id=316186
+
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+const text = "นี่คือข้อความตัวอย่าง"; // complex-script string requiring shaping
+const anchorX = 400;
+const baselineY = 40;
+const tolerance = 3;
+
+ctx.font = "30px sans-serif";
+ctx.textBaseline = "middle";
+
+// Ground-truth advance width, measured independently of the drawing path.
+const measuredWidth = ctx.measureText(text).width;
+
+// Horizontal ink extent [min, max] of the white text, or null if nothing painted.
+function inkExtent(align) {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "white";
+    ctx.textAlign = align;
+    ctx.fillText(text, anchorX, baselineY);
+
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+    let minX = canvas.width, maxX = -1;
+    for (let y = 0; y < canvas.height; y++) {
+        for (let x = 0; x < canvas.width; x++) {
+            if (data[(y * canvas.width + x) * 4 + 3] > 30) {
+                if (x < minX) minX = x;
+                if (x > maxX) maxX = x;
+            }
+        }
+    }
+    return maxX < 0 ? null : { min: minX, max: maxX };
+}
+
+const left = inkExtent("left");
+const center = inkExtent("center");
+const right = inkExtent("right");
+
+test(() => {
+    assert_greater_than(measuredWidth, 1, "measureText() reports a non-zero width");
+    assert_not_equals(left, null, "left-aligned text is painted");
+    assert_not_equals(center, null, "center-aligned text is painted");
+    assert_not_equals(right, null, "right-aligned text is painted");
+}, "Complex text is measured and painted");
+
+// With the same anchor and text, the rendered glyph run is identical for every
+// alignment, just translated by the alignment offset (left: 0, center: -width/2,
+// right: -width). So the ink shifts left by exactly width/2 and width. The bug made
+// both offsets 0. Comparing extents of the same glyph run cancels per-glyph side
+// bearings, so the relationship is exact within rounding.
+test(() => {
+    assert_approx_equals(left.min - center.min, measuredWidth / 2, tolerance,
+        "center shifts the text left by half the advance width");
+}, "textAlign 'center' is honored for complex text");
+
+test(() => {
+    assert_approx_equals(left.min - right.min, measuredWidth, tolerance,
+        "right shifts the text left by the full advance width");
+    // Original symptom: right-aligned text overran the right edge and was clipped.
+    assert_less_than_equal(right.max, anchorX + tolerance,
+        "right-aligned text ends at the anchor instead of overflowing");
+}, "textAlign 'right' is honored for complex text");
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1518,13 +1518,13 @@ TextShapingResult FontCascade::layoutComplexText(const TextRun& run, unsigned fr
     ComplexTextController controller(*this, run, false, 0, forTextEmphasis == ForTextEmphasis::Yes);
     GlyphBuffer glyphBufferForStartingIndex;
     controller.advance(from, &glyphBufferForStartingIndex);
-    float widthBeforeSegment = controller.totalAdvance().width();
+    float widthBeforeSegment = controller.runWidthSoFar();
     controller.advance(to, &result.glyphBuffer);
 
     if (result.glyphBuffer.isEmpty())
         return result;
 
-    result.width = controller.totalAdvance().width() - widthBeforeSegment;
+    result.width = controller.runWidthSoFar() - widthBeforeSegment;
 
     if (run.rtl()) {
         // Exploit the fact that the sum of the paint advances is equal to


### PR DESCRIPTION
#### e7e477090c85c92c3e89c22ee8c45df3c72c876f
<pre>
Regression: Canvas textAlign center/right ignored for complex text (Thai) because cached shaped-text width is computed as 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=316186">https://bugs.webkit.org/show_bug.cgi?id=316186</a>
<a href="https://rdar.apple.com/178622405">rdar://178622405</a>

Reviewed by NOBODY (OOPS!).

FontCascade::layoutComplexText() computed the width of the shaped segment
using ComplexTextController::totalAdvance(), which returns the advance of
the *entire* run (it is accumulated up front over all complex runs), not
the width consumed so far by advance(). For the full-run case used by the
canvas shaped-text cache (from = 0, to = length) this produced:

      widthBeforeSegment = controller.totalAdvance().width();   // already full width
      result.width       = controller.totalAdvance().width() - widthBeforeSegment;
                         // = fullWidth - fullWidth = 0

So TextShapingResult::width was 0 for any complex-shaped run.

CanvasRenderingContext2DBase::drawTextUnchecked() feeds that cached width
into textOffset(), where the center/right alignment offsets are -width/2
and -width respectively. With width == 0 both offsets collapse to 0, so
&quot;center&quot; and &quot;right&quot; rendered identically to &quot;left&quot;: the text was drawn
starting at the anchor and, for right alignment, ran off the canvas and
appeared truncated. Latin text was unaffected because it does not take
the cached shaped-text path. measureText() was correct because it uses
FontCascade::width(), not the cached value.

The sibling layoutSimpleText() and widthOfTextRange() both correctly use
runWidthSoFar() (the width advanced so far) for this computation; complex
text was the inconsistent outlier. Use runWidthSoFar() in
layoutComplexText() to match.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::layoutComplexText const):
* LayoutTests/fast/canvas/canvas-text-align-complex-text-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-text-align-complex-text.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7e477090c85c92c3e89c22ee8c45df3c72c876f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175261 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123469 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d11679a-b1de-4c7d-80e7-a4591da399f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129192 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c650de3d-c844-4cc1-8881-c4a50387f1e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109717 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/189880e2-0406-46f4-8136-3bb14bf69b94) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30553 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29246 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23402 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177794 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30696 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137541 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137468 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103095 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32761 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25701 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38972 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112046 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38369 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3787 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38614 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->