### PR TITLE
media/modern-media-controls/icon-service/icon-service-bundle-load.html is a flaky text failure

### DIFF
--- a/LayoutTests/media/modern-media-controls/icon-service/icon-service-bundle-load.html
+++ b/LayoutTests/media/modern-media-controls/icon-service/icon-service-bundle-load.html
@@ -13,24 +13,29 @@ description("Verifies that media-control button icons load from the WebCore fram
 
 const video = document.querySelector("video");
 
-video.addEventListener("canplaythrough", async () => {
-    await UIHelper.animationFrame();
+function buttonsWithCommittedIcon(mediaControls)
+{
+    return Array.from(mediaControls.querySelectorAll("button")).filter((button) => {
+        const picture = button.querySelector("picture");
+        if (!picture)
+            return false;
+        const match = window.getComputedStyle(picture).maskImage.match(/url\("?([^"\s)]+)"?\)/);
+        return match && match[1].startsWith("blob:");
+    });
+}
 
+video.addEventListener("canplaythrough", async () => {
     const shadowRoot = internals.shadowRoot(video);
     const mediaControls = shadowRoot.lastChild;
-    const buttons = Array.from(mediaControls.querySelectorAll("button"));
+
+    const maximumFrames = 120;
+    await UIHelper.waitForCondition(() => buttonsWithCommittedIcon(mediaControls).length > 0, maximumFrames);
 
     window.buttonsChecked = 0;
     window.buttonsWithEmptyIcon = 0;
-    for (const button of buttons) {
+    for (const button of buttonsWithCommittedIcon(mediaControls)) {
         const picture = button.querySelector("picture");
-        if (!picture)
-            continue;
-
-        const maskImage = window.getComputedStyle(picture).maskImage;
-        const match = maskImage.match(/url\("?([^"\s)]+)"?\)/);
-        if (!match || !match[1].startsWith("blob:"))
-            continue;
+        const match = window.getComputedStyle(picture).maskImage.match(/url\("?([^"\s)]+)"?\)/);
 
         const response = await fetch(match[1]);
         const blob = await response.blob();

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2431,8 +2431,6 @@ webkit.org/b/316016 [ Debug ] fast/mediastream/image-capture-take-photo.html [ S
 
 webkit.org/b/316014 fast/dom/move-embedded-during-update.html [ Pass Failure ]
 
-webkit.org/b/316020 [ Tahoe+ ] media/modern-media-controls/icon-service/icon-service-bundle-load.html [ Pass Failure ]
-
 webkit.org/b/316012 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-resize-observer-removes-auto.html [ Pass Failure ]
 
 webkit.org/b/316006 [ Tahoe+ Release arm64 ] imported/w3c/web-platform-tests/svg/animations/svgpointlist-animation-invalid-value-1.html [ Pass Failure ]

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -190,20 +190,24 @@ window.UIHelper = class UIHelper {
         await UIHelper.delayFor(0);
     }
 
-    static async waitForCondition(conditionFunc)
+    static async waitForCondition(conditionFunc, maximumFrames = Infinity)
     {
-        while (!conditionFunc()) {
+        for (let frames = 0; !conditionFunc(); ++frames) {
+            if (frames >= maximumFrames)
+                return false;
             await UIHelper.animationFrame();
         }
+        return true;
     }
 
-    static async waitForConditionAsync(conditionFunc)
+    static async waitForConditionAsync(conditionFunc, maximumFrames = Infinity)
     {
-        var condition = await conditionFunc();
-        while (!condition) {
+        for (let frames = 0; !(await conditionFunc()); ++frames) {
+            if (frames >= maximumFrames)
+                return false;
             await UIHelper.animationFrame();
-            condition = await conditionFunc();
         }
+        return true;
     }
 
     static sendEventStream(eventStream)


### PR DESCRIPTION
#### 5f563512b5c64f92104fedc8ecf373518c2a14ee
<pre>
media/modern-media-controls/icon-service/icon-service-bundle-load.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=316020">https://bugs.webkit.org/show_bug.cgi?id=316020</a>
<a href="https://rdar.apple.com/178452109">rdar://178452109</a>

Reviewed by Tim Horton and Megan Gardner.

This test checked the media control icons after a single rAF, but since
the icons were loaded into `blob: URL` &lt;img&gt;s, they were only committed in
some future rendering update.

To address the flakiness, we wait until at least one icon has committed
a `blob:` mask-image. We bound the wait till 120 frames so as to not
time out in the failing case. To support this test change, we add an
optional maximumFrames argument to the waitForCondition methods in
UIHelper.

* LayoutTests/media/modern-media-controls/icon-service/icon-service-bundle-load.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async waitForCondition):
(window.UIHelper.async waitForConditionAsync):

Canonical link: <a href="https://commits.webkit.org/314519@main">https://commits.webkit.org/314519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a51772d6cbefa172db7fd85d2666788f253e60f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175396 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129307 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31688 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109832 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23536 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177928 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137660 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39908 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137581 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40596 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148956 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103242 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25324 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32871 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39106 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38503 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3908 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38646 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->