### PR TITLE
[MSE] Playback stalls after rapid seeks when readyState transitions mid-seek

### DIFF
--- a/LayoutTests/media/media-source/media-source-seek-readystate-no-stall-expected.txt
+++ b/LayoutTests/media/media-source/media-source-seek-readystate-no-stall-expected.txt
@@ -1,0 +1,14 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer('video/mp4; codecs="avc1.4d401e"'))
+RUN(sourceBuffer.appendBuffer(MP4.concat(init, makeSegment(1, 0, 100))))
+EVENT(updateend)
+RUN(video.play())
+EVENT(playing)
+
+Test: rapid seek burst with mid-seek readyState transitions
+EXPECTED (effRate == '1') OK
+
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-seek-readystate-no-stall.html
+++ b/LayoutTests/media/media-source/media-source-seek-readystate-no-stall.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="timeout" content="long">
+    <title>media-source-seek-readystate-no-stall</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Regression test: rapid seeks combined with readyState transitions
+    // landing mid-seek must not leave the renderer paused once the seek
+    // completes.
+
+    var source;
+    var sourceBuffer;
+    var init;
+    var effRate;
+
+    function makeSegment(seq, baseDecodeTime, count) {
+        const samples = [];
+        for (let i = 0; i < count; i++)
+            samples.push({ duration: 100, compositionTimeOffset: 0, isSync: true });
+        return MP4.mediaSegment({
+            sequenceNumber: seq,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime, samples }],
+        });
+    }
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(MP4.VIDEO_TYPE)) {
+            failTest(`${MP4.VIDEO_TYPE} is not supported`);
+            return;
+        }
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        waitFor(video, 'error').then(failTest);
+
+        run(`sourceBuffer = source.addSourceBuffer('${MP4.VIDEO_TYPE}')`);
+        source.duration = 1000;
+
+        init = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }],
+        });
+        // Seed: init + 10s of samples starting at t=0 so playback can begin.
+        run('sourceBuffer.appendBuffer(MP4.concat(init, makeSegment(1, 0, 100)))');
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('video.play()');
+        await waitFor(video, 'playing');
+
+        consoleWrite('');
+        consoleWrite('Test: rapid seek burst with mid-seek readyState transitions');
+
+        let seq = 2;
+        effRate = 1;
+        let base = 100000;
+        for (let i = 0; i < 8; i++) {
+            const target = (base + 500) / 1000;
+            video.currentTime = target;
+            await waitFor(video, 'seeking', true);
+
+            // Drop readyState by clearing buffered, then climb back to
+            // HAVE_ENOUGH_DATA by appending data covering the seek target
+            // while the seek is in flight.
+            sourceBuffer.remove(0, source.duration);
+            await waitFor(sourceBuffer, 'updateend', true);
+
+            sourceBuffer.appendBuffer(makeSegment(seq++, base, 100));
+            await waitFor(sourceBuffer, 'updateend', true);
+
+            await Promise.race([
+                waitFor(video, 'seeked', true),
+                new Promise(r => setTimeout(r, 1000)),
+            ]);
+
+            // Let the rate change propagate before sampling.
+            await new Promise(r => setTimeout(r, 50));
+            effRate = internals.effectiveRate(video);
+            if (!effRate)
+                break;
+
+            base += 100000;
+        }
+
+        testExpected('effRate', 1);
+
+        consoleWrite('');
+        endTest();
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -668,6 +668,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::completeSeek(const MediaTime& seekedT
 
     if (hasVideo())
         setHasAvailableVideoFrame(true);
+
+    // Apply any state transition deferred by updateStateFromReadyState() while seeking.
+    updateStateFromReadyState();
 }
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::seeking() const
@@ -1187,6 +1190,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setReadyState(MediaPlayer::ReadyState
 void MediaPlayerPrivateMediaSourceAVFObjC::updateStateFromReadyState()
 {
     assertIsMainThread();
+    // Seek owns renderer rate and event sequencing from prepareToSeek through completeSeek.
+    if (seeking())
+        return;
     if (shouldBePlaying()) {
         dispatchToRendererQueue([](auto& renderer) {
             renderer.play();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5552,6 +5552,12 @@ bool Internals::isPlayerPaused(const HTMLMediaElement& element) const
     return player && player->paused();
 }
 
+double Internals::effectiveRate(const HTMLMediaElement& element) const
+{
+    RefPtr player = element.player();
+    return player ? player->effectiveRate() : 0.0;
+}
+
 void Internals::forceStereoDecoding(HTMLMediaElement& element)
 {
     element.forceStereoDecoding();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -938,6 +938,7 @@ public:
     bool NODELETE isPlayerVisibleInViewport(const HTMLMediaElement&) const;
     bool isPlayerMuted(const HTMLMediaElement&) const;
     bool isPlayerPaused(const HTMLMediaElement&) const;
+    double effectiveRate(const HTMLMediaElement&) const;
     void NODELETE forceStereoDecoding(HTMLMediaElement&);
     void beginAudioSessionInterruption();
     void endAudioSessionInterruption();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1135,6 +1135,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] boolean isPlayerVisibleInViewport(HTMLMediaElement element);
     [Conditional=VIDEO] boolean isPlayerMuted(HTMLMediaElement element);
     [Conditional=VIDEO] boolean isPlayerPaused(HTMLMediaElement element);
+    [Conditional=VIDEO] double effectiveRate(HTMLMediaElement element);
     [Conditional=VIDEO] undefined forceStereoDecoding(HTMLMediaElement element);
 
     MockPageOverlay installMockPageOverlay(PageOverlayType type);


### PR DESCRIPTION
#### ae9751dfb31afc7a17c1b0f36da7c5a145831793
<pre>
[MSE] Playback stalls after rapid seeks when readyState transitions mid-seek
<a href="https://bugs.webkit.org/show_bug.cgi?id=316273">https://bugs.webkit.org/show_bug.cgi?id=316273</a>
<a href="https://rdar.apple.com/177990720">rdar://177990720</a>

Reviewed by Eric Carlson.

A seek is a multi-step operation that owns the renderer&apos;s playback rate
from prepareToSeek (rate=0) through maybeCompleteSeek (rate=m_rate) until
completeSeek finally clears m_seeking on the main thread. The renderer-
side work runs on the MediaSource queue; completeSeek hops back to the
main thread once the finishSeek IPC round-trip resolves. During that
trailing window the renderer is already playing at m_rate, but
MediaPlayerPrivate still considers itself mid-seek.

If the MediaSource fires monitorSourceBuffers in that window and
readyState transitions (HAVE_METADATA -&gt; HAVE_ENOUGH_DATA is the common
case on the BBC stream, where the source buffer is evicted and refilled
during a rapid rewind), updateStateFromReadyState runs on the main
thread, observes shouldBePlaying()==false (because seeking() is still
true), and calls stall(). That stall() is dispatched to the renderer
queue and lands after maybeCompleteSeek&apos;s setSynchronizerRate(m_rate),
overriding it back to 0. completeSeek then fires &apos;seeked&apos; on a renderer
that is paused at the OS level. Nothing reissues setSynchronizerRate(1)
until the user manually pauses and plays again.

The race is more visible when MediaContainment is on -- finishSeek
crosses an IPC boundary, widening the window in which the rogue stall
can dispatch -- but the underlying invariant violation exists in both
modes: state-reactive code on the main thread must not flip the
renderer&apos;s rate while the seek path is still mid-flight.

Treat the seek path as the sole owner of rate and readyState propagation
between prepareToSeek and completeSeek. updateStateFromReadyState
returns early while seeking(); completeSeek re-invokes it so any
transition that was suppressed mid-seek (rate and readyStateChanged) is
applied exactly once when the seek lands. m_readyState itself is still
updated synchronously, so readers see the current value during the
seek -- only the side-effecting notification is deferred. This also
coalesces the burst of intermediate waiting/canplay/playing events the
BBC player observed across each rewind.

A new internals.effectiveRate(HTMLMediaElement) exposes the renderer&apos;s
effective playback rate so the regression test can assert the bug
directly.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::completeSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateStateFromReadyState):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::effectiveRate):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* LayoutTests/media/media-source/media-source-seek-readystate-no-stall.html: Added.
* LayoutTests/media/media-source/media-source-seek-readystate-no-stall-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/314534@main">https://commits.webkit.org/314534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfc7d2b00fd8064501478a1496b924990d0fbdb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123676 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6b03a1b-cf1c-45d1-a20d-09417bdae6cf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129374 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1445324f-6745-4864-aceb-8e83d5502bbd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149530 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109899 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dba3efd5-41d6-47b6-b4cc-3a073f57ad9e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23609 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178002 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30903 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137729 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39981 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137648 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37078 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149024 "Passed tests") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32939 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112254 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38576 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3976 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38821 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38719 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->