### PR TITLE
Use protect() instead of Ref/RefPtr { } in IPC code

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -1028,8 +1028,8 @@ Connection::AsyncReplyHandlerWithDispatcher Connection::makeAsyncReplyHandlerWit
     // where it's been created.
     return {
         {
-            [completionHandler = makeAsyncReplyCompletionHandler<T, C>(std::forward<C>(completionHandler), CompletionHandlerCallThread::AnyThread), dispatcher = Ref { dispatcher }](Connection* connection, std::unique_ptr<Decoder>&& decoder) mutable {
-                dispatcher->dispatch([connection = RefPtr { connection }, completionHandler = WTF::move(completionHandler), decoder = WTF::move(decoder)]() mutable {
+            [completionHandler = makeAsyncReplyCompletionHandler<T, C>(std::forward<C>(completionHandler), CompletionHandlerCallThread::AnyThread), dispatcher = protect(dispatcher)](Connection* connection, std::unique_ptr<Decoder>&& decoder) mutable {
+                dispatcher->dispatch([connection = protect(connection), completionHandler = WTF::move(completionHandler), decoder = WTF::move(decoder)]() mutable {
                     completionHandler(connection.get(), decoder.get());
                 });
             }, CompletionHandlerCallThread::AnyThread

--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -484,7 +484,7 @@ void handleMessageSynchronous(Connection& connection, Decoder& decoder, UniqueRe
 
     logMessage(connection, MessageType::name(), object, *arguments);
     auto completionHandler = ValidationType::wrapCompletionHandler(CompletionHandlerType(
-    [replyEncoder = WTF::move(replyEncoder), connection = Ref { connection }] (auto&&... args) mutable {
+    [replyEncoder = WTF::move(replyEncoder), connection = protect(connection)] (auto&&... args) mutable {
         logReply(connection, MessageType::name(), args...);
         (replyEncoder.get() << ... << std::forward<decltype(args)>(args));
         connection->sendSyncReply(WTF::move(replyEncoder));
@@ -514,7 +514,7 @@ void handleMessageSynchronous(StreamServerConnection& connection, Decoder& decod
 
     logMessage(connection, MessageType::name(), object, *arguments);
     callMemberFunction(object, function, WTF::move(*arguments),
-        CompletionHandlerType([syncRequestID = decoder.syncRequestID(), connection = Ref { connection }] (auto&&... args) mutable {
+        CompletionHandlerType([syncRequestID = decoder.syncRequestID(), connection = protect(connection)] (auto&&... args) mutable {
             logReply(connection, MessageType::name(), args...);
             connection->sendSyncReply<MessageType>(syncRequestID, std::forward<decltype(args)>(args)...);
         }));
@@ -542,7 +542,7 @@ void handleMessageAsync(C& connection, Decoder& decoder, T* object, MF U::* func
 
     logMessage(connection, MessageType::name(), object, *arguments);
     auto completionHandler = ValidationType::wrapCompletionHandler(CompletionHandlerType(
-        [replyID = *replyID, connection = Ref { connection }] (auto&&... args) mutable {
+        [replyID = *replyID, connection = protect(connection)] (auto&&... args) mutable {
             connection->template sendAsyncReply<MessageType>(replyID, std::forward<decltype(args)>(args)...);
         }, MessageType::callbackThread));
     if constexpr (ValidationType::returnsVoid) {
@@ -585,7 +585,7 @@ void handleMessageAsyncWithoutUsingIPCConnection(Decoder& decoder, Function<void
     using CompletionHandlerType = typename ValidationType::CompletionHandlerType;
 
     CompletionHandlerType completionHandler {
-        [destinationID = decoder.destinationID(), replyHandler = WTF::move(replyHandler), object = Ref { *object }] (auto&&... args) mutable {
+        [destinationID = decoder.destinationID(), replyHandler = WTF::move(replyHandler), object = protect(*object)] (auto&&... args) mutable {
             auto encoder = makeUniqueRef<Encoder>(MessageType::asyncMessageReplyName(), destinationID);
             (encoder.get() << ... << std::forward<decltype(args)>(args));
             replyHandler(WTF::move(encoder));

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
@@ -45,7 +45,7 @@ public:
 
     void enqueueMessage(Connection& connection, UniqueRef<Decoder>&& message) final
     {
-        m_dispatcher.dispatch([connection = Ref { connection }, message = WTF::move(message), receiver = Ref { m_receiver.get() }]() mutable {
+        m_dispatcher.dispatch([connection = protect(connection), message = WTF::move(message), receiver = protect(m_receiver.get())]() mutable {
             connection->dispatchMessageReceiverMessage(receiver.get(), WTF::move(message));
         });
     }
@@ -66,7 +66,7 @@ public:
 
     void enqueueMessage(Connection& connection, UniqueRef<Decoder>&& message) final
     {
-        m_queue->dispatch([connection = Ref { connection }, message = WTF::move(message), receiver = m_receiver]() mutable {
+        m_queue->dispatch([connection = protect(connection), message = WTF::move(message), receiver = m_receiver]() mutable {
             connection->dispatchMessageReceiverMessage(receiver.get(), WTF::move(message));
         });
     }

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
@@ -65,7 +65,7 @@ auto SharedBufferReference::serializableBuffer() const -> std::optional<Serializ
         return std::nullopt;
     if (!m_size)
         return SerializableBuffer { 0, std::nullopt, std::nullopt };
-    auto sharedMemoryBuffer = m_memory ? m_memory : SharedMemory::copyBuffer(Ref { *m_buffer });
+    auto sharedMemoryBuffer = m_memory ? m_memory : SharedMemory::copyBuffer(protect(*m_buffer));
     if (!sharedMemoryBuffer)
         return std::nullopt;
     return SerializableBuffer { m_size, sharedMemoryBuffer->createHandle(SharedMemory::Protection::ReadOnly), m_ledger };
@@ -97,7 +97,7 @@ std::span<const uint8_t> SharedBufferReference::span() const LIFETIME_BOUND
         return { };
 
     if (!m_buffer->isContiguous())
-        m_buffer = RefPtr { m_buffer }->makeContiguous();
+        m_buffer = protect(m_buffer)->makeContiguous();
 
     return downcast<SharedBuffer>(m_buffer.get())->span().first(m_size);
 }

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -123,7 +123,7 @@ void StreamClientConnection::setMaxBatchSize(unsigned size)
 void StreamClientConnection::open(Connection::Client& receiver, SerialFunctionDispatcher& dispatcher)
 {
     lazyInitialize(m_dedicatedConnectionClient, makeUniqueWithoutRefCountedCheck<DedicatedConnectionClient>(*this, receiver));
-    m_connection->open(Ref { *m_dedicatedConnectionClient }.get(), dispatcher);
+    m_connection->open(protect(*m_dedicatedConnectionClient), dispatcher);
 }
 
 Error StreamClientConnection::flushSentMessages()

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
@@ -41,7 +41,7 @@ StreamConnectionBuffer::~StreamConnectionBuffer() = default;
 
 StreamConnectionBuffer::Handle StreamConnectionBuffer::createHandle()
 {
-    auto handle = Ref { m_sharedMemory }->createHandle(WebCore::SharedMemory::Protection::ReadWrite);
+    auto handle = protect(m_sharedMemory)->createHandle(WebCore::SharedMemory::Protection::ReadWrite);
     if (!handle)
         CRASH();
     return { WTF::move(*handle) };


### PR DESCRIPTION
#### 4072def53f5ef79fe3b9bd9eb11c53042f2d350a
<pre>
Use protect() instead of Ref/RefPtr { } in IPC code
<a href="https://bugs.webkit.org/show_bug.cgi?id=316279">https://bugs.webkit.org/show_bug.cgi?id=316279</a>
<a href="https://rdar.apple.com/178687645">rdar://178687645</a>

Reviewed by Zak Ridouh.

Mechanical migration from brace-initialized Ref/RefPtr temporaries to the
protect() free function in Source/WebKit/Platform/IPC/, aligning with the
codebase-wide transition.

All 13 instances are lambda captures, inline temporaries, or function
arguments. One .get() call is dropped where Ref&apos;s implicit operator T&amp;()
suffices.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::makeAsyncReplyHandlerWithDispatcher):
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessageSynchronous):
(IPC::handleMessageAsync):
(IPC::handleMessageAsyncWithoutUsingIPCConnection):
* Source/WebKit/Platform/IPC/MessageReceiveQueues.h:
(IPC::FunctionDispatcherQueue::enqueueMessage):
(IPC::WorkQueueMessageReceiverQueue::enqueueMessage):
* Source/WebKit/Platform/IPC/SharedBufferReference.cpp:
(IPC::SharedBufferReference::serializableBuffer):
(IPC::SharedBufferReference::span):
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::open):
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp:
(IPC::StreamConnectionBuffer::createHandle):

Canonical link: <a href="https://commits.webkit.org/314538@main">https://commits.webkit.org/314538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc839398f387c5e26dffb4f1c67299eeeabbf5bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123650 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129351 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65f8d4b0-a2d9-428d-87bd-90577de2b50d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109876 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09e41bdb-47d1-4819-9a13-33398f6c7141) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30707 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29406 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23583 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140676 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177976 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30877 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28908 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137704 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137623 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37084 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40643 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103312 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32914 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25865 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39153 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112228 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38550 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3951 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38795 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38693 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->