### PR TITLE
[CMake] Stub internal SDK headers absent from non-internal SDKs

### DIFF
--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -109,14 +109,65 @@ unset(_additions_candidates)
 unset(_additions)
 unset(_additions_found)
 
-if (EXISTS "/usr/local/include/WebKitAdditions" AND NOT EXISTS "/usr/local/include/AppleFeatures/AppleFeatures.h")
-    set(_apple_features_stub "${CMAKE_BINARY_DIR}/generated-stubs/AppleFeatures")
-    file(MAKE_DIRECTORY "${_apple_features_stub}")
-    file(CONFIGURE OUTPUT "${_apple_features_stub}/AppleFeatures.h" CONTENT
-        "/* Auto-generated stub -- AppleFeatures not available in this SDK. */\n")
-    add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-isystem${CMAKE_BINARY_DIR}/generated-stubs>")
-    message(STATUS "AppleFeatures stub generated (WebKitAdditions present, AppleFeatures SDK absent)")
-    unset(_apple_features_stub)
+# An internal WebKitAdditions install provides headers that pull in internal-SDK-only headers. When
+# it is present but the build targets a non-internal SDK, those headers are missing; generate minimal
+# stubs for them so the build still succeeds, with the corresponding features disabled. Prefer the
+# internal SDK (e.g. -DCMAKE_OSX_SYSROOT=macosx.internal), which provides the real headers.
+# FIXME: Remove this once building against the internal SDK is fully supported.
+if (EXISTS "/usr/local/include/WebKitAdditions"
+    AND NOT EXISTS "/usr/local/include/AppleFeatures/AppleFeatures.h"
+    AND NOT EXISTS "${CMAKE_OSX_SYSROOT}/usr/local/include/AppleFeatures/AppleFeatures.h")
+    set(_stub_dir "${CMAKE_BINARY_DIR}/generated-stubs")
+
+    file(CONFIGURE OUTPUT "${_stub_dir}/AppleFeatures/AppleFeatures.h" CONTENT
+        "/* Auto-generated stub. */\n")
+
+    file(CONFIGURE OUTPUT "${_stub_dir}/CoreAnalytics/CoreAnalytics.h" CONTENT
+        "/* Auto-generated stub. */\n")
+
+    file(CONFIGURE OUTPUT "${_stub_dir}/os/feature_private.h" CONTENT
+"/* Auto-generated stub. */
+#pragma once
+#ifndef os_feature_enabled
+#define os_feature_enabled(NAMESPACE, FEATURE) (0)
+#endif
+#ifndef os_feature_enabled_simple
+#define os_feature_enabled_simple(NAMESPACE, FEATURE, DEFAULT_VALUE) (DEFAULT_VALUE)
+#endif
+")
+
+    # Mirror the declarations from WTF's OSVariantSPI.h; the symbols resolve at link time.
+    file(CONFIGURE OUTPUT "${_stub_dir}/os/variant_private.h" CONTENT
+"/* Auto-generated stub. */
+#pragma once
+#include <stdbool.h>
+#ifdef __cplusplus
+extern \"C\" {
+#endif
+bool os_variant_allows_internal_security_policies(const char *);
+bool os_variant_is_basesystem(const char *);
+#ifdef __cplusplus
+}
+#endif
+")
+
+    # Forward to the public dyld header; stub the one notifier the additions header uses.
+    file(CONFIGURE OUTPUT "${_stub_dir}/mach-o/dyld_priv.h" CONTENT
+"/* Auto-generated stub. */
+#pragma once
+#include <mach-o/dyld.h>
+#ifndef _dyld_register_dlsym_notifier
+#define _dyld_register_dlsym_notifier(NOTIFIER) ((void)(NOTIFIER))
+#endif
+")
+
+    # Apply to C-family and Swift; Swift needs it via -Xcc to reach the Clang importer.
+    add_compile_options(
+        "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-isystem${_stub_dir}>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -isystem${_stub_dir}>"
+    )
+    message(STATUS "Using stubs for internal SDK headers absent from the selected SDK")
+    unset(_stub_dir)
 endif ()
 
 # FIXME: Audit and reduce these suppressions. https://bugs.webkit.org/show_bug.cgi?id=312034


### PR DESCRIPTION
#### 3c34d7add0eb2530cb991b0b8ee5b2557f0f4b1c
<pre>
[CMake] Stub internal SDK headers absent from non-internal SDKs
<a href="https://bugs.webkit.org/show_bug.cgi?id=316237">https://bugs.webkit.org/show_bug.cgi?id=316237</a>
<a href="https://rdar.apple.com/178659249">rdar://178659249</a>

Reviewed by NOBODY (OOPS!).

An internal WebKitAdditions install provides headers that include
internal-SDK-only headers. When such an install is present but the build
targets a non-internal SDK, those headers are missing, which cascades through
the wtf module to most Swift and C++ targets.

Generate minimal stubs for the missing headers so the build succeeds against
a non-internal SDK, with the corresponding features disabled. The stub
directory is now passed to Swift as well as C-family compiles, since the
Clang importer resolves these includes while building the modules; the
previous stub covered only C-family, so the Swift module builds still failed.
Building against the internal SDK continues to use the real headers.

* Source/cmake/OptionsCocoa.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c34d7add0eb2530cb991b0b8ee5b2557f0f4b1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175410 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123617 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f7ba027-184b-467c-a089-89c24707274d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129321 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91075 "1 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e3045ae-ca7d-43f1-94cd-00fa9f892076) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109846 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b6538c3-df5f-43fc-a8de-dbe1b9fd7708) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30679 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29379 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23550 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158519 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140648 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177942 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27256 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137675 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137594 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148974 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103266 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25840 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199041 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39120 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53433 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38517 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3926 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38762 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38660 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->