### PR TITLE
AX: AXObjectCache destructor wipes a newer cache's isolated tree out of treeFrameCache during overlapping iframe document transitions

### DIFF
--- a/LayoutTests/accessibility/iframe-content-remains-accessible-after-navigation-expected.txt
+++ b/LayoutTests/accessibility/iframe-content-remains-accessible-after-navigation-expected.txt
@@ -1,0 +1,9 @@
+This test ensures iframe content remains accessible across rapid iframe document replacements.
+
+PASS: yesButton && yesButton.title.includes('Yes') === true
+PASS: noButton && noButton.title.includes('No') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/iframe-content-remains-accessible-after-navigation.html
+++ b/LayoutTests/accessibility/iframe-content-remains-accessible-after-navigation.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<iframe id="iframe" src="resources/iframe-with-buttons.html" width="500" height="200"></iframe>
+
+<script>
+var output = "This test ensures iframe content remains accessible across rapid iframe document replacements.\n\n";
+
+var yesButton, noButton;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var iframeElement = document.getElementById("iframe");
+    setTimeout(async () => {
+        // Establish the initial iframe accessibility state.
+        yesButton = await waitForElementById("yes-btn");
+        touchAccessibilityTree(accessibilityController.rootElement);
+
+        // Replace the iframe document several times.
+        for (let navCount = 1; navCount <= 3; navCount++) {
+            await new Promise(resolve => {
+                iframeElement.addEventListener("load", function onLoad() {
+                    iframeElement.removeEventListener("load", onLoad);
+                    resolve();
+                });
+                iframeElement.src = `resources/iframe-with-buttons.html?nav=${navCount}`;
+            });
+
+            await waitFor(() => {
+                let candidate = accessibilityController.accessibleElementById("yes-btn");
+                return candidate && !candidate.isEqual(yesButton);
+            });
+            yesButton = accessibilityController.accessibleElementById("yes-btn");
+        }
+
+        noButton = accessibilityController.accessibleElementById("no-btn");
+        output += expect("yesButton && yesButton.title.includes('Yes')", "true");
+        output += expect("noButton && noButton.title.includes('No')", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/resources/iframe-with-buttons.html
+++ b/LayoutTests/accessibility/resources/iframe-with-buttons.html
@@ -1,0 +1,8 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+<p>Hello there!</p>
+<button id="yes-btn">Yes</button>
+<button id="no-btn">No</button>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -479,9 +479,18 @@ AXObjectCache::~AXObjectCache()
     m_selectedTextRangeTimer.stop();
     m_updateTreeSnapshotTimer.stop();
 
-    if (auto tree = AXIsolatedTree::treeForFrameID(m_frameID))
-        tree->setPageActivityState({ });
-    AXIsolatedTree::removeTreeForFrameID(m_frameID);
+    RefPtr existingTree = AXIsolatedTree::treeForFrameID(m_frameID);
+    if (existingTree) {
+        existingTree->setPageActivityState({ });
+        if (existingTree->treeID() == treeID()) {
+            // Only remove the tree if it belongs to this cache. During cross-document navigation, a new
+            // AXObjectCache may have already been created for the same frameID and stored a fresh tree in
+            // treeFrameCache. We must not wipe the new cache's tree when the previous cache is finally
+            // destructed. Without this guard, the new cache's AXLocalFrame parent loses its tree mapping
+            // and AXIsolatedObject::crossFrameChildObject returns null, breaking iframe access in ITM.
+            AXIsolatedTree::removeTreeForFrameID(m_frameID);
+        }
+    }
 #endif
 
     AXTreeStore::remove(m_id);


### PR DESCRIPTION
#### 28e2def3391fcf13871b39813d3c2fa8d91d9a06
<pre>
AX: AXObjectCache destructor wipes a newer cache&apos;s isolated tree out of treeFrameCache during overlapping iframe document transitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=316278">https://bugs.webkit.org/show_bug.cgi?id=316278</a>
<a href="https://rdar.apple.com/178166741">rdar://178166741</a>

Reviewed by Dominic Mazzoni.

When an iframe&apos;s document is replaced, there can be a window in which two
AXObjectCaches for the same frameID are alive at once. When this happens,
the older cache&apos;s destructor calls AXIsolatedTree::removeTreeForFrameID(m_frameID)
unconditionally. By the time it runs, the newer cache may have already stored its
own isolated tree under the same frameID, so the destructor wiped the newer
cache&apos;s tree out of treeFrameCache. This makes the the iframe&apos;s content inaccessible.

With this commit, we now only remove the tree if it belongs to this cache
(treeID match). This is the same ownership check getOrCreateIsolatedTree() already
uses for its active &quot;navigation removal&quot; path.

* LayoutTests/accessibility/iframe-content-remains-accessible-after-navigation-expected.txt: Added.
* LayoutTests/accessibility/iframe-content-remains-accessible-after-navigation.html: Added.
* LayoutTests/accessibility/resources/iframe-with-buttons.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::~AXObjectCache):

Canonical link: <a href="https://commits.webkit.org/314572@main">https://commits.webkit.org/314572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81bf18dba951b10b8db82936e9dc31bad9fe0447

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123713 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129408 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109933 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30773 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29472 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23646 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178039 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30940 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137762 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33650 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137681 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37107 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40706 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149061 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103412 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32980 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25927 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39216 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112291 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38613 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4013 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38858 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38756 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->