### PR TITLE
[Wasm] `Table` constructor should fill funcref tables when the default value is a wrapper function

### DIFF
--- a/JSTests/stress/wasm-table-constructor-wrapper-function-default.js
+++ b/JSTests/stress/wasm-table-constructor-wrapper-function-default.js
@@ -1,0 +1,100 @@
+// Regression test: new WebAssembly.Table({element: "funcref", initial: N}, value)
+// with a WebAssemblyWrapperFunction default value (a JS function imported into
+// wasm and re-exported) passed the constructor's type check but the fill loop
+// only stored WebAssemblyFunction defaults, leaving every funcref entry null.
+// Table.prototype.set and Table.prototype.grow stored the same value correctly.
+
+if (!this.WebAssembly)
+    quit(0);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " (expected " + expected + ")");
+}
+
+// (module (import "m" "f" (func (result i32))) (export "f" (func 0)))
+const reexportingModule = new WebAssembly.Module(new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+    0x02, 0x07, 0x01, 0x01, 0x6d, 0x01, 0x66, 0x00, 0x00,
+    0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+]));
+
+// (module (func (export "f") (result i32) (i32.const 7)))
+const exportingModule = new WebAssembly.Module(new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+    0x03, 0x02, 0x01, 0x00,
+    0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+    0x0a, 0x06, 0x01, 0x04, 0x00, 0x41, 0x07, 0x0b,
+]));
+
+// (module (import "m" "t" (table 3 funcref))
+//         (func (export "call") (param i32) (result i32)
+//             (call_indirect (result i32) (local.get 0))))
+const callingModule = new WebAssembly.Module(new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x0a, 0x02, 0x60, 0x00, 0x01, 0x7f, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+    0x02, 0x09, 0x01, 0x01, 0x6d, 0x01, 0x74, 0x01, 0x70, 0x00, 0x03,
+    0x03, 0x02, 0x01, 0x01,
+    0x07, 0x08, 0x01, 0x04, 0x63, 0x61, 0x6c, 0x6c, 0x00, 0x00,
+    0x0a, 0x09, 0x01, 0x07, 0x00, 0x20, 0x00, 0x11, 0x00, 0x00, 0x0b,
+]));
+
+const wrapper = new WebAssembly.Instance(reexportingModule, { m: { f: () => 42 } }).exports.f;
+
+for (const element of ["funcref", "anyfunc"]) {
+    const table = new WebAssembly.Table({ element, initial: 3 }, wrapper);
+    for (let i = 0; i < 3; ++i) {
+        shouldBe(table.get(i), wrapper);
+        shouldBe(table.get(i)(), 42);
+    }
+
+    // The wasm-callable half of each slot must be populated too: call_indirect
+    // through the constructor-filled slots dispatches to the wrapped JS function.
+    const caller = new WebAssembly.Instance(callingModule, { m: { t: table } }).exports.call;
+    for (let i = 0; i < 3; ++i)
+        shouldBe(caller(i), 42);
+}
+
+// Constructor-filled slots keep their values alive across GC.
+{
+    let table;
+    (function () {
+        const transientWrapper = new WebAssembly.Instance(reexportingModule, { m: { f: () => 13 } }).exports.f;
+        table = new WebAssembly.Table({ element: "funcref", initial: 2 }, transientWrapper);
+    })();
+    if (typeof fullGC === "function")
+        fullGC();
+    for (let i = 0; i < 2; ++i) {
+        shouldBe(typeof table.get(i), "function");
+        shouldBe(table.get(i)(), 13);
+    }
+}
+
+// WebAssemblyFunction default values keep working.
+const wasmFunction = new WebAssembly.Instance(exportingModule).exports.f;
+const table = new WebAssembly.Table({ element: "funcref", initial: 2 }, wasmFunction);
+for (let i = 0; i < 2; ++i) {
+    shouldBe(table.get(i), wasmFunction);
+    shouldBe(table.get(i)(), 7);
+}
+
+// Null and absent default values keep producing null entries.
+shouldBe(new WebAssembly.Table({ element: "funcref", initial: 1 }, null).get(0), null);
+shouldBe(new WebAssembly.Table({ element: "funcref", initial: 1 }).get(0), null);
+
+// Non-function default values keep throwing.
+let threw = false;
+try {
+    new WebAssembly.Table({ element: "funcref", initial: 1 }, () => 1);
+} catch (error) {
+    threw = true;
+    shouldBe(error instanceof TypeError, true);
+}
+shouldBe(threw, true);
+
+// Externref tables keep storing arbitrary default values.
+const externTable = new WebAssembly.Table({ element: "externref", initial: 2 }, "hello");
+shouldBe(externTable.get(0), "hello");
+shouldBe(externTable.get(1), "hello");

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
@@ -113,13 +113,11 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyTable, (JSGlobalObject* globalObj
     JSValue defaultValue = callFrame->argumentCount() < 2
         ? defaultValueForReferenceType(jsWebAssemblyTable->table()->wasmType())
         : callFrame->uncheckedArgument(1);
-    WebAssemblyFunction* wasmFunction = nullptr;
-    WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
-    if (jsWebAssemblyTable->table()->isFuncrefTable() && !defaultValue.isNull() && !isWebAssemblyHostFunction(defaultValue, wasmFunction, wasmWrapperFunction))
+    if (jsWebAssemblyTable->table()->isFuncrefTable() && !defaultValue.isNull() && !isWebAssemblyHostFunction(defaultValue))
         return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.constructor expects the second argument to be null or an instance of WebAssembly.Function"_s);
     for (uint32_t tableIndex = 0; tableIndex < initial; ++tableIndex) {
-        if (jsWebAssemblyTable->table()->isFuncrefTable() && wasmFunction)
-            jsWebAssemblyTable->set(tableIndex, wasmFunction);
+        if (jsWebAssemblyTable->table()->isFuncrefTable() && !defaultValue.isNull())
+            jsWebAssemblyTable->set(tableIndex, defaultValue);
         if (jsWebAssemblyTable->table()->isExternrefTable())
             jsWebAssemblyTable->set(tableIndex, defaultValue);
         RETURN_IF_EXCEPTION(throwScope, encodedJSValue());


### PR DESCRIPTION
#### 7a35a1699bc9a8bf0450993321b16ec73d8f4e04
<pre>
[Wasm] `Table` constructor should fill funcref tables when the default value is a wrapper function
<a href="https://bugs.webkit.org/show_bug.cgi?id=316280">https://bugs.webkit.org/show_bug.cgi?id=316280</a>

Reviewed by Yusuke Suzuki.

new WebAssembly.Table({element: &quot;funcref&quot;, initial: N}, value) type-checks the
second argument with isWebAssemblyHostFunction, which accepts both
WebAssemblyFunction and WebAssemblyWrapperFunction (a JS function imported into
wasm and re-exported). The fill loop, however, only stored the default value
when it was a WebAssemblyFunction, so a wrapper-function default silently left
every entry null even though the constructor accepted it. The same value passed
to Table.prototype.set or Table.prototype.grow was stored correctly, so the
constructor disagreed with the rest of the JS API. 314219@main fixed the same
pattern on the Table::grow path.

Fix the fill loop to store any non-null funcref default value. The preceding
type check already guarantees that a non-null default on a funcref table is a
WebAssemblyFunctionBase, which is exactly what FuncRefTable::set expects. Since
nothing reads the isWebAssemblyHostFunction out-parameters anymore, switch to
the overload without them.

    const wrapper = new WebAssembly.Instance(reexportingModule, { m: { f: () =&gt; 42 } }).exports.f;
    const table = new WebAssembly.Table({ element: &quot;funcref&quot;, initial: 3 }, wrapper);
    table.get(0);  // was null, now wrapper

Test: JSTests/stress/wasm-table-constructor-wrapper-function-default.js

* JSTests/stress/wasm-table-constructor-wrapper-function-default.js: Added.
(shouldBe):
(i.shouldBe.caller):
(catch):
* Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/314543@main">https://commits.webkit.org/314543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55d41cffe0e711c5d85c40156e91d3eb06b41e55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123649 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129349 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109874 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30705 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29405 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23582 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158551 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177975 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27288 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30876 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137703 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137622 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37088 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148997 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103311 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32911 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25863 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199073 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39152 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112227 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53445 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38549 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3949 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38794 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->