### PR TITLE
createVideoInfoFromAVCC() forms a span past the end of AVCC buffer for malformed input

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm
@@ -74,10 +74,10 @@ RefPtr<VideoInfo> createVideoInfoFromAVCC(std::span<const uint8_t> avcc)
         auto nalType = reader.read<uint8_t>();
         if (!nalType || (*nalType & 0x1f) != kSPSNAL)
             return nullptr;
-        paramSets.append({ avcc.subspan(reader.byteOffset() - 1, *size) });
-        paramSets.last()[0] &= ~kNAL_REF_IDC_SEQ_PARAM_SET;
         if (!reader.skipBytes(*size - kNALTypeSize))
             return nullptr;
+        paramSets.append({ avcc.subspan(reader.byteOffset() - *size, *size) });
+        paramSets.last()[0] &= ~kNAL_REF_IDC_SEQ_PARAM_SET;
     }
 
     // unsigned int(8) numOfPictureParameterSets;
@@ -91,10 +91,10 @@ RefPtr<VideoInfo> createVideoInfoFromAVCC(std::span<const uint8_t> avcc)
         auto nalType = reader.read<uint8_t>();
         if (!nalType || (*nalType & 0x1f) != kPPSNAL)
             return nullptr;
-        paramSets.append({ avcc.subspan(reader.byteOffset() - 1, *size) });
-        paramSets.last()[0] |= kNAL_REF_IDC_PIC_PARAM_SET;
         if (!reader.skipBytes(*size - kNALTypeSize))
             return nullptr;
+        paramSets.append({ avcc.subspan(reader.byteOffset() - *size, *size) });
+        paramSets.last()[0] |= kNAL_REF_IDC_PIC_PARAM_SET;
     }
 
     Vector<const uint8_t*> paramSetPtrs { paramSets.size(), [&paramSets](auto index) {

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -671,6 +671,7 @@
 				WebCore/cocoa/CoreMediaUtilities.mm,
 				WebCore/cocoa/DatabaseTrackerTest.mm,
 				WebCore/cocoa/GraphicsContextCGTests.mm,
+				WebCore/cocoa/H264UtilitiesCocoaTests.mm,
 				WebCore/cocoa/ImageRotationSessionVT.cpp,
 				WebCore/cocoa/IOSurfaceTests.mm,
 				WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/H264UtilitiesCocoaTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/H264UtilitiesCocoaTests.mm
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(COCOA)
+
+#import "Test.h"
+#import <WebCore/H264UtilitiesCocoa.h>
+#import <WebCore/TrackInfo.h>
+#import <array>
+
+namespace TestWebKitAPI {
+
+TEST(H264UtilitiesCocoa, MalformedAVCCWithTruncatedSPSDoesNotCrash)
+{
+    // The SPS size field claims 0xFFFF bytes, but only the 1-byte NAL header
+    // actually follows in the buffer. createVideoInfoFromAVCC must reject this
+    // before forming a span past the end of the input.
+    constexpr auto avcc = WTF::toArray<uint8_t>({
+        0x01,        // configurationVersion
+        0x42,        // AVCProfileIndication
+        0x00,        // profile_compatibility
+        0x1e,        // AVCLevelIndication
+        0xff,        // reserved (6) | lengthSizeMinusOne (2) = 3
+        0xe1,        // reserved (3) | numOfSequenceParameterSets (5) = 1
+        0xff, 0xff,  // SPS size = 65535 (attacker-chosen)
+        0x07,        // NAL type = SPS, with no payload bytes following
+    });
+    EXPECT_FALSE(!!WebCore::createVideoInfoFromAVCC(avcc));
+}
+
+TEST(H264UtilitiesCocoa, MalformedAVCCWithTruncatedPPSDoesNotCrash)
+{
+    // Same bug pattern as the SPS loop, but in the PPS loop. Provide one
+    // well-formed (empty) SPS, then a PPS whose size field overruns the buffer.
+    constexpr auto avcc = WTF::toArray<uint8_t>({
+        0x01,        // configurationVersion
+        0x42,        // AVCProfileIndication
+        0x00,        // profile_compatibility
+        0x1e,        // AVCLevelIndication
+        0xff,        // reserved | lengthSizeMinusOne = 3
+        0xe1,        // reserved | numOfSequenceParameterSets = 1
+        0x00, 0x01,  // SPS size = 1 (NAL header only)
+        0x07,        // SPS NAL type
+        0x01,        // numOfPictureParameterSets = 1
+        0xff, 0xff,  // PPS size = 65535 (attacker-chosen)
+        0x08,        // NAL type = PPS, with no payload bytes following
+    });
+    EXPECT_FALSE(!!WebCore::createVideoInfoFromAVCC(avcc));
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### c195e933ce50176cc8364190abe293b5a859836c
<pre>
createVideoInfoFromAVCC() forms a span past the end of AVCC buffer for malformed input
<a href="https://bugs.webkit.org/show_bug.cgi?id=316276">https://bugs.webkit.org/show_bug.cgi?id=316276</a>

Reviewed by Jean-Yves Avenard.

The SPS and PPS loops in createVideoInfoFromAVCC() each read a 16-bit
NAL unit size from the AVCC blob and then form a span over *size bytes
starting at the NAL header byte, before validating that *size bytes
actually remain in the buffer. The bounds check via BitReader::skipBytes()
happens immediately afterward and bails out, but the std::span::subspan()
call and the subsequent Vector&lt;uint8_t&gt; copy have already run by then.

For a 9-byte AVCC blob crafted so the SPS size field is 0xFFFF (only
the 1-byte NAL header actually follows), subspan(8, 65535) violates
the C++ precondition that Offset + Count &lt;= size().

This is not exploitable in shipping WebKit: builds enable hardened
libc++, so the precondition violation aborts the process at the
subspan() call before any out-of-bounds memory is touched. The
observable effect is a clean WebContent crash on malformed AVCC
embedded in a WebM container&apos;s codec_private. There is no information
leak and no memory corruption. Without libc++ hardening the same
construct would be undefined behavior and could read up to 64 KB
past the buffer during the Vector copy, but that configuration is
not shipped.

Move skipBytes() above the subspan() call in both the SPS and PPS
loops so the buffer is proven to contain *size bytes before we form
a span over them. Adjust the offset from byteOffset() - 1 to
byteOffset() - *size to account for skipBytes() now advancing the
reader past the entire NAL unit.

Test: TestWebKitAPI.H264UtilitiesCocoa.MalformedAVCCWithTruncatedSPSDoesNotCrash
      TestWebKitAPI.H264UtilitiesCocoa.MalformedAVCCWithTruncatedPPSDoesNotCrash

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm:
(WebCore::createVideoInfoFromAVCC):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/H264UtilitiesCocoaTests.mm: Added.
(TestWebKitAPI::TEST(H264UtilitiesCocoa, MalformedAVCCWithTruncatedSPSDoesNotCrash)):
(TestWebKitAPI::TEST(H264UtilitiesCocoa, MalformedAVCCWithTruncatedPPSDoesNotCrash)):

Canonical link: <a href="https://commits.webkit.org/314605@main">https://commits.webkit.org/314605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bac7538b20ea02445b8913890ec149d4d567756

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166602 "19 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175650 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74fd60eb-2ad5-4a22-b9d8-d8355d8d8d51) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40100 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/129532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169561 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/110057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fff7bc79-98f9-4d28-9107-c42e902e41a3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23791 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178184 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29101 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/137891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40162 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/137808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37128 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149192 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103587 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33098 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39361 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38757 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4147 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39002 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38900 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->