### PR TITLE
REGRESSION(311870@main): [macOS Release x86_64] imported/w3c/web-platform-tests/css/selectors/invalidation/has-complexity.html is a constant TIMEOUT

### DIFF
--- a/LayoutTests/fast/selectors/has-complexity-traversal-count-expected.txt
+++ b/LayoutTests/fast/selectors/has-complexity-traversal-count-expected.txt
@@ -1,0 +1,4 @@
+
+PASS :has() child-change invalidation produces correct styles
+PASS :has() child-change invalidation is not O(n^2)
+

--- a/LayoutTests/fast/selectors/has-complexity-traversal-count.html
+++ b/LayoutTests/fast/selectors/has-complexity-traversal-count.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>:has() style invalidation should not be O(n^2)</title>
+<link rel="author" title="Antti Koivisto" href="mailto:antti@apple.com">
+<link rel="help" href="https://drafts.csswg.org/selectors/#relational">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<!--
+  WebKit-specific (internals) regression test for has-complexity.html. The imported WPT can only catch the
+  O(n^2) :has() invalidation regression via a timeout, which is flaky and machine-dependent. This measures the
+  style-invalidation traversal count instead and asserts it scales linearly with the number of elements.
+-->
+<style>
+div, main { color: grey }
+main:has(span) .subject { color: red }
+main:has(span + span) .subject { color: green }
+main:has(span + final) .subject { color: blue }
+main:has(nonexistent + span) .subject { color: black }
+main:has(span) span { color: black }
+main:has(nonexistent) span { color: black }
+main:has(div div span) .subject { color: purple }
+</style>
+<body>
+<script>
+const grey = 'rgb(128, 128, 128)';
+const red = 'rgb(255, 0, 0)';
+const green = 'rgb(0, 128, 0)';
+const blue = 'rgb(0, 0, 255)';
+const purple = 'rgb(128, 0, 128)';
+
+// Builds the has-complexity tree and runs its full mutation sequence with `count` elements per phase,
+// returning the total style-invalidation traversal count. When `checkColors` is set, also asserts the
+// computed color after each phase (mirroring has-complexity.html's correctness checks).
+function runScenario(count, checkColors) {
+    const main = document.createElement("main");
+    const container = document.createElement("div");
+    container.appendChild(document.createElement("span"));
+    main.appendChild(container);
+    const subject = document.createElement("div");
+    subject.className = "subject";
+    main.appendChild(subject);
+    document.body.appendChild(main);
+
+    const color = () => getComputedStyle(subject).color;
+    let total = 0;
+    const phase = (mutate, expectedColor, description) => {
+        internals.resetStyleInvalidationTraversalCount();
+        mutate();
+        document.body.offsetHeight; // Force a style update.
+        total += internals.styleInvalidationTraversalCount;
+        if (checkColors)
+            assert_equals(color(), expectedColor, description);
+    };
+
+    if (checkColors)
+        assert_equals(color(), red, "before appending");
+
+    phase(() => {
+        for (let i = 0; i < count; ++i)
+            container.appendChild(document.createElement("span"));
+    }, green, "after appending spans");
+
+    phase(() => {
+        for (let i = 0; i < count - 1; ++i)
+            container.appendChild(document.createElement("span"));
+        container.appendChild(document.createElement("final"));
+    }, blue, "after appending more spans and a final");
+
+    phase(() => {
+        const div = document.createElement("div");
+        for (let i = 0; i < count; ++i)
+            div.appendChild(document.createElement("span"));
+        container.appendChild(div);
+    }, purple, "after appending a div with spans");
+
+    phase(() => {
+        container.lastElementChild.remove(); // The div.
+    }, blue, "after removing the div");
+
+    phase(() => {
+        for (let i = 0; i < count; ++i)
+            container.lastElementChild.remove();
+    }, green, "after removing elements one-by-one");
+
+    phase(() => {
+        container.replaceChildren();
+    }, grey, "after removing the remaining elements");
+
+    main.remove();
+    return total;
+}
+
+test(() => {
+    runScenario(50, true);
+}, ":has() child-change invalidation produces correct styles");
+
+test(() => {
+    // The traversal count must scale ~linearly with the element count. An O(n^2) regression pushes the
+    // ratio toward 4 (and times out at scale); a linear implementation keeps it near 2.
+    const atN = runScenario(200, false);
+    const at2N = runScenario(400, false);
+    assert_less_than(at2N / atN, 3, `traversal count should scale linearly (${atN} at 200 elements, ${at2N} at 400)`);
+}, ":has() child-change invalidation is not O(n^2)");
+</script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5413,9 +5413,6 @@ webkit.org/b/195466 imported/w3c/web-platform-tests/html/semantics/embedded-cont
 webkit.org/b/311276 imported/w3c/web-platform-tests/css/selectors/media/media-playback-state.html [ Pass Failure ]
 webkit.org/b/311276 imported/w3c/web-platform-tests/css/selectors/invalidation/media-pseudo-classes-in-has.html [ Pass Failure ]
 
-# Skipped in main file, let's skip as it's timing out in EWS after 311870@main
-imported/w3c/web-platform-tests/css/selectors/invalidation/has-complexity.html [ Skip ]
-
 webkit.org/b/261024 fast/multicol/pagination/RightToLeft-rl-hittest.html [ Failure ]
 webkit.org/b/146731 fast/backgrounds/hidpi-background-image-contain-cover-scale-needs-more-precision.html [ ImageOnlyFailure ]
 webkit.org/b/197473 imported/w3c/web-platform-tests/resource-timing/resource-timing-level1.sub.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2336,8 +2336,6 @@ webkit.org/b/315398 [ Release ] http/tests/site-isolation/accessibility/client/s
 [ Release ] imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.serviceworker.html [ Skip ]
 [ Release ] imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html [ Skip ]
 
-webkit.org/b/315668 [ Release x86_64 ] imported/w3c/web-platform-tests/css/selectors/invalidation/has-complexity.html [ Timeout ]
-
 webkit.org/b/315710 [ Sequoia ] imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/box-shadow-table-row-display.html [ ImageOnlyFailure ]
 
 webkit.org/b/315734 [ Sequoia Release x86_64 ] fast/webgpu/image-data-8-bytes-per-pixel.html [ Timeout ]

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -108,18 +108,31 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
     };
 
     auto hasAlreadyMatchedAndMutationIsIrrelevant = [&](const InvalidationRuleSet& invalidationRuleSet) {
-        // For the first changed element at the mutation point, check if a neighbor already matches the
-        // :has() argument. If so, adding/removing one more matching element doesn't change the :has() result.
+        // Check if a pre-existing neighbor already matches the :has() argument. If so, adding/removing one
+        // more matching element doesn't change the :has() result, so no invalidation is needed.
         // This doesn't apply inside :not() (inverted logic) or for sibling :has() arguments (direction matters).
-        if (!isChild || changedElementRelation != ChangedElementRelation::SelfOrDescendant)
-            return false;
-        if (m_childChange.previousSiblingElement != changedElement.previousElementSibling())
+        if (!isChild)
             return false;
         if (invalidationRuleSet.isNegation == IsNegation::Yes)
             return false;
         if (isSiblingHasRelation(invalidationRuleSet.matchElement))
             return false;
-        return true;
+
+        switch (changedElementRelation) {
+        case ChangedElementRelation::SelfOrDescendant:
+            // The changed element must be exactly at the mutation point so a sibling probe reflects pre-mutation state.
+            return m_childChange.previousSiblingElement == changedElement.previousElementSibling();
+        case ChangedElementRelation::Sibling:
+            // The changed element is itself a pre-existing neighbor. Only safe when the argument is a purely
+            // structural sibling combinator (so an element's match depends only on itself and preceding siblings)
+            // and the mutation is at the end of the element list, so every visited (preceding) sibling's match is
+            // unaffected by it — meaning "it matches now" == "it matched before the mutation".
+            return invalidationRuleSet.hasArgumentProperties.contains(HasArgumentProperty::StructuralSibling) && !m_childChange.nextSiblingElement;
+        case ChangedElementRelation::FirstOrLastChild:
+            return false;
+        }
+        ASSERT_NOT_REACHED();
+        return false;
     };
 
     auto hasMatchingInvalidationSelector = [&](auto& invalidationRuleSet) {
@@ -130,7 +143,12 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
         for (auto& selector : invalidationRuleSet.invalidationSelectors) {
             if (hasAlreadyMatchedAndMutationIsIrrelevant(invalidationRuleSet)) {
                 // FIXME: We could cache this state across invalidations instead of just testing a single sibling.
-                RefPtr sibling = m_childChange.previousSiblingElement ? m_childChange.previousSiblingElement : m_childChange.nextSiblingElement;
+                // For sibling visits the changed element is itself the pre-existing neighbor to probe.
+                RefPtr<Element> sibling;
+                if (changedElementRelation == ChangedElementRelation::Sibling)
+                    sibling = &changedElement;
+                else
+                    sibling = m_childChange.previousSiblingElement ? m_childChange.previousSiblingElement : m_childChange.nextSiblingElement;
                 if (sibling && selectorChecker.match(selector, *sibling, checkingContext)) {
                     matchingHasSelectors.add(&selector);
                     continue;
@@ -153,6 +171,11 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
             return;
         for (auto& invalidationRuleSet : *invalidationRuleSets) {
             if (!canAffectElementsWithStyle(invalidationRuleSet))
+                continue;
+            // Order-insensitive :has() arguments can only change when the changed element's own subtree changes,
+            // which the SelfOrDescendant traversal already covers. Re-evaluating them per sibling is redundant
+            // (and re-walks the bearer subtree on every mutation), so skip them on sibling visits.
+            if (changedElementRelation == ChangedElementRelation::Sibling && !invalidationRuleSet.hasArgumentProperties.contains(HasArgumentProperty::OrderSensitive))
                 continue;
             if (!hasMatchingInvalidationSelector(invalidationRuleSet))
                 continue;
@@ -197,10 +220,10 @@ void ChildChangeInvalidation::invalidateForHasSiblings(MatchingHasSelectors& mat
         return;
 
     if (RefPtr next = m_childChange.nextSiblingElement; next && parentElement().childrenAffectedByFirstChildRules() && !next->previousElementSibling())
-        invalidateForChangedElement(*next, matchingHasSelectors, ChangedElementRelation::Sibling);
+        invalidateForChangedElement(*next, matchingHasSelectors, ChangedElementRelation::FirstOrLastChild);
 
     if (RefPtr previous = m_childChange.previousSiblingElement; previous && parentElement().childrenAffectedByLastChildRules() && !previous->nextElementSibling())
-        invalidateForChangedElement(*previous, matchingHasSelectors, ChangedElementRelation::Sibling);
+        invalidateForChangedElement(*previous, matchingHasSelectors, ChangedElementRelation::FirstOrLastChild);
 }
 
 void ChildChangeInvalidation::invalidateForHasBeforeMutation()

--- a/Source/WebCore/style/ChildChangeInvalidation.h
+++ b/Source/WebCore/style/ChildChangeInvalidation.h
@@ -47,7 +47,7 @@ private:
     void invalidateAfterChange();
     void checkForSiblingStyleChanges();
     using MatchingHasSelectors = HashSet<const CSSSelector*>;
-    enum class ChangedElementRelation : uint8_t { SelfOrDescendant, Sibling };
+    enum class ChangedElementRelation : uint8_t { SelfOrDescendant, Sibling, FirstOrLastChild };
     enum class MutationPhase : bool { Before, After };
     void invalidateForChangedElement(Element&, MatchingHasSelectors&, ChangedElementRelation);
     void invalidateForHasSiblings(MatchingHasSelectors&, MutationPhase);

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -293,6 +293,50 @@ void ScopeRuleSets::collectFeatures() const
     m_features.shrinkToFit();
 }
 
+// Classifies a :has() argument for sibling-combinator invalidation. Recurses into logical
+// :is()/:where()/:not()/:has(); other pseudo-classes are leaf "non-logical" pseudos.
+struct HasArgumentSiblingInfo {
+    bool hasSiblingCombinator { false }; // + or ~
+    bool hasPositionalPseudo { false }; // :nth-child(), :first-child, ... (sibling-relative)
+    bool hasNonLogicalPseudo { false }; // any non-logical pseudo-class (positional, stateful, etc.)
+
+    OptionSet<HasArgumentProperty> properties() const
+    {
+        OptionSet<HasArgumentProperty> result;
+        if (hasSiblingCombinator || hasPositionalPseudo)
+            result.add(HasArgumentProperty::OrderSensitive);
+        if (hasSiblingCombinator && !hasNonLogicalPseudo)
+            result.add(HasArgumentProperty::StructuralSibling);
+        return result;
+    }
+};
+
+static void scanHasArgument(const CSSSelector& complexSelector, HasArgumentSiblingInfo& info)
+{
+    for (const CSSSelector* simpleSelector = &complexSelector; simpleSelector; simpleSelector = simpleSelector->precedingInComplexSelector()) {
+        auto relation = simpleSelector->relation();
+        if (relation == CSSSelector::Relation::DirectAdjacent || relation == CSSSelector::Relation::IndirectAdjacent)
+            info.hasSiblingCombinator = true;
+        if (simpleSelector->match() == CSSSelector::Match::PseudoClass && !isLogicalCombinationPseudoClass(simpleSelector->pseudoClass())) {
+            info.hasNonLogicalPseudo = true;
+            if (pseudoClassIsRelativeToSiblings(simpleSelector->pseudoClass()))
+                info.hasPositionalPseudo = true;
+        }
+        if (const CSSSelectorList* selectorList = simpleSelector->selectorList()) {
+            for (const auto& subSelector : *selectorList)
+                scanHasArgument(subSelector, info);
+        }
+    }
+}
+
+static OptionSet<HasArgumentProperty> hasArgumentProperties(const CSSSelectorList& argument)
+{
+    HasArgumentSiblingInfo info;
+    for (const auto& complexSelector : argument)
+        scanHasArgument(complexSelector, info);
+    return info.properties();
+}
+
 template<typename KeyType, typename Hash, typename HashTraits>
 static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& key, HashMap<KeyType, std::unique_ptr<Vector<InvalidationRuleSet>>, Hash, HashTraits>& ruleSetMap, const HashMap<KeyType, std::unique_ptr<RuleFeatureVector>, Hash, HashTraits>& ruleFeatures)
 {
@@ -353,6 +397,7 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
                 WTF::move(invalidationSelector),
                 key.matchElement,
                 key.isNegation,
+                hasArgumentProperties(*key.invalidationSelector),
                 *key.scopeSelector
             };
         }));

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -27,6 +27,7 @@
 #include "UserAgentStyle.h"
 #include <memory>
 #include <wtf/HashMap.h>
+#include <wtf/OptionSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
 
@@ -46,6 +47,20 @@ enum class DeclarationOrigin : uint8_t;
 class InspectorCSSOMWrappers;
 class Resolver;
 
+// Properties of a :has() argument used to limit sibling-combinator invalidation visits.
+enum class HasArgumentProperty : uint8_t {
+    // The argument depends on sibling order/position (a sibling combinator or a sibling-relative pseudo-class
+    // anywhere). Order-insensitive arguments don't need sibling-combinator invalidation visits — the changed
+    // element's own SelfOrDescendant traversal covers them — so they are skipped there to avoid re-walking the
+    // bearer subtree on every mutation.
+    OrderSensitive = 1 << 0,
+    // The order-sensitivity is *purely* structural sibling combinators (+/~) with no positional or stateful
+    // pseudo-classes (recursing into :is()/:where()/:not()). For these an element's match depends only on itself
+    // and its preceding siblings, so the hasAlreadyMatchedAndMutationIsIrrelevant short-circuit can be applied on
+    // sibling-combinator visits when the mutation is at the end of the element list.
+    StructuralSibling = 1 << 1,
+};
+
 struct InvalidationRuleSet {
     RefPtr<RuleSet> ruleSet;
     // Invalidation selectors are used for attribute selector and :has() invalidation.
@@ -55,6 +70,7 @@ struct InvalidationRuleSet {
     CSSSelectorList invalidationSelectors;
     MatchElement matchElement;
     IsNegation isNegation;
+    OptionSet<HasArgumentProperty> hasArgumentProperties;
     // Selector for the :has() scope element, used to bound invalidation traversal.
     //   - Specific selectors: strong scope.
     //   - Universal `*`: weak scope (bearer has no compound peer); scope element is still


### PR DESCRIPTION
#### 281e57821ea91d94b3896b9cc2eac7b7eff0be3b
<pre>
REGRESSION(311870@main): [macOS Release x86_64] imported/w3c/web-platform-tests/css/selectors/invalidation/has-complexity.html is a constant TIMEOUT
<a href="https://bugs.webkit.org/show_bug.cgi?id=315668">https://bugs.webkit.org/show_bug.cgi?id=315668</a>
<a href="https://rdar.apple.com/178056302">rdar://178056302</a>

Reviewed by Alan Baradlay.

311870@main fixed a part of invalidation code that had not worked at all because an overflowing bitfield.
That exposed a O(n^2) performance issue with sibling combinator style invalidation.

Fix by expanding the existing hasAlreadyMatchedAndMutationIsIrrelevant optimization in ChildChangeInvalidation
to cover sibling combinator visits. Order-insensitive :has() arguments are skipped there entirely since the
changed element&apos;s own traversal already covers them. Arguments using only sibling combinators (+/~) are
short-circuited when the mutation is at the end of the element list, where a pre-existing sibling&apos;s match is
provably unaffected by it (which also makes the end-of-list removal case linear).

Test: fast/selectors/has-complexity-traversal-count.html
* LayoutTests/fast/selectors/has-complexity-traversal-count-expected.txt: Added.
* LayoutTests/fast/selectors/has-complexity-traversal-count.html: Added.

Add a test that records invalidation traversal counts for the cases tested by has-complexity.html.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):
(WebCore::Style::ChildChangeInvalidation::invalidateForHasSiblings):
* Source/WebCore/style/ChildChangeInvalidation.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::HasArgumentSiblingInfo::isOrderSensitive const):
(WebCore::Style::HasArgumentSiblingInfo::isStructuralSibling const):
(WebCore::Style::scanHasArgument):
(WebCore::Style::hasArgumentSiblingInfo):
(WebCore::Style::ensureInvalidationRuleSets):
* Source/WebCore/style/StyleScopeRuleSets.h:

Canonical link: <a href="https://commits.webkit.org/314509@main">https://commits.webkit.org/314509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eb7e24164c32b4a998a46bfc473ca141480536f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175314 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123521 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d0d622e-3b43-47aa-a97d-2e73cdf57e1e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129234 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9416c77-284f-41bd-9930-e31891504fd3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109759 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ffc4be0-bd39-439c-9ca7-6073c6fa231e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30594 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29289 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23454 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140562 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177846 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30748 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137587 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137510 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37059 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103153 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32808 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25749 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39024 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112098 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38421 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3835 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38666 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38564 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->