### PR TITLE
[curl] REGRESSION(276696@main): Web Inspector: WebSocket response status text is one character short

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/inspector/before-load-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/inspector/before-load-expected.txt
@@ -6,6 +6,8 @@ Tests that WebSockets created before the inspector loads are also tracked.
 PASS: Should have 1 WebSocketResource
 PASS: Resource should be a WebSocket.
 PASS: Resource URL should be "ws://127.0.0.1:8880/websocket/tests/hybi/inspector/echo".
+PASS: Resource status code should be 101.
+PASS: Resource status text should be "Switching Protocols".
 PASS: Resource should have request headers.
 PASS: Resource should have response headers.
 Resource readyState should be Symbol(open).

--- a/LayoutTests/http/tests/websocket/tests/hybi/inspector/before-load.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/inspector/before-load.html
@@ -56,6 +56,8 @@ function test()
 
             InspectorTest.expectThat(webSocketResource instanceof WI.WebSocketResource, "Resource should be a WebSocket.");
             InspectorTest.expectEqual(webSocketResource.url, url, `Resource URL should be "${url}".`);
+            InspectorTest.expectEqual(webSocketResource.statusCode, 101, "Resource status code should be 101.");
+            InspectorTest.expectEqual(webSocketResource.statusText, "Switching Protocols", "Resource status text should be \"Switching Protocols\".");
             InspectorTest.expectThat(!isEmptyObject(webSocketResource.requestHeaders), "Resource should have request headers.");
             InspectorTest.expectThat(!isEmptyObject(webSocketResource.responseHeaders), "Resource should have response headers.");
             InspectorTest.log(`Resource readyState should be ${String(webSocketResource.readyState)}.`);

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -430,7 +430,7 @@ int WebSocketHandshake::readStatusLine(std::span<const uint8_t> header, int& sta
     }
 
     statusCode = parseInteger<int>(statusCodeString).value();
-    statusText = String(byteCast<Latin1Character>(header.subspan(*secondSpaceIndex + 1, index - *secondSpaceIndex - 3))); // Exclude "\r\n".
+    statusText = String(byteCast<Latin1Character>(header.subspan(*secondSpaceIndex + 1, lineLength - *secondSpaceIndex - 3))); // Exclude "\r\n".
     return lineLength;
 }
 


### PR DESCRIPTION
#### 64ba9cf9f8892b0964453a9fbe7e8272dc900714
<pre>
[curl] REGRESSION(276696@main): Web Inspector: WebSocket response status text is one character short
<a href="https://bugs.webkit.org/show_bug.cgi?id=316266">https://bugs.webkit.org/show_bug.cgi?id=316266</a>

Reviewed by Don Olmstead.

276696@main should&apos;ve used `lineLength` instead of `index` to match the same logic as before

`index` points to the `\n` so subtracting one from that will miss a character since `std::span::subspan` will not include the item at `offset + count`

* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::WebSocketHandshake::readStatusLine):

* LayoutTests/http/tests/websocket/tests/hybi/inspector/before-load.html:
* LayoutTests/http/tests/websocket/tests/hybi/inspector/before-load-expected.txt:

Canonical link: <a href="https://commits.webkit.org/314637@main">https://commits.webkit.org/314637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0023198a998e4615538f018967edb02124fcae1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123760 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129451 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91173 "3 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109976 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30825 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29515 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23693 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140796 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178087 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30987 "Found 1 new failure in wtf/StdLibExtras.h") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137811 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33662 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137728 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37149 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40753 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149108 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103471 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33021 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25973 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39263 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112338 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38660 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4062 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38905 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->