### PR TITLE
[macOS] Certain build configurations failing due to NSViewCornerConfiguration availability

### DIFF
--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -871,6 +871,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return;
 
     WebCore::CornerRadii newRadii;
+ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     if (RetainPtr<NSViewCornerRadii> radii = self._effectiveCornerRadii) {
         newRadii = WebCore::CornerRadii {
             static_cast<float>([radii topLeft]),
@@ -879,6 +880,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             static_cast<float>([radii bottomRight])
         };
     }
+ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     if (_lastViewCornerRadii == newRadii)
         return;
@@ -887,6 +889,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     _page->setScrollbarAvoidanceCornerRadii(WTF::move(newRadii));
 }
 
+ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
 - (NSViewCornerConfiguration *)_cornerConfiguration
 {
     if (self.enclosingScrollView)
@@ -894,6 +897,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     return [NSViewCornerConfiguration configurationWithRadius:(id)_NSCornerRadius.containerConcentricRadius];
 }
+ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm
@@ -58,6 +58,7 @@
     [self _invalidateCornerConfiguration];
 }
 
+ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
 - (NSViewCornerConfiguration *)_cornerConfiguration
 {
     return [NSViewCornerConfiguration
@@ -66,6 +67,7 @@
         bottomLeftRadius:(id)[_NSCornerRadius fixedRadius:self.bottomLeftRadius]
         bottomRightRadius:(id)[_NSCornerRadius fixedRadius:self.bottomRightRadius]];
 }
+ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 @end
 
@@ -139,10 +141,12 @@ static std::optional<CGRect> scrollbarFrameRect(TestWKWebView *webView, Scrollba
 
 static void verifyVerticalScrollbarFrameRectIsCorrect(RetainPtr<TestWKWebView> webView)
 {
+ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     auto topLeftRadius = [webView _effectiveCornerRadii].topLeft;
     auto topRightRadius = [webView _effectiveCornerRadii].topRight;
     auto bottomLeftRadius = [webView _effectiveCornerRadii].bottomLeft;
     auto bottomRightRadius = [webView _effectiveCornerRadii].bottomRight;
+ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     auto topObscuredContentInset = [webView obscuredContentInsets].top;
     auto bottomObscuredContentInset = [webView obscuredContentInsets].bottom;
@@ -199,8 +203,10 @@ static void verifyVerticalScrollbarFrameRectIsCorrect(RetainPtr<TestWKWebView> w
 
 static void verifyHorizontalScrollbarFrameRectIsCorrect(RetainPtr<TestWKWebView> webView)
 {
+ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     auto bottomLeftRadius = [webView _effectiveCornerRadii].bottomLeft;
     auto bottomRightRadius = [webView _effectiveCornerRadii].bottomRight;
+ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     auto leftObscuredContentInset = webView.get().obscuredContentInsets.left;
     auto rightObscuredContentInset = webView.get().obscuredContentInsets.right;
@@ -238,6 +244,7 @@ static void verifyScrollbarFrameRectsAreCorrect(RetainPtr<TestWKWebView> webView
     verifyHorizontalScrollbarFrameRectIsCorrect(webView);
 }
 
+ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
 static void verifyWebViewHasExpectedCornerRadii(RetainPtr<TestWKWebView> webView, WebCore::CornerRadii cornerRadii)
 {
     auto topLeftRadius = [webView _effectiveCornerRadii].topLeft;
@@ -250,6 +257,7 @@ static void verifyWebViewHasExpectedCornerRadii(RetainPtr<TestWKWebView> webView
     EXPECT_EQ(bottomLeftRadius, cornerRadii.bottomLeft().width());
     EXPECT_EQ(bottomRightRadius, cornerRadii.bottomRight().width());
 }
+ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 static RetainPtr<TestWKWebView> scrollbarAvoidanceTestWebView()
 {
@@ -271,7 +279,9 @@ TEST(ScrollbarTests, ScrollbarAvoidanceForTitledWindow)
     RetainPtr window = scrollbarAvoidanceTestWindow();
     [[window contentView] addSubview:webView.get()];
 
+ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     EXPECT_TRUE([webView _effectiveCornerRadii].bottomRight);
+ALLOW_NEW_API_WITHOUT_GUARDS_END
     verifyScrollbarFrameRectsAreCorrect(webView);
 }
 
@@ -285,7 +295,9 @@ TEST(ScrollbarTests, ScrollbarAvoidanceForWindowWithUnifiedCompactToolbar)
     [window setToolbarStyle:NSWindowToolbarStyleUnifiedCompact];
     [[window contentView] addSubview:webView.get()];
 
+ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     EXPECT_TRUE([webView _effectiveCornerRadii].bottomRight);
+ALLOW_NEW_API_WITHOUT_GUARDS_END
     verifyScrollbarFrameRectsAreCorrect(webView);
 }
 
@@ -299,7 +311,9 @@ TEST(ScrollbarTests, ScrollbarAvoidanceForWindowWithUnifiedToolbar)
     [window setToolbarStyle:NSWindowToolbarStyleUnified];
     [[window contentView] addSubview:webView.get()];
 
+ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     EXPECT_TRUE([webView _effectiveCornerRadii].bottomRight);
+ALLOW_NEW_API_WITHOUT_GUARDS_END
     verifyScrollbarFrameRectsAreCorrect(webView);
 }
 


### PR DESCRIPTION
#### c02af6edab45b2717fc3f0e05ad512a294ea60b0
<pre>
[macOS] Certain build configurations failing due to NSViewCornerConfiguration availability
<a href="https://bugs.webkit.org/show_bug.cgi?id=316259">https://bugs.webkit.org/show_bug.cgi?id=316259</a>
<a href="https://rdar.apple.com/178636492">rdar://178636492</a>

Reviewed by Abrar Rahman Protyasha.

Use ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN/ALLOW_NEW_API_WITHOUT_GUARDS_END
where necessary.

* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _viewDidChangeEffectiveCornerRadii]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm:
(TestWebKitAPI::verifyVerticalScrollbarFrameRectIsCorrect):
(TestWebKitAPI::verifyHorizontalScrollbarFrameRectIsCorrect):
(TestWebKitAPI::TEST(ScrollbarTests, ScrollbarAvoidanceForTitledWindow)):
(TestWebKitAPI::TEST(ScrollbarTests, ScrollbarAvoidanceForWindowWithUnifiedCompactToolbar)):
(TestWebKitAPI::TEST(ScrollbarTests, ScrollbarAvoidanceForWindowWithUnifiedToolbar)):

Canonical link: <a href="https://commits.webkit.org/314505@main">https://commits.webkit.org/314505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb51189dcf65644f5c17b374e55ec39dd9f83610

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175387 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39837 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/129295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169298 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31678 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109820 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23527 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177919 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28854 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/137647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39899 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137569 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40587 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148945 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/103233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25321 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32861 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39097 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/38494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3897 "Passed tests") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/38739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/38637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->