### PR TITLE
Add layout test for canvas line stroke IPC batching cross-buffer flush

### DIFF
--- a/LayoutTests/fast/canvas/canvas-line-batch-flush-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-line-batch-flush-expected.txt
@@ -1,0 +1,12 @@
+Regression test for webkit.org/b/315554: drawImage from an unparented source canvas must flush the source's pending strokeLine batch before its pixels are sampled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS directNonBlank is > 1000
+PASS destNonBlank is directNonBlank
+PASS bytesDifferent is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/canvas-line-batch-flush.html
+++ b/LayoutTests/fast/canvas/canvas-line-batch-flush.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<canvas id="dest" width="400" height="400"></canvas>
+<div id="console"></div>
+<script>
+description("Regression test for webkit.org/b/315554: drawImage from an unparented source canvas must flush the source's pending strokeLine batch before its pixels are sampled.");
+
+const SIZE = 400;
+const NUM_LINES = 200; // > maxPendingLineStrokes (64) so the source has both
+                       // auto-flushed full batches and trailing pending lines.
+const colors = ["#101010", "#808080", "#c0c0c0", "#e01040", "#10c030", "#744cba", "#e05010"];
+
+function lcg(seed) {
+    let s = seed >>> 0;
+    return () => {
+        s = (s * 1664525 + 1013904223) >>> 0;
+        return s / 0x100000000;
+    };
+}
+
+function drawLines(ctx) {
+    const rand = lcg(0xC0FFEE);
+    for (let i = 0; i < NUM_LINES; i++) {
+        ctx.strokeStyle = colors[Math.floor(rand() * colors.length)];
+        ctx.lineWidth = 1 + Math.floor(rand() * 6);
+        ctx.beginPath();
+        ctx.moveTo(rand() * SIZE, rand() * SIZE);
+        ctx.lineTo(rand() * SIZE, rand() * SIZE);
+        ctx.stroke();
+    }
+}
+
+function countNonBlank(data) {
+    let count = 0;
+    for (let i = 3; i < data.length; i += 4) {
+        if (data[i])
+            count++;
+    }
+    return count;
+}
+
+// Reference path: strokes go directly on a parented canvas; the subsequent
+// getImageData() forces any pending batch to flush.
+const direct = document.createElement("canvas");
+direct.width = direct.height = SIZE;
+drawLines(direct.getContext("2d"));
+const directData = direct.getContext("2d").getImageData(0, 0, SIZE, SIZE).data;
+const directNonBlank = countNonBlank(directData);
+
+// Sanity: catches a silent rendering failure that would otherwise blank both
+// paths and produce a false-positive pixel comparison.
+shouldBeGreaterThan("directNonBlank", "1000");
+
+// Test path: strokes target an UNPARENTED canvas. We never read back from it,
+// so only the cross-buffer drawImage from a parented canvas can flush the
+// pending strokeLine batch via recordResourceUse(ImageBuffer&).
+const src = document.createElement("canvas");
+src.width = src.height = SIZE;
+drawLines(src.getContext("2d"));
+
+const dest = document.getElementById("dest");
+const dctx = dest.getContext("2d");
+dctx.drawImage(src, 0, 0);
+const destData = dctx.getImageData(0, 0, SIZE, SIZE).data;
+const destNonBlank = countNonBlank(destData);
+
+let bytesDifferent = 0;
+for (let i = 0; i < destData.length; i++) {
+    if (destData[i] !== directData[i])
+        bytesDifferent++;
+}
+
+// If the cross-buffer flush regresses, trailing pending strokes (those not
+// auto-flushed at the 64-line batch boundary) are dropped from the source —
+// destNonBlank < directNonBlank — or, if no batch was filled, nothing renders.
+shouldBe("destNonBlank", "directNonBlank");
+shouldBe("bytesDifferent", "0");
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
#### 3d9354729747344128c15783067e6a0e5d2d799e
<pre>
Add layout test for canvas line stroke IPC batching cross-buffer flush
<a href="https://bugs.webkit.org/show_bug.cgi?id=316285">https://bugs.webkit.org/show_bug.cgi?id=316285</a>
<a href="https://rdar.apple.com/178693435">rdar://178693435</a>

Reviewed by Simon Fraser.

Followup test coverage for 314520@main. Canvas single-line strokeLine
calls are coalesced in RemoteGraphicsContextProxy and only sent over IPC
when something observes the source buffer&apos;s contents. drawImage from
another canvas must trigger that flush via recordResourceUse(ImageBuffer&amp;);
without it, trailing pending strokes (those that did not fill a 64-line
batch) are dropped from the source.

The test strokes 200 random lines onto an unparented source canvas (so
no read-back forces a flush) and drawImages it into a parented
destination canvas. It asserts the destination pixels are byte-equal to
a separately-rendered direct-stroke reference, and that the reference
itself is non-blank — the latter catches a silent rendering failure
that would otherwise blank both paths and produce a false-positive
pixel comparison.

* LayoutTests/fast/canvas/canvas-line-batch-flush-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-line-batch-flush.html: Added.

Canonical link: <a href="https://commits.webkit.org/314598@main">https://commits.webkit.org/314598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46a3f542a4a68239c848e5b4a6658053d6074c52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175455 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123662 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129361 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109886 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30723 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29419 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23595 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140692 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177988 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137716 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39967 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137635 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37124 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149011 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103333 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32929 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25877 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39165 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38562 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3963 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38807 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38705 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->