### PR TITLE
[GTK][WPE] Skia Compositor: implement batched painting

### DIFF
--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -19,6 +19,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/SkiaCompositingLayer.h
     platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.h
     platform/graphics/skia/SkiaCompositingLayerFilters.h
+    platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
     platform/graphics/skia/SkiaCompositingLayerOverlapRegions.h
     platform/graphics/skia/SkiaGPUAtlas.h
     platform/graphics/skia/SkiaHarfBuzzFont.h

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -62,6 +62,7 @@ platform/graphics/skia/SkiaBackingStore.cpp
 platform/graphics/skia/SkiaCompositingLayer.cpp
 platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp
 platform/graphics/skia/SkiaCompositingLayerFilters.cpp
+platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
 platform/graphics/skia/SkiaCompositingLayerOverlapRegions.cpp
 platform/graphics/skia/SkiaGPUAtlas.cpp
 platform/graphics/skia/SkiaHarfBuzzFont.cpp

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -90,6 +90,26 @@ void SkiaBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint)
     }
 }
 
+Vector<SkCanvas::ImageSetEntry> SkiaBackingStore::buildImageSet(size_t matrixIndex, float opacity, bool enableAntialias) const
+{
+    if (m_tiles.isEmpty())
+        return { };
+
+    FloatRect layerRect = { { }, m_size };
+
+    Vector<SkCanvas::ImageSetEntry> images;
+    for (auto& tile : m_tiles.values()) {
+        const auto& image = tile.image();
+        if (!image)
+            continue;
+
+        // FIXME: implement per edge antialiasing.
+        unsigned aaFlags = enableAntialias && allTileEdgesExposed(layerRect, tile.rect()) ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
+        images.append(SkCanvas::ImageSetEntry(image, SkRect::MakeWH(image->width(), image->height()), SkRect(tile.rect()), matrixIndex, opacity, aaFlags, false));
+    }
+    return images;
+}
+
 void SkiaBackingStore::drawDebugBorders(SkCanvas& canvas, const SkPaint& paint)
 {
     for (const auto& tile : m_tiles.values())
@@ -160,7 +180,7 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
     WTFEndSignpost(this, SkiaBackingStoreTileUpdate);
 }
 
-sk_sp<SkImage> SkiaBackingStore::Tile::image()
+sk_sp<SkImage> SkiaBackingStore::Tile::image() const
 {
     if (!m_cachedImage && m_texture) {
         auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -29,6 +29,7 @@
 #include "CoordinatedBackingStoreProxy.h"
 #include "FloatRect.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkCanvas.h>
 #include <skia/core/SkSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/HashMap.h>
@@ -47,6 +48,7 @@ public:
 
     void update(const FloatSize&, float scale, CoordinatedBackingStoreProxy::Update&&);
     void paintToCanvas(SkCanvas&, const SkPaint&);
+    Vector<SkCanvas::ImageSetEntry> buildImageSet(size_t matrixIndex, float opacity, bool enableAntialias) const;
     void drawDebugBorders(SkCanvas&, const SkPaint&);
 
 private:
@@ -62,7 +64,7 @@ private:
 
         void update(const IntRect& dirtyRect, const IntRect& tileRect, CoordinatedTileBuffer&);
         const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
-        sk_sp<SkImage> image();
+        sk_sp<SkImage> image() const;
 
     private:
         void ensureTexture(const IntSize&, CoordinatedTileBuffer&);
@@ -70,7 +72,7 @@ private:
         float m_scale { 1. };
         FloatRect m_rect;
         RefPtr<BitmapTexture> m_texture;
-        sk_sp<SkImage> m_cachedImage;
+        mutable sk_sp<SkImage> m_cachedImage;
     };
 
     HashMap<uint32_t, Tile> m_tiles;

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -427,6 +427,7 @@ bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& damage
 
     context.mode = PaintMode::Paint;
     recursivePaint(canvas, context);
+    context.imageSetBatch.flushIfNeeded(canvas);
 
     recursiveCleanUpAfterPaint();
 
@@ -464,45 +465,70 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
     if (m_size.isEmpty() || !m_visible || !m_contentsVisible || !hasVisualContent())
         return;
 
-    TransformationMatrix transform(context.accumulatedReplicaTransform);
-    transform.multiply(m_transforms.combined);
-
-    canvas.save();
-    canvas.concat(SkM44(transform));
-
     if (context.mode == PaintMode::Paint) {
         paintContents(canvas, context);
 #if ENABLE(DAMAGE_TRACKING)
-        collectFrameDamage(canvas, context, transform);
+        collectFrameDamage(canvas, context);
 #endif
     }
-
-    canvas.restore();
 }
 
 void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context)
 {
-    SkPaint paint;
-    paint.setStyle(SkPaint::kFill_Style);
-    auto ctm = canvas.getLocalToDeviceAs3x3();
-    paint.setAntiAlias(!ctm.preservesAxisAlignment() && !ctm.preservesRightAngles());
-    paint.setAlphaf(context.opacity);
-    if (context.blendMode)
-        paint.setBlendMode(*context.blendMode);
-    if (context.colorFilter)
-        paint.setColorFilter(context.colorFilter);
+    TransformationMatrix transform(context.accumulatedReplicaTransform);
+    transform.multiply(m_transforms.combined);
+
+    auto ctm = SkM44(transform).asM33();
+    bool enableAntialias = !ctm.preservesAxisAlignment() && !ctm.preservesRightAngles();
+
+    context.imageSetBatch.updatePaintProperties(canvas, context.colorFilter, context.blendMode);
+
+    auto setupPaint = [&] -> SkPaint {
+        SkPaint paint;
+        paint.setStyle(SkPaint::kFill_Style);
+        paint.setAntiAlias(enableAntialias);
+        paint.setAlphaf(context.opacity);
+        if (context.blendMode)
+            paint.setBlendMode(*context.blendMode);
+        if (context.colorFilter)
+            paint.setColorFilter(context.colorFilter);
+        return paint;
+    };
 
     if (m_backingStore)
-        m_backingStore->paintToCanvas(canvas, paint);
+        context.imageSetBatch.addImageSet(canvas, *m_backingStore, ctm, context.opacity, enableAntialias);
 
     if (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()) {
+        ScopedFlush autoFlush(canvas, context.imageSetBatch, ScopedFlush::Mode::FlushBefore);
+        canvas.concat(SkM44(transform));
+        SkPaint paint = setupPaint();
         paint.setColor(SkColor(m_contentsSolidColor.colorWithAlphaMultipliedBy(context.opacity)));
         canvas.drawRect(m_contentsRect, paint);
     } else if (m_contentsBuffer || m_imageBackingStore) {
-        bool shouldClipContents = m_contentsClippingRect.isRounded() || !m_contentsClippingRect.rect().contains(m_contentsRect);
-        SkAutoCanvasRestore autoRestore(&canvas, shouldClipContents);
-        if (shouldClipContents)
-            clipRect(canvas, m_contentsClippingRect);
+        bool shouldPaintNow = [&] {
+            if (m_contentsClippingRect.isRounded())
+                return true;
+
+            if (!m_contentsBuffer && !m_contentsTiling.size.isEmpty())
+                return true;
+
+            if (is<CoordinatedPlatformLayerBufferHolePunch>(m_contentsBuffer))
+                return true;
+
+            // FIXME: clip is not correctly applied with batched painting.
+            if (!m_contentsClippingRect.rect().contains(m_contentsRect))
+                return true;
+
+            return false;
+        }();
+
+        ScopedFlush autoFlush(canvas, context.imageSetBatch, shouldPaintNow ? ScopedFlush::Mode::FlushBefore : ScopedFlush::Mode::DoNothing);
+        if (shouldPaintNow) {
+            canvas.concat(SkM44(transform));
+
+            if (m_contentsClippingRect.isRounded() || !m_contentsClippingRect.rect().contains(m_contentsRect))
+                clipRect(canvas, m_contentsClippingRect);
+        }
 
         sk_sp<SkImage> image;
 
@@ -512,6 +538,7 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
                 TransformationMatrix matrix = canvas.getLocalToDevice();
                 downcast<CoordinatedPlatformLayerBufferHolePunch>(*m_contentsBuffer).setHolePunchVideoRectangle(enclosingIntRect(matrix.mapRect(m_contentsRect)));
 #endif
+                SkPaint paint = setupPaint();
                 paint.setBlendMode(SkBlendMode::kClear);
                 canvas.drawRect(SkRect(m_contentsRect), paint);
             } else
@@ -523,24 +550,35 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
                 SkMatrix matrix;
                 matrix.setScale(m_contentsTiling.size.width() / tileImage->width(), m_contentsTiling.size.height() / tileImage->height());
                 matrix.postTranslate(-m_contentsTiling.phase.width(), -m_contentsTiling.phase.height());
+                SkPaint paint = setupPaint();
                 paint.setShader(tileImage->makeShader(SkTileMode::kRepeat, SkTileMode::kRepeat, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), matrix));
                 canvas.drawRect(m_contentsRect, paint);
             }
         }
 
         if (image) {
-            canvas.drawImageRect(image, SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(m_contentsRect),
-                SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
+            if (shouldPaintNow) {
+                SkPaint paint = setupPaint();
+                canvas.drawImageRect(image, SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(m_contentsRect),
+                    SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
+            } else {
+                auto clippingRect = m_contentsClippingRect.rect();
+                if (clippingRect.contains(m_contentsRect))
+                    clippingRect = { };
+                context.imageSetBatch.addImage(canvas, image, m_contentsRect, clippingRect, ctm, context.opacity, enableAntialias);
+            }
         }
     }
 }
 
 #if ENABLE(DAMAGE_TRACKING)
-void SkiaCompositingLayer::collectFrameDamage(SkCanvas& canvas, PaintContext& context, const TransformationMatrix& transform)
+void SkiaCompositingLayer::collectFrameDamage(SkCanvas& canvas, PaintContext& context)
 {
     if (!frameDamagePropagationEnabled() || !context.frameDamage)
         return;
 
+    TransformationMatrix transform(context.accumulatedReplicaTransform);
+    transform.multiply(m_transforms.combined);
     auto frameDamage = transform.mapRect(effectiveLayerRect());
     auto clipBounds = FloatRect(this->clipBounds(canvas, context));
     if (!clipBounds.isEmpty())
@@ -567,10 +605,11 @@ void SkiaCompositingLayer::paintDebugIndicators(SkCanvas& canvas, PaintContext& 
 
     TransformationMatrix transform(context.accumulatedReplicaTransform);
     transform.multiply(m_transforms.combined);
-    SkAutoCanvasRestore autoRestore(&canvas, true);
-    canvas.concat(SkM44(transform));
 
     if (m_debugBorder) {
+        SkAutoCanvasRestore autoRestore(&canvas, true);
+        canvas.concat(SkM44(transform));
+
         SkPaint borderPaint;
         borderPaint.setStyle(SkPaint::kStroke_Style);
         borderPaint.setColor(SkColor(m_debugBorder->color));
@@ -615,8 +654,7 @@ void SkiaCompositingLayer::paintDebugIndicators(SkCanvas& canvas, PaintContext& 
         m_repaintCountOverlay.baselineOffset = -textBounds.fTop + padding;
     }
 
-    SkAutoCanvasRestore overlayRestore(&canvas, true);
-    canvas.resetMatrix();
+    SkAutoCanvasRestore autoRestore(&canvas, true);
 
     SkPaint backgroundPaint;
     backgroundPaint.setColor(m_debugBorder ? SkColor(m_debugBorder->color) : SK_ColorBLACK);
@@ -677,18 +715,22 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
 
     const bool contentsRectClipsDescendants = !m_preserves3D && m_contentsRectClipsDescendants && (m_contentsClippingRect.isRounded() || !m_contentsClippingRect.rect().contains(m_contentsRect));
     const bool masksToBounds = !m_preserves3D && m_masksToBounds;
-    const bool shouldClip = masksToBounds || contentsRectClipsDescendants;
-    SkAutoCanvasRestore autoRestore(&canvas, shouldClip);
-    if (shouldClip) {
-        FloatRoundedRect rect = contentsRectClipsDescendants ? m_contentsClippingRect : FloatRoundedRect(effectiveLayerRect());
-        TransformationMatrix clipTransform(context.accumulatedReplicaTransform);
+    TransformationMatrix clipTransform;
+    FloatRoundedRect clippingRect;
+    if (masksToBounds || contentsRectClipsDescendants) {
+        clipTransform = context.accumulatedReplicaTransform;
         clipTransform.multiply(m_transforms.combined);
         if (!contentsRectClipsDescendants)
             clipTransform.translate(m_boundsOrigin.x(), m_boundsOrigin.y());
 
+        FloatRoundedRect rect = contentsRectClipsDescendants ? m_contentsClippingRect : FloatRoundedRect(effectiveLayerRect());
         if (!canSkipClip(rect, clipTransform))
-            clipRect(canvas, rect, clipTransform);
+            clippingRect = rect;
     }
+
+    ScopedFlush autoFlush(canvas, context.imageSetBatch, clippingRect.isEmpty() ? ScopedFlush::Mode::DoNothing : ScopedFlush::Mode::FlushBeforeAndAfter);
+    if (!clippingRect.isEmpty())
+        clipRect(canvas, clippingRect, clipTransform);
 
     for (auto& child : m_children)
         child->recursivePaint(canvas, context);
@@ -779,10 +821,13 @@ void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintC
     if (!surfaceCanvas)
         return;
 
+    context.imageSetBatch.flushIfNeeded(canvas);
+
     surfaceCanvas->clear(SK_ColorTRANSPARENT);
     surfaceCanvas->translate(-surfaceRect.x(), -surfaceRect.y());
     SetForScope scopedOffset(context.offset, toIntSize(surfaceRect.location()));
     paintFunction(*surfaceCanvas, context);
+    context.imageSetBatch.flushIfNeeded(*surfaceCanvas);
     grContext->flushAndSubmit(surface.get(), GrSyncCpu::kNo);
 
     canvas.drawImageRect(surface->makeImageSnapshot(), SkRect::MakeWH(surfaceRect.width(), surfaceRect.height()), SkRect::Make(surfaceRect), SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), paint, SkCanvas::kFast_SrcRectConstraint);
@@ -790,6 +835,8 @@ void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintC
 
 void SkiaCompositingLayer::paintBackdrop(SkCanvas& canvas, PaintContext& context)
 {
+    context.imageSetBatch.flushIfNeeded(canvas);
+
     SkAutoCanvasRestore autoRestore(&canvas, true);
     TransformationMatrix clipTransform(context.accumulatedReplicaTransform);
     clipTransform.multiply(m_transforms.combined);
@@ -835,7 +882,8 @@ void SkiaCompositingLayer::paintWithMaskAndBackdrop(SkCanvas& canvas, PaintConte
         if (!shouldClipPath)
             maskImage = m_mask->maskImage();
     }
-    SkAutoCanvasRestore autoRestore(&canvas, shouldClipPath || maskImage);
+
+    ScopedFlush autoFlush(canvas, context.imageSetBatch, shouldClipPath || maskImage ? ScopedFlush::Mode::FlushBeforeAndAfter : ScopedFlush::Mode::DoNothing);
     if (shouldClipPath || maskImage) {
         TransformationMatrix transform(context.accumulatedReplicaTransform);
         transform.multiply(m_mask->m_transforms.combined);
@@ -1059,7 +1107,7 @@ void SkiaCompositingLayer::paintWithOpacity(SkCanvas& canvas, PaintContext& cont
     }
 
     for (const auto& rect : data.nonOverlapRegion.rects()) {
-        SkAutoCanvasRestore autoRestore(&canvas, true);
+        ScopedFlush autoFlush(canvas, context.imageSetBatch, ScopedFlush::Mode::FlushBeforeAndAfter);
         canvas.clipIRect(SkIRect::MakeLTRB(rect.x(), rect.y(), rect.maxX(), rect.maxY()));
         paintWithReplica(canvas, context);
     }
@@ -1114,7 +1162,7 @@ void SkiaCompositingLayer::paintWithBlendMode(SkCanvas& canvas, PaintContext& co
     }
 
     for (const auto& rect : data.nonOverlapRegion.rects()) {
-        SkAutoCanvasRestore autoRestore(&canvas, true);
+        ScopedFlush autoFlush(canvas, context.imageSetBatch, ScopedFlush::Mode::FlushBeforeAndAfter);
         canvas.clipIRect(SkIRect::MakeLTRB(rect.x(), rect.y(), rect.maxX(), rect.maxY()));
         paintWithFilterAndMask(canvas, context);
     }
@@ -1166,7 +1214,7 @@ void SkiaCompositingLayer::paintWith3DRenderingContext(SkCanvas& canvas, PaintCo
     collect3DRenderingContextLayers(layers);
 
     SkiaCompositingLayer3DRenderingContext::paint(layers, [&](SkiaCompositingLayer& layer, std::optional<SkPath> clipPath) {
-        SkAutoCanvasRestore autoRestore(&canvas, clipPath.has_value());
+        ScopedFlush autoFlush(canvas, context.imageSetBatch, clipPath ? ScopedFlush::Mode::FlushBeforeAndAfter : ScopedFlush::Mode::DoNothing);
         if (clipPath)
             canvas.clipPath(*clipPath);
 

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -34,6 +34,7 @@
 #include "FloatPoint3D.h"
 #include "FloatRect.h"
 #include "FloatRoundedRect.h"
+#include "SkiaCompositingLayerImageSetBatch.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
 #include "TextureMapperAnimation.h"
 #include "TransformationMatrix.h"
@@ -112,6 +113,8 @@ public:
     bool hasDebugIndicators() const { return m_debugBorder.has_value() || m_repaintCount.has_value(); }
 
 private:
+    using ScopedFlush = SkiaCompositingLayerImageSetBatch::ScopedFlush;
+
     SkiaCompositingLayer() = default;
 
     void removeFromParent();
@@ -142,6 +145,7 @@ private:
         RefPtr<SkiaCompositingLayer> paintingBackdropForLayer;
         bool skipAfterBackdrop { false };
         std::optional<Damage>& frameDamage;
+        SkiaCompositingLayerImageSetBatch imageSetBatch;
     };
 
     struct Filter {
@@ -160,7 +164,7 @@ private:
     void paintContents(SkCanvas&, PaintContext&);
     void paintDebugIndicators(SkCanvas&, PaintContext&);
 #if ENABLE(DAMAGE_TRACKING)
-    void collectFrameDamage(SkCanvas&, PaintContext&, const TransformationMatrix&);
+    void collectFrameDamage(SkCanvas&, PaintContext&);
 #endif
     void paintSelfAndChildren(SkCanvas&, PaintContext&);
     void paintWithIntermediateSurface(SkCanvas&, PaintContext&, const IntRect&, SkPaint*, PaintFunction&&);

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaCompositingLayerImageSetBatch.h"
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "FloatRect.h"
+#include "SkiaBackingStore.h"
+
+namespace WebCore {
+
+void SkiaCompositingLayerImageSetBatch::updatePaintProperties(SkCanvas& canvas, const sk_sp<SkColorFilter>& colorFilter, const std::optional<SkBlendMode>& blendMode)
+{
+    if (!m_imageSet.isEmpty() && (m_blendMode != blendMode || m_colorFilter != colorFilter))
+        flushIfNeeded(canvas);
+
+    m_blendMode = blendMode;
+    m_colorFilter = colorFilter;
+}
+
+void SkiaCompositingLayerImageSetBatch::updateSamplingOptions(SkCanvas& canvas, SkSamplingOptions samplingOptions)
+{
+    if (!m_imageSet.isEmpty() && m_samplingOptions != samplingOptions)
+        flushIfNeeded(canvas);
+
+    m_samplingOptions = samplingOptions;
+}
+
+void SkiaCompositingLayerImageSetBatch::addImageSet(SkCanvas& canvas, SkiaBackingStore& backingStore, const SkMatrix& ctm, float opacity, bool enableAntialias)
+{
+    updateSamplingOptions(canvas, SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone));
+
+    if (m_preViewMatrices.isEmpty() || m_preViewMatrices.last() != ctm)
+        m_preViewMatrices.append(ctm);
+
+    auto imageSet = backingStore.buildImageSet(m_preViewMatrices.size() - 1, opacity, enableAntialias);
+    if (m_imageSet.isEmpty())
+        m_imageSet = WTF::move(imageSet);
+    else
+        m_imageSet.appendVector(WTF::move(imageSet));
+}
+
+void SkiaCompositingLayerImageSetBatch::addImage(SkCanvas& canvas, const sk_sp<SkImage>& image, const FloatRect& rect, const FloatRect& clip, const SkMatrix& ctm, float opacity, bool enableAntialias)
+{
+    updateSamplingOptions(canvas, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone));
+
+    if (m_preViewMatrices.isEmpty() || m_preViewMatrices.last() != ctm)
+        m_preViewMatrices.append(ctm);
+
+    if (!clip.isEmpty()) {
+        auto quad = SkRect(clip).toQuad();
+        for (const auto& point : quad)
+            m_dstClips.append(point);
+    }
+
+    size_t matrixIndex = m_preViewMatrices.size() - 1;
+    unsigned aaFlags = enableAntialias ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
+    m_imageSet.append(SkCanvas::ImageSetEntry(image, SkRect::MakeWH(image->width(), image->height()), SkRect(rect), matrixIndex, opacity, aaFlags, !clip.isEmpty()));
+}
+
+void SkiaCompositingLayerImageSetBatch::flushIfNeeded(SkCanvas& canvas)
+{
+    if (m_imageSet.isEmpty())
+        return;
+
+    SkPaint paint;
+    if (m_blendMode)
+        paint.setBlendMode(*m_blendMode);
+    if (m_colorFilter)
+        paint.setColorFilter(m_colorFilter);
+
+    canvas.experimental_DrawEdgeAAImageSet(m_imageSet.span().data(), m_imageSet.size(), m_dstClips.span().data(),
+        m_preViewMatrices.span().data(), m_samplingOptions, &paint, SkCanvas::kFast_SrcRectConstraint);
+
+    m_imageSet.clear();
+    m_dstClips.clear();
+    m_preViewMatrices.clear();
+    m_blendMode = std::nullopt;
+    m_samplingOptions = { };
+}
+
+SkiaCompositingLayerImageSetBatch::ScopedFlush::ScopedFlush(SkCanvas& canvas, SkiaCompositingLayerImageSetBatch& imageSetBatch, Mode mode)
+    : m_canvas(canvas)
+    , m_imageSetBatch(imageSetBatch)
+    , m_mode(mode)
+    , m_saveCount(canvas.getSaveCount())
+{
+    if (m_mode != Mode::DoNothing) {
+        m_imageSetBatch.flushIfNeeded(m_canvas);
+        canvas.save();
+    }
+}
+
+SkiaCompositingLayerImageSetBatch::ScopedFlush::~ScopedFlush()
+{
+    if (m_mode == Mode::FlushBeforeAndAfter)
+        m_imageSetBatch.flushIfNeeded(m_canvas);
+
+    if (m_mode != Mode::DoNothing)
+        m_canvas.restoreToCount(m_saveCount);
+}
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkCanvas.h>
+#include <skia/core/SkColorFilter.h>
+#include <skia/core/SkImage.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/ForbidHeapAllocation.h>
+#include <wtf/Noncopyable.h>
+
+namespace WebCore {
+class FloatRect;
+class SkiaBackingStore;
+
+class SkiaCompositingLayerImageSetBatch {
+    WTF_MAKE_NONCOPYABLE(SkiaCompositingLayerImageSetBatch);
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    SkiaCompositingLayerImageSetBatch() = default;
+    ~SkiaCompositingLayerImageSetBatch() = default;
+
+    void updatePaintProperties(SkCanvas&, const sk_sp<SkColorFilter>&, const std::optional<SkBlendMode>&);
+    void updateSamplingOptions(SkCanvas&, SkSamplingOptions);
+    void addImageSet(SkCanvas&, SkiaBackingStore&, const SkMatrix&, float opacity, bool enableAntialias);
+    void addImage(SkCanvas&, const sk_sp<SkImage>&, const FloatRect&, const FloatRect& clip, const SkMatrix&, float opacity, bool enableAntialias);
+    void flushIfNeeded(SkCanvas&);
+
+    class ScopedFlush {
+    public:
+        enum class Mode : uint8_t { DoNothing, FlushBefore, FlushBeforeAndAfter };
+        ScopedFlush(SkCanvas&, SkiaCompositingLayerImageSetBatch&, Mode);
+        ~ScopedFlush();
+
+    private:
+        ScopedFlush(ScopedFlush&&) = delete;
+        ScopedFlush(const ScopedFlush&) = delete;
+        ScopedFlush& operator=(ScopedFlush&&) = delete;
+        ScopedFlush& operator=(const ScopedFlush&) = delete;
+
+        SkCanvas& m_canvas;
+        SkiaCompositingLayerImageSetBatch& m_imageSetBatch;
+        Mode m_mode { Mode::DoNothing };
+        int m_saveCount { 0 };
+    };
+
+private:
+    Vector<SkCanvas::ImageSetEntry> m_imageSet;
+    Vector<SkPoint> m_dstClips;
+    Vector<SkMatrix> m_preViewMatrices;
+    sk_sp<SkColorFilter> m_colorFilter;
+    std::optional<SkBlendMode> m_blendMode;
+    SkSamplingOptions m_samplingOptions;
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)


### PR DESCRIPTION
#### 14f3f90b25369f7cb674514274346ff440a20865
<pre>
[GTK][WPE] Skia Compositor: implement batched painting
<a href="https://bugs.webkit.org/show_bug.cgi?id=316294">https://bugs.webkit.org/show_bug.cgi?id=316294</a>

Reviewed by Nikolas Zimmermann.

Using the experimental SkCanvas API to draw a set of images with a
single call, we can group draw operations in batches before passing them
to skia. This is more efficient when we have many layers painting
content that can be merged.

* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::buildImageSet const):
(WebCore::SkiaBackingStore::Tile::image const):
(WebCore::SkiaBackingStore::Tile::image): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.h:
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paint):
(WebCore::SkiaCompositingLayer::paintSelf):
(WebCore::SkiaCompositingLayer::paintContents):
(WebCore::SkiaCompositingLayer::collectFrameDamage):
(WebCore::SkiaCompositingLayer::paintDebugIndicators):
(WebCore::SkiaCompositingLayer::paintSelfAndChildren):
(WebCore::SkiaCompositingLayer::paintWithIntermediateSurface):
(WebCore::SkiaCompositingLayer::paintBackdrop):
(WebCore::SkiaCompositingLayer::paintWithMaskAndBackdrop):
(WebCore::SkiaCompositingLayer::paintWithOpacity):
(WebCore::SkiaCompositingLayer::paintWithBlendMode):
(WebCore::SkiaCompositingLayer::paintWith3DRenderingContext):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp: Added.
(WebCore::SkiaCompositingLayerImageSetBatch::updatePaintProperties):
(WebCore::SkiaCompositingLayerImageSetBatch::updateSamplingOptions):
(WebCore::SkiaCompositingLayerImageSetBatch::addImageSet):
(WebCore::SkiaCompositingLayerImageSetBatch::addImage):
(WebCore::SkiaCompositingLayerImageSetBatch::flushIfNeeded):
(WebCore::SkiaCompositingLayerImageSetBatch::ScopedFlush::ScopedFlush):
(WebCore::SkiaCompositingLayerImageSetBatch::ScopedFlush::~ScopedFlush):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h: Added.

Canonical link: <a href="https://commits.webkit.org/314626@main">https://commits.webkit.org/314626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ae0827fc2e824ce911f383afacd9d3e5300c6c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175721 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123930 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129590 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110115 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29662 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23862 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178255 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31155 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137951 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137868 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149255 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103692 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25366 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33154 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26120 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39432 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112506 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38828 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4210 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->