### PR TITLE
[LBSE] Compensate for content box offset when applying zoom to outermost SVG viewport container

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
@@ -130,8 +130,6 @@ inline AffineTransform viewBoxToViewTransform(const SVGSVGElement& svgSVGElement
 
 void RenderSVGViewportContainer::updateLayerTransform()
 {
-    ASSERT(hasLayer());
-
     // First update the supplemental layer transform.
     Ref useSVGSVGElement = svgSVGElement();
     auto viewportSize = this->viewportSize();
@@ -144,8 +142,23 @@ void RenderSVGViewportContainer::updateLayerTransform()
             m_supplementalLayerTransform.translate(translation);
 
         // Handle zoom - take effective zoom from outermost <svg> element.
-        if (auto scale = useSVGSVGElement->renderer()->style().usedZoom(); scale != 1) {
-            m_supplementalLayerTransform.scale(scale);
+        CheckedRef svgRoot = downcast<RenderSVGRoot>(*useSVGSVGElement->renderer());
+        if (auto scale = svgRoot->style().usedZoom(); scale != 1) {
+            // The outermost viewport container is positioned at the content box origin
+            // (border + padding offset from the SVG root's border box). In paintLayerByApplyingTransform(),
+            // the layer's positional offset is applied via translateRight AFTER the supplemental transform.
+            // Without compensation, the zoom scale would be applied to this positional offset, causing
+            // the SVG content to be shifted by (zoom - 1) * contentBoxOffset. Wrap the scale with
+            // compensating translations to prevent the positional offset from being scaled.
+            auto contentBoxOffset = svgRoot->contentBoxLocation();
+            if (!contentBoxOffset.isZero()) {
+                auto cbx = contentBoxOffset.x().toFloat();
+                auto cby = contentBoxOffset.y().toFloat();
+                m_supplementalLayerTransform.translate(cbx, cby);
+                m_supplementalLayerTransform.scale(scale);
+                m_supplementalLayerTransform.translate(-cbx, -cby);
+            } else
+                m_supplementalLayerTransform.scale(scale);
             viewportSize.scale(1.0 / scale);
         }
     } else if (!m_viewport.location().isZero())


### PR DESCRIPTION
#### 480dd8d99f0e46329bde642066e5d20de40348e6
<pre>
[LBSE] Compensate for content box offset when applying zoom to outermost SVG viewport container
<a href="https://bugs.webkit.org/show_bug.cgi?id=316238">https://bugs.webkit.org/show_bug.cgi?id=316238</a>

Reviewed by Rob Buis.

Wrap the zoom scale of the outermost viewport container&apos;s supplemental layer
transform with compensating translations around the content box origin. The
layer&apos;s positional offset (border + padding) is applied via translateRight
after the supplemental transform in paintLayerByApplyingTransform(), so without
compensation the zoom would scale that positional offset and shift the SVG
content by (zoom - 1) * contentBoxOffset. Also drop the now-incorrect
hasLayer() assertion in updateLayerTransform().

Fixes svg/zoom/page/zoom-svg-float-border-padding.xml when conditional
layer creation is enabled.

* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
(WebCore::RenderSVGViewportContainer::updateLayerTransform):

Canonical link: <a href="https://commits.webkit.org/314535@main">https://commits.webkit.org/314535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63a46d42be61971aa960fd5596f6371fa4190144

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123675 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129373 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109898 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29431 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23608 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178001 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30902 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137728 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137647 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37080 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149023 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103350 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32938 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39178 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112253 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38575 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3975 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->