### PR TITLE
netflix.com: v2: Webpage scrolls when adjusting volume slider (VisionOS / iPad) -- narrower fix after revert of 314097@main

### DIFF
--- a/LayoutTests/fast/events/touch/ios/netflix-volume-slider-touch-action-quirk-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/netflix-volume-slider-touch-action-quirk-expected.txt
@@ -1,0 +1,10 @@
+Tests that the Netflix volume-slider quirk prevents page scrolling when dragging the vertical scrubber, but allows scrolling when dragging a horizontal sibling. (rdar://178545839)
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS scrollYAfterVerticalScrubberDrag is initialScrollY
+PASS scrollYAfterHorizontalScrubberDrag > initialScrollY is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/touch/ios/netflix-volume-slider-touch-action-quirk.html
+++ b/LayoutTests/fast/events/touch/ios/netflix-volume-slider-touch-action-quirk.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width">
+    <script src="../../../../resources/js-test.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+    <style>
+        body { margin: 0; height: 4000px; }
+        #vertical-scrubber, #horizontal-scrubber {
+            width: 300px;
+            height: 200px;
+            background: #ccc;
+            margin-top: 50px;
+        }
+        #horizontal-scrubber { background: #eee; }
+    </style>
+    <script>
+        jsTestIsAsync = true;
+
+        let initialScrollY = 0;
+        let scrollYAfterVerticalScrubberDrag = 0;
+        let scrollYAfterHorizontalScrubberDrag = 0;
+
+        window.internals?.setTopDocumentURLForQuirks("https://www.netflix.com");
+
+        addEventListener("load", async () => {
+            description("Tests that the Netflix volume-slider quirk prevents page scrolling when dragging the vertical scrubber, but allows scrolling when dragging a horizontal sibling. (rdar://178545839)");
+
+            if (!window.testRunner || !testRunner.runUIScript) {
+                debug("This test requires WebKitTestRunner.");
+                finishJSTest();
+                return;
+            }
+
+            window.scrollTo(0, 0);
+            initialScrollY = window.scrollY;
+
+            const verticalScrubber = document.getElementById("vertical-scrubber");
+            const verticalScrubberRect = verticalScrubber.getBoundingClientRect();
+            const verticalCenterX = verticalScrubberRect.left + verticalScrubberRect.width / 2;
+            const verticalStartY = verticalScrubberRect.top + verticalScrubberRect.height * 0.25;
+            const verticalEndY = verticalScrubberRect.top + verticalScrubberRect.height * 0.75;
+
+            await UIHelper.dragFromPointToPoint(verticalCenterX, verticalStartY, verticalCenterX, verticalEndY, 0.5);
+
+            scrollYAfterVerticalScrubberDrag = window.scrollY;
+            shouldBe("scrollYAfterVerticalScrubberDrag", "initialScrollY");
+
+            const horizontalScrubber = document.getElementById("horizontal-scrubber");
+            const horizontalScrubberRect = horizontalScrubber.getBoundingClientRect();
+            const horizontalCenterX = horizontalScrubberRect.left + horizontalScrubberRect.width / 2;
+            const horizontalStartY = horizontalScrubberRect.top + horizontalScrubberRect.height / 2;
+            const horizontalEndY = 50;
+
+            await UIHelper.dragFromPointToPoint(horizontalCenterX, horizontalStartY, horizontalCenterX, horizontalEndY, 1.0);
+
+            scrollYAfterHorizontalScrubberDrag = window.scrollY;
+            shouldBeTrue("scrollYAfterHorizontalScrubberDrag > initialScrollY");
+
+            finishJSTest();
+        });
+    </script>
+</head>
+<body>
+<div id="vertical-scrubber" data-uia="scrubber" aria-orientation="vertical"></div>
+<div id="horizontal-scrubber" data-uia="scrubber" aria-orientation="horizontal"></div>
+<div id="description"></div>
+<div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -868,6 +868,18 @@ bool Quirks::needsGoogleTranslateScrollingQuirk() const
 #endif
 }
 
+// netflix.com rdar://178545839
+bool Quirks::needsNetflixVolumeSliderQuirk() const
+{
+#if PLATFORM(IOS) || PLATFORM(VISION)
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsNetflixVolumeSliderQuirk);
+#else
+    return false;
+#endif
+}
+
 // play.geforcenow.com https://webkit.org/b/303622
 // FIXME: Remove as soon as nvidia adjusts the site for Safari. https://webkit.org/b/303718
 bool Quirks::needsGeforcenowWarningDisplayNoneQuirk() const
@@ -3620,6 +3632,10 @@ static void handleNetflixQuirks(QuirksData& quirksData, const URL& /* quirksURL 
         QuirksData::SiteSpecificQuirk::NeedsSeekingSupportDisabledQuirk,
 #if PLATFORM(VISION)
         QuirksData::SiteSpecificQuirk::NeedsNowPlayingFullscreenSwapQuirk,
+#endif
+#if PLATFORM(IOS) || PLATFORM(VISION)
+        // netflix.com rdar://178545839
+        QuirksData::SiteSpecificQuirk::NeedsNetflixVolumeSliderQuirk,
 #endif
 #if ENABLE(TOUCH_EVENTS)
         // netflix.com https://bugs.webkit.org/show_bug.cgi?id=304608

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -146,6 +146,7 @@ public:
     bool needsZomatoEmailLoginLabelQuirk() const;
     bool NODELETE needsGoogleMapsScrollingQuirk() const;
     bool NODELETE needsGoogleTranslateScrollingQuirk() const;
+    bool NODELETE needsNetflixVolumeSliderQuirk() const;
     bool needsGeforcenowWarningDisplayNoneQuirk() const;
 
     bool needsYahooVolumeSliderQuirk() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -103,6 +103,9 @@ struct QuirksData {
         NeedsGoogleMapsScrollingQuirk,
         NeedsGoogleTranslateScrollingQuirk,
 #endif
+#if PLATFORM(IOS) || PLATFORM(VISION)
+        NeedsNetflixVolumeSliderQuirk,
+#endif
         NeedsGeforcenowWarningDisplayNoneQuirk,
         NeedsExpediaGroupAnimationQuirk,
         NeedsMediaRewriteRangeRequestQuirk,

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1029,6 +1029,16 @@ void Adjuster::adjustForSiteSpecificQuirks(Style::ComputedStyle& style) const
         if (is<HTMLBodyElement>(*m_element) && m_element->hasClassName(className))
             style.setUsedTouchAction(CSS::Keyword::Auto { });
     }
+    // netflix.com rdar://178545839
+    if (documentQuirks.needsNetflixVolumeSliderQuirk()) {
+        static MainThreadNeverDestroyed<const QualifiedName> dataUiaAttr(nullAtom(), "data-uia"_s, nullAtom());
+        static MainThreadNeverDestroyed<const AtomString> scrubberValue("scrubber"_s);
+        static MainThreadNeverDestroyed<const AtomString> verticalValue("vertical"_s);
+        if (is<HTMLDivElement>(*m_element)
+            && m_element->attributeWithoutSynchronization(dataUiaAttr) == scrubberValue
+            && m_element->attributeWithoutSynchronization(HTMLNames::aria_orientationAttr) == verticalValue)
+            style.setUsedTouchAction(CSS::Keyword::None { });
+    }
     if (documentQuirks.needsFacebookStoriesCreationFormQuirk(*m_element, style))
         style.setDisplayMaintainingOriginalDisplay(DisplayType::BlockFlex);
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### af3beda8beed365c8f045920742d74f428fe1e79
<pre>
netflix.com: v2: Webpage scrolls when adjusting volume slider (VisionOS / iPad) -- narrower fix after revert of 314097@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=316263">https://bugs.webkit.org/show_bug.cgi?id=316263</a>
<a href="https://rdar.apple.com/178545839">rdar://178545839</a>

Reviewed by Abrar Rahman Protyasha and Lily Spiniolas.

The problem: on iPad and visionOS, dragging the volume slider on netflix.com
causes the page to scroll along with the gesture. Netflix&apos;s slider does not
declare touch-action: none on the element, so WebKit treats the vertical drag
as a page-scroll candidate while Netflix&apos;s react pointer handlers fire in parallel.
The original fix (310491@main, <a href="https://rdar.apple.com/173988278">rdar://173988278</a>) added preventDefault-on-pointerdown
plumbing to suppress this scroll, but that approach was reverted (314097@main, <a href="https://rdar.apple.com/177895899">rdar://177895899</a>)
because it broke synthetic-click delivery on cluesbysam.com. On iPad and
visionOS, this means the user can&apos;t drag the volume slider without scrolling
the page away from the playing video.

The fix: a quirk that adds touch-action: none on the volume slider, mirroring
the pre-existing quirk: needsGoogleMapsScrollingQuirk. the right long term fix is
for netflix to author touch-action: none themselves, since they have not,
the quirk applies the equivalent on their behalf. The quirk lives in
StyleAdjuster and matches an HTMLDivElement on netflix.com with data-uia=&quot;scrubber&quot;
and aria-orientation=&quot;vertical&quot;. The change takes the existing touch-action
path and suppresses all browser handled gestures. Other approaches were
ruled out: a WebKit wide change to preventDefault semantics is what the previous
revert reversed, and a UA stylesheet rule on input[type=range] would affect
every site with a vertical range input.

* LayoutTests/fast/events/touch/ios/netflix-volume-slider-touch-action-quirk-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/netflix-volume-slider-touch-action-quirk.html: Added.
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):

Canonical link: <a href="https://commits.webkit.org/314617@main">https://commits.webkit.org/314617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/852f5ce8ecb69d84f025d1372f7f4484c1ff6a9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123810 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129495 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110020 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30856 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29557 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23743 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140827 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178136 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31036 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137846 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137764 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37134 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149151 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103527 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33060 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26016 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39312 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112387 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38709 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4106 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38954 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38852 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->