### PR TITLE
Web Inspector: Avoid using `alwaysOutOfDate = 1` to force execution of Copy User Interface Resources in incremental builds

### DIFF
--- a/Source/WebInspectorUI/Scripts/generate-userinterface-depfile.sh
+++ b/Source/WebInspectorUI/Scripts/generate-userinterface-depfile.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Writes the dependency file for the "Copy User Interface Resources" phase,
+# the input list Xcode checks to decide whether that phase needs to rerun.
+#
+# Lists directories as well as files: a directory's mtime catches add/remove/rename,
+# a file's only catches in-place edits (on APFS a dir's mtime doesn't move on those).
+# Don't narrow this to files.
+
+set -e
+
+depfile="$1"
+if [ -z "${depfile}" ]; then
+    echo "usage: $(basename "$0") <output-depfile>" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "${depfile}")"
+
+tmp="$(mktemp "${depfile}.XXXXXX")"
+trap 'rm -f "${tmp}"' EXIT
+
+# Emit Make depfile format: a "dependencies:" target, one prerequisite per line.
+find "${SRCROOT}/UserInterface" -name '.*' -prune -o -print \
+    | LC_ALL=C sort \
+    | awk '
+        BEGIN { printf "dependencies:" }
+        { gsub(/[ \\]/, "\\\\&"); printf " \\\n    %s", $0 }
+        END { printf "\n" }
+    ' > "${tmp}"
+
+mv "${tmp}" "${depfile}"

--- a/Source/WebInspectorUI/WebInspectorUI.xcodeproj/project.pbxproj
+++ b/Source/WebInspectorUI/WebInspectorUI.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		1C60FF1914E73C64006CD77D /* combine-resources.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "combine-resources.pl"; sourceTree = "<group>"; };
 		1C60FF1A14E73DCA006CD77D /* remove-console-asserts.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "remove-console-asserts.pl"; sourceTree = "<group>"; };
 		1C60FFE114E79B0F006CD77D /* copy-user-interface-resources.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "copy-user-interface-resources.pl"; sourceTree = "<group>"; };
+		D1F11E5314E73C64006CD901 /* generate-userinterface-depfile.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "generate-userinterface-depfile.sh"; sourceTree = "<group>"; };
 		1C78EE131760E115002F6AA5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1C78EE1617611340002F6AA5 /* WebInspectorUI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorUI.cpp; sourceTree = "<group>"; };
 		BF0A00042E18A0A10063278B /* WebInspectorUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorUI.h; sourceTree = "<group>"; };
@@ -71,6 +72,7 @@
 			children = (
 				1C60FF1914E73C64006CD77D /* combine-resources.pl */,
 				1C60FFE114E79B0F006CD77D /* copy-user-interface-resources.pl */,
+				D1F11E5314E73C64006CD901 /* generate-userinterface-depfile.sh */,
 				1C60FF1A14E73DCA006CD77D /* remove-console-asserts.pl */,
 			);
 			path = Scripts;
@@ -183,12 +185,13 @@
 /* Begin PBXShellScriptBuildPhase section */
 		1C60FF1214E6D9AF006CD77D /* Copy User Interface Resources */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
+			dependencyFile = "$(DERIVED_FILE_DIR)/UserInterface.d";
 			files = (
 			);
 			inputPaths = (
 				"$(SRCROOT)/UserInterface",
+				"$(SRCROOT)/Scripts/generate-userinterface-depfile.sh",
 				"$(SRCROOT)/Scripts/copy-user-interface-resources.pl",
 				"$(JAVASCRIPTCORE_PRIVATE_HEADERS_DIR)/InspectorBackendCommands.js",
 			);
@@ -198,7 +201,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"${ACTION}\" == \"installapi\" || \"${ACTION}\" == \"installhdrs\" ]]; then\n    exit\nfi\n\n/usr/bin/perl \"${SRCROOT}/Scripts/copy-user-interface-resources.pl\"\ntouch \"${DERIVED_FILE_DIR}/copy-user-interface-resources.stamp\"\n";
+			shellScript = "set -e\n\ndepfile=\"${DERIVED_FILE_DIR}/UserInterface.d\"\n\nif [[ \"${ACTION}\" == \"installapi\" || \"${ACTION}\" == \"installhdrs\" ]]; then\n    echo \"dependencies: \" > \"${depfile}\"\n    exit\nfi\n\n\"${SRCROOT}/Scripts/generate-userinterface-depfile.sh\" \"${depfile}\"\n\n/usr/bin/perl \"${SRCROOT}/Scripts/copy-user-interface-resources.pl\"\ntouch \"${DERIVED_FILE_DIR}/copy-user-interface-resources.stamp\"\n";
 		};
 		6577FFC9276ACA680011AEC8 /* Create Symlink to Cryptex Path */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
#### a7db3c97ff50280c0f897b66165c2565d68310ed
<pre>
Web Inspector: Avoid using `alwaysOutOfDate = 1` to force execution of Copy User Interface Resources in incremental builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=314844">https://bugs.webkit.org/show_bug.cgi?id=314844</a>

Reviewed by BJ Burg.

The &quot;Copy User Interface Resources&quot; phase was originally marked as
alwaysOutOfDate, which was a stopgap for the lack of a reliable signal
telling Xcode which files under UserInterface had changed, and that
wasted work on most incremental builds.

This patch gives Xcode that signal: the phase now declares a
dependencyFile and writes it during the build, so the copy reruns only
when a resource it lists actually changes. It has to be a dependencyFile
rather than an xcfilelist because Xcode loads inputFileListPaths before
any phase runs, and a list produced during the build wouldn&apos;t exist yet.

Tested manually by building release WebInspectorUI:
- A clean build produces the dependency file.
- A no-change rebuild skips the copy phase.
- An in-place edit, an added file, and a removed file under
  UserInterface each retriggers the copy phase.

* Source/WebInspectorUI/Scripts/generate-userinterface-depfile.sh: Added.
* Source/WebInspectorUI/WebInspectorUI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/314494@main">https://commits.webkit.org/314494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c649e1d862e5b81a7d7528430f147f649150ea5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/166304 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/39794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/33375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/40220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/175352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/169263 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/40220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/33375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/40220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/23492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158461 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/40220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/33375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177884 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/33375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/177884 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/39864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/39801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177884 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/40551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/33375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/103196 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25315 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/40551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/33375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/39062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/38459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/33375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/38704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/38602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->