### PR TITLE
SVGGeometryElement path query APIs should respect CSS 'd' property for display:none elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt
@@ -1,7 +1,7 @@
 
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: default
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none and inline style The element's path is empty.
+PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none and inline style
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: default
 FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: none The object is in an invalid state.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, circle with display: default

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPathElement.getTotalLength-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPathElement.getTotalLength-01-expected.txt
@@ -1,5 +1,5 @@
 
 PASS SVGPathElement.getTotalLength: 'display:none', path with d attribute specified on element
-FAIL SVGPathElement.getTotalLength: 'display:none', path with d attribute specified as styles assert_equals: expected 100 but got 0
-FAIL SVGPathElement.getTotalLength: 'display:none', path with d attribute specified on element and as styles assert_equals: expected 100 but got 233.1370849609375
+PASS SVGPathElement.getTotalLength: 'display:none', path with d attribute specified as styles
+PASS SVGPathElement.getTotalLength: 'display:none', path with d attribute specified on element and as styles
 

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -243,6 +243,12 @@ const SVGPathByteStream& SVGPathElement::pathByteStream() const
                 return pathFunction->parameters.data.byteStream;
             return SVGPathByteStream::empty();
         }
+
+        if (CheckedPtr style = const_cast<SVGPathElement&>(*this).computedStyle()) {
+            if (auto& pathFunction = style->d().tryPath())
+                return pathFunction->parameters.data.byteStream;
+            return SVGPathByteStream::empty();
+        }
     }
 
     return Ref { m_pathSegList }->currentPathByteStream();


### PR DESCRIPTION
#### eb458f3f6ccb0add6e136fd9d1377897594de6ea
<pre>
SVGGeometryElement path query APIs should respect CSS &apos;d&apos; property for display:none elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=304701">https://bugs.webkit.org/show_bug.cgi?id=304701</a>
<a href="https://rdar.apple.com/167195297">rdar://167195297</a>

Reviewed by Taher Ali.

Per the SVG specification [1], getTotalLength() and getPointAtLength() should
compute path geometry based on the effective path data, which includes CSS &apos;d&apos;
property values. Both APIs route through pathByteStream(), which currently only
checks renderer-&gt;style(). That style is null for non-rendered elements, so
display:none elements fail to read the CSS &apos;d&apos; property.

Fix by falling back to computedStyle() when there is no renderer, allowing
display:none elements to access their CSS &apos;d&apos; property values. This applies to
every caller of pathByteStream().

[1] <a href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGeometryElement">https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGeometryElement</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPathElement.getTotalLength-01-expected.txt: Ditto
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::pathByteStream const):

Canonical link: <a href="https://commits.webkit.org/314654@main">https://commits.webkit.org/314654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/298b5062c43109ff5096a387df2e0b811c3822d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175784 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d98fdff-3837-4c44-b8f8-e6bdf99a2406) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40234 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129647 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b8e52b71-f5b1-4497-bd4a-f00012b1ba0a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110172 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4732574a-0608-4246-a55b-2820b41fe58d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178318 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31218 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/29220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138008 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40296 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137923 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37158 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149311 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103781 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33213 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39495 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112569 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38891 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4266 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39136 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39034 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->