### PR TITLE
Add WKWebpagePreferences SPI to enable Global Privacy Control per-navigation

### DIFF
--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -202,6 +202,9 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
         frame->settings().setTouchEventDOMAttributesEnabled(*overrideValue);
 #endif
 
+    if (auto overrideValue = websitePolicies.globalPrivacyControlEnabled)
+        frame->settings().setGlobalPrivacyControlEnabled(*overrideValue);
+
     documentLoader.applyPoliciesToSettings();
 }
 

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -70,6 +70,7 @@ public:
 #if ENABLE(TOUCH_EVENTS)
     std::optional<bool> overrideTouchEventDOMAttributesEnabled;
 #endif
+    std::optional<bool> globalPrivacyControlEnabled;
     WebsiteAutoplayPolicy autoplayPolicy { WebsiteAutoplayPolicy::Default };
     WebsitePopUpPolicy popUpPolicy { WebsitePopUpPolicy::Default };
     WebsiteMetaViewportPolicy metaViewportPolicy { WebsiteMetaViewportPolicy::Default };

--- a/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
+++ b/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
@@ -70,6 +70,7 @@ struct WebKit::WebsitePoliciesData {
 #if ENABLE(TOUCH_EVENTS)
     std::optional<bool> overrideTouchEventDOMAttributesEnabled;
 #endif
+    std::optional<bool> globalPrivacyControlEnabled;
     WebKit::WebsiteAutoplayPolicy autoplayPolicy;
     WebKit::WebsitePopUpPolicy popUpPolicy;
     WebKit::WebsiteMetaViewportPolicy metaViewportPolicy;

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -138,6 +138,9 @@ public:
     bool allowPrivacyProxy() const { return m_data.allowPrivacyProxy; }
     void setAllowPrivacyProxy(bool allow) { m_data.allowPrivacyProxy = allow; }
 
+    std::optional<bool> globalPrivacyControlEnabled() const { return m_data.globalPrivacyControlEnabled; }
+    void setGlobalPrivacyControlEnabled(std::optional<bool> enabled) { m_data.globalPrivacyControlEnabled = enabled; }
+
     WebCore::HTTPSByDefaultMode httpsByDefaultMode() const { return m_data.httpsByDefaultMode; }
     void setHTTPSByDefault(WebCore::HTTPSByDefaultMode mode) { m_data.httpsByDefaultMode = mode; }
     bool isUpgradeWithUserMediatedFallbackEnabled() { return advancedPrivacyProtections().contains(WebCore::AdvancedPrivacyProtections::HTTPSOnly) || httpsByDefaultMode() == WebCore::HTTPSByDefaultMode::UpgradeWithUserMediatedFallback; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -555,6 +555,16 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return _websitePolicies->allowPrivacyProxy();
 }
 
+- (void)_setGlobalPrivacyControlEnabled:(BOOL)enabled
+{
+    _websitePolicies->setGlobalPrivacyControlEnabled(enabled);
+}
+
+- (BOOL)_globalPrivacyControlEnabled
+{
+    return protect(*_websitePolicies)->globalPrivacyControlEnabled().value_or(false);
+}
+
 - (_WKWebsiteColorSchemePreference)_colorSchemePreference
 {
     switch (_websitePolicies->colorSchemePreference()) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -139,4 +139,6 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 
 @property (nonatomic, setter=setOverrideReferrer:) NSString *_overrideReferrerForAllRequests WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+@property (nonatomic, setter=_setGlobalPrivacyControlEnabled:) BOOL _globalPrivacyControlEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
@@ -2247,3 +2247,142 @@ TEST(WebpagePreferences, LoadHTMLString)
     [webView loadHTMLString:html baseURL:nil];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "false");
 }
+
+TEST(WebpagePreferences, GlobalPrivacyControlNavigatorAPI)
+{
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+
+    __block BOOL nextNavigationGPC = YES;
+    navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        [preferences _setGlobalPrivacyControlEnabled:nextNavigationGPC];
+        decisionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    NSString *html = @"<script>alert(String(navigator.globalPrivacyControl))</script>";
+    [webView loadHTMLString:html baseURL:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "true");
+
+    nextNavigationGPC = NO;
+    [webView loadHTMLString:html baseURL:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "false");
+}
+
+TEST(WebpagePreferences, GlobalPrivacyControlRequestHeader)
+{
+    using namespace TestWebKitAPI;
+
+    bool sawMainResourceRequest { false };
+    bool sawSubresourceRequest { false };
+    bool sawNoOverrideRequest { false };
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
+        auto request = co_await connection.awaitableReceiveHTTPRequest();
+        auto path = HTTPServer::parsePath(request);
+        bool hasGPCHeader = !!strnstr(request.span().data(), "\r\nSec-GPC: 1\r\n", request.size());
+        if (path == "/main"_s) {
+            EXPECT_TRUE(hasGPCHeader);
+            sawMainResourceRequest = true;
+            co_await connection.awaitableSend(HTTPResponse("<script>fetch('/sub').then(() => {});</script>"_s).serialize());
+            continue;
+        }
+        if (path == "/sub"_s) {
+            EXPECT_TRUE(hasGPCHeader);
+            sawSubresourceRequest = true;
+            co_await connection.awaitableSend(HTTPResponse(""_s).serialize());
+            continue;
+        }
+        if (path == "/no-override"_s) {
+            EXPECT_FALSE(hasGPCHeader);
+            sawNoOverrideRequest = true;
+            co_await connection.awaitableSend(HTTPResponse(""_s).serialize());
+            continue;
+        }
+        EXPECT_FALSE(true);
+    } });
+
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    webView.get().navigationDelegate = delegate.get();
+
+    delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        [preferences _setGlobalPrivacyControlEnabled:YES];
+        completionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+    [webView loadRequest:server.requestWithLocalhost("/main"_s)];
+    Util::run(&sawSubresourceRequest);
+    EXPECT_TRUE(sawMainResourceRequest);
+
+    RetainPtr defaultWebView = adoptNS([TestWKWebView new]);
+    [defaultWebView loadRequest:server.requestWithLocalhost("/no-override"_s)];
+    Util::run(&sawNoOverrideRequest);
+}
+
+TEST(WebpagePreferences, GlobalPrivacyControlNavigatorAPIInSubframe)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer server({
+        { "/main.html"_s, { "<iframe src='/sub.html'></iframe>"_s } },
+        { "/sub.html"_s, { "<script>alert(String(navigator.globalPrivacyControl))</script>"_s } },
+    }, HTTPServer::Protocol::Http);
+
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        if (action.targetFrame.mainFrame)
+            [preferences _setGlobalPrivacyControlEnabled:YES];
+        completionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+    [webView setNavigationDelegate:delegate.get()];
+
+    [webView loadRequest:server.requestWithLocalhost("/main.html"_s)];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "true");
+}
+
+TEST(WebpagePreferences, GlobalPrivacyControlRequestHeaderInSubframe)
+{
+    using namespace TestWebKitAPI;
+
+    bool sawMainResourceRequest { false };
+    bool sawSubframeMainResourceRequest { false };
+    bool sawSubframeSubresourceRequest { false };
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
+        auto request = co_await connection.awaitableReceiveHTTPRequest();
+        auto path = HTTPServer::parsePath(request);
+        bool hasGPCHeader = !!strnstr(request.span().data(), "\r\nSec-GPC: 1\r\n", request.size());
+        if (path == "/main"_s) {
+            EXPECT_TRUE(hasGPCHeader);
+            sawMainResourceRequest = true;
+            co_await connection.awaitableSend(HTTPResponse("<iframe src='/subframe'></iframe>"_s).serialize());
+            continue;
+        }
+        if (path == "/subframe"_s) {
+            EXPECT_TRUE(hasGPCHeader);
+            sawSubframeMainResourceRequest = true;
+            co_await connection.awaitableSend(HTTPResponse("<script>fetch('/subframe-subresource').then(() => {});</script>"_s).serialize());
+            continue;
+        }
+        if (path == "/subframe-subresource"_s) {
+            EXPECT_TRUE(hasGPCHeader);
+            sawSubframeSubresourceRequest = true;
+            co_await connection.awaitableSend(HTTPResponse(""_s).serialize());
+            continue;
+        }
+        EXPECT_FALSE(true);
+    } });
+
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    webView.get().navigationDelegate = delegate.get();
+
+    delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        if (action.targetFrame.mainFrame)
+            [preferences _setGlobalPrivacyControlEnabled:YES];
+        completionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+    [webView loadRequest:server.requestWithLocalhost("/main"_s)];
+    Util::run(&sawSubframeSubresourceRequest);
+    EXPECT_TRUE(sawMainResourceRequest);
+    EXPECT_TRUE(sawSubframeMainResourceRequest);
+}


### PR DESCRIPTION
#### 2ef16c20194cea0ebf31081d993b2c5a54ef8b4a
<pre>
Add WKWebpagePreferences SPI to enable Global Privacy Control per-navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=316225">https://bugs.webkit.org/show_bug.cgi?id=316225</a>
<a href="https://rdar.apple.com/178649267">rdar://178649267</a>

Reviewed by Matthew Finkel.

Plumb a globalPrivacyControlEnabled override through WebsitePoliciesData so clients can opt a
navigation into GPC via -[WKWebpagePreferences _setGlobalPrivacyControlEnabled:]. When set, the
website policy applies to the document&apos;s Settings, enabling both navigator.globalPrivacyControl and
the Sec-GPC request header for the main frame, subframes, and subresources.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm

* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::WebsitePoliciesData::applyToDocumentLoader):
* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/Shared/WebsitePoliciesData.serialization.in:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setGlobalPrivacyControlEnabled:]):
(-[WKWebpagePreferences _globalPrivacyControlEnabled]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm:

Canonical link: <a href="https://commits.webkit.org/314588@main">https://commits.webkit.org/314588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e635eb38cce9c251c339407896c01fa3f83072ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175585 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129482 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169496 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110007 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29542 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23726 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178119 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137834 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137752 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149136 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103510 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25352 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33047 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26001 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39295 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112370 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38692 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4090 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38937 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38835 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->