### PR TITLE
[Wasm] OMG tail call patchpoint needs to clobber late pinned registers.

### DIFF
--- a/JSTests/wasm/stress/omg-indirect-tail-call-late-input-clobber.js
+++ b/JSTests/wasm/stress/omg-indirect-tail-call-late-input-clobber.js
@@ -1,0 +1,110 @@
+//@ runDefaultWasm("--useWasmTailCalls=1", "--useBBQJIT=1", "--useConcurrentJIT=0", "--thresholdForBBQOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeSoon=0", "--thresholdForOMGOptimizeAfterWarmUp=50", "--thresholdForOMGOptimizeSoon=50", "--wasmInliningMaximumWasmCalleeSize=0")
+
+load("../gc-spec-harness/wasm-module-builder.js", "caller relative");
+
+const callerArgumentCount = 12;
+const targetArgumentCount = 24;
+const argumentBase = 0x110000;
+const observedIndex = 22;
+
+function assertEqual(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error(`expected ${expected}, got ${actual}`);
+}
+
+function makeTarget()
+{
+    const ownerBuilder = new WasmModuleBuilder();
+    ownerBuilder.addFunction("owned", makeSig([], []))
+        .addBody([])
+        .exportFunc();
+    const owner = ownerBuilder.instantiate();
+
+    const targetBuilder = new WasmModuleBuilder();
+    targetBuilder.addImport("x", "owned", makeSig([], []));
+    const targetType = targetBuilder.addType(makeSig(
+        Array(targetArgumentCount).fill(kWasmI32),
+        [kWasmI32]));
+    targetBuilder.addFunction("dump", targetType)
+        .addBody([kExprLocalGet, observedIndex])
+        .exportFunc();
+    return targetBuilder.instantiate({ x: { owned: owner.exports.owned } });
+}
+
+function makeRelay()
+{
+    const builder = new WasmModuleBuilder();
+    const targetType = builder.addType(makeSig(
+        Array(targetArgumentCount).fill(kWasmI32),
+        [kWasmI32]));
+    builder.addMemory(1);
+
+    const body = [kExprLocalGet, 0, kExprIf, kWasmI32];
+    for (let index = 0; index < callerArgumentCount; ++index)
+        body.push(kExprLocalGet, 1 + index);
+    for (let index = callerArgumentCount; index < targetArgumentCount; ++index)
+        body.push(...wasmI32Const(argumentBase + index));
+    body.push(
+        kExprLocalGet, 1 + callerArgumentCount,
+        kExprReturnCallRef, ...wasmUnsignedLeb(targetType),
+        kExprElse, ...wasmI32Const(31337),
+        kExprEnd);
+
+    builder.addFunction("entry", makeSig(
+        [
+            kWasmI32,
+            ...Array(callerArgumentCount).fill(kWasmI32),
+            wasmRefType(targetType),
+        ],
+        [kWasmI32]))
+        .addBody(body)
+        .exportFunc();
+    return builder.instantiate();
+}
+
+function makeOuter(relayFunction, targetFunction)
+{
+    const builder = new WasmModuleBuilder();
+    const targetType = builder.addType(makeSig(
+        Array(targetArgumentCount).fill(kWasmI32),
+        [kWasmI32]));
+    const relayType = builder.addType(makeSig(
+        [
+            kWasmI32,
+            ...Array(callerArgumentCount).fill(kWasmI32),
+            wasmRefType(targetType),
+        ],
+        [kWasmI32]));
+    const dump = builder.addImport("t", "dump", targetType);
+    const relay = builder.addImport("r", "entry", relayType);
+    builder.addDeclarativeElementSegment([dump]);
+
+    const body = [...wasmI32Const(1)];
+    for (let index = 0; index < callerArgumentCount; ++index)
+        body.push(...wasmI32Const(argumentBase + index));
+    body.push(
+        kExprRefFunc, ...wasmUnsignedLeb(dump),
+        kExprReturnCall, ...wasmUnsignedLeb(relay));
+
+    builder.addFunction("entry", makeSig([], [kWasmI32]))
+        .addBody(body)
+        .exportFunc();
+    return builder.instantiate({
+        t: { dump: targetFunction },
+        r: { entry: relayFunction },
+    });
+}
+
+const target = makeTarget();
+const relay = makeRelay();
+const outer = makeOuter(relay.exports.entry, target.exports.dump);
+const warmupArguments = [0];
+for (let index = 0; index < callerArgumentCount; ++index)
+    warmupArguments.push(argumentBase + index);
+warmupArguments.push(target.exports.dump);
+
+for (let index = 0; index < wasmTestLoopCount; ++index)
+    assertEqual(relay.exports.entry(...warmupArguments), 31337);
+
+assertEqual(outer.exports.entry(), argumentBase + observedIndex);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -1971,6 +1971,8 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
         unsigned patchArgsIndex = patchpoint->reps().size();
         patchpoint->append(calleeCode, ValueRep(GPRInfo::nonPreservedNonArgumentGPR0));
         patchpoint->append(calleeInstance, ValueRep::SomeRegister);
+        // Cross-instance setup below reloads pinned registers before the tail-call shuffle consumes late inputs.
+        patchpoint->clobberLate(RegisterSet::wasmPinnedRegisters());
         // emitRestoreInstanceFrameIfNeeded needs two scratches. wasmBaseMemoryPointer is
         // always pinned so B3 won't allocate it. wasmBoundsCheckingSizeRegister
         // is only pinned in BoundsChecking mode, so in Signaling mode we need B3 to give us a


### PR DESCRIPTION
#### c18d1e3571f490235aa624c1593e7d1289ea7ba6
<pre>
[Wasm] OMG tail call patchpoint needs to clobber late pinned registers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=316227">https://bugs.webkit.org/show_bug.cgi?id=316227</a>
<a href="https://rdar.apple.com/178479084">rdar://178479084</a>

Reviewed by Justin Michaud and Dan Hecht.

312691@main switched OMG&apos;s tail-call shuffle to a parallel-move algorithm and constrained
the boxed callee plus stack-bound outgoing arguments as LateColdAny so B3 was free to
place them in callee-save registers. 312795@main moved cross-instance pinned-register
restoration off the caller side and into the tail-call patchpoint itself, reloading
wasmBaseMemoryPointer and wasmBoundsCheckingSizeRegister from the callee instance before
prepareForCall-&gt;run() runs the shuffle. The combination is unsafe on a
return_call_ref/return_call_indirect: those late inputs are still live across the
context-switch reload, but I removed line that marked the pinned registers as late
clobbers. Thus, B3 could allocate one of them to a pinned register and the reload would
overwrite the value before the shuffle consumed it.

Declare RegisterSet::wasmPinnedRegisters() as a late clobber on the root-tail path in
OMGIRGenerator::emitIndirectCall so B3 keeps live late inputs out of those registers.

Test: JSTests/wasm/stress/omg-indirect-tail-call-late-input-clobber.js
Canonical link: <a href="https://commits.webkit.org/314548@main">https://commits.webkit.org/314548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb334e13ebcd5ce022c33bfa4759ffb53fe9c303

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175331 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123538 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129249 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91033 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149411 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109774 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30604 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29303 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23471 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158440 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177863 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27177 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30765 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28814 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137603 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137525 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148904 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103170 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25331 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32821 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25771 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198684 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39041 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112115 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 32445 issues") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53375 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38438 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3857 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38683 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38581 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->