### PR TITLE
[CMake][Mac] Jumbo unified builds with @cost weighting

### DIFF
--- a/Source/WTF/Scripts/generate-unified-source-bundles.py
+++ b/Source/WTF/Scripts/generate-unified-source-bundles.py
@@ -51,7 +51,7 @@ def bundle_prefix_and_size_for_path(path: Path, args) -> tuple[str, int]:
     for filt in args.dense_bundle_filter:
         pattern, _, name = filt.partition('=')
         if fnmatch.fnmatch(path, pattern):
-            return name or sanitize(pattern), MAX_DENSE_BUNDLE_SIZE
+            return name or sanitize(pattern), max(MAX_DENSE_BUNDLE_SIZE, args.max_bundle_size)
     return sanitize(str(top_level_directory)), args.max_bundle_size
 
 
@@ -64,6 +64,7 @@ class SourceFile:
 
     def __init__(self, file_line: str, file_index: int, args):
         self.unifiable = True
+        self.cost = 1
         self.file_index = file_index
         self._non_arc = False
         self._header_group: Optional[str] = None
@@ -81,6 +82,9 @@ class SourceFile:
                     self._non_arc = True
                 elif attribute.startswith('header:'):
                     self._header_group = attribute[7:]
+                elif attribute.startswith('cost:'):
+                    if args.enforce_cost:
+                        self.cost = int(attribute[5:])
                 else:
                     raise RuntimeError("unknown attribute: " + attribute)
             file_line = file_line[:attribute_start]
@@ -179,11 +183,11 @@ class BundleManager:
                     self._bundle_count_by_prefix[self._last_bundling_prefix] = self.bundle_count
                 self.bundle_count = self._bundle_count_by_prefix.get(bundle_prefix, 0)
             self._last_bundling_prefix = bundle_prefix
-        if self.file_count >= bundle_size:
+        if self.file_count > 0 and self.file_count + source_file.cost > bundle_size:
             log(self._args, "Flushing because new bundle is full ({} sources)".format(self.file_count))
             self.flush()
         self.current_bundle_text += '#include "{}"\n'.format(source_file)
-        self.file_count += 1
+        self.file_count += source_file.cost
 
 
 def process_file_for_unified_source_generation(source_file: SourceFile, args, bundle_managers: dict[str, BundleManager], generated_sources: list[str], input_sources: list[str]) -> None:
@@ -236,6 +240,8 @@ def parse_args():
                         help='Use global sequential numbers for header-grouped bundle filenames and set the limit on the number.')
     parser.add_argument('--max-bundle-size', type=int, default=8,
                         help='The number of files to merge into a single bundle (default: 8).')
+    parser.add_argument('--enforce-cost', action='store_true', default=False,
+                        help='Honor @cost annotations when packing bundles.')
     parser.add_argument('--dense-bundle-filter', action='append', default=[],
                         help='Densely bundle files matching the given path glob (repeatable). '
                              'Use GLOB=NAME to set the bundle filename tag explicitly.')

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -97,27 +97,27 @@ Modules/async-clipboard/ClipboardItem.cpp
 Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
 Modules/async-clipboard/ClipboardItemPasteboardDataSource.cpp
 Modules/async-clipboard/NavigatorClipboard.cpp
-Modules/audiosession/DOMAudioSession.cpp
+Modules/audiosession/DOMAudioSession.cpp @cost:3
 Modules/audiosession/NavigatorAudioSession.cpp
-Modules/beacon/NavigatorBeacon.cpp
+Modules/beacon/NavigatorBeacon.cpp @cost:5
 Modules/cache/CacheStorageConnection.cpp
-Modules/cache/DOMCache.cpp
+Modules/cache/DOMCache.cpp @cost:4
 Modules/cache/DOMCacheEngine.cpp
-Modules/cache/DOMCacheStorage.cpp
-Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp
+Modules/cache/DOMCacheStorage.cpp @cost:4
+Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp @cost:5
 Modules/compression/CompressionStream.cpp
-Modules/compression/CompressionStreamEncoder.cpp
-Modules/compression/DecompressionStreamDecoder.cpp
+Modules/compression/CompressionStreamEncoder.cpp @cost:4
+Modules/compression/DecompressionStreamDecoder.cpp @cost:4
 Modules/compression/ZStream.cpp
-Modules/contact-picker/ContactsManager.cpp
+Modules/contact-picker/ContactsManager.cpp @cost:4
 Modules/contact-picker/NavigatorContacts.cpp
 Modules/cookie-store/CookieChangeEvent.cpp
-Modules/cookie-store/CookieStore.cpp
+Modules/cookie-store/CookieStore.cpp @cost:4
 Modules/cookie-store/CookieStoreManager.cpp
 Modules/cookie-store/ExtendableCookieChangeEvent.cpp
 Modules/credentialmanagement/BasicCredential.cpp
-Modules/credentialmanagement/CredentialsContainer.cpp
-Modules/credentialmanagement/NavigatorCredentials.cpp
+Modules/credentialmanagement/CredentialsContainer.cpp @cost:3
+Modules/credentialmanagement/NavigatorCredentials.cpp @cost:3
 Modules/entriesapi/DOMFileSystem.cpp
 Modules/entriesapi/ErrorCallback.cpp
 Modules/entriesapi/FileSystemDirectoryEntry.cpp
@@ -126,64 +126,64 @@ Modules/entriesapi/FileSystemEntriesCallback.cpp
 Modules/entriesapi/FileSystemEntry.cpp
 Modules/entriesapi/FileSystemFileEntry.cpp
 Modules/entriesapi/HTMLInputElementEntriesAPI.cpp
-Modules/fetch/FetchBody.cpp
-Modules/fetch/FetchBodyConsumer.cpp
-Modules/fetch/FetchBodyOwner.cpp
-Modules/fetch/FetchBodySource.cpp
+Modules/fetch/FetchBody.cpp @cost:3
+Modules/fetch/FetchBodyConsumer.cpp @cost:3
+Modules/fetch/FetchBodyOwner.cpp @cost:3
+Modules/fetch/FetchBodySource.cpp @cost:4
 Modules/fetch/FetchHeaders.cpp
-Modules/fetch/FetchLoader.cpp
-Modules/fetch/FetchRequest.cpp
-Modules/fetch/FetchResponse.cpp
+Modules/fetch/FetchLoader.cpp @cost:3
+Modules/fetch/FetchRequest.cpp @cost:3
+Modules/fetch/FetchResponse.cpp @cost:4
 Modules/fetch/FormDataConsumer.cpp
 Modules/fetch/IPAddressSpace.cpp
-Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
+Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp @cost:3
 Modules/filesystem/FileSystemDirectoryHandle.cpp
 Modules/filesystem/FileSystemFileHandle.cpp
 Modules/filesystem/FileSystemHandle.cpp
 Modules/filesystem/FileSystemHandleStorageKeepAlive.cpp
-Modules/filesystem/FileSystemStorageConnection.cpp
+Modules/filesystem/FileSystemStorageConnection.cpp @cost:3
 Modules/filesystem/FileSystemSyncAccessHandle.cpp
 Modules/filesystem/FileSystemWritableFileStream.cpp
-Modules/filesystem/FileSystemWritableFileStreamSink.cpp
-Modules/filesystem/WorkerFileSystemStorageConnection.cpp
+Modules/filesystem/FileSystemWritableFileStreamSink.cpp @cost:3
+Modules/filesystem/WorkerFileSystemStorageConnection.cpp @cost:3
 Modules/geolocation/GeoNotifier.cpp
-Modules/geolocation/Geolocation.cpp
+Modules/geolocation/Geolocation.cpp @cost:3
 Modules/geolocation/GeolocationController.cpp
 Modules/geolocation/GeolocationCoordinates.cpp
 Modules/geolocation/NavigatorGeolocation.cpp
 Modules/highlight/AppHighlightRangeData.cpp
-Modules/highlight/AppHighlightStorage.cpp
-Modules/highlight/Highlight.cpp
-Modules/highlight/HighlightRegistry.cpp
-Modules/identity/CredentialRequestCoordinator.cpp
-Modules/identity/DigitalCredential.cpp
+Modules/highlight/AppHighlightStorage.cpp @cost:4
+Modules/highlight/Highlight.cpp @cost:4
+Modules/highlight/HighlightRegistry.cpp @cost:3
+Modules/identity/CredentialRequestCoordinator.cpp @cost:3
+Modules/identity/DigitalCredential.cpp @cost:3
 Modules/identity/DigitalCredentialsRequestDataBuilder.cpp
 Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.cpp
-Modules/indexeddb/IDBCursor.cpp
+Modules/indexeddb/IDBCursor.cpp @cost:3
 Modules/indexeddb/IDBCursorWithValue.cpp
 Modules/indexeddb/IDBDatabase.cpp
 Modules/indexeddb/IDBDatabaseIdentifier.cpp
 Modules/indexeddb/IDBDatabaseNameAndVersionRequest.cpp
-Modules/indexeddb/IDBFactory.cpp
+Modules/indexeddb/IDBFactory.cpp @cost:3
 Modules/indexeddb/IDBGetAllOptions.cpp
 Modules/indexeddb/IDBGetAllResult.cpp
 Modules/indexeddb/IDBGetResult.cpp
 Modules/indexeddb/IDBIndex.cpp
-Modules/indexeddb/IDBKey.cpp
+Modules/indexeddb/IDBKey.cpp @cost:4
 Modules/indexeddb/IDBKeyData.cpp
 Modules/indexeddb/IDBKeyPath.cpp
 Modules/indexeddb/IDBKeyRange.cpp
 Modules/indexeddb/IDBKeyRangeData.cpp
-Modules/indexeddb/IDBObjectStore.cpp
+Modules/indexeddb/IDBObjectStore.cpp @cost:4
 Modules/indexeddb/IDBOpenDBRequest.cpp
 Modules/indexeddb/IDBRecord.cpp
-Modules/indexeddb/IDBRequest.cpp
+Modules/indexeddb/IDBRequest.cpp @cost:3
 Modules/indexeddb/IDBRequestCompletionEvent.cpp
-Modules/indexeddb/IDBTransaction.cpp
+Modules/indexeddb/IDBTransaction.cpp @cost:5
 Modules/indexeddb/IDBValue.cpp
 Modules/indexeddb/IDBVersionChangeEvent.cpp
-Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp
-Modules/indexeddb/client/IDBConnectionProxy.cpp
+Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp @cost:3
+Modules/indexeddb/client/IDBConnectionProxy.cpp @cost:3
 Modules/indexeddb/client/IDBConnectionToServer.cpp
 Modules/indexeddb/client/TransactionOperation.cpp
 Modules/indexeddb/server/IDBConnectionToClient.cpp
@@ -196,9 +196,9 @@ Modules/indexeddb/server/MemoryCursor.cpp
 Modules/indexeddb/server/MemoryIDBBackingStore.cpp
 Modules/indexeddb/server/MemoryIndex.cpp
 Modules/indexeddb/server/MemoryIndexCursor.cpp
-Modules/indexeddb/server/MemoryObjectStore.cpp
+Modules/indexeddb/server/MemoryObjectStore.cpp @cost:3
 Modules/indexeddb/server/MemoryObjectStoreCursor.cpp
-Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+Modules/indexeddb/server/SQLiteIDBBackingStore.cpp @cost:5
 Modules/indexeddb/server/SQLiteMemoryIDBBackingStore.cpp
 Modules/indexeddb/server/SQLiteIDBCursor.cpp
 Modules/indexeddb/server/SQLiteIDBTransaction.cpp
@@ -220,14 +220,14 @@ Modules/indexeddb/shared/IDBResourceIdentifier.cpp
 Modules/indexeddb/shared/IDBResultData.cpp
 Modules/indexeddb/shared/IDBTransactionInfo.cpp
 Modules/indexeddb/shared/IndexKey.cpp
-Modules/mediacapabilities/MediaCapabilities.cpp
+Modules/mediacapabilities/MediaCapabilities.cpp @cost:3
 Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
 Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
-Modules/mediacontrols/LocalDOMWindowMediaControls.cpp @header:RenderStyleGetters
-Modules/mediacontrols/MediaControlsHost.cpp @header:RenderStyleGetters
-Modules/mediacontrols/MediaControlsUtils.cpp @header:RenderStyleGetters
+Modules/mediacontrols/LocalDOMWindowMediaControls.cpp @header:RenderStyleGetters @cost:6
+Modules/mediacontrols/MediaControlsHost.cpp @header:RenderStyleGetters @cost:9
+Modules/mediacontrols/MediaControlsUtils.cpp @header:RenderStyleGetters @cost:6
 Modules/mediarecorder/BlobEvent.cpp
-Modules/mediarecorder/MediaRecorder.cpp
+Modules/mediarecorder/MediaRecorder.cpp @cost:4
 Modules/mediarecorder/MediaRecorderErrorEvent.cpp
 Modules/mediasession/MediaMetadata.cpp
 Modules/mediasession/MediaSession.cpp
@@ -238,59 +238,59 @@ Modules/mediasource/BufferedChangeEvent.cpp
 Modules/mediasource/DOMURLMediaSource.cpp
 Modules/mediasource/ManagedMediaSource.cpp
 Modules/mediasource/ManagedSourceBuffer.cpp
-Modules/mediasource/MediaSource.cpp
+Modules/mediasource/MediaSource.cpp @cost:5
 Modules/mediasource/MediaSourceHandle.cpp
 Modules/mediasource/MediaSourceInterfaceMainThread.cpp
 Modules/mediasource/MediaSourceInterfaceWorker.cpp
 Modules/mediasource/MediaSourceRegistry.cpp
 Modules/mediasource/SampleMap.cpp
-Modules/mediasource/SourceBuffer.cpp
+Modules/mediasource/SourceBuffer.cpp @cost:6
 Modules/mediasource/SourceBufferList.cpp
 Modules/mediasource/VideoPlaybackQuality.cpp
-Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
-Modules/mediastream/ImageCapture.cpp
+Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp @cost:4
+Modules/mediastream/ImageCapture.cpp @cost:4
 Modules/mediastream/InputDeviceInfo.cpp
 Modules/mediastream/MediaDeviceInfo.cpp
-Modules/mediastream/MediaDevices.cpp
-Modules/mediastream/MediaStream.cpp
-Modules/mediastream/MediaStreamTrack.cpp
+Modules/mediastream/MediaDevices.cpp @cost:4
+Modules/mediastream/MediaStream.cpp @cost:3
+Modules/mediastream/MediaStreamTrack.cpp @cost:5
 Modules/mediastream/MediaStreamTrackEvent.cpp
 Modules/mediastream/MediaStreamTrackHandle.cpp
-Modules/mediastream/MediaStreamTrackProcessor.cpp
+Modules/mediastream/MediaStreamTrackProcessor.cpp @cost:5
 Modules/mediastream/MediaTrackCapabilities.cpp
 Modules/mediastream/MediaTrackConstraints.cpp
-Modules/mediastream/NavigatorMediaDevices.cpp
+Modules/mediastream/NavigatorMediaDevices.cpp @cost:4
 Modules/mediastream/OverconstrainedErrorEvent.cpp
-Modules/mediastream/PeerConnectionBackend.cpp
+Modules/mediastream/PeerConnectionBackend.cpp @cost:5
 Modules/mediastream/RTCCertificate.cpp
-Modules/mediastream/RTCController.cpp
+Modules/mediastream/RTCController.cpp @cost:3
 Modules/mediastream/RTCDTMFSender.cpp
 Modules/mediastream/RTCDTMFToneChangeEvent.cpp
 Modules/mediastream/RTCDataChannel.cpp
 Modules/mediastream/RTCDataChannelEvent.cpp
 Modules/mediastream/RTCDataChannelRemoteHandler.cpp
 Modules/mediastream/RTCDataChannelRemoteSource.cpp
-Modules/mediastream/RTCDtlsTransport.cpp
+Modules/mediastream/RTCDtlsTransport.cpp @cost:3
 Modules/mediastream/RTCEncodedAudioFrame.cpp
-Modules/mediastream/RTCEncodedFrame.cpp
+Modules/mediastream/RTCEncodedFrame.cpp @cost:4
 Modules/mediastream/RTCEncodedVideoFrame.cpp
 Modules/mediastream/RTCError.cpp
 Modules/mediastream/RTCErrorEvent.cpp
 Modules/mediastream/RTCIceCandidate.cpp
 Modules/mediastream/RTCIceCandidateFields.cpp
-Modules/mediastream/RTCIceTransport.cpp
-Modules/mediastream/RTCPeerConnection.cpp
+Modules/mediastream/RTCIceTransport.cpp @cost:3
+Modules/mediastream/RTCPeerConnection.cpp @cost:5
 Modules/mediastream/RTCPeerConnectionIceErrorEvent.cpp
 Modules/mediastream/RTCPeerConnectionIceEvent.cpp
-Modules/mediastream/RTCRtpReceiver.cpp
-Modules/mediastream/RTCRtpSFrameTransform.cpp
+Modules/mediastream/RTCRtpReceiver.cpp @cost:3
+Modules/mediastream/RTCRtpSFrameTransform.cpp @cost:3
 Modules/mediastream/RTCRtpSFrameTransformErrorEvent.cpp
 Modules/mediastream/RTCRtpSFrameTransformer.cpp
 Modules/mediastream/RTCRtpScriptTransform.cpp
-Modules/mediastream/RTCRtpScriptTransformer.cpp
-Modules/mediastream/RTCRtpSender.cpp
-Modules/mediastream/RTCEncodedStreamProducer.cpp
-Modules/mediastream/RTCRtpTransceiver.cpp
+Modules/mediastream/RTCRtpScriptTransformer.cpp @cost:3
+Modules/mediastream/RTCRtpSender.cpp @cost:3
+Modules/mediastream/RTCEncodedStreamProducer.cpp @cost:3
+Modules/mediastream/RTCRtpTransceiver.cpp @cost:3
 Modules/mediastream/RTCRtpTransform.cpp
 Modules/mediastream/RTCSctpTransport.cpp
 Modules/mediastream/RTCSessionDescription.cpp
@@ -301,7 +301,7 @@ Modules/mediastream/STUNMessageParsing.cpp
 Modules/mediastream/UserMediaController.cpp
 Modules/mediastream/UserMediaRequest.cpp
 Modules/mediastream/VideoTrackGenerator.cpp
-Modules/model-element/HTMLModelElement.cpp @header:RenderStyleGetters
+Modules/model-element/HTMLModelElement.cpp @header:RenderStyleGetters @cost:10
 Modules/model-element/LazyLoadModelObserver.cpp
 Modules/model-element/ModelPlayer.cpp
 Modules/model-element/ModelPlayerAnimationState.cpp
@@ -735,18 +735,18 @@ bindings/js/JSExtendableMessageEventCustom.cpp
 bindings/js/JSFetchEventCustom.cpp
 bindings/js/JSHTMLAllCollectionCustom.cpp
 bindings/js/JSHTMLCanvasElementCustom.cpp
-bindings/js/JSHTMLElementCustom.cpp
+bindings/js/JSHTMLElementCustom.cpp @cost:3
 bindings/js/JSHTMLTemplateElementCustom.cpp
 bindings/js/JSHistoryCustom.cpp
 bindings/js/JSIDBCursorCustom.cpp
 bindings/js/JSIDBCursorWithValueCustom.cpp
 bindings/js/JSIDBObjectStoreCustom.cpp
 bindings/js/JSIDBRecordCustom.cpp
-bindings/js/JSIDBRequestCustom.cpp
+bindings/js/JSIDBRequestCustom.cpp @cost:3
 bindings/js/JSIDBSerializationGlobalObject.cpp
 bindings/js/JSIDBTransactionCustom.cpp
 bindings/js/JSImageDataCustom.cpp
-bindings/js/JSIntersectionObserverCustom.cpp
+bindings/js/JSIntersectionObserverCustom.cpp @cost:3
 bindings/js/JSIntersectionObserverEntryCustom.cpp
 bindings/js/JSKeyframeEffectCustom.cpp
 bindings/js/JSLazyEventListener.cpp
@@ -760,18 +760,18 @@ bindings/js/JSMutationObserverCustom.cpp
 bindings/js/JSMutationRecordCustom.cpp
 bindings/js/JSNavigateEventCustom.cpp
 bindings/js/JSNavigationCustom.cpp
-bindings/js/JSNavigatorCustom.cpp
+bindings/js/JSNavigatorCustom.cpp @cost:3
 bindings/js/JSNodeCustom.cpp
 bindings/js/JSNodeIteratorCustom.cpp
-bindings/js/JSNodeListCustom.cpp
+bindings/js/JSNodeListCustom.cpp @cost:3
 bindings/js/JSObservableArray.cpp
-bindings/js/JSOffscreenCanvasRenderingContext2DCustom.cpp
-bindings/js/JSPaintRenderingContext2DCustom.cpp
-bindings/js/JSPaintWorkletGlobalScopeCustom.cpp
+bindings/js/JSOffscreenCanvasRenderingContext2DCustom.cpp @cost:3
+bindings/js/JSPaintRenderingContext2DCustom.cpp @cost:3
+bindings/js/JSPaintWorkletGlobalScopeCustom.cpp @cost:3
 bindings/js/JSPaymentMethodChangeEventCustom.cpp
 bindings/js/JSPaymentResponseCustom.cpp
 bindings/js/JSPerformanceObserverCustom.cpp
-bindings/js/JSPluginElementFunctions.cpp
+bindings/js/JSPluginElementFunctions.cpp @cost:3
 bindings/js/JSPopStateEventCustom.cpp
 bindings/js/JSPromiseRejectionEventCustom.cpp
 bindings/js/JSRTCRtpSFrameTransformCustom.cpp
@@ -779,11 +779,11 @@ bindings/js/JSRangeCustom.cpp
 bindings/js/JSReadableStreamSourceCustom.cpp
 bindings/js/JSReportBodyCustom.cpp
 bindings/js/JSReportingObserverCustom.cpp
-bindings/js/JSResizeObserverCustom.cpp
+bindings/js/JSResizeObserverCustom.cpp @cost:3
 bindings/js/JSResizeObserverEntryCustom.cpp
 bindings/js/JSSVGViewSpecCustom.cpp
-bindings/js/JSServiceWorkerGlobalScopeCustom.cpp
-bindings/js/JSShadowRealmGlobalScopeBase.cpp
+bindings/js/JSServiceWorkerGlobalScopeCustom.cpp @cost:4
+bindings/js/JSShadowRealmGlobalScopeBase.cpp @cost:3
 bindings/js/JSShadowRootCustom.cpp
 bindings/js/JSStaticRangeCustom.cpp
 bindings/js/JSStylePropertyMapReadOnlyCustom.cpp
@@ -990,10 +990,10 @@ css/CSSSelectorList.cpp
 css/CSSStartingStyleRule.cpp
 css/CSSStringValue.cpp
 css/CSSStyleDeclaration.cpp
-css/CSSStyleProperties.cpp
+css/CSSStyleProperties.cpp @cost:3
 css/CSSStyleRule.cpp
-css/CSSStyleSheet.cpp
-css/CSSStyleSheetObservableArray.cpp
+css/CSSStyleSheet.cpp @cost:3
+css/CSSStyleSheetObservableArray.cpp @cost:4
 css/CSSSupportsRule.cpp
 css/CSSTextShadowPropertyValue.cpp
 css/CSSToLengthConversionData.cpp @header:RenderStyleGetters
@@ -1001,7 +1001,7 @@ css/CSSTransformListValue.cpp
 css/CSSURLValue.cpp
 css/CSSUnicodeRangeValue.cpp
 css/CSSUnits.cpp
-css/CSSValue.cpp
+css/CSSValue.cpp @cost:4
 css/CSSValueList.cpp
 css/CSSValuePair.cpp
 css/CSSValuePool.cpp
@@ -1013,20 +1013,20 @@ css/CSSWebkitBoxReflectValue.cpp
 css/ComputedStyleDependencies.cpp
 css/DOMCSSNamespace.cpp
 css/DOMCSSPaintWorklet.cpp
-css/DOMCSSRegisterCustomProperty.cpp
+css/DOMCSSRegisterCustomProperty.cpp @cost:3
 css/DOMMatrix.cpp
-css/DOMMatrixReadOnly.cpp
-css/FontFace.cpp
-css/FontFaceSet.cpp
+css/DOMMatrixReadOnly.cpp @cost:4
+css/FontFace.cpp @cost:5
+css/FontFaceSet.cpp @cost:3
 css/ImmutableStyleProperties.cpp
 css/MediaList.cpp
 css/MediaQueryList.cpp
 css/MediaQueryListEvent.cpp
-css/MediaQueryMatcher.cpp
+css/MediaQueryMatcher.cpp @cost:3
 css/MediaQueryParserContext.cpp
 css/MutableStyleProperties.cpp
 css/PropertySetCSSDescriptors.cpp
-css/SelectorChecker.cpp
+css/SelectorChecker.cpp @cost:6
 css/SelectorFilter.cpp
 css/ShorthandSerializer.cpp
 css/StyleAttributeMutationScope.cpp
@@ -1037,14 +1037,14 @@ css/StyleRule.cpp
 css/StyleRuleFunction.cpp
 css/StyleRuleImport.cpp
 css/StyleSheet.cpp
-css/StyleSheetContents.cpp
+css/StyleSheetContents.cpp @cost:3
 css/StyleSheetList.cpp
 css/calc/CSSCalcOperator.cpp
 css/calc/CSSCalcSymbolTable.cpp
 css/calc/CSSCalcSymbolsAllowed.cpp
 css/calc/CSSCalcTree+ComputedStyleDependencies.cpp
 css/calc/CSSCalcTree+Copy.cpp
-css/calc/CSSCalcTree+Evaluation.cpp
+css/calc/CSSCalcTree+Evaluation.cpp @cost:3
 css/calc/CSSCalcTree+Parser.cpp
 css/calc/CSSCalcTree+Serialization.cpp
 css/calc/CSSCalcTree+Simplification.cpp @header:RenderStyleGetters
@@ -1060,26 +1060,26 @@ css/deprecated-cssom/DeprecatedCSSOMValue.cpp
 css/deprecated-cssom/DeprecatedCSSOMValueList.cpp
 css/parser/CSSAtRuleID.cpp
 css/parser/CSSCustomPropertySyntax.cpp
-css/parser/CSSParser.cpp
+css/parser/CSSParser.cpp @cost:3
 css/parser/CSSParserContext.cpp
 css/parser/CSSParserFastPaths.cpp
 css/parser/CSSParserObserverWrapper.cpp
 css/parser/CSSParserToken.cpp
 css/parser/CSSParserTokenRange.cpp
-css/parser/CSSPropertyParser.cpp
+css/parser/CSSPropertyParser.cpp @cost:3
 css/parser/CSSPropertyParserConsumer+Align.cpp
 css/parser/CSSPropertyParserConsumer+Anchor.cpp
 css/parser/CSSPropertyParserConsumer+Animations.cpp
 css/parser/CSSPropertyParserConsumer+Background.cpp
 css/parser/CSSPropertyParserConsumer+Box.cpp
-css/parser/CSSPropertyParserConsumer+Color.cpp
+css/parser/CSSPropertyParserConsumer+Color.cpp @cost:7
 css/parser/CSSPropertyParserConsumer+ColorAdjust.cpp
 css/parser/CSSPropertyParserConsumer+ColorInterpolationMethod.cpp
 css/parser/CSSPropertyParserConsumer+Content.cpp
 css/parser/CSSPropertyParserConsumer+CounterStyles.cpp
 css/parser/CSSPropertyParserConsumer+Display.cpp
 css/parser/CSSPropertyParserConsumer+Easing.cpp
-css/parser/CSSPropertyParserConsumer+Filter.cpp
+css/parser/CSSPropertyParserConsumer+Filter.cpp @cost:3
 css/parser/CSSPropertyParserConsumer+Font.cpp
 css/parser/CSSPropertyParserConsumer+Grid.cpp
 css/parser/CSSPropertyParserConsumer+Ident.cpp
@@ -1299,7 +1299,7 @@ dom/DeviceOrientationAndMotionAccessController.cpp
 dom/DeviceOrientationController.cpp
 dom/DeviceOrientationData.cpp
 dom/DeviceOrientationEvent.cpp
-dom/Document.cpp @header:RenderStyleGetters
+dom/Document.cpp @header:RenderStyleGetters @cost:22
 dom/DocumentFontLoader.cpp
 dom/DocumentFragment.cpp
 dom/DocumentFullscreen.cpp
@@ -1480,7 +1480,7 @@ domjit/JSDocumentFragmentDOMJIT.cpp
 domjit/JSElementDOMJIT.cpp
 domjit/JSEventDOMJIT.cpp
 domjit/JSNodeDOMJIT.cpp
-editing/AlternativeTextController.cpp
+editing/AlternativeTextController.cpp @cost:3
 editing/AppendNodeCommand.cpp
 editing/ApplyBlockElementCommand.cpp @header:RenderStyleGetters
 editing/ApplyStyleCommand.cpp @header:RenderStyleGetters
@@ -1510,15 +1510,15 @@ editing/IndentOutdentCommand.cpp
 editing/InsertIntoTextNodeCommand.cpp
 editing/InsertLineBreakCommand.cpp @header:RenderStyleGetters
 editing/InsertListCommand.cpp @header:RenderStyleGetters
-editing/InsertNestedListCommand.cpp
+editing/InsertNestedListCommand.cpp @cost:5
 editing/InsertNodeBeforeCommand.cpp
 editing/InsertParagraphSeparatorCommand.cpp @header:RenderStyleGetters
 editing/InsertTextCommand.cpp
-editing/MarkupAccumulator.cpp
+editing/MarkupAccumulator.cpp @cost:5
 editing/MergeIdenticalElementsCommand.cpp
-editing/ModifySelectionListLevel.cpp
+editing/ModifySelectionListLevel.cpp @cost:5
 editing/MoveSelectionCommand.cpp
-editing/RemoveFormatCommand.cpp
+editing/RemoveFormatCommand.cpp @cost:5
 editing/RemoveNodeCommand.cpp
 editing/RemoveNodePreservingChildrenCommand.cpp
 editing/RenderedPosition.cpp @header:RenderStyleGetters
@@ -1527,7 +1527,7 @@ editing/ReplaceRangeWithTextCommand.cpp
 editing/ReplaceSelectionCommand.cpp @header:RenderStyleGetters
 editing/SetNodeAttributeCommand.cpp
 editing/SetSelectionCommand.cpp
-editing/SimplifyMarkupCommand.cpp
+editing/SimplifyMarkupCommand.cpp @cost:5
 editing/SmartReplace.cpp
 editing/SpellChecker.cpp
 editing/SpellingCorrectionCommand.cpp
@@ -1538,7 +1538,7 @@ editing/TextCheckingHelper.cpp
 editing/TextInsertionBaseCommand.cpp
 editing/TextIterator.cpp @header:RenderStyleGetters
 editing/TextManipulationController.cpp @header:RenderStyleGetters
-editing/TypingCommand.cpp
+editing/TypingCommand.cpp @cost:3
 editing/UnlinkCommand.cpp
 editing/VisiblePosition.cpp @header:RenderStyleGetters
 editing/VisibleSelection.cpp
@@ -1575,12 +1575,12 @@ html/BaseClickableWithKeyInputType.cpp
 html/BaseDateAndTimeInputType.cpp
 html/BaseTextInputType.cpp
 html/ButtonInputType.cpp
-html/CanvasBase.cpp @header:RenderStyleGetters
+html/CanvasBase.cpp @header:RenderStyleGetters @cost:8
 html/CanvasNoiseInjection.cpp
-html/CheckboxInputType.cpp @header:RenderStyleGetters
-html/ColorInputType.cpp @header:RenderStyleGetters
+html/CheckboxInputType.cpp @header:RenderStyleGetters @cost:6
+html/ColorInputType.cpp @header:RenderStyleGetters @cost:9
 html/CustomPaintCanvas.cpp
-html/CustomPaintImage.cpp @header:RenderStyleGetters
+html/CustomPaintImage.cpp @header:RenderStyleGetters @cost:6
 html/DOMFormData.cpp
 html/DOMTokenList.cpp
 html/DOMURL.cpp
@@ -1598,16 +1598,16 @@ html/FormListedElement.cpp
 html/GenericCachedHTMLCollection.cpp
 html/HTMLAllCollection.cpp
 html/HTMLAnchorElement.cpp
-html/HTMLAreaElement.cpp @header:RenderStyleGetters
+html/HTMLAreaElement.cpp @header:RenderStyleGetters @cost:5
 html/HTMLArticleElement.cpp
-html/HTMLAttachmentElement.cpp @header:RenderStyleGetters
+html/HTMLAttachmentElement.cpp @header:RenderStyleGetters @cost:6
 html/HTMLAudioElement.cpp
 html/HTMLBDIElement.cpp
-html/HTMLBRElement.cpp @header:RenderStyleGetters
+html/HTMLBRElement.cpp @header:RenderStyleGetters @cost:4
 html/HTMLBaseElement.cpp
 html/HTMLBodyElement.cpp
-html/HTMLButtonElement.cpp @header:RenderStyleGetters
-html/HTMLCanvasElement.cpp @header:RenderStyleGetters
+html/HTMLButtonElement.cpp @header:RenderStyleGetters @cost:5
+html/HTMLCanvasElement.cpp @header:RenderStyleGetters @cost:10
 html/HTMLCollection.cpp
 html/HTMLDListElement.cpp
 html/HTMLDataElement.cpp
@@ -1621,49 +1621,49 @@ html/HTMLElement.cpp
 html/HTMLEmbedElement.cpp
 html/HTMLFieldSetElement.cpp
 html/HTMLFontElement.cpp
-html/HTMLFormControlElement.cpp @header:RenderStyleGetters
+html/HTMLFormControlElement.cpp @header:RenderStyleGetters @cost:7
 html/HTMLFormControlsCollection.cpp
 html/HTMLFormElement.cpp
 html/HTMLFrameElement.cpp
 html/HTMLFrameElementBase.cpp
 html/HTMLFrameOwnerElement.cpp
-html/HTMLFrameSetElement.cpp @header:RenderStyleGetters
+html/HTMLFrameSetElement.cpp @header:RenderStyleGetters @cost:6
 html/HTMLHRElement.cpp
 html/HTMLHeadElement.cpp
 html/HTMLHeadingElement.cpp
 html/HTMLHtmlElement.cpp
-html/HTMLIFrameElement.cpp @header:RenderStyleGetters
-html/HTMLImageElement.cpp @header:RenderStyleGetters
+html/HTMLIFrameElement.cpp @header:RenderStyleGetters @cost:5
+html/HTMLImageElement.cpp @header:RenderStyleGetters @cost:8
 html/HTMLImageLoader.cpp
-html/HTMLInputElement.cpp @header:RenderStyleGetters
+html/HTMLInputElement.cpp @header:RenderStyleGetters @cost:9
 html/HTMLLIElement.cpp
 html/HTMLLabelElement.cpp
 html/HTMLLegendElement.cpp
 html/HTMLLinkElement.cpp
 html/HTMLMapElement.cpp
-html/HTMLMarqueeElement.cpp @header:RenderStyleGetters
+html/HTMLMarqueeElement.cpp @header:RenderStyleGetters @cost:5
 html/HTMLMaybeFormAssociatedCustomElement.cpp
-html/HTMLMediaElement.cpp @header:RenderStyleGetters
+html/HTMLMediaElement.cpp @header:RenderStyleGetters @cost:15
 html/HTMLMenuElement.cpp
 html/HTMLMetaElement.cpp
-html/HTMLMeterElement.cpp @header:RenderStyleGetters
+html/HTMLMeterElement.cpp @header:RenderStyleGetters @cost:5
 html/HTMLModElement.cpp
 html/HTMLNameCollection.cpp
 html/HTMLOListElement.cpp
 html/HTMLObjectElement.cpp
 html/HTMLOptGroupElement.cpp
-html/HTMLOptionElement.cpp @header:RenderStyleGetters
+html/HTMLOptionElement.cpp @header:RenderStyleGetters @cost:7
 html/HTMLOptionsCollection.cpp
 html/HTMLOutputElement.cpp
 html/HTMLParagraphElement.cpp
 html/HTMLParamElement.cpp
 html/HTMLPictureElement.cpp
-html/HTMLPlugInElement.cpp @header:RenderStyleGetters
+html/HTMLPlugInElement.cpp @header:RenderStyleGetters @cost:9
 html/HTMLPreElement.cpp
-html/HTMLProgressElement.cpp @header:RenderStyleGetters
+html/HTMLProgressElement.cpp @header:RenderStyleGetters @cost:6
 html/HTMLQuoteElement.cpp
 html/HTMLScriptElement.cpp
-html/HTMLSelectElement.cpp @header:RenderStyleGetters
+html/HTMLSelectElement.cpp @header:RenderStyleGetters @cost:9
 html/HTMLSelectedContentElement.cpp
 html/HTMLSlotElement.cpp
 html/HTMLSourceElement.cpp
@@ -1671,16 +1671,16 @@ html/HTMLSpanElement.cpp
 html/HTMLStyleElement.cpp
 html/HTMLSummaryElement.cpp
 html/HTMLTableCaptionElement.cpp
-html/HTMLTableCellElement.cpp @header:RenderStyleGetters
-html/HTMLTableColElement.cpp @header:RenderStyleGetters
-html/HTMLTableElement.cpp @header:RenderStyleGetters
+html/HTMLTableCellElement.cpp @header:RenderStyleGetters @cost:4
+html/HTMLTableColElement.cpp @header:RenderStyleGetters @cost:5
+html/HTMLTableElement.cpp @header:RenderStyleGetters @cost:5
 html/HTMLTablePartElement.cpp
 html/HTMLTableRowElement.cpp
 html/HTMLTableRowsCollection.cpp
 html/HTMLTableSectionElement.cpp
 html/HTMLTemplateElement.cpp
-html/HTMLTextAreaElement.cpp @header:RenderStyleGetters
-html/HTMLTextFormControlElement.cpp @header:RenderStyleGetters
+html/HTMLTextAreaElement.cpp @header:RenderStyleGetters @cost:8
+html/HTMLTextFormControlElement.cpp @header:RenderStyleGetters @cost:9
 html/HTMLTimeElement.cpp
 html/HTMLTitleElement.cpp
 html/HTMLTrackElement.cpp
@@ -1694,9 +1694,9 @@ html/ImageBitmap.cpp
 html/ImageData.cpp
 html/ImageDataArray.cpp
 html/ImageDocument.cpp
-html/ImageInputType.cpp @header:RenderStyleGetters
+html/ImageInputType.cpp @header:RenderStyleGetters @cost:5
 html/InputMode.cpp
-html/InputType.cpp @header:RenderStyleGetters
+html/InputType.cpp @header:RenderStyleGetters @cost:7
 html/InputTypeNames.cpp
 html/LabelsNodeList.cpp
 html/LazyLoadFrameObserver.cpp
@@ -1706,12 +1706,12 @@ html/LinkIconCollector.cpp
 html/LinkRelAttribute.cpp
 html/MediaController.cpp
 html/MediaDocument.cpp
-html/MediaElementSession.cpp @header:RenderStyleGetters
+html/MediaElementSession.cpp @header:RenderStyleGetters @cost:8
 html/MediaFragmentURIParser.cpp
 html/ModelDocument.cpp
 html/MonthInputType.cpp
 html/NavigatorUserActivation.cpp
-html/NumberInputType.cpp @header:RenderStyleGetters
+html/NumberInputType.cpp @header:RenderStyleGetters @cost:6
 html/OffscreenCanvas.cpp
 html/Origin.cpp
 html/PDFDocument.cpp
@@ -1721,15 +1721,15 @@ html/PluginDocument.cpp
 html/PublicURLManager.cpp
 html/RadioInputType.cpp
 html/RadioNodeList.cpp
-html/RangeInputType.cpp @header:RenderStyleGetters
+html/RangeInputType.cpp @header:RenderStyleGetters @cost:7
 html/ResetInputType.cpp
-html/SearchInputType.cpp @header:RenderStyleGetters
+html/SearchInputType.cpp @header:RenderStyleGetters @cost:6
 html/StepRange.cpp
 html/SubmitEvent.cpp
 html/SubmitInputType.cpp
 html/TelephoneInputType.cpp
 html/TextDocument.cpp
-html/TextFieldInputType.cpp @header:RenderStyleGetters
+html/TextFieldInputType.cpp @header:RenderStyleGetters @cost:9
 html/TextInputType.cpp
 html/TimeInputType.cpp
 html/TimeRanges.cpp
@@ -1740,7 +1740,7 @@ html/URLRegistry.cpp
 html/URLSearchParams.cpp
 html/UserActivation.cpp
 html/ValidatedFormListedElement.cpp
-html/ValidationMessage.cpp @header:RenderStyleGetters
+html/ValidationMessage.cpp @header:RenderStyleGetters @cost:5
 html/WeekInputType.cpp
 html/canvas/ANGLEInstancedArrays.cpp
 html/canvas/CanvasFilterContextSwitcher.cpp
@@ -1749,8 +1749,8 @@ html/canvas/CanvasLayerContextSwitcher.cpp
 html/canvas/CanvasPath.cpp
 html/canvas/CanvasPattern.cpp
 html/canvas/CanvasRenderingContext.cpp
-html/canvas/CanvasRenderingContext2D.cpp @header:RenderStyleGetters
-html/canvas/CanvasRenderingContext2DBase.cpp @header:RenderStyleGetters
+html/canvas/CanvasRenderingContext2D.cpp @header:RenderStyleGetters @cost:8
+html/canvas/CanvasRenderingContext2DBase.cpp @header:RenderStyleGetters @cost:9
 html/canvas/CanvasStyle.cpp
 html/canvas/EXTBlendMinMax.cpp
 html/canvas/EXTClipControl.cpp
@@ -1860,18 +1860,18 @@ html/parser/HTMLTokenizer.cpp
 html/parser/HTMLTreeBuilder.cpp
 html/parser/TextDocumentParser.cpp
 html/shadow/AutoFillButtonElement.cpp
-html/shadow/DataListButtonElement.cpp @header:RenderStyleGetters
+html/shadow/DataListButtonElement.cpp @header:RenderStyleGetters @cost:5
 html/shadow/DateTimeEditElement.cpp
-html/shadow/DateTimeFieldElement.cpp @header:RenderStyleGetters
+html/shadow/DateTimeFieldElement.cpp @header:RenderStyleGetters @cost:6
 html/shadow/DateTimeFieldElements.cpp
-html/shadow/DateTimeNumericFieldElement.cpp @header:RenderStyleGetters
-html/shadow/DateTimeSymbolicFieldElement.cpp @header:RenderStyleGetters
-html/shadow/MediaControlTextTrackContainerElement.cpp @header:RenderStyleGetters
-html/shadow/SelectFallbackButtonElement.cpp @header:RenderStyleGetters
-html/shadow/SelectPopoverElement.cpp @header:RenderStyleGetters
-html/shadow/SliderThumbElement.cpp @header:RenderStyleGetters
-html/shadow/SpinButtonElement.cpp @header:RenderStyleGetters
-html/shadow/TextControlInnerElements.cpp @header:RenderStyleGetters
+html/shadow/DateTimeNumericFieldElement.cpp @header:RenderStyleGetters @cost:6
+html/shadow/DateTimeSymbolicFieldElement.cpp @header:RenderStyleGetters @cost:6
+html/shadow/MediaControlTextTrackContainerElement.cpp @header:RenderStyleGetters @cost:7
+html/shadow/SelectFallbackButtonElement.cpp @header:RenderStyleGetters @cost:6
+html/shadow/SelectPopoverElement.cpp @header:RenderStyleGetters @cost:5
+html/shadow/SliderThumbElement.cpp @header:RenderStyleGetters @cost:8
+html/shadow/SpinButtonElement.cpp @header:RenderStyleGetters @cost:6
+html/shadow/TextControlInnerElements.cpp @header:RenderStyleGetters @cost:7
 html/shadow/TextPlaceholderElement.cpp
 html/track/AudioTrack.cpp
 html/track/AudioTrackConfiguration.cpp
@@ -2188,7 +2188,7 @@ mathml/MathMLTokenElement.cpp @header:RenderStyleGetters
 mathml/MathMLUnderOverElement.cpp @header:RenderStyleGetters
 mathml/MathMLUnknownElement.cpp
 page/ActivityState.cpp
-page/AutoscrollController.cpp @header:RenderStyleGetters
+page/AutoscrollController.cpp @header:RenderStyleGetters @cost:6
 page/BarProp.cpp
 page/CaptionUserPreferences.cpp
 page/Chrome.cpp
@@ -2201,43 +2201,43 @@ page/DOMTimer.cpp
 page/DOMWindow.cpp
 page/DOMWindowExtension.cpp
 page/DatabaseProvider.cpp
-page/DebugPageOverlays.cpp @header:RenderStyleGetters
+page/DebugPageOverlays.cpp @header:RenderStyleGetters @cost:6
 page/DeprecatedGlobalSettings.cpp
 page/DeviceController.cpp
 page/DiagnosticLoggingKeys.cpp
 page/DisabledAdaptations.cpp
-page/DragController.cpp @header:RenderStyleGetters
+page/DragController.cpp @header:RenderStyleGetters @cost:8
 page/EditorClient.cpp
-page/ElementTargetingController.cpp @header:RenderStyleGetters
+page/ElementTargetingController.cpp @header:RenderStyleGetters @cost:10
 page/ElementTargetingTypes.cpp
 page/EventCounts.cpp
-page/EventHandler.cpp @header:RenderStyleGetters
+page/EventHandler.cpp @header:RenderStyleGetters @cost:11
 page/EventSource.cpp
 page/FocusController.cpp
 page/Frame.cpp
 page/FrameConsoleClient.cpp
 page/FrameDestructionObserver.cpp
 page/FrameIdentifier.cpp
-page/FrameSnapshotting.cpp @header:RenderStyleGetters
+page/FrameSnapshotting.cpp @header:RenderStyleGetters @cost:6
 page/FrameTree.cpp
-page/FrameView.cpp @header:RenderStyleGetters
+page/FrameView.cpp @header:RenderStyleGetters @cost:6
 page/History.cpp
 page/ImageAnalysisQueue.cpp
-page/ImageOverlayController.cpp @header:RenderStyleGetters
+page/ImageOverlayController.cpp @header:RenderStyleGetters @cost:6
 page/IntelligenceTextEffectsSupport.cpp
-page/InteractionRegion.cpp @header:RenderStyleGetters
-page/IntersectionObserver.cpp @header:RenderStyleGetters
+page/InteractionRegion.cpp @header:RenderStyleGetters @cost:9
+page/IntersectionObserver.cpp @header:RenderStyleGetters @cost:9
 page/IntersectionObserverEntry.cpp
 page/LargestContentfulPaint.cpp
-page/LargestContentfulPaintData.cpp @header:RenderStyleGetters
+page/LargestContentfulPaintData.cpp @header:RenderStyleGetters @cost:7
 page/LocalDOMWindow.cpp
 page/LocalDOMWindowProperty.cpp
-page/LocalFrame.cpp @header:RenderStyleGetters
-page/LocalFrameView.cpp @header:RenderStyleGetters
-page/LocalFrameViewLayoutContext.cpp @header:RenderStyleGetters
+page/LocalFrame.cpp @header:RenderStyleGetters @cost:11
+page/LocalFrameView.cpp @header:RenderStyleGetters @cost:13
+page/LocalFrameViewLayoutContext.cpp @header:RenderStyleGetters @cost:8
 page/Location.cpp
 page/LoginStatus.cpp
-page/MemoryRelease.cpp @header:RenderStyleGetters
+page/MemoryRelease.cpp @header:RenderStyleGetters @cost:9
 page/MouseEventWithHitTestResults.cpp
 page/NavigateEvent.cpp
 page/Navigation.cpp
@@ -2254,8 +2254,8 @@ page/NavigatorUAData.cpp
 page/OpportunisticTaskScheduler.cpp
 page/OriginAccessEntry.cpp
 page/OriginAccessPatterns.cpp
-page/Page.cpp @header:RenderStyleGetters
-page/PageColorSampler.cpp @header:RenderStyleGetters
+page/Page.cpp @header:RenderStyleGetters @cost:16
+page/PageColorSampler.cpp @header:RenderStyleGetters @cost:6
 page/PageConfiguration.cpp
 page/PageGroup.cpp
 page/PageGroupLoadDeferrer.cpp
@@ -2280,31 +2280,31 @@ page/PerformanceTiming.cpp
 page/PerformanceUserTiming.cpp
 page/PointerCaptureController.cpp
 page/PointerLockController.cpp
-page/PrintContext.cpp @header:RenderStyleGetters
+page/PrintContext.cpp @header:RenderStyleGetters @cost:7
 page/ProcessWarming.cpp
-page/Quirks.cpp @header:RenderStyleGetters
+page/Quirks.cpp @header:RenderStyleGetters @cost:11
 page/RemoteDOMWindow.cpp
 page/RemoteFrame.cpp
 page/RemoteFrameGeometryTransformer.cpp
 page/RemoteFrameLayoutInfo.cpp
 page/RemoteFrameView.cpp
 page/RenderingUpdateScheduler.cpp
-page/ResizeObservation.cpp @header:RenderStyleGetters
+page/ResizeObservation.cpp @header:RenderStyleGetters @cost:5
 page/ResizeObserver.cpp
 page/ResourceUsageOverlay.cpp
 page/ResourceUsageThread.cpp
 page/Screen.cpp
 page/ScreenOrientation.cpp
 page/ScriptTrackingPrivacyCategory.cpp
-page/ScrollBehavior.cpp @header:RenderStyleGetters
+page/ScrollBehavior.cpp @header:RenderStyleGetters @cost:4
 page/SecurityOrigin.cpp
 page/SecurityOriginData.cpp
 page/SecurityPolicy.cpp
-page/SettingsBase.cpp @header:RenderStyleGetters
+page/SettingsBase.cpp @header:RenderStyleGetters @cost:6
 page/ShadowRealmGlobalScope.cpp
 page/ShareDataReader.cpp
-page/SpatialNavigation.cpp @header:RenderStyleGetters
-page/TextIndicator.cpp @header:RenderStyleGetters
+page/SpatialNavigation.cpp @header:RenderStyleGetters @cost:6
+page/TextIndicator.cpp @header:RenderStyleGetters @cost:6
 page/UndoItem.cpp
 page/UndoManager.cpp
 page/UserContentController.cpp
@@ -2336,12 +2336,12 @@ page/csp/ContentSecurityPolicySource.cpp
 page/csp/ContentSecurityPolicySourceList.cpp
 page/csp/ContentSecurityPolicySourceListDirective.cpp
 page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
-page/scrolling/AsyncScrollingCoordinator.cpp @header:RenderStyleGetters
-page/scrolling/ScrollAnchoringController.cpp @header:RenderStyleGetters
+page/scrolling/AsyncScrollingCoordinator.cpp @header:RenderStyleGetters @cost:6
+page/scrolling/ScrollAnchoringController.cpp @header:RenderStyleGetters @cost:6
 page/scrolling/ScrollLatchingController.cpp
-page/scrolling/ScrollSnapOffsetsInfo.cpp @header:RenderStyleGetters
+page/scrolling/ScrollSnapOffsetsInfo.cpp @header:RenderStyleGetters @cost:6
 page/scrolling/ScrollingConstraints.cpp
-page/scrolling/ScrollingCoordinator.cpp @header:RenderStyleGetters
+page/scrolling/ScrollingCoordinator.cpp @header:RenderStyleGetters @cost:6
 page/scrolling/ScrollingCoordinatorTypes.cpp
 page/scrolling/ScrollingStateFixedNode.cpp
 page/scrolling/ScrollingStateFrameHostingNode.cpp
@@ -2375,7 +2375,7 @@ page/scrolling/ScrollingTreeViewportConstrainedNode.cpp
 page/scrolling/ThreadedScrollingCoordinator.cpp
 page/scrolling/ThreadedScrollingTree.cpp
 page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
-page/text-extraction/TextExtraction.cpp @header:RenderStyleGetters
+page/text-extraction/TextExtraction.cpp @header:RenderStyleGetters @cost:12
 page/text-extraction/TextExtractionTypes.cpp
 platform/AudioDecoder.cpp
 platform/AudioEncoder.cpp
@@ -2389,7 +2389,7 @@ platform/Cursor.cpp
 platform/DateComponents.cpp
 platform/Decimal.cpp
 platform/DragData.cpp
-platform/DragImage.cpp
+platform/DragImage.cpp @cost:3
 platform/EventTrackingRegions.cpp
 platform/FileChooser.cpp
 platform/FileMonitor.cpp
@@ -2399,7 +2399,7 @@ platform/FrameRateMonitor.cpp
 platform/SelectionGeometry.cpp
 platform/StringEntropyHelpers.cpp
 platform/KeyboardScroll.cpp
-platform/KeyboardScrollingAnimator.cpp
+platform/KeyboardScrollingAnimator.cpp @cost:3
 platform/LLVMProfiling.cpp
 platform/LayoutUnit.cpp
 platform/LegacySchemeRegistry.cpp
@@ -2443,8 +2443,8 @@ platform/ScrollAnimationSmooth.cpp
 platform/ScrollAnimator.cpp
 platform/ScrollSnapAnimatorState.cpp
 platform/ScrollTypes.cpp
-platform/ScrollView.cpp
-platform/ScrollableArea.cpp
+platform/ScrollView.cpp @cost:3
+platform/ScrollableArea.cpp @cost:3
 platform/Scrollbar.cpp
 platform/ScrollbarTheme.cpp
 platform/ScrollbarThemeComposite.cpp
@@ -2480,7 +2480,7 @@ platform/VideoPixelFormat.cpp
 platform/WebCoreMainThread.cpp
 platform/WebCorePersistentCoders.cpp
 platform/Widget.cpp
-platform/animation/AcceleratedEffect.cpp
+platform/animation/AcceleratedEffect.cpp @cost:3
 platform/animation/AcceleratedEffectStack.cpp @no-unify
 platform/animation/AcceleratedEffectValues.cpp @header:RenderStyleGetters
 platform/animation/AcceleratedTimeline.cpp
@@ -2910,123 +2910,123 @@ plugins/DOMPlugin.cpp
 plugins/DOMPluginArray.cpp
 plugins/PluginData.cpp
 plugins/PluginInfoProvider.cpp
-rendering/AccessibilityRegionContext.cpp @header:RenderStyleGetters
-rendering/AncestorSubgridIterator.cpp @header:RenderStyleGetters
-rendering/AutoTableLayout.cpp @header:RenderStyleGetters
-rendering/BackgroundPainter.cpp @header:RenderStyleGetters
-rendering/BaselineAlignment.cpp @header:RenderStyleGetters
+rendering/AccessibilityRegionContext.cpp @header:RenderStyleGetters @cost:6
+rendering/AncestorSubgridIterator.cpp @header:RenderStyleGetters @cost:5
+rendering/AutoTableLayout.cpp @header:RenderStyleGetters @cost:6
+rendering/BackgroundPainter.cpp @header:RenderStyleGetters @cost:7
+rendering/BaselineAlignment.cpp @header:RenderStyleGetters @cost:4
 rendering/BidiRun.cpp
-rendering/BlockStepSizing.cpp @header:RenderStyleGetters
-rendering/BorderEdge.cpp @header:RenderStyleGetters
-rendering/BorderPainter.cpp @header:RenderStyleGetters
-rendering/BorderShape.cpp @header:RenderStyleGetters
+rendering/BlockStepSizing.cpp @header:RenderStyleGetters @cost:4
+rendering/BorderEdge.cpp @header:RenderStyleGetters @cost:4
+rendering/BorderPainter.cpp @header:RenderStyleGetters @cost:6
+rendering/BorderShape.cpp @header:RenderStyleGetters @cost:5
 rendering/BreakablePositions.cpp
-rendering/CSSFilterRenderer.cpp @header:RenderStyleGetters
-rendering/CaretRectComputation.cpp @header:RenderStyleGetters
+rendering/CSSFilterRenderer.cpp @header:RenderStyleGetters @cost:6
+rendering/CaretRectComputation.cpp @header:RenderStyleGetters @cost:6
 rendering/ClipRect.cpp
 rendering/ContentfulPaintChecker.cpp
 rendering/CounterNode.cpp
-rendering/EllipsisBoxPainter.cpp @header:RenderStyleGetters
-rendering/EventRegion.cpp @header:RenderStyleGetters
-rendering/FixedTableLayout.cpp @header:RenderStyleGetters
-rendering/FloatingObjects.cpp @header:RenderStyleGetters
-rendering/GlyphDisplayListCache.cpp @header:RenderStyleGetters
+rendering/EllipsisBoxPainter.cpp @header:RenderStyleGetters @cost:5
+rendering/EventRegion.cpp @header:RenderStyleGetters @cost:5
+rendering/FixedTableLayout.cpp @header:RenderStyleGetters @cost:5
+rendering/FloatingObjects.cpp @header:RenderStyleGetters @cost:5
+rendering/GlyphDisplayListCache.cpp @header:RenderStyleGetters @cost:5
 rendering/GlyphDisplayListCacheRemoval.cpp
-rendering/Grid.cpp @header:RenderStyleGetters
-rendering/GridBaselineAlignment.cpp @header:RenderStyleGetters
-rendering/GridLayoutFunctions.cpp @header:RenderStyleGetters
+rendering/Grid.cpp @header:RenderStyleGetters @cost:5
+rendering/GridBaselineAlignment.cpp @header:RenderStyleGetters @cost:5
+rendering/GridLayoutFunctions.cpp @header:RenderStyleGetters @cost:5
 rendering/RenderGridLayoutState.cpp
-rendering/GridMasonryLayout.cpp @header:RenderStyleGetters
-rendering/GridTrackSizingAlgorithm.cpp @header:RenderStyleGetters
+rendering/GridMasonryLayout.cpp @header:RenderStyleGetters @cost:5
+rendering/GridTrackSizingAlgorithm.cpp @header:RenderStyleGetters @cost:6
 rendering/HitTestLocation.cpp
-rendering/HitTestRequest.cpp @header:RenderStyleGetters
-rendering/HitTestResult.cpp @header:RenderStyleGetters
+rendering/HitTestRequest.cpp @header:RenderStyleGetters @cost:4
+rendering/HitTestResult.cpp @header:RenderStyleGetters @cost:7
 rendering/HitTestingTransformState.cpp
-rendering/ImageQualityController.cpp @header:RenderStyleGetters
-rendering/InlineBoxPainter.cpp @header:RenderStyleGetters
+rendering/ImageQualityController.cpp @header:RenderStyleGetters @cost:5
+rendering/InlineBoxPainter.cpp @header:RenderStyleGetters @cost:6
 rendering/LayerAncestorClippingStack.cpp
 rendering/LayerOverlapMap.cpp
 rendering/LayoutScope.cpp
-rendering/RelayoutScopeForScrollbarChange.cpp @header:RenderStyleGetters
+rendering/RelayoutScopeForScrollbarChange.cpp @header:RenderStyleGetters @cost:5
 rendering/ScrollbarUpdateScope.cpp @header:RenderStyleGetters
 rendering/LayoutDisallowedScope.cpp
 rendering/LayoutRepainter.cpp
-rendering/LegacyInlineBox.cpp @header:RenderStyleGetters
-rendering/LegacyInlineFlowBox.cpp @header:RenderStyleGetters
-rendering/LegacyInlineIterator.cpp @header:RenderStyleGetters
-rendering/LegacyInlineTextBox.cpp @header:RenderStyleGetters
-rendering/LegacyLineLayout.cpp @header:RenderStyleGetters
-rendering/LegacyRootInlineBox.cpp @header:RenderStyleGetters
-rendering/MarkedText.cpp @header:RenderStyleGetters
-rendering/MotionPath.cpp @header:RenderStyleGetters
-rendering/NinePieceImagePainter.cpp @header:RenderStyleGetters
-rendering/OrderIterator.cpp @header:RenderStyleGetters
-rendering/OutlinePainter.cpp @header:RenderStyleGetters
+rendering/LegacyInlineBox.cpp @header:RenderStyleGetters @cost:5
+rendering/LegacyInlineFlowBox.cpp @header:RenderStyleGetters @cost:6
+rendering/LegacyInlineIterator.cpp @header:RenderStyleGetters @cost:4
+rendering/LegacyInlineTextBox.cpp @header:RenderStyleGetters @cost:7
+rendering/LegacyLineLayout.cpp @header:RenderStyleGetters @cost:7
+rendering/LegacyRootInlineBox.cpp @header:RenderStyleGetters @cost:5
+rendering/MarkedText.cpp @header:RenderStyleGetters @cost:6
+rendering/MotionPath.cpp @header:RenderStyleGetters @cost:5
+rendering/NinePieceImagePainter.cpp @header:RenderStyleGetters @cost:5
+rendering/OrderIterator.cpp @header:RenderStyleGetters @cost:4
+rendering/OutlinePainter.cpp @header:RenderStyleGetters @cost:6
 rendering/PathOperation.cpp
 rendering/PointerEventsHitRules.cpp
-rendering/PositionedLayoutConstraints.cpp @header:RenderStyleGetters
-rendering/ReferencedSVGResources.cpp @header:RenderStyleGetters
+rendering/PositionedLayoutConstraints.cpp @header:RenderStyleGetters @cost:6
+rendering/ReferencedSVGResources.cpp @header:RenderStyleGetters @cost:6
 rendering/RegionContext.cpp
-rendering/RenderAttachment.cpp @header:RenderStyleGetters
-rendering/RenderBlock.cpp @header:RenderStyleGetters
-rendering/RenderBlockFlow.cpp @header:RenderStyleGetters
-rendering/RenderBox.cpp @header:RenderStyleGetters
-rendering/RenderBoxModelObject.cpp @header:RenderStyleGetters
-rendering/RenderButton.cpp @header:RenderStyleGetters
-rendering/RenderCombineText.cpp @header:RenderStyleGetters
-rendering/RenderCounter.cpp @header:RenderStyleGetters
-rendering/RenderDeprecatedFlexibleBox.cpp @header:RenderStyleGetters
-rendering/RenderElement.cpp @header:RenderStyleGetters
-rendering/RenderEmbeddedObject.cpp @header:RenderStyleGetters
-rendering/RenderFileUploadControl.cpp @header:RenderStyleGetters
-rendering/RenderFlexibleBox.cpp @header:RenderStyleGetters
-rendering/RenderFragmentContainer.cpp @header:RenderStyleGetters
-rendering/RenderFragmentContainerSet.cpp @header:RenderStyleGetters
-rendering/RenderFragmentedFlow.cpp @header:RenderStyleGetters
-rendering/RenderFrame.cpp @header:RenderStyleGetters
-rendering/RenderFrameBase.cpp @header:RenderStyleGetters
-rendering/RenderFrameSet.cpp @header:RenderStyleGetters
-rendering/RenderGeometryMap.cpp @header:RenderStyleGetters
-rendering/RenderGrid.cpp @header:RenderStyleGetters
-rendering/RenderHTMLCanvas.cpp @header:RenderStyleGetters
+rendering/RenderAttachment.cpp @header:RenderStyleGetters @cost:6
+rendering/RenderBlock.cpp @header:RenderStyleGetters @cost:8
+rendering/RenderBlockFlow.cpp @header:RenderStyleGetters @cost:8
+rendering/RenderBox.cpp @header:RenderStyleGetters @cost:10
+rendering/RenderBoxModelObject.cpp @header:RenderStyleGetters @cost:7
+rendering/RenderButton.cpp @header:RenderStyleGetters @cost:7
+rendering/RenderCombineText.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderCounter.cpp @header:RenderStyleGetters @cost:6
+rendering/RenderDeprecatedFlexibleBox.cpp @header:RenderStyleGetters @cost:7
+rendering/RenderElement.cpp @header:RenderStyleGetters @cost:12
+rendering/RenderEmbeddedObject.cpp @header:RenderStyleGetters @cost:7
+rendering/RenderFileUploadControl.cpp @header:RenderStyleGetters @cost:7
+rendering/RenderFlexibleBox.cpp @header:RenderStyleGetters @cost:7
+rendering/RenderFragmentContainer.cpp @header:RenderStyleGetters @cost:6
+rendering/RenderFragmentContainerSet.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderFragmentedFlow.cpp @header:RenderStyleGetters @cost:6
+rendering/RenderFrame.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderFrameBase.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderFrameSet.cpp @header:RenderStyleGetters @cost:6
+rendering/RenderGeometryMap.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderGrid.cpp @header:RenderStyleGetters @cost:7
+rendering/RenderHTMLCanvas.cpp @header:RenderStyleGetters @cost:6
 rendering/RenderHighlight.cpp
-rendering/RenderIFrame.cpp @header:RenderStyleGetters
-rendering/RenderImage.cpp @header:RenderStyleGetters
-rendering/RenderImageResource.cpp @header:RenderStyleGetters
-rendering/RenderInline.cpp @header:RenderStyleGetters
-rendering/RenderLayer.cpp @header:RenderStyleGetters
-rendering/RenderLayerBacking.cpp @header:RenderStyleGetters
-rendering/RenderLayerCompositor.cpp @header:RenderStyleGetters
-rendering/RenderLayerFilters.cpp @header:RenderStyleGetters
-rendering/RenderLayerModelObject.cpp @header:RenderStyleGetters
-rendering/RenderLayerSVGAdditions.cpp @header:RenderStyleGetters
-rendering/RenderLayerScrollableArea.cpp @header:RenderStyleGetters
-rendering/RenderLayoutState.cpp @header:RenderStyleGetters
-rendering/RenderLineBoxList.cpp @header:RenderStyleGetters
-rendering/RenderLineBreak.cpp @header:RenderStyleGetters
-rendering/RenderListBox.cpp @header:RenderStyleGetters
-rendering/RenderListItem.cpp @header:RenderStyleGetters
-rendering/RenderListMarker.cpp @header:RenderStyleGetters
-rendering/RenderMarquee.cpp @header:RenderStyleGetters
-rendering/RenderMedia.cpp @header:RenderStyleGetters
-rendering/RenderMenuList.cpp @header:RenderStyleGetters
-rendering/RenderMeter.cpp @header:RenderStyleGetters
+rendering/RenderIFrame.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderImage.cpp @header:RenderStyleGetters @cost:8
+rendering/RenderImageResource.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderInline.cpp @header:RenderStyleGetters @cost:7
+rendering/RenderLayer.cpp @header:RenderStyleGetters @cost:11
+rendering/RenderLayerBacking.cpp @header:RenderStyleGetters @cost:10
+rendering/RenderLayerCompositor.cpp @header:RenderStyleGetters @cost:9
+rendering/RenderLayerFilters.cpp @header:RenderStyleGetters @cost:6
+rendering/RenderLayerModelObject.cpp @header:RenderStyleGetters @cost:8
+rendering/RenderLayerSVGAdditions.cpp @header:RenderStyleGetters @cost:7
+rendering/RenderLayerScrollableArea.cpp @header:RenderStyleGetters @cost:8
+rendering/RenderLayoutState.cpp @header:RenderStyleGetters @cost:6
+rendering/RenderLineBoxList.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderLineBreak.cpp @header:RenderStyleGetters @cost:6
+rendering/RenderListBox.cpp @header:RenderStyleGetters @cost:8
+rendering/RenderListItem.cpp @header:RenderStyleGetters @cost:7
+rendering/RenderListMarker.cpp @header:RenderStyleGetters @cost:8
+rendering/RenderMarquee.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderMedia.cpp @header:RenderStyleGetters @cost:6
+rendering/RenderMenuList.cpp @header:RenderStyleGetters @cost:8
+rendering/RenderMeter.cpp @header:RenderStyleGetters @cost:5
 rendering/RenderModel.cpp
-rendering/RenderMultiColumnFlow.cpp @header:RenderStyleGetters
-rendering/RenderMultiColumnSet.cpp @header:RenderStyleGetters
-rendering/RenderMultiColumnSpannerPlaceholder.cpp @header:RenderStyleGetters
-rendering/RenderObject.cpp @header:RenderStyleGetters
-rendering/RenderProgress.cpp @header:RenderStyleGetters
-rendering/RenderQuote.cpp @header:RenderStyleGetters
-rendering/RenderReplaced.cpp @header:RenderStyleGetters
-rendering/RenderReplica.cpp @header:RenderStyleGetters
-rendering/RenderScrollbar.cpp @header:RenderStyleGetters
-rendering/RenderScrollbarPart.cpp @header:RenderStyleGetters
+rendering/RenderMultiColumnFlow.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderMultiColumnSet.cpp @header:RenderStyleGetters @cost:6
+rendering/RenderMultiColumnSpannerPlaceholder.cpp @header:RenderStyleGetters @cost:6
+rendering/RenderObject.cpp @header:RenderStyleGetters @cost:9
+rendering/RenderProgress.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderQuote.cpp @header:RenderStyleGetters @cost:6
+rendering/RenderReplaced.cpp @header:RenderStyleGetters @cost:8
+rendering/RenderReplica.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderScrollbar.cpp @header:RenderStyleGetters @cost:7
+rendering/RenderScrollbarPart.cpp @header:RenderStyleGetters @cost:5
 rendering/RenderScrollbarTheme.cpp
-rendering/RenderSearchField.cpp @header:RenderStyleGetters
-rendering/RenderSelection.cpp @header:RenderStyleGetters
+rendering/RenderSearchField.cpp @header:RenderStyleGetters @cost:7
+rendering/RenderSelection.cpp @header:RenderStyleGetters @cost:6
 rendering/RenderSelectionGeometry.cpp
-rendering/RenderSlider.cpp @header:RenderStyleGetters
+rendering/RenderSlider.cpp @header:RenderStyleGetters @cost:6
 rendering/RenderTable.cpp @header:RenderStyleGetters
 rendering/RenderTableCaption.cpp @header:RenderStyleGetters
 rendering/RenderTableCell.cpp @header:RenderStyleGetters
@@ -3193,106 +3193,106 @@ storage/StorageEventDispatcher.cpp
 storage/StorageMap.cpp
 storage/StorageNamespaceProvider.cpp
 storage/StorageUtilities.cpp
-style/AnchorPositionEvaluator.cpp @header:RenderStyleGetters
-style/AttributeChangeInvalidation.cpp
-style/ChildChangeInvalidation.cpp @header:RenderStyleGetters
-style/ClassChangeInvalidation.cpp
-style/ContainerQueryEvaluator.cpp @header:RenderStyleGetters
+style/AnchorPositionEvaluator.cpp @header:RenderStyleGetters @cost:8
+style/AttributeChangeInvalidation.cpp @cost:4
+style/ChildChangeInvalidation.cpp @header:RenderStyleGetters @cost:5
+style/ClassChangeInvalidation.cpp @cost:4
+style/ContainerQueryEvaluator.cpp @header:RenderStyleGetters @cost:5
 style/CustomFunctionRegistry.cpp
-style/ElementRuleCollector.cpp
+style/ElementRuleCollector.cpp @cost:6
 style/HasSelectorFilter.cpp
-style/IdChangeInvalidation.cpp
-style/InlineTextBoxStyle.cpp @header:RenderStyleGetters
+style/IdChangeInvalidation.cpp @cost:3
+style/InlineTextBoxStyle.cpp @header:RenderStyleGetters @cost:6
 style/InspectorCSSOMWrappers.cpp
-style/MatchResultCache.cpp @header:RenderStyleGetters
-style/MatchedDeclarationsCache.cpp @header:RenderStyleGetters
+style/MatchResultCache.cpp @header:RenderStyleGetters @cost:5
+style/MatchedDeclarationsCache.cpp @header:RenderStyleGetters @cost:6
 style/PageRuleCollector.cpp
 style/PropertyAllowlist.cpp
-style/PropertyCascade.cpp
-style/PseudoClassChangeInvalidation.cpp
+style/PropertyCascade.cpp @cost:3
+style/PseudoClassChangeInvalidation.cpp @cost:3
 style/PseudoElementUtilities.cpp
 style/ResolvedScopedName.cpp
 style/RuleData.cpp
 style/RuleFeature.cpp
 style/RuleSet.cpp
-style/RuleSetBuilder.cpp
+style/RuleSetBuilder.cpp @cost:3
 style/ScopedName.cpp
-style/StyleAdjuster.cpp @header:RenderStyleGetters
-style/StyleBuilder.cpp @header:RenderStyleGetters
-style/StyleBuilderState.cpp @header:RenderStyleGetters
-style/StyleChange.cpp @header:RenderStyleGetters
-style/StyleChangedAnimatableProperties.cpp @header:RenderStyleGetters
-style/StyleColorResolver.cpp @header:RenderStyleGetters
+style/StyleAdjuster.cpp @header:RenderStyleGetters @cost:9
+style/StyleBuilder.cpp @header:RenderStyleGetters @cost:7
+style/StyleBuilderState.cpp @header:RenderStyleGetters @cost:8
+style/StyleChange.cpp @header:RenderStyleGetters @cost:4
+style/StyleChangedAnimatableProperties.cpp @header:RenderStyleGetters @cost:4
+style/StyleColorResolver.cpp @header:RenderStyleGetters @cost:4
 style/StyleCustomProperty.cpp
-style/StyleCustomPropertyRegistry.cpp @header:RenderStyleGetters
-style/StyleDifference.cpp @header:RenderStyleGetters
-style/StyleExtractor.cpp @header:RenderStyleGetters
-style/StyleFontSizeFunctions.cpp @header:RenderStyleGetters
-style/StyleInterpolation.cpp @header:RenderStyleGetters
-style/StyleInvalidator.cpp
+style/StyleCustomPropertyRegistry.cpp @header:RenderStyleGetters @cost:6
+style/StyleDifference.cpp @header:RenderStyleGetters @cost:5
+style/StyleExtractor.cpp @header:RenderStyleGetters @cost:6
+style/StyleFontSizeFunctions.cpp @header:RenderStyleGetters @cost:5
+style/StyleInterpolation.cpp @header:RenderStyleGetters @cost:6
+style/StyleInvalidator.cpp @cost:4
 style/StyleLocalPropertyRegistry.cpp
 style/StyleNameScope.cpp
-style/StylePendingResources.cpp @header:RenderStyleGetters
-style/StyleRelations.cpp @header:RenderStyleGetters
-style/StyleResolveForDocument.cpp @header:RenderStyleGetters
+style/StylePendingResources.cpp @header:RenderStyleGetters @cost:5
+style/StyleRelations.cpp @header:RenderStyleGetters @cost:5
+style/StyleResolveForDocument.cpp @header:RenderStyleGetters @cost:7
 style/StyleResolveForFont.cpp
-style/StyleResolver.cpp @header:RenderStyleGetters
-style/StyleScope.cpp @header:RenderStyleGetters
+style/StyleResolver.cpp @header:RenderStyleGetters @cost:9
+style/StyleScope.cpp @header:RenderStyleGetters @cost:10
 style/StyleScopeRuleSets.cpp
 style/StyleSheetContentsCache.cpp
-style/StyleSubstitutionResolver.cpp @header:RenderStyleGetters
-style/StyleTransformResolver.cpp
-style/StyleTreeResolver.cpp @header:RenderStyleGetters
+style/StyleSubstitutionResolver.cpp @header:RenderStyleGetters @cost:6
+style/StyleTransformResolver.cpp @cost:4
+style/StyleTreeResolver.cpp @header:RenderStyleGetters @cost:9
 style/StyleUpdate.cpp
-style/Styleable.cpp @header:RenderStyleGetters
-style/UserAgentStyle.cpp @header:RenderStyleGetters
-style/calc/StyleCalculationTree+Conversion.cpp @header:RenderStyleGetters
+style/Styleable.cpp @header:RenderStyleGetters @cost:7
+style/UserAgentStyle.cpp @header:RenderStyleGetters @cost:6
+style/calc/StyleCalculationTree+Conversion.cpp @header:RenderStyleGetters @cost:7
 style/calc/StyleCalculationTree+Copy.cpp
 style/calc/StyleCalculationTree+Evaluation.cpp
 style/calc/StyleCalculationTree.cpp
 style/calc/StyleCalculationValue.cpp
 style/calc/StyleCalculationValueMap.cpp
-style/computed/data/StyleAppleColorFilterData.cpp
-style/computed/data/StyleBackdropFilterData.cpp
-style/computed/data/StyleBackgroundData.cpp
-style/computed/data/StyleBorderImageData.cpp
-style/computed/data/StyleBoxData.cpp
+style/computed/data/StyleAppleColorFilterData.cpp @cost:5
+style/computed/data/StyleBackdropFilterData.cpp @cost:5
+style/computed/data/StyleBackgroundData.cpp @cost:5
+style/computed/data/StyleBorderImageData.cpp @cost:4
+style/computed/data/StyleBoxData.cpp @cost:5
 style/computed/data/StyleCustomPropertyData.cpp
-style/computed/data/StyleDeprecatedFlexibleBoxData.cpp
-style/computed/data/StyleFilterData.cpp
-style/computed/data/StyleFlexibleBoxData.cpp
-style/computed/data/StyleFontData.cpp
-style/computed/data/StyleGridData.cpp
-style/computed/data/StyleGridItemData.cpp
-style/computed/data/StyleInheritedData.cpp
-style/computed/data/StyleInheritedRareData.cpp
-style/computed/data/StyleMarqueeData.cpp
-style/computed/data/StyleMaskBorderData.cpp
-style/computed/data/StyleMultiColumnData.cpp
-style/computed/data/StyleNonInheritedData.cpp
-style/computed/data/StyleNonInheritedMiscData.cpp
-style/computed/data/StyleNonInheritedRareData.cpp
-style/computed/data/StyleSVGData.cpp
-style/computed/data/StyleSVGFillData.cpp
-style/computed/data/StyleSVGLayoutData.cpp
-style/computed/data/StyleSVGMarkerResourceData.cpp
-style/computed/data/StyleSVGNonInheritedMiscData.cpp
-style/computed/data/StyleSVGShadowData.cpp
-style/computed/data/StyleSVGStopData.cpp
-style/computed/data/StyleSVGStrokeData.cpp
+style/computed/data/StyleDeprecatedFlexibleBoxData.cpp @cost:5
+style/computed/data/StyleFilterData.cpp @cost:5
+style/computed/data/StyleFlexibleBoxData.cpp @cost:5
+style/computed/data/StyleFontData.cpp @cost:5
+style/computed/data/StyleGridData.cpp @cost:5
+style/computed/data/StyleGridItemData.cpp @cost:5
+style/computed/data/StyleInheritedData.cpp @cost:5
+style/computed/data/StyleInheritedRareData.cpp @cost:6
+style/computed/data/StyleMarqueeData.cpp @cost:5
+style/computed/data/StyleMaskBorderData.cpp @cost:5
+style/computed/data/StyleMultiColumnData.cpp @cost:5
+style/computed/data/StyleNonInheritedData.cpp @cost:5
+style/computed/data/StyleNonInheritedMiscData.cpp @cost:6
+style/computed/data/StyleNonInheritedRareData.cpp @cost:8
+style/computed/data/StyleSVGData.cpp @cost:5
+style/computed/data/StyleSVGFillData.cpp @cost:5
+style/computed/data/StyleSVGLayoutData.cpp @cost:5
+style/computed/data/StyleSVGMarkerResourceData.cpp @cost:5
+style/computed/data/StyleSVGNonInheritedMiscData.cpp @cost:5
+style/computed/data/StyleSVGShadowData.cpp @cost:5
+style/computed/data/StyleSVGStopData.cpp @cost:5
+style/computed/data/StyleSVGStrokeData.cpp @cost:5
 style/computed/data/StyleSurroundData.cpp
-style/computed/data/StyleTransformData.cpp
-style/computed/data/StyleVisitedLinkColorData.cpp
-style/computed/StyleComputedStyle.cpp
-style/computed/StyleComputedStyleBase.cpp @header:RenderStyleGetters
-style/computed/StyleComputedStyleProperties+GettersCustom.cpp @header:RenderStyleGetters
-style/computed/StyleComputedStyleProperties+InitialCustom.cpp @header:RenderStyleGetters
+style/computed/data/StyleTransformData.cpp @cost:5
+style/computed/data/StyleVisitedLinkColorData.cpp @cost:5
+style/computed/StyleComputedStyle.cpp @cost:5
+style/computed/StyleComputedStyleBase.cpp @header:RenderStyleGetters @cost:6
+style/computed/StyleComputedStyleProperties+GettersCustom.cpp @header:RenderStyleGetters @cost:5
+style/computed/StyleComputedStyleProperties+InitialCustom.cpp @header:RenderStyleGetters @cost:4
 style/values/align/StyleAlignContent.cpp
 style/values/align/StyleAlignItems.cpp
-style/values/align/StyleAlignSelf.cpp @header:RenderStyleGetters
+style/values/align/StyleAlignSelf.cpp @header:RenderStyleGetters @cost:5
 style/values/align/StyleJustifyContent.cpp
 style/values/align/StyleJustifyItems.cpp
-style/values/align/StyleJustifySelf.cpp @header:RenderStyleGetters
+style/values/align/StyleJustifySelf.cpp @header:RenderStyleGetters @cost:5
 style/values/anchor-position/StylePositionAnchor.cpp
 style/values/anchor-position/StylePositionAreaAxis.cpp
 style/values/anchor-position/StylePositionAreaSelf.cpp
@@ -3312,17 +3312,17 @@ style/values/backgrounds/StyleBorderImageRepeat.cpp
 style/values/backgrounds/StyleBorderImageSlice.cpp
 style/values/backgrounds/StyleBorderImageSource.cpp
 style/values/backgrounds/StyleBorderImageWidth.cpp
-style/values/backgrounds/StyleBorderImage.cpp
-style/values/backgrounds/StyleLineWidth.cpp @header:RenderStyleGetters
+style/values/backgrounds/StyleBorderImage.cpp @cost:5
+style/values/backgrounds/StyleLineWidth.cpp @header:RenderStyleGetters @cost:5
 style/values/backgrounds/StyleRepeatStyle.cpp
 style/values/borders/StyleBorderRadius.cpp
-style/values/borders/StyleBoxShadow.cpp @header:RenderStyleGetters
+style/values/borders/StyleBoxShadow.cpp @header:RenderStyleGetters @cost:5
 style/values/borders/StyleCornerShapeValue.cpp
 style/values/box/StyleMarginTrim.cpp
 style/values/break/StyleOrphans.cpp
 style/values/break/StyleWidows.cpp
 style/values/color-adjust/StyleColorScheme.cpp
-style/values/color/StyleColor.cpp @header:RenderStyleGetters
+style/values/color/StyleColor.cpp @header:RenderStyleGetters @cost:9
 style/values/color/StyleColorLayers.cpp
 style/values/color/StyleColorMix.cpp
 style/values/color/StyleColorOptions.cpp
@@ -3331,14 +3331,14 @@ style/values/color/StyleCurrentColor.cpp
 style/values/color/StyleDynamicRangeLimit.cpp
 style/values/color/StyleDynamicRangeLimitMix.cpp
 style/values/color/StyleHexColor.cpp
-style/values/color/StyleKeywordColor.cpp @header:RenderStyleGetters
+style/values/color/StyleKeywordColor.cpp @header:RenderStyleGetters @cost:5
 style/values/color/StyleLightDarkColor.cpp
 style/values/color/StyleOpacity.cpp
 style/values/color/StyleRelativeAlphaColor.cpp
 style/values/color/StyleResolvedColor.cpp
 style/values/contain/StyleContain.cpp
 style/values/contain/StyleContainerType.cpp
-style/values/content/StyleContent.cpp @header:RenderStyleGetters
+style/values/content/StyleContent.cpp @header:RenderStyleGetters @cost:6
 style/values/content/StyleQuotes.cpp
 style/values/counter-styles/StyleCounterStyle.cpp
 style/values/css2/StyleZIndex.cpp
@@ -3354,7 +3354,7 @@ style/values/filter-effects/StyleAppleInvertLightnessFunction.cpp
 style/values/filter-effects/StyleBlurFunction.cpp
 style/values/filter-effects/StyleBrightnessFunction.cpp
 style/values/filter-effects/StyleContrastFunction.cpp
-style/values/filter-effects/StyleDropShadowFunction.cpp @header:RenderStyleGetters
+style/values/filter-effects/StyleDropShadowFunction.cpp @header:RenderStyleGetters @cost:5
 style/values/filter-effects/StyleFilter.cpp
 style/values/filter-effects/StyleFilterReference.cpp
 style/values/filter-effects/StyleGrayscaleFunction.cpp
@@ -3368,44 +3368,44 @@ style/values/fonts/StyleFontFamily.cpp
 style/values/fonts/StyleFontFamilyName.cpp
 style/values/fonts/StyleFontFeatureSettings.cpp
 style/values/fonts/StyleFontPalette.cpp
-style/values/fonts/StyleFontSizeAdjust.cpp @header:RenderStyleGetters
+style/values/fonts/StyleFontSizeAdjust.cpp @header:RenderStyleGetters @cost:5
 style/values/fonts/StyleFontStyle.cpp
 style/values/fonts/StyleFontVariantAlternates.cpp
 style/values/fonts/StyleFontVariantEastAsian.cpp
 style/values/fonts/StyleFontVariantLigatures.cpp
 style/values/fonts/StyleFontVariantNumeric.cpp
 style/values/fonts/StyleFontVariationSettings.cpp
-style/values/fonts/StyleFontWeight.cpp @header:RenderStyleGetters
+style/values/fonts/StyleFontWeight.cpp @header:RenderStyleGetters @cost:5
 style/values/fonts/StyleFontWidth.cpp
 style/values/grid/StyleGridAutoFlow.cpp
 style/values/grid/StyleGridLineNames.cpp
 style/values/grid/StyleGridNamedLinesMap.cpp
 style/values/grid/StyleGridPosition.cpp
-style/values/grid/StyleGridPositionsResolver.cpp @header:RenderStyleGetters
+style/values/grid/StyleGridPositionsResolver.cpp @header:RenderStyleGetters @cost:5
 style/values/grid/StyleGridTemplateAreas.cpp
-style/values/grid/StyleGridTemplateList.cpp @header:RenderStyleGetters
+style/values/grid/StyleGridTemplateList.cpp @header:RenderStyleGetters @cost:6
 style/values/grid/StyleGridTrackBreadth.cpp
 style/values/grid/StyleGridTrackSize.cpp
 style/values/grid/StyleGridTrackSizes.cpp
 style/values/grid/StyleFlowTolerance.cpp
-style/values/images/kinds/StyleCachedImage.cpp @header:RenderStyleGetters
-style/values/images/kinds/StyleCanvasImage.cpp @header:RenderStyleGetters
+style/values/images/kinds/StyleCachedImage.cpp @header:RenderStyleGetters @cost:6
+style/values/images/kinds/StyleCanvasImage.cpp @header:RenderStyleGetters @cost:6
 style/values/images/kinds/StyleCrossfadeImage.cpp
 style/values/images/kinds/StyleCursorImage.cpp
-style/values/images/kinds/StyleFilterImage.cpp @header:RenderStyleGetters
-style/values/images/kinds/StyleGeneratedImage.cpp @header:RenderStyleGetters
-style/values/images/kinds/StyleGradientImage.cpp @header:RenderStyleGetters
+style/values/images/kinds/StyleFilterImage.cpp @header:RenderStyleGetters @cost:6
+style/values/images/kinds/StyleGeneratedImage.cpp @header:RenderStyleGetters @cost:6
+style/values/images/kinds/StyleGradientImage.cpp @header:RenderStyleGetters @cost:6
 style/values/images/kinds/StyleImageSet.cpp
 style/values/images/kinds/StyleInvalidImage.cpp
 style/values/images/kinds/StyleMultiImage.cpp
 style/values/images/kinds/StyleColorImage.cpp
 style/values/images/kinds/StyleNamedImage.cpp
-style/values/images/kinds/StylePaintImage.cpp @header:RenderStyleGetters
-style/values/images/StyleGradient.cpp @header:RenderStyleGetters
+style/values/images/kinds/StylePaintImage.cpp @header:RenderStyleGetters @cost:6
+style/values/images/StyleGradient.cpp @header:RenderStyleGetters @cost:6
 style/values/images/StyleImageOrNone.cpp
 style/values/images/StyleImageOrientation.cpp
 style/values/images/StyleImageWrapper.cpp
-style/values/inline/StyleLineHeight.cpp @header:RenderStyleGetters
+style/values/inline/StyleLineHeight.cpp @header:RenderStyleGetters @cost:5
 style/values/inline/StyleVerticalAlign.cpp
 style/values/inline/StyleWebKitInitialLetter.cpp
 style/values/lists/StyleCounterIncrement.cpp
@@ -3422,7 +3422,7 @@ style/values/masking/StyleMaskBorderWidth.cpp
 style/values/masking/StyleMaskBorder.cpp
 style/values/masking/StyleMaskLayer.cpp
 style/values/masking/StyleMaskMode.cpp
-style/values/math/StyleMathDepth.cpp @header:RenderStyleGetters
+style/values/math/StyleMathDepth.cpp @header:RenderStyleGetters @cost:5
 style/values/motion/StyleOffsetAnchor.cpp
 style/values/motion/StyleOffsetPath.cpp
 style/values/motion/StyleOffsetPosition.cpp
@@ -3440,10 +3440,10 @@ style/values/overflow/StyleOverflowClipMargin.cpp
 style/values/page/StylePageSize.cpp
 style/values/pointerevents/StyleTouchAction.cpp
 style/values/primitives/StyleCustomIdent.cpp
-style/values/primitives/StyleLengthResolution.cpp @header:RenderStyleGetters
+style/values/primitives/StyleLengthResolution.cpp @header:RenderStyleGetters @cost:6
 style/values/primitives/StyleLengthWrapperData.cpp
 style/values/primitives/StylePosition.cpp
-style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp @header:RenderStyleGetters
+style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp @header:RenderStyleGetters @cost:5
 style/values/primitives/StyleRatio.cpp
 style/values/primitives/StyleString.cpp
 style/values/primitives/StyleURL.cpp
@@ -3464,7 +3464,7 @@ style/values/shapes/StyleBasicShape.cpp
 style/values/shapes/StyleCircleFunction.cpp
 style/values/shapes/StyleEllipseFunction.cpp
 style/values/shapes/StyleInsetFunction.cpp
-style/values/shapes/StylePathFunction.cpp @header:RenderStyleGetters
+style/values/shapes/StylePathFunction.cpp @header:RenderStyleGetters @cost:5
 style/values/shapes/StylePathOperationWrappers.cpp
 style/values/shapes/StylePolygonFunction.cpp
 style/values/shapes/StyleRectFunction.cpp
@@ -3472,29 +3472,29 @@ style/values/shapes/StyleShapeFunction.cpp
 style/values/shapes/StyleShapeOutside.cpp
 style/values/shapes/StyleXywhFunction.cpp
 style/values/size-adjust/StyleTextSizeAdjust.cpp
-style/values/sizing/StyleAspectRatio.cpp @header:RenderStyleGetters
+style/values/sizing/StyleAspectRatio.cpp @header:RenderStyleGetters @cost:5
 style/values/sizing/StyleContainIntrinsicSize.cpp
 style/values/sizing/StylePreferredSize.cpp
 style/values/speech/StyleSpeakAs.cpp
 style/values/svg/StyleSVGBaselineShift.cpp
 style/values/svg/StyleSVGGlyphOrientationVertical.cpp
-style/values/svg/StyleSVGPaint.cpp @header:RenderStyleGetters
+style/values/svg/StyleSVGPaint.cpp @header:RenderStyleGetters @cost:6
 style/values/svg/StyleSVGPaintOrder.cpp
 style/values/svg/StyleSVGPathData.cpp
 style/values/svg/StyleSVGStrokeDasharray.cpp
 style/values/svg/StyleSVGStrokeDashoffset.cpp
 style/values/text-decoration/StyleTextDecorationLine.cpp
-style/values/text-decoration/StyleTextDecorationThickness.cpp @header:RenderStyleGetters
+style/values/text-decoration/StyleTextDecorationThickness.cpp @header:RenderStyleGetters @cost:5
 style/values/text-decoration/StyleTextEmphasisPosition.cpp
 style/values/text-decoration/StyleTextEmphasisStyle.cpp
-style/values/text-decoration/StyleTextShadow.cpp @header:RenderStyleGetters
-style/values/text-decoration/StyleTextUnderlineOffset.cpp @header:RenderStyleGetters
+style/values/text-decoration/StyleTextShadow.cpp @header:RenderStyleGetters @cost:5
+style/values/text-decoration/StyleTextUnderlineOffset.cpp @header:RenderStyleGetters @cost:5
 style/values/text-decoration/StyleTextUnderlinePosition.cpp
 style/values/text/StyleHangingPunctuation.cpp
 style/values/text/StyleLetterSpacing.cpp @header:RenderStyleGetters
 style/values/text/StyleTabSize.cpp
-style/values/text/StyleTextAlign.cpp @header:RenderStyleGetters
-style/values/text/StyleTextAlignLast.cpp @header:RenderStyleGetters
+style/values/text/StyleTextAlign.cpp @header:RenderStyleGetters @cost:5
+style/values/text/StyleTextAlignLast.cpp @header:RenderStyleGetters @cost:5
 style/values/text/StyleTextAutospace.cpp
 style/values/text/StyleTextIndent.cpp
 style/values/text/StyleTextTransform.cpp
@@ -3511,7 +3511,7 @@ style/values/transforms/StylePerspective.cpp
 style/values/transforms/StyleRotate.cpp
 style/values/transforms/StyleScale.cpp
 style/values/transforms/StyleTransform.cpp
-style/values/transforms/StyleTransformFunction.cpp @header:RenderStyleGetters
+style/values/transforms/StyleTransformFunction.cpp @header:RenderStyleGetters @cost:6
 style/values/transforms/StyleTransformList.cpp
 style/values/transforms/StyleTranslate.cpp
 style/values/transitions/StyleSingleTransitionProperty.cpp
@@ -3665,18 +3665,18 @@ workers/AbstractWorker.cpp
 workers/DedicatedWorkerGlobalScope.cpp
 workers/DedicatedWorkerThread.cpp
 workers/ScriptBuffer.cpp
-workers/Worker.cpp
+workers/Worker.cpp @cost:3
 workers/WorkerAnimationController.cpp
-workers/WorkerConsoleClient.cpp
+workers/WorkerConsoleClient.cpp @cost:6
 workers/WorkerEventLoop.cpp
 workers/WorkerFontLoadRequest.cpp
-workers/WorkerGlobalScope.cpp
-workers/WorkerInspectorProxy.cpp
+workers/WorkerGlobalScope.cpp @cost:5
+workers/WorkerInspectorProxy.cpp @cost:3
 workers/WorkerLocation.cpp
-workers/WorkerMessagingProxy.cpp
+workers/WorkerMessagingProxy.cpp @cost:3
 workers/WorkerNotificationClient.cpp
 workers/WorkerOrWorkletGlobalScope.cpp
-workers/WorkerOrWorkletScriptController.cpp
+workers/WorkerOrWorkletScriptController.cpp @cost:6
 workers/WorkerOrWorkletThread.cpp
 workers/WorkerRunLoop.cpp
 workers/WorkerSTWParticipation.cpp
@@ -3685,17 +3685,17 @@ workers/WorkerThread.cpp
 workers/service/ExtendableEvent.cpp
 workers/service/ExtendableMessageEvent.cpp
 workers/service/FetchEvent.cpp
-workers/service/InstallEvent.cpp
+workers/service/InstallEvent.cpp @cost:4
 workers/service/NavigationPreloadManager.cpp
 workers/service/SWClientConnection.cpp
 workers/service/ServiceWorker.cpp
 workers/service/ServiceWorkerClient.cpp
 workers/service/ServiceWorkerClientData.cpp
-workers/service/ServiceWorkerClients.cpp
-workers/service/ServiceWorkerContainer.cpp
+workers/service/ServiceWorkerClients.cpp @cost:3
+workers/service/ServiceWorkerContainer.cpp @cost:4
 workers/service/ServiceWorkerContextData.cpp
 workers/service/ServiceWorkerData.cpp
-workers/service/ServiceWorkerGlobalScope.cpp
+workers/service/ServiceWorkerGlobalScope.cpp @cost:3
 workers/service/ServiceWorkerJob.cpp
 workers/service/ServiceWorkerJobData.cpp
 workers/service/ServiceWorkerProvider.cpp
@@ -3705,25 +3705,25 @@ workers/service/ServiceWorkerRegistrationKey.cpp
 workers/service/ServiceWorkerRegistrationOptions.cpp
 workers/service/ServiceWorkerRoute.cpp
 workers/service/ServiceWorkerWindowClient.cpp
-workers/service/WorkerSWClientConnection.cpp
+workers/service/WorkerSWClientConnection.cpp @cost:3
 workers/service/background-fetch/BackgroundFetch.cpp
 workers/service/background-fetch/BackgroundFetchEngine.cpp
 workers/service/background-fetch/BackgroundFetchEvent.cpp
 workers/service/background-fetch/BackgroundFetchManager.cpp
 workers/service/background-fetch/BackgroundFetchRecord.cpp
-workers/service/background-fetch/BackgroundFetchRegistration.cpp
+workers/service/background-fetch/BackgroundFetchRegistration.cpp @cost:3
 workers/service/background-fetch/BackgroundFetchUpdateUIEvent.cpp
 workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.cpp
 workers/service/context/SWContextManager.cpp
 workers/service/context/ServiceWorkerDebuggable.cpp
 workers/service/context/ServiceWorkerFetch.cpp
 workers/service/context/ServiceWorkerInspectorProxy.cpp
-workers/service/context/ServiceWorkerThread.cpp
-workers/service/context/ServiceWorkerThreadProxy.cpp
+workers/service/context/ServiceWorkerThread.cpp @cost:3
+workers/service/context/ServiceWorkerThreadProxy.cpp @cost:4
 workers/service/server/SWOriginStore.cpp
 workers/service/server/SWRegistrationDatabase.cpp
 workers/service/server/SWScriptStorage.cpp
-workers/service/server/SWServer.cpp
+workers/service/server/SWServer.cpp @cost:3
 workers/service/server/SWServerJobQueue.cpp
 workers/service/server/SWServerRegistration.cpp
 workers/service/server/SWServerToContextConnection.cpp
@@ -3735,7 +3735,7 @@ workers/shared/SharedWorkerProvider.cpp
 workers/shared/SharedWorkerScriptLoader.cpp
 workers/shared/context/SharedWorkerContextManager.cpp
 workers/shared/context/SharedWorkerThread.cpp
-workers/shared/context/SharedWorkerThreadProxy.cpp
+workers/shared/context/SharedWorkerThreadProxy.cpp @cost:3
 worklets/PaintWorkletGlobalScope.cpp
 worklets/Worklet.cpp
 worklets/WorkletGlobalScope.cpp
@@ -3794,16 +3794,16 @@ JSMathMLElementWrapperFactory.cpp
 JSSVGElementWrapperFactory.cpp
 MathMLElementFactory.cpp
 RenderStyleProperties.cpp
-SVGElementFactory.cpp
-StyleBuilderGenerated.cpp
-StyleChangedAnimatablePropertiesGenerated.cpp
-StyleComputedStyleProperties.cpp
-StyleExtractorGenerated.cpp
-StyleInterpolationWrapperMap.cpp
+SVGElementFactory.cpp @cost:4
+StyleBuilderGenerated.cpp @cost:13
+StyleChangedAnimatablePropertiesGenerated.cpp @cost:6
+StyleComputedStyleProperties.cpp @cost:6
+StyleExtractorGenerated.cpp @cost:17
+StyleInterpolationWrapperMap.cpp @cost:16
 StylePropertyShorthandFunctions.cpp
 UserAgentStyleSheetsData.cpp
-WebCoreJSBuiltinInternals.cpp
-WebCoreJSBuiltins.cpp
+WebCoreJSBuiltinInternals.cpp @cost:4
+WebCoreJSBuiltins.cpp @cost:4
 
 // IDL bindings
 // FIXME: We should probably move these into ${DerivedSources}/bindings/js/ so they get bundled with the custom bindings.
@@ -3976,7 +3976,7 @@ JSCSSStyleDeclaration.cpp
 JSCSSStyleImageValue.cpp
 JSCSSStyleProperties.cpp
 JSCSSStyleRule.cpp
-JSCSSStyleSheet.cpp
+JSCSSStyleSheet.cpp @cost:3
 JSCSSStyleValue.cpp
 JSCSSSupportsRule.cpp
 JSCSSTransformComponent.cpp
@@ -4639,7 +4639,7 @@ JSMutationRecord.cpp
 JSNVShaderNoperspectiveInterpolation.cpp
 JSNamedNodeMap.cpp
 JSNavigateEvent.cpp
-JSNavigation.cpp
+JSNavigation.cpp @cost:3
 JSNavigationActivation.cpp
 JSNavigationCurrentEntryChangeEvent.cpp
 JSNavigationDestination.cpp
@@ -5050,13 +5050,13 @@ JSServiceWorker.cpp
 JSServiceWorkerClient.cpp
 JSServiceWorkerClientType.cpp
 JSServiceWorkerClients.cpp
-JSServiceWorkerContainer.cpp
+JSServiceWorkerContainer.cpp @cost:3
 JSServiceWorkerGlobalScope.cpp
-JSServiceWorkerRegistration.cpp
+JSServiceWorkerRegistration.cpp @cost:3
 JSServiceWorkerUpdateViaCache.cpp
 JSServiceWorkerWindowClient.cpp
 JSShadowRealmGlobalScope.cpp
-JSShadowRoot.cpp
+JSShadowRoot.cpp @cost:3
 JSShadowRootInit.cpp
 JSShadowRootMode.cpp
 JSShareData.cpp
@@ -5064,7 +5064,7 @@ JSSharedWorker.cpp
 JSSharedWorkerGlobalScope.cpp
 JSSlotAssignmentMode.cpp
 JSSlotable.cpp
-JSSourceBuffer.cpp
+JSSourceBuffer.cpp @cost:3
 JSSourceBufferList.cpp
 JSSpeechRecognition.cpp
 JSSpeechRecognitionAlternative.cpp
@@ -5244,7 +5244,7 @@ JSWebGLProvokingVertex.cpp
 JSWebGLQuery.cpp
 JSWebGLRenderSharedExponent.cpp
 JSWebGLRenderbuffer.cpp
-JSWebGLRenderingContext.cpp
+JSWebGLRenderingContext.cpp @cost:7
 JSWebGLRenderingContextBase.cpp
 JSWebGLSampler.cpp
 JSWebGLShader.cpp

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -21,8 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-GPUProcess/GPUProcess.cpp
-GPUProcess/GPUConnectionToWebProcess.cpp
+GPUProcess/GPUProcess.cpp @cost:7
+GPUProcess/GPUConnectionToWebProcess.cpp @cost:8
 GPUProcess/GPUProcessPreferences.cpp
 GPUProcess/RemoteSharedResourceCache.cpp
 GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp
@@ -31,13 +31,13 @@ GPUProcess/ShapeDetection/RemoteTextDetector.cpp
 GPUProcess/ShapeDetection/ShapeDetectionObjectHeap.cpp
 GPUProcess/graphics/ImageBufferShareableAllocator.cpp
 GPUProcess/graphics/RemoteDisplayListRecorder.cpp
-GPUProcess/graphics/RemoteGraphicsContext.cpp
-GPUProcess/graphics/RemoteGraphicsContextGL.cpp
-GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp
+GPUProcess/graphics/RemoteGraphicsContext.cpp @cost:3
+GPUProcess/graphics/RemoteGraphicsContextGL.cpp @cost:3
+GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp @cost:3
 GPUProcess/graphics/RemoteImageBuffer.cpp
 GPUProcess/graphics/RemoteImageBufferGraphicsContext.cpp
 GPUProcess/graphics/RemoteImageBufferSet.cpp
-GPUProcess/graphics/RemoteRenderingBackend.cpp
+GPUProcess/graphics/RemoteRenderingBackend.cpp @cost:6
 GPUProcess/graphics/RemoteResourceCache.cpp
 GPUProcess/graphics/RemoteSnapshot.cpp
 GPUProcess/graphics/RemoteSnapshotRecorder.cpp
@@ -55,9 +55,9 @@ GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
 GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
 GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
 GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
-GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+GPUProcess/graphics/WebGPU/RemoteDevice.cpp @cost:3
 GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
-GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+GPUProcess/graphics/WebGPU/RemoteGPU.cpp @cost:3
 GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
 GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
 GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
@@ -74,105 +74,105 @@ GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp
 GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
 GPUProcess/graphics/WebGPU/RemoteXRSubImage.cpp
 GPUProcess/graphics/WebGPU/RemoteXRView.cpp
-GPUProcess/graphics/WebGPU/WebGPUObjectHeap.cpp
+GPUProcess/graphics/WebGPU/WebGPUObjectHeap.cpp @cost:3
 GPUProcess/media/RemoteAudioHardwareListenerProxy.cpp
 GPUProcess/media/RemoteAudioSessionProxy.cpp
 GPUProcess/media/RemoteAudioSessionProxyManager.cpp
-GPUProcess/media/RemoteAudioTrackProxy.cpp
-GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+GPUProcess/media/RemoteAudioTrackProxy.cpp @cost:3
+GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp @cost:3
 GPUProcess/media/RemoteCDMFactoryProxy.cpp
 GPUProcess/media/RemoteCDMInstanceProxy.cpp
 GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
 GPUProcess/media/RemoteCDMProxy.cpp
 GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
-GPUProcess/media/RemoteLegacyCDMProxy.cpp
+GPUProcess/media/RemoteLegacyCDMProxy.cpp @cost:3
 GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
 GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.cpp
-GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
-GPUProcess/media/RemoteMediaPlayerProxy.cpp
-GPUProcess/media/RemoteMediaResource.cpp
-GPUProcess/media/RemoteMediaResourceLoader.cpp
+GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp @cost:4
+GPUProcess/media/RemoteMediaPlayerProxy.cpp @cost:4
+GPUProcess/media/RemoteMediaResource.cpp @cost:3
+GPUProcess/media/RemoteMediaResourceLoader.cpp @cost:3
 GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
-GPUProcess/media/RemoteMediaSourceProxy.cpp
+GPUProcess/media/RemoteMediaSourceProxy.cpp @cost:3
 GPUProcess/media/RemoteRemoteCommandListenerProxy.cpp
-GPUProcess/media/RemoteSourceBufferProxy.cpp
-GPUProcess/media/RemoteTextTrackProxy.cpp
-GPUProcess/media/RemoteVideoTrackProxy.cpp
+GPUProcess/media/RemoteSourceBufferProxy.cpp @cost:4
+GPUProcess/media/RemoteTextTrackProxy.cpp @cost:3
+GPUProcess/media/RemoteVideoTrackProxy.cpp @cost:3
 GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
 
 ModelProcess/ModelProcess.cpp
 ModelProcess/ModelConnectionToWebProcess.cpp
 ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
 
-NetworkProcess/BackgroundFetchLoad.cpp
-NetworkProcess/DatabaseUtilities.cpp
-NetworkProcess/EarlyHintsResourceLoader.cpp
+NetworkProcess/BackgroundFetchLoad.cpp @cost:4
+NetworkProcess/DatabaseUtilities.cpp @cost:3
+NetworkProcess/EarlyHintsResourceLoader.cpp @cost:6
 NetworkProcess/NetworkActivityTracker.cpp
-NetworkProcess/NetworkBroadcastChannelRegistry.cpp
-NetworkProcess/NetworkCORSPreflightChecker.cpp
-NetworkProcess/NetworkConnectionToWebProcess.cpp
-NetworkProcess/NetworkContentRuleListManager.cpp
-NetworkProcess/NetworkDataTask.cpp
-NetworkProcess/NetworkDataTaskBlob.cpp
-NetworkProcess/NetworkLoad.cpp
-NetworkProcess/NetworkLoadChecker.cpp
-NetworkProcess/NetworkLoadScheduler.cpp
+NetworkProcess/NetworkBroadcastChannelRegistry.cpp @cost:4
+NetworkProcess/NetworkCORSPreflightChecker.cpp @cost:4
+NetworkProcess/NetworkConnectionToWebProcess.cpp @cost:8
+NetworkProcess/NetworkContentRuleListManager.cpp @cost:3
+NetworkProcess/NetworkDataTask.cpp @cost:3
+NetworkProcess/NetworkDataTaskBlob.cpp @cost:3
+NetworkProcess/NetworkLoad.cpp @cost:4
+NetworkProcess/NetworkLoadChecker.cpp @cost:7
+NetworkProcess/NetworkLoadScheduler.cpp @cost:3
 NetworkProcess/NetworkOriginAccessPatterns.cpp
-NetworkProcess/NetworkProcess.cpp
+NetworkProcess/NetworkProcess.cpp @cost:11
 NetworkProcess/NetworkProcessPlatformStrategies.cpp
-NetworkProcess/NetworkResourceLoadParameters.cpp
-NetworkProcess/NetworkResourceLoadMap.cpp
-NetworkProcess/NetworkResourceLoader.cpp
+NetworkProcess/NetworkResourceLoadParameters.cpp @cost:3
+NetworkProcess/NetworkResourceLoadMap.cpp @cost:4
+NetworkProcess/NetworkResourceLoader.cpp @cost:9
 NetworkProcess/NetworkSchemeRegistry.cpp
-NetworkProcess/NetworkSession.cpp
+NetworkProcess/NetworkSession.cpp @cost:9
 NetworkProcess/NetworkSocketChannel.cpp
-NetworkProcess/PingLoad.cpp
-NetworkProcess/PreconnectTask.cpp
+NetworkProcess/PingLoad.cpp @cost:4
+NetworkProcess/PreconnectTask.cpp @cost:3
 
-NetworkProcess/Authentication/AuthenticationManager.cpp
+NetworkProcess/Authentication/AuthenticationManager.cpp @cost:7
 
 NetworkProcess/Classifier/ITPThirdPartyData.cpp
 NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.cpp
-NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp @cost:6
 
-NetworkProcess/Cookies/WebCookieManager.cpp
+NetworkProcess/Cookies/WebCookieManager.cpp @cost:3
 
-NetworkProcess/Downloads/Download.cpp
-NetworkProcess/Downloads/DownloadManager.cpp
-NetworkProcess/Downloads/DownloadMonitor.cpp
-NetworkProcess/Downloads/PendingDownload.cpp
+NetworkProcess/Downloads/Download.cpp @cost:4
+NetworkProcess/Downloads/DownloadManager.cpp @cost:5
+NetworkProcess/Downloads/DownloadMonitor.cpp @cost:4
+NetworkProcess/Downloads/PendingDownload.cpp @cost:5
 
 NetworkProcess/Notifications/NetworkNotificationManager.cpp
-NetworkProcess/Notifications/WebPushDaemonConnection.cpp
+NetworkProcess/Notifications/WebPushDaemonConnection.cpp @cost:3
 
-NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp
-NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp @cost:3
+NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp @cost:3
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDebugInfo.cpp
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.cpp
-NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
-NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
+NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp @cost:3
+NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp @cost:3
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.cpp
-NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp
-NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.cpp
+NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp @cost:3
+NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.cpp @cost:3
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.cpp
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.cpp
 
-NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
-NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
-NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
-NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
+NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp @cost:4
+NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp @cost:5
+NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp @cost:3
+NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp @cost:3
 NetworkProcess/ServiceWorker/WebSWOriginStore.cpp @no-unify
 NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
 NetworkProcess/ServiceWorker/WebSWServerConnection.cpp @no-unify
 NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp @no-unify
 
 NetworkProcess/SharedWorker/WebSharedWorker.cpp
-NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
-NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
-NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp @cost:3
+NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp @cost:4
+NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp @cost:4
 
 NetworkProcess/storage/BackgroundFetchStoreManager.cpp
-NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
+NetworkProcess/storage/BackgroundFetchStoreImpl.cpp @cost:3
 NetworkProcess/storage/CacheStorageCache.cpp
 NetworkProcess/storage/CacheStorageMemoryStore.cpp
 NetworkProcess/storage/CacheStorageManager.cpp
@@ -187,7 +187,7 @@ NetworkProcess/storage/IDBStorageManager.cpp
 NetworkProcess/storage/IDBStorageRegistry.cpp
 NetworkProcess/storage/LocalStorageManager.cpp
 NetworkProcess/storage/MemoryStorageArea.cpp
-NetworkProcess/storage/NetworkStorageManager.cpp
+NetworkProcess/storage/NetworkStorageManager.cpp @cost:7
 NetworkProcess/storage/OriginQuotaManager.cpp
 NetworkProcess/storage/OriginStorageManager.cpp
 NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -197,21 +197,21 @@ NetworkProcess/storage/StorageAreaBase.cpp
 NetworkProcess/storage/StorageAreaRegistry.cpp
 
 NetworkProcess/cache/AsyncRevalidation.cpp
-NetworkProcess/cache/NetworkCache.cpp
+NetworkProcess/cache/NetworkCache.cpp @cost:4
 NetworkProcess/cache/NetworkCacheBlobStorage.cpp
 NetworkProcess/cache/NetworkCacheCoders.cpp
 NetworkProcess/cache/NetworkCacheData.cpp
-NetworkProcess/cache/NetworkCacheEntry.cpp
+NetworkProcess/cache/NetworkCacheEntry.cpp @cost:3
 NetworkProcess/cache/NetworkCacheFileSystem.cpp
 NetworkProcess/cache/NetworkCacheKey.cpp
-NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
-NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp @cost:3
+NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp @cost:4
 NetworkProcess/cache/NetworkCacheStorage.cpp
 NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
 NetworkProcess/cache/PrefetchCache.cpp
 
-NetworkProcess/webrtc/NetworkMDNSRegister.cpp
-NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
+NetworkProcess/webrtc/NetworkMDNSRegister.cpp @cost:4
+NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp @cost:4
 
 NetworkProcess/webtransport/NetworkTransportSession.cpp
 NetworkProcess/webtransport/NetworkTransportStream.cpp
@@ -400,7 +400,7 @@ Shared/WebsiteData/WebsiteData.cpp
 Shared/XR/XRDeviceProxy.cpp
 
 UIProcess/AboutSchemeHandler.cpp
-UIProcess/AuxiliaryProcessProxy.cpp
+UIProcess/AuxiliaryProcessProxy.cpp @cost:4
 UIProcess/BackgroundProcessResponsivenessTimer.cpp
 UIProcess/BrowsingContextGroup.cpp
 UIProcess/DeviceIdHashSaltStorage.cpp
@@ -408,14 +408,14 @@ UIProcess/DisplayLink.cpp
 UIProcess/DisplayLinkProcessProxyClient.cpp
 UIProcess/DrawingAreaProxy.cpp
 UIProcess/EnhancedSecurityTracking.cpp
-UIProcess/FindStringCallbackAggregator.cpp
+UIProcess/FindStringCallbackAggregator.cpp @cost:3
 UIProcess/FindTextMatchesCallbackAggregator.cpp
 UIProcess/FrameLoadState.cpp
 UIProcess/FrameProcess.cpp
-UIProcess/GeolocationPermissionRequestManagerProxy.cpp
+UIProcess/GeolocationPermissionRequestManagerProxy.cpp @cost:3
 UIProcess/GeolocationPermissionRequestProxy.cpp
 UIProcess/LegacyGlobalSettings.cpp
-UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
+UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp @cost:4
 UIProcess/MediaKeySystemPermissionRequestProxy.cpp
 UIProcess/OverrideLanguages.cpp
 UIProcess/PageClient.cpp
@@ -437,7 +437,7 @@ UIProcess/ResponsivenessTimer.cpp
 UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
 UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
 UIProcess/SpeechRecognitionServer.cpp
-UIProcess/SuspendedPageProxy.cpp
+UIProcess/SuspendedPageProxy.cpp @cost:5
 UIProcess/SystemPreviewController.cpp
 UIProcess/SpeechRecognitionPermissionManager.cpp
 UIProcess/TextChecker.cpp
@@ -445,7 +445,7 @@ UIProcess/TextCheckerCompletion.cpp
 UIProcess/TextExtractionAssertionScope.cpp
 UIProcess/UIProcessLogInitialization.cpp
 UIProcess/UserMediaPermissionCheckProxy.cpp
-UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+UIProcess/UserMediaPermissionRequestManagerProxy.cpp @cost:5
 UIProcess/UserMediaPermissionRequestProxy.cpp
 UIProcess/UserMediaProcessManager.cpp
 UIProcess/VisitedLinkStore.cpp
@@ -456,14 +456,14 @@ UIProcess/WebColorPicker.cpp
 UIProcess/WebContextClient.cpp
 UIProcess/WebContextInjectedBundleClient.cpp
 UIProcess/WebContextMenuListenerProxy.cpp
-UIProcess/WebContextMenuProxy.cpp
+UIProcess/WebContextMenuProxy.cpp @cost:3
 UIProcess/WebDataListSuggestionsDropdown.cpp
 UIProcess/WebDateTimePicker.cpp
-UIProcess/WebEditCommandProxy.cpp
+UIProcess/WebEditCommandProxy.cpp @cost:3
 UIProcess/WebFormClient.cpp
 UIProcess/WebFormSubmissionListenerProxy.cpp
 UIProcess/WebFramePolicyListenerProxy.cpp
-UIProcess/WebFrameProxy.cpp
+UIProcess/WebFrameProxy.cpp @cost:6
 UIProcess/WebFullScreenManagerProxy.cpp
 UIProcess/WebGeolocationManagerProxy.cpp
 UIProcess/WebGeolocationProvider.cpp
@@ -474,18 +474,18 @@ UIProcess/WebPageDiagnosticLoggingClient.cpp
 UIProcess/WebPageGroup.cpp
 UIProcess/WebPageInjectedBundleClient.cpp
 UIProcess/WebPageProxy.cpp
-UIProcess/WebPageProxyMessageReceiverRegistration.cpp
-UIProcess/WebPageProxyTesting.cpp
+UIProcess/WebPageProxyMessageReceiverRegistration.cpp @cost:3
+UIProcess/WebPageProxyTesting.cpp @cost:4
 UIProcess/WebPasteboardProxy.cpp
 UIProcess/WebPermissionControllerProxy.cpp
 UIProcess/WebPreferences.cpp
 UIProcess/WebProcessActivityState.cpp
 UIProcess/WebProcessCache.cpp
-UIProcess/WebProcessPool.cpp
-UIProcess/WebProcessProxy.cpp
+UIProcess/WebProcessPool.cpp @cost:8
+UIProcess/WebProcessProxy.cpp @cost:8
 UIProcess/WebScreenOrientationManagerProxy.cpp
 UIProcess/WebURLSchemeHandler.cpp
-UIProcess/WebURLSchemeTask.cpp
+UIProcess/WebURLSchemeTask.cpp @cost:3
 
 UIProcess/API/APIAttachment.cpp
 UIProcess/API/APIContentRuleList.cpp
@@ -614,7 +614,7 @@ UIProcess/Extensions/WebExtensionMatchPattern.cpp
 UIProcess/Extensions/WebExtensionStorageSQLiteStore.cpp
 
 UIProcess/Extensions/API/WebExtensionContextAPIDeclarativeNetRequest.cpp
-UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp
+UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp @cost:3
 
 UIProcess/Gamepad/UIGamepad.cpp
 UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -622,20 +622,20 @@ UIProcess/Gamepad/UIGamepadProvider.cpp
 // TODO: This file should be "unified" once GTK's PluginProcess2 is removed.
 UIProcess/Launcher/ProcessLauncher.cpp @no-unify
 
-UIProcess/Network/NetworkProcessProxy.cpp
+UIProcess/Network/NetworkProcessProxy.cpp @cost:7
 
-UIProcess/GPU/GPUProcessProxy.cpp
+UIProcess/GPU/GPUProcessProxy.cpp @cost:4
 
 UIProcess/Model/ModelProcessProxy.cpp
 
 UIProcess/Inspector/FrameInspectorTargetProxy.cpp
-UIProcess/Inspector/InspectorTargetProxy.cpp
-UIProcess/Inspector/PageInspectorTargetProxy.cpp
+UIProcess/Inspector/InspectorTargetProxy.cpp @cost:3
+UIProcess/Inspector/PageInspectorTargetProxy.cpp @cost:3
 UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
 UIProcess/Inspector/WasmDebuggerDebuggable.cpp
 UIProcess/Inspector/WebInspectorBackendProxy.cpp
 UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
-UIProcess/Inspector/WebInspectorUIProxy.cpp
+UIProcess/Inspector/WebInspectorUIProxy.cpp @cost:4
 UIProcess/Inspector/WebInspectorUtilities.cpp
 UIProcess/Inspector/WebPageDebuggable.cpp
 UIProcess/Inspector/WebPageInspectorController.cpp
@@ -658,7 +658,7 @@ UIProcess/Notifications/WebNotificationManagerProxy.cpp
 UIProcess/Notifications/WebNotificationProvider.cpp
 
 UIProcess/UserContent/WebScriptMessageHandler.cpp
-UIProcess/UserContent/WebUserContentControllerProxy.cpp
+UIProcess/UserContent/WebUserContentControllerProxy.cpp @cost:3
 
 UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp
 UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp
@@ -678,12 +678,12 @@ UIProcess/WebsiteData/EnhancedSecuritySitesHolder.cpp
 UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
 UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
 UIProcess/WebsiteData/WebsiteDataRecord.cpp
-UIProcess/WebsiteData/WebsiteDataStore.cpp
+UIProcess/WebsiteData/WebsiteDataStore.cpp @cost:5
 UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
 
 UIProcess/XR/PlatformXRSystem.cpp
 
-WebProcess/WebProcess.cpp
+WebProcess/WebProcess.cpp @cost:11
 WebProcess/WebSleepDisablerClient.cpp
 WebProcess/WebSystemSoundDelegate.cpp
 
@@ -691,7 +691,7 @@ WebProcess/WebSystemSoundDelegate.cpp
 WebProcess/Automation/WebAutomationSessionProxy.cpp @no-unify
 WebProcess/Automation/WebAutomationDOMWindowObserver.cpp
 
-WebProcess/Cache/WebCacheStorageConnection.cpp
+WebProcess/Cache/WebCacheStorageConnection.cpp @cost:3
 WebProcess/Cache/WebCacheStorageProvider.cpp
 
 WebProcess/Databases/WebDatabaseProvider.cpp
@@ -707,7 +707,7 @@ WebProcess/Extensions/WebExtensionControllerProxy.cpp
 
 WebProcess/FileAPI/BlobRegistryProxy.cpp
 
-WebProcess/FullScreen/WebFullScreenManager.cpp
+WebProcess/FullScreen/WebFullScreenManager.cpp @cost:8
 
 WebProcess/Gamepad/WebGamepad.cpp
 WebProcess/Gamepad/WebGamepadProvider.cpp
@@ -715,7 +715,7 @@ WebProcess/Gamepad/WebGamepadProvider.cpp
 WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
 WebProcess/Geolocation/WebGeolocationManager.cpp
 
-WebProcess/InjectedBundle/InjectedBundle.cpp
+WebProcess/InjectedBundle/InjectedBundle.cpp @cost:4
 WebProcess/InjectedBundle/InjectedBundleClient.cpp
 WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
 WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
@@ -731,11 +731,11 @@ WebProcess/InjectedBundle/API/c/WKBundle.cpp
 WebProcess/InjectedBundle/API/c/WKBundleBackForwardList.cpp
 WebProcess/InjectedBundle/API/c/WKBundleBackForwardListItem.cpp
 WebProcess/InjectedBundle/API/c/WKBundleDOMWindowExtension.cpp
-WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp @cost:3
 WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp
 WebProcess/InjectedBundle/API/c/WKBundleNavigationAction.cpp
 WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp
-WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+WebProcess/InjectedBundle/API/c/WKBundlePage.cpp @cost:3
 WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
 WebProcess/InjectedBundle/API/c/WKBundleRangeHandle.cpp
 WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp
@@ -747,7 +747,7 @@ WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp @no-unify
 WebProcess/Inspector/RemoteWebInspectorUI.cpp
 WebProcess/Inspector/UIProcessForwardingFrontendChannel.cpp
 WebProcess/Inspector/FrameInspectorTarget.cpp
-WebProcess/Inspector/WebInspectorBackend.cpp
+WebProcess/Inspector/WebInspectorBackend.cpp @cost:3
 WebProcess/Inspector/WebInspectorBackendClient.cpp
 WebProcess/Inspector/BackendResourceDataStore.cpp
 WebProcess/Inspector/FrameNetworkAgentProxy.cpp
@@ -772,7 +772,7 @@ WebProcess/Model/ModelProcessModelPlayer.cpp
 WebProcess/Model/ModelProcessModelPlayerManager.cpp
 WebProcess/Model/ModelProcessModelPlayerTransformState.cpp
 
-WebProcess/GPU/GPUProcessConnection.cpp
+WebProcess/GPU/GPUProcessConnection.cpp @cost:3
 WebProcess/GPU/RemoteSharedResourceCacheProxy.cpp
 WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
 WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
@@ -788,9 +788,9 @@ WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
-WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp @cost:3
 WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp
-WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp @cost:3
 WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp
@@ -813,19 +813,19 @@ WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.cpp
 WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
 WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.cpp
 WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
-WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
-WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
-WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
-WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp @cost:3
+WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp @cost:6
+WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp @cost:3
+WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp @cost:3
 WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
 WebProcess/GPU/graphics/RemoteNativeImageProxy.cpp
 WebProcess/GPU/graphics/RemoteSnapshotRecorderProxy.cpp
-WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp @cost:5
 WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
 WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
-WebProcess/GPU/media/AudioVideoRendererRemote.cpp
-WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
-WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+WebProcess/GPU/media/AudioVideoRendererRemote.cpp @cost:5
+WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp @cost:5
+WebProcess/GPU/media/MediaSourcePrivateRemote.cpp @cost:3
 WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
 WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
 WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -835,37 +835,37 @@ WebProcess/GPU/media/RemoteCDMInstance.cpp
 WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
 WebProcess/GPU/media/RemoteLegacyCDM.cpp
 WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
-WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
+WebProcess/GPU/media/RemoteLegacyCDMSession.cpp @cost:3
 WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp
 WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
 WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp @no-unify
 WebProcess/GPU/media/RemoteMediaResourceLoaderProxy.cpp
 WebProcess/GPU/media/RemoteMediaResourceProxy.cpp
-WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
+WebProcess/GPU/media/RemoteVideoFrameProxy.cpp @cost:3
 WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
 WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
-WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+WebProcess/GPU/media/SourceBufferPrivateRemote.cpp @cost:4
 WebProcess/GPU/media/TextTrackPrivateRemote.cpp
 WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
 WebProcess/GPU/media/WebMediaStrategy.cpp
-WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp @cost:4
 WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
 WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
 WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
 
-WebProcess/Network/NetworkProcessConnection.cpp
-WebProcess/Network/WebLoaderStrategy.cpp
+WebProcess/Network/NetworkProcessConnection.cpp @cost:4
+WebProcess/Network/WebLoaderStrategy.cpp @cost:4
 WebProcess/Network/WebResourceInterceptController.cpp
 WebProcess/Network/WebResourceLoader.cpp
 WebProcess/Network/WebSocketChannel.cpp @no-unify
 WebProcess/Network/WebSocketChannelManager.cpp
 WebProcess/Network/WebSocketProvider.cpp
-WebProcess/Network/WebTransportSession.cpp
+WebProcess/Network/WebTransportSession.cpp @cost:4
 
 WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.cpp
 WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
-WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
-WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp @cost:3
+WebProcess/Network/webrtc/LibWebRTCProvider.cpp @cost:3
 WebProcess/Network/webrtc/LibWebRTCResolver.cpp
 WebProcess/Network/webrtc/LibWebRTCSocket.cpp
 WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
@@ -878,18 +878,18 @@ WebProcess/Network/webrtc/WebRTCResolver.cpp
 WebProcess/Notifications/NotificationPermissionRequestManager.cpp
 WebProcess/Notifications/WebNotificationManager.cpp
 
-WebProcess/Plugins/PluginView.cpp
+WebProcess/Plugins/PluginView.cpp @cost:6
 WebProcess/Plugins/WebPluginInfoProvider.cpp
 
 WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
 
 WebProcess/Storage/RemoteWorkerFrameLoaderClient.cpp
-WebProcess/Storage/WebSWClientConnection.cpp
-WebProcess/Storage/WebSWContextManagerConnection.cpp
+WebProcess/Storage/WebSWClientConnection.cpp @cost:4
+WebProcess/Storage/WebSWContextManagerConnection.cpp @cost:5
 WebProcess/Storage/WebSWOriginTable.cpp
 WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
 WebProcess/Storage/WebServiceWorkerProvider.cpp
-WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp @cost:4
 WebProcess/Storage/WebSharedWorkerObjectConnection.cpp
 WebProcess/Storage/WebSharedWorkerProvider.cpp
 
@@ -900,11 +900,11 @@ WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
 
 WebProcess/WebCoreSupport/RemoteWebLockRegistry.cpp
 WebProcess/WebCoreSupport/SessionStateConversion.cpp
-WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
+WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp @cost:6
 WebProcess/WebCoreSupport/WebAttachmentElementClient.cpp
 WebProcess/WebCoreSupport/WebBadgeClient.cpp
 WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
-WebProcess/WebCoreSupport/WebChromeClient.cpp
+WebProcess/WebCoreSupport/WebChromeClient.cpp @cost:6
 WebProcess/WebCoreSupport/WebColorChooser.cpp
 WebProcess/WebCoreSupport/WebContextMenuClient.cpp
 WebProcess/WebCoreSupport/WebCryptoClient.cpp
@@ -913,17 +913,17 @@ WebProcess/WebCoreSupport/WebDateTimeChooser.cpp
 WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp
 WebProcess/WebCoreSupport/WebDragClient.cpp
 WebProcess/WebCoreSupport/WebEditorClient.cpp
-WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp @cost:3
 WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
 WebProcess/WebCoreSupport/WebGeolocationClient.cpp
-WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp @cost:4
 WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp
 WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
 WebProcess/WebCoreSupport/WebNotificationClient.cpp
 WebProcess/WebCoreSupport/WebPasteboardOverrides.cpp
 WebProcess/WebCoreSupport/WebPerformanceLoggingClient.cpp
 WebProcess/WebCoreSupport/WebPermissionController.cpp
-WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+WebProcess/WebCoreSupport/WebPlatformStrategies.cpp @cost:4
 WebProcess/WebCoreSupport/WebPopupMenu.cpp
 WebProcess/WebCoreSupport/WebDocumentSyncClient.cpp
 WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp
@@ -937,10 +937,10 @@ WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
 WebProcess/WebCoreSupport/WebStorageConnection.cpp
 WebProcess/WebCoreSupport/WebWorkerClient.cpp
 
-WebProcess/WebPage/DrawingArea.cpp
-WebProcess/WebPage/EventDispatcher.cpp
+WebProcess/WebPage/DrawingArea.cpp @cost:3
+WebProcess/WebPage/EventDispatcher.cpp @cost:3
 WebProcess/WebPage/FindIndicator.cpp
-WebProcess/WebPage/FindController.cpp
+WebProcess/WebPage/FindController.cpp @cost:3
 WebProcess/WebPage/IPCTestingAPI.cpp
 WebProcess/WebPage/MomentumEventDispatcher.cpp
 WebProcess/WebPage/PageBanner.cpp
@@ -950,11 +950,11 @@ WebProcess/WebPage/WebContextMenu.cpp
 WebProcess/WebPage/WebCookieCache.cpp
 WebProcess/WebPage/WebCookieJar.cpp
 WebProcess/WebPage/WebDisplayRefreshMonitor.cpp
-WebProcess/WebPage/WebFoundTextRangeController.cpp
-WebProcess/WebPage/WebFrame.cpp
+WebProcess/WebPage/WebFoundTextRangeController.cpp @cost:3
+WebProcess/WebPage/WebFrame.cpp @cost:6
 WebProcess/WebPage/WebHistoryItemClient.cpp
 WebProcess/WebPage/WebOpenPanelResultListener.cpp
-WebProcess/WebPage/WebPage.cpp
+WebProcess/WebPage/WebPage.cpp @cost:18
 WebProcess/WebPage/WebPageGroupProxy.cpp
 WebProcess/WebPage/WebPageOverlay.cpp
 WebProcess/WebPage/WebPageTesting.cpp
@@ -982,43 +982,43 @@ NetworkTransportSessionMessageReceiver.cpp
 RTCDataChannelRemoteManagerMessageReceiver.cpp
 RTCDataChannelRemoteManagerProxyMessageReceiver.cpp
 RemoteAudioMediaStreamTrackRendererInternalUnitManagerMessageReceiver.cpp
-RemoteSnapshotRecorderMessageReceiver.cpp
-RemoteGraphicsContextMessageReceiver.cpp
-RemoteGraphicsContextGLMessageReceiver.cpp
+RemoteSnapshotRecorderMessageReceiver.cpp @cost:5
+RemoteGraphicsContextMessageReceiver.cpp @cost:9
+RemoteGraphicsContextGLMessageReceiver.cpp @cost:13
 RemoteGraphicsContextGLProxyMessageReceiver.cpp
 PlatformXRSystemMessageReceiver.cpp
 PlatformXRSystemProxyMessageReceiver.cpp
 PushClientConnectionMessageReceiver.cpp
-RemoteAdapterMessageReceiver.cpp
+RemoteAdapterMessageReceiver.cpp @cost:5
 RemoteAudioVideoRendererProxyManagerMessageReceiver.cpp
-RemoteBarcodeDetectorMessageReceiver.cpp
-RemoteBindGroupMessageReceiver.cpp
-RemoteBindGroupLayoutMessageReceiver.cpp
-RemoteBufferMessageReceiver.cpp
-RemoteCommandBufferMessageReceiver.cpp
-RemoteCommandEncoderMessageReceiver.cpp
-RemoteCompositorIntegrationMessageReceiver.cpp
-RemoteComputePassEncoderMessageReceiver.cpp
-RemoteComputePipelineMessageReceiver.cpp
+RemoteBarcodeDetectorMessageReceiver.cpp @cost:5
+RemoteBindGroupMessageReceiver.cpp @cost:5
+RemoteBindGroupLayoutMessageReceiver.cpp @cost:5
+RemoteBufferMessageReceiver.cpp @cost:5
+RemoteCommandBufferMessageReceiver.cpp @cost:5
+RemoteCommandEncoderMessageReceiver.cpp @cost:6
+RemoteCompositorIntegrationMessageReceiver.cpp @cost:5
+RemoteComputePassEncoderMessageReceiver.cpp @cost:5
+RemoteComputePipelineMessageReceiver.cpp @cost:5
 RemoteMeshMessageReceiver.cpp
-RemoteDeviceMessageReceiver.cpp
-RemoteExternalTextureMessageReceiver.cpp
-RemoteFaceDetectorMessageReceiver.cpp
-RemoteGPUMessageReceiver.cpp
+RemoteDeviceMessageReceiver.cpp @cost:6
+RemoteExternalTextureMessageReceiver.cpp @cost:5
+RemoteFaceDetectorMessageReceiver.cpp @cost:5
+RemoteGPUMessageReceiver.cpp @cost:5
 RemoteGPUProxyMessageReceiver.cpp
 RemoteVideoFrameObjectHeapMessageReceiver.cpp
 RemoteVideoFrameObjectHeapProxyProcessorMessageReceiver.cpp
-RemotePipelineLayoutMessageReceiver.cpp
-RemotePresentationContextMessageReceiver.cpp
-RemoteQuerySetMessageReceiver.cpp
-RemoteQueueMessageReceiver.cpp
-RemoteRenderBundleMessageReceiver.cpp
-RemoteRenderBundleEncoderMessageReceiver.cpp
-RemoteRenderPassEncoderMessageReceiver.cpp
+RemotePipelineLayoutMessageReceiver.cpp @cost:5
+RemotePresentationContextMessageReceiver.cpp @cost:5
+RemoteQuerySetMessageReceiver.cpp @cost:5
+RemoteQueueMessageReceiver.cpp @cost:5
+RemoteRenderBundleMessageReceiver.cpp @cost:5
+RemoteRenderBundleEncoderMessageReceiver.cpp @cost:5
+RemoteRenderPassEncoderMessageReceiver.cpp @cost:5
 RemoteRenderPipelineMessageReceiver.cpp
 RemoteSamplerMessageReceiver.cpp
 RemoteShaderModuleMessageReceiver.cpp
-RemoteTextDetectorMessageReceiver.cpp
+RemoteTextDetectorMessageReceiver.cpp @cost:5
 RemoteTextureMessageReceiver.cpp
 RemoteTextureViewMessageReceiver.cpp
 RemoteXRBindingMessageReceiver.cpp
@@ -1029,12 +1029,12 @@ RemoteWebLockRegistryMessageReceiver.cpp
 ServiceWorkerDownloadTaskMessageReceiver.cpp
 WebBroadcastChannelRegistryMessageReceiver.cpp
 WebFrameMessageReceiver.cpp
-WebFrameProxyMessageReceiver.cpp
-WebLockRegistryProxyMessageReceiver.cpp
+WebFrameProxyMessageReceiver.cpp @cost:10
+WebLockRegistryProxyMessageReceiver.cpp @cost:10
 WebPermissionControllerMessageReceiver.cpp
-WebPermissionControllerProxyMessageReceiver.cpp
+WebPermissionControllerProxyMessageReceiver.cpp @cost:10
 WebScreenOrientationManagerMessageReceiver.cpp
-WebScreenOrientationManagerProxyMessageReceiver.cpp
+WebScreenOrientationManagerProxyMessageReceiver.cpp @cost:10
 WebSharedWorkerContextManagerConnectionMessageReceiver.cpp
 WebSharedWorkerObjectConnectionMessageReceiver.cpp
 WebSharedWorkerServerConnectionMessageReceiver.cpp

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -41,7 +41,7 @@ NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
 NetworkProcess/Cookies/mac/WebCookieManagerMac.mm @nonARC
 
 NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm @nonARC
-NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
+NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp @cost:3
 
 NetworkProcess/Downloads/cocoa/DownloadCocoa.mm @nonARC
 
@@ -86,7 +86,7 @@ GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
 GPUProcess/webrtc/LibWebRTCCodecsProxy.mm @nonARC @no-unify
 GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
 GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm @nonARC
-GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp @cost:3
 
 ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm @nonARC
 ModelProcess/cocoa/ModelProcessCocoa.mm @nonARC
@@ -443,7 +443,7 @@ UIProcess/Cocoa/AutomationSessionClient.mm @nonARC
 UIProcess/Cocoa/BrowsingWarningCocoa.mm @nonARC
 UIProcess/Cocoa/CoreTelephonyUtilities.mm @nonARC
 UIProcess/Cocoa/DiagnosticLoggingClient.mm @nonARC
-UIProcess/Cocoa/DisplayCaptureSessionManager.mm @nonARC
+UIProcess/Cocoa/DisplayCaptureSessionManager.mm @nonARC @cost:3
 UIProcess/Cocoa/DownloadProxyMapCocoa.mm @nonARC
 UIProcess/Cocoa/ExtensionCapabilityGranter.mm @nonARC
 UIProcess/Cocoa/FindClient.mm @nonARC
@@ -457,7 +457,7 @@ UIProcess/Cocoa/LegacySessionStateCoding.cpp
 UIProcess/Cocoa/MediaUtilities.mm @nonARC
 UIProcess/Cocoa/MediaPermissionUtilities.mm @nonARC
 UIProcess/Cocoa/NavigationState.mm @nonARC
-UIProcess/Cocoa/PageClientImplCocoa.mm @nonARC
+UIProcess/Cocoa/PageClientImplCocoa.mm @nonARC @cost:3
 UIProcess/Cocoa/PlatformWritingToolsUtilities.mm @nonARC
 UIProcess/Cocoa/PlatformXRCoordinator.mm @nonARC
 UIProcess/Cocoa/PlaybackSessionManagerProxy.mm @nonARC
@@ -468,7 +468,7 @@ UIProcess/Cocoa/SessionStateCoding.mm @nonARC
 UIProcess/Cocoa/SystemPreviewControllerCocoa.mm @nonARC
 UIProcess/Cocoa/TextCheckingController.mm @nonARC
 UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm @nonARC
-UIProcess/Cocoa/UIDelegate.mm @nonARC
+UIProcess/Cocoa/UIDelegate.mm @nonARC @cost:3
 UIProcess/Cocoa/UIProcessLogInitializationCocoa.mm @nonARC
 UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
 UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm @nonARC
@@ -478,11 +478,11 @@ UIProcess/Cocoa/ViewSnapshotStoreCocoa.mm @nonARC
 UIProcess/Cocoa/WebGeolocationManagerProxyCocoa.cpp
 UIProcess/Cocoa/WebKitSwiftSoftLink.mm @nonARC @no-unify
 UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm @nonARC
-UIProcess/Cocoa/WebPageProxyCocoa.mm @nonARC
-UIProcess/Cocoa/WebPasteboardProxyCocoa.mm @nonARC
+UIProcess/Cocoa/WebPageProxyCocoa.mm @nonARC @cost:12
+UIProcess/Cocoa/WebPasteboardProxyCocoa.mm @nonARC @cost:5
 UIProcess/Cocoa/WebPreferencesCocoa.mm @nonARC
 UIProcess/Cocoa/WebProcessCacheCocoa.mm @nonARC
-UIProcess/Cocoa/WebProcessPoolCocoa.mm @nonARC
+UIProcess/Cocoa/WebProcessPoolCocoa.mm @nonARC @cost:5
 UIProcess/Cocoa/WebProcessProxyCocoa.mm @nonARC
 UIProcess/Cocoa/WebURLSchemeHandlerCocoa.mm @nonARC
 UIProcess/Cocoa/WKColorExtensionView.mm @nonARC
@@ -672,8 +672,8 @@ UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm @nonARC
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm @nonARC
 UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm @nonARC
 UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm @nonARC
-UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
-UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
+UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp @cost:3
+UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp @cost:3
 UIProcess/RemoteLayerTree/mac/ScrollingTreePluginScrollingNodeRemoteMac.cpp
 
 UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm @nonARC
@@ -696,10 +696,10 @@ UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm @nonARC
 UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm @nonARC
 UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm @nonARC
 UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm @nonARC
-UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
-UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp @cost:3
+UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp @cost:3
 UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.cpp
-UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp
+UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp @cost:3
 
 UIProcess/WebAuthentication/Cocoa/AuthenticationServicesCoreSoftLink.mm @nonARC @no-unify
 UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm @nonARC
@@ -748,8 +748,8 @@ WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
 WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
 WebProcess/cocoa/TextRecognitionRequest.cpp
 WebProcess/cocoa/UserMediaCaptureManager.cpp
-WebProcess/cocoa/VideoPresentationManager.mm @nonARC
-WebProcess/cocoa/WebProcessCocoa.mm @nonARC
+WebProcess/cocoa/VideoPresentationManager.mm @nonARC @cost:7
+WebProcess/cocoa/WebProcessCocoa.mm @nonARC @cost:4
 
 WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm @nonARC
 
@@ -847,7 +847,7 @@ WebProcess/MediaCache/WebMediaKeyStorageManager.cpp
 WebProcess/Plugins/PDF/PDFAnnotationTypeHelpers.mm @nonARC
 WebProcess/Plugins/PDF/PDFIncrementalLoader.mm @nonARC
 WebProcess/Plugins/PDF/PDFPlugin.mm @nonARC
-WebProcess/Plugins/PDF/PDFPluginBase.mm @nonARC
+WebProcess/Plugins/PDF/PDFPluginBase.mm @nonARC @cost:7
 WebProcess/Plugins/PDF/PDFPluginAnnotation.mm @nonARC
 WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm @nonARC
 WebProcess/Plugins/PDF/PDFPluginPasswordField.mm @nonARC
@@ -855,15 +855,15 @@ WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm @nonARC
 WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm @nonARC
 WebProcess/Plugins/PDF/PDFScriptEvaluation.mm @nonARC
 WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm @nonARC
-WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm @nonARC
+WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm @nonARC @cost:3
 WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.mm @nonARC
-WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm @nonARC
-WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm @nonARC
+WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm @nonARC @cost:3
+WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm @nonARC @cost:3
 WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm @nonARC
 WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm @nonARC
-WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm @nonARC
-WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm @nonARC
-WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm @nonARC
+WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm @nonARC @cost:3
+WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm @nonARC @cost:3
+WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm @nonARC @cost:7
 
 WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
 WebProcess/WebCoreSupport/WebValidationMessageClient.cpp
@@ -892,31 +892,31 @@ WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm @nonARC
 WebProcess/WebPage/Cocoa/TextAnimationController.mm @nonARC
 WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm @nonARC
 WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm @nonARC
-WebProcess/WebPage/Cocoa/WebPageCocoa.mm @nonARC
+WebProcess/WebPage/Cocoa/WebPageCocoa.mm @nonARC @cost:10
 WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.cpp
 
 WebProcess/WebPage/ios/FindIndicatorIOS.cpp
 WebProcess/WebPage/ios/WebPageIOS.mm @nonARC
 
 WebProcess/WebPage/mac/PageBannerMac.mm @nonARC
-WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm @nonARC
+WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm @nonARC @cost:3
 WebProcess/WebPage/mac/TiledCoreAnimationScrollingCoordinator.mm @nonARC
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm @nonARC
-WebProcess/WebPage/mac/WebPageMac.mm @nonARC
+WebProcess/WebPage/mac/WebPageMac.mm @nonARC @cost:7
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm @nonARC
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm @nonARC
 
-WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm @nonARC
-WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm @nonARC
-WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm @nonARC
-WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm @nonARC
+WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm @nonARC @cost:3
+WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm @nonARC @cost:3
+WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm @nonARC @cost:3
+WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm @nonARC @cost:3
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.mm @nonARC
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm @nonARC
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
-WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm @nonARC
+WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm @nonARC @cost:4
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm @nonARC @no-unify
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm @nonARC
-WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm @nonARC
+WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm @nonARC @cost:3
 
 // Derived Sources
 AudioSessionRoutingArbitratorProxyMessageReceiver.cpp
@@ -924,12 +924,12 @@ AuthenticationManagerMessageReceiver.cpp
 AuxiliaryProcessMessageReceiver.cpp
 DownloadProxyMessageReceiver.cpp
 DrawingAreaMessageReceiver.cpp
-DrawingAreaProxyMessageReceiver.cpp
+DrawingAreaProxyMessageReceiver.cpp @cost:10
 DigitalCredentialsCoordinatorMessageReceiver.cpp
 EventDispatcherMessageReceiver.cpp
-GPUConnectionToWebProcessMessageReceiver.cpp
+GPUConnectionToWebProcessMessageReceiver.cpp @cost:6
 GPUProcessConnectionMessageReceiver.cpp
-GPUProcessMessageReceiver.cpp
+GPUProcessMessageReceiver.cpp @cost:7
 GPUProcessProxyMessageReceiver.cpp
 LegacyCustomProtocolManagerMessageReceiver.cpp
 LegacyCustomProtocolManagerProxyMessageReceiver.cpp
@@ -939,41 +939,41 @@ LibWebRTCNetworkMessageReceiver.cpp
 LogStreamMessageReceiver.cpp
 Shared/LogStream.mm @no-unify
 ModelConnectionToWebProcessMessageReceiver.cpp
-MediaPlayerPrivateRemoteMessageReceiver.cpp
+MediaPlayerPrivateRemoteMessageReceiver.cpp @cost:5
 MediaSourcePrivateRemoteMessageReceiverMessageReceiver.cpp
 ModelProcessConnectionMessageReceiver.cpp
 ModelProcessMessageReceiver.cpp
 ModelProcessModelPlayerProxyMessageReceiver.cpp
 ModelProcessProxyMessageReceiver.cpp
-NetworkConnectionToWebProcessMessageReceiver.cpp
-NetworkContentRuleListManagerMessageReceiver.cpp
+NetworkConnectionToWebProcessMessageReceiver.cpp @cost:9
+NetworkContentRuleListManagerMessageReceiver.cpp @cost:3
 NetworkMDNSRegisterMessageReceiver.cpp
-NetworkProcessConnectionMessageReceiver.cpp
-NetworkProcessMessageReceiver.cpp
-NetworkProcessProxyMessageReceiver.cpp
-NetworkResourceLoaderMessageReceiver.cpp
+NetworkProcessConnectionMessageReceiver.cpp @cost:3
+NetworkProcessMessageReceiver.cpp @cost:9
+NetworkProcessProxyMessageReceiver.cpp @cost:6
+NetworkResourceLoaderMessageReceiver.cpp @cost:5
 NetworkRTCMonitorMessageReceiver.cpp
-NetworkRTCProviderMessageReceiver.cpp
+NetworkRTCProviderMessageReceiver.cpp @cost:3
 NetworkSocketChannelMessageReceiver.cpp
-NetworkStorageManagerMessageReceiver.cpp
-NotificationManagerMessageHandlerMessageReceiver.cpp
-PlaybackSessionManagerMessageReceiver.cpp
-PlaybackSessionManagerProxyMessageReceiver.cpp
+NetworkStorageManagerMessageReceiver.cpp @cost:6
+NotificationManagerMessageHandlerMessageReceiver.cpp @cost:3
+PlaybackSessionManagerMessageReceiver.cpp @cost:3
+PlaybackSessionManagerProxyMessageReceiver.cpp @cost:3
 RemoteAudioDestinationManagerMessageReceiver.cpp
 RemoteAudioHardwareListenerMessageReceiver.cpp
 RemoteAudioSessionMessageReceiver.cpp
 RemoteAudioSessionProxyMessageReceiver.cpp
 RemoteAudioSourceProviderManagerMessageReceiver.cpp
 RemoteCaptureSampleManagerMessageReceiver.cpp
-RemoteCDMFactoryProxyMessageReceiver.cpp
+RemoteCDMFactoryProxyMessageReceiver.cpp @cost:3
 RemoteCDMInstanceMessageReceiver.cpp
-RemoteCDMInstanceProxyMessageReceiver.cpp
+RemoteCDMInstanceProxyMessageReceiver.cpp @cost:3
 RemoteCDMInstanceSessionMessageReceiver.cpp
 RemoteCDMInstanceSessionProxyMessageReceiver.cpp
 RemoteCDMProxyMessageReceiver.cpp
-RemoteImageBufferMessageReceiver.cpp
+RemoteImageBufferMessageReceiver.cpp @cost:5
 RemoteImageBufferProxyMessageReceiver.cpp
-RemoteImageBufferSetMessageReceiver.cpp
+RemoteImageBufferSetMessageReceiver.cpp @cost:5
 RemoteImageDecoderAVFManagerMessageReceiver.cpp
 RemoteImageDecoderAVFProxyMessageReceiver.cpp
 RemoteLayerTreeDrawingAreaProxyMessageReceiver.cpp
@@ -996,78 +996,78 @@ RemoteMediaSourceProxyMessageReceiver.cpp
 RemoteObjectRegistryMessageReceiver.cpp
 RemoteRemoteCommandListenerMessageReceiver.cpp
 RemoteRemoteCommandListenerProxyMessageReceiver.cpp
-RemoteRenderingBackendMessageReceiver.cpp
+RemoteRenderingBackendMessageReceiver.cpp @cost:7
 RemoteRenderingBackendProxyMessageReceiver.cpp
 RemoteSampleBufferDisplayLayerManagerMessageReceiver.cpp
 RemoteSampleBufferDisplayLayerMessageReceiver.cpp
 RemoteScrollingCoordinatorMessageReceiver.cpp
-RemoteSharedResourceCacheMessageReceiver.cpp
+RemoteSharedResourceCacheMessageReceiver.cpp @cost:5
 RemoteSourceBufferProxyMessageReceiver.cpp
 RemoteWebInspectorUIMessageReceiver.cpp
 RemoteWebInspectorUIProxyMessageReceiver.cpp
 SampleBufferDisplayLayerMessageReceiver.cpp
 SecItemShimProxyMessageReceiver.cpp
-SerializedTypeInfo.mm @nonARC
+SerializedTypeInfo.mm @nonARC @cost:14
 ServiceWorkerFetchTaskMessageReceiver.cpp
 SmartMagnificationControllerMessageReceiver.cpp
 SourceBufferPrivateRemoteMessageReceiverMessageReceiver.cpp
 SpeechRecognitionRealtimeMediaSourceManagerMessageReceiver.cpp
-SpeechRecognitionRemoteRealtimeMediaSourceManagerMessageReceiver.cpp
-SpeechRecognitionServerMessageReceiver.cpp
+SpeechRecognitionRemoteRealtimeMediaSourceManagerMessageReceiver.cpp @cost:10
+SpeechRecognitionServerMessageReceiver.cpp @cost:10
 StorageAreaMapMessageReceiver.cpp
 TextCheckingControllerProxyMessageReceiver.cpp
-UserMediaCaptureManagerMessageReceiver.cpp
-UserMediaCaptureManagerProxyMessageReceiver.cpp
-VideoPresentationManagerMessageReceiver.cpp
-VideoPresentationManagerProxyMessageReceiver.cpp
-ViewGestureControllerMessageReceiver.cpp
+UserMediaCaptureManagerMessageReceiver.cpp @cost:3
+UserMediaCaptureManagerProxyMessageReceiver.cpp @cost:3
+VideoPresentationManagerMessageReceiver.cpp @cost:3
+VideoPresentationManagerProxyMessageReceiver.cpp @cost:3
+ViewGestureControllerMessageReceiver.cpp @cost:10
 ViewGestureGeometryCollectorMessageReceiver.cpp
 ViewUpdateDispatcherMessageReceiver.cpp
-VisitedLinkStoreMessageReceiver.cpp
+VisitedLinkStoreMessageReceiver.cpp @cost:9
 VisitedLinkTableControllerMessageReceiver.cpp
-WebAuthenticatorCoordinatorProxyMessageReceiver.cpp
-WebAutomationSessionProxyMessageReceiver.cpp
+WebAuthenticatorCoordinatorProxyMessageReceiver.cpp @cost:4
+WebAutomationSessionProxyMessageReceiver.cpp @cost:3
 WebBackForwardListMessageReceiver.cpp
-WebCookieManagerMessageReceiver.cpp
+WebCookieManagerMessageReceiver.cpp @cost:3
 WebDeviceOrientationUpdateProviderMessageReceiver.cpp
 WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp
-WebExtensionContextMessageReceiver.cpp
-WebExtensionContextProxyMessageReceiver.cpp
-WebExtensionControllerMessageReceiver.cpp
-WebExtensionControllerProxyMessageReceiver.cpp
+WebExtensionContextMessageReceiver.cpp @cost:11
+WebExtensionContextProxyMessageReceiver.cpp @cost:7
+WebExtensionControllerMessageReceiver.cpp @cost:6
+WebExtensionControllerProxyMessageReceiver.cpp @cost:6
 WebFileSystemStorageConnectionMessageReceiver.cpp
-WebFullScreenManagerMessageReceiver.cpp
-WebFullScreenManagerProxyMessageReceiver.cpp
+WebFullScreenManagerMessageReceiver.cpp @cost:3
+WebFullScreenManagerProxyMessageReceiver.cpp @cost:10
 WebGeolocationManagerMessageReceiver.cpp
-WebGeolocationManagerProxyMessageReceiver.cpp
-WebIDBConnectionToServerMessageReceiver.cpp
+WebGeolocationManagerProxyMessageReceiver.cpp @cost:10
+WebIDBConnectionToServerMessageReceiver.cpp @cost:3
 WasmDebuggerDispatcherMessageReceiver.cpp
 WebInspectorInterruptDispatcherMessageReceiver.cpp
 WebInspectorBackendMessageReceiver.cpp
-WebInspectorBackendProxyMessageReceiver.cpp
-ProxyingNetworkAgentMessageReceiver.cpp
-ProxyingPageAgentMessageReceiver.cpp
-WebInspectorUIExtensionControllerMessageReceiver.cpp
+WebInspectorBackendProxyMessageReceiver.cpp @cost:4
+ProxyingNetworkAgentMessageReceiver.cpp @cost:3
+ProxyingPageAgentMessageReceiver.cpp @cost:3
+WebInspectorUIExtensionControllerMessageReceiver.cpp @cost:3
 WebInspectorUIExtensionControllerProxyMessageReceiver.cpp
-WebInspectorUIMessageReceiver.cpp
-WebInspectorUIProxyMessageReceiver.cpp
+WebInspectorUIMessageReceiver.cpp @cost:3
+WebInspectorUIProxyMessageReceiver.cpp @cost:4
 WebNotificationManagerMessageReceiver.cpp
-WebPageMessageReceiver.cpp
-WebPageProxyMessageReceiver.cpp
+WebPageMessageReceiver.cpp @cost:22
+WebPageProxyMessageReceiver.cpp @cost:33
 WebPageTestingMessageReceiver.cpp
-WebPasteboardProxyMessageReceiver.cpp
+WebPasteboardProxyMessageReceiver.cpp @cost:15
 WebPaymentCoordinatorMessageReceiver.cpp
-WebPaymentCoordinatorProxyMessageReceiver.cpp
-WebProcessMessageReceiver.cpp
-WebProcessPoolMessageReceiver.cpp
-WebProcessProxyMessageReceiver.cpp
-WebResourceLoaderMessageReceiver.cpp
-WebRTCMonitorMessageReceiver.cpp
+WebPaymentCoordinatorProxyMessageReceiver.cpp @cost:3
+WebProcessMessageReceiver.cpp @cost:9
+WebProcessPoolMessageReceiver.cpp @cost:10
+WebProcessProxyMessageReceiver.cpp @cost:15
+WebResourceLoaderMessageReceiver.cpp @cost:3
+WebRTCMonitorMessageReceiver.cpp @cost:3
 WebRTCResolverMessageReceiver.cpp
 WebSocketChannelMessageReceiver.cpp
 WebSpeechRecognitionConnectionMessageReceiver.cpp
-WebSWClientConnectionMessageReceiver.cpp
-WebSWContextManagerConnectionMessageReceiver.cpp
-WebSWServerConnectionMessageReceiver.cpp
-WebSWServerToContextConnectionMessageReceiver.cpp
+WebSWClientConnectionMessageReceiver.cpp @cost:3
+WebSWContextManagerConnectionMessageReceiver.cpp @cost:5
+WebSWServerConnectionMessageReceiver.cpp @cost:5
+WebSWServerToContextConnectionMessageReceiver.cpp @cost:5
 WebUserContentControllerMessageReceiver.cpp

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -30,7 +30,7 @@ GPUProcess/media/RemoteAudioDestinationManager.cpp
 
 GPUProcess/media/gstreamer/RemoteMediaPlayerProxyGStreamer.cpp
 
-NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp @cost:7
 
 NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp
 
@@ -353,7 +353,7 @@ WebProcess/WebCoreSupport/gtk/WebEditorClientGtk.cpp
 
 WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp
 
-WebProcess/WebPage/ViewGestureGeometryCollector.cpp
+WebProcess/WebPage/ViewGestureGeometryCollector.cpp @cost:5
 
 WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp @no-unify
 WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp

--- a/Source/WebKitLegacy/SourcesCocoa.txt
+++ b/Source/WebKitLegacy/SourcesCocoa.txt
@@ -121,68 +121,68 @@ mac/DOM/DOMHTMLTitleElement.mm @nonARC
 mac/DOM/DOMHTMLUListElement.mm @nonARC
 mac/DOM/DOMHTMLVideoElement.mm @nonARC
 mac/DOM/DOMImplementation.mm @nonARC
-mac/DOM/DOMInternal.mm @nonARC
-mac/DOM/DOMKeyboardEvent.mm @nonARC
-mac/DOM/DOMMediaError.mm @nonARC
-mac/DOM/DOMMediaList.mm @nonARC
-mac/DOM/DOMMouseEvent.mm @nonARC
-mac/DOM/DOMMutationEvent.mm @nonARC
-mac/DOM/DOMNamedNodeMap.mm @nonARC
-mac/DOM/DOMNode.mm @nonARC
-mac/DOM/DOMNodeIterator.mm @nonARC
-mac/DOM/DOMNodeList.mm @nonARC
+mac/DOM/DOMInternal.mm @nonARC @cost:4
+mac/DOM/DOMKeyboardEvent.mm @nonARC @cost:3
+mac/DOM/DOMMediaError.mm @nonARC @cost:3
+mac/DOM/DOMMediaList.mm @nonARC @cost:3
+mac/DOM/DOMMouseEvent.mm @nonARC @cost:3
+mac/DOM/DOMMutationEvent.mm @nonARC @cost:3
+mac/DOM/DOMNamedNodeMap.mm @nonARC @cost:3
+mac/DOM/DOMNode.mm @nonARC @cost:4
+mac/DOM/DOMNodeIterator.mm @nonARC @cost:3
+mac/DOM/DOMNodeList.mm @nonARC @cost:3
 mac/DOM/DOMObject.mm @nonARC
-mac/DOM/DOMOverflowEvent.mm @nonARC
-mac/DOM/DOMProcessingInstruction.mm @nonARC
-mac/DOM/DOMProgressEvent.mm @nonARC
-mac/DOM/DOMRGBColor.mm @nonARC
-mac/DOM/DOMRange.mm @nonARC
-mac/DOM/DOMRect.mm @nonARC
-mac/DOM/DOMStyleSheet.mm @nonARC
-mac/DOM/DOMStyleSheetList.mm @nonARC
-mac/DOM/DOMText.mm @nonARC
-mac/DOM/DOMTextEvent.mm @nonARC
-mac/DOM/DOMTimeRanges.mm @nonARC
-mac/DOM/DOMTokenList.mm @nonARC
-mac/DOM/DOMTreeWalker.mm @nonARC
-mac/DOM/DOMUIEvent.mm @nonARC
+mac/DOM/DOMOverflowEvent.mm @nonARC @cost:3
+mac/DOM/DOMProcessingInstruction.mm @nonARC @cost:3
+mac/DOM/DOMProgressEvent.mm @nonARC @cost:3
+mac/DOM/DOMRGBColor.mm @nonARC @cost:3
+mac/DOM/DOMRange.mm @nonARC @cost:5
+mac/DOM/DOMRect.mm @nonARC @cost:3
+mac/DOM/DOMStyleSheet.mm @nonARC @cost:3
+mac/DOM/DOMStyleSheetList.mm @nonARC @cost:3
+mac/DOM/DOMText.mm @nonARC @cost:3
+mac/DOM/DOMTextEvent.mm @nonARC @cost:3
+mac/DOM/DOMTimeRanges.mm @nonARC @cost:3
+mac/DOM/DOMTokenList.mm @nonARC @cost:3
+mac/DOM/DOMTreeWalker.mm @nonARC @cost:3
+mac/DOM/DOMUIEvent.mm @nonARC @cost:3
 mac/DOM/DOMUIKitExtensions.mm @nonARC
-mac/DOM/DOMUtility.mm @nonARC
-mac/DOM/DOMWheelEvent.mm @nonARC
+mac/DOM/DOMUtility.mm @nonARC @cost:5
+mac/DOM/DOMWheelEvent.mm @nonARC @cost:3
 mac/DOM/DOMXPath.mm @nonARC
-mac/DOM/DOMXPathExpression.mm @nonARC
-mac/DOM/DOMXPathResult.mm @nonARC
+mac/DOM/DOMXPathExpression.mm @nonARC @cost:3
+mac/DOM/DOMXPathResult.mm @nonARC @cost:3
 mac/DOM/ExceptionHandlers.mm @nonARC
-mac/DOM/ObjCEventListener.mm @nonARC
+mac/DOM/ObjCEventListener.mm @nonARC @cost:3
 mac/DOM/ObjCNodeFilterCondition.mm @nonARC
-mac/DOM/WebDOMOperations.mm @nonARC
+mac/DOM/WebDOMOperations.mm @nonARC @cost:11
 
-mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm @nonARC
+mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm @nonARC @cost:4
 
-mac/Misc/WebSharingServicePickerController.mm @nonARC
+mac/Misc/WebSharingServicePickerController.mm @nonARC @cost:3
 
 mac/Plugins/WebBasePluginPackage.mm @nonARC
-mac/Plugins/WebPluginContainerCheck.mm @nonARC
-mac/Plugins/WebPluginController.mm @nonARC
+mac/Plugins/WebPluginContainerCheck.mm @nonARC @cost:5
+mac/Plugins/WebPluginController.mm @nonARC @cost:4
 mac/Plugins/WebPluginDatabase.mm @nonARC
 
-mac/History/WebBackForwardList.mm @nonARC
+mac/History/WebBackForwardList.mm @nonARC @cost:4
 mac/WebCoreSupport/TextIndicatorWindow.mm @nonARC
-mac/WebCoreSupport/WebFrameLoaderClient.mm @nonARC
+mac/WebCoreSupport/WebFrameLoaderClient.mm @nonARC @cost:7
 
-mac/WebInspector/WebInspector.mm @nonARC
+mac/WebInspector/WebInspector.mm @nonARC @cost:4
 
-mac/WebView/WebClipView.mm @nonARC
-mac/WebView/WebDataSource.mm @nonARC
-mac/WebView/WebFrame.mm @nonARC
-mac/WebView/WebFrameView.mm @nonARC
-mac/WebView/WebFullScreenController.mm @nonARC
-mac/WebView/WebHTMLView.mm @nonARC
-mac/WebView/WebImmediateActionController.mm @nonARC
+mac/WebView/WebClipView.mm @nonARC @cost:4
+mac/WebView/WebDataSource.mm @nonARC @cost:4
+mac/WebView/WebFrame.mm @nonARC @cost:14
+mac/WebView/WebFrameView.mm @nonARC @cost:5
+mac/WebView/WebFullScreenController.mm @nonARC @cost:8
+mac/WebView/WebHTMLView.mm @nonARC @cost:10
+mac/WebView/WebImmediateActionController.mm @nonARC @cost:9
 mac/WebView/WebPDFRepresentation.mm @nonARC
-mac/WebView/WebPDFView.mm @nonARC
-mac/WebView/WebScriptDebugger.mm @nonARC
-mac/WebView/WebScriptDebugDelegate.mm @nonARC
-mac/WebView/WebScriptWorld.mm @nonARC
-mac/WebView/WebView.mm @nonARC
+mac/WebView/WebPDFView.mm @nonARC @cost:5
+mac/WebView/WebScriptDebugger.mm @nonARC @cost:4
+mac/WebView/WebScriptDebugDelegate.mm @nonARC @cost:4
+mac/WebView/WebScriptWorld.mm @nonARC @cost:3
+mac/WebView/WebView.mm @nonARC @cost:16
 mac/WebView/WebViewRenderingUpdateScheduler.mm @nonARC

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -203,6 +203,8 @@ set(JavaScriptCore_LIBRARY_TYPE SHARED)
 set(WebCore_LIBRARY_TYPE SHARED)
 set(WebKit_LIBRARY_TYPE SHARED)
 
+set(WEBKIT_MAX_BUNDLE_SIZE 128)
+
 # Add PrivateFrameworks to framework search path (mirrors Base.xcconfig).
 if (CMAKE_OSX_SYSROOT)
     add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks>")

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -43,6 +43,9 @@ macro(WEBKIT_COMPUTE_SOURCES _framework)
     if (${_framework} STREQUAL "WebCore")
         list(APPEND gusb_args --dense-bundle-filter "JS*=JSBindings" --dense-bundle-filter "bindings/*=JSBindings")
     endif ()
+    if (DEFINED WEBKIT_MAX_BUNDLE_SIZE)
+        list(APPEND gusb_args --max-bundle-size ${WEBKIT_MAX_BUNDLE_SIZE} --enforce-cost)
+    endif ()
 
     if (ENABLE_UNIFIED_BUILDS)
         execute_process(COMMAND ${Python_EXECUTABLE} ${WTF_SCRIPTS_DIR}/generate-unified-source-bundles.py


### PR DESCRIPTION
#### 9816b1440ae4ae7ef2be80ba086248d29e820aec
<pre>
[CMake][Mac] Jumbo unified builds with @cost weighting
<a href="https://bugs.webkit.org/show_bug.cgi?id=316219">https://bugs.webkit.org/show_bug.cgi?id=316219</a>
<a href="https://rdar.apple.com/178646839">rdar://178646839</a>

Reviewed by Pascoe.

Speeds up clean build time by about 2 minutes (27.5%).

Raised the unified build member count from 8 to 128. (Up to 128 is
measurably profitable, and beyond that is not.)

To counter-act the potential increase in incremental build time, we
already have:
  * adaptive unified builds
  * tuned prefix headers

To that, this patch adds @cost annotation for particularly costly unified
build members. @cost is an optional annotation to indicate a file&apos;s wall
time cost to compile, relative to the median. It addresses the case where
a unified bundle contains many long pole files. It&apos;s not a regression for
an incremental build to wait on one long pole, but it is a regression for
it to wait on many.

I don&apos;t think we need a fancy system for keeping @cost always up to date.
If we ever see a long pole in the future, we can slap a new @cost on it.

All incremental build times after first touch (cold) are un-changed.
First touch (cold) times are mostly un-changed on average, but there are
some small losses:

┌────────────────────────────────────────────────────────────┬
│          First touch (cold) incremental build time         │
├───────────────────────────┬──────────┬──────────┬──────────┼
│        sub-target         │    N=8   │   N=128  │     Δ    │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ WebCoreJSBindings         │   10.3 s │    8.2 s │   −2.1 s │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ WebCoreRenderStyleInlines │    4.1 s │    2.0 s │   −2.0 s │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ JavaScriptCoreJIT         │    1.1 s │    1.9 s │   +0.7 s │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ WebKitNetworkProcess      │    4.1 s │    4.5 s │   +0.4 s │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ WebCoreStyle              │    4.4 s │    5.7 s │   +1.3 s │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ WebCore (platform/)       │    2.8 s │    4.8 s │   +2.0 s │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ WebCoreDOMAndRendering    │    4.4 s │    6.5 s │   +2.1 s │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ JavaScriptCore            │    1.1 s │    3.5 s │   +2.3 s │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ WebKitUIProcess           │    2.2 s │    3.0 s │   +0.7 s │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ WebKitShared              │    4.1 s │    6.9 s │   +2.9 s │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ WebKitGPUProcess          │    4.1 s │    5.2 s │   +1.1 s │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ WebKitWebProcess          │    4.7 s │    9.5 s │   +4.9 s │
├───────────────────────────┼──────────┼──────────┼──────────┼
│ WebCore (Modules/)        │    2.8 s │    8.7 s │   +5.9 s │
└───────────────────────────┴──────────┴──────────┴──────────┴

Source/cmake/WebKitMacros.cmake:
- Forward WEBKIT_MAX_BUNDLE_SIZE as --max-bundle-size

Source/cmake/OptionsMac.cmake:
- set WEBKIT_MAX_BUNDLE_SIZE 128 (Mac-only for now; other ports can opt
  in once we A/B test compile time and validate EWS)

* Source/WTF/Scripts/generate-unified-source-bundles.py:
(bundle_prefix_and_size_for_path):
(SourceFile.__init__):
(BundleManager.add_file): Added support for a file that costs greater
than implicit 1.

(parse_args):
* Source/WebCore/Sources.txt:
* Source/WebKit/Sources.txt:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKitLegacy/SourcesCocoa.txt: Added cost annotations.

* Source/cmake/OptionsMac.cmake: Set unified bundle member count to 128.
* Source/cmake/WebKitMacros.cmake:

Canonical link: <a href="https://commits.webkit.org/314497@main">https://commits.webkit.org/314497@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4577fe192684930dd6c6e557c0f4a2f71637c36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166292 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175340 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123547 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129255 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91039 "Build is in progress. Recent messages:") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7654eacc-7aa9-47ff-a96c-fdd9475adffb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31637 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109780 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6a1717d-7025-40d2-9da1-b6d2d7a6b8c0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23480 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158449 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177872 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27186 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137608 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33457 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137530 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; Running re-run-api-tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148901 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103182 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25318 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32827 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25768 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198693 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112124 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/53376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38447 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3854 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38692 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38590 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->