### PR TITLE
[SVG] tspan outline box is swapped and mirrored in vertical writing-mode text

### DIFF
--- a/LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-align-06-b-expected.txt
+++ b/LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-align-06-b-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 480x360
             RenderSVGInlineText {#text} at (0,0) size 17x68
               chunk 1 (vertical) text run 1 at (-10.40,0.00) startOffset 0 endOffset 1 height 33.52: "t"
               chunk 1 (vertical) text run 2 at (-10.40,33.52) startOffset 1 endOffset 2 height 33.52: "e"
-            RenderSVGTSpan {tspan} at (7,67) size 34x17
+            RenderSVGTSpan {tspan} at (7,67) size 17x34
               RenderSVGInlineText {#text} at (7,67) size 17x34
                 chunk 1 (vertical) text run 1 at (-3.40,67.03) startOffset 0 endOffset 1 height 33.52: "7"
             RenderSVGInlineText {#text} at (0,100) size 15x68
@@ -22,7 +22,7 @@ layer at (0,0) size 480x360
             RenderSVGInlineText {#text} at (25,0) size 17x68
               chunk 1 (vertical) text run 1 at (69.60,0.00) startOffset 0 endOffset 1 height 33.52: "t"
               chunk 1 (vertical) text run 2 at (69.60,33.52) startOffset 1 endOffset 2 height 33.52: "e"
-            RenderSVGTSpan {tspan} at (0,67) size 135x27
+            RenderSVGTSpan {tspan} at (0,67) size 27x135
               RenderSVGInlineText {#text} at (0,67) size 27x135
                 chunk 1 (vertical) text run 1 at (48.60,67.03) startOffset 0 endOffset 1 height 33.52: "-"
                 chunk 1 (vertical) text run 2 at (48.60,100.55) startOffset 1 endOffset 2 height 33.52: "7"
@@ -35,12 +35,12 @@ layer at (0,0) size 480x360
             RenderSVGInlineText {#text} at (16,0) size 17x68
               chunk 1 (vertical) text run 1 at (169.60,0.00) startOffset 0 endOffset 1 height 33.52: "t"
               chunk 1 (vertical) text run 2 at (169.60,33.52) startOffset 1 endOffset 2 height 33.52: "e"
-            RenderSVGTSpan {tspan} at (0,67) size 101x17
+            RenderSVGTSpan {tspan} at (0,67) size 17x101
               RenderSVGInlineText {#text} at (0,67) size 17x101
                 chunk 1 (vertical) text run 1 at (152.84,67.03) startOffset 0 endOffset 1 height 33.52: "s"
                 chunk 1 (vertical) text run 2 at (152.84,100.55) startOffset 1 endOffset 2 height 33.52: "u"
                 chunk 1 (vertical) text run 3 at (152.84,134.06) startOffset 2 endOffset 3 height 33.52: "b"
-            RenderSVGTSpan {tspan} at (17,167) size 35x16
+            RenderSVGTSpan {tspan} at (17,167) size 16x35
               RenderSVGInlineText {#text} at (17,167) size 15x34
                 chunk 1 (vertical) text run 1 at (169.60,167.58) startOffset 0 endOffset 1 height 33.52: "x"
             RenderSVGInlineText {#text} at (20,201) size 9x34
@@ -49,14 +49,14 @@ layer at (0,0) size 480x360
             RenderSVGInlineText {#text} at (0,0) size 17x68
               chunk 1 (vertical) text run 1 at (249.60,0.00) startOffset 0 endOffset 1 height 33.52: "t"
               chunk 1 (vertical) text run 2 at (249.60,33.52) startOffset 1 endOffset 2 height 33.52: "e"
-            RenderSVGTSpan {tspan} at (16,67) size 169x17
+            RenderSVGTSpan {tspan} at (16,67) size 18x168
               RenderSVGInlineText {#text} at (16,67) size 17x168
                 chunk 1 (vertical) text run 1 at (266.36,67.03) startOffset 0 endOffset 1 height 33.52: "s"
                 chunk 1 (vertical) text run 2 at (266.36,100.55) startOffset 1 endOffset 2 height 33.52: "u"
                 chunk 1 (vertical) text run 3 at (266.36,134.06) startOffset 2 endOffset 3 height 33.52: "p"
                 chunk 1 (vertical) text run 4 at (266.36,167.58) startOffset 3 endOffset 4 height 33.52: "e"
                 chunk 1 (vertical) text run 5 at (266.36,201.09) startOffset 4 endOffset 5 height 33.52: "r"
-            RenderSVGTSpan {tspan} at (0,234) size 35x16
+            RenderSVGTSpan {tspan} at (0,234) size 16x35
               RenderSVGInlineText {#text} at (0,234) size 15x34
                 chunk 1 (vertical) text run 1 at (249.60,234.61) startOffset 0 endOffset 1 height 33.52: "x"
             RenderSVGInlineText {#text} at (4,268) size 9x34

--- a/LayoutTests/platform/mac/svg/text/text-align-06-b-expected.txt
+++ b/LayoutTests/platform/mac/svg/text/text-align-06-b-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
             RenderSVGInlineText {#text} at (0,0) size 17x68
               chunk 1 (vertical) text run 1 at (-10.40,0.00) startOffset 0 endOffset 1 height 33.52: "t"
               chunk 1 (vertical) text run 2 at (-10.40,33.52) startOffset 1 endOffset 2 height 33.52: "e"
-            RenderSVGTSpan {tspan} at (7,67) size 34x17
+            RenderSVGTSpan {tspan} at (7,67) size 17x34
               RenderSVGInlineText {#text} at (7,67) size 17x34
                 chunk 1 (vertical) text run 1 at (-3.40,67.03) startOffset 0 endOffset 1 height 33.52: "7"
             RenderSVGInlineText {#text} at (0,100) size 15x68
@@ -22,7 +22,7 @@ layer at (0,0) size 800x600
             RenderSVGInlineText {#text} at (25,0) size 17x68
               chunk 1 (vertical) text run 1 at (69.60,0.00) startOffset 0 endOffset 1 height 33.52: "t"
               chunk 1 (vertical) text run 2 at (69.60,33.52) startOffset 1 endOffset 2 height 33.52: "e"
-            RenderSVGTSpan {tspan} at (0,67) size 135x27
+            RenderSVGTSpan {tspan} at (0,67) size 27x135
               RenderSVGInlineText {#text} at (0,67) size 27x135
                 chunk 1 (vertical) text run 1 at (48.60,67.03) startOffset 0 endOffset 1 height 33.52: "-"
                 chunk 1 (vertical) text run 2 at (48.60,100.55) startOffset 1 endOffset 2 height 33.52: "7"
@@ -35,12 +35,12 @@ layer at (0,0) size 800x600
             RenderSVGInlineText {#text} at (16,0) size 17x68
               chunk 1 (vertical) text run 1 at (169.60,0.00) startOffset 0 endOffset 1 height 33.52: "t"
               chunk 1 (vertical) text run 2 at (169.60,33.52) startOffset 1 endOffset 2 height 33.52: "e"
-            RenderSVGTSpan {tspan} at (0,67) size 101x17
+            RenderSVGTSpan {tspan} at (0,67) size 17x101
               RenderSVGInlineText {#text} at (0,67) size 17x101
                 chunk 1 (vertical) text run 1 at (152.84,67.03) startOffset 0 endOffset 1 height 33.52: "s"
                 chunk 1 (vertical) text run 2 at (152.84,100.55) startOffset 1 endOffset 2 height 33.52: "u"
                 chunk 1 (vertical) text run 3 at (152.84,134.06) startOffset 2 endOffset 3 height 33.52: "b"
-            RenderSVGTSpan {tspan} at (17,167) size 35x16
+            RenderSVGTSpan {tspan} at (17,167) size 16x35
               RenderSVGInlineText {#text} at (17,167) size 15x34
                 chunk 1 (vertical) text run 1 at (169.60,167.58) startOffset 0 endOffset 1 height 33.52: "x"
             RenderSVGInlineText {#text} at (20,201) size 9x34
@@ -49,14 +49,14 @@ layer at (0,0) size 800x600
             RenderSVGInlineText {#text} at (0,0) size 17x68
               chunk 1 (vertical) text run 1 at (249.60,0.00) startOffset 0 endOffset 1 height 33.52: "t"
               chunk 1 (vertical) text run 2 at (249.60,33.52) startOffset 1 endOffset 2 height 33.52: "e"
-            RenderSVGTSpan {tspan} at (16,67) size 169x17
+            RenderSVGTSpan {tspan} at (16,67) size 18x168
               RenderSVGInlineText {#text} at (16,67) size 17x168
                 chunk 1 (vertical) text run 1 at (266.36,67.03) startOffset 0 endOffset 1 height 33.52: "s"
                 chunk 1 (vertical) text run 2 at (266.36,100.55) startOffset 1 endOffset 2 height 33.52: "u"
                 chunk 1 (vertical) text run 3 at (266.36,134.06) startOffset 2 endOffset 3 height 33.52: "p"
                 chunk 1 (vertical) text run 4 at (266.36,167.58) startOffset 3 endOffset 4 height 33.52: "e"
                 chunk 1 (vertical) text run 5 at (266.36,201.09) startOffset 4 endOffset 5 height 33.52: "r"
-            RenderSVGTSpan {tspan} at (0,234) size 35x16
+            RenderSVGTSpan {tspan} at (0,234) size 16x35
               RenderSVGInlineText {#text} at (0,234) size 15x34
                 chunk 1 (vertical) text run 1 at (249.60,234.61) startOffset 0 endOffset 1 height 33.52: "x"
             RenderSVGInlineText {#text} at (4,268) size 9x34
@@ -65,3 +65,5 @@ layer at (0,0) size 800x600
       RenderSVGInlineText {#text} at (0,0) size 264x46
         chunk 1 text run 1 at (10.00,340.00) startOffset 0 endOffset 16 width 263.34: "$Revision: 1.5 $"
     RenderSVGRect {rect} at (0,0) size 800x600 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
+selection start: position 0 of child 0 {#text} of child 1 {text} of child 13 {g} of child 27 {svg} of document
+selection end:   position 16 of child 0 {#text} of child 15 {text} of child 27 {svg} of document

--- a/LayoutTests/svg/text/text-align-06-b.svg
+++ b/LayoutTests/svg/text/text-align-06-b.svg
@@ -61,7 +61,11 @@
    <rect id="test-frame" x="1" y="1" width="478" height="358" fill="none" stroke="#000000"/>
 <script>
 if (window.testRunner)
-    window.testRunner.dumpSelectionRect();
+    testRunner.dumpSelectionRect();
+var range = document.createRange();
+range.selectNode(window.document.documentElement);
+var selection = window.getSelection();
+selection.removeAllRanges();
+selection.addRange(range);
 </script>
 </svg>
-

--- a/LayoutTests/svg/text/tspan-multiple-outline-vertical-expected.svg
+++ b/LayoutTests/svg/text/tspan-multiple-outline-vertical-expected.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600">
+  <style>
+    text { font: 32px sans-serif; }
+  </style>
+  <text x="10" y="10" writing-mode="tb">
+    <tspan dx="1.5em">tspan1</tspan>
+    <tspan dx="1.5em">tspan2</tspan>
+  </text>
+  <g id="outlines" fill="none" stroke="black" stroke-width="1"/>
+  <script><![CDATA[
+    // Draw a 1px box around each <tspan> using the SVG-native getExtentOfChar(),
+    // which builds each glyph's extent from the same text fragments as the
+    // outline box (SVGInlineTextBox::calculateBoundaries) but via an independent
+    // DOM code path. Unioning the per-character extents reproduces the tspan's
+    // outline box exactly, independent of font and platform. A CSS
+    // "outline: 1px solid" is painted just outside the border box, so inflate by
+    // half the stroke width to align the center-drawn SVG stroke with it.
+    function drawOutlines() {
+      var svgNS = "http://www.w3.org/2000/svg";
+      var outlines = document.getElementById("outlines");
+      var text = document.querySelector("text");
+      // Force SVG text layout so character metrics are available.
+      text.getBBox();
+      var tspans = document.querySelectorAll("tspan");
+      for (var i = 0; i < tspans.length; ++i) {
+        var tspan = tspans[i];
+        var n = tspan.getNumberOfChars();
+        var left = Infinity, top = Infinity, right = -Infinity, bottom = -Infinity;
+        for (var c = 0; c < n; ++c) {
+          var e = tspan.getExtentOfChar(c);
+          left = Math.min(left, e.x);
+          top = Math.min(top, e.y);
+          right = Math.max(right, e.x + e.width);
+          bottom = Math.max(bottom, e.y + e.height);
+        }
+        var rect = document.createElementNS(svgNS, "rect");
+        // Snap to integer device pixels so the centered SVG stroke renders as a
+        // crisp 1px line (matching the pixel-snapped CSS outline), rather than
+        // anti-aliasing across two rows/columns on fractional edges.
+        left = Math.round(left);
+        top = Math.round(top);
+        right = Math.round(right);
+        bottom = Math.round(bottom);
+        rect.setAttribute("x", left - 0.5);
+        rect.setAttribute("y", top - 0.5);
+        rect.setAttribute("width", (right - left) + 1);
+        rect.setAttribute("height", (bottom - top) + 1);
+        outlines.appendChild(rect);
+      }
+    }
+    window.addEventListener("load", drawOutlines);
+    drawOutlines();
+  ]]></script>
+</svg>

--- a/LayoutTests/svg/text/tspan-multiple-outline-vertical.svg
+++ b/LayoutTests/svg/text/tspan-multiple-outline-vertical.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600">
+  <style>
+    text { font: 32px sans-serif; }
+    tspan { outline: 1px solid black; }
+  </style>
+  <text x="10" y="10" writing-mode="tb">
+    <tspan dx="1.5em">tspan1</tspan>
+    <tspan dx="1.5em">tspan2</tspan>
+  </text>
+</svg>

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -153,6 +153,11 @@ void OutlinePainter::paintOutline(const RenderInline& renderer, const LayoutPoin
     auto isHorizontalWritingMode = renderer.isHorizontalWritingMode();
     CheckedRef containingBlock = *renderer.containingBlock();
     auto isFlipped = containingBlock->writingMode().isBlockFlipped();
+    // Legacy SVG text fragments are laid out in absolute (physical) coordinates by the SVG
+    // text layout engine, so their inline box rects are already physical and must not be
+    // block-flipped (e.g. writing-mode="tb" maps to vertical-rl, which is block-flipped).
+    if (renderer.isRenderSVGInline())
+        isFlipped = false;
     Vector<LayoutRect> rects;
     for (auto box = InlineIterator::lineLeftmostInlineBoxFor(renderer); box; box.traverseInlineBoxLineRightward()) {
         // Start with the inline box's own rect as the base, ensuring the outline

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -157,7 +157,7 @@ void RenderSVGInline::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) co
 
     FloatRect textBoundingBox = textAncestor->strokeBoundingBox();
     for (auto* box = firstLegacyInlineBox(); box; box = box->nextLineBox())
-        quads.append(localToAbsoluteQuad(FloatRect(textBoundingBox.x() + box->x(), textBoundingBox.y() + box->y(), box->logicalWidth(), box->logicalHeight()), MapCoordinatesMode::UseTransforms, wasFixed));
+        quads.append(localToAbsoluteQuad(FloatRect(textBoundingBox.x() + box->x(), textBoundingBox.y() + box->y(), box->width(), box->height()), MapCoordinatesMode::UseTransforms, wasFixed));
 }
 
 void RenderSVGInline::willBeDestroyed()

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -522,8 +522,11 @@ FloatRect RenderSVGText::layoutChildBoxes(LegacyInlineFlowBox* start, SVGTextFra
             boxRect = textBox->calculateBoundaries();
             textBox->setX(boxRect.x());
             textBox->setY(boxRect.y());
-            textBox->setLogicalWidth(boxRect.width());
-            textBox->setLogicalHeight(boxRect.height());
+            // calculateBoundaries() returns a visual rect, but the inline box stores
+            // logical extents. width()/height() (and thus frameRect()) transpose these
+            // for vertical writing modes, so feed the logical setters accordingly.
+            textBox->setLogicalWidth(textBox->isHorizontal() ? boxRect.width() : boxRect.height());
+            textBox->setLogicalHeight(textBox->isHorizontal() ? boxRect.height() : boxRect.width());
         } else {
             // Skip generated content.
             if (!child->renderer().node())
@@ -535,8 +538,8 @@ FloatRect RenderSVGText::layoutChildBoxes(LegacyInlineFlowBox* start, SVGTextFra
             boxRect = flowBox.calculateBoundaries();
             flowBox.setX(boxRect.x());
             flowBox.setY(boxRect.y());
-            flowBox.setLogicalWidth(boxRect.width());
-            flowBox.setLogicalHeight(boxRect.height());
+            flowBox.setLogicalWidth(flowBox.isHorizontal() ? boxRect.width() : boxRect.height());
+            flowBox.setLogicalHeight(flowBox.isHorizontal() ? boxRect.height() : boxRect.width());
         }
         childRect.unite(boxRect);
     }


### PR DESCRIPTION
#### 90f1a5cab715ce34e55db1dc68da919e24fcb130
<pre>
[SVG] tspan outline box is swapped and mirrored in vertical writing-mode text
<a href="https://bugs.webkit.org/show_bug.cgi?id=316221">https://bugs.webkit.org/show_bug.cgi?id=316221</a>
<a href="https://rdar.apple.com/178652913">rdar://178652913</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chromium.

Inspred by (Merge - Test only): <a href="https://chromium.googlesource.com/chromium/src.git/+/9e370a37157d26aa866cab25ff0649f162967638">https://chromium.googlesource.com/chromium/src.git/+/9e370a37157d26aa866cab25ff0649f162967638</a>

An `outline` on a `&lt;tspan&gt;` inside vertical SVG text (writing-mode=&quot;tb&quot;)
was painted with the wrong shape and position: the box came out wide
instead of tall, and was mirrored horizontally relative to the text it
was supposed to wrap. Two independent defects were involved.

1. RenderSVGText::layoutChildBoxes() stored the *visual* width/height
  returned by calculateBoundaries() directly into the inline box&apos;s
  *logical* width/height fields. LegacyInlineBox::width()/height() (and
  thus frameRect()) transpose logical extents into visual ones for
  non-horizontal boxes, so for vertical text the box&apos;s frameRect ended
  up with its width and height swapped, producing a wide-instead-of-tall
  outline. The values are now assigned orientation-aware so frameRect()
  matches calculateBoundaries() again. RenderSVGInline::absoluteQuads()
  is updated to read width()/height() instead of the logical extents to
  stay consistent (a no-op for horizontal text).

2. After (1) the box had the correct dimensions but was still mirrored.
  OutlinePainter::paintOutline(const RenderInline&amp;) applies a
  block-direction flip when the containing block&apos;s writing mode is
  block-flipped. SVG writing-mode=&quot;tb&quot; maps to vertical-rl, which is
  block-flipped, but flipped writing-mode does not apply to SVG text:
  it has no multi-line block-direction layout (vertical-rl and
  vertical-lr are equivalent for SVG text), and the SVG text layout
  engine already produces absolute (physical) fragment coordinates. The
  flip therefore double-counts and mirrors the outline relative to the
  glyphs, so it is now skipped for SVG inline text.

All three changes are no-ops for horizontal SVG text and for non-SVG
inlines.

* LayoutTests/platform/mac/svg/W3C-SVG-1.1/text-align-06-b-expected.txt:
* LayoutTests/platform/mac/svg/text/text-align-06-b-expected.txt:
* LayoutTests/svg/text/tspan-multiple-outline-vertical-expected.svg: Added.
* LayoutTests/svg/text/tspan-multiple-outline-vertical.svg: Added.
* LayoutTests/svg/text/text-align-06-b.svg:
* Source/WebCore/rendering/OutlinePainter.cpp:
(WebCore::OutlinePainter::paintOutline const):
* Source/WebCore/rendering/svg/RenderSVGInline.cpp:
(WebCore::RenderSVGInline::absoluteQuads const):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::layoutChildBoxes):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90f1a5cab715ce34e55db1dc68da919e24fcb130

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123545 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd5e72b0-c171-4930-913e-371a6a189047) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39787 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129253 "Found 4 new test failures: svg/W3C-SVG-1.1/text-align-06-b.svg svg/batik/text/verticalText.svg svg/batik/text/verticalTextOnPath.svg svg/text/text-align-06-b.svg (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91037 "3 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d294096c-4236-42fd-ade9-06e19667d14e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169249 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31635 "Found 5 new test failures: svg/W3C-SVG-1.1/text-align-06-b.svg svg/batik/text/verticalText.svg svg/batik/text/verticalTextOnPath.svg svg/text/text-align-06-b.svg svg/text/text-vkern.svg (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109778 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1233f14d-3b4c-4ff5-94c0-24e23acf13ce) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30613 "Exiting early after 10 failures. 10 tests run. 2 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29308 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23478 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140582 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177870 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30772 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28813 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137606 "Found 4 new test failures: svg/W3C-SVG-1.1/text-align-06-b.svg svg/batik/text/verticalText.svg svg/batik/text/verticalTextOnPath.svg svg/text/text-align-06-b.svg (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137528 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148903 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103177 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32824 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25770 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39048 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112122 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38445 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3856 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38690 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38588 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->