### PR TITLE
[GTK][WPE] Limit the damage region of the scrollbar to the region actually painted

### DIFF
--- a/Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp
@@ -150,9 +150,10 @@ void ScrollerCoordinated::updateValues()
 
     canvas->clear(SK_ColorTRANSPARENT);
 
+    Damage damage(state.frameRect);
     GraphicsContextSkia context(*canvas, RenderingMode::Accelerated, RenderingPurpose::DOM);
     context.scale(contentsScale);
-    scrollerImp->paint(context, state.frameRect, state);
+    scrollerImp->paint(context, state.frameRect, state, damage);
 
     grContext->flushAndSubmit(surface.get(), GLFence::isSupported(display.glDisplay()) ? GrSyncCpu::kNo : GrSyncCpu::kYes);
     auto buffer = CoordinatedPlatformLayerBufferRGB::create(WTF::move(texture), { TextureMapperFlags::ShouldBlend }, GLFence::create(display.glDisplay()));
@@ -162,7 +163,7 @@ void ScrollerCoordinated::updateValues()
     Locker layerLocker { hostLayer->lock() };
     hostLayer->setContentsRect(state.frameRect);
     hostLayer->setContentsClippingRect(FloatRoundedRect(state.frameRect));
-    hostLayer->setContentsBuffer(WTF::move(buffer));
+    hostLayer->setContentsBuffer(WTF::move(buffer), WTF::move(damage));
 }
 
 void ScrollerCoordinated::setHoveredAndPressedParts(ScrollbarPart hoveredPart, ScrollbarPart pressedPart)

--- a/Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.cpp
+++ b/Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.cpp
@@ -28,11 +28,12 @@
 
 #if USE(THEME_ADWAITA)
 
+#include "Damage.h"
 #include "GraphicsContext.h"
 
 namespace WebCore::AdwaitaScrollbarPainter {
 
-void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const State& scrollbar)
+void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const State& scrollbar, Damage* damageOut)
 {
     if (graphicsContext.paintingDisabled())
         return;
@@ -109,6 +110,11 @@ void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const St
         } else
             frame.setHeight(scrollbarBorderSize);
         graphicsContext.fillRect(frame, scrollbarBorderColor);
+
+        if (damageOut && opacity) {
+            frame.intersect(damageRect);
+            damageOut->add(frame);
+        }
     } else if (scrollbar.hoveredPart != NoPart) {
         int thumbCornerSize = thumbSize / 2;
         FloatSize corner(thumbCornerSize, thumbCornerSize);
@@ -143,6 +149,11 @@ void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const St
         graphicsContext.setFillRule(WindRule::EvenOdd);
         graphicsContext.setFillColor(overlayTroughBorderColor);
         graphicsContext.fillPath(path);
+
+        if (damageOut && opacity) {
+            troughBorder.intersect(damageRect);
+            damageOut->add(troughBorder);
+        }
     }
 
     int thumbCornerSize;
@@ -206,6 +217,11 @@ void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const St
         graphicsContext.setFillRule(WindRule::EvenOdd);
         graphicsContext.setFillColor(overlayThumbBorderColor);
         graphicsContext.fillPath(path);
+
+        if (damageOut && opacity) {
+            thumbBorder.intersect(damageRect);
+            damageOut->add(thumbBorder);
+        }
     }
 
     if (opacity != 1)

--- a/Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.h
+++ b/Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 
+class Damage;
 class GraphicsContext;
 
 namespace AdwaitaScrollbarPainter {
@@ -76,7 +77,7 @@ struct State {
     std::optional<ScrollbarColor> scrollbarColor;
 };
 
-void paint(GraphicsContext&, const IntRect&, const State&);
+void paint(GraphicsContext&, const IntRect&, const State&, Damage* damageOut = nullptr);
 
 } // namespace AdwaitaScrollbarPainter
 } // namespace WebCore

--- a/Source/WebCore/platform/adwaita/ScrollerImpAdwaita.h
+++ b/Source/WebCore/platform/adwaita/ScrollerImpAdwaita.h
@@ -33,9 +33,9 @@ namespace WebCore {
 
 class ScrollerImpAdwaita : public ThreadSafeRefCounted<ScrollerImpAdwaita> {
 public:
-    void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const AdwaitaScrollbarPainter::State& state)
+    void paint(GraphicsContext& graphicsContext, const IntRect& damageRect, const AdwaitaScrollbarPainter::State& state, Damage& damageOut)
     {
-        AdwaitaScrollbarPainter::paint(graphicsContext, damageRect, state);
+        AdwaitaScrollbarPainter::paint(graphicsContext, damageRect, state, &damageOut);
     }
 };
 

--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if USE(COORDINATED_GRAPHICS)
+#if USE(COORDINATED_GRAPHICS) || USE(THEME_ADWAITA)
 #include "FloatRect.h"
 #include "LayoutSize.h"
 #include "Region.h"
@@ -558,4 +558,4 @@ static inline WTF::TextStream& operator<<(WTF::TextStream& ts, const Damage& dam
 
 } // namespace WebCore
 
-#endif // USE(COORDINATED_GRAPHICS)
+#endif // USE(COORDINATED_GRAPHICS) || USE(THEME_ADWAITA)


### PR DESCRIPTION
#### 0512cc56a87943685d365ba2784aaa5274c333c5
<pre>
[GTK][WPE] Limit the damage region of the scrollbar to the region actually painted
<a href="https://bugs.webkit.org/show_bug.cgi?id=316268">https://bugs.webkit.org/show_bug.cgi?id=316268</a>

Reviewed by Carlos Garcia Campos.

The whole scrollbar layer was always damaged while the overlay scrollbar is
hiding even though the most part of the overlay scrollbar is transparent. Only
the visible part, scrollbar thumb area, should be damaged during the hiding
animaiton.

* Source/WebCore/page/scrolling/coordinated/ScrollerCoordinated.cpp:
(WebCore::ScrollerCoordinated::updateValues):
* Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.cpp:
(WebCore::AdwaitaScrollbarPainter::paint):
* Source/WebCore/platform/adwaita/AdwaitaScrollbarPainter.h:
* Source/WebCore/platform/adwaita/ScrollerImpAdwaita.h:
(WebCore::ScrollerImpAdwaita::paint):
* Source/WebCore/platform/graphics/Damage.h:

Canonical link: <a href="https://commits.webkit.org/314540@main">https://commits.webkit.org/314540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad0aae2332dc937d5e8601171759c701e8e8a90c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168301 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129385 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109910 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29444 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23623 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178016 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30917 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137740 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137659 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149036 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103372 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25329 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32952 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39193 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112268 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38590 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3988 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38733 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->