### PR TITLE
Reduce use of `.get()` for smart pointers in model element code

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -144,7 +144,7 @@ HTMLModelElement::HTMLModelElement(const QualifiedName& tagName, Document& docum
 #endif
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
     , m_screenPropertiesChangedObserver(ScreenPropertiesChangedObserver::create([weakThis = WeakPtr { *this }](PlatformDisplayID displayID) {
-        RefPtr protectedThis = weakThis.get();
+        RefPtr protectedThis { weakThis };
         if (!protectedThis)
             return;
         auto platformScreen = PlatformScreen::singleton();
@@ -422,7 +422,7 @@ void HTMLModelElement::didFinishLoading(ModelPlayer& modelPlayer)
             renderer->updateFromElement();
 
         if (oldPlayer) {
-            if (RefPtr provider = m_modelPlayerProvider.get())
+            if (RefPtr provider = m_modelPlayerProvider)
                 provider->deleteModelPlayer(*oldPlayer);
         }
 
@@ -659,7 +659,7 @@ void HTMLModelElement::createModelPlayer()
 #if ENABLE(GPU_PROCESS_MODEL)
     RefPtr<ModelPlayer> modelPlayer;
 #endif
-    if (RefPtr modelPlayerProvider = m_modelPlayerProvider.get()) {
+    if (RefPtr modelPlayerProvider = m_modelPlayerProvider) {
         modelPlayer = modelPlayerProvider->createModelPlayer(*this);
 #if ENABLE(GPU_PROCESS_MODEL)
         if (routingToPending)
@@ -720,7 +720,7 @@ void HTMLModelElement::deleteModelPlayer()
         if (modelPlayerProvider && modelPlayer)
             modelPlayerProvider->deleteModelPlayer(*modelPlayer);
 
-        RefPtr protectedThis = weakThis.get();
+        RefPtr protectedThis { weakThis };
         if (protectedThis)
             protectedThis->m_modelPlayer = nullptr;
     };
@@ -739,7 +739,7 @@ void HTMLModelElement::deletePendingModelPlayer()
     RefPtr pendingPlayer = std::exchange(m_pendingModelPlayer, nullptr);
     if (!pendingPlayer)
         return;
-    if (RefPtr provider = m_modelPlayerProvider.get())
+    if (RefPtr provider = m_modelPlayerProvider)
         provider->deleteModelPlayer(*pendingPlayer);
 #endif
 }
@@ -798,7 +798,7 @@ void HTMLModelElement::reloadModelPlayer()
 #if ENABLE(MODEL_PROCESS)
     if (!m_modelPlayerProvider)
         m_modelPlayerProvider = document().page()->modelPlayerProvider();
-    if (RefPtr modelPlayerProvider = m_modelPlayerProvider.get()) {
+    if (RefPtr modelPlayerProvider = m_modelPlayerProvider) {
         modelPlayer = modelPlayerProvider->createModelPlayer(*this);
         m_modelPlayer = modelPlayer.copyRef();
     }
@@ -1675,7 +1675,7 @@ void HTMLModelElement::ensureImmersivePresentation(CompletionHandler<void(Except
 {
     setDetachedForImmersive(true);
     ensureModelPlayer([weakThis = WeakPtr { *this }, completion = WTF::move(completion)](auto result) mutable {
-        RefPtr protectedThis = weakThis.get();
+        RefPtr protectedThis { weakThis };
         if (!protectedThis)
             return completion(Exception { ExceptionCode::AbortError });
 
@@ -1693,7 +1693,7 @@ void HTMLModelElement::ensureImmersivePresentation(CompletionHandler<void(Except
         }
 
         modelPlayer->ensureImmersivePresentation([weakThis, completion = WTF::move(completion)](auto contextID) mutable {
-            RefPtr protectedThis = weakThis.get();
+            RefPtr protectedThis { weakThis };
             if (!protectedThis)
                 return completion(Exception { ExceptionCode::AbortError });
 
@@ -1719,7 +1719,7 @@ void HTMLModelElement::exitImmersivePresentation(CompletionHandler<void()>&& com
 
     auto generation = m_immersiveDetachGeneration;
     modelPlayer->exitImmersivePresentation([weakThis = WeakPtr { *this }, generation, completion = WTF::move(completion)] mutable {
-        RefPtr protectedThis = weakThis.get();
+        RefPtr protectedThis { weakThis };
         if (!protectedThis)
             return completion();
 

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
@@ -48,7 +48,7 @@ DummyModelPlayer::~DummyModelPlayer() = default;
 
 void DummyModelPlayer::load(Model& model, LayoutSize)
 {
-    if (RefPtr client = m_client.get())
+    if (RefPtr client = m_client)
         client->didFailLoading(*this, ResourceError { errorDomainWebKitInternal, 0, model.url(), "Trying to load model via DummyModelPlayer"_s });
 }
 


### PR DESCRIPTION
#### b7a7dec11368575406a43983320f48067ad8f17b
<pre>
Reduce use of `.get()` for smart pointers in model element code
<a href="https://bugs.webkit.org/show_bug.cgi?id=316283">https://bugs.webkit.org/show_bug.cgi?id=316283</a>
<a href="https://rdar.apple.com/178691695">rdar://178691695</a>

Reviewed by Etienne Segonzac.

`RefPtr&lt;T&gt;` has a constructor that takes `WeakPtr&lt;T&gt;` directly (RefPtr.h:104),
calling `.get()` internally. Removing redundant `.get()` calls at ten sites
across two files in `Source/WebCore/Modules/model-element/` simplifies the
code without changing behavior — the constructor invokes `.get()` itself.

For the five statement-form `RefPtr` initializations from `WeakPtr`, also
switched from copy-init (`=`) to brace-init (`{}`) per current WebKit style.

No new tests needed (no behavioral change).

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::HTMLModelElement):
(WebCore::HTMLModelElement::didFinishLoading):
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::deleteModelPlayer):
(WebCore::HTMLModelElement::deletePendingModelPlayer):
(WebCore::HTMLModelElement::reloadModelPlayer):
(WebCore::HTMLModelElement::ensureImmersivePresentation):
(WebCore::HTMLModelElement::exitImmersivePresentation):
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp:
(WebCore::DummyModelPlayer::load):

Canonical link: <a href="https://commits.webkit.org/314559@main">https://commits.webkit.org/314559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c85bdc54c2a0debb7f825b1c0ca8971db3a41e71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123660 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129359 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109884 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30715 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29417 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23593 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177986 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30887 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137714 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137633 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37100 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149008 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103329 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32924 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25874 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112238 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38560 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4028 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38703 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->