### PR TITLE
[YARR] Change FixedCount model from save-at-END to save-at-BEGIN

### DIFF
--- a/JSTests/stress/yarr-quantified-parentheses-unified-backtracking.js
+++ b/JSTests/stress/yarr-quantified-parentheses-unified-backtracking.js
@@ -1,0 +1,78 @@
+// Regression coverage for the unified save-at-BEGIN model for quantified
+// parenthesised subpatterns in YarrJIT (FixedCount/Greedy/NonGreedy share one
+// ParenContext push/pop flow; FixedCount is min == max). Throws on mismatch.
+// Expected values were verified against the Yarr interpreter and V8.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: got ${actual}, expected ${expected}`);
+}
+
+function match(re, str) {
+    let m = re.exec(str);
+    return m === null ? "null" : JSON.stringify(Array.from(m).map(x => x === undefined ? null : x)) + "@" + m.index;
+}
+
+function test(reSource, flags, str, expected) {
+    // Compile once and execute repeatedly so the Yarr JIT tiers up and the
+    // JIT-compiled code path (not just the interpreter) is exercised.
+    let re = new RegExp(reSource, flags);
+    for (let i = 0; i < 200; ++i)
+        shouldBe(match(re, str), expected);
+}
+
+// --- FixedCount with backtrackable single-alternative content ---
+test("(a+){2}b", "", "aaab", '["aaab","a"]@0');
+test("(a+){3}", "", "aaaa", '["aaaa","a"]@0');
+test("(a+){2}$", "", "aaaa", '["aaaa","a"]@0');
+test("(a){3}", "", "aaa", '["aaa","a"]@0');
+test("(a){3}", "", "aa", "null");
+test("(ab){2,2}", "", "abab", '["abab","ab"]@0');
+
+// --- FixedCount with multiple alternatives (inter-iteration alt retry) ---
+test("(a+|b+){2}c", "", "aabbc", '["aabbc","bb"]@0');
+test("(a+|b+){2}c", "", "aabc", '["aabc","b"]@0');
+test("(a|b){3}", "", "abab", '["aba","a"]@0');
+test("(?:(a+)b){2}", "", "abaab", '["abaab","aa"]@0');
+test("(?:(a+)b){2}", "", "aabab", '["aabab","a"]@0');
+
+// --- Nested FixedCount / Greedy ---
+test("((a+)+){2}", "", "aaaa", '["aaaa","a","a"]@0');
+test("(\\w)\\1{2}", "", "aaa", '["aaa","a"]@0');
+
+// --- Greedy / NonGreedy regression guards (must be unaffected) ---
+test("(ab|cd)*", "", "abcdab", '["abcdab","ab"]@0');
+test("(a+?){2,4}", "", "aaaa", '["aaaa","a"]@0');
+test("(a+){2,}", "", "aaaa", '["aaaa","a"]@0');
+test("(a*){3}", "", "aaa", '["aaa",""]@0');
+test("(a+)*?b", "", "aaab", '["aaab","aaa"]@0');
+
+// --- Backtrack-then-FAIL: backtracking exhausts every iteration distribution and
+//     bails out (no trailing match exists). This drives BEGIN.bt all the way down
+//     to count == 0 (noPreviousIteration) and exercises the failure-propagation /
+//     capture-clearing paths that the "backtrack then succeed" cases above do not. ---
+
+// Single-alt backtrackable FixedCount: every split of the a's across N iterations
+// is tried, the trailing 'b' never matches, so the whole match fails.
+test("(a+){2}b", "", "aaa", "null");
+test("(a+){3}b", "", "aaaa", "null");
+test("(a+){4}b", "", "aaaaaa", "null");
+
+// Multi-alternative FixedCount: both alternatives are tried in every iteration
+// before bailing out.
+test("(a+|b+){2}c", "", "aabb", "null");
+test("(a+|b+){2}c", "", "ab", "null");
+test("(a+|b+){3}c", "", "aabb", "null");
+
+// Nested FixedCount: inner and outer iteration counts both backtrack to exhaustion.
+test("((a+)+){2}b", "", "aaaa", "null");
+
+// FixedCount bails out, then an enclosing alternation succeeds: the failed group's
+// captures must be cleared (undefined) before the alternative is taken.
+test("(?:(a+){2}b|a+)", "", "aaa", '["aaa",null]@0');
+test("((a+){2}b)|(a+)", "", "aaa", '["aaa",null,null,"aaa"]@0');
+
+// Same bail-out chain through the shared code path for Greedy-below-min and
+// NonGreedy (both reduce to "re-drive previous content, then fail").
+test("(a+){2,}b", "", "aaa", "null");
+test("(a+){2,4}?b", "", "aaa", "null");

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -713,7 +713,6 @@ class YarrGenerator final : public YarrJITInfo {
             uint32_t begin;
             uint32_t matchAmount;
         } beginAndMatchAmount;
-        uint32_t end;
         uintptr_t returnAddress;
         struct Subpatterns {
             unsigned start;
@@ -740,11 +739,6 @@ class YarrGenerator final : public YarrJITInfo {
         static constexpr ptrdiff_t NODELETE matchAmountOffset()
         {
             return offsetof(ParenContext, beginAndMatchAmount) + offsetof(BeginAndMatchAmount, matchAmount);
-        }
-
-        static constexpr ptrdiff_t NODELETE endOffset()
-        {
-            return offsetof(ParenContext, end);
         }
 
         static constexpr ptrdiff_t NODELETE returnAddressOffset()
@@ -819,24 +813,18 @@ class YarrGenerator final : public YarrJITInfo {
         m_jit.loadPair32(parenContextGPR, MacroAssembler::TrustedImm32(ParenContext::beginOffset()), beginGPR, matchAmountGPR);
     }
 
-    void saveParenContext(MacroAssembler::RegisterID parenContextReg, MacroAssembler::RegisterID tempReg, unsigned firstSubpattern, unsigned lastSubpattern, unsigned subpatternBaseFrameLocation, bool clearCapturesAfterSave = true, bool useBeginIndexFromFrame = false)
+    void saveParenContext(MacroAssembler::RegisterID parenContextReg, MacroAssembler::RegisterID tempReg, unsigned firstSubpattern, unsigned lastSubpattern, unsigned subpatternBaseFrameLocation)
     {
         BitVector duplicateNamedCaptureGroups;
         bool hasNamedCaptures = m_pattern.hasDuplicateNamedCaptureGroups();
 
-        // For FixedCount saved at END, use frame.beginIndex (iteration start) instead of m_regs.index (current position).
-        // This is needed because content's backtrack expects beginIndex to be the iteration start.
-        // Also we store m_regs.index to endOffset so we save both begin and end.
-        if (useBeginIndexFromFrame) {
-            loadFromFrame(subpatternBaseFrameLocation + BackTrackInfoParentheses::beginIndex(), tempReg);
-            m_jit.store32(tempReg, MacroAssembler::Address(parenContextReg, ParenContext::beginOffset()));
-            loadFromFrame(subpatternBaseFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), tempReg);
-            m_jit.store32(tempReg, MacroAssembler::Address(parenContextReg, ParenContext::matchAmountOffset()));
-            m_jit.store32(m_regs.index, MacroAssembler::Address(parenContextReg, ParenContext::endOffset()));
-        } else {
-            loadFromFrame(subpatternBaseFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), tempReg);
-            storeBeginAndMatchAmountToParenContext(m_regs.index, tempReg, parenContextReg);
-        }
+        // Save-at-BEGIN: snapshot the machine state as it is before this iteration
+        // runs (current index as the iteration's begin, plus the current match count),
+        // so that on backtrack we can restore it and either accept fewer iterations or
+        // re-drive an earlier iteration's content. Used uniformly for FixedCount,
+        // Greedy and NonGreedy (FixedCount is simply min == max).
+        loadFromFrame(subpatternBaseFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), tempReg);
+        storeBeginAndMatchAmountToParenContext(m_regs.index, tempReg, parenContextReg);
         loadFromFrame(subpatternBaseFrameLocation + BackTrackInfoParentheses::returnAddressIndex(), tempReg);
         m_jit.storePtr(tempReg, MacroAssembler::Address(parenContextReg, ParenContext::returnAddressOffset()));
         if (shouldRecordSubpatterns()) {
@@ -848,16 +836,14 @@ class YarrGenerator final : public YarrJITInfo {
                     if (duplicateNamedGroup)
                         duplicateNamedCaptureGroups.set(duplicateNamedGroup);
                 }
-                // For Greedy/NonGreedy, clear captures after saving at BEGIN (before iteration runs).
-                // For FixedCount, we save at END and should NOT clear (iteration already set them).
-                if (clearCapturesAfterSave)
-                    clearSubpattern(subpattern);
+                // Clear captures after saving, so each iteration starts with the nested
+                // capture groups reset to undefined (ECMAScript spec requirement).
+                clearSubpattern(subpattern);
             }
             for (unsigned duplicateNamedGroupId : duplicateNamedCaptureGroups) {
                 loadDuplicateNamedGroupSubpatternId(duplicateNamedGroupId, tempReg);
                 m_jit.store32(tempReg, MacroAssembler::Address(parenContextReg, ParenContext::duplicateNamedCaptureOffset(m_parenContextSizes, duplicateNamedGroupId)));
-                if (clearCapturesAfterSave)
-                    storeDuplicateNamedGroupSubpatternId(duplicateNamedGroupId, 0);
+                storeDuplicateNamedGroupSubpatternId(duplicateNamedGroupId, 0);
             }
         }
         subpatternBaseFrameLocation += YarrStackSpaceForBackTrackInfoParentheses;
@@ -1803,8 +1789,9 @@ class YarrGenerator final : public YarrJITInfo {
         // Shared UTF-16 lead surrogate across all repeated alternatives' first character.
         std::optional<char16_t> m_bodyAltSharedLead;
 
-        // For single-alt FixedCount with backtrackable content: label for content's backtrack entry.
-        // BEGIN.bt jumps here for within-iteration backtracking.
+        // For quantified parentheses (FixedCount/Greedy/NonGreedy): label for the
+        // content's backtrack entry. BEGIN.bt jumps here to re-drive an iteration's
+        // content (within-iteration / inter-iteration backtracking).
         MacroAssembler::Label m_contentBacktrackEntryLabel;
     };
 
@@ -1929,11 +1916,6 @@ class YarrGenerator final : public YarrJITInfo {
         BacktrackRecords& NODELETE backtrackRecords()
         {
             return m_backtrackRecords;
-        }
-
-        void recordReturnAddress(MacroAssembler::DataLabelPtr dataLabel, MacroAssembler::Label backtrackLocation)
-        {
-            m_backtrackRecords.append(ReturnAddressRecord(dataLabel, backtrackLocation));
         }
 
         static void linkBacktrackRecords(LinkBuffer& linkBuffer, const BacktrackRecords& backtrackRecords)
@@ -3955,15 +3937,6 @@ class YarrGenerator final : public YarrJITInfo {
                     termMatchTargets.last() = alternative->m_isLastAlternative ? MatchTargets(MatchTargets::PreferredTarget::MatchSuccessFallThrough) : MatchTargets(endOp->m_jumps, op.m_jumps, MatchTargets::PreferredTarget::MatchFailFallThrough);
                 }
 
-                // For FixedCount with multiple alternatives and quantityMaxCount > 1, store a return address
-                // that will be patched later in BEGIN.bt to point to the correct target.
-                // For quantityMaxCount == 1 (ParenthesesSubpatternOnce), we use the normal returnAddress approach.
-                bool isFixedCountMultiAlt = term->quantityType == QuantifierType::FixedCount && term->quantityMaxCount > 1;
-                if (op.m_op == YarrOpCode::NestedAlternativeBegin && isFixedCountMultiAlt) {
-                    unsigned parenthesesFrameLocation = term->frameLocation;
-                    op.m_returnAddress = storeToFrameWithPatch(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
-                }
-
                 // Calculate how much input we need to check for, and if non-zero check.
                 op.m_checkAdjust = Checked<unsigned>(alternative->m_minimumSize);
                 if ((term->quantityType == QuantifierType::FixedCount) && (term->quantityMaxCount == 1) && (term->type != PatternTerm::Type::ParentheticalAssertion))
@@ -3990,10 +3963,7 @@ class YarrGenerator final : public YarrJITInfo {
                     termMatchTargets.last() = alternative->m_isLastAlternative ? MatchTargets(MatchTargets::PreferredTarget::MatchSuccessFallThrough) : MatchTargets(endOp->m_jumps, op.m_jumps, MatchTargets::PreferredTarget::MatchFailFallThrough);
 
                 // In the non-simple case, store a 'return address' so we can backtrack correctly.
-                // For FixedCount with quantityMaxCount > 1, we DON'T store here - we store the return address AFTER m_reentry.
-                // For quantityMaxCount == 1 (ParenthesesSubpatternOnce), we still use the returnAddress approach.
-                bool isFixedCountMultiAlt = term->quantityType == QuantifierType::FixedCount && term->quantityMaxCount > 1;
-                if (op.m_op == YarrOpCode::NestedAlternativeNext && !isFixedCountMultiAlt) {
+                if (op.m_op == YarrOpCode::NestedAlternativeNext) {
                     unsigned parenthesesFrameLocation = term->frameLocation;
                     op.m_returnAddress = storeToFrameWithPatch(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
                 }
@@ -4020,14 +3990,6 @@ class YarrGenerator final : public YarrJITInfo {
 
                 // This is the entry point for the next alternative.
                 defineReentryLabel(op);
-
-                // For FixedCount with quantityMaxCount > 1, store a return address AFTER m_reentry, so that when we
-                // jump here for inter-iteration backtracking, the address gets stored correctly.
-                // The address will be patched in BEGIN.bt to point to the correct target.
-                if (op.m_op == YarrOpCode::NestedAlternativeNext && isFixedCountMultiAlt) {
-                    unsigned parenthesesFrameLocation = term->frameLocation;
-                    op.m_returnAddress = storeToFrameWithPatch(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
-                }
 
                 // Calculate how much input we need to check for, and if non-zero check.
                 op.m_checkAdjust = alternative->m_minimumSize;
@@ -4056,12 +4018,7 @@ class YarrGenerator final : public YarrJITInfo {
                 PatternTerm* term = op.m_term;
 
                 // In the non-simple case, store a 'return address' so we can backtrack correctly.
-                // For FixedCount with quantityMaxCount > 1, we DON'T store here - we preserve the returnAddress from
-                // NestedAlternativeNext (or the null marker from NestedAlternativeBegin).
-                // This is crucial for inter-iteration backtracking.
-                // For quantityMaxCount == 1 (ParenthesesSubpatternOnce), we use the normal returnAddress approach.
-                bool isFixedCountMultiAlt = term->quantityType == QuantifierType::FixedCount && term->quantityMaxCount > 1;
-                if (op.m_op == YarrOpCode::NestedAlternativeEnd && !isFixedCountMultiAlt) {
+                if (op.m_op == YarrOpCode::NestedAlternativeEnd) {
                     unsigned parenthesesFrameLocation = term->frameLocation;
                     op.m_returnAddress = storeToFrameWithPatch(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
                 }
@@ -4290,8 +4247,27 @@ class YarrGenerator final : public YarrJITInfo {
 
             // YarrOpCode::ParenthesesSubpatternBegin/End
             //
-            // These nodes support capturing subpatterns and non-capturing subpatterns that
-            // require ParenContext for inter-iteration state management.
+            // These nodes handle capturing subpatterns and non-capturing subpatterns
+            // that need ParenContext for inter-iteration state management. All three
+            // quantifier types (FixedCount, Greedy, NonGreedy) share one model:
+            //
+            //   - matchAmount counts the ParenContexts currently on the stack, exactly
+            //     like the interpreter (++ on push, -- on pop; see
+            //     append/popParenthesesDisjunctionContext in YarrInterpreter.cpp).
+            //   - BEGIN.forward pushes a ParenContext snapshotting the pre-iteration
+            //     state (save-at-BEGIN), increments matchAmount, and clears nested
+            //     captures for the new iteration.
+            //   - END.forward decides whether to loop back for another iteration. It
+            //     does NOT touch matchAmount (the push already counted this iteration).
+            //   - On backtrack, BEGIN.bt pops the most recent iteration's context; the
+            //     pop's decrement is performed by restoreParenContext (which restores
+            //     the pre-push count saved in the popped context). It then either accepts
+            //     fewer iterations (Greedy) or re-drives an earlier iteration's content
+            //     (FixedCount / below-min). Re-driving passes through no increment, so
+            //     the count stays correct without any compensating arithmetic.
+            //
+            // FixedCount is just the case where min == max == N: it loops to exactly N
+            // and never accepts fewer, so it always re-drives earlier content on backtrack.
             case YarrOpCode::ParenthesesSubpatternBegin: {
                 termMatchTargets.append(MatchTargets());
 
@@ -4302,37 +4278,12 @@ class YarrGenerator final : public YarrJITInfo {
                 storeToFrame(MacroAssembler::TrustedImm32(0), parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
                 storeToFrame(MacroAssembler::TrustedImmPtr(nullptr), parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
 
-                // Quantifier-specific setup:
-                //
-                // Greedy: Store beginIndex for empty match detection. We try to match as many
-                //   iterations as possible, then backtrack to try fewer if needed.
-                //
-                // NonGreedy: With min == 0, initially skip the subpattern (set beginIndex = -1
-                //   and jump to end); on backtrack, we'll re-enter here to try matching the
-                //   subpattern. With min > 0, fall through to run min mandatory iterations
-                //   first, then lazily stop (END.forward enforces the mandatory-loop part).
-                //
-                // FixedCount: Must match exactly N times. Mark the new ParenContext as "incomplete"
-                //   (matchAmount = -1) so BEGIN.bt can skip failed iterations during backtracking.
-                //   Clear captures at start of each iteration (ECMAScript spec requirement).
-                //
-                // FIXME: for capturing parens, could use the index in the capture array?
-                switch (term->quantityType) {
-                case QuantifierType::NonGreedy: {
-                    if (!term->quantityMinCount) {
-                        storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
-                        op.m_jumps.append(m_jit.jump());
-                    }
-                    break;
-                }
-                case QuantifierType::Greedy: {
-                    break;
-                }
-                case QuantifierType::FixedCount: {
-                    // Example: (?:abc){3,3}, (?:x){5,5}, (x){5,5}
-                    // The semantics are: match exactly N times. Any failure = total failure.
-                    break;
-                }
+                // NonGreedy with min == 0: initially skip the subpattern (set beginIndex = -1
+                // and jump to end); on backtrack we re-enter here to try matching it. With
+                // min > 0 we fall through to run the mandatory iterations first.
+                if (term->quantityType == QuantifierType::NonGreedy && !term->quantityMinCount) {
+                    storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
+                    op.m_jumps.append(m_jit.jump());
                 }
 
                 defineReentryLabel(op);
@@ -4344,22 +4295,19 @@ class YarrGenerator final : public YarrJITInfo {
                 m_jit.storePtr(currParenContextReg, MacroAssembler::Address(newParenContextReg, ParenContext::nextOffset()));
                 storeToFrame(newParenContextReg, parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
 
-                // For Greedy/NonGreedy, save at BEGIN (they need pre-iteration state for "accept fewer" backtracking).
-                // For FixedCount, save at END (they need post-iteration state for inter-iteration backtracking).
-                if (term->quantityType != QuantifierType::FixedCount)
-                    saveParenContext(newParenContextReg, m_regs.regT2, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation);
-                else {
-                    // Mark the context as "incomplete" with matchAmount = -1.
-                    // This marker is used by BEGIN.bt to detect contexts for failed iterations.
-                    // We store this for ALL FixedCount patterns (single-alt and multi-alt) so that
-                    // BEGIN.bt can skip incomplete contexts.
-                    m_jit.store32(MacroAssembler::TrustedImm32(-1), MacroAssembler::Address(newParenContextReg, ParenContext::matchAmountOffset()));
+                // Save the pre-iteration state (save-at-BEGIN) and clear nested captures
+                // so this iteration starts fresh.
+                saveParenContext(newParenContextReg, m_regs.regT2, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation);
 
-                    // Clear captures at BEGIN (before iteration runs) so each iteration starts fresh.
-                    if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
-                        for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
-                            clearSubpattern(subpattern);
-                    }
+                // This iteration's context is now on the stack: bump matchAmount. The
+                // save above captured the pre-increment count, so the popped context
+                // restores exactly this value on backtrack. (The NonGreedy min==0 skip
+                // path jumps over this push, leaving matchAmount == 0.)
+                {
+                    const MacroAssembler::RegisterID countTemporary = m_regs.regT2;
+                    loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), countTemporary);
+                    m_jit.add32(MacroAssembler::TrustedImm32(1), countTemporary);
+                    storeToFrame(countTemporary, parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
                 }
 
                 storeToFrame(m_regs.index, parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
@@ -4398,10 +4346,11 @@ class YarrGenerator final : public YarrJITInfo {
                 if (!term->parentheses.disjunction->m_minimumSize)
                     m_abortExecution.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, frameAddress().withOffset(parenthesesFrameLocation * sizeof(void*))));
 
+                // matchAmount was already incremented at this iteration's BEGIN (on
+                // push), so after iteration k it equals k. We only need to read it here
+                // for the loop-back comparison below.
                 const MacroAssembler::RegisterID countTemporary = m_regs.regT1;
                 loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), countTemporary);
-                m_jit.add32(MacroAssembler::TrustedImm32(1), countTemporary);
-                storeToFrame(countTemporary, parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
 
                 // If the parenthese are capturing, store the ending index value to the
                 // captures array, offsetting as necessary.
@@ -4426,9 +4375,12 @@ class YarrGenerator final : public YarrJITInfo {
                 }
 
                 switch (term->quantityType) {
+                case QuantifierType::FixedCount:
                 case QuantifierType::Greedy: {
-                    // If the parentheses are quantified Greedy then add a label to jump back
-                    // to if we get a failed match from after the parentheses.
+                    // FixedCount and Greedy both loop back while we are still below the
+                    // maximum iteration count (FixedCount has max == N, so it stops at
+                    // exactly N; Greedy with an infinite max always loops back). If we get
+                    // a failed match from after the parentheses we re-enter at this label.
                     if (term->quantityMaxCount != quantifyInfinite)
                         m_jit.branch32(MacroAssembler::Below, countTemporary, MacroAssembler::Imm32(term->quantityMaxCount)).linkTo(beginOp.m_reentry, &m_jit);
                     else
@@ -4444,32 +4396,6 @@ class YarrGenerator final : public YarrJITInfo {
                     if (term->quantityMinCount)
                         m_jit.branch32(MacroAssembler::Below, countTemporary, MacroAssembler::Imm32(term->quantityMinCount)).linkTo(beginOp.m_reentry, &m_jit);
                     beginOp.m_jumps.link(&m_jit);
-                    defineReentryLabel(op);
-                    break;
-                }
-                case QuantifierType::FixedCount: {
-                    // For FixedCount, save ParenContext at END (after iteration completes).
-                    // This captures the post-iteration state needed for "retry differently" backtracking.
-                    // Don't clear captures after saving - we want to keep the final capture values.
-
-                    // For FixedCount with multiple alternatives (NestedAlternative), we DON'T store
-                    // returnAddress here. NestedAlternativeEnd already stored its returnAddress,
-                    // and saveParenContext will capture that. This allows backtracking to jump to
-                    // NestedAlternativeEnd's backtrack entry to retry alternatives.
-                    // For FixedCount without alternatives (SimpleNestedAlternative), we store
-                    // returnAddress here for backtracking to return to.
-                    bool hasMultipleAlternatives = term->parentheses.disjunction->m_alternatives.size() != 1;
-                    if (!hasMultipleAlternatives)
-                        op.m_returnAddress = storeToFrameWithPatch(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
-
-                    const MacroAssembler::RegisterID parenContextReg = m_regs.regT0;
-                    loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex(), parenContextReg);
-                    saveParenContext(parenContextReg, m_regs.regT2, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation, false, true);
-
-                    // If we haven't matched enough times yet, loop back.
-                    // If not, we've matched the required number of times, continue to next opcode.
-                    // Set the reentry point for backtracking to propagate failure upward.
-                    m_jit.branch32(MacroAssembler::Below, countTemporary, MacroAssembler::Imm32(term->quantityMaxCount)).linkTo(beginOp.m_reentry, &m_jit);
                     defineReentryLabel(op);
                     break;
                 }
@@ -4840,12 +4766,6 @@ class YarrGenerator final : public YarrJITInfo {
                 // If the alternative had adjusted the input position we must link
                 // backtracking to here, correct, and then jump on. If not we can
                 // link the backtracks directly to their destination.
-                // For FixedCount multi-alt, when jumping to next alternative during inter-iteration
-                // backtracking, we need to restore the index to beginIndex (iteration start position).
-                // This is because ParenthesesSubpatternBegin.bt loads endIndex for content backtracking,
-                // but trying a different alternative requires the start position.
-                bool isFixedCountMultiAlt = op.m_term->quantityType == QuantifierType::FixedCount && op.m_term->quantityMaxCount > 1;
-
                 if (op.m_checkAdjust) {
                     if (!m_backtrackingState.isEmpty()) {
                         // Handle the cases where we need to link the backtracks here.
@@ -4853,11 +4773,6 @@ class YarrGenerator final : public YarrJITInfo {
                         m_jit.sub32(MacroAssembler::Imm32(op.m_checkAdjust), m_regs.index);
                         if (!isLastAlternative) {
                             // An alternative that is not the last should jump to its successor.
-                            if (isFixedCountMultiAlt) {
-                                // Restore index to iteration start for trying next alternative.
-                                unsigned parenthesesFrameLocation = op.m_term->frameLocation;
-                                loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex(), m_regs.index);
-                            }
                             m_jit.jump(nextOp.m_reentry);
                         } else if (!isBegin) {
                             // The last of more than one alternatives must jump back to the beginning.
@@ -4871,15 +4786,7 @@ class YarrGenerator final : public YarrJITInfo {
                     // Handle the cases where we can link the backtracks directly to their destinations.
                     if (!isLastAlternative) {
                         // An alternative that is not the last should jump to its successor.
-                        if (isFixedCountMultiAlt) {
-                            // For FixedCount multi-alt, we need to restore index before jumping.
-                            // Can't use linkTo directly since we need to emit code first.
-                            m_backtrackingState.link(*this, op);
-                            unsigned parenthesesFrameLocation = op.m_term->frameLocation;
-                            loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex(), m_regs.index);
-                            m_jit.jump(nextOp.m_reentry);
-                        } else
-                            m_backtrackingState.linkTo(nextOp.m_reentry, &m_jit);
+                        m_backtrackingState.linkTo(nextOp.m_reentry, &m_jit);
                     } else if (!isBegin) {
                         // The last of more than one alternatives must jump back to the beginning.
                         m_backtrackingState.takeBacktracksToJumpList(nextOp.m_jumps, &m_jit);
@@ -4896,8 +4803,7 @@ class YarrGenerator final : public YarrJITInfo {
 
                 // For non-simple alternatives, link the alternative's 'return address'
                 // so that we backtrack back out into the previous alternative.
-                // For FixedCount with quantityMaxCount > 1, we use a different approach: direct address jumping for inter-iteration backtracking.
-                if (op.m_op == YarrOpCode::NestedAlternativeNext && !isFixedCountMultiAlt)
+                if (op.m_op == YarrOpCode::NestedAlternativeNext)
                     m_backtrackingState.append(op.m_returnAddress);
 
                 // If there is more than one alternative, then the last alternative will
@@ -4931,18 +4837,14 @@ class YarrGenerator final : public YarrJITInfo {
                 if (op.m_op == YarrOpCode::NestedAlternativeEnd) {
                     m_backtrackingState.link(*this, op);
 
-                    // Jump to the return address stored by whichever alternative was taken.
-                    // For FixedCount multi-alt: returnAddress was stored by NestedAlternativeBegin/Next
-                    // For others: returnAddress was stored by NestedAlternativeEnd itself
+                    // Jump to the return address stored by whichever alternative was taken
+                    // (stored during forward generation by NestedAlternativeNext/End, and
+                    // carried across iterations via the ParenContext save/restore).
                     unsigned parenthesesFrameLocation = term->frameLocation;
                     loadFromFrameAndJump(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
 
                     // Link the DataLabelPtr associated with the end of the last alternative to this point.
-                    // For FixedCount multi-alt, op.m_returnAddress is not set (we preserve the one from Begin/Next),
-                    // so we skip this. For others, we need to link it for proper backtracking.
-                    bool isFixedCountMultiAlt = term->quantityType == QuantifierType::FixedCount && term->quantityMaxCount > 1;
-                    if (!isFixedCountMultiAlt)
-                        m_backtrackingState.append(op.m_returnAddress);
+                    m_backtrackingState.append(op.m_returnAddress);
                 }
                 op.m_contentBacktrackEntryLabel = m_jit.label();
                 break;
@@ -5105,14 +5007,18 @@ class YarrGenerator final : public YarrJITInfo {
             // ParenContext for inter-iteration backtracking (FixedCount with backtrackable
             // content, multi-alt FixedCount, or Greedy/NonGreedy quantifiers).
             //
-            // Greedy/NonGreedy:
-            //   - Save state at BEGIN (pre-iteration) for "accept fewer iterations" backtracking
-            //   - On backtrack: restore state and try with fewer iterations
+            // In all quantifiers, we always save the state at BEGIN (save-at-BEGIN model).
+            // Each iteration's pre-iteration state is snapshotted into a ParenContext that
+            // is pushed at BEGIN.fwd and popped at BEGIN.bt. matchAmount counts the
+            // ParenContexts currently on the stack: it is incremented once on push at
+            // BEGIN.forward, and the matching decrement happens on pop at BEGIN.bt (performed
+            // by restoreParenContext, which restores the popped context's saved pre-push
+            // count). END.forward does not touch it.
             //
-            // FixedCount (capturing or with backtrackable content):
-            //   - Save state at END (post-iteration) for "retry differently" backtracking
-            //   - On backtrack: restore state and try different match within iteration
-            //   - Uses "incomplete" marker (matchAmount=-1) to skip contexts from failed iterations
+            // On backtrack we restore the popped context and either
+            //     1. accept fewer iterations (Greedy at/above min) or,
+            //     2. re-drive the previous iteration's content (FixedCount / below min / NonGreedy).
+            // FixedCount is simply min == max == N.
 
             case YarrOpCode::ParenthesesSubpatternBegin: {
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
@@ -5125,183 +5031,18 @@ class YarrGenerator final : public YarrJITInfo {
 
                 loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex(), currParenContextReg);
 
-                // For FixedCount, we need to handle inter-iteration backtracking.
-                // Check if the current ParenContext is "incomplete" (iteration failed before END).
-                // An incomplete context has matchAmount == -1 (marker stored at BEGIN).
-                // If incomplete, skip it and try the previous iteration's context.
-                // If complete, restore from it and retry the iteration's content.
-                if (term->quantityType == QuantifierType::FixedCount) {
-                    // First, skip any incomplete contexts (failed iterations that never reached END).
-                    // Incomplete contexts have matchAmount == -1 stored at BEGIN.
-
-                    MacroAssembler::Label checkContext = m_jit.label();
-
-                    // If no context, propagate failure
-                    MacroAssembler::Jump noContext = m_jit.branchTestPtr(MacroAssembler::Zero, currParenContextReg);
-
-                    // Check if this context is incomplete (matchAmount == -1 in ParenContext)
-                    MacroAssembler::Jump isComplete = m_jit.branch32(MacroAssembler::NotEqual,
-                        MacroAssembler::Address(currParenContextReg, ParenContext::matchAmountOffset()),
-                        MacroAssembler::TrustedImm32(-1));
-
-                    // Incomplete context: free it and advance to the next one.
-                    //
-                    // With the END.bt mark in ParenthesesSubpatternEnd.bt propagating up
-                    // through every enclosing FixedCount layer, any outer ParenContext
-                    // whose saved frame contains a pointer to this ctx is itself in one
-                    // of two states:
-                    //   (a) Already marked incomplete by its own END.bt, so outer Begin.bt
-                    //       will skip it (and free it here in turn), never reading the
-                    //       stale pointer.
-                    //   (b) About to be overwritten by outer END.forward's saveParenContext
-                    //       once its own content backtrack succeeds, replacing the stale
-                    //       pointer with the current post-retry state.
-                    // In neither case is the stale pointer read. Freeing is therefore safe,
-                    // and required to keep FixedCount{N} bounded at N ParenContext
-                    // allocations across arbitrary backtracking.
-                    m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), newParenContextReg);
-                    freeParenContext(currParenContextReg);
-                    m_jit.move(newParenContextReg, currParenContextReg);
-                    storeToFrame(currParenContextReg, parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
-                    m_jit.jump(checkContext);
-
-                    // Complete context found - restore from it
-                    isComplete.link(&m_jit);
-
-                    // Restore state from ParenContext (captures, frame slots).
-                    restoreParenContext(currParenContextReg, m_regs.regT2, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation);
-
-                    // FixedCount backtracking:
-                    //
-                    // We use a conservative approach that always treats content as backtrackable.
-                    // This simplifies the code while handling all cases correctly:
-                    //
-                    // Single-alternative:
-                    //   Example: /(a+){2}b/ matching "aaab"
-                    //   Restore iter1's END state (endIndex), jump to content's backtrack entry.
-                    //   If content backtrack succeeds, continue forward to END.
-                    //   If content backtrack exhausts options, try previous iteration.
-                    //
-                    // Multi-alternative:
-                    //   Example: /(a+|b+){2}c/ matching "aabbc"
-                    //   Uses returnAddress to jump to current alternative's content backtrack.
-                    //   If that exhausts, tries next alternative (via NestedAlternative chain).
-                    //   If all alternatives exhausted, tries previous iteration's context.
-
-                    bool hasMultipleAlternatives = term->parentheses.disjunction->m_alternatives.size() != 1;
-                    if (!hasMultipleAlternatives) {
-                        // Single-alternative FixedCount
-                        // Example: /(a+){2}b/ - need to backtrack into (a+) to try fewer 'a's
-                        //
-                        // We always treat this as having backtrackable content (conservative approach).
-                        // This simplifies the code and avoids special-casing.
-
-                        // Load the END position from the context. Content's backtrack expects
-                        // index at where the iteration ended.
-                        m_jit.load32(MacroAssembler::Address(currParenContextReg, ParenContext::endOffset()), m_regs.index);
-
-                        // Reuse this context in-place for the retry: mark it incomplete.
-                        // If content-backtrack succeeds, END.forward's saveParenContext
-                        // overwrites the marker. If it fails, next Begin.bt skips it.
-                        // Not freeing keeps outer layers' chain snapshots valid.
-                        m_jit.store32(MacroAssembler::TrustedImm32(-1), MacroAssembler::Address(currParenContextReg, ParenContext::matchAmountOffset()));
-
-                        // Decrement matchAmount (we're retrying the previous iteration)
-                        const MacroAssembler::RegisterID countTemporary = m_regs.regT2;
-                        loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), countTemporary);
-                        m_jit.sub32(MacroAssembler::TrustedImm32(1), countTemporary);
-                        storeToFrame(countTemporary, parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
-
-                        // Jump to content's backtrack entry point.
-                        // We can't use fallthrough() here because backtrack generation runs in
-                        // reverse order, so content's backtrack code was already generated.
-                        // If content backtrack succeeds, execution continues forward to END.
-                        // If content backtrack fails, it falls through to try previous iteration.
-                        YarrOp& endOp = m_ops[op.m_nextOp];
-                        ASSERT(endOp.m_op == YarrOpCode::ParenthesesSubpatternEnd);
-                        ASSERT(endOp.m_contentBacktrackEntryLabel.isSet());
-                        m_jit.jump(endOp.m_contentBacktrackEntryLabel);
-                    } else {
-                        // Multi-alternative FixedCount
-                        //
-                        // Multi-alt uses address-based jumping: each alternative stores a returnAddress
-                        // that points to the current alternative's content backtrack entry.
-                        // We always treat this as having backtrackable content (conservative approach).
-                        //
-                        // Example: /(a+|b+){2}c/ matching "aabc"
-                        //
-                        // Forward execution:
-                        //   iter1: (a+) greedily matches "aa", stores returnAddress -> (a+).bt
-                        //   iter2: (a+) tries but fails (only "bc"), tries (b+) matches "b"
-                        //   "c" matches -> success
-                        //
-                        // If something after fails and we backtrack here:
-                        //   1. Restore iter1's END state (index where iteration ended)
-                        //   2. Jump to stored returnAddress (current alt's content backtrack)
-                        //   3. (a+) backtracks: "aa" -> "a"
-                        //   4. If succeeds, continue forward to END
-                        //   5. If (a+) exhausts, falls through to try next alt (b+) at iter1's BEGIN
-                        //   6. If all alts exhausted at iter1, try iter0's context (previous iteration)
-                        //
-                        // returnAddress patching (at link time):
-                        //   Begin.returnAddress -> Next[0].m_contentBacktrackEntryLabel
-                        //   Next[i].returnAddress -> Next[i+1].m_contentBacktrackEntryLabel
-                        //   Last Next.returnAddress -> End.m_contentBacktrackEntryLabel
-
-                        // NestedAlternativeBegin is always at opIndex + 1
-                        size_t beginOpIndex = opIndex + 1;
-                        ASSERT(m_ops[beginOpIndex].m_op == YarrOpCode::NestedAlternativeBegin || m_ops[beginOpIndex].m_op == YarrOpCode::SimpleNestedAlternativeBegin);
-
-                        // Restore endIndex for content backtracking (where the iteration ended)
-                        m_jit.load32(MacroAssembler::Address(currParenContextReg, ParenContext::endOffset()), m_regs.index);
-
-                        // Reuse this context in-place for the retry (see single-alt path above).
-                        m_jit.store32(MacroAssembler::TrustedImm32(-1), MacroAssembler::Address(currParenContextReg, ParenContext::matchAmountOffset()));
-
-                        // Decrement matchAmount (we're retrying the previous iteration)
-                        const MacroAssembler::RegisterID countTemporary = m_regs.regT2;
-                        loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), countTemporary);
-                        m_jit.sub32(MacroAssembler::TrustedImm32(1), countTemporary);
-                        storeToFrame(countTemporary, parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
-
-                        // Jump to the stored address (content backtrack entry of current alternative)
-                        loadFromFrameAndJump(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
-
-                        // Record return addresses to be patched at link time
-                        // Chain: Begin -> Next[0] -> Next[1] -> ... -> End
-                        // Each points to the NEXT alternative's content backtrack entry
-                        YarrOp* prevOp = &m_ops[beginOpIndex];
-                        size_t altOpIndex = prevOp->m_nextOp;
-                        while (altOpIndex != notFound) {
-                            YarrOp& altOp = m_ops[altOpIndex];
-                            if (altOp.m_op == YarrOpCode::NestedAlternativeNext) {
-                                ASSERT(altOp.m_contentBacktrackEntryLabel.isSet());
-                                m_backtrackingState.recordReturnAddress(prevOp->m_returnAddress, altOp.m_contentBacktrackEntryLabel);
-                                prevOp = &altOp;
-                            } else if (altOp.m_op == YarrOpCode::NestedAlternativeEnd) {
-                                // Last alternative's returnAddress points to End's content backtrack
-                                // When End's content backtrack fails, it tries previous iteration
-                                ASSERT(altOp.m_contentBacktrackEntryLabel.isSet());
-                                m_backtrackingState.recordReturnAddress(prevOp->m_returnAddress, altOp.m_contentBacktrackEntryLabel);
-                                break;
-                            }
-                            altOpIndex = altOp.m_nextOp;
-                        }
-                    }
-
-                    // No context available - propagate failure
-                    noContext.link(&m_jit);
-                    if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
-                        for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
-                            clearSubpattern(subpattern);
-                    }
-                    storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
-                    m_backtrackingState.fallthrough();
-                    break;
-                }
-
-                // Greedy/NonGreedy path: pop the latest iteration's context and decide
-                // how to continue backtracking based on the quantifier direction.
+                // Pop the most recent iteration's context and decide how to continue
+                // backtracking based on the quantifier direction. This is the single,
+                // unified flow for FixedCount, Greedy and NonGreedy:
+                //   - restoreParenContext brings back the pre-iteration state: it leaves
+                //     m_regs.index at the end of the previous iteration AND restores
+                //     matchAmount to the popped context's saved (pre-push) value. That
+                //     restore IS the pop's decrement — the count now equals the number of
+                //     contexts still on the stack. No explicit decrement is needed.
+                //   - We then free the popped context and either accept fewer iterations
+                //     (Greedy at/above min) or re-drive the now-topmost iteration's content
+                //     (FixedCount / below min / NonGreedy). FixedCount has min == max, so
+                //     it never accepts fewer.
                 restoreParenContext(currParenContextReg, m_regs.regT2, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation);
 
                 m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), newParenContextReg);
@@ -5316,9 +5057,6 @@ class YarrGenerator final : public YarrJITInfo {
                 auto noPreviousIteration = m_jit.branchTest32(MacroAssembler::Zero, countTemporary);
                 m_jit.load32(MacroAssembler::Address(newParenContextReg, ParenContext::beginOffset()), m_regs.regT2);
                 storeToFrame(m_regs.regT2, parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
-
-                m_jit.sub32(MacroAssembler::TrustedImm32(1), countTemporary);
-                storeToFrame(countTemporary, parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
 
                 switch (term->quantityType) {
                 case QuantifierType::NonGreedy: {
@@ -5342,17 +5080,22 @@ class YarrGenerator final : public YarrJITInfo {
                     break;
                 }
 
+                case QuantifierType::FixedCount:
                 case QuantifierType::Greedy: {
-                    // Greedy: we took as many iterations as possible, so backtracking reduces
-                    // the count. We can accept fewer iterations only if count >= min: the next
-                    // bt step's restore would land us at "count actual iterations" worth
-                    // of position (since restoreParenContext gives state pre-iter (k+1) =
-                    // post-iter k where k = count).
+                    // Greedy: we took as many iterations as possible, so backtracking pops
+                    // the topmost one. countTemporary now holds the surviving count (the
+                    // number of contexts still on the stack after the pop). We can accept
+                    // fewer iterations when that surviving count is still >= min.
+                    //
+                    // FixedCount is min == max: the surviving count after a pop is always
+                    // < min, so the accept-fewer test below is never satisfied and it always
+                    // re-drives the previous iteration's content (jumping to the content
+                    // backtrack entry) — exactly the desired "match exactly N" behavior.
+                    // A count of 0 (no previous iteration) is a complete failure.
                     if (term->quantityMinCount) {
-                        // countTemporary was decremented above, so it now holds
-                        // (surviving count - 1). Accept fewer iterations when the surviving
-                        // count is still >= min, i.e. countTemporary >= min - 1.
-                        m_jit.branch32(MacroAssembler::AboveOrEqual, countTemporary, MacroAssembler::Imm32(term->quantityMinCount - 1)).linkTo(endOp.m_reentry, &m_jit);
+                        // Accept the surviving iterations when there are still at least min
+                        // of them; otherwise re-drive the previous iteration's content.
+                        m_jit.branch32(MacroAssembler::AboveOrEqual, countTemporary, MacroAssembler::Imm32(term->quantityMinCount)).linkTo(endOp.m_reentry, &m_jit);
 
                         // Jump to content backtrack entry. The earlier restoreParenContext already left m_regs.index at the end of iter k.
                         ASSERT(endOp.m_op == YarrOpCode::ParenthesesSubpatternEnd);
@@ -5384,11 +5127,6 @@ class YarrGenerator final : public YarrJITInfo {
 
                     storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
                     m_backtrackingState.fallthrough();
-                    break;
-                }
-
-                case QuantifierType::FixedCount: {
-                    RELEASE_ASSERT_NOT_REACHED();
                     break;
                 }
                 }
@@ -5443,25 +5181,10 @@ class YarrGenerator final : public YarrJITInfo {
                 }
                 case QuantifierType::FixedCount: {
                     // Backtracking into the End means something after the parentheses failed.
-                    // Mark the head context as incomplete (matchAmount = -1) so BEGIN.bt's
-                    // skip-incomplete loop discards it rather than restoring from it.
-                    //
-                    // The just-completed iteration's saved inner parenContextHead pointers
-                    // may reference ctxs that the upcoming content-backtrack cycle will
-                    // free (via inner Greedy/NonGreedy Begin.bt). If we restored this ctx,
-                    // those stale pointers would be written back to the frame. By marking
-                    // and skipping, BEGIN.bt advances to the previous iteration's ctx
-                    // whose saved pointers reference chains that are dangling-but-intact
-                    // (per-iteration inner chain isolation).
-                    //
-                    // If content backtrack succeeds, END.forward will re-save this ctx,
-                    // overwriting the -1 with a positive matchAmount (complete again).
-                    //
-                    // BEGIN.bt handles the context manipulation and decrementing matchAmount,
-                    // then jumps to m_contentBacktrackEntryLabel (set below after fallthrough).
-                    const MacroAssembler::RegisterID parenContextReg = m_regs.regT0;
-                    loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex(), parenContextReg);
-                    m_jit.store32(MacroAssembler::TrustedImm32(-1), MacroAssembler::Address(parenContextReg, ParenContext::matchAmountOffset()));
+                    // For FixedCount we just fall through to the content backtrack entry below
+                    // to re-drive the most recent iteration's content; if it exhausts, it
+                    // reaches BEGIN.bt which pops to the previous iteration. No special
+                    // per-context bookkeeping is needed in the unified save-at-BEGIN model.
                     break;
                 }
                 }


### PR DESCRIPTION
#### a92d79b27748d415391c3d35e3e1df41781e4534
<pre>
[YARR] Change FixedCount model from save-at-END to save-at-BEGIN
<a href="https://bugs.webkit.org/show_bug.cgi?id=316275">https://bugs.webkit.org/show_bug.cgi?id=316275</a>
<a href="https://rdar.apple.com/178684581">rdar://178684581</a>

Reviewed by Marcus Plutowski.

This patch improves YarrJIT FixedCount model from save-at-END (saving
the ParenContext at the end of parentheses) to save-at-BEGIN (saving the
snapshot of ParenContext at the begin of parentheses). We always save at
begin, and this is a snapshot of the complete previous iteration. If
match-amount is 0, then this means that we have never matched yet.
FixedCount was naturally fit with save-at-END model, but this makes
handling really complicated. Rather, we should always use save-at-BEGIN
model in all quantifiers so we can significantly simplify our handling
of FixedCount.

So let&apos;s summarize how it gets handled.

1. ParenthesesSubpatternsBegin.fwd

FixedCount handling is exactly the same to Greedy.
We save ParenContext at BEGIN, which is the snapshot of the previous iteration.
If this parentheses is entirely failed, then we load this snapshot and
do the previous iteration&apos;s backtracking.
Then we bump the current stack&apos;s matchAmount which indicates the current
iteration number. When it gets saved (at BEGIN), then that snapshot
captures how many iterations it succeeded before.

2. ParenthesesSubpatternsEnd.fwd

FixedCount handling is exactly the same to Greedy. We attempt to run
fixed count iterations, which is the same / similar to Greedy. If the
current iteration amount matches against quantityMaxCount, then we
stop iteration and go to the subsequent pattern. Otherwise, jumping back
to Begin&apos;s reentry to start the next iteration.

3. ParenthesesSubpatternsEnd.bt

If the subsequent pattern failed, we come to this. Greedy checks whether
it did any iteration before, and if it was completely skipped before,
then it jumps to the ParenthesesSubpatternsBegin.bt (and going to the
complete failure). On the other hand, FixedCount case means that we are
always running at least one iteration. So just fallthrough, and running
the content backtracking inside the parentheses.

4. ParenthesesSubpatternsBegin.bt

Coming here when the iteration completely failed and we need to roll
back the previous iteration and try to do content backtracking inside it.
FixedCount handling is exactly the same to Greedy again! We reload the
snapshot taken at ParenthesesSubpatternsBegin.fwd to continue backtracking
of the previous iteration. Since matchAmount of the previous iteration
was captured when it gets completed (and it is a bumped number in
ParenthesesSubpatternsBegin.fwd), we do not need to change matchAmount.
If the matchAmount is zero, then it means we exhaust all iterations, so
it is a complete failure. If the loaded matchAmount is enough compared
to min-count, then just go to the next subsequent pattern. Otherwise
jumping to the content backtracking site to continue backtracking in the
previous iteration.

Test: JSTests/stress/yarr-quantified-parentheses-unified-backtracking.js

* JSTests/stress/yarr-quantified-parentheses-unified-backtracking.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/314558@main">https://commits.webkit.org/314558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3647a92235d5b0000e81b6cfb2bd1da7df876ddd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123735 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/adf69d69-ce6a-4e1c-8692-3e9364801ac1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129427 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/090f1db9-fc51-4e45-8787-7bcf542203dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169439 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109952 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b35270e0-d90f-47a9-9f69-f6418471a703) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23668 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158637 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178061 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27374 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30962 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/28996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137780 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137699 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149087 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103446 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25335 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32996 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199159 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112313 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53457 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38635 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4041 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38880 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38778 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->