### PR TITLE
Dispatch boundary events when hovered element is removed from the DOM

### DIFF
--- a/LayoutTests/fast/events/pointerleave-after-ancestor-removal-expected.txt
+++ b/LayoutTests/fast/events/pointerleave-after-ancestor-removal-expected.txt
@@ -1,0 +1,10 @@
+Verifies pointerleave fires on the retargeted ancestor after subtree removal.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS containerLeaveReceived is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Other

--- a/LayoutTests/fast/events/pointerleave-after-ancestor-removal.html
+++ b/LayoutTests/fast/events/pointerleave-after-ancestor-removal.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+#container { width: 200px; height: 200px; background: #eee; }
+#wrapper { width: 100%; height: 100%; }
+#btn { width: 100px; height: 50px; }
+#other { width: 200px; height: 200px; background: #ccc; margin-top: 20px; }
+</style>
+</head>
+<body>
+<div id="container">
+    <div id="wrapper"><button id="btn">Hover me</button></div>
+</div>
+<div id="other">Other</div>
+<script>
+    description("Verifies pointerleave fires on the retargeted ancestor after subtree removal.");
+    window.jsTestIsAsync = true;
+
+    var container = document.getElementById('container');
+    var wrapper = document.getElementById('wrapper');
+    var btn = document.getElementById('btn');
+    var other = document.getElementById('other');
+    var containerLeaveReceived = false;
+
+    container.addEventListener('pointerleave', function() { containerLeaveReceived = true; });
+
+    if (window.eventSender) {
+        var r = btn.getBoundingClientRect();
+        eventSender.mouseMoveTo(r.left + r.width / 2, r.top + r.height / 2);
+
+        container.removeChild(wrapper);
+
+        var r2 = other.getBoundingClientRect();
+        eventSender.mouseMoveTo(r2.left + r2.width / 2, r2.top + r2.height / 2);
+    }
+
+    UIHelper.waitForCondition(() => containerLeaveReceived).then(() => {
+        shouldBeTrue("containerLeaveReceived");
+        finishJSTest();
+    });
+</script>
+</body>
+</html>

--- a/LayoutTests/fullscreen/fullscreen-controls-stay-visible-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-controls-stay-visible-expected.txt
@@ -1,0 +1,8 @@
+Tests that a controls overlay that stays in the DOM does not receive a spurious pointerleave on fullscreen entry.
+
+Controls
+EVENT(webkitfullscreenchange)
+EXPECTED (document.fullscreenElement == '[object HTMLDivElement]') OK
+EXPECTED (visible == 'true') OK
+END OF TEST
+

--- a/LayoutTests/fullscreen/fullscreen-controls-stay-visible.html
+++ b/LayoutTests/fullscreen/fullscreen-controls-stay-visible.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="full-screen-test.js"></script>
+<style>
+#target { position: relative; width: 400px; height: 300px; background: #111; }
+#target:fullscreen { width: 100%; height: 100%; }
+#controls { position: absolute; inset: 0; }
+</style>
+</head>
+<body>
+<p>Tests that a controls overlay that stays in the DOM does not receive a
+spurious pointerleave on fullscreen entry.</p>
+<div id="target">
+    <div id="controls">Controls</div>
+</div>
+<script>
+    var target = document.getElementById('target');
+    var controls = document.getElementById('controls');
+    var visible = true;
+
+    controls.addEventListener('pointerleave', function() { visible = false; });
+
+    var callback;
+    waitForEvent(document, 'webkitfullscreenchange', function(event) {
+        if (callback)
+            callback(event);
+    });
+
+    if (window.eventSender) {
+        var r = controls.getBoundingClientRect();
+        eventSender.mouseMoveTo(r.left + r.width / 2, r.top + r.height / 2);
+    }
+
+    callback = function() {
+        testExpected("document.fullscreenElement", target);
+
+        setTimeout(function() {
+            testExpected("visible", true);
+            endTest();
+        }, 300);
+    };
+
+    runWithKeyDown(function() { target.requestFullscreen(); });
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8438,3 +8438,5 @@ webkit.org/b/316218 fast/scrolling/ios/scroll-into-view-smooth-after-snap.html [
 webkit.org/b/316228 fast/dom/Orientation/no-orientation-change-event-when-unparenting-view.html [ Failure ]
 
 webkit.org/b/316118 imported/w3c/web-platform-tests/url/IdnaTestV2.any.html [ Failure ]
+
+fast/events/pointerleave-after-ancestor-removal.html [ Skip ]

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -523,8 +523,13 @@ void EventHandler::nodeWillBeRemoved(Node& nodeToBeRemoved)
             m_mouseMoveTargetOverride = elementBeingRemoved->parentElementInComposedTree();
     }
 
-    if (nodeToBeRemoved.isShadowIncludingInclusiveAncestorOf(m_lastElementUnderMouse.get()))
-        m_lastElementUnderMouse = nullptr;
+    if (nodeToBeRemoved.isShadowIncludingInclusiveAncestorOf(m_lastElementUnderMouse.get())) {
+        if (&nodeToBeRemoved != m_lastElementUnderMouse.get()) {
+            RefPtr elementBeingRemoved = dynamicDowncast<Element>(nodeToBeRemoved);
+            m_lastElementUnderMouse = elementBeingRemoved ? elementBeingRemoved->parentElementInComposedTree() : nullptr;
+        } else
+            m_lastElementUnderMouse = nullptr;
+    }
 
     if (nodeToBeRemoved.isShadowIncludingInclusiveAncestorOf(m_clickCaptureElement.get()))
         m_clickCaptureElement = nullptr;


### PR DESCRIPTION
#### 737bafc43518490ea971c421dd5a1884a15c9c14
<pre>
Dispatch boundary events when hovered element is removed from the DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=316229">https://bugs.webkit.org/show_bug.cgi?id=316229</a>
<a href="https://rdar.apple.com/177476277">rdar://177476277</a>

Reviewed by Abrar Rahman Protyasha.

Pointer Events §5.1.3 (Firing events using the PointerEvent interface) states
that when the previousTarget is no longer connected, the UA must update it to
the nearest still-connected parent. WebKit was instead nulling
m_lastElementUnderMouse in nodeWillBeRemoved, causing the next mouse event to
skip boundary dispatch entirely.

This left JS-driven hover state stuck on sites like bsky.app where the video
player re-renders controls on fullscreen entry, removing the hovered button
without ever dispatching pointerleave.

The fix retargets m_lastElementUnderMouse to parentElementInComposedTree() of
the removed element when the removal is an ancestor-subtree removal (not the
element itself, which may be re-inserted by appendChild).

Tests: fast/events/pointerleave-after-ancestor-removal.html
       fullscreen/fullscreen-controls-stay-visible.html

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::nodeWillBeRemoved):

Canonical link: <a href="https://commits.webkit.org/314650@main">https://commits.webkit.org/314650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8f1d5f509571ee511b00f7a0fb9eefa41943549

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123727 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/24c3b7b0-71d2-4a0c-83e5-ae261ba07ad0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129419 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91148 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ecb0af4a-79d4-41b2-a9b7-6c3a09ead3df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109944 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cdd1c2e-2b89-4370-9b0e-e771e997d614) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30785 "") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29484 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23660 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178053 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30954 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137773 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137692 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37156 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103432 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32990 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25940 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39230 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112305 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38627 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4029 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38872 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38770 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->