### PR TITLE
[CMake][Mac] Purge most @no-unify

### DIFF
--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -51,12 +51,12 @@ assembler/CPU.cpp
 assembler/JITOperationList.cpp
 assembler/LinkBuffer.cpp
 assembler/MacroAssembler.cpp
-assembler/MacroAssemblerARM64.cpp @no-unify
-assembler/MacroAssemblerARMv7.cpp @no-unify
+assembler/MacroAssemblerARM64.cpp @no-unify-when(bundle<=8)
+assembler/MacroAssemblerARMv7.cpp @no-unify-when(bundle<=8)
 assembler/MacroAssemblerCodeRef.cpp
 assembler/MacroAssemblerPrinter.cpp
-assembler/MacroAssemblerRISCV64.cpp @no-unify
-assembler/MacroAssemblerX86_64.cpp @no-unify
+assembler/MacroAssemblerRISCV64.cpp @no-unify-when(bundle<=8)
+assembler/MacroAssemblerX86_64.cpp @no-unify-when(bundle<=8)
 assembler/PerfLog.cpp
 assembler/Printer.cpp
 assembler/ProbeContext.cpp
@@ -438,10 +438,9 @@ dfg/DFGSSACalculator.cpp
 dfg/DFGSSAConversionPhase.cpp
 dfg/DFGSSALoweringPhase.cpp
 dfg/DFGSnippetParams.cpp
-// These files take a long time to compile so we do them individually.
-dfg/DFGSpeculativeJIT.cpp @no-unify
-dfg/DFGSpeculativeJIT32_64.cpp @no-unify
-dfg/DFGSpeculativeJIT64.cpp @no-unify
+dfg/DFGSpeculativeJIT.cpp @no-unify-when(bundle<=8) @cost:9
+dfg/DFGSpeculativeJIT32_64.cpp @no-unify-when(bundle<=8)
+dfg/DFGSpeculativeJIT64.cpp @no-unify-when(bundle<=8) @cost:4
 dfg/DFGStackLayoutPhase.cpp
 dfg/DFGStaticExecutionCountEstimationPhase.cpp
 dfg/DFGStoreBarrierClusteringPhase.cpp
@@ -476,7 +475,7 @@ disassembler/RISCV64Disassembler.cpp
 disassembler/X86Disassembler.cpp
 
 disassembler/ARM64/A64DOpcode.cpp
-disassembler/ARM64/Binja.c @no-unify
+disassembler/ARM64/Binja.c @no-unify // C source; cannot bundle with C++.
 
 disassembler/zydis/Zydis.c
 
@@ -500,8 +499,7 @@ ftl/FTLJITFinalizer.cpp
 ftl/FTLLazySlowPath.cpp
 ftl/FTLLink.cpp
 ftl/FTLLocation.cpp
-// This file takes a long time to compile so we do it individually.
-ftl/FTLLowerDFGToB3.cpp @no-unify
+ftl/FTLLowerDFGToB3.cpp @no-unify-when(bundle<=8) @cost:10
 ftl/FTLOSREntry.cpp
 ftl/FTLOSRExit.cpp
 ftl/FTLOSRExitCompiler.cpp
@@ -719,7 +717,7 @@ parser/LexerUnicodeProperties.cpp
 parser/ModuleAnalyzer.cpp
 parser/Nodes.cpp
 parser/NodesAnalyzeModule.cpp
-parser/Parser.cpp @no-unify
+parser/Parser.cpp @no-unify-when(bundle<=8) @cost:4
 parser/ParserArena.cpp
 parser/SourceProvider.cpp
 parser/SourceProviderCache.cpp
@@ -985,10 +983,10 @@ runtime/JSTypedArrayConstructors.cpp
 runtime/JSTypedArrayPrototypes.cpp
 runtime/JSTypedArrayViewConstructor.cpp
 runtime/JSTypedArrayViewPrototype.cpp
-runtime/JSTypedArrayViewPrototypeFunctions1.cpp @no-unify
-runtime/JSTypedArrayViewPrototypeFunctions2.cpp @no-unify
-runtime/JSTypedArrayViewPrototypeFunctions3.cpp @no-unify
-runtime/JSTypedArrayViewPrototypeFunctions4.cpp @no-unify
+runtime/JSTypedArrayViewPrototypeFunctions1.cpp @no-unify-when(bundle<=8) @cost:4
+runtime/JSTypedArrayViewPrototypeFunctions2.cpp @no-unify-when(bundle<=8) @cost:4
+runtime/JSTypedArrayViewPrototypeFunctions3.cpp @no-unify-when(bundle<=8) @cost:3
+runtime/JSTypedArrayViewPrototypeFunctions4.cpp @no-unify-when(bundle<=8) @cost:3
 runtime/JSTypedArrays.cpp
 runtime/JSWeakMap.cpp
 runtime/JSWeakObjectRef.cpp
@@ -1182,8 +1180,8 @@ tools/VMInspector.cpp
 wasm/WasmAddressType.cpp
 wasm/WasmOMGIRGenerator.cpp
 wasm/WasmBBQDisassembler.cpp
-wasm/WasmBBQJIT.cpp @no-unify
-wasm/WasmBBQJIT64.cpp @no-unify
+wasm/WasmBBQJIT.cpp @no-unify-when(bundle<=8) @cost:5
+wasm/WasmBBQJIT64.cpp @no-unify-when(bundle<=8) @cost:3
 wasm/WasmBBQPlan.cpp
 wasm/WasmBinding.cpp
 wasm/WasmBranchHintsSectionParser.cpp
@@ -1205,7 +1203,7 @@ wasm/WasmInliningDecision.cpp
 wasm/WasmInstanceAnchor.cpp
 wasm/WasmIPIntGenerator.cpp
 wasm/WasmIPIntPlan.cpp
-wasm/WasmIPIntSlowPaths.cpp @no-unify
+wasm/WasmIPIntSlowPaths.cpp @no-unify-when(bundle<=8)
 wasm/WasmMachineThreads.cpp
 wasm/WasmMemory.cpp
 wasm/WasmMemoryInformation.cpp
@@ -1237,8 +1235,7 @@ wasm/WasmWorklist.cpp
 wasm/js/JSToWasm.cpp
 wasm/js/JSToWasm.h
 wasm/js/JSWebAssembly.cpp
-// FIXME: Remove this @no-unify when clang-AS-debug builds stops crashing in register allocation.
-wasm/js/JSWebAssemblyArray.cpp @no-unify
+wasm/js/JSWebAssemblyArray.cpp @no-unify-when(bundle<=8)
 wasm/js/JSWebAssemblyCompileError.cpp
 wasm/js/JSWebAssemblyException.cpp
 wasm/js/JSWebAssemblyGlobal.cpp

--- a/Source/WTF/Scripts/generate-unified-source-bundles.py
+++ b/Source/WTF/Scripts/generate-unified-source-bundles.py
@@ -78,6 +78,12 @@ class SourceFile:
                 attribute = attribute.strip()
                 if attribute == 'no-unify':
                     self.unifiable = False
+                elif attribute.startswith('no-unify-when('):
+                    m = re.fullmatch(r'no-unify-when\(bundle<=(\d+)\)', attribute)
+                    if not m:
+                        raise RuntimeError("malformed attribute: @" + attribute)
+                    if args.max_bundle_size <= int(m.group(1)):
+                        self.unifiable = False
                 elif attribute == 'nonARC':
                     self._non_arc = True
                 elif attribute.startswith('header:'):

--- a/Source/WTF/wtf/ObjCRuntimeExtras.h
+++ b/Source/WTF/wtf/ObjCRuntimeExtras.h
@@ -49,14 +49,14 @@ ReturnType wtfCallIMP(IMP implementation, id target, SEL selector, ArgumentTypes
 
 namespace WTF {
 
-WTF_EXPORT_PRIVATE MallocSpan<Method, SystemMalloc> class_copyMethodListSpan(Class);
-WTF_EXPORT_PRIVATE MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> class_copyProtocolListSpan(Class);
-WTF_EXPORT_PRIVATE MallocSpan<objc_property_t, SystemMalloc> class_copyPropertyListSpan(Class);
-WTF_EXPORT_PRIVATE MallocSpan<Ivar, SystemMalloc> class_copyIvarListSpan(Class);
+WTF_EXPORT_PRIVATE MallocSpan<::Method, SystemMalloc> class_copyMethodListSpan(::Class);
+WTF_EXPORT_PRIVATE MallocSpan<__unsafe_unretained ::Protocol *, SystemMalloc> class_copyProtocolListSpan(::Class);
+WTF_EXPORT_PRIVATE MallocSpan<objc_property_t, SystemMalloc> class_copyPropertyListSpan(::Class);
+WTF_EXPORT_PRIVATE MallocSpan<Ivar, SystemMalloc> class_copyIvarListSpan(::Class);
 WTF_EXPORT_PRIVATE MallocSpan<objc_property_attribute_t, SystemMalloc> property_copyAttributeListSpan(objc_property_t);
-WTF_EXPORT_PRIVATE MallocSpan<objc_method_description, SystemMalloc> protocol_copyMethodDescriptionListSpan(Protocol *, BOOL isRequiredMethod, BOOL isInstanceMethod);
-WTF_EXPORT_PRIVATE MallocSpan<objc_property_t, SystemMalloc> protocol_copyPropertyListSpan(Protocol *);
-WTF_EXPORT_PRIVATE MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> protocol_copyProtocolListSpan(Protocol *);
+WTF_EXPORT_PRIVATE MallocSpan<objc_method_description, SystemMalloc> protocol_copyMethodDescriptionListSpan(::Protocol *, BOOL isRequiredMethod, BOOL isInstanceMethod);
+WTF_EXPORT_PRIVATE MallocSpan<objc_property_t, SystemMalloc> protocol_copyPropertyListSpan(::Protocol *);
+WTF_EXPORT_PRIVATE MallocSpan<__unsafe_unretained ::Protocol *, SystemMalloc> protocol_copyProtocolListSpan(::Protocol *);
 
 template<typename Type>
 std::span<const char> objcEncode()

--- a/Source/WTF/wtf/spi/cocoa/objcSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/objcSPI.h
@@ -49,7 +49,11 @@ void objc_destroyWeak(id*);
 void objc_copyWeak(id*, id*);
 void objc_moveWeak(id*, id*);
 
+#ifdef __cplusplus
+void _class_setCustomDeallocInitiation(::Class);
+#else
 void _class_setCustomDeallocInitiation(Class);
+#endif
 void _objc_deallocOnMainThreadHelper(void* object);
 
 WTF_EXTERN_C_END

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -388,7 +388,7 @@ Modules/streams/ReadableStreamDefaultReader.cpp
 Modules/streams/ReadableStreamReadRequest.cpp
 Modules/streams/ReadableStreamToSharedBufferSink.cpp
 Modules/streams/ReadableStreamSource.cpp
-Modules/streams/StreamPipeToUtilities.cpp @no-unify
+Modules/streams/StreamPipeToUtilities.cpp @no-unify-when(bundle<=8) @cost:3
 Modules/streams/StreamTeeUtilities.cpp
 Modules/streams/StreamTransferUtilities.cpp
 Modules/streams/TransformStream.cpp
@@ -695,7 +695,7 @@ bindings/js/JSCanvasRenderingContext2DCustom.cpp
 bindings/js/JSCustomElementInterface.cpp
 bindings/js/JSCustomElementRegistryCustom.cpp
 bindings/js/JSCustomEventCustom.cpp
-bindings/js/JSDOMBindingFacade.cpp @no-unify
+bindings/js/JSDOMBindingFacade.cpp @no-unify-when(bundle<=8) @cost:4
 bindings/js/JSDOMBindingSecurity.cpp
 bindings/js/JSDOMBuiltinConstructorBase.cpp
 bindings/js/JSDOMConstructorBase.cpp
@@ -1310,7 +1310,7 @@ dom/DocumentOrShadowRootFullscreen.cpp
 dom/DocumentParser.cpp
 dom/DocumentSharedObjectPool.cpp
 dom/DocumentStorageAccess.cpp
-dom/DocumentTouch.cpp @no-unify
+dom/DocumentTouch.cpp @no-unify-when(bundle<=8)
 dom/DocumentType.cpp
 dom/DragEvent.cpp
 dom/Element.cpp @header:RenderStyleGetters
@@ -1442,9 +1442,9 @@ dom/TextEvent.cpp
 dom/TextNodeTraversal.cpp
 dom/ToggleEvent.cpp
 dom/ToggleEventTask.cpp
-dom/Touch.cpp @no-unify
-dom/TouchEvent.cpp @no-unify
-dom/TouchList.cpp @no-unify
+dom/Touch.cpp @no-unify-when(bundle<=8)
+dom/TouchEvent.cpp @no-unify-when(bundle<=8)
+dom/TouchList.cpp @no-unify-when(bundle<=8)
 dom/TransformSourceLibxslt.cpp
 dom/Traversal.cpp
 dom/TreeScope.cpp
@@ -2080,7 +2080,7 @@ loader/CrossOriginEmbedderPolicy.cpp
 loader/CrossOriginOpenerPolicy.cpp
 loader/CrossOriginPreflightChecker.cpp
 loader/CrossOriginPreflightResultCache.cpp
-loader/CustomHeaderFields.cpp @no-unify
+loader/CustomHeaderFields.cpp @no-unify-when(bundle<=8)
 loader/DefaultResourceLoadPriority.cpp
 loader/DocumentLoader.cpp
 loader/DocumentThreadableLoader.cpp
@@ -2481,7 +2481,7 @@ platform/WebCoreMainThread.cpp
 platform/WebCorePersistentCoders.cpp
 platform/Widget.cpp
 platform/animation/AcceleratedEffect.cpp @cost:3
-platform/animation/AcceleratedEffectStack.cpp @no-unify
+platform/animation/AcceleratedEffectStack.cpp @no-unify-when(bundle<=8)
 platform/animation/AcceleratedEffectValues.cpp @header:RenderStyleGetters
 platform/animation/AcceleratedTimeline.cpp
 platform/animation/TimingFunction.cpp
@@ -4121,7 +4121,7 @@ JSDOMStringList.cpp
 JSDOMStringMap.cpp
 JSDOMTokenList.cpp
 JSDOMURL.cpp
-JSDOMWindow.cpp @no-unify
+JSDOMWindow.cpp @no-unify-when(bundle<=8) @cost:44
 JSDataCue.cpp
 JSDataTransfer.cpp
 JSDataTransferItem.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -136,7 +136,7 @@ accessibility/cocoa/AXCoreObjectCocoa.mm @nonARC
 accessibility/cocoa/AXObjectCacheCocoa.mm @nonARC
 accessibility/cocoa/AXTextMarkerCocoa.mm @nonARC
 accessibility/cocoa/AccessibilityObjectCocoa.mm @nonARC
-accessibility/cocoa/WebAccessibilityObjectWrapperBase.mm @nonARC @no-unify
+accessibility/cocoa/WebAccessibilityObjectWrapperBase.mm @nonARC @no-unify-when(bundle<=8) @cost:4
 accessibility/ios/AXObjectCacheIOS.mm @nonARC
 accessibility/ios/AXRemoteTokenIOS.mm @nonARC
 accessibility/ios/AccessibilityObjectIOS.mm @nonARC
@@ -145,14 +145,14 @@ accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm @nonARC
 accessibility/isolatedtree/mac/AXIsolatedTreeMac.mm @nonARC
 accessibility/mac/AXObjectCacheMac.mm @nonARC
 accessibility/mac/AccessibilityObjectMac.mm @nonARC
-accessibility/mac/WebAccessibilityObjectWrapperMac.mm @nonARC @no-unify
+accessibility/mac/WebAccessibilityObjectWrapperMac.mm @nonARC @no-unify-when(bundle<=8) @cost:10
 bindings/js/ScriptControllerMac.mm @nonARC
-bridge/objc/ObjCRuntimeObject.mm @nonARC @no-unify
-bridge/objc/WebScriptObject.mm @nonARC @no-unify
-bridge/objc/objc_class.mm @nonARC @no-unify
-bridge/objc/objc_instance.mm @nonARC @no-unify
-bridge/objc/objc_runtime.mm @nonARC @no-unify
-bridge/objc/objc_utility.mm @nonARC @no-unify
+bridge/objc/ObjCRuntimeObject.mm @nonARC @no-unify-when(bundle<=8) @cost:4
+bridge/objc/WebScriptObject.mm @nonARC @no-unify-when(bundle<=8) @cost:6
+bridge/objc/objc_class.mm @nonARC @no-unify-when(bundle<=8) @cost:5
+bridge/objc/objc_instance.mm @nonARC @no-unify-when(bundle<=8) @cost:4
+bridge/objc/objc_runtime.mm @nonARC @no-unify-when(bundle<=8) @cost:5
+bridge/objc/objc_utility.mm @nonARC @no-unify-when(bundle<=8) @cost:5
 crypto/cocoa/CommonCryptoDERUtilities.cpp
 crypto/cocoa/CryptoAlgorithmAESCBCCocoa.cpp
 crypto/cocoa/CryptoAlgorithmAESCFBCocoa.cpp
@@ -194,9 +194,9 @@ editing/cocoa/EditorCocoa.mm @nonARC
 editing/cocoa/FontAttributeChangesCocoa.mm @nonARC
 editing/cocoa/FontAttributesCocoa.mm @nonARC
 editing/cocoa/FontShadowCocoa.mm @nonARC
-editing/cocoa/HTMLConverter.mm @nonARC @no-unify
-editing/cocoa/NodeHTMLConverter.mm @nonARC @no-unify
-editing/cocoa/EditingHTMLConverter.mm @nonARC @no-unify
+editing/cocoa/HTMLConverter.mm @nonARC @no-unify-when(bundle<=8) @cost:4
+editing/cocoa/NodeHTMLConverter.mm @nonARC @no-unify-when(bundle<=8) @cost:10
+editing/cocoa/EditingHTMLConverter.mm @nonARC @no-unify-when(bundle<=8) @cost:9
 editing/cocoa/WebArchiveResourceFromNSAttributedString.mm @nonARC
 editing/cocoa/WebArchiveResourceWebResourceHandler.mm @nonARC
 editing/cocoa/WebContentReaderCocoa.mm @nonARC
@@ -205,7 +205,7 @@ editing/ios/DictationCommandIOS.cpp
 editing/ios/EditorIOS.mm @nonARC
 editing/mac/EditorMac.mm @nonARC
 editing/mac/FrameSelectionMac.mm @nonARC
-editing/mac/TextAlternativeWithRange.mm @nonARC @no-unify
+editing/mac/TextAlternativeWithRange.mm @nonARC @no-unify-when(bundle<=8)
 editing/mac/TextUndoInsertionMarkupMac.mm @nonARC
 fileapi/FileCocoa.mm @nonARC
 history/mac/HistoryItemMac.mm @nonARC
@@ -301,7 +301,7 @@ platform/cf/MediaAccessibilitySoftLink.cpp
 platform/cf/RunLoopObserverCF.cpp
 platform/cf/SharedBufferCF.cpp
 platform/cocoa/AppleVisualEffect.cpp
-platform/cocoa/ContentFilterUnblockHandlerCocoa.mm @nonARC @no-unify
+platform/cocoa/ContentFilterUnblockHandlerCocoa.mm @nonARC @no-unify-when(bundle<=8)
 platform/cocoa/CoreLocationGeolocationProvider.mm @nonARC
 platform/cocoa/CoreVideoSoftLink.cpp
 platform/cocoa/DragDataCocoa.mm @nonARC
@@ -323,13 +323,13 @@ platform/cocoa/PasteboardCocoa.mm @nonARC
 platform/cocoa/PasteboardCustomDataCocoa.mm @nonARC
 platform/cocoa/PhotosFormatSoftLink.mm @nonARC
 platform/cocoa/PlatformPasteboardCocoa.mm @nonARC
-platform/cocoa/PlatformSpeechSynthesizerCocoa.mm @nonARC @no-unify
+platform/cocoa/PlatformSpeechSynthesizerCocoa.mm @nonARC @no-unify-when(bundle<=8)
 platform/cocoa/PlaybackSessionModelMediaElement.mm @nonARC
 platform/cocoa/PowerSourceNotifier.mm @nonARC
 platform/cocoa/PublicSuffixStoreCocoa.mm @nonARC
 platform/cocoa/RemoteCommandListenerCocoa.mm @nonARC
 platform/cocoa/SearchPopupMenuCocoa.mm @nonARC
-platform/cocoa/SerializedPlatformDataCueValue.mm @nonARC @no-unify
+platform/cocoa/SerializedPlatformDataCueValue.mm @nonARC @no-unify-when(bundle<=8)
 platform/cocoa/SharedBufferCocoa.mm @nonARC
 platform/cocoa/SharedMemoryCocoa.mm @nonARC
 platform/cocoa/StringUtilities.mm @nonARC
@@ -342,7 +342,7 @@ platform/cocoa/UserAgentCocoa.mm @nonARC
 platform/cocoa/VideoPresentationModelVideoElement.mm @nonARC
 platform/cocoa/VideoPresentationLayerProvider.mm @nonARC
 platform/cocoa/VideoToolboxSoftLink.cpp
-platform/cocoa/WebCoreAdditions.mm @nonARC @no-unify
+platform/cocoa/WebCoreAdditions.mm @nonARC @no-unify // #includes opaque WebKitAdditions sources.
 platform/cocoa/WebCoreNSErrorExtras.mm @nonARC
 platform/cocoa/WebCoreNSURLExtras.mm @nonARC
 platform/cocoa/WebCoreObjCExtras.mm @nonARC
@@ -358,8 +358,8 @@ platform/gamepad/mac/LogitechGamepad.cpp
 platform/gamepad/mac/MultiGamepadProvider.mm @nonARC
 platform/gamepad/mac/StadiaHIDGamepad.cpp
 platform/graphics/MediaPlaybackTargetPicker.cpp
-platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm @nonARC @no-unify
-platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm @nonARC @no-unify
+platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm @nonARC @no-unify-when(bundle<=8)
+platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm @nonARC @no-unify-when(bundle<=8)
 platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm @nonARC
 platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
 platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.cpp
@@ -370,11 +370,11 @@ platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm @nonARC
 platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
 platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm @nonARC
 platform/graphics/avfoundation/SampleBufferDisplayLayer.cpp
-platform/graphics/avfoundation/WebAVSampleBufferListener.mm @nonARC @no-unify
+platform/graphics/avfoundation/WebAVSampleBufferListener.mm @nonARC @no-unify-when(bundle<=8)
 platform/graphics/avfoundation/WebMediaSessionManagerMac.cpp
 platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm @nonARC
-platform/graphics/avfoundation/objc/AVAssetTrackUtilities.mm @nonARC @no-unify
-platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm @nonARC @no-unify
+platform/graphics/avfoundation/objc/AVAssetTrackUtilities.mm @nonARC @no-unify-when(bundle<=8)
+platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm @nonARC @no-unify-when(bundle<=8)
 platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm @nonARC
 platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm @nonARC
 platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm @nonARC
@@ -384,22 +384,22 @@ platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm @nonARC
 platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm @nonARC
 platform/graphics/avfoundation/objc/ContentKeyGroupFactoryAVFObjC.mm @nonARC
 platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm @nonARC
-platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm @nonARC @no-unify
-platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm @nonARC @no-unify
-platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm @nonARC @no-unify
-platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.mm @nonARC @no-unify
-platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm @nonARC @no-unify
-platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm @nonARC @no-unify
-platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm @nonARC @no-unify
+platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm @nonARC @no-unify-when(bundle<=8)
+platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm @nonARC @no-unify-when(bundle<=8)
+platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm @nonARC @no-unify-when(bundle<=8)
+platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.mm @nonARC @no-unify-when(bundle<=8)
+platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm @nonARC @no-unify-when(bundle<=8) @cost:9
+platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm @nonARC @no-unify-when(bundle<=8) @cost:8
+platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm @nonARC @no-unify-when(bundle<=8) @cost:6
 platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm @nonARC
 platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm @nonARC
-platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm @nonARC @no-unify
-platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm @nonARC @no-unify
+platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm @nonARC @no-unify-when(bundle<=8) @cost:7
+platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm @nonARC @no-unify-when(bundle<=8) @cost:5
 platform/graphics/avfoundation/objc/TextTrackPrivateMediaSourceAVFObjC.cpp
-platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm @nonARC @no-unify
+platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm @nonARC @no-unify-when(bundle<=8)
 platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
 platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm @nonARC
-platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm @nonARC @no-unify
+platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm @nonARC @no-unify-when(bundle<=8)
 platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm @nonARC
 platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/LayerPool.cpp
@@ -444,13 +444,13 @@ platform/graphics/cg/NativeImageCG.cpp
 platform/graphics/cg/PDFDocumentImage.cpp
 platform/graphics/cg/PathCG.cpp
 platform/graphics/cg/PatternCG.cpp
-platform/graphics/cg/ShareableBitmapCG.mm @nonARC @no-unify
-platform/graphics/cg/ShareableSpatialImage.cpp @no-unify
+platform/graphics/cg/ShareableBitmapCG.mm @nonARC @no-unify-when(bundle<=8)
+platform/graphics/cg/ShareableSpatialImage.cpp @no-unify-when(bundle<=8)
 platform/graphics/cg/TransformationMatrixCG.cpp
 platform/graphics/cg/UTIRegistry.mm @nonARC
-platform/graphics/cocoa/AV1UtilitiesCocoa.mm @nonARC @no-unify
+platform/graphics/cocoa/AV1UtilitiesCocoa.mm @nonARC @no-unify-when(bundle<=8)
 platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
-platform/graphics/cocoa/CMUtilities.mm @nonARC @no-unify
+platform/graphics/cocoa/CMUtilities.mm @nonARC @no-unify-when(bundle<=8)
 platform/graphics/cocoa/ColorCocoa.mm @nonARC
 platform/graphics/cocoa/CVPixelBufferUtilities.cpp
 platform/graphics/cocoa/FloatRectCocoa.mm @nonARC
@@ -473,9 +473,9 @@ platform/graphics/cocoa/IconCocoa.mm @nonARC
 platform/graphics/cocoa/IntRectCocoa.mm @nonARC
 platform/graphics/cocoa/ImageAdapterCocoa.mm @nonARC
 platform/graphics/cocoa/MediaPlayerCocoa.mm @nonARC
-platform/graphics/cocoa/MediaPlayerPrivateWebM.mm @nonARC @no-unify
+platform/graphics/cocoa/MediaPlayerPrivateWebM.mm @nonARC @no-unify-when(bundle<=8) @cost:7
 platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp
-platform/graphics/cocoa/PlatformTimeRangesCocoa.mm @nonARC @no-unify
+platform/graphics/cocoa/PlatformTimeRangesCocoa.mm @nonARC @no-unify-when(bundle<=8)
 platform/graphics/cocoa/ShareableCVPixelBuffer.cpp
 platform/graphics/cocoa/ShareableCVPixelFormat.cpp
 platform/graphics/cocoa/ShareableGainMap.cpp
@@ -486,8 +486,8 @@ platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
 platform/graphics/cocoa/TextTrackRepresentationCocoa.mm @nonARC
 platform/graphics/cocoa/TransformationMatrixCocoa.cpp
 platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
-platform/graphics/cocoa/VP9UtilitiesCocoa.mm @nonARC @no-unify
-platform/graphics/cocoa/VideoTargetFactory.mm @nonARC @no-unify
+platform/graphics/cocoa/VP9UtilitiesCocoa.mm @nonARC @no-unify // Includes libwebrtc headers with macro pollution.
+platform/graphics/cocoa/VideoTargetFactory.mm @nonARC @no-unify-when(bundle<=8)
 platform/graphics/cocoa/WebActionDisablingCALayerDelegate.mm @nonARC
 platform/graphics/cocoa/WebCoreCALayerExtras.mm @nonARC
 platform/graphics/cocoa/WebCoreDecompressionSession.mm @nonARC
@@ -621,11 +621,11 @@ platform/ios/wak/WKView.mm @nonARC
 platform/ios/wak/WebCoreThread.mm @nonARC
 platform/ios/wak/WebCoreThreadRun.cpp
 platform/ios/wak/WebCoreThreadSystemInterface.cpp
-platform/mac/CursorMac.mm @nonARC @no-unify
+platform/mac/CursorMac.mm @nonARC @no-unify-when(bundle<=8)
 platform/mac/DataDetectorHighlight.mm @nonARC
 platform/mac/HIDDevice.cpp
 platform/mac/HIDElement.cpp
-platform/mac/KeyEventMac.mm @nonARC @no-unify
+platform/mac/KeyEventMac.mm @nonARC @no-unify-when(bundle<=8)
 platform/mac/LocalCurrentGraphicsContextMac.mm @nonARC
 platform/mac/LocalDefaultSystemAppearance.mm @nonARC
 platform/mac/NSScrollerImpDetails.mm @nonARC
@@ -634,21 +634,21 @@ platform/mac/PasteboardWriter.mm @nonARC
 platform/mac/PlatformEventFactoryMac.mm @nonARC
 platform/mac/PlatformPasteboardMac.mm @nonARC
 platform/mac/PlatformScreenMac.mm @nonARC
-platform/mac/PlaybackSessionInterfaceMac.mm @nonARC @no-unify
+platform/mac/PlaybackSessionInterfaceMac.mm @nonARC @no-unify-when(bundle<=8)
 platform/mac/PowerObserverMac.cpp
 platform/mac/RevealUtilities.mm @nonARC
-platform/mac/ScrollAnimatorMac.mm @nonARC @no-unify
+platform/mac/ScrollAnimatorMac.mm @nonARC @no-unify-when(bundle<=8) @cost:3
 platform/mac/ScrollAnimationRubberBand.mm @nonARC
 platform/mac/ScrollViewMac.mm @nonARC
-platform/mac/ScrollbarMac.mm @nonARC @no-unify
-platform/mac/ScrollbarsControllerMac.mm @nonARC @no-unify
-platform/mac/ScrollbarThemeMac.mm @nonARC @no-unify
+platform/mac/ScrollbarMac.mm @nonARC @no-unify-when(bundle<=8)
+platform/mac/ScrollbarsControllerMac.mm @nonARC @no-unify-when(bundle<=8) @cost:3
+platform/mac/ScrollbarThemeMac.mm @nonARC @no-unify-when(bundle<=8) @cost:3
 platform/mac/ScrollingEffectsController.mm @nonARC
 platform/mac/ScrollingMomentumCalculatorMac.mm @nonARC
 platform/mac/SerializedPlatformDataCueMac.mm @nonARC
 platform/mac/SuddenTermination.mm @nonARC
 platform/mac/ThemeMac.mm @nonARC
-platform/mac/ThreadCheck.mm @nonARC @no-unify
+platform/mac/ThreadCheck.mm @nonARC @no-unify-when(bundle<=8)
 platform/mac/UserActivityMac.mm @nonARC
 platform/mac/UserAgentMac.mm @nonARC
 platform/mac/ValidationBubbleMac.mm @nonARC
@@ -663,8 +663,8 @@ platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
 platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
 platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm @nonARC
 platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
-platform/mediastream/cocoa/AVCaptureDeviceManager.mm @nonARC @no-unify
-platform/mediastream/cocoa/AVVideoCaptureSource.mm @nonARC @no-unify
+platform/mediastream/cocoa/AVCaptureDeviceManager.mm @nonARC @no-unify-when(bundle<=8)
+platform/mediastream/cocoa/AVVideoCaptureSource.mm @nonARC @no-unify-when(bundle<=8) @cost:3
 platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp
 platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
 platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
@@ -719,7 +719,7 @@ platform/network/cocoa/ResourceHandleCocoa.mm @nonARC
 platform/network/cocoa/ResourceResponseCocoa.mm @nonARC
 platform/network/cocoa/SynchronousLoaderClient.mm @nonARC
 platform/network/cocoa/UTIUtilities.mm @nonARC
-platform/network/cocoa/WebCoreNSURLSession.mm @nonARC @no-unify
+platform/network/cocoa/WebCoreNSURLSession.mm @nonARC @no-unify-when(bundle<=8)
 platform/network/cocoa/WebCoreURLResponse.mm @nonARC
 platform/network/ios/NetworkStateNotifierIOS.mm @nonARC
 platform/network/ios/WebCoreURLResponseIOS.mm @nonARC
@@ -747,6 +747,6 @@ testing/cocoa/WebViewVisualIdentificationOverlay.mm @nonARC
 // The following files aren't unified with others to prevent them from being merged
 // with files that include system headers that include system OpenGL headers.
 
-platform/graphics/angle/GraphicsContextGLANGLE.cpp @no-unify
-platform/graphics/cocoa/GraphicsContextGLCocoa.mm @nonARC @no-unify
-platform/graphics/cv/GraphicsContextGLCVCocoa.mm @nonARC @no-unify
+platform/graphics/angle/GraphicsContextGLANGLE.cpp @no-unify // ANGLE headers redefine GL types/macros that collide with system OpenGL.
+platform/graphics/cocoa/GraphicsContextGLCocoa.mm @nonARC @no-unify // ANGLE headers redefine GL types/macros that collide with system OpenGL.
+platform/graphics/cv/GraphicsContextGLCVCocoa.mm @nonARC @no-unify // ANGLE headers redefine GL types/macros that collide with system OpenGL.

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -110,85 +110,85 @@ typedef CF_ENUM(UInt32, AXTextSelectionGranularity)
 
 #endif // AXTextStateChangeDefined
 
-static AXTextStateChangeType NODELETE platformChangeTypeForWebCoreChangeType(WebCore::AXTextStateChangeType changeType)
+static NSNumber *platformChangeTypeForWebCoreChangeType(WebCore::AXTextStateChangeType changeType)
 {
     switch (changeType) {
     case WebCore::AXTextStateChangeType::Unknown:
-        return kAXTextStateChangeTypeUnknown;
+        return @(kAXTextStateChangeTypeUnknown);
     case WebCore::AXTextStateChangeType::Edit:
-        return kAXTextStateChangeTypeEdit;
+        return @(kAXTextStateChangeTypeEdit);
     case WebCore::AXTextStateChangeType::SelectionMove:
-        return kAXTextStateChangeTypeSelectionMove;
+        return @(kAXTextStateChangeTypeSelectionMove);
     case WebCore::AXTextStateChangeType::SelectionExtend:
-        return kAXTextStateChangeTypeSelectionExtend;
+        return @(kAXTextStateChangeTypeSelectionExtend);
     case WebCore::AXTextStateChangeType::SelectionBoundary:
-        return kAXTextStateChangeTypeSelectionBoundary;
+        return @(kAXTextStateChangeTypeSelectionBoundary);
     }
 }
 
-static AXTextEditType NODELETE platformEditTypeForWebCoreEditType(WebCore::AXTextEditType changeType)
+static NSNumber *platformEditTypeForWebCoreEditType(WebCore::AXTextEditType changeType)
 {
     switch (changeType) {
     case WebCore::AXTextEditType::Unknown:
-        return kAXTextEditTypeUnknown;
+        return @(kAXTextEditTypeUnknown);
     case WebCore::AXTextEditType::Delete:
-        return kAXTextEditTypeDelete;
+        return @(kAXTextEditTypeDelete);
     case WebCore::AXTextEditType::Insert:
-        return kAXTextEditTypeInsert;
+        return @(kAXTextEditTypeInsert);
     case WebCore::AXTextEditType::Typing:
-        return kAXTextEditTypeTyping;
+        return @(kAXTextEditTypeTyping);
     case WebCore::AXTextEditType::Dictation:
-        return kAXTextEditTypeDictation;
+        return @(kAXTextEditTypeDictation);
     case WebCore::AXTextEditType::Cut:
-        return kAXTextEditTypeCut;
+        return @(kAXTextEditTypeCut);
     case WebCore::AXTextEditType::Paste:
-        return kAXTextEditTypePaste;
+        return @(kAXTextEditTypePaste);
     case WebCore::AXTextEditType::Replace:
-        return kAXTextEditTypeUnknown; // Does not exist in platform enum.
+        return @(kAXTextEditTypeUnknown); // Does not exist in platform enum.
     case WebCore::AXTextEditType::AttributesChange:
-        return kAXTextEditTypeAttributesChange;
+        return @(kAXTextEditTypeAttributesChange);
     }
 }
 
-static AXTextSelectionDirection NODELETE platformDirectionForWebCoreDirection(WebCore::AXTextSelectionDirection direction)
+static NSNumber *platformDirectionForWebCoreDirection(WebCore::AXTextSelectionDirection direction)
 {
     switch (direction) {
     case WebCore::AXTextSelectionDirection::Unknown:
-        return kAXTextSelectionDirectionUnknown;
+        return @(kAXTextSelectionDirectionUnknown);
     case WebCore::AXTextSelectionDirection::Beginning:
-        return kAXTextSelectionDirectionBeginning;
+        return @(kAXTextSelectionDirectionBeginning);
     case WebCore::AXTextSelectionDirection::End:
-        return kAXTextSelectionDirectionEnd;
+        return @(kAXTextSelectionDirectionEnd);
     case WebCore::AXTextSelectionDirection::Previous:
-        return kAXTextSelectionDirectionPrevious;
+        return @(kAXTextSelectionDirectionPrevious);
     case WebCore::AXTextSelectionDirection::Next:
-        return kAXTextSelectionDirectionNext;
+        return @(kAXTextSelectionDirectionNext);
     case WebCore::AXTextSelectionDirection::Discontiguous:
-        return kAXTextSelectionDirectionDiscontiguous;
+        return @(kAXTextSelectionDirectionDiscontiguous);
     }
 }
 
-static AXTextSelectionGranularity NODELETE platformGranularityForWebCoreGranularity(WebCore::AXTextSelectionGranularity granularity)
+static NSNumber *platformGranularityForWebCoreGranularity(WebCore::AXTextSelectionGranularity granularity)
 {
     switch (granularity) {
     case WebCore::AXTextSelectionGranularity::Unknown:
-        return kAXTextSelectionGranularityUnknown;
+        return @(kAXTextSelectionGranularityUnknown);
     case WebCore::AXTextSelectionGranularity::Character:
-        return kAXTextSelectionGranularityCharacter;
+        return @(kAXTextSelectionGranularityCharacter);
     case WebCore::AXTextSelectionGranularity::Word:
-        return kAXTextSelectionGranularityWord;
+        return @(kAXTextSelectionGranularityWord);
     case WebCore::AXTextSelectionGranularity::Line:
-        return kAXTextSelectionGranularityLine;
+        return @(kAXTextSelectionGranularityLine);
     case WebCore::AXTextSelectionGranularity::Sentence:
-        return kAXTextSelectionGranularitySentence;
+        return @(kAXTextSelectionGranularitySentence);
     case WebCore::AXTextSelectionGranularity::Paragraph:
-        return kAXTextSelectionGranularityParagraph;
+        return @(kAXTextSelectionGranularityParagraph);
     case WebCore::AXTextSelectionGranularity::Page:
-        return kAXTextSelectionGranularityPage;
+        return @(kAXTextSelectionGranularityPage);
     case WebCore::AXTextSelectionGranularity::Document:
-        return kAXTextSelectionGranularityDocument;
+        return @(kAXTextSelectionGranularityDocument);
     case WebCore::AXTextSelectionGranularity::All:
-        return kAXTextSelectionGranularityAll;
+        return @(kAXTextSelectionGranularityAll);
     }
 }
 
@@ -530,12 +530,12 @@ void AXObjectCache::postTextSelectionChangePlatformNotification(AccessibilityObj
     if (m_isSynchronizingSelection)
         [userInfo setObject:@YES forKey:NSAccessibilityTextStateSyncKey];
     if (intent.type != AXTextStateChangeType::Unknown) {
-        [userInfo setObject:@(platformChangeTypeForWebCoreChangeType(intent.type)) forKey:NSAccessibilityTextStateChangeTypeKey];
+        [userInfo setObject:platformChangeTypeForWebCoreChangeType(intent.type) forKey:NSAccessibilityTextStateChangeTypeKey];
         switch (intent.type) {
         case AXTextStateChangeType::SelectionMove:
         case AXTextStateChangeType::SelectionExtend:
         case AXTextStateChangeType::SelectionBoundary:
-            [userInfo setObject:@(platformDirectionForWebCoreDirection(intent.selection.direction)) forKey:NSAccessibilityTextSelectionDirection];
+            [userInfo setObject:platformDirectionForWebCoreDirection(intent.selection.direction) forKey:NSAccessibilityTextSelectionDirection];
             switch (intent.selection.direction) {
             case AXTextSelectionDirection::Unknown:
                 break;
@@ -543,7 +543,7 @@ void AXObjectCache::postTextSelectionChangePlatformNotification(AccessibilityObj
             case AXTextSelectionDirection::End:
             case AXTextSelectionDirection::Previous:
             case AXTextSelectionDirection::Next:
-                [userInfo setObject:@(platformGranularityForWebCoreGranularity(intent.selection.granularity)) forKey:NSAccessibilityTextSelectionGranularity];
+                [userInfo setObject:platformGranularityForWebCoreGranularity(intent.selection.granularity) forKey:NSAccessibilityTextSelectionGranularity];
                 break;
             case AXTextSelectionDirection::Discontiguous:
                 break;
@@ -596,7 +596,7 @@ static NSDictionary *textReplacementChangeDictionary(AXObjectCache& cache, Acces
         return nil;
 
     auto change = adoptNS([[NSMutableDictionary alloc] initWithCapacity:4]);
-    [change setObject:@(platformEditTypeForWebCoreEditType(type)) forKey:NSAccessibilityTextEditType];
+    [change setObject:platformEditTypeForWebCoreEditType(type) forKey:NSAccessibilityTextEditType];
     if (length > AXValueChangeTruncationLength) {
         [change setObject:@(length) forKey:NSAccessibilityTextChangeValueLength];
         text = [text substringToIndex:AXValueChangeTruncationLength];
@@ -621,7 +621,7 @@ void AXObjectCache::postTextStateChangePlatformNotification(AccessibilityObject*
 void AXObjectCache::postUserInfoForChanges(AccessibilityObject& rootWebArea, AccessibilityObject& object, RetainPtr<NSMutableArray> changes)
 {
     auto userInfo = adoptNS([[NSMutableDictionary alloc] initWithCapacity:4]);
-    [userInfo setObject:@(platformChangeTypeForWebCoreChangeType(AXTextStateChangeType::Edit)) forKey:NSAccessibilityTextStateChangeTypeKey];
+    [userInfo setObject:platformChangeTypeForWebCoreChangeType(AXTextStateChangeType::Edit) forKey:NSAccessibilityTextStateChangeTypeKey];
     auto changesArray = changes.autorelease();
     if (changesArray.count)
         [userInfo setObject:changesArray forKey:NSAccessibilityTextChangeValues];

--- a/Source/WebCore/bridge/objc/objc_runtime.mm
+++ b/Source/WebCore/bridge/objc/objc_runtime.mm
@@ -199,7 +199,7 @@ JSValue ObjcArray::valueAt(JSGlobalObject* lexicalGlobalObject, unsigned int ind
     if (index > [_array count])
         return throwException(lexicalGlobalObject, scope, createRangeError(lexicalGlobalObject, "Index exceeds array size."_s));
     @try {
-        id obj = [_array objectAtIndex:index];
+        id obj = [(NSArray *)_array objectAtIndex:index];
         if (obj)
             return convertObjcValueToValue (lexicalGlobalObject, &obj, ObjcObjectType, m_rootObject.get());
     } @catch(NSException* localException) {

--- a/Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.mm
@@ -45,7 +45,7 @@ static RetainPtr<NSMutableDictionary> readSearchFieldRecentSearchesPlist(NSStrin
     return adoptNS([[NSMutableDictionary alloc] initWithContentsOfFile:searchFieldRecentSearchesPlistPath(baseDirectory)]);
 }
 
-static WallTime toSystemClockTime(NSDate *date)
+static WallTime searchPopupWallTimeFromNSDate(NSDate *date)
 {
     ASSERT(date);
     return WallTime::fromRawSeconds(date.timeIntervalSince1970);
@@ -177,7 +177,7 @@ Vector<RecentSearch> loadRecentSearchesFromFile(const String& name, const String
         if (![searchString isKindOfClass:[NSString class]])
             continue;
 
-        searchItems.append({ String { searchString }, toSystemClockTime(date.get()) });
+        searchItems.append({ String { searchString }, searchPopupWallTimeFromNSDate(date.get()) });
     }
 
     return searchItems;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm
@@ -39,7 +39,10 @@
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
+#if !defined(WebCore_AVKitLibrary_SoftLinked)
+#define WebCore_AVKitLibrary_SoftLinked
 SOFTLINK_AVKIT_FRAMEWORK()
+#endif
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVOutputDeviceMenuController)
 
 using namespace WebCore;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
@@ -39,7 +39,10 @@
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
+#if !defined(WebCore_AVKitLibrary_SoftLinked)
+#define WebCore_AVKitLibrary_SoftLinked
 SOFTLINK_AVKIT_FRAMEWORK()
+#endif
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVRoutePickerView)
 
 using namespace WebCore;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.mm
@@ -45,9 +45,6 @@
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
-SOFTLINK_AVKIT_FRAMEWORK()
-SOFT_LINK_CLASS_OPTIONAL(AVKit, AVOutputDeviceMenuController)
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaPlaybackTargetPickerMac);

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -41,7 +41,10 @@
 
 #import <pal/cf/CoreMediaSoftLink.h>
 
+#if !defined(WebCore_AVKitLibrary_SoftLinked)
+#define WebCore_AVKitLibrary_SoftLinked
 SOFTLINK_AVKIT_FRAMEWORK()
+#endif
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVValueTiming)
 
 namespace WebCore {

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -1033,5 +1033,6 @@ bool WebSWServerConnection::checkTopOrigin(const WebCore::SecurityOriginData& or
 } // namespace WebKit
 
 #undef MESSAGE_CHECK
+#undef MESSAGE_CHECK_WITH_RETURN_VALUE
 #undef SWSERVERCONNECTION_RELEASE_LOG
 #undef SWSERVERCONNECTION_RELEASE_LOG_ERROR

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -161,10 +161,10 @@ NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp @cost:4
 NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp @cost:5
 NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp @cost:3
 NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp @cost:3
-NetworkProcess/ServiceWorker/WebSWOriginStore.cpp @no-unify
+NetworkProcess/ServiceWorker/WebSWOriginStore.cpp @no-unify-when(bundle<=8)
 NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
-NetworkProcess/ServiceWorker/WebSWServerConnection.cpp @no-unify
-NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp @no-unify
+NetworkProcess/ServiceWorker/WebSWServerConnection.cpp @no-unify-when(bundle<=8) @cost:11
+NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp @no-unify-when(bundle<=8) @cost:6
 
 NetworkProcess/SharedWorker/WebSharedWorker.cpp
 NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp @cost:3
@@ -588,18 +588,17 @@ UIProcess/Authentication/AuthenticationDecisionListener.cpp
 UIProcess/Authentication/WebCredential.cpp
 UIProcess/Authentication/WebProtectionSpace.cpp
 
-// FIXME(206266): AutomationProtocolObjects.h's "namespace Protocol" conflicts with objc/runtime.h's "typedef struct objc_object Protocol"
-UIProcess/Automation/BidiBrowserAgent.cpp @no-unify
-UIProcess/Automation/BidiBrowsingContextAgent.cpp @no-unify
-UIProcess/Automation/BidiPermissionsAgent.cpp @no-unify
-UIProcess/Automation/BidiScriptAgent.cpp @no-unify
-UIProcess/Automation/BidiSessionAgent.cpp @no-unify
-UIProcess/Automation/BidiStorageAgent.cpp @no-unify
-UIProcess/Automation/BidiUserContext.cpp @no-unify
-UIProcess/Automation/InspectorPassthroughChannel.cpp @no-unify
-UIProcess/Automation/SimulatedInputDispatcher.cpp @no-unify
-UIProcess/Automation/WebAutomationSession.cpp @no-unify
-UIProcess/Automation/WebDriverBidiProcessor.cpp @no-unify
+UIProcess/Automation/BidiBrowserAgent.cpp @no-unify-when(bundle<=8)
+UIProcess/Automation/BidiBrowsingContextAgent.cpp @no-unify-when(bundle<=8)
+UIProcess/Automation/BidiPermissionsAgent.cpp @no-unify-when(bundle<=8)
+UIProcess/Automation/BidiScriptAgent.cpp @no-unify-when(bundle<=8)
+UIProcess/Automation/BidiSessionAgent.cpp @no-unify-when(bundle<=8)
+UIProcess/Automation/BidiStorageAgent.cpp @no-unify-when(bundle<=8)
+UIProcess/Automation/BidiUserContext.cpp @no-unify-when(bundle<=8)
+UIProcess/Automation/InspectorPassthroughChannel.cpp @no-unify-when(bundle<=8)
+UIProcess/Automation/SimulatedInputDispatcher.cpp @no-unify-when(bundle<=8)
+UIProcess/Automation/WebAutomationSession.cpp @no-unify-when(bundle<=8) @cost:8
+UIProcess/Automation/WebDriverBidiProcessor.cpp @no-unify-when(bundle<=8)
 
 UIProcess/Downloads/DownloadProxy.cpp
 UIProcess/Downloads/DownloadProxyMap.cpp
@@ -620,8 +619,7 @@ UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp @cost:3
 UIProcess/Gamepad/UIGamepad.cpp
 UIProcess/Gamepad/UIGamepadProvider.cpp
 
-// TODO: This file should be "unified" once GTK's PluginProcess2 is removed.
-UIProcess/Launcher/ProcessLauncher.cpp @no-unify
+UIProcess/Launcher/ProcessLauncher.cpp @no-unify-when(bundle<=8)
 
 UIProcess/Network/NetworkProcessProxy.cpp @cost:7
 
@@ -688,8 +686,7 @@ WebProcess/WebProcess.cpp @cost:11
 WebProcess/WebSleepDisablerClient.cpp
 WebProcess/WebSystemSoundDelegate.cpp
 
-// FIXME(206266): AutomationProtocolObjects.h's "namespace Protocol" conflicts with objc/runtime.h's "typedef struct objc_object Protocol"
-WebProcess/Automation/WebAutomationSessionProxy.cpp @no-unify
+WebProcess/Automation/WebAutomationSessionProxy.cpp @no-unify-when(bundle<=8) @cost:4
 WebProcess/Automation/WebAutomationDOMWindowObserver.cpp
 
 WebProcess/Cache/WebCacheStorageConnection.cpp @cost:3
@@ -742,8 +739,8 @@ WebProcess/InjectedBundle/API/c/WKBundleRangeHandle.cpp
 WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp
 
 WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.cpp
-WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp @no-unify
-WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp @no-unify
+WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp @no-unify-when(bundle<=8)
+WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp @no-unify-when(bundle<=8)
 
 WebProcess/Inspector/RemoteWebInspectorUI.cpp
 WebProcess/Inspector/UIProcessForwardingFrontendChannel.cpp
@@ -839,7 +836,7 @@ WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
 WebProcess/GPU/media/RemoteLegacyCDMSession.cpp @cost:3
 WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp
 WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
-WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp @no-unify
+WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp @no-unify-when(bundle<=8)
 WebProcess/GPU/media/RemoteMediaResourceLoaderProxy.cpp
 WebProcess/GPU/media/RemoteMediaResourceProxy.cpp
 WebProcess/GPU/media/RemoteVideoFrameProxy.cpp @cost:3
@@ -858,7 +855,7 @@ WebProcess/Network/NetworkProcessConnection.cpp @cost:4
 WebProcess/Network/WebLoaderStrategy.cpp @cost:4
 WebProcess/Network/WebResourceInterceptController.cpp
 WebProcess/Network/WebResourceLoader.cpp
-WebProcess/Network/WebSocketChannel.cpp @no-unify
+WebProcess/Network/WebSocketChannel.cpp @no-unify-when(bundle<=8)
 WebProcess/Network/WebSocketChannelManager.cpp
 WebProcess/Network/WebSocketProvider.cpp
 WebProcess/Network/WebTransportSession.cpp @cost:4

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -74,7 +74,7 @@ GPUProcess/cocoa/GPUProcessCocoa.mm @nonARC
 GPUProcess/graphics/Model/MeshImpl.cpp
 GPUProcess/graphics/Model/WebKitMesh.mm
 GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
-GPUProcess/graphics/ScopedRenderingResourcesRequestCocoa.mm @nonARC @no-unify
+GPUProcess/graphics/ScopedRenderingResourcesRequestCocoa.mm @nonARC @no-unify-when(bundle<=8)
 GPUProcess/ios/GPUProcessIOS.mm @nonARC
 GPUProcess/mac/GPUProcessMac.mm @nonARC
 GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp
@@ -83,7 +83,7 @@ GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
 GPUProcess/media/cocoa/VideoReceiverEndpointManager.mm @nonARC
 GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm @nonARC
 GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
-GPUProcess/webrtc/LibWebRTCCodecsProxy.mm @nonARC @no-unify
+GPUProcess/webrtc/LibWebRTCCodecsProxy.mm @nonARC @no-unify // Includes libwebrtc headers with macro pollution.
 GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
 GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm @nonARC
 GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp @cost:3
@@ -98,7 +98,7 @@ Platform/classifier/cocoa/TextExtractionFilter.mm @nonARC
 Platform/classifier/cocoa/ResourceLoadStatisticsClassifierCocoa.cpp
 Platform/classifier/ResourceLoadStatisticsClassifier.cpp
 
-Platform/cocoa/AssertionCapability.mm @nonARC @no-unify
+Platform/cocoa/AssertionCapability.mm @nonARC @no-unify-when(bundle<=8)
 Platform/cocoa/ExtensionCapabilityGrant.mm @nonARC
 Platform/cocoa/MediaCapability.mm @nonARC
 Platform/cocoa/MediaPlaybackTargetContextSerialized.mm @nonARC
@@ -106,7 +106,7 @@ Platform/cocoa/MediaPlaybackTargetSerialized.cpp
 Platform/cocoa/PaymentAuthorizationPresenter.mm @nonARC
 Platform/cocoa/PaymentAuthorizationViewController.mm @nonARC
 Platform/cocoa/WKPaymentAuthorizationDelegate.mm @nonARC
-Platform/cocoa/WebKitAdditions.mm @nonARC @no-unify
+Platform/cocoa/WebKitAdditions.mm @nonARC @no-unify // #includes opaque WebKitAdditions sources.
 Platform/cocoa/WebPrivacyHelpers.mm @nonARC
 
 Platform/ios/PaymentAuthorizationController.mm @nonARC
@@ -194,7 +194,7 @@ Shared/Cocoa/SandboxExtensionCocoa.mm @nonARC
 Shared/Cocoa/SandboxInitialiationParametersCocoa.mm @nonARC
 Shared/Cocoa/SandboxUtilities.mm @nonARC
 Shared/Cocoa/SharedCARingBuffer.cpp
-Shared/Cocoa/TCCSoftLink.mm @nonARC @no-unify
+Shared/Cocoa/TCCSoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
 Shared/Cocoa/WebErrorsCocoa.mm @nonARC
 Shared/Cocoa/WebKit2InitializeCocoa.mm @nonARC
 Shared/Cocoa/WKNSArray.mm @nonARC
@@ -288,7 +288,7 @@ UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.mm @nonARC
 UIProcess/API/Cocoa/_WKAutomationSessionTesting.mm @nonARC
 UIProcess/API/Cocoa/_WKContentRuleListAction.mm @nonARC
 UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm @nonARC
-UIProcess/API/Cocoa/_WKCustomHeaderFields.mm @nonARC @no-unify
+UIProcess/API/Cocoa/_WKCustomHeaderFields.mm @nonARC @no-unify-when(bundle<=8)
 UIProcess/API/Cocoa/_WKDataTask.mm @nonARC
 UIProcess/API/Cocoa/_WKDownload.mm @nonARC
 UIProcess/API/Cocoa/_WKElementAction.mm @nonARC
@@ -477,7 +477,7 @@ UIProcess/Cocoa/UserMediaPermissionRequestProxyCocoa.mm @nonARC
 UIProcess/Cocoa/VideoPresentationManagerProxy.mm @nonARC
 UIProcess/Cocoa/ViewSnapshotStoreCocoa.mm @nonARC
 UIProcess/Cocoa/WebGeolocationManagerProxyCocoa.cpp
-UIProcess/Cocoa/WebKitSwiftSoftLink.mm @nonARC @no-unify
+UIProcess/Cocoa/WebKitSwiftSoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
 UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm @nonARC
 UIProcess/Cocoa/WebPageProxyCocoa.mm @nonARC @cost:12
 UIProcess/Cocoa/WebPasteboardProxyCocoa.mm @nonARC @cost:5
@@ -703,15 +703,15 @@ UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp @cost:3
 UIProcess/RemoteLayerTree/RemoteProgressBasedTimeline.cpp
 UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.cpp @cost:3
 
-UIProcess/WebAuthentication/Cocoa/AuthenticationServicesCoreSoftLink.mm @nonARC @no-unify
+UIProcess/WebAuthentication/Cocoa/AuthenticationServicesCoreSoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
 UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm @nonARC
 UIProcess/WebAuthentication/Cocoa/CcidConnection.mm @nonARC
 UIProcess/WebAuthentication/Cocoa/CcidService.mm @nonARC
-UIProcess/WebAuthentication/Cocoa/LocalAuthenticationSoftLink.mm @nonARC @no-unify
+UIProcess/WebAuthentication/Cocoa/LocalAuthenticationSoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
 UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm @nonARC
 UIProcess/WebAuthentication/Cocoa/LocalConnection.mm @nonARC
 UIProcess/WebAuthentication/Cocoa/LocalService.mm @nonARC
-UIProcess/WebAuthentication/Cocoa/NearFieldSoftLink.mm @nonARC @no-unify
+UIProcess/WebAuthentication/Cocoa/NearFieldSoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
 UIProcess/WebAuthentication/Cocoa/NfcConnection.mm @nonARC
 UIProcess/WebAuthentication/Cocoa/NfcService.mm @nonARC
 UIProcess/WebAuthentication/Cocoa/WKASCAuthorizationPresenterDelegate.mm @nonARC
@@ -916,7 +916,7 @@ WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.mm @nonARC
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm @nonARC
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm @nonARC @cost:4
-WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm @nonARC @no-unify
+WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm @nonARC @no-unify-when(bundle<=8) @cost:4
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm @nonARC
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm @nonARC @cost:3
 
@@ -939,7 +939,7 @@ LibWebRTCCodecsMessageReceiver.cpp
 LibWebRTCCodecsProxyMessageReceiver.cpp
 LibWebRTCNetworkMessageReceiver.cpp
 LogStreamMessageReceiver.cpp
-Shared/LogStream.mm @no-unify
+Shared/LogStream.mm @no-unify-when(bundle<=8)
 ModelConnectionToWebProcessMessageReceiver.cpp
 MediaPlayerPrivateRemoteMessageReceiver.cpp @cost:5
 MediaSourcePrivateRemoteMessageReceiverMessageReceiver.cpp


### PR DESCRIPTION
#### 1457fd953016e6768e2919edad68e34aadef8a7f
<pre>
[CMake][Mac] Purge most @no-unify
<a href="https://bugs.webkit.org/show_bug.cgi?id=316269">https://bugs.webkit.org/show_bug.cgi?id=316269</a>
<a href="https://rdar.apple.com/178680121">rdar://178680121</a>

Reviewed by Zak Ridouh, Mike Wyrzykowski, Brandon Stewart, and Pascoe.

~3% clean build speedup.

With jumbo unified sources, most @no-unify is pessimization.

* Source/JavaScriptCore/Sources.txt: Replace @no-unify with
@no-unify-when(bundle&lt;=8). This avoids a compile time regression in Xcode, where
bundle member count is 8. Add @cost where needed to avoid long pole bundles.

* Source/WTF/Scripts/generate-unified-source-bundles.py: Parsing for the new
@no-unify-when(bundle&lt;= syntax.

(SourceFile.__init__):
* Source/WTF/wtf/ObjCRuntimeExtras.h:
* Source/WTF/wtf/spi/cocoa/objcSPI.h: ::-qualify objc runtime types so a
bundle-mate&apos;s file-scope `using namespace JSC::Bindings` cannot make
Method/Class/Protocol ambiguous.

* Source/WebCore/Sources.txt: Replace @no-unify with @no-unify-when(bundle&lt;=8).
(See above.)

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm: Return NSNumber * instead of
a typdef name because the global CF_ENUM and our WebCore:: type of the same name conflict,
and anyway the caller wants an NSNumber *.

(platformChangeTypeForWebCoreChangeType):
(platformEditTypeForWebCoreEditType):
(platformDirectionForWebCoreDirection):
(platformGranularityForWebCoreGranularity):
(WebCore::AXObjectCache::postTextSelectionChangePlatformNotification):
(WebCore::AXObjectCache::postUserInfoForChanges):
* Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.mm: Use a more specific
name to avoid a conflict with another file.

* Source/WebCore/bridge/objc/objc_runtime.mm:
(JSC::Bindings::ObjcArray::valueAt const): Cast to a more specific type to
avoid ambiguity about which selector declaration we&apos;re going to invoke
(-Wobjc-multiple-method-names).

(WebCore::searchPopupWallTimeFromNSDate):
(WebCore::loadRecentSearchesFromFile):
(WebCore::toSystemClockTime): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/AVOutputDeviceMenuControllerTargetPicker.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.mm:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm: Guard soft-linking
to avoid conflicts when more than one file soft-links.

* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp: Undef
MESSAGE_CHECK_WITH_RETURN_VALUE like our other macros, to avoid a name conflict.

* Source/WebKit/Sources.txt: Replace @no-unify with @no-unify-when(bundle&lt;=8).
(See above.)
* Source/WebKit/SourcesCocoa.txt:

Canonical link: <a href="https://commits.webkit.org/314596@main">https://commits.webkit.org/314596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d3c08ca2d2c0df7db205fe9b76f7838ea702ba2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166573 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175621 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40071 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/129507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169532 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110032 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23762 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158730 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178155 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27467 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29075 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/137864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40133 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137782 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103553 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25354 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33075 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199252 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39331 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/53490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38728 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4121 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38973 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38871 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->