### PR TITLE
Cherry-pick(s) 95b97d3d6fc0. rdar://176061219

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
@@ -54,7 +54,11 @@ public:
     const IDBResourceIdentifier& openRequestIdentifier() LIFETIME_BOUND { return m_openRequestIdentifier; }
     UniqueIDBDatabase* database() { return m_database.get(); }
     WEBCORE_EXPORT CheckedPtr<UniqueIDBDatabase> checkedDatabase();
+<<<<<<< HEAD
     UniqueIDBDatabaseManager* NODELETE manager();
+=======
+    UniqueIDBDatabaseManager* manager();
+>>>>>>> 95b97d3d6fc0 ([IndexedDB] Use-After-Free caused by use of `-0.0` for HashMap Key)
     IDBConnectionToClient& connectionToClient() { return m_connectionToClient; }
 
     WEBCORE_EXPORT void NODELETE connectionPendingCloseFromClient();


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176061219 to main. The following sources [917854a9c245] will still need to be cherry-picked once the conflict is resolved.

```[IndexedDB] Use-After-Free caused by use of `-0.0` for HashMap Key
rdar://172834266

Reviewed by Brady Eidson.

IndexValueStore uses HashMap with key type IDBKeyData to store index records. For IDBKeyData, when its type is Number
or Date, the value passed to Hasher is a double. Since Hasher uses the raw bits to create the hash, -0.0 and +0.0
produce different hashes, meaning the HashMap can have two separate entries for IDBKeyData values of -0.0 and +0.0.
However, IDBKeyData::operator== returns true for -0.0 and +0.0 because it uses IEEE 754 comparison. This inconsistency
can corrupt the map: for example, an attempt to remove the entry for +0.0 can match and destroy the entry for -0.0
instead, leaving a cursor still referencing the freed entry (see the new test). To fix this, normalize -0.0 to +0.0
before passing to Hasher.

This patch also fixes two other issues. First, MemoryIndex::transactionAborted does not invalidate existing cursors when
a transaction is aborted, so a cursor may hold a reference to an index record that is destroyed during the rollback.
This patch fixes that by calling notifyCursorsOfAllRecordsChanged() before replaying the rollback.

Second, the network process does not validate the DidFinishHandlingVersionChangeTransaction message. An uncompromised
web content process will not send this message while the version change transaction is still in progress (i.e. before it
is committed or aborted). The network process should verify this before proceeding, as the handler resets internal state
such as UniqueIDBDatabase::m_versionChangeTransaction, which could lead to unexpected behavior.

Test: storage/indexeddb/index-unique-negative-zero-private.html

* LayoutTests/storage/indexeddb/index-unique-negative-zero-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/index-unique-negative-zero-private.html: Added.
* LayoutTests/storage/indexeddb/resources/index-unique-negative-zero.js: Added.
(prepareDatabase):
(onOpenSuccess.transaction.onabort):
(onOpenSuccess):
(insertSecondRecord):
(secondRecordFailed):
(testCount.request.onsuccess):
(testCount):
(testCursor.request.onsuccess):
(testCursor):
* Source/WebCore/Modules/indexeddb/IDBKeyData.h:
(WebCore::add):
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp:
(WebCore::IDBServer::MemoryIndex::transactionAborted):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::isVersionChangeTransactionFinishingOrFinished const):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::abort):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::abortWithoutCallback):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::commit):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::isFinishingOrFinished const):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::setIsFinishingOrFinished):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::didFinishHandlingVersionChangeTransaction):

Originally-landed-as: 305413.585@rapid/safari-7624.2.5.110-branch (95b97d3d6fc0). rdar://176061219

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cbe21b56ba32e9596ec282f0c3f53afdf2b55b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166224 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/39714 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/33295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175271 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123479 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/168090 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/40140 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39718 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/175271 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123479 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/169183 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/40140 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/33295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175271 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/40140 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39718 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/23412 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/40140 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/33295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177804 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30706 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/33295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/177804 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/39783 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/39718 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177804 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/40471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/33295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/103108 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/40471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/33295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/38982 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112056 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/38379 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/33295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/38624 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/38522 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->