### PR TITLE
[Re-land] [Site Isolation] [intersection-observer] Make converting from main frame local to absolute coordinate SI-safe

### DIFF
--- a/LayoutTests/http/tests/intersection-observer/resources/root-margin-with-zoom-subframe.html
+++ b/LayoutTests/http/tests/intersection-observer/resources/root-margin-with-zoom-subframe.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #target {
+    position: absolute;
+    height: 40px;
+    width: 40px;
+    background-color: green;
+  }
+</style>
+
+<div id="target"></div>
+
+<script>
+  let options = {
+    rootMargin: '40px 0px 0px 0px',
+    threshold: [1]
+  }
+
+  let observer = new IntersectionObserver((observations) => {
+    const lastObservation = observations[observations.length - 1];
+    window.top.postMessage({
+      isIntersecting: lastObservation.isIntersecting
+    }, "*");
+  }, options);
+
+  observer.observe(document.getElementById("target"));
+</script>

--- a/LayoutTests/http/tests/intersection-observer/resources/zoomed-page-subframe.html
+++ b/LayoutTests/http/tests/intersection-observer/resources/zoomed-page-subframe.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="target"></div>
+
+<script>
+  let options = {
+    threshold: [1]
+  };
+
+  let observer = new IntersectionObserver((observations) => {
+    const lastObservation = observations[observations.length - 1];
+    window.top.postMessage({
+      intersectionRect: {
+        x: lastObservation.intersectionRect.x,
+        y: lastObservation.intersectionRect.y,
+        width: lastObservation.intersectionRect.width,
+        height: lastObservation.intersectionRect.height
+      },
+      isIntersecting: lastObservation.isIntersecting
+    }, "*");
+  }, options);
+
+  observer.observe(target);
+</script>

--- a/LayoutTests/http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin-expected.txt
+++ b/LayoutTests/http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Intersection Observer: root margin is applied when observer is in a same-origin iframe, and page is zoomed
+

--- a/LayoutTests/http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin.html
+++ b/LayoutTests/http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: root margin is applied when observer is in a same-origin iframe, and page is zoomed</title>
+
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 40px;
+    height: 40px;
+    display: block;
+    position: fixed;
+    left: 0;
+    top: -40px;
+    border: 0;
+  }
+</style>
+
+<iframe id="iframe"></iframe>
+
+<script>
+  isIntersecting = null;
+  window.addEventListener("message", event => {
+    isIntersecting = event.data.isIntersecting;
+  });
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = "resources/root-margin-with-zoom-subframe.html";
+    });
+  }
+
+  promise_test(async (t) => {
+    window.internals.setPageZoomFactor(2);
+
+    await loadFrame();
+
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+
+    assert_true(isIntersecting);
+  });
+</script>

--- a/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin-expected.txt
+++ b/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Intersection Observer in a cross-origin iframe works when the page is zoomed
+

--- a/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html
+++ b/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+
+<title>Tests that intersection observer works in a cross-origin iframe when the page is zoomed</title>
+
+<style>
+  #subframe {
+    width: 300px;
+    height: 300px;
+  }
+
+  #spacer {
+    height: 2000px;
+  }
+</style>
+
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe id="subframe"></iframe>
+<div id="spacer"></div>
+
+<script>
+  lastObservation = null;
+  window.addEventListener("message", event => {
+    lastObservation = event.data;
+  });
+
+  function assertRect(actual, expectedX, expectedY, expectedWidth, expectedHeight) {
+    assert_equals(actual.x, expectedX);
+    assert_equals(actual.y, expectedY);
+    assert_equals(actual.width, expectedWidth);
+    assert_equals(actual.height, expectedHeight);
+  }
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      subframe.addEventListener("load", resolve, { once: true });
+      subframe.src = "http://localhost:8000/intersection-observer/resources/zoomed-page-subframe.html";
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+
+    await UIHelper.zoomToScale(2);
+
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    assert_true(lastObservation.isIntersecting, "Target is initially visible");
+    assertRect(lastObservation.intersectionRect, 0, 0, 100, 100);
+
+    window.scroll(0, 2000);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    assert_false(lastObservation.isIntersecting, "Scrolled past target, target is no longer visible");
+    assertRect(lastObservation.intersectionRect, 0, 0, 0, 0);
+
+    window.scroll(0, 0);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    assert_true(lastObservation.isIntersecting, "Scrolled to top of page, target is visible again");
+    assertRect(lastObservation.intersectionRect, 0, 0, 100, 100);
+  }, "Intersection Observer in a cross-origin iframe works when the page is zoomed");
+</script>

--- a/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-same-origin-expected.txt
+++ b/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-same-origin-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Intersection Observer in a same-origin iframe works when the page is zoomed
+

--- a/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-same-origin.html
+++ b/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-same-origin.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+
+<title>Tests that intersection observer works in a same-origin iframe when the page is zoomed</title>
+
+<style>
+  #subframe {
+    width: 300px;
+    height: 300px;
+  }
+
+  #spacer {
+    height: 2000px;
+  }
+</style>
+
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe id="subframe"></iframe>
+<div id="spacer"></div>
+
+<script>
+  lastObservation = null;
+  window.addEventListener("message", event => {
+    lastObservation = event.data;
+  });
+
+  function assertRect(actual, expectedX, expectedY, expectedWidth, expectedHeight) {
+    assert_equals(actual.x, expectedX);
+    assert_equals(actual.y, expectedY);
+    assert_equals(actual.width, expectedWidth);
+    assert_equals(actual.height, expectedHeight);
+  }
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      subframe.addEventListener("load", resolve, { once: true });
+      subframe.src = "resources/zoomed-page-subframe.html";
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+
+    await UIHelper.zoomToScale(2);
+
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    assert_true(lastObservation.isIntersecting, "Target is initially visible");
+    assertRect(lastObservation.intersectionRect, 0, 0, 100, 100);
+
+    window.scroll(0, 2000);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    assert_false(lastObservation.isIntersecting, "Scrolled past target, target is no longer visible");
+    assertRect(lastObservation.intersectionRect, 0, 0, 0, 0);
+
+    window.scroll(0, 0);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    assert_true(lastObservation.isIntersecting, "Scrolled to top of page, target is visible again");
+    assertRect(lastObservation.intersectionRect, 0, 0, 100, 100);
+  }, "Intersection Observer in a same-origin iframe works when the page is zoomed");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/root-margin-in-same-origin-iframe-subframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/root-margin-in-same-origin-iframe-subframe.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #target {
+    position: absolute;
+    height: 40px;
+    width: 40px;
+    background-color: green;
+  }
+</style>
+
+<div id="target"></div>
+
+<script>
+  let options = {
+    rootMargin: '40px 0px 0px 0px',
+    threshold: [1]
+  }
+
+  let observer = new IntersectionObserver((observations) => {
+    const lastObservation = observations[observations.length - 1];
+    window.top.postMessage({
+      isIntersecting: lastObservation.isIntersecting
+    }, "*");
+  }, options);
+
+  observer.observe(document.getElementById("target"));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Intersection Observer: root margin is applied when observer is in a same-origin iframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: root margin is applied when observer is in a same-origin iframe</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/common/rendering-utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 40px;
+    height: 40px;
+    display: block;
+    position: fixed;
+    left: 0;
+    top: -40px;
+    border: 0;
+  }
+</style>
+
+<iframe id="iframe"></iframe>
+
+<script>
+  isIntersecting = null;
+  window.addEventListener("message", event => {
+    isIntersecting = event.data.isIntersecting;
+  });
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = "resources/root-margin-in-same-origin-iframe-subframe.html";
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_true(isIntersecting);
+  });
+</script>

--- a/LayoutTests/intersection-observer/zoomed-visual-viewport.html
+++ b/LayoutTests/intersection-observer/zoomed-visual-viewport.html
@@ -54,7 +54,7 @@
         promise_test(async t => {
             await UIHelper.renderingUpdate();
             await UIHelper.renderingUpdate();
-            assert_false(lastObservation.isIntersecting, "Target is initially visible");
+            assert_false(lastObservation.isIntersecting, "Target is initially not visible");
             assertRootBounds(lastObservation.rootBounds, 0, 0, document.documentElement.clientWidth, document.documentElement.clientHeight);
 
             await UIHelper.zoomToScale(2);
@@ -63,13 +63,13 @@
             container.scrollTop = 1000;
             await UIHelper.renderingUpdate();
             await UIHelper.renderingUpdate();
-            assert_true(lastObservation.isIntersecting, "Scrolled past target, target is no longer visible");
+            assert_true(lastObservation.isIntersecting, "Scrolled into target, target is now visible");
             assertRootBounds(lastObservation.rootBounds, 0, 0, document.documentElement.clientWidth, document.documentElement.clientHeight);
 
             container.scrollTop = 0;
             await UIHelper.renderingUpdate();
             await UIHelper.renderingUpdate();
-            assert_false(lastObservation.isIntersecting, "Scrolled to top of container, target is visible again");
+            assert_false(lastObservation.isIntersecting, "Scrolled to top of container, target is no longer visible again");
             assertRootBounds(lastObservation.rootBounds, 0, 0, document.documentElement.clientWidth, document.documentElement.clientHeight);
         });
     </script>

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -363,6 +363,7 @@ http/tests/security/block-top-level-navigations-by-third-party-sandboxed-iframe.
 http/tests/security/frameNavigation/not-opener.html [ Failure ]
 
 # Intersection Observer x Site Isolation is not fully implemented.
+http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html [ Failure ]
 imported/w3c/web-platform-tests/intersection-observer/cross-origin-tall-iframe.sub.html [ Failure ]
 imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin.html [ Failure ]
 imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -278,6 +278,7 @@ http/tests/security/frameNavigation/not-opener.html [ Failure ]
 inspector/unit-tests/target-manager.html [ Skip ]
 
 # Intersection Observer x Site Isolation is not fully implemented.
+http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html [ Failure ]
 imported/w3c/web-platform-tests/intersection-observer/cross-origin-tall-iframe.sub.html [ Failure ]
 imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin.html [ Failure ]
 imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin.html [ Failure ]

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -503,8 +503,9 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
 {
     bool isFirstObservation = !registration.previousThresholdIndex;
 
-    // This is only set for explicit roots.
-    // FIXME: remove one remaining place that needs this to work with implicit root.
+    // This is not set if the root is implicit (meaning the root is the main frame),
+    // it's cross-origin with the target, and Site Isolation is enabled. In that case,
+    // the renderer is in another process and can't be accessed.
     CheckedPtr<RenderBox> rootRenderer;
 
     CheckedPtr<RenderElement> targetRenderer;
@@ -564,12 +565,8 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
             return;
         }
 
-        // This is needed to get the root's renderer to compute the root bounds.
-        // FIXME: remove this when computing root bounds no longer requires rootRenderer.
-        RefPtr hostLocalFrameView = dynamicDowncast<LocalFrameView>(hostFrameView);
-        if (!hostLocalFrameView)
-            return;
-        rootRenderer = hostLocalFrameView->renderView();
+        if (RefPtr hostLocalFrameView = dynamicDowncast<LocalFrameView>(hostFrameView))
+            rootRenderer = hostLocalFrameView->renderView();
 
         intersectionState.canComputeIntersection = true;
         intersectionState.rootBounds = layoutViewportRectForIntersection();
@@ -582,25 +579,11 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
     }
 
     if (applyRootMargin == ApplyRootMargin::Yes) {
-        auto rootUsedZoom = [&] () -> float {
-            if (rootRenderer)
-                return rootRenderer->style().usedZoom();
-
-            // If applyRootMargin is Yes, the root and target frames are same-origin.
-            // Therefore the root frame should be in the same process as the target frame
-            // (with or without Site Isolation)
-            auto* hostLocalFrameView = dynamicDowncast<LocalFrameView>(hostFrameView);
-            ASSERT(hostLocalFrameView);
-            if (!hostLocalFrameView)
-                return 1;
-
-            CheckedPtr hostRenderView = hostLocalFrameView->renderView();
-            ASSERT(hostRenderView);
-            if (!hostRenderView)
-                return 1;
-
-            return hostRenderView->style().usedZoom();
-        }();
+        // If applyRootMargin is Yes, the root and target frames are same-origin.
+        // Therefore the root renderer should be available, as the root is in the
+        // same process as the target (with or without Site Isolation)
+        ASSERT(rootRenderer);
+        float rootUsedZoom = rootRenderer ? rootRenderer->style().usedZoom() : 1;
 
         expandRootBoundsWithRootMargin(intersectionState.rootBounds, scrollMarginBox(), rootUsedZoom);
         expandRootBoundsWithRootMargin(intersectionState.rootBounds, rootMarginBox(), rootUsedZoom);
@@ -662,8 +645,30 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
     if (isFirstObservation || intersectionState.isIntersecting)
         intersectionState.absoluteTargetRect = targetRenderer->localToAbsoluteQuad(FloatRect(localTargetBounds)).boundingBox();
 
+    auto rootLocalToAbsoluteRect = [&] (FloatRect rect) {
+        if (rootRenderer)
+            return rootRenderer->localToAbsoluteQuad(rect).boundingBox();
+
+        // The below codepath is specific to implicit root, where the root is the main frame.
+        ASSERT(!root());
+
+        // When page scale is > 1 (e.g by pinch-to-zoom), a scale transform is applied on the
+        // main frame's RenderView in Style::resolveForDocument(). Therefore we have to apply
+        // this transform to the local coordinate to turn it into absolute.
+        // This is identical to calling localToAbsoluteQuad() on the main frame's RenderView,
+        // as it'll apply the same transform.
+        // Not applicable on iOS family as they apply page scale differently.
+        // FIXME: replace the platform ifdef with something else.
+#if !PLATFORM(IOS_FAMILY)
+        if (RefPtr hostPage = hostFrameView.frame().page())
+            rect.scale(hostPage->pageScaleFactor());
+#endif
+
+        return rect;
+    };
+
     if (intersectionState.isIntersecting) {
-        auto rootAbsoluteIntersectionRect = rootRenderer->localToAbsoluteQuad(rootLocalIntersectionRect).boundingBox();
+        auto rootAbsoluteIntersectionRect = rootLocalToAbsoluteRect(rootLocalIntersectionRect);
 
         if (root() && &targetRenderer->frame() == &rootRenderer->frame())
             intersectionState.absoluteIntersectionRect = rootAbsoluteIntersectionRect;
@@ -694,7 +699,7 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
 
     intersectionState.observationChanged = isFirstObservation || intersectionState.thresholdIndex != registration.previousThresholdIndex;
     if (intersectionState.observationChanged) {
-        intersectionState.absoluteRootBounds = rootRenderer->localToAbsoluteQuad(intersectionState.rootBounds).boundingBox();
+        intersectionState.absoluteRootBounds = rootLocalToAbsoluteRect(intersectionState.rootBounds);
 
         if (!intersectionState.absoluteTargetRect)
             intersectionState.absoluteTargetRect = targetRenderer->localToAbsoluteQuad(FloatRect(localTargetBounds)).boundingBox();


### PR DESCRIPTION
#### e6378110c18b876c4eb40c0c905ac117b4dd2d34
<pre>
[Re-land] [Site Isolation] [intersection-observer] Make converting from main frame local to absolute coordinate SI-safe
<a href="https://rdar.apple.com/178652266">rdar://178652266</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316270">https://bugs.webkit.org/show_bug.cgi?id=316270</a>

Reviewed by Simon Fraser.

This is a re-land of 313774@main which got reverted in 314529@main.
Original message follows:

    In some places, IntersectionObserver::computeIntersectionState calls
    localToAbsoluteQuad() on the root renderer. In Site Isolation mode, if the root is
    implicit (meaning the root is the main frame) and the intersection observer is in
    a cross-site frame, then the observer lives in a different process than the main
    frame and won&apos;t have access to the root renderer (the main frame&apos;s RenderView).
    Hence we need a way to make it work.

    Normally the RenderView local coordinates is already absolute, but pinch-to-zoom
    puts a page scale transform on the RenderView, which makes the local and absolute
    coordinate different (see the attempt at 303055@main that got reverted at
    306392@main). This patch applies the page scale to the local coordinate to convert
    it to absolute. The page scale is fetched from the Page object and is synchronized
    between processes.

It got reverted because a condition that should&apos;ve been PLATFORM(IOS_FAMILY) is
PLATFORM(IOS) instead, which causes regression on visionOS (is IOS_FAMILY but not IOS)
Fix this in the reland.

Given that intersection observer is used everywhere, and we&apos;ve had to revert twice (!)
for the same issue,  make this change extra safe by creating a non-SI and SI path.
The non-SI path still uses localToAbsoluteQuad, while the SI path uses the approach
added in this patch. This way, there&apos;re no behavioral changes in non-SI cases.

Tests: http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin.html
       http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html
       http/tests/intersection-observer/zoomed-page-iframe-same-origin.html
       imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe.html

* LayoutTests/http/tests/intersection-observer/resources/root-margin-with-zoom-subframe.html: Added.
* LayoutTests/http/tests/intersection-observer/resources/zoomed-page-subframe.html: Added.
* LayoutTests/http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin-expected.txt: Added.
* LayoutTests/http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin.html: Added.
    - Add a test that checks that root margin is applied when the intersection observer
      is in a same-origin iframe, and the whole page is zoomed.

* LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin-expected.txt: Added.
* LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html: Added.
    - Add a test that checks that intersection observer works when the observer
      is in a cross-origin iframe, and the whole page is zoomed.

* LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-same-origin-expected.txt: Added.
* LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-same-origin.html: Added.
    - Add a test that checks that intersection observer works when the observer
      is in a same-origin iframe, and the whole page is zoomed.

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/root-margin-in-same-origin-iframe-subframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe.html: Added.
    - Add a test that checks that root margin is applied when the intersection observer
      is in a same-origin iframe.

* LayoutTests/intersection-observer/zoomed-visual-viewport.html:
    - Fix assert messages - some asserts expect true but the message says it should be false,
      and vice versa.

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
    - Mark LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html
      as failed - Intersection Observer x Site Isolation currently doesn&apos;t work as there&apos;re
      some more work to do.

* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::computeIntersectionState const):

Canonical link: <a href="https://commits.webkit.org/315001@main">https://commits.webkit.org/315001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/361b7b5e5f9e1df587b8df0175026ba252e2d0b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176605 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125231 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eeac5bdc-901c-4359-b95e-d09bd5390044) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130355 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6b72642-df5d-488b-8351-05dbb49401c4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110872 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fec2c194-a1c6-42c6-81f6-2af5cb4ca884) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31749 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30447 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25338 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141736 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179146 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32039 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29956 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138751 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138637 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37391 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150030 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104947 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33894 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26909 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40311 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113392 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39708 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5010 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39959 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->