### PR TITLE
moveBefore() needs to handle selections

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6117,9 +6117,6 @@ webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBef
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/select-option-optgroup.html [ Skip ]
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/css-transition-trigger.html [ Skip ]
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/relevant-mutations.html [ Skip ]
-webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/selection-preserve.html [ Skip ]
-webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/hover-style-update.html [ Skip ]
-webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/pointer-events.html [ Skip ]
 
 # Flaky crash.
 webkit.org/b/315031 imported/w3c/web-platform-tests/dom/nodes/moveBefore/throws-exception.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/selection-preserve-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/selection-preserve-expected.txt
@@ -1,12 +1,21 @@
+Four
 One
 Two
 Three
-Four
 
-FAIL moveBefore should not reset selection with preceding text assert_equals: expected Text node "This text does not move" but got Text node "Text"
-FAIL moveBefore resets selection that enters a subtree, when the whole selection is moved assert_equals: expected Text node "Grandparent paragraph" but got Text node "Parent paragraph"
-FAIL moveBefore anchor node moved up to expand selection and absorb nodes assert_equals: expected Text node "Child paragraph one" but got Text node "Parent paragraph"
-FAIL moveBefore move intersecting nodes out of a selection assert_false: expected false got true
-FAIL moveBefore focus node moved up to shrink selection and exclude nodes; focus node gets reset assert_equals: expected Text node "Parent paragraph" but got Text node "Paragraph two"
-FAIL moveBefore selection is not preserved, especially when underlying range gets inverted assert_equals: expected Text node "Three" but got Text node "Four"
+FAIL moveBefore should not reset selection with preceding text assert_equals: expected Text node "This text does not move" but got Element node <div id="old_parent">
+      <span id="notMove">This text ...
+FAIL moveBefore resets selection that enters a subtree, when the whole selection is moved assert_equals: expected Text node "Grandparent paragraph" but got Element node <div id="grandparentDiv">
+    <div id="parentDiv">
+      ...
+FAIL moveBefore anchor node moved up to expand selection and absorb nodes assert_equals: expected Text node "Child paragraph one" but got Element node <div id="parentDiv">
+
+      <div id="childDiv">
+   ...
+PASS moveBefore move intersecting nodes out of a selection
+FAIL moveBefore focus node moved up to shrink selection and exclude nodes; focus node gets reset assert_equals: expected Text node "Parent paragraph" but got Element node <div id="parentDiv">
+      <div id="childDiv">
+        <s...
+FAIL moveBefore selection is not preserved, especially when underlying range gets inverted assert_equals: expected Text node "Three" but got Element node <ul id="list">
+      <li id="i4">Four</li><li id="i1">One...
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/dom/nodes/moveBefore/selection-preserve-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/dom/nodes/moveBefore/selection-preserve-expected.txt
@@ -1,7 +1,7 @@
+Four
 One
 Two
 Three
-Four
 
 FAIL moveBefore should not reset selection with preceding text assert_equals: expected Text node "This text does not move" but got null
 FAIL moveBefore resets selection that enters a subtree, when the whole selection is moved assert_equals: expected Text node "Grandparent paragraph" but got null

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6911,6 +6911,9 @@ void Document::nodeWillBeMoved(Node& node)
 
     for (Ref range : m_ranges)
         range->nodeWillBeRemoved(node);
+
+    if (RefPtr frame = this->frame())
+        frame->selection().nodeWillBeRemoved(node);
 }
 
 void Document::parentlessNodeMovedToNewDocument(Node& node)


### PR DESCRIPTION
#### 7aeb5ed5836e6fd06bca752f0ec6c491f8058e51
<pre>
moveBefore() needs to handle selections
<a href="https://bugs.webkit.org/show_bug.cgi?id=316302">https://bugs.webkit.org/show_bug.cgi?id=316302</a>

Reviewed by Ryosuke Niwa.

This calls FrameSelection::nodeWillBeRemoved() from within Document::nodeWillBeMoved().
This correctly resets the ContainsSelectionEndPoint state flag, which fixes some crashes.

While the selection-preserve.html test itself now runs, it largely fails still, but
this is also true in Firefox&apos;s implementation so will need further investigations as it might
be the test itself that&apos;s broken.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/selection-preserve-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/dom/nodes/moveBefore/selection-preserve-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::nodeWillBeMoved):

Canonical link: <a href="https://commits.webkit.org/314898@main">https://commits.webkit.org/314898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69c7b3a04cf447c334803ca2ea6c0efe35dd3543

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176627 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130377 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150564 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110894 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25359 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179167 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32060 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138772 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138658 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37321 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150051 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104981 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33914 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26930 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40331 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113414 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39728 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5031 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->