### PR TITLE
[WPE] Add class descriptions to the WPE Platform main classes

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEBuffer.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBuffer.cpp
@@ -34,6 +34,18 @@
 /**
  * WPEBuffer:
  *
+ * A buffer to be rendered on a [class@View].
+ *
+ * [class@Buffer] is an abstract class that represents a buffer produced by the
+ * web engine and handed to a [class@View] for display through
+ * [method@View.render_buffer]. The WPE platform library provides three
+ * concrete implementations: [class@BufferDMABuf], [class@BufferSHM] and
+ * #WPEBufferAndroid.
+ *
+ * [class@Buffer] offers helpers to import a buffer's contents as an EGL image
+ * with [method@Buffer.import_to_egl_image] or as pixels in memory with
+ * [method@Buffer.import_to_pixels], as well as rendering and release
+ * fences for use when the display supports explicit sync.
  */
 struct _WPEBufferPrivate {
     GWeakPtr<WPEDisplay> display;

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferAndroid.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferAndroid.cpp
@@ -37,6 +37,10 @@
 /**
  * WPEBufferAndroid:
  *
+ * A #WPEBuffer backed by an AHardwareBuffer.
+ *
+ * #WPEBufferAndroid is a #WPEBuffer that wraps an Android `AHardwareBuffer`.
+ * It is only available on Android builds of the WPE platform library.
  */
 struct _WPEBufferAndroidPrivate {
     AHardwareBuffer* ahb;

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
@@ -45,6 +45,12 @@
 /**
  * WPEBufferDMABuf:
  *
+ * A [class@Buffer] backed by a DMA-BUF.
+ *
+ * [class@BufferDMABuf] is a [class@Buffer] that wraps one or more DMA-BUF file
+ * descriptors, identified by a DRM format (FourCC) and a modifier. This is the
+ * buffer type used for hardware-accelerated rendering and, where supported,
+ * direct scanout.
  */
 struct _WPEBufferDMABufPrivate {
     uint32_t format;

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp
@@ -33,6 +33,11 @@
 /**
  * WPEBufferSHM:
  *
+ * A [class@Buffer] backed by shared memory.
+ *
+ * [class@BufferSHM] is a [class@Buffer] that wraps a block of shared memory holding
+ * the pixel data, used for software rendering. The only supported pixel format
+ * is %WPE_PIXEL_FORMAT_ARGB8888.
  */
 struct _WPEBufferSHMPrivate {
     WPEPixelFormat format;

--- a/Source/WebKit/WPEPlatform/wpe/WPEClipboard.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEClipboard.cpp
@@ -40,6 +40,15 @@
 /**
  * WPEClipboard:
  *
+ * A clipboard for copy and paste.
+ *
+ * [class@Clipboard] is an abstract class that gives access to the platform's
+ * clipboard. Get the clipboard of a display with [method@Display.get_clipboard].
+ *
+ * Clipboard contents are represented by [struct@ClipboardContent], which can hold
+ * text and arbitrary data identified by MIME type. Set the contents with
+ * [method@Clipboard.set_content] and read them with
+ * [method@Clipboard.read_text] or [method@Clipboard.read_bytes].
  */
 struct _WPEClipboardPrivate {
     GWeakPtr<WPEDisplay> display;

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -56,6 +56,23 @@
 /**
  * WPEDisplay:
  *
+ * A connection to a native display.
+ *
+ * [class@Display] is an abstract class that platform implementations derive to
+ * represent a connection to a native display, such as a Wayland or DRM
+ * display. It is the root of the WPE platform API: a [class@Display] creates the
+ * [class@View] and [class@Toplevel] instances used to show web content, and gives
+ * access to the platform's keymap, clipboard, screens and preferred buffer
+ * formats.
+ *
+ * Use [func@Display.get_default] to get the default display, which is
+ * obtained by loading the available platform implementations and connecting
+ * to the first one that succeeds. A platform implementation may also be
+ * instantiated directly, in which case [method@Display.connect] must be
+ * called before the display is used.
+ *
+ * When a connected [class@Display] is passed to a WebKitWebView on construction,
+ * the web view is rendered using the WPE platform API.
  */
 struct _WPEDisplayPrivate {
     bool eglInitialized;

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepad.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepad.cpp
@@ -33,6 +33,14 @@
 /**
  * WPEGamepad:
  *
+ * A gamepad device.
+ *
+ * [class@Gamepad] is an abstract class that platform implementations derive to
+ * represent a connected gamepad. It reports input through the
+ * [signal@Gamepad::button-event] and [signal@Gamepad::axis-event]
+ * signals, and may support force feedback through [method@Gamepad.rumble].
+ *
+ * Gamepads are tracked by a [class@GamepadManager].
  */
 struct _WPEGamepadPrivate {
     CString name;

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepadManager.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepadManager.cpp
@@ -33,6 +33,15 @@
 /**
  * WPEGamepadManager:
  *
+ * Tracks the available gamepads.
+ *
+ * [class@GamepadManager] is an abstract class that platform implementations derive
+ * to track the set of connected [class@Gamepad] devices. Create the manager for a
+ * display with [method@Display.create_gamepad_manager].
+ *
+ * It notifies device hotplugging with the
+ * [signal@GamepadManager::device-added] and
+ * [signal@GamepadManager::device-removed] signals.
  */
 struct _WPEGamepadManagerPrivate {
     ListHashSet<GRefPtr<WPEGamepad>> gamepads;

--- a/Source/WebKit/WPEPlatform/wpe/WPEKeymap.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEKeymap.cpp
@@ -31,6 +31,15 @@
 /**
  * WPEKeymap:
  *
+ * A keyboard mapping.
+ *
+ * [class@Keymap] is an abstract class that platform implementations derive to
+ * translate between hardware keycodes and key symbols, and to track the state
+ * of modifier keys. Get the keymap of a display with [method@Display.get_keymap].
+ *
+ * Use [method@Keymap.get_entries_for_keyval] and
+ * [method@Keymap.translate_keyboard_state] to convert between keycodes and
+ * key symbols.
  */
 struct _WPEKeymapPrivate {
 };

--- a/Source/WebKit/WPEPlatform/wpe/WPEKeymapXKB.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEKeymapXKB.cpp
@@ -37,6 +37,12 @@
 /**
  * WPEKeymapXKB:
  *
+ * A [class@Keymap] implementation based on XKB.
+ *
+ * [class@KeymapXKB] is the [class@Keymap] implementation used by the built-in
+ * platforms. It is backed by libxkbcommon; use
+ * [method@KeymapXKB.get_xkb_keymap] and [method@KeymapXKB.get_xkb_state]
+ * to access the underlying `xkb_keymap` and `xkb_state`.
  */
 struct _WPEKeymapXKBPrivate {
     struct xkb_keymap* xkbKeymap;

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
@@ -42,6 +42,14 @@
 /**
  * WPEScreen:
  *
+ * A monitor connected to a [class@Display].
+ *
+ * [class@Screen] is an abstract class that platform implementations derive to
+ * represent a monitor. Enumerate the screens of a display with
+ * [method@Display.get_n_screens] and [method@Display.get_screen].
+ *
+ * A screen exposes its position, size, physical size, scale and refresh rate,
+ * and provides a [class@ScreenSyncObserver] to be notified on vertical sync.
  */
 struct _WPEScreenPrivate {
     guint32 id;

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
@@ -47,6 +47,18 @@
 /**
  * WPEToplevel:
  *
+ * A toplevel window.
+ *
+ * [class@Toplevel] is an abstract class that platform implementations derive to
+ * represent a native toplevel window (or its equivalent on platforms that do
+ * not have windows). A [class@Toplevel] hosts one or more [class@View] instances; the
+ * maximum is set on construction and returned by [method@Toplevel.get_max_views].
+ *
+ * The toplevel owns the window-level state: its title, size, scale, the
+ * [class@Screen] it is on, and whether it is fullscreen, maximized or minimized
+ * (see [flags@ToplevelState]). Platform implementations notify changes to
+ * this state with functions like [method@Toplevel.resized] and
+ * [method@Toplevel.state_changed].
  */
 struct _WPEToplevelPrivate {
     GWeakPtr<WPEDisplay> display;

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -46,6 +46,19 @@
 /**
  * WPEView:
  *
+ * A view that renders the contents of a WebKitWebView.
+ *
+ * [class@View] is an abstract class that platform implementations derive to
+ * represent the surface where web content is rendered. A [class@View] always
+ * belongs to a [class@Display] and is normally created automatically by a
+ * WebKitWebView when it is constructed with a [class@Display].
+ *
+ * The view receives the buffers produced by the web engine through
+ * [method@View.render_buffer] and notifies their state with the
+ * [signal@View::buffer-rendered] and [signal@View::buffer-released]
+ * signals. It also delivers input to the web content: platform
+ * implementations dispatch events with [method@View.event], which a
+ * browser application can observe through the [signal@View::event] signal.
  */
 struct _WPEViewPrivate {
     GRefPtr<WPEDisplay> display;


### PR DESCRIPTION
#### c44add6f2d035459b4dd65247081b11cf36c0a06
<pre>
[WPE] Add class descriptions to the WPE Platform main classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=316207">https://bugs.webkit.org/show_bug.cgi?id=316207</a>

Reviewed by Patrick Griffis.

* Source/WebKit/WPEPlatform/wpe/WPEBuffer.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEBufferAndroid.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEClipboard.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEGamepad.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEGamepadManager.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEKeymap.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEKeymapXKB.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:

Canonical link: <a href="https://commits.webkit.org/314484@main">https://commits.webkit.org/314484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e7d01253030446781233f8925d736befb119ecf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166270 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/39760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/33341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/40186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/175318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169229 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/40186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/33341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/40186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/23458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/40186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/33341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/33341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/177850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/39830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/39764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/40517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/33341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/103157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25309 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/40517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/33341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/39028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/38425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/33341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/38670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/38568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->