### PR TITLE
moveBefore() needs to reset :lang() and :dir()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-dir-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-dir-expected.txt
@@ -1,0 +1,4 @@
+InnerTarget
+
+PASS moveBefore() correctly updates the computed dir for moved nodes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-dir.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-dir.html
@@ -1,0 +1,32 @@
+<!-- webkit-test-runner [ MoveBeforeEnabled=true ] -->
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+  <div dir="ltr">
+    <div id="source">
+      <span id="target"><span id="inner">Inner</span>Target</span>
+    </div>
+  </div>
+
+  <div dir="rtl">
+    <div id="dest"></div>
+  </div>
+</body>
+
+<script>
+  test(() => {
+      assert_true(target.matches(':dir(ltr)'));
+      assert_true(inner.matches(':dir(ltr)'));
+      assert_false(target.matches(':dir(rtl)'));
+      assert_false(inner.matches(':dir(rtl)'));
+
+      dest.moveBefore(target, null);
+
+      assert_false(target.matches(':dir(ltr)'));
+      assert_false(inner.matches(':dir(ltr)'));
+      assert_true(target.matches(':dir(rtl)'));
+      assert_true(inner.matches(':dir(rtl)'));
+  }, 'moveBefore() correctly updates the computed dir for moved nodes');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-lang-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-lang-expected.txt
@@ -1,0 +1,4 @@
+InnerTarget
+
+PASS moveBefore() correctly updates the computed lang for moved nodes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-lang.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-lang.html
@@ -1,0 +1,32 @@
+<!-- webkit-test-runner [ MoveBeforeEnabled=true ] -->
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+  <div lang="en">
+    <div id="source">
+      <span id="target"><span id="inner">Inner</span>Target</span>
+    </div>
+  </div>
+
+  <div lang="fr">
+    <div id="dest"></div>
+  </div>
+</body>
+
+<script>
+  test(() => {
+      assert_true(target.matches(':lang(en)'));
+      assert_true(inner.matches(':lang(en)'));
+      assert_false(target.matches(':lang(fr)'));
+      assert_false(inner.matches(':lang(fr)'));
+
+      dest.moveBefore(target, null);
+
+      assert_false(target.matches(':lang(en)'));
+      assert_false(inner.matches(':lang(en)'));
+      assert_true(target.matches(':lang(fr)'));
+      assert_true(inner.matches(':lang(fr)'));
+  }, 'moveBefore() correctly updates the computed lang for moved nodes');
+</script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3280,6 +3280,11 @@ void Element::movingSteps(bool isSubtreeRoot, ContainerNode& oldParent)
             updateNameForDocument(*newHTMLDocument, nullAtom(), nameValue);
     }
 
+    if (!is<HTMLSlotElement>(*this))
+        updateEffectiveTextDirectionIfNeeded();
+
+    updateEffectiveLangState();
+
     if (!isSubtreeRoot || !hasFocusWithin())
         return;
 


### PR DESCRIPTION
#### 9f4453c1370328f1417f3286840598c01e0b3f6a
<pre>
moveBefore() needs to reset :lang() and :dir()
<a href="https://bugs.webkit.org/show_bug.cgi?id=316304">https://bugs.webkit.org/show_bug.cgi?id=316304</a>

Reviewed by Ryosuke Niwa.

The Element::movingSteps() are updated to update the effective text direction,
and the effective lang state for the moved node.

This was previously missing test coverage so some tests are also added.

Tests: imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-dir.html
       imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-lang.html

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-dir-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-dir.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-lang-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-lang.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::movingSteps):

Canonical link: <a href="https://commits.webkit.org/314695@main">https://commits.webkit.org/314695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44706d04e28dfbdb8f72f1c90fceff4cb78c7c5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123711 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129405 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91136 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149566 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109930 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30768 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29467 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23644 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178037 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30938 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137760 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137679 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37179 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149060 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103410 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32974 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25926 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39214 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112289 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38611 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4012 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38856 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->