### PR TITLE
[SVG intrinsic sizing] height: max-content uses default width instead of the used width when only a viewBox is present

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/svg-intrinsic-size-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/svg-intrinsic-size-008-expected.txt
@@ -8,7 +8,5 @@ PASS svg 1
 PASS svg 2
 PASS svg 3
 PASS svg 4
-FAIL svg 5 assert_equals:
-<svg viewBox="0 0 4 1" data-expected-client-width="400" data-expected-client-height="100"></svg>
-clientWidth expected 400 but got 300
+PASS svg 5
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -202,14 +202,14 @@ LayoutUnit RenderSVGRoot::computeReplacedLogicalHeight(std::optional<LayoutUnit>
         return containingBlock()->availableLogicalHeight(AvailableLogicalHeightType::IncludeMarginBorderPadding);
 
     // For intrinsic sizing keywords (e.g. max-content), when the SVG has no intrinsic height
-    // but has an intrinsic ratio (from viewBox), compute the height using the width and the
+    // but has an intrinsic ratio (from viewBox), compute the height from the used width and the
     // aspect ratio.
     if (style().logicalHeight().isIntrinsic()) {
         Ref element = svgSVGElement();
         if (!element->hasIntrinsicHeight()) {
             FloatSize viewBoxSize = element->currentViewBoxRect().size();
             if (!viewBoxSize.isEmpty()) {
-                float width = element->hasIntrinsicWidth() ? element->intrinsicWidth() : defaultWidth;
+                float width = element->hasIntrinsicWidth() ? element->intrinsicWidth() : (estimatedUsedWidth ? estimatedUsedWidth.value() : contentBoxLogicalWidth()).toFloat();
                 double ratio = viewBoxSize.height() / viewBoxSize.width();
                 return computeReplacedLogicalHeightRespectingMinMaxHeight(LayoutUnit(width * ratio));
             }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -183,14 +183,14 @@ LayoutUnit LegacyRenderSVGRoot::computeReplacedLogicalHeight(std::optional<Layou
         return containingBlock()->availableLogicalHeight(AvailableLogicalHeightType::IncludeMarginBorderPadding);
 
     // For intrinsic sizing keywords (e.g. max-content), when the SVG has no intrinsic height
-    // but has an intrinsic ratio (from viewBox), compute the height using the width and the
+    // but has an intrinsic ratio (from viewBox), compute the height from the used width and the
     // aspect ratio.
     if (style().logicalHeight().isIntrinsic()) {
         Ref element = svgSVGElement();
         if (!element->hasIntrinsicHeight()) {
             FloatSize viewBoxSize = element->currentViewBoxRect().size();
             if (!viewBoxSize.isEmpty()) {
-                float width = element->hasIntrinsicWidth() ? element->intrinsicWidth() : legacySVGRootDefaultWidth;
+                float width = element->hasIntrinsicWidth() ? element->intrinsicWidth() : (estimatedUsedWidth ? estimatedUsedWidth.value() : contentBoxLogicalWidth()).toFloat();
                 double ratio = viewBoxSize.height() / viewBoxSize.width();
                 return computeReplacedLogicalHeightRespectingMinMaxHeight(LayoutUnit(width * ratio));
             }


### PR DESCRIPTION
#### 96eae58972a85900b99139da99d64c69ae9a2201
<pre>
[SVG intrinsic sizing] height: max-content uses default width instead of the used width when only a viewBox is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=316299">https://bugs.webkit.org/show_bug.cgi?id=316299</a>
<a href="https://rdar.apple.com/178712792">rdar://178712792</a>

Reviewed by Alan Baradlay.

Follow-up to 313864@main. When an SVG has only a viewBox and resolves an
intrinsic height keyword (e.g. height: max-content), we derived the height
from the 300px default width via the aspect ratio, ignoring the used width.
The upstream svg-intrinsic-size-008.html synced in 314370@main expects the
&quot;Just viewBox&quot; case (height:max-content in a 400x400 block) to be 400x100,
but we produced 300x75 and this is also expected [1] &amp; [2]:

Use the estimated used width when provided, otherwise contentBoxLogicalWidth(),
mirroring RenderReplaced::computeReplacedLogicalHeight.

[1] <a href="https://github.com/w3c/csswg-drafts/issues/13149#issuecomment-4569048300">https://github.com/w3c/csswg-drafts/issues/13149#issuecomment-4569048300</a>
[2] <a href="https://github.com/w3c/csswg-drafts/issues/13149#issuecomment-4146914054">https://github.com/w3c/csswg-drafts/issues/13149#issuecomment-4146914054</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/svg-intrinsic-size-008-expected.txt: Progression
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::computeReplacedLogicalHeight const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::computeReplacedLogicalHeight const):

Canonical link: <a href="https://commits.webkit.org/314556@main">https://commits.webkit.org/314556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d7800935720b1a01fa66ee9592318165e9b7de3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123692 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129387 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109912 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30748 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29448 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23625 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178018 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30919 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137742 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137661 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37098 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103375 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32957 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25908 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39195 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112270 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38592 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3994 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38735 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->