### PR TITLE
ANGLE: Metal: webgl/1.0.x/conformance/extensions/webgl-compressed-texture-astc.html crashes on iOS simulator

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4576,6 +4576,8 @@ webgl/1.0.x/conformance/textures/canvas/tex-2d-rgb-rgb-unsigned_byte.html [ Pass
 webgl/2.0.y/conformance/textures/canvas/tex-2d-rgb-rgb-unsigned_byte.html [ Pass Timeout ]
 
 webkit.org/b/229934 webgl/1.0.x/conformance/extensions/webgl-depth-texture.html [ Failure ]
+
+webkit.org/b/254398 webgl/1.0.x/conformance/extensions/webgl-compressed-texture-astc.html [ Failure ]
 webkit.org/b/254398 webgl/2.0.y/conformance/extensions/webgl-compressed-texture-astc.html [ Failure ]
 
 # webkit.org/b/255177 Batch mark expectations for newly failing tests introduced with iOS 16.4 update

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm
@@ -412,19 +412,17 @@ bool PreferStagedTextureUploads(const gl::Context *context,
                                 const Format &textureObjFormat,
                                 StagingPurpose purpose)
 {
-    // The simulator MUST upload all textures as staged.
-    if (TARGET_OS_SIMULATOR)
-    {
-        return true;
-    }
-
-    ContextMtl *contextMtl             = mtl::GetImpl(context);
-    const angle::FeaturesMtl &features = contextMtl->getDisplay()->getFeatures();
-
+    // Compressed textures cannot be uploaded from staging textures.
     const gl::InternalFormat &intendedInternalFormat = textureObjFormat.intendedInternalFormat();
     if (intendedInternalFormat.compressed || textureObjFormat.actualAngleFormat().isBlock)
     {
         return false;
+    }
+
+    // The simulator MUST upload all non-compressed textures as staged.
+    if (TARGET_OS_SIMULATOR)
+    {
+        return true;
     }
 
     // If the intended internal format is luminance, we can still
@@ -438,6 +436,9 @@ bool PreferStagedTextureUploads(const gl::Context *context,
     {
         return (purpose == StagingPurpose::Initialization);
     }
+
+    ContextMtl *contextMtl             = mtl::GetImpl(context);
+    const angle::FeaturesMtl &features = contextMtl->getDisplay()->getFeatures();
 
     if (features.disableStagedInitializationOfPackedTextureFormats.enabled)
     {

--- a/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_expectations.txt
+++ b/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_expectations.txt
@@ -1316,8 +1316,6 @@
 40096874 IOS METAL : CubeMapTextureTest.SampleCoordinateTransformGrad_ES3/* = SKIP
 40096874 IOS METAL : EGLDisplaySelectionTestDeviceId.DeviceId/* = SKIP
 40096874 IOS METAL : EGLDisplaySelectionTestDeviceId.DeviceIdConcurrently/* = SKIP
-40096874 IOS METAL : ETC1CompressedTextureTest.ETC1CompressedImageDraws/* = SKIP
-40096874 IOS METAL : KTXCompressedTextureTest.CompressedTexImageETC1/* = SKIP
 40096874 IOS METAL : MaxTextureSizeTest.Render1xTexture/* = SKIP
 40096874 IOS METAL : MultisampleTest.AlphaToSampleCoverage/* = SKIP
 40096838 IOS METAL : PixelLocalStorageTest.BlendColorMaskAndClear/ES3_Metal_EmulatePixelLocalStorage* = SKIP
@@ -1395,29 +1393,14 @@
 40096883 IOS METAL : Texture2DDepthStencilTestES3.TexSampleModes*Swizzled/* = SKIP
 375244081 IOS METAL : GLSLTest_ES3.MaxVaryingWithFeedbackAndGLline/* = SKIP
 496604559 IOS METAL : RobustResourceInitTestES3.DrawThenInvalidateThenVerifyDepthStencil/* = SKIP
-507904704 IOS METAL : CompressedTextureASTCTest.Test/* = SKIP
-507904704 IOS METAL : CompressedTextureEACR11STest.Test/* = SKIP
-507904704 IOS METAL : CompressedTextureEACR11UTest.Test/* = SKIP
-507904704 IOS METAL : CompressedTextureEACRG11STest.Test/* = SKIP
-507904704 IOS METAL : CompressedTextureEACRG11UTest.Test/* = SKIP
-507904704 IOS METAL : CompressedTextureETC1SubTest.Test/* = SKIP
-507904704 IOS METAL : CompressedTextureETC2RGB8A1SRGBTest.Test/* = SKIP
-507904704 IOS METAL : CompressedTextureETC2RGB8A1Test.Test/* = SKIP
-507904704 IOS METAL : CompressedTextureETC2RGB8SRGBTest.Test/* = SKIP
-507904704 IOS METAL : CompressedTextureETC2RGB8Test.Test/* = SKIP
-507904704 IOS METAL : CompressedTextureETC2RGBA8SRGBTest.Test/* = SKIP
-507904704 IOS METAL : CompressedTextureETC2RGBA8Test.Test/* = SKIP
-507904704 IOS METAL : ETC1CompressedTextureTest.ETC1CompressedImageNPOT/* = SKIP
-507904704 IOS METAL : ETC1CompressedTextureTest.ETC1CompressedSubImage/* = SKIP
-507904704 IOS METAL : ETC1CompressedTextureTest.ETC1ShrinkThenGrowMaxLevels/* = SKIP
-507904704 IOS METAL : Texture2DTestES3.SampleThenFullUpdateThenSampleAgainCompressed/* = SKIP
-507904704 IOS METAL : TextureSizeLimitTest.CompressedASTC/* = SKIP
-507904704 IOS METAL : WebGLCompatibilityTest.EnableCompressedTextureExtensionETC1/* = SKIP
 
 // Simulator does not support compare functions in the sampler state
 365066518 IOS METAL : ShadowSamplerFunctionTexture2DTest.Test/* = SKIP
 365066518 IOS METAL : ShadowSamplerFunctionTexture2DArrayTest.Test/* = SKIP
 365066518 IOS METAL : ShadowSamplerFunctionTextureCubeTest.Test/* = SKIP
+
+// webkit.org/b/316306
+0 IOSSIMULATOR METAL : WebGL2CompatibilityTest.CompressedTextureASTCEmptyStorageError/* = SKIP
 
 // D3D11 backend does not support LOD options with shadow samplers
 365066518 D3D11 : ShadowSamplerFunctionTexture2DTest.Test/*__TextureBias_Mipmapped = SKIP

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp
@@ -3500,6 +3500,49 @@ TEST_P(WebGLCompatibilityTest, CompressedTexImageBPTC)
     }
 }
 
+// Sampling an uninitialized COMPRESSED_RGBA_ASTC_4x4_KHR texture allocated via glTexStorage2D
+// should yield NaN per the ASTC spec for empty/undefined block data; the NaN-to-magenta shader
+// should therefore produce magenta. Isolates the first failing sub-test of the WebGL conformance
+// test webgl/2.0.y/conformance/extensions/webgl-compressed-texture-astc.html on Metal.
+TEST_P(WebGL2CompatibilityTest, CompressedTextureASTCEmptyStorageError)
+{
+    ANGLE_SKIP_TEST_IF(!EnsureGLExtensionEnabled("GL_KHR_texture_compression_astc_ldr"));
+
+    constexpr char kFS[] = R"(#version 300 es
+precision mediump float;
+uniform sampler2D u_tex2D;
+in vec2 v_texCoord;
+out vec4 out_color;
+void main()
+{
+    vec4 c = texture(u_tex2D, v_texCoord);
+    if (all(isnan(c)))
+        out_color = vec4(1, 0, 1, 1);
+    else
+        out_color = c;
+})";
+
+    ANGLE_GL_PROGRAM(program, essl3_shaders::vs::Texture2DLod(), kFS);
+    glUseProgram(program);
+    glUniform1i(glGetUniformLocation(program, essl3_shaders::Texture2DUniform()), 0);
+
+    GLTexture texture;
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+    glTexStorage2D(GL_TEXTURE_2D, 1, GL_COMPRESSED_RGBA_ASTC_4x4_KHR, 16, 16);
+    ASSERT_GL_NO_ERROR();
+
+    glViewport(0, 0, getWindowWidth(), getWindowHeight());
+    drawQuad(program, essl3_shaders::PositionAttrib(), 0.0f, 1.0f, /*useVertexBuffer=*/true);
+    ASSERT_GL_NO_ERROR();
+
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::magenta);
+}
+
 TEST_P(WebGLCompatibilityTest, L32FTextures)
 {
     constexpr float textureData[]   = {15.1f, 0.0f, 0.0f, 0.0f};


### PR DESCRIPTION
#### 0980a3910af96aa936ab738bd595fd620c0d6a96
<pre>
ANGLE: Metal: webgl/1.0.x/conformance/extensions/webgl-compressed-texture-astc.html crashes on iOS simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=316306">https://bugs.webkit.org/show_bug.cgi?id=316306</a>
<a href="https://rdar.apple.com/178590024">rdar://178590024</a>

Reviewed by Dan Glastonbury.

Regressed in &quot;ebcdce442f Metal: Remove compressed texture uploads with
staging textures&quot; The commit removed support for staged compressed
texture uploads altogether.

Fix by:
- Avoid forcing staged texture uploads for compressed textures on iOS
  simulator.
- Enable compressed texture tests for iOS.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm:
(rx::mtl::PreferStagedTextureUploads):
* Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_expectations.txt:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp:

Canonical link: <a href="https://commits.webkit.org/314832@main">https://commits.webkit.org/314832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99e6f5512f052b4181d942c3be984c21cd04af8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123934 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4ae9fd9-63bb-4b13-aad5-e1c54a124800) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129594 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91265 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96cbd8cf-8002-4fe9-ad78-ad78db76d9a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110119 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1e7c314-d6ed-41f8-ad9c-41c637ccc0aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30964 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29666 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23866 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178259 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29168 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137954 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33813 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137871 "Found 1 new API test failure: WebKitGTK/TestWebKitNetworkSession:/webkit/WebKitNetworkSession/ephemeral (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37277 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149259 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103700 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33158 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26124 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39436 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38832 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4214 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39077 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38975 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->