### PR TITLE
Implement CSS object-view-box parsing and feature flag

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -245,6 +245,7 @@ PASS min-width
 PASS mix-blend-mode
 PASS object-fit
 PASS object-position
+PASS object-view-box
 PASS offset-anchor
 PASS offset-distance
 PASS offset-path

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -217,6 +217,7 @@ PASS min-width
 PASS mix-blend-mode
 PASS object-fit
 PASS object-position
+PASS object-view-box
 PASS offset-anchor
 PASS offset-distance
 PASS offset-path

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/animation/object-view-box-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/animation/object-view-box-interpolation-expected.txt
@@ -1,51 +1,51 @@
 
 
-FAIL CSS Transitions: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0) should be [inset(0px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0.5) should be [inset(10px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <object-view-box> from [inset(0px)] to [inset(20px)] at (1) should be [inset(20px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0) should be [inset(0px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0.5) should be [inset(10px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <object-view-box> from [inset(0px)] to [inset(20px)] at (1) should be [inset(20px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0) should be [inset(0px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0.5) should be [inset(10px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <object-view-box> from [inset(0px)] to [inset(20px)] at (1) should be [inset(20px)] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0) should be [inset(0px)] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0.5) should be [inset(10px)] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <object-view-box> from [inset(0px)] to [inset(20px)] at (1) should be [inset(20px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0) should be [inset(0%)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0.5) should be [inset(10%)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <object-view-box> from [inset(0%)] to [inset(20%)] at (1) should be [inset(20%)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0) should be [inset(0%)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0.5) should be [inset(10%)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <object-view-box> from [inset(0%)] to [inset(20%)] at (1) should be [inset(20%)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0) should be [inset(0%)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0.5) should be [inset(10%)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <object-view-box> from [inset(0%)] to [inset(20%)] at (1) should be [inset(20%)] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0) should be [inset(0%)] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0.5) should be [inset(10%)] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <object-view-box> from [inset(0%)] to [inset(20%)] at (1) should be [inset(20%)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0) should be [rect(0px 10px 20px 30px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0.5) should be [rect(5px 15px 25px 35px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (1) should be [rect(10px 20px 30px 40px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0) should be [rect(0px 10px 20px 30px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0.5) should be [rect(5px 15px 25px 35px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (1) should be [rect(10px 20px 30px 40px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0) should be [rect(0px 10px 20px 30px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0.5) should be [rect(5px 15px 25px 35px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (1) should be [rect(10px 20px 30px 40px)] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0) should be [rect(0px 10px 20px 30px)] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0.5) should be [rect(5px 15px 25px 35px)] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (1) should be [rect(10px 20px 30px 40px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0) should be [xywh(0px 10px 20px 30px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0.5) should be [xywh(5px 15px 25px 35px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (1) should be [xywh(10px 20px 30px 40px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0) should be [xywh(0px 10px 20px 30px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0.5) should be [xywh(5px 15px 25px 35px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (1) should be [xywh(10px 20px 30px 40px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0) should be [xywh(0px 10px 20px 30px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0.5) should be [xywh(5px 15px 25px 35px)] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (1) should be [xywh(10px 20px 30px 40px)] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0) should be [xywh(0px 10px 20px 30px)] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0.5) should be [xywh(5px 15px 25px 35px)] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (1) should be [xywh(10px 20px 30px 40px)] assert_true: 'from' value should be supported expected true got false
+PASS CSS Transitions: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0) should be [inset(0px)]
+PASS CSS Transitions: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0.5) should be [inset(10px)]
+PASS CSS Transitions: property <object-view-box> from [inset(0px)] to [inset(20px)] at (1) should be [inset(20px)]
+PASS CSS Transitions with transition: all: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0) should be [inset(0px)]
+PASS CSS Transitions with transition: all: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0.5) should be [inset(10px)]
+PASS CSS Transitions with transition: all: property <object-view-box> from [inset(0px)] to [inset(20px)] at (1) should be [inset(20px)]
+PASS CSS Animations: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0) should be [inset(0px)]
+PASS CSS Animations: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0.5) should be [inset(10px)]
+PASS CSS Animations: property <object-view-box> from [inset(0px)] to [inset(20px)] at (1) should be [inset(20px)]
+PASS Web Animations: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0) should be [inset(0px)]
+PASS Web Animations: property <object-view-box> from [inset(0px)] to [inset(20px)] at (0.5) should be [inset(10px)]
+PASS Web Animations: property <object-view-box> from [inset(0px)] to [inset(20px)] at (1) should be [inset(20px)]
+PASS CSS Transitions: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0) should be [inset(0%)]
+PASS CSS Transitions: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0.5) should be [inset(10%)]
+PASS CSS Transitions: property <object-view-box> from [inset(0%)] to [inset(20%)] at (1) should be [inset(20%)]
+PASS CSS Transitions with transition: all: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0) should be [inset(0%)]
+PASS CSS Transitions with transition: all: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0.5) should be [inset(10%)]
+PASS CSS Transitions with transition: all: property <object-view-box> from [inset(0%)] to [inset(20%)] at (1) should be [inset(20%)]
+PASS CSS Animations: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0) should be [inset(0%)]
+PASS CSS Animations: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0.5) should be [inset(10%)]
+PASS CSS Animations: property <object-view-box> from [inset(0%)] to [inset(20%)] at (1) should be [inset(20%)]
+PASS Web Animations: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0) should be [inset(0%)]
+PASS Web Animations: property <object-view-box> from [inset(0%)] to [inset(20%)] at (0.5) should be [inset(10%)]
+PASS Web Animations: property <object-view-box> from [inset(0%)] to [inset(20%)] at (1) should be [inset(20%)]
+PASS CSS Transitions: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0) should be [rect(0px 10px 20px 30px)]
+PASS CSS Transitions: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0.5) should be [rect(5px 15px 25px 35px)]
+PASS CSS Transitions: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (1) should be [rect(10px 20px 30px 40px)]
+PASS CSS Transitions with transition: all: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0) should be [rect(0px 10px 20px 30px)]
+PASS CSS Transitions with transition: all: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0.5) should be [rect(5px 15px 25px 35px)]
+PASS CSS Transitions with transition: all: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (1) should be [rect(10px 20px 30px 40px)]
+PASS CSS Animations: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0) should be [rect(0px 10px 20px 30px)]
+PASS CSS Animations: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0.5) should be [rect(5px 15px 25px 35px)]
+PASS CSS Animations: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (1) should be [rect(10px 20px 30px 40px)]
+PASS Web Animations: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0) should be [rect(0px 10px 20px 30px)]
+PASS Web Animations: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (0.5) should be [rect(5px 15px 25px 35px)]
+PASS Web Animations: property <object-view-box> from [rect(0px 10px 20px 30px)] to [rect(10px 20px 30px 40px)] at (1) should be [rect(10px 20px 30px 40px)]
+PASS CSS Transitions: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0) should be [xywh(0px 10px 20px 30px)]
+PASS CSS Transitions: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0.5) should be [xywh(5px 15px 25px 35px)]
+PASS CSS Transitions: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (1) should be [xywh(10px 20px 30px 40px)]
+PASS CSS Transitions with transition: all: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0) should be [xywh(0px 10px 20px 30px)]
+PASS CSS Transitions with transition: all: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0.5) should be [xywh(5px 15px 25px 35px)]
+PASS CSS Transitions with transition: all: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (1) should be [xywh(10px 20px 30px 40px)]
+PASS CSS Animations: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0) should be [xywh(0px 10px 20px 30px)]
+PASS CSS Animations: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0.5) should be [xywh(5px 15px 25px 35px)]
+PASS CSS Animations: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (1) should be [xywh(10px 20px 30px 40px)]
+PASS Web Animations: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0) should be [xywh(0px 10px 20px 30px)]
+PASS Web Animations: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (0.5) should be [xywh(5px 15px 25px 35px)]
+PASS Web Animations: property <object-view-box> from [xywh(0px 10px 20px 30px)] to [xywh(10px 20px 30px 40px)] at (1) should be [xywh(10px 20px 30px 40px)]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-view-box-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-view-box-parsing-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL e.style['object-view-box'] = "inset(10%)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['object-view-box'] = "inset(10px 20px 30px 40px)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['object-view-box'] = "rect(1px 10% 100px 50%)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['object-view-box'] = "rect(auto auto auto auto)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['object-view-box'] = "rect(auto 5px auto 10%)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['object-view-box'] = "xywh(1px 10% 100px 50%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['object-view-box'] = "inset(10%)" should set the property value
+PASS e.style['object-view-box'] = "inset(10px 20px 30px 40px)" should set the property value
+PASS e.style['object-view-box'] = "rect(1px 10% 100px 50%)" should set the property value
+PASS e.style['object-view-box'] = "rect(auto auto auto auto)" should set the property value
+PASS e.style['object-view-box'] = "rect(auto 5px auto 10%)" should set the property value
+PASS e.style['object-view-box'] = "xywh(1px 10% 100px 50%)" should set the property value
 PASS e.style['object-view-box'] = "circle(10px)" should not set the property value
 PASS e.style['object-view-box'] = "ellipse(10px 20px)" should not set the property value
 PASS e.style['object-view-box'] = "polygon(10px 20px 30px)" should not set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-view-box-transition-mutation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-view-box-transition-mutation-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Unrelated mutation does not affect object-view-box transition assert_equals: before mutation expected (string) "inset(10px)" but got (undefined) undefined
+PASS Unrelated mutation does not affect object-view-box transition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
@@ -1,9 +1,9 @@
 
 
-FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 441
-FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 441
-FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 441
-FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 442
+FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 442
+FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 442
+FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 442
+FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
 PASS <select></select> has a shadow tree with slot
 PASS <select multiple=""></select> has a shadow tree with slot
 PASS <select size="4"></select> has a shadow tree with slot

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -245,6 +245,7 @@ PASS min-width
 PASS mix-blend-mode
 PASS object-fit
 PASS object-position
+PASS object-view-box
 PASS offset-anchor
 PASS offset-distance
 PASS offset-path

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
@@ -1,9 +1,9 @@
 
 
-FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 440
-FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 440
-FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 440
-FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 441
+FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 441
+FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 441
+FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 441
+FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 442
 PASS <select></select> has a shadow tree with slot
 PASS <select multiple=""></select> has a shadow tree with slot
 PASS <select size="4"></select> has a shadow tree with slot

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -244,6 +244,7 @@ PASS min-width
 PASS mix-blend-mode
 PASS object-fit
 PASS object-position
+PASS object-view-box
 PASS offset-anchor
 PASS offset-distance
 PASS offset-path

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
@@ -1,9 +1,9 @@
 
 
-FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
-FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
-FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
-FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 444
+FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 444
+FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 444
+FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 444
+FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 445
 PASS <select></select> has a shadow tree with slot
 PASS <select multiple=""></select> has a shadow tree with slot
 PASS <select size="4"></select> has a shadow tree with slot

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -232,6 +232,7 @@ PASS min-width
 PASS mix-blend-mode
 PASS object-fit
 PASS object-position
+PASS object-view-box
 PASS offset-anchor
 PASS offset-distance
 PASS offset-path

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1249,6 +1249,20 @@ CSSMathDepthEnabled:
     WebCore:
       default: true
       
+CSSObjectViewBoxEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS object-view-box property"
+  humanReadableDescription: "Enable support for CSS object-view-box property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSOverflowClipMarginEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3325,6 +3325,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/images/StyleImageOrientation.h
     style/values/images/StyleImageWrapper.h
     style/values/images/StyleObjectPosition.h
+    style/values/images/StyleObjectViewBox.h
 
     style/values/images/kinds/StyleImage.h
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1088,6 +1088,7 @@ css/parser/CSSPropertyParserConsumer+Inline.cpp
 css/parser/CSSPropertyParserConsumer+Lists.cpp
 css/parser/CSSPropertyParserConsumer+Masking.cpp
 css/parser/CSSPropertyParserConsumer+Motion.cpp
+css/parser/CSSPropertyParserConsumer+ObjectViewBox.cpp
 css/parser/CSSPropertyParserConsumer+Overflow.cpp
 css/parser/CSSPropertyParserConsumer+Percentage.cpp
 css/parser/CSSPropertyParserConsumer+Position.cpp
@@ -3406,6 +3407,7 @@ style/values/images/StyleGradient.cpp @header:RenderStyleGetters @cost:6
 style/values/images/StyleImageOrNone.cpp
 style/values/images/StyleImageOrientation.cpp
 style/values/images/StyleImageWrapper.cpp
+style/values/images/StyleObjectViewBox.cpp
 style/values/inline/StyleLineHeight.cpp @header:RenderStyleGetters @cost:5
 style/values/inline/StyleVerticalAlign.cpp
 style/values/inline/StyleWebKitInitialLetter.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -6849,6 +6849,23 @@
                 "url": "https://www.w3.org/TR/css3-images/#object-position"
             }
         },
+        "object-view-box": {
+            "animation-type": "see prose",
+            "initial": "none",
+            "codegen-properties": {
+                "settings-flag": "cssObjectViewBoxEnabled",
+                "computed-style-storage-path": ["m_nonInheritedData", "miscData"],
+                "computed-style-storage-kind": "reference",
+                "computed-style-type": "Style::ObjectViewBox",
+                "parser-function": "consumeObjectViewBox",
+                "parser-grammar-unused": "none | <basic-shape-rect>",
+                "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form and the strong value representation."
+            },
+            "specification": {
+                "category": "css-images",
+                "url": "https://drafts.csswg.org/css-images-5/#the-object-view-box"
+            }
+        },
         "offset-path": {
             "animation-type": "by computed value",
             "initial": "none",

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ObjectViewBox.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ObjectViewBox.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSPropertyParserConsumer+ObjectViewBox.h"
+
+#include "CSSParserTokenRange.h"
+#include "CSSPropertyParserConsumer+Ident.h"
+#include "CSSPropertyParserConsumer+Shapes.h"
+#include "CSSPropertyParserState.h"
+#include "CSSValueKeywords.h"
+
+namespace WebCore {
+namespace CSSPropertyParserHelpers {
+
+RefPtr<CSSValue> consumeObjectViewBox(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    // <'object-view-box'> = none | <basic-shape-rect>
+    // https://drafts.csswg.org/css-images-5/#the-object-view-box
+
+    if (range.peek().id() == CSSValueNone)
+        return consumeIdent(range);
+
+    return consumeBasicShapeRect(range, state);
+}
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ObjectViewBox.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ObjectViewBox.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class CSSParserTokenRange;
+class CSSValue;
+
+namespace CSS {
+struct PropertyParserState;
+}
+
+namespace CSSPropertyParserHelpers {
+
+// MARK: <'object-view-box'>
+// https://drafts.csswg.org/css-images-5/#the-object-view-box
+
+RefPtr<CSSValue> consumeObjectViewBox(CSSParserTokenRange&, CSS::PropertyParserState&);
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp
@@ -63,6 +63,18 @@ template<CSSValueID Name, typename T> std::optional<CSS::BasicShape> toBasicShap
     return toBasicShape<Name>(WTF::move(*parameters));
 }
 
+template<CSSValueID Name, typename T> CSS::BasicShapeRect toBasicShapeRect(T&& parameters)
+{
+    return CSS::BasicShapeRect { FunctionNotation<Name, T> { WTF::move(parameters) } };
+}
+
+template<CSSValueID Name, typename T> std::optional<CSS::BasicShapeRect> toBasicShapeRect(std::optional<T>&& parameters)
+{
+    if (!parameters)
+        return { };
+    return toBasicShapeRect<Name>(WTF::move(*parameters));
+}
+
 static std::optional<CSS::FillRule> peekFillRule(CSSParserTokenRange& range)
 {
     // <'fill-rule'> = nonzero | evenodd
@@ -1005,6 +1017,37 @@ RefPtr<CSSValue> consumeBasicShape(CSSParserTokenRange& range, CSS::PropertyPars
 
     range = rangeCopy;
     return CSSBasicShapeValue::create(WTF::move(*result));
+}
+
+// MARK: - <basic-shape-rect>
+
+RefPtr<CSSValue> consumeBasicShapeRect(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+{
+    // <basic-shape-rect> = <inset()> | <rect()> | <xywh()>
+    // https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape-rect
+
+    if (range.peek().type() != FunctionToken)
+        return { };
+
+    auto rangeCopy = range;
+    auto id = rangeCopy.peek().functionId();
+    auto args = consumeFunction(rangeCopy);
+
+    std::optional<CSS::BasicShapeRect> result;
+    if (id == CSSValueInset)
+        result = toBasicShapeRect<CSSValueInset>(consumeBasicShapeInsetFunctionParameters(args, state));
+    else if (id == CSSValueRect)
+        result = toBasicShapeRect<CSSValueRect>(consumeBasicShapeRectFunctionParameters(args, state));
+    else if (id == CSSValueXywh)
+        result = toBasicShapeRect<CSSValueXywh>(consumeBasicShapeXywhFunctionParameters(args, state));
+
+    if (!result || !args.atEnd())
+        return { };
+
+    range = rangeCopy;
+    return CSSBasicShapeValue::create(WTF::switchOn(WTF::move(*result), [](auto&& shape) -> CSS::BasicShape {
+        return { WTF::move(shape) };
+    }));
 }
 
 RefPtr<CSSValue> consumePath(CSSParserTokenRange& range, CSS::PropertyParserState& state)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.h
@@ -49,6 +49,10 @@ enum class BasicShapeParsingOptions : uint8_t {
 // https://drafts.csswg.org/css-shapes/#typedef-basic-shape
 RefPtr<CSSValue> consumeBasicShape(CSSParserTokenRange&, CSS::PropertyParserState&, OptionSet<BasicShapeParsingOptions>);
 
+// <basic-shape-rect> = <inset()> | <rect()> | <xywh()>
+// https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape-rect
+RefPtr<CSSValue> consumeBasicShapeRect(CSSParserTokenRange&, CSS::PropertyParserState&);
+
 // <path()> = path( <'fill-rule'>? , <string> )
 // https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-path
 RefPtr<CSSValue> consumePath(CSSParserTokenRange&, CSS::PropertyParserState&);

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -74,6 +74,7 @@
 #include "CSSPropertyParserConsumer+Masking.h"
 #include "CSSPropertyParserConsumer+Motion.h"
 #include "CSSPropertyParserConsumer+NumberDefinitions.h"
+#include "CSSPropertyParserConsumer+ObjectViewBox.h"
 #include "CSSPropertyParserConsumer+Overflow.h"
 #include "CSSPropertyParserConsumer+Percentage.h"
 #include "CSSPropertyParserConsumer+PercentageDefinitions.h"

--- a/Source/WebCore/css/values/shapes/CSSBasicShape.h
+++ b/Source/WebCore/css/values/shapes/CSSBasicShape.h
@@ -49,5 +49,13 @@ using BasicShape = Variant<
     XywhFunction
 >;
 
+// <basic-shape-rect> = <inset()> | <rect()> | <xywh()>
+// https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape-rect
+using BasicShapeRect = Variant<
+    InsetFunction,
+    RectFunction,
+    XywhFunction
+>;
+
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -143,6 +143,7 @@ inline OffsetDistance forwardInheritedValue(const OffsetDistance& value) { auto 
 inline OffsetPath forwardInheritedValue(const OffsetPath& value) { auto copy = value; return copy; }
 inline OffsetPosition forwardInheritedValue(const OffsetPosition& value) { auto copy = value; return copy; }
 inline OffsetRotate forwardInheritedValue(const OffsetRotate& value) { auto copy = value; return copy; }
+inline ObjectViewBox forwardInheritedValue(const ObjectViewBox& value) { auto copy = value; return copy; }
 inline OutlineOffset forwardInheritedValue(const OutlineOffset& value) { auto copy = value; return copy; }
 inline OverflowClipMargin forwardInheritedValue(const OverflowClipMargin& value) { auto copy = value; return copy; }
 inline Position forwardInheritedValue(const Position& value) { auto copy = value; return copy; }

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -307,6 +307,7 @@ struct OffsetPosition;
 struct OffsetRotate;
 struct Opacity;
 struct Orphans;
+struct ObjectViewBox;
 struct OutlineOffset;
 struct OverflowClipMargin;
 struct PaddingEdge;

--- a/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.cpp
@@ -58,6 +58,7 @@ NonInheritedMiscData::NonInheritedMiscData()
     , justifyItems(ComputedStyle::initialJustifyItems())
     , justifySelf(ComputedStyle::initialJustifySelf())
     , objectPosition(ComputedStyle::initialObjectPosition())
+    , objectViewBox(ComputedStyle::initialObjectViewBox())
     , order(ComputedStyle::initialOrder())
     , tableLayout(static_cast<unsigned>(ComputedStyle::initialTableLayout()))
     , appearance(static_cast<unsigned>(ComputedStyle::initialAppearance()))
@@ -91,6 +92,7 @@ NonInheritedMiscData::NonInheritedMiscData(const NonInheritedMiscData& o)
     , justifyItems(o.justifyItems)
     , justifySelf(o.justifySelf)
     , objectPosition(o.objectPosition)
+    , objectViewBox(o.objectViewBox)
     , order(o.order)
     , hasAttrContent(o.hasAttrContent)
     , hasDisplayAffectedByAnimations(o.hasDisplayAffectedByAnimations)
@@ -138,6 +140,7 @@ bool NonInheritedMiscData::operator==(const NonInheritedMiscData& o) const
         && justifyItems == o.justifyItems
         && justifySelf == o.justifySelf
         && objectPosition == o.objectPosition
+        && objectViewBox == o.objectViewBox
         && order == o.order
         && hasAttrContent == o.hasAttrContent
         && hasDisplayAffectedByAnimations == o.hasDisplayAffectedByAnimations
@@ -190,6 +193,7 @@ void NonInheritedMiscData::dumpDifferences(TextStream& ts, const NonInheritedMis
     LOG_IF_DIFFERENT(justifyItems);
     LOG_IF_DIFFERENT(justifySelf);
     LOG_IF_DIFFERENT(objectPosition);
+    LOG_IF_DIFFERENT(objectViewBox);
     LOG_IF_DIFFERENT(order);
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasAttrContent);

--- a/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedMiscData.h
@@ -39,6 +39,7 @@
 #include <WebCore/StyleJustifySelf.h>
 #include <WebCore/StyleMaskLayers.h>
 #include <WebCore/StyleObjectPosition.h>
+#include <WebCore/StyleObjectViewBox.h>
 #include <WebCore/StyleOpacity.h>
 #include <WebCore/StyleOrder.h>
 #include <WebCore/StyleResize.h>
@@ -98,6 +99,7 @@ public:
     JustifySelf justifySelf;
 
     ObjectPosition objectPosition;
+    ObjectViewBox objectViewBox;
     Order order;
 
     PREFERRED_TYPE(bool) unsigned hasAttrContent : 1 { false };

--- a/Source/WebCore/style/values/images/StyleObjectViewBox.cpp
+++ b/Source/WebCore/style/values/images/StyleObjectViewBox.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleObjectViewBox.h"
+
+#include "CSSBasicShapeValue.h"
+#include "CSSKeywordValue.h"
+#include "StyleBasicShape.h"
+#include "StyleBuilderState.h"
+#include "StyleComputedStyle.h"
+#include "StyleKeyword+Serialization.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+Serialization.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto CSSValueConversion<ObjectViewBox>::operator()(BuilderState& state, const CSSValue& value) -> ObjectViewBox
+{
+    if (isValueID(value, CSSValueNone))
+        return CSS::Keyword::None { };
+
+    // <basic-shape-rect> variants (inset, rect, xywh) all resolve to InsetFunction
+    auto& shapeValue = downcast<CSSBasicShapeValue>(value);
+    auto styleShape = toStyle(shapeValue.shape(), state);
+    if (auto* rect = std::get_if<BasicShapeRect>(&styleShape))
+        return { WTF::move(*rect) };
+
+    ASSERT_NOT_REACHED();
+    return CSS::Keyword::None { };
+}
+
+// MARK: - CSSValue creation
+
+Ref<CSSValue> CSSValueCreation<ObjectViewBox>::operator()(CSSValuePool&, const ComputedStyle& style, const ObjectViewBox& value)
+{
+    if (value.isNone())
+        return CSSKeywordValue::create(CSSValueNone);
+    return CSSBasicShapeValue::create(toCSS(BasicShape { *value.tryRect() }, style));
+}
+
+// MARK: - Serialization
+
+void Serialize<ObjectViewBox>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const ComputedStyle& style, const ObjectViewBox& value)
+{
+    if (value.isNone()) {
+        serializationForCSS(builder, context, style, CSS::Keyword::None { });
+        return;
+    }
+    serializationForCSS(builder, context, style, BasicShape { *value.tryRect() });
+}
+
+// MARK: - Blending
+
+auto Blending<ObjectViewBox>::canBlend(const ObjectViewBox& from, const ObjectViewBox& to) -> bool
+{
+    if (from.isNone() || to.isNone())
+        return false;
+    return Style::canBlend(*from.tryRect(), *to.tryRect());
+}
+
+auto Blending<ObjectViewBox>::blend(const ObjectViewBox& from, const ObjectViewBox& to, const BlendingContext& context) -> ObjectViewBox
+{
+    if (context.isDiscrete) {
+        ASSERT(!context.progress || context.progress == 1.0);
+        return context.progress ? to : from;
+    }
+
+    ASSERT(canBlend(from, to));
+    return { Style::blend(*from.tryRect(), *to.tryRect(), context) };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/images/StyleObjectViewBox.h
+++ b/Source/WebCore/style/values/images/StyleObjectViewBox.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleInsetFunction.h>
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// All <basic-shape-rect> variants (inset(), rect(), xywh()) canonicalize to
+// InsetFunction during style building. See StyleRectFunction.h and
+// StyleXywhFunction.h for the conversions.
+using BasicShapeRect = InsetFunction;
+
+// <'object-view-box'> = none | <basic-shape-rect>
+// https://drafts.csswg.org/css-images-5/#the-object-view-box
+struct ObjectViewBox {
+    using Value = Variant<CSS::Keyword::None, BasicShapeRect>;
+
+    ObjectViewBox(CSS::Keyword::None none)
+        : m_value(none) { }
+    ObjectViewBox(BasicShapeRect&& rect)
+        : m_value(WTF::move(rect)) { }
+
+    bool isNone() const { return WTF::holdsAlternative<CSS::Keyword::None>(m_value); }
+    bool isRect() const { return WTF::holdsAlternative<BasicShapeRect>(m_value); }
+
+    std::optional<BasicShapeRect> tryRect() const
+    {
+        if (auto* rect = std::get_if<BasicShapeRect>(&m_value))
+            return *rect;
+        return std::nullopt;
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        return WTF::switchOn(m_value, std::forward<F>(f)...);
+    }
+
+    bool operator==(const ObjectViewBox&) const = default;
+
+private:
+    Value m_value;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<ObjectViewBox> {
+    auto operator()(BuilderState&, const CSSValue&) -> ObjectViewBox;
+};
+
+// MARK: - CSSValue creation
+
+template<> struct CSSValueCreation<ObjectViewBox> {
+    Ref<CSSValue> operator()(CSSValuePool&, const ComputedStyle&, const ObjectViewBox&);
+};
+
+// MARK: - Serialization
+
+template<> struct Serialize<ObjectViewBox> {
+    void operator()(StringBuilder&, const CSS::SerializationContext&, const ComputedStyle&, const ObjectViewBox&);
+};
+
+// MARK: - Blending
+
+template<> struct Blending<ObjectViewBox> {
+    auto canBlend(const ObjectViewBox& from, const ObjectViewBox& to) -> bool;
+    auto blend(const ObjectViewBox& from, const ObjectViewBox& to, const BlendingContext&) -> ObjectViewBox;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::ObjectViewBox)


### PR DESCRIPTION
#### 54d003b450a00cc0ac4054756a52e78a0e628f1b
<pre>
Implement CSS object-view-box parsing and feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=316220">https://bugs.webkit.org/show_bug.cgi?id=316220</a>
<a href="https://rdar.apple.com/178647990">rdar://178647990</a>

Reviewed by Sammy Gill and Tim Nguyen.

Add the cssObjectViewBoxEnabled feature flag and implement parsing for
the CSS object-view-box property. Accepts none | &lt;basic-shape-rect&gt;
(inset(), rect(), xywh()). All three forms canonicalize to InsetFunction
in the computed style. The round &lt;border-radius&gt; form of inset() and
rendering are left for a follow-up.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ObjectViewBox.cpp: Added.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ObjectViewBox.h: Added.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/data/StyleNonInheritedMiscData.cpp:
* Source/WebCore/style/computed/data/StyleNonInheritedMiscData.h:
* Source/WebCore/style/values/images/StyleObjectViewBox.cpp: Added.
* Source/WebCore/style/values/images/StyleObjectViewBox.h: Added.

Canonical link: <a href="https://commits.webkit.org/315073@main">https://commits.webkit.org/315073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71d5b1874b101912de1484aafb4bb62005186d19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177254 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125652 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130670 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111187 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32122 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30827 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25957 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160577 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179854 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29205 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32606 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139093 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41528 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138975 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37439 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42216 "Built successfully") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/105495 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34262 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27303 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200636 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40720 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113972 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53900 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40117 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5403 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->