### PR TITLE
Cherry-pick 305413.548@safari-7624-branch (e509924cdce7)

### DIFF
--- a/LayoutTests/http/tests/web-locks/resources/shared-worker.js
+++ b/LayoutTests/http/tests/web-locks/resources/shared-worker.js
@@ -1,0 +1,5 @@
+self.onconnect = (event) => {
+    navigator.locks.request('abc', {mode: 'shared'}, () => {
+        event.ports[0].postMessage('PASS');
+    }).catch((error) => event.ports[0].postMessage(`FAIL - ${error}`));
+}

--- a/LayoutTests/http/tests/web-locks/web-lock-in-blob-url-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-blob-url-expected.txt
@@ -1,0 +1,4 @@
+This tests acquiring a web lock in blob URL. You should see PASS below
+
+PASS
+

--- a/LayoutTests/http/tests/web-locks/web-lock-in-blob-url.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-blob-url.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests acquiring a web lock in blob URL. You should see PASS below</p>
+<div id="result">Running</div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 3000);
+}
+onmessage = (message) => {
+    result.textContent = message.data;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+const blob = new Blob([`<!DOCTYPE html><script>
+navigator.locks.request('abc', {mode: 'shared'}, () => {
+    top.postMessage('PASS', '*');
+});
+<` + '/script>'], {type: "text/html"});
+
+const iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+iframe.src = URL.createObjectURL(blob);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-data-url-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-data-url-expected.txt
@@ -1,0 +1,4 @@
+This tests acquiring a web lock in data URL. You should see PASS below
+
+PASS
+

--- a/LayoutTests/http/tests/web-locks/web-lock-in-data-url.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-data-url.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 3000);
+}
+onmessage = (message) => {
+    result.textContent = message.data;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+<p>This tests acquiring a web lock in data URL. You should see PASS below</p>
+<div id="result">Running</div>
+<iframe src="data:text/html,
+<!DOCTYPE html>
+<script>
+top.postMessage(navigator.locks ? 'FAIL' : 'PASS', '*');
+</script>"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-opaque-srcdoc-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-opaque-srcdoc-expected.txt
@@ -1,0 +1,4 @@
+This tests acquiring a web lock in srcdoc with sandbox attribute. You should see PASS below
+
+PASS
+

--- a/LayoutTests/http/tests/web-locks/web-lock-in-opaque-srcdoc.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-opaque-srcdoc.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 3000);
+}
+onmessage = () => {
+    result.textContent = 'PASS';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+<p>This tests acquiring a web lock in srcdoc with sandbox attribute. You should see PASS below</p>
+<div id="result">Running</div>
+<iframe sandbox="allow-scripts" srcdoc="
+<!DOCTYPE html>
+<script>
+navigator.locks.request('abc', {mode: 'shared'}, () => {
+    top.postMessage('FAIL - Lock acquired', '*');
+}).then(
+    () => top.postMessage('FAIL - Promise resolved', '*'),
+    () => top.postMessage('PASS', '*'))
+</script>"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-serviceworker-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-serviceworker-expected.txt
@@ -1,0 +1,3 @@
+This tests acquiring a web lock in a service worker. You should see PASS below
+
+PASS

--- a/LayoutTests/http/tests/web-locks/web-lock-in-serviceworker-service-worker.js
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-serviceworker-service-worker.js
@@ -1,0 +1,21 @@
+self.addEventListener("activate", (event) => {
+    event.waitUntil(clients.claim());
+});
+
+self.addEventListener("fetch", (event) => {
+    if (event.request.url.indexOf("test1") >= 0) {
+        event.respondWith(new Promise((resolve) => {
+            navigator.locks.request('abc', {mode: 'shared'}, () => {
+                resolve(new Response("PASS"));
+            }).catch((error) => {
+                resolve(new Response(`FAIL - ${error}`));
+            });
+        }));
+        return;
+    }
+    if (event.request.mode !== "navigate") {
+        event.respondWith(Response.error());
+        return;
+    }
+    event.respondWith(fetch(event.request.url));
+});

--- a/LayoutTests/http/tests/web-locks/web-lock-in-serviceworker.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-serviceworker.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+if (window.testRunner) {
+    testRunner.setUseSeparateServiceWorkerProcess(true);
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 3000);
+}
+
+async function register() {
+    const serviceWorkerURL = './web-lock-in-serviceworker-service-worker.js?' + Date.now();
+    const registration = await navigator.serviceWorker.register(serviceWorkerURL);
+    if (registration.active)
+        return registration;
+    return new Promise((resolve) => {
+        const worker = registration.installing;
+        worker.addEventListener("statechange", () => {
+            if (worker.state == "activated")
+                resolve(registration);
+        });
+    });
+}
+
+async function runTest() {
+    const registration = await register();
+
+    if (!navigator.serviceWorker.controller)
+        await new Promise(resolve => navigator.serviceWorker.addEventListener('controllerchange', resolve));
+
+    const response = await fetch('./test1');
+
+    result.textContent = await response.text();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+runTest();
+
+</script>
+<p>This tests acquiring a web lock in a service worker. You should see PASS below</p>
+<div id="result">Running</div>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-sharedworker-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-sharedworker-expected.txt
@@ -1,0 +1,3 @@
+This tests acquiring a web lock in a shared worker. You should see PASS below
+
+PASS

--- a/LayoutTests/http/tests/web-locks/web-lock-in-sharedworker.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-sharedworker.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 3000);
+}
+
+const worker = new SharedWorker('./resources/shared-worker.js');
+worker.port.onmessage = (event) => {
+    result.textContent = event.data;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+</script>
+<p>This tests acquiring a web lock in a shared worker. You should see PASS below</p>
+<div id="result">Running</div>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-srcdoc-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-srcdoc-expected.txt
@@ -1,0 +1,4 @@
+This tests acquiring a web lock in srcdoc. You should see PASS below
+
+PASS
+

--- a/LayoutTests/http/tests/web-locks/web-lock-in-srcdoc.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-srcdoc.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 3000);
+}
+onmessage = () => {
+    result.textContent = 'PASS';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+<p>This tests acquiring a web lock in srcdoc. You should see PASS below</p>
+<div id="result">Running</div>
+<iframe srcdoc="
+<!DOCTYPE html>
+<script>
+navigator.locks.request('abc', {mode: 'shared'}, () => {
+    top.postMessage('PASS', '*');
+});
+</script>"></iframe>
+</body>
+</html>

--- a/LayoutTests/ipc/weblock-registry-origin-expected.txt
+++ b/LayoutTests/ipc/weblock-registry-origin-expected.txt
@@ -1,0 +1,2 @@
+This test passes if the WebLock isn't granted.
+PASS

--- a/LayoutTests/ipc/weblock-registry-origin.html
+++ b/LayoutTests/ipc/weblock-registry-origin.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] --> 
+<html>
+<head>
+<script>
+
+async function runTest()
+{
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    if (!window.IPC) {
+        result.textContent = window.testRunner ? 'PASS' : 'This test requires IPC testing API';
+        return;
+    }
+
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+
+    const { CoreIPC, IPCWireTap } = await import('./coreipc.js');
+    const uiOutgoingTap = new IPCWireTap('UI', 'Outgoing');
+
+    function waitForNextRequestLock()
+    {
+        return new Promise((resolve) => {
+            const uiOutgoingTap = new IPCWireTap('UI', 'Outgoing');
+            uiOutgoingTap.tapNext(IPC.messages.WebLockRegistryProxy_RequestLock.name, (...args) => resolve(args));
+        });
+    }
+
+    function acquireLockLegitimately()
+    {
+        return new Promise((resolve) => {
+            navigator.locks.request('abc', {mode: 'shared'}, resolve);
+        });
+    }
+
+    function waitForNextLockComplete()
+    {
+        return new Promise((resolve) => {
+            const uiIncomingTap = new IPCWireTap('UI', 'Incoming');
+            uiIncomingTap.tapNext(IPC.messages.RemoteWebLockRegistry_DidCompleteLockRequest.name, (...args) => resolve(args));
+        });
+    }
+
+    const lockRequest = waitForNextRequestLock();
+
+    await acquireLockLegitimately();
+
+    let [process, connectionID, messageName, typedArguments, msgArguments] = await lockRequest;
+
+    lockComplete = waitForNextLockComplete();
+
+    CoreIPC.UI.WebLockRegistryProxy.RequestLock(connectionID, {
+        clientOrigin: {
+            topOrigin: {
+                data: {
+                    variantType: msgArguments.clientOrigin.topOrigin.data.variantType,
+                    variant: {
+                        protocol: 'https',
+                        host: 'webkit.org',
+                        port: 80,
+                    },
+                }
+            },
+            clientOrigin: {
+                data: {
+                    variantType: msgArguments.clientOrigin.topOrigin.data.variantType,
+                    variant: {
+                        protocol: 'https',
+                        host: 'webkit.org',
+                        port: 80,
+                    },
+                }
+            },
+        },
+        identifier: {
+            processIdentifier: msgArguments.clientID.processIdentifier,
+            object: 123456789,
+        },
+        clientID: {
+            processIdentifier: msgArguments.clientID.processIdentifier,
+            object: msgArguments.clientID.object,
+        },
+        name: msgArguments.name,
+        mode: msgArguments.mode,
+        steal: false,
+        ifAvailable: msgArguments.ifAvailable,
+    });
+
+    await acquireLockLegitimately();
+
+    [process, connectionID, messageName, typedArguments, msgArguments] = await lockComplete;
+    result.textContent = msgArguments.lockIdentifier.object == 123456789 ? 'FAIL - Acquired lock' : 'PASS';
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</head>
+<body onload="runTest()">
+This test passes if the WebLock isn't granted.
+<div id="result"></div>
+</body>
+</html>
+

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -339,6 +339,9 @@ void WebFrameProxy::didFailProvisionalLoad()
 void WebFrameProxy::didCommitLoad(const String& contentType, const WebCore::CertificateInfo& certificateInfo, bool containsPluginDocument, DocumentSecurityPolicy&& documentSecurityPolicy, HashSet<WebCore::SecurityOriginData>&& cspOriginsThatUpgradeInsecureNavigations)
 {
     m_frameLoadState.didCommitLoad();
+    if (RefPtr page = m_page)
+        protect(process())->didCommitLoadClientOrigin(ClientOrigin { SecurityOriginData::fromURL(page->mainFrame()->url()), SecurityOriginData::fromURL(m_frameLoadState.url()) });
+
     if (m_isShowingInitialAboutBlank && !url().isAboutBlank())
         m_isShowingInitialAboutBlank = false;
 

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.cpp
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.cpp
@@ -60,6 +60,7 @@ void WebLockRegistryProxy::requestLock(WebCore::ClientOrigin&& clientOrigin, Web
     MESSAGE_CHECK(lockIdentifier.processIdentifier() == m_process->coreProcessIdentifier());
     MESSAGE_CHECK(clientID.processIdentifier() == m_process->coreProcessIdentifier());
     MESSAGE_CHECK(name.length() <= WebCore::WebLock::maxNameLength);
+    MESSAGE_CHECK(m_process->hasCommittedClientOrigin(clientOrigin));
     m_hasEverRequestedLocks = true;
 
     RefPtr dataStore = m_process->websiteDataStore();
@@ -81,15 +82,20 @@ void WebLockRegistryProxy::releaseLock(WebCore::ClientOrigin&& clientOrigin, Web
 {
     MESSAGE_CHECK(lockIdentifier.processIdentifier() == m_process->coreProcessIdentifier());
     MESSAGE_CHECK(clientID.processIdentifier() == m_process->coreProcessIdentifier());
+    MESSAGE_CHECK(m_process->hasCommittedClientOrigin(clientOrigin));
     Ref process = m_process.get();
-    if (RefPtr dataStore = process->websiteDataStore())
-        dataStore->webLockRegistry().releaseLock(process->sessionID(), WTF::move(clientOrigin), lockIdentifier, clientID, WTF::move(name));
+    RefPtr dataStore = process->websiteDataStore();
+    if (!dataStore)
+        return;
+
+    dataStore->webLockRegistry().releaseLock(process->sessionID(), WTF::move(clientOrigin), lockIdentifier, clientID, WTF::move(name));
 }
 
 void WebLockRegistryProxy::abortLockRequest(WebCore::ClientOrigin&& clientOrigin, WebCore::WebLockIdentifier lockIdentifier, WebCore::ScriptExecutionContextIdentifier clientID, String&& name, CompletionHandler<void(bool)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION(lockIdentifier.processIdentifier() == m_process->coreProcessIdentifier(), completionHandler(false));
     MESSAGE_CHECK_COMPLETION(clientID.processIdentifier() == m_process->coreProcessIdentifier(), completionHandler(false));
+    MESSAGE_CHECK_COMPLETION(m_process->hasCommittedClientOrigin(clientOrigin), completionHandler(false));
     RefPtr dataStore = m_process->websiteDataStore();
     if (!dataStore) {
         completionHandler(false);
@@ -101,6 +107,8 @@ void WebLockRegistryProxy::abortLockRequest(WebCore::ClientOrigin&& clientOrigin
 
 void WebLockRegistryProxy::snapshot(WebCore::ClientOrigin&& clientOrigin, CompletionHandler<void(WebCore::WebLockManagerSnapshot&&)>&& completionHandler)
 {
+    MESSAGE_CHECK_COMPLETION(m_process->hasCommittedClientOrigin(clientOrigin), completionHandler(WebCore::WebLockManagerSnapshot { }));
+
     RefPtr dataStore = m_process->websiteDataStore();
     if (!dataStore) {
         completionHandler(WebCore::WebLockManagerSnapshot { });
@@ -113,6 +121,7 @@ void WebLockRegistryProxy::snapshot(WebCore::ClientOrigin&& clientOrigin, Comple
 void WebLockRegistryProxy::clientIsGoingAway(WebCore::ClientOrigin&& clientOrigin, WebCore::ScriptExecutionContextIdentifier clientID)
 {
     MESSAGE_CHECK(clientID.processIdentifier() == m_process->coreProcessIdentifier());
+    MESSAGE_CHECK(m_process->hasCommittedClientOrigin(clientOrigin));
     if (RefPtr dataStore = WebsiteDataStore::existingDataStoreForSessionID(m_process->sessionID()))
         dataStore->webLockRegistry().clientIsGoingAway(m_process->sessionID(), WTF::move(clientOrigin), clientID);
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -975,6 +975,20 @@ void WebProcessProxy::sendPageCloseMessage(std::optional<WebPageProxyIdentifier>
     }, pageID);
 }
 
+bool WebProcessProxy::hasCommittedClientOrigin(const WebCore::ClientOrigin& clientOrigin) const
+{
+    if (isRunningWorkers()) {
+        ASSERT(m_site);
+        return Site { clientOrigin.topOrigin } == *m_site && Site { clientOrigin.clientOrigin } == *m_site;
+    }
+    return m_committedClientOrigins.contains(clientOrigin);
+}
+
+void WebProcessProxy::didCommitLoadClientOrigin(WebCore::ClientOrigin&& clientOrigin)
+{
+    m_committedClientOrigins.add(WTF::move(clientOrigin));
+}
+
 void WebProcessProxy::addVisitedLinkStoreUser(VisitedLinkStore& visitedLinkStore, WebPageProxyIdentifier pageID)
 {
     auto& users = m_visitedLinkStoresWithUsers.ensure(visitedLinkStore, [] {

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -307,6 +307,9 @@ public:
 
     void didCreateWebPageInProcess(WebCore::PageIdentifier);
 
+    bool hasCommittedClientOrigin(const WebCore::ClientOrigin&) const;
+    void didCommitLoadClientOrigin(WebCore::ClientOrigin&&);
+
     void addVisitedLinkStoreUser(VisitedLinkStore&, WebPageProxyIdentifier);
     void removeVisitedLinkStoreUser(VisitedLinkStore&, WebPageProxyIdentifier);
 
@@ -824,6 +827,8 @@ private:
     UserInitiatedActionMap m_userInitiatedActionMap;
     HashMap<WebCore::PageIdentifier, UserInitiatedActionByAuthorizationTokenMap> m_userInitiatedActionByAuthorizationTokenMap;
     uint64_t m_frameProcessCount { 0 };
+
+    HashSet<WebCore::ClientOrigin> m_committedClientOrigins; // Only grows because WebProcess can navigate back to an old origin in a history item.
 
     WeakHashMap<VisitedLinkStore, HashSet<WebPageProxyIdentifier>> m_visitedLinkStoresWithUsers;
 


### PR DESCRIPTION
#### 49c4af0a8d5f3b4f68fe029748cef419f3dcc84b
<pre>
Cherry-pick 305413.548@safari-7624-branch (e509924cdce7)
<a href="https://bugs.webkit.org/show_bug.cgi?id=316223">https://bugs.webkit.org/show_bug.cgi?id=316223</a>
<a href="https://rdar.apple.com/178648871">rdar://178648871</a>

    Reviewed by Brady Eidson and Chris Dumez.

    Check the authenticity of origins given to WebLockRegistryProxy::requestLock by
    keeping track of every ClientOrigin that got committed in WebFrameProxy.

    Test: http/tests/web-locks/web-lock-in-blob-url.html
          http/tests/web-locks/web-lock-in-data-url.html
          http/tests/web-locks/web-lock-in-opaque-srcdoc.html
          http/tests/web-locks/web-lock-in-serviceworker.html
          http/tests/web-locks/web-lock-in-sharedworker.html
          http/tests/web-locks/web-lock-in-srcdoc.html
          ipc/weblock-registry-origin.html

    * LayoutTests/http/tests/web-locks/resources/shared-worker.js: Added.
    (self.onconnect):
    * LayoutTests/http/tests/web-locks/web-lock-in-blob-url-expected.txt: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-blob-url.html: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-data-url-expected.txt: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-data-url.html: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-opaque-srcdoc-expected.txt: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-opaque-srcdoc.html: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-serviceworker-expected.txt: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-serviceworker-service-worker.js: Added.
    (event.event.request.url.indexOf):
    * LayoutTests/http/tests/web-locks/web-lock-in-serviceworker.html: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-sharedworker-expected.txt: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-sharedworker.html: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-srcdoc-expected.txt: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-srcdoc.html: Added.
    * LayoutTests/ipc/weblock-registry-origin-expected.txt: Added.
    * LayoutTests/ipc/weblock-registry-origin.html: Added.
    * Source/WebKit/UIProcess/WebFrameProxy.cpp:
    (WebKit::WebFrameProxy::didCommitLoad):
    * Source/WebKit/UIProcess/WebLockRegistryProxy.cpp:
    (WebKit::WebLockRegistryProxy::requestLock):
    (WebKit::WebLockRegistryProxy::releaseLock):
    (WebKit::WebLockRegistryProxy::abortLockRequest):
    (WebKit::WebLockRegistryProxy::snapshot):
    (WebKit::WebLockRegistryProxy::clientIsGoingAway):
    * Source/WebKit/UIProcess/WebProcessProxy.cpp:
    (WebKit::WebProcessProxy::hasCommittedClientOrigin const):
    (WebKit::WebProcessProxy::didCommitLoadClientOrigin):
    * Source/WebKit/UIProcess/WebProcessProxy.h:

Originally-landed-as: 305413.548@safari-7624-branch (e509924cdce7). <a href="https://rdar.apple.com/172389530">rdar://172389530</a>
Canonical link: <a href="https://commits.webkit.org/314557@main">https://commits.webkit.org/314557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6abe4b67ffd7c6d6a7b09ba0de1ca12acef3b8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123604 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54dc9cc5-d00e-490a-8d0e-2ffc87c7a36c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129308 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfeaaeeb-4a13-448b-9913-a1f8b79061ae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31689 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109833 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/524193c0-9e9c-480f-abb5-2aa634bd6244) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30667 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29366 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23537 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140636 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177929 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30831 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137661 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137582 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148958 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103247 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25334 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32873 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25824 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39107 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112182 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38504 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3910 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38749 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->