### PR TITLE
Layout test archive download 400s with "Query too broad"

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/configuration_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/configuration_unittest.py
@@ -20,6 +20,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
+import re
 import unittest
 
 from resultsdbpy.controller.configuration import Configuration
@@ -95,4 +97,45 @@ class ConfigurationUnittest(unittest.TestCase):
         self.assertEqual(
             Configuration(platform='iOS', version='12', is_simulator=False, architecture='arm64', style='Release').to_query(),
             'platform=iOS&is_simulator=False&version=12.0.0&architecture=arm64&style=Release',
+        )
+
+    def test_javascript_to_params_emits_every_member(self):
+        '''The JS Configuration.toParams() literal must round-trip every member that the
+        Python Configuration model exposes. Drift here under-specifies URLs consumed by
+        @configuration_for_query routes, which then collide on shared (uuid, suite)
+        partitions and fail with "Query too broad" when reconstructing archives.
+
+        Specifically guards two regressions:
+          1. sdk dropped entirely from the literal.
+          2. architecture passed through a DEFAULT_ARCHITECTURE-based stripping helper,
+             which substring-matches and silently collapses arm64 / arm64e / arm64_32.
+        '''
+        js_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'view', 'static', 'js', 'configuration.js',
+        )
+        with open(js_path) as source_file:
+            source = source_file.read()
+
+        match = re.search(r'toParams\s*\(\s*\)\s*\{(.*?)\n    \}', source, re.DOTALL)
+        self.assertIsNotNone(match, 'Could not locate toParams() in configuration.js')
+        body = match.group(1)
+
+        for member in Configuration.REQUIRED_MEMBERS + Configuration.OPTIONAL_MEMBERS + Configuration.FILTERING_MEMBERS:
+            self.assertRegex(
+                body,
+                rf'\b{re.escape(member)}\s*:',
+                f"configuration.js toParams() is missing key '{member}'",
+            )
+
+        self.assertRegex(
+            body,
+            r'sdk\s*:\s*\[\s*this\.sdk\s*\]',
+            'toParams() must emit sdk: [this.sdk] so SDK builds disambiguate archives sharing a uuid',
+        )
+        self.assertRegex(
+            body,
+            r'architecture\s*:\s*\[\s*this\.architecture\s*\]',
+            'toParams() must emit architecture: [this.architecture] without DEFAULT_ARCHITECTURE-based stripping; '
+            'stripping substring-matches and collapses arm64, arm64e, and arm64_32',
         )

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/configuration.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/configuration.js
@@ -320,9 +320,6 @@ class Configuration {
         const ending = this.version_name ? this.version_name.substring(this.version_name.length - 2) : null;
         if ([' A', ' B', ' C', ' D', ' E', ' F', ' G', ' H'].includes(ending))
             version_name = this.version_name.substring(0, this.version_name.length - 2);
-        let architecture = null;
-        if (this.architecture != null && (DEFAULT_ARCHITECTURE == null || this.architecture.search(DEFAULT_ARCHITECTURE) < 0))
-            architecture = this.architecture;
         return {
             platform: [this.platform],
             version:[this.version ? Configuration.integerToVersion(this.version) : null],
@@ -331,7 +328,8 @@ class Configuration {
             style: [this.style],
             flavor: [this.flavor],
             model: [this.model],
-            architecture: [architecture],
+            architecture: [this.architecture],
+            sdk: [this.sdk],
         };
     }
 }


### PR DESCRIPTION
#### 6bb162075b576d365ec363b73f361313b5ae41ff
<pre>
Layout test archive download 400s with &quot;Query too broad&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=316206">https://bugs.webkit.org/show_bug.cgi?id=316206</a>
<a href="https://rdar.apple.com/178632607">rdar://178632607</a>

Reviewed by Jonathan Bedard.

Sometimes the uuid collides with another archive adding more detail to the URL should avoid this collision

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/configuration_unittest.py:
(ConfigurationUnittest.test_to_query):
(ConfigurationUnittest):
(ConfigurationUnittest.test_javascript_to_params_emits_every_member):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/configuration.js:
(Configuration.prototype.toParams):
(Configuration):

Canonical link: <a href="https://commits.webkit.org/314492@main">https://commits.webkit.org/314492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3536f1415059148e70a63d0377f2416d8a95cef5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175280 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123488 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fc324e3-3e15-46c9-bc7f-a42bae59e31e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129209 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a8e3f2b-7009-4922-a482-41bc79376ccc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109734 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d99cc87-d730-4103-83a0-94520c767385) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/165551 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29262 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23421 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177813 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137557 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/165635 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137484 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37047 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40480 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148853 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103118 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32781 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25720 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38991 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38388 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3806 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38633 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->