### PR TITLE
Compute the scroll-state value of container-type

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5678,9 +5678,10 @@ imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-lay
 imported/w3c/web-platform-tests/css/css-conditional/container-queries/inline-size-bfc-floats.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-010.html [ ImageOnlyFailure ]
 
-# Scroll-state container queries (unsupported), enable parsing test only.
+# Scroll-state container queries (unsupported), enable parsing and computed-value tests only.
 imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state [ Skip ]
 imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/container-type-scroll-state-parsing.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/container-type-scroll-state-computed.html [ Pass ]
 
 webkit.org/b/279424 [ Debug ] imported/w3c/web-platform-tests/css/css-conditional/container-queries/svg-foreignobject-no-size-container.html [ Skip ] # Crash
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/container-type-scroll-state-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/container-type-scroll-state-computed-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Property container-type value 'scroll-state' assert_equals: expected "scroll-state" but got "normal"
-FAIL Property container-type value 'scroll-state size' assert_equals: expected "size scroll-state" but got "normal"
-FAIL Property container-type value 'inline-size scroll-state' assert_equals: expected "inline-size scroll-state" but got "normal"
+PASS Property container-type value 'scroll-state'
+PASS Property container-type value 'scroll-state size'
+PASS Property container-type value 'inline-size scroll-state'
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3284,7 +3284,7 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
         // Check our containing block chain. If anything in the chain needs a layout, then require a full layout.
         for (CheckedPtr currentRenderer = renderer; currentRenderer && !currentRenderer->isRenderView(); currentRenderer = currentRenderer->container()) {
 
-            if (!currentRenderer->style().containerType().isNormal()) {
+            if (currentRenderer->style().containerType().hasSizeContainment()) {
                 requireFullLayout = true;
                 break;
             }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4792,7 +4792,7 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
     // FIXME: This is not as efficient as it could be. For example if an ancestor has a non-inherited style change but
     // the styles are otherwise clean we would not need to re-resolve descendants.
     for (auto& element : elementsRequiringComputedStyle | std::views::reverse) {
-        if (computedStyle && !computedStyle->containerType().isNormal() && mode != ResolveComputedStyleMode::Editability) {
+        if (computedStyle && computedStyle->containerType().hasSizeContainment() && mode != ResolveComputedStyleMode::Editability) {
             // If we find a query container we need to bail out and do full style update to resolve it.
             if (document->updateStyleIfNeeded())
                 return this->computedStyle();

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1356,7 +1356,7 @@ bool RenderBlock::establishesIndependentFormattingContextIgnoringDisplayType(con
         || style.hasOutOfFlowPosition()
         || isBlockBoxWithPotentiallyScrollableOverflow()
         || style.usedContain().contains(Style::ContainValue::Layout)
-        || !style.containerType().isNormal()
+        || style.containerType().hasSizeContainment()
         || Style::ContainmentChecker { style, *element }.shouldApplyPaintContainment()
         || (style.display().isBlockType() && !style.blockStepSize().isNone());
 }

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -171,7 +171,7 @@ void RenderBox::willBeDestroyed()
     if (hasInitializedStyle()) {
         if (!style().scrollSnapAlign().isNone())
             view().unregisterBoxWithScrollSnapPositions(*this);
-        if (!style().containerType().isNormal())
+        if (style().containerType().hasSizeContainment())
             view().unregisterContainerQueryBox(*this);
         if (!style().anchorNames().isNone())
             view().unregisterAnchor(*this);
@@ -303,9 +303,9 @@ void RenderBox::styleWillChange(Style::Difference diff, const RenderStyle& newSt
             view().unregisterBoxWithScrollSnapPositions(*this);
     }
 
-    if (!newStyle.containerType().isNormal())
+    if (newStyle.containerType().hasSizeContainment())
         view().registerContainerQueryBox(*this);
-    else if (oldStyle && !oldStyle->containerType().isNormal())
+    else if (oldStyle && oldStyle->containerType().hasSizeContainment())
         view().unregisterContainerQueryBox(*this);
 
     if (!newStyle.positionTryFallbacks().isNone() && newStyle.hasOutOfFlowPosition())

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2826,7 +2826,8 @@ bool RenderElement::hasEligibleContainmentForSizeQuery() const
         return shouldApplySizeContainment();
     if (type.hasInlineSize())
         return shouldApplyInlineSizeContainment();
-    if (type.isNormal())
+    // `scroll-state` (without a size axis) establishes no size containment, same as `normal`.
+    if (type.isNormal() || type.hasScrollState())
         return true;
     ASSERT_NOT_REACHED();
     return false;

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -158,7 +158,7 @@ static inline bool hasValidStyleForProperty(Element& element, CSSPropertyID prop
 
     auto isQueryContainer = [&](Element& element) {
         auto* style = element.renderStyle();
-        return style && !style->containerType().isNormal();
+        return style && style->containerType().hasSizeContainment();
     };
 
     if (isQueryContainer(element))

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1102,7 +1102,7 @@ void TreeResolver::pushParent(Element& element, const RenderStyle& style, Option
 #endif
 {
     scope().selectorMatchingState.selectorFilter.pushParent(&element);
-    if (!style.containerType().isNormal())
+    if (style.containerType().hasSizeContainment())
         scope().selectorMatchingState.containerQueryEvaluationState.sizeQueryContainers.append(element);
 
     Parent parent(element, style, changes, descendantsToResolve, isInDisplayNoneTree);
@@ -1465,7 +1465,7 @@ auto TreeResolver::updateStateForQueryContainer(Element& element, const RenderSt
         return LayoutInterleavingAction::None;
 
     auto* existingStyle = element.renderOrDisplayContentsStyle();
-    if (!style->containerType().isNormal() || (existingStyle && !existingStyle->containerType().isNormal())) {
+    if (style->containerType().hasSizeContainment() || (existingStyle && existingStyle->containerType().hasSizeContainment())) {
         // If any of the queries use font-size relative units then a font size change
         // may affect their evaluation, so force re-evaluating all descendants.
         if (styleChangeAffectsRelativeUnits(*style, existingStyle))

--- a/Source/WebCore/style/values/contain/StyleContainerType.cpp
+++ b/Source/WebCore/style/values/contain/StyleContainerType.cpp
@@ -27,6 +27,7 @@
 #include "StyleContainerType.h"
 
 #include "CSSKeywordValue.h"
+#include "CSSValuePair.h"
 #include "StyleBuilderChecking.h"
 
 namespace WebCore {
@@ -36,17 +37,46 @@ namespace Style {
 
 auto CSSValueConversion<ContainerType>::operator()(BuilderState& state, const CSSValue& value) -> ContainerType
 {
-    if (auto* keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
+    if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
         switch (keywordValue->valueID()) {
         case CSSValueNormal:
             return CSS::Keyword::Normal { };
         case CSSValueSize:
-            return CSS::Keyword::Size { };
+            return { ContainerTypeValue::Size };
         case CSSValueInlineSize:
-            return CSS::Keyword::InlineSize { };
+            return { ContainerTypeValue::InlineSize };
+        case CSSValueScrollState:
+            return { ContainerTypeValue::ScrollState };
         default:
             break;
         }
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return CSS::Keyword::Normal { };
+    }
+
+    // The `[ size | inline-size ] || scroll-state` combination arrives as a CSSValuePair.
+    if (RefPtr pair = dynamicDowncast<CSSValuePair>(value)) {
+        ContainerType::EnumSet result;
+        auto addComponent = [&](const CSSValue& component) -> bool {
+            RefPtr keyword = dynamicDowncast<CSSKeywordValue>(component);
+            if (!keyword)
+                return false;
+            switch (keyword->valueID()) {
+            case CSSValueSize:
+                result.value.add(ContainerTypeValue::Size);
+                return true;
+            case CSSValueInlineSize:
+                result.value.add(ContainerTypeValue::InlineSize);
+                return true;
+            case CSSValueScrollState:
+                result.value.add(ContainerTypeValue::ScrollState);
+                return true;
+            default:
+                return false;
+            }
+        };
+        if (addComponent(pair->first()) && addComponent(pair->second()))
+            return result;
     }
 
     state.setCurrentPropertyInvalidAtComputedValueTime();

--- a/Source/WebCore/style/values/contain/StyleContainerType.h
+++ b/Source/WebCore/style/values/contain/StyleContainerType.h
@@ -30,55 +30,56 @@
 namespace WebCore {
 namespace Style {
 
-// <'container-type'> = normal | size | inline-size
+// <'container-type'> = normal | [ [ size | inline-size ] || scroll-state ]
 // https://drafts.csswg.org/css-conditional-5/#container-type
+
+// The combinable container-type flags. `normal` is intentionally not a value here:
+// it is represented by the empty set (see ContainerType::isNormal()).
+enum class ContainerTypeValue : uint8_t {
+    Size,
+    InlineSize,
+    ScrollState,
+};
+
+using ContainerTypeValueEnumSet = SpaceSeparatedEnumSet<ContainerTypeValue>;
+
 struct ContainerType {
-    constexpr ContainerType(CSS::Keyword::Normal)
-        : m_type { Type::Normal }
-    {
-    }
+    using EnumSet = ContainerTypeValueEnumSet;
+    using value_type = ContainerTypeValueEnumSet::value_type;
 
-    constexpr ContainerType(CSS::Keyword::Size)
-        : m_type { Type::Size }
-    {
-    }
+    constexpr ContainerType(CSS::Keyword::Normal) : m_value { } { }
+    constexpr ContainerType(CSS::Keyword::Size) : m_value { ContainerTypeValue::Size } { }
+    constexpr ContainerType(CSS::Keyword::InlineSize) : m_value { ContainerTypeValue::InlineSize } { }
+    constexpr ContainerType(CSS::Keyword::ScrollState) : m_value { ContainerTypeValue::ScrollState } { }
+    constexpr ContainerType(EnumSet&& set) : m_value { WTF::move(set) } { }
+    constexpr ContainerType(value_type value) : ContainerType { EnumSet { value } } { }
+    constexpr ContainerType(std::initializer_list<value_type> initializerList) : ContainerType { EnumSet { initializerList } } { }
 
-    constexpr ContainerType(CSS::Keyword::InlineSize)
-        : m_type { Type::InlineSize }
-    {
-    }
-
-    constexpr bool isNormal() const { return m_type == Type::Normal; }
-    constexpr bool hasSize() const { return m_type == Type::Size; }
-    constexpr bool hasInlineSize() const { return m_type == Type::InlineSize; }
+    constexpr bool isNormal() const { return m_value.isEmpty(); }
+    constexpr bool hasSize() const { return m_value.contains(ContainerTypeValue::Size); }
+    constexpr bool hasInlineSize() const { return m_value.contains(ContainerTypeValue::InlineSize); }
+    constexpr bool hasScrollState() const { return m_value.contains(ContainerTypeValue::ScrollState); }
     constexpr bool hasSizeContainment() const { return hasSize() || hasInlineSize(); }
 
-    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
     {
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
 
-        switch (m_type) {
-        case Type::Normal:
+        if (isNormal())
             return visitor(CSS::Keyword::Normal { });
-        case Type::Size:
-            return visitor(CSS::Keyword::Size { });
-        case Type::InlineSize:
-            return visitor(CSS::Keyword::InlineSize { });
-        }
-        RELEASE_ASSERT_NOT_REACHED();
+        return visitor(m_value);
     }
 
     constexpr bool operator==(const ContainerType&) const = default;
 
 private:
-    enum Type : uint8_t { Normal, Size, InlineSize };
-    Type m_type;
+    EnumSet m_value;
 };
 
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<ContainerType> {
-    ContainerType NODELETE operator()(BuilderState&, const CSSValue&);
+    auto operator()(BuilderState&, const CSSValue&) -> ContainerType;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
+++ b/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
@@ -44,6 +44,7 @@
 #include "ScrollTypes.h"
 #include "StyleBuilderState.h"
 #include "StyleContain.h"
+#include "StyleContainerType.h"
 #include "StyleDisplay.h"
 #include "StyleHangingPunctuation.h"
 #include "StyleImageOrientation.h"
@@ -2407,6 +2408,12 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 
 #define TYPE Style::ContainValue
 #define FOR_EACH(CASE) CASE(Size) CASE(InlineSize) CASE(Layout) CASE(Style) CASE(Paint)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
+#define TYPE Style::ContainerTypeValue
+#define FOR_EACH(CASE) CASE(Size) CASE(InlineSize) CASE(ScrollState)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH


### PR DESCRIPTION
#### 3866f2f70936658606dee96b20f9613b97f77248
<pre>
Compute the scroll-state value of container-type
<a href="https://bugs.webkit.org/show_bug.cgi?id=316214">https://bugs.webkit.org/show_bug.cgi?id=316214</a>

Reviewed by Tim Nguyen.

Parsing of `container-type: scroll-state` already landed, but the value was
dropped at computed-value time and serialized back as `normal`, because
Style::ContainerType could only represent normal/size/inline-size.

Re-model Style::ContainerType as a flag set (mirroring Style::Contain), so
that `scroll-state` and the `size scroll-state` / `inline-size scroll-state`
combinations are representable and round-trip through getComputedStyle.

This is a value-representation change only. Since `isNormal()` now means
&quot;empty set&quot;, the size-containment call sites that previously used
`!isNormal()` are switched to the explicit `hasSizeContainment()` predicate.
This is behavior-neutral for normal/size/inline-size, and keeps `scroll-state`
behaving exactly like `normal` for now; making scroll-state establish a query
container is left to a follow-up.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/container-type-scroll-state-computed-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateLayoutIfDimensionsOutOfDate):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resolveComputedStyle):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::establishesIndependentFormattingContextIgnoringDisplayType const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::willBeDestroyed):
(WebCore::RenderBox::styleWillChange):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::hasEligibleContainmentForSizeQuery const):
* Source/WebCore/style/StyleExtractor.cpp:
(WebCore::Style::hasValidStyleForProperty):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::pushParent):
(WebCore::Style::TreeResolver::updateStateForQueryContainer):
* Source/WebCore/style/values/contain/StyleContainerType.cpp:
(WebCore::Style::CSSValueConversion&lt;ContainerType&gt;::operator):
* Source/WebCore/style/values/contain/StyleContainerType.h:
(WebCore::Style::ContainerType::ContainerType):
(WebCore::Style::ContainerType::isNormal const):
(WebCore::Style::ContainerType::hasSize const):
(WebCore::Style::ContainerType::hasInlineSize const):
(WebCore::Style::ContainerType::hasScrollState const):
(WebCore::Style::ContainerType::switchOn const):
(): Deleted.
* Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h:

Canonical link: <a href="https://commits.webkit.org/314551@main">https://commits.webkit.org/314551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbb0a196864cbce6f59a4dfc505164012348e45a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123651 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129350 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109875 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30706 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29407 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23584 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177977 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30878 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28907 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137705 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137624 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37095 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148998 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/103313 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25864 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39154 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112229 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38551 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3950 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38796 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->