### PR TITLE
ASSERTION FAILED: !m_deferredScrollDelta platform/ScrollView.cpp(504) : virtual void WebCore::ScrollView::scrollTo(const WebCore::ScrollPosition &)

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-clamp-during-layout-with-pending-async-scroll-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-clamp-during-layout-with-pending-async-scroll-crash-expected.txt
@@ -1,0 +1,10 @@
+Test for bug 250907: scrollTo() should not assert when a layout clamps the scroll position while an asynchronous scroll update is pending.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-clamp-during-layout-with-pending-async-scroll-crash.html
+++ b/LayoutTests/fast/scrolling/scroll-clamp-during-layout-with-pending-async-scroll-crash.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="spacer" style="height: 20000px"></div>
+<script>
+description("Test for bug 250907: scrollTo() should not assert when a layout clamps the scroll position while an asynchronous scroll update is pending.");
+jsTestIsAsync = true;
+
+const spacer = document.getElementById("spacer");
+
+function tick(remaining)
+{
+    if (!remaining) {
+        testPassed("Did not crash.");
+        finishJSTest();
+        return;
+    }
+
+    if (window.eventSender) {
+        eventSender.mouseScrollBy(0, -20);
+        eventSender.mouseScrollBy(0, -20);
+    }
+
+    spacer.style.height = (remaining % 2) ? "400px" : "20000px";
+    document.body.offsetWidth;
+
+    requestAnimationFrame(() => tick(remaining - 1));
+}
+
+onload = () => {
+    window.scrollTo(0, 20000);
+    tick(20);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -527,8 +527,7 @@ void ScrollView::scrollTo(const ScrollPosition& newPosition)
     // We should not attempt to actually modify layer contents if the layout phase
     // is not complete. Instead, defer the scroll event until the layout finishes.
     if (shouldDeferScrollUpdateAfterContentSizeChange()) {
-        ASSERT(!m_deferredScrollDelta);
-        m_deferredScrollDelta = scrollDelta;
+        m_deferredScrollDelta = m_deferredScrollDelta ? *m_deferredScrollDelta + scrollDelta : scrollDelta;
         return;
     }
 


### PR DESCRIPTION
#### 20aa31cf4f7e280ed5d31810bc553ae98175ca20
<pre>
ASSERTION FAILED: !m_deferredScrollDelta platform/ScrollView.cpp(504) : virtual void WebCore::ScrollView::scrollTo(const WebCore::ScrollPosition &amp;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=250907">https://bugs.webkit.org/show_bug.cgi?id=250907</a>

Reviewed by Simon Fraser.

scrollTo() defers updates during layout into a single-shot m_deferredScrollDelta,
asserting nothing is already pending. But AsyncScrollingCoordinator::applyScrollUpdate()
drains queued scrolling-thread updates before applying its own, and both passes re-enter
scrollTo() via reconcileScrollingState(): the first defers, the second asserts. The
assertion is wrong because a delta can legitimately already be pending; in release the
second assignment silently overwrites the first, leaving layers at a bad offset.

Coalesce by summing instead, matching scrollContents()&apos;s cumulative-delta semantics and
the sibling m_deferredScrollOffsets handling.

Reachable wherever a layout is forced mid-pending-scroll: fullscreen enter, pinch-zoom
(commitTransientZoom), or a layout-flushing DOM read like offsetWidth.

* LayoutTests/fast/scrolling/scroll-clamp-during-layout-with-pending-async-scroll-crash-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-clamp-during-layout-with-pending-async-scroll-crash.html: Added.
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::scrollTo):

Canonical link: <a href="https://commits.webkit.org/314619@main">https://commits.webkit.org/314619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73be9873a13ebb594f8b2517704967584b6341f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175675 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129549 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110074 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23816 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178209 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31109 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137910 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40187 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33765 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137827 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149210 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103627 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25364 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33117 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39386 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112460 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38782 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4165 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39027 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->