### PR TITLE
[YARR] String list fast path drops a non-final empty alternative

### DIFF
--- a/JSTests/stress/regexp-string-list-empty-alternative.js
+++ b/JSTests/stress/regexp-string-list-empty-alternative.js
@@ -1,0 +1,83 @@
+// Test that the Yarr string list fast path correctly matches an empty
+// alternative that is not the last alternative, e.g. /^(?:c||b)/.
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error((message ? message + ": " : "") + "expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+function shouldBeMatch(result, expectedStrings, expectedIndex, message) {
+    if (expectedStrings === null) {
+        shouldBe(result, null, message);
+        return;
+    }
+    if (result === null)
+        throw new Error((message ? message + ": " : "") + "expected a match but got null");
+    shouldBe(result.length, expectedStrings.length, message + " (length)");
+    for (var i = 0; i < expectedStrings.length; ++i)
+        shouldBe(result[i], expectedStrings[i], message + " [" + i + "]");
+    shouldBe(result.index, expectedIndex, message + " (index)");
+}
+
+// Empty alternative in the middle.
+shouldBeMatch(/^(?:c||b)/.exec("bccc"), [""], 0, "/^(?:c||b)/ vs \"bccc\"");
+shouldBeMatch(/^(?:c||b)/.exec("cccc"), ["c"], 0, "/^(?:c||b)/ vs \"cccc\"");
+shouldBeMatch(/^(?:c||b)/.exec("zzzz"), [""], 0, "/^(?:c||b)/ vs \"zzzz\"");
+shouldBeMatch(/^(?:c||b)/.exec(""), [""], 0, "/^(?:c||b)/ vs \"\"");
+
+// Empty alternative first.
+shouldBeMatch(/^(?:|c)/.exec("c"), [""], 0, "/^(?:|c)/ vs \"c\"");
+shouldBeMatch(/^(?:|foo|bar)/.exec("bar"), [""], 0, "/^(?:|foo|bar)/ vs \"bar\"");
+
+// Multiple empty alternatives.
+shouldBeMatch(/^(?:||b)/.exec("b"), [""], 0, "/^(?:||b)/ vs \"b\"");
+
+// Empty alternative last already worked; check for regressions.
+shouldBeMatch(/^(?:c|b|)/.exec("bccc"), ["b"], 0, "/^(?:c|b|)/ vs \"bccc\"");
+shouldBeMatch(/^(?:c|b|)/.exec("zzzz"), [""], 0, "/^(?:c|b|)/ vs \"zzzz\"");
+
+// Multi-character alternatives.
+shouldBeMatch(/^(?:foo||bar)/.exec("bar"), [""], 0, "/^(?:foo||bar)/ vs \"bar\"");
+shouldBeMatch(/^(?:foo||bar)/.exec("foofoo"), ["foo"], 0, "/^(?:foo||bar)/ vs \"foofoo\"");
+
+// EOL anchored string lists: alternatives after an empty one stay reachable.
+shouldBeMatch(/^(?:c||b)$/.exec("c"), ["c"], 0, "/^(?:c||b)$/ vs \"c\"");
+shouldBeMatch(/^(?:c||b)$/.exec("b"), ["b"], 0, "/^(?:c||b)$/ vs \"b\"");
+shouldBeMatch(/^(?:c||b)$/.exec(""), [""], 0, "/^(?:c||b)$/ vs \"\"");
+shouldBeMatch(/^(?:c||b)$/.exec("bc"), null, 0, "/^(?:c||b)$/ vs \"bc\"");
+
+// Not a string list: no BOL anchor.
+shouldBeMatch(/(?:c||b)/.exec("bccc"), [""], 0, "/(?:c||b)/ vs \"bccc\"");
+
+// Not a string list: capturing group.
+shouldBeMatch(/^(c||b)/.exec("bccc"), ["", ""], 0, "/^(c||b)/ vs \"bccc\"");
+
+// Not a string list: quantified group. A zero-length iteration is rejected
+// by RepeatMatcher, so the "b" alternative matches.
+shouldBeMatch(/^(?:c||b)?/.exec("bccc"), ["b"], 0, "/^(?:c||b)?/ vs \"bccc\"");
+
+// String list without empty alternatives: fast path regression check.
+shouldBeMatch(/^(?:foo|bar|baz)/.exec("barxx"), ["bar"], 0, "/^(?:foo|bar|baz)/ vs \"barxx\"");
+shouldBeMatch(/^(?:foo|bar|baz)/.exec("qux"), null, 0, "/^(?:foo|bar|baz)/ vs \"qux\"");
+
+// Flags.
+shouldBeMatch(/^(?:c||b)/i.exec("Bccc"), [""], 0, "/^(?:c||b)/i vs \"Bccc\"");
+shouldBeMatch(/^(?:c||b)/m.exec("x\nbc"), [""], 0, "/^(?:c||b)/m vs \"x\\nbc\"");
+
+var stickyRe = /^(?:c||b)/y;
+stickyRe.lastIndex = 0;
+shouldBeMatch(stickyRe.exec("bccc"), [""], 0, "/^(?:c||b)/y vs \"bccc\"");
+shouldBe(stickyRe.lastIndex, 0, "sticky lastIndex after zero-length match");
+
+var globalRe = /^(?:c||b)/g;
+globalRe.lastIndex = 0;
+shouldBeMatch(globalRe.exec("bccc"), [""], 0, "/^(?:c||b)/g vs \"bccc\"");
+shouldBe(globalRe.lastIndex, 0, "global lastIndex after zero-length match");
+
+// 16-bit strings.
+shouldBeMatch(/^(?:あ||い)/.exec("いい"), [""], 0, "/^(?:\\u3042||\\u3044)/ vs \"\\u3044\\u3044\"");
+shouldBeMatch(/^(?:あ||い)/.exec("ああ"), ["あ"], 0, "/^(?:\\u3042||\\u3044)/ vs \"\\u3042\\u3042\"");
+
+// test() and replace() use the same match.
+shouldBe(/^(?:c||b)/.test("zzz"), true, "/^(?:c||b)/.test(\"zzz\")");
+shouldBe("bccc".replace(/^(?:c||b)/, "X"), "Xbccc", "replace with /^(?:c||b)/");

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2013,7 +2013,7 @@ public:
     //     matched string alternative, without jumping to backtracking doe to fixup offests.
     //     Instead we fixup the offsets, if needed, at the top of the next alternative's
     //     matching JIT code.
-    void NODELETE checkForTerminalParentheses()
+    void checkForTerminalParentheses()
     {
         // This check is much too crude; should be just checking whether the candidate
         // node contains nested capturing subpatterns, not the whole expression!
@@ -2041,8 +2041,13 @@ public:
                 PatternTerm& term = terms[1];
 
                 PatternDisjunction* nestedDisjunction = term.parentheses.disjunction;
+                constexpr unsigned emptyAlternativeNotFound = std::numeric_limits<unsigned>::max();
+                unsigned firstEmptyAlternative = emptyAlternativeNotFound;
                 for (unsigned alt = 0; isStringList && alt < nestedDisjunction->m_alternatives.size(); ++alt) {
                     Vector<PatternTerm>& innerTerms = nestedDisjunction->m_alternatives[alt]->m_terms;
+
+                    if (innerTerms.isEmpty() && firstEmptyAlternative == emptyAlternativeNotFound)
+                        firstEmptyAlternative = alt;
 
                     for (size_t termIndex = 0; termIndex < innerTerms.size(); ++termIndex) {
                         PatternTerm& innerTerm = innerTerms[termIndex];
@@ -2055,8 +2060,16 @@ public:
                     }
                 }
 
+                bool isEOLStringList = terms.size() == 3 && terms[2].type == PatternTerm::Type::AssertionEOL;
                 term.parentheses.isStringList = isStringList;
-                term.parentheses.isEOLStringList = (terms.size() == 3 && terms[2].type == PatternTerm::Type::AssertionEOL);
+                term.parentheses.isEOLStringList = isEOLStringList;
+
+                // In a non-EOL string list the first empty alternative always matches and ends the match, so later
+                // alternatives are unreachable. Drop them so the empty alternative is last and the JIT can fall through to success.
+                if (isStringList && !isEOLStringList && firstEmptyAlternative != emptyAlternativeNotFound && firstEmptyAlternative + 1 < nestedDisjunction->m_alternatives.size()) {
+                    nestedDisjunction->m_alternatives.shrink(firstEmptyAlternative + 1);
+                    nestedDisjunction->m_alternatives.last()->m_isLastAlternative = true;
+                }
             }
 
             if (isStringList)


### PR DESCRIPTION
#### e6d0f57f8d04cafcc07b9f35be0a9212b0745d04
<pre>
[YARR] String list fast path drops a non-final empty alternative
<a href="https://bugs.webkit.org/show_bug.cgi?id=316288">https://bugs.webkit.org/show_bug.cgi?id=316288</a>

Reviewed by Yusuke Suzuki.

A regex like /^(?:c||b)/ matched against &quot;bccc&quot; returned &quot;b&quot; under the
RegExp JIT instead of the empty string. The JIT &quot;string list&quot; fast path
plants each alternative&apos;s success jump off its character comparisons, so
an empty alternative emits no jump and execution falls through into the
next alternative as if the empty one had failed. The interpreter and the
spec match the empty alternative and return a zero-length match.

Without a trailing end-of-line anchor a string list is terminal: the
first empty alternative always matches and ends the overall match, so any
alternatives after it are unreachable. Drop them while building the
pattern, which leaves the empty alternative last so the JIT matches it via
its existing fall-through success path. Alternatives after an empty one
are kept when the list is end-of-line anchored, since there the empty
alternative does not guarantee an overall match.

* JSTests/stress/regexp-string-list-empty-alternative.js: Added.
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::checkForTerminalParentheses):

Canonical link: <a href="https://commits.webkit.org/314686@main">https://commits.webkit.org/314686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fb2faa780e4c188e1ee8cfffffe2c536208c5b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175493 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123700 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129394 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91123 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109919 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30756 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29456 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23633 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158602 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140725 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178026 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27339 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30927 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137749 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137668 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37175 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149048 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103394 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32963 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25914 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199124 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39203 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112278 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53452 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38600 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4000 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->