### PR TITLE
[Wasm] Reduce FuncRefTable entry size

### DIFF
--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -187,10 +187,10 @@ namespace JSC::B3 {
     macro(VM_exception, VM::exceptionOffset(), Mutability::Mutable) \
     macro(WatchpointSet_state, WatchpointSet::offsetOfState(), Mutability::Mutable) \
     macro(WasmFuncRefTable_functions, Wasm::FuncRefTable::offsetOfFunctions(), Mutability::Mutable) \
-    macro(WasmFuncRefTableFunction_boxedCallee, Wasm::FuncRefTable::Function::offsetOfFunction() + Wasm::WasmToWasmImportableFunction::offsetOfBoxedCallee(), Mutability::Mutable) \
-    macro(WasmFuncRefTableFunction_entrypointLoadLocation, Wasm::FuncRefTable::Function::offsetOfFunction() + Wasm::WasmToWasmImportableFunction::offsetOfEntrypointLoadLocation(), Mutability::Mutable) \
-    macro(WasmFuncRefTableFunction_rtt, Wasm::FuncRefTable::Function::offsetOfFunction() + Wasm::WasmToWasmImportableFunction::offsetOfRTT(), Mutability::Mutable) \
-    macro(WasmFuncRefTableFunction_targetInstance, Wasm::FuncRefTable::Function::offsetOfFunction() + Wasm::WasmToWasmImportableFunction::offsetOfTargetInstance(), Mutability::Mutable) \
+    macro(WasmFuncRefTableFunction_boxedCallee, Wasm::FuncRefTable::Function::offsetOfBoxedCallee(), Mutability::Mutable) \
+    macro(WasmFuncRefTableFunction_entrypointLoadLocation, Wasm::FuncRefTable::Function::offsetOfEntrypointLoadLocation(), Mutability::Mutable) \
+    macro(WasmFuncRefTableFunction_rtt, Wasm::FuncRefTable::Function::offsetOfRTT(), Mutability::Mutable) \
+    macro(WasmFuncRefTableFunction_targetInstance, Wasm::FuncRefTable::Function::offsetOfTargetInstance(), Mutability::Mutable) \
     macro(WasmGlobal_value, Wasm::Global::offsetOfValue(), Mutability::Mutable) \
     macro(WasmGlobal_owner, Wasm::Global::offsetOfOwner(), Mutability::Immutable) \
     macro(WasmGlobalValue_owner, Wasm::Global::Value::offsetOfOwner(), Mutability::Immutable) \

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4874,11 +4874,11 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
 #if CPU(ARM64)
                 m_jit.addLeftShift64(callableFunctionBuffer, calleeIndexLocation.asGPR(), TrustedImm32(getLSBSet(sizeof(FuncRefTable::Function))), importableFunction);
 #elif CPU(ARM)
-                m_jit.lshift32(calleeIndexLocation.asGPR(), TrustedImm32(getLSBSet(sizeof(FuncRefTable::Function))), importableFunction);
-                m_jit.addPtr(callableFunctionBuffer, importableFunction);
+                m_jit.lshiftPtr(TrustedImm32(getLSBSet(sizeof(FuncRefTable::Function))), calleeIndexLocation.asGPR());
+                m_jit.addPtr(callableFunctionBuffer, calleeIndexLocation.asGPR(), importableFunction);
 #else
-                m_jit.lshift64(calleeIndexLocation.asGPR(), TrustedImm32(getLSBSet(sizeof(FuncRefTable::Function))), importableFunction);
-                m_jit.addPtr(callableFunctionBuffer, importableFunction);
+                m_jit.lshiftPtr(TrustedImm32(getLSBSet(sizeof(FuncRefTable::Function))), calleeIndexLocation.asGPR());
+                m_jit.addPtr(callableFunctionBuffer, calleeIndexLocation.asGPR(), importableFunction);
 #endif
             } else {
                 m_jit.move(TrustedImmPtr(sizeof(FuncRefTable::Function)), importableFunction);

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -959,6 +959,7 @@ struct alignas(8) WasmCallableFunction {
 struct WasmToWasmImportableFunction : public WasmCallableFunction {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(WasmToWasmImportableFunction);
     static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WasmToWasmImportableFunction, rtt); }
+    bool isEmpty() const { return !rtt; }
 
     const RTT* rtt { nullptr };
 };

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -1146,21 +1146,23 @@ static ALWAYS_INLINE UGPRPair prepareCallIndirectImpl(JSWebAssemblyInstance* ins
         function = &table->function(*functionIndex);
     }
 
-    if (!function->m_function.rtt) [[unlikely]]
+    if (!function->rtt) [[unlikely]]
         IPINT_THROW(Wasm::ExceptionType::BadSignature);
 
-    if (!function->m_function.rtt->isSubRTT(rtt)) [[unlikely]]
+    if (!function->rtt->isSubRTT(rtt)) [[unlikely]]
         IPINT_THROW(Wasm::ExceptionType::BadSignature);
 
-    auto boxedCallee = function->m_function.boxedCallee.encodedBits();
+    auto boxedCallee = function->boxedCallee.encodedBits();
+    Wasm::FunctionSpaceIndex savedFunctionIndex = *functionIndex;
     Register* calleeReturn = std::bit_cast<Register*>(functionIndex);
     *calleeReturn = boxedCallee;
 
     Register& functionInfoSlot = calleeReturn[1];
-    if (function->m_function.isJS())
-        functionInfoSlot = reinterpret_cast<uintptr_t>(uncheckedDowncast<WebAssemblyFunctionBase>(function->m_value.get())->callLinkInfo());
-    else {
-        auto* targetInstance = function->m_function.targetInstance.get();
+    if (function->isJS()) {
+        Wasm::FuncRefTable* funcTable = instance->table(tableIndex)->asFuncrefTable();
+        functionInfoSlot = reinterpret_cast<uintptr_t>(funcTable->get(savedFunctionIndex)->callLinkInfo());
+    } else {
+        auto* targetInstance = function->targetInstance.get();
         functionInfoSlot = targetInstance;
         if (instance != targetInstance)
             callProfile.observeCrossInstanceCall();
@@ -1168,10 +1170,10 @@ static ALWAYS_INLINE UGPRPair prepareCallIndirectImpl(JSWebAssemblyInstance* ins
             callProfile.observeCallIndirect(boxedCallee);
     }
 
-    IPINT_HANDLE_STEP_INTO_CALL(instance->vm(), function->m_function.boxedCallee, function->m_function.targetInstance.get());
+    IPINT_HANDLE_STEP_INTO_CALL(instance->vm(), function->boxedCallee, function->targetInstance.get());
 
-    auto callTarget = *function->m_function.entrypointLoadLocation;
-    WASM_CALL_RETURN(function->m_function.targetInstance.get(), callTarget);
+    auto callTarget = *function->entrypointLoadLocation;
+    WASM_CALL_RETURN(function->targetInstance.get(), callTarget);
 }
 
 static ALWAYS_INLINE UGPRPair prepareCallRefImpl(JSWebAssemblyInstance* instance, CallFrame* callFrame, uint32_t callProfileIndex, IPIntStackEntry* sp)

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -6393,10 +6393,10 @@ auto OMGIRGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIn
     // FIXME: when we have trap handlers, we can just let the call fail because RTT is nullptr.
     // https://bugs.webkit.org/show_bug.cgi?id=177210
     static_assert(sizeof(WasmToWasmImportableFunction::rtt) == sizeof(uintptr_t), "Load codegen assumes ptr");
-    Value* calleeCallee = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), callableFunction, safeCast<int32_t>(FuncRefTable::Function::offsetOfFunction() + WasmToWasmImportableFunction::offsetOfBoxedCallee()));
+    Value* calleeCallee = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), callableFunction, safeCast<int32_t>(FuncRefTable::Function::offsetOfBoxedCallee()));
     m_heaps.decorateMemory(&m_heaps.WasmFuncRefTableFunction_boxedCallee, calleeCallee);
 
-    Value* calleeInstance = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), callableFunction, safeCast<int32_t>(FuncRefTable::Function::offsetOfFunction() + WasmToWasmImportableFunction::offsetOfTargetInstance()));
+    Value* calleeInstance = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), callableFunction, safeCast<int32_t>(FuncRefTable::Function::offsetOfTargetInstance()));
     m_heaps.decorateMemory(&m_heaps.WasmFuncRefTableFunction_targetInstance, calleeInstance);
 
     auto inliningResult = tryInliningPolymorphicCalls(callProfileIndex, calleeInstance, calleeCallee, signature, args, callType, isTailCallRootCaller, continuation);
@@ -6405,10 +6405,10 @@ auto OMGIRGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIn
 
     auto fastValuesList = WTF::move(inliningResult.value());
 
-    Value* calleeCodeLocation = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), callableFunction, safeCast<int32_t>(FuncRefTable::Function::offsetOfFunction() + WasmToWasmImportableFunction::offsetOfEntrypointLoadLocation()));
+    Value* calleeCodeLocation = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), callableFunction, safeCast<int32_t>(FuncRefTable::Function::offsetOfEntrypointLoadLocation()));
     m_heaps.decorateMemory(&m_heaps.WasmFuncRefTableFunction_entrypointLoadLocation, calleeCodeLocation);
 
-    Value* calleeRTT = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), callableFunction, safeCast<int32_t>(FuncRefTable::Function::offsetOfFunction() + WasmToWasmImportableFunction::offsetOfRTT()));
+    Value* calleeRTT = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), callableFunction, safeCast<int32_t>(FuncRefTable::Function::offsetOfRTT()));
     m_heaps.decorateMemory(&m_heaps.WasmFuncRefTableFunction_rtt, calleeRTT);
 
     Value* expectedRTT = constant(pointerType(), std::bit_cast<uintptr_t>(&signature));

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -164,12 +164,16 @@ std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
         auto* defaultFunction = dynamicDowncast<WebAssemblyFunctionBase>(defaultValue);
         ASSERT(defaultFunction || defaultValue.isNull());
         bool success = checkedGrow(funcTable->m_importableFunctions, [&](auto& slot) {
-            ASSERT(slot.m_value.isNull());
             if (defaultFunction)
-                slot.setFunction(vm, m_owner, defaultFunction);
+                slot = defaultFunction->importableFunction();
         });
         if (!success) [[unlikely]]
             return std::nullopt;
+        success = checkedGrow(funcTable->m_wrappers, [&](auto& slot) {
+            if (defaultFunction)
+                slot.set(vm, m_owner, defaultFunction);
+        });
+        RELEASE_ASSERT_WITH_MESSAGE(success, "First grow size succeeded so the second should too");
         setLength(newLength);
         for (auto& instance : funcTable->m_instances) {
             if (auto* strongReference = instance.get())
@@ -212,9 +216,11 @@ JSValue Table::get(uint32_t index)
 {
     ASSERT(index < length());
     ASSERT(m_owner);
-    return visitDerived([&](auto& table) {
-        return table.get(index);
-    });
+    if (auto* funcTable = asFuncrefTable()) {
+        auto* wrapper = funcTable->get(index);
+        return wrapper ? JSValue(wrapper) : jsNull();
+    }
+    return static_cast<ExternOrAnyRefTable*>(this)->get(index);
 }
 
 template<typename Visitor>
@@ -232,10 +238,8 @@ void Table::visitAggregateImpl(Visitor& visitor)
     case TableElementType::Funcref: {
         auto* table = static_cast<FuncRefTable*>(this);
         for (unsigned i = 0; i < m_length; ++i) {
-            auto& slot = table->m_importableFunctions.get()[i];
-            visitor.append(slot.m_value);
-            visitor.append(slot.m_function.targetInstance);
-            visitor.append(slot.m_function.importFunction);
+            visitor.append(table->m_wrappers.get()[i]);
+            visitor.append(table->m_importableFunctions.get()[i].targetInstance);
         }
         break;
     }
@@ -284,10 +288,12 @@ FuncRefTable::FuncRefTable(VM& vm, uint32_t initial, std::optional<uint32_t> max
     else
         m_importableFunctions = MallocPtr<Function, VMMalloc>::malloc(sizeof(Function) * Checked<size_t>(allocatedLength(m_length)));
 
+    m_wrappers = MallocPtr<WriteBarrier<WebAssemblyFunctionBase>, VMMalloc>::malloc(sizeof(WriteBarrier<WebAssemblyFunctionBase>) * Checked<size_t>(allocatedLength(m_length)));
+
     for (uint32_t i = 0; i < allocatedLength(m_length); ++i) {
         new (&m_importableFunctions.get()[i]) Function();
         ASSERT(m_importableFunctions.get()[i].isEmpty()); // We rely on this in compiled code.
-        ASSERT(m_importableFunctions.get()[i].m_value.isNull());
+        new (&m_wrappers.get()[i]) WriteBarrier<WebAssemblyFunctionBase>();
     }
 }
 
@@ -309,14 +315,10 @@ void FuncRefTable::setFunction(uint32_t index, WebAssemblyFunctionBase* function
 {
     ASSERT(index < length());
     ASSERT_WITH_SECURITY_IMPLICATION(isSubtype(function->type(), wasmType()));
+    VM& vm = function->instance()->vm();
     auto& slot = m_importableFunctions.get()[index];
-    slot.setFunction(function->instance()->vm(), m_owner, function);
-}
-
-void FuncRefTable::Function::setFunction(VM& vm, JSCell* owner, WebAssemblyFunctionBase* function)
-{
-    m_function = function->importableFunction();
-    m_value.set(vm, owner, function);
+    slot = function->importableFunction();
+    m_wrappers.get()[index].set(vm, m_owner, function);
 }
 
 void FuncRefTable::setLazy(uint32_t index, JSWebAssemblyInstance* targetInstance, FunctionSpaceIndex functionIndex)
@@ -327,33 +329,29 @@ void FuncRefTable::setLazy(uint32_t index, JSWebAssemblyInstance* targetInstance
     ASSERT(wasmCallee);
 
     auto& slot = m_importableFunctions.get()[index];
-    slot.m_function = WasmOrJSImportableFunction { };
-    slot.m_function.boxedCallee = wasmCallee.get();
-    slot.m_function.targetInstance.setWithoutWriteBarrier(targetInstance);
-    slot.m_function.entrypointLoadLocation = calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(functionIndex);
-    slot.m_function.rtt = &targetInstance->module().rttFromFunctionIndexSpace(functionIndex);
+    slot.boxedCallee = wasmCallee.get();
+    slot.targetInstance.set(m_owner->vm(), m_owner, targetInstance);
+    slot.entrypointLoadLocation = calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(functionIndex);
+    slot.rtt = &targetInstance->module().rttFromFunctionIndexSpace(functionIndex);
 
-    slot.m_value.clear();
-    // The struct copy into slot.m_function does not propagate a write barrier for its
-    // embedded WriteBarriers (targetInstance, importFunction), so fire one on m_owner.
-    m_owner->vm().writeBarrier(m_owner);
+    m_wrappers.get()[index].clear();
 }
 
-JSValue FuncRefTable::get(uint32_t index)
+WebAssemblyFunctionBase* FuncRefTable::get(uint32_t index)
 {
     auto& slot = m_importableFunctions.get()[index];
-    if (JSValue cached = slot.m_value.get())
+    if (auto* cached = m_wrappers.get()[index].get())
         return cached;
     if (slot.isEmpty())
-        return jsNull();
+        return nullptr;
 
-    auto* wasmCallee = uncheckedDowncast<Wasm::Callee>(slot.m_function.boxedCallee.asNativeCallee());
+    auto* wasmCallee = uncheckedDowncast<Wasm::Callee>(slot.boxedCallee.asNativeCallee());
     FunctionSpaceIndex functionIndex = wasmCallee->index();
-    JSWebAssemblyInstance* targetInstance = slot.m_function.targetInstance.get();
+    JSWebAssemblyInstance* targetInstance = slot.targetInstance.get();
     ASSERT(targetInstance);
-    JSValue wrapper = targetInstance->ensureFunctionWrapper(functionIndex);
-    ASSERT(wrapper.isCallable());
-    slot.m_value.set(m_owner->vm(), m_owner, wrapper);
+    auto* wrapper = uncheckedDowncast<WebAssemblyFunctionBase>(targetInstance->ensureFunctionWrapper(functionIndex));
+    ASSERT(wrapper->isCallable());
+    m_wrappers.get()[index].set(m_owner->vm(), m_owner, wrapper);
     return wrapper;
 }
 
@@ -372,6 +370,7 @@ void FuncRefTable::copyFunction(FuncRefTable* srcTable, uint32_t dstIndex, uint3
     }
 
     m_importableFunctions.get()[dstIndex] = srcSlot;
+    m_wrappers.get()[dstIndex].copyFrom(srcTable->m_wrappers.get()[srcIndex]);
     // Write barrier our owner for good measure.
     m_owner->vm().writeBarrier(m_owner);
 }
@@ -381,7 +380,7 @@ void FuncRefTable::clear(uint32_t index)
     ASSERT(wasmType().isNullable());
     m_importableFunctions.get()[index] = FuncRefTable::Function { };
     ASSERT(m_importableFunctions.get()[index].isEmpty()); // We rely on this in compiled code.
-    ASSERT(m_importableFunctions.get()[index].m_value.isNull());
+    m_wrappers.get()[index].clear();
 }
 
 void FuncRefTable::set(uint32_t index, JSValue value)

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -134,20 +134,9 @@ public:
     friend class Table;
 
     using JSWebAssemblyInstanceWeakCGSet = WeakGCSet<JSWebAssemblyInstance>;
-
+    using Function = WasmToWasmImportableFunction;
 
     JS_EXPORT_PRIVATE ~FuncRefTable();
-
-    struct Function {
-        void setFunction(VM&, JSCell* owner, WebAssemblyFunctionBase*);
-        bool isEmpty() const { return !m_function.rtt; }
-        static constexpr ptrdiff_t offsetOfFunction() { return OBJECT_OFFSETOF(Function, m_function); }
-        static constexpr ptrdiff_t offsetOfValue() { return OBJECT_OFFSETOF(Function, m_value); }
-
-        WasmOrJSImportableFunction m_function;
-        WriteBarrier<Unknown> m_value { NullWriteBarrierTag };
-        void* m_padding { nullptr };
-    };
 
     void setFunction(uint32_t, WebAssemblyFunctionBase*);
     void setLazy(uint32_t, JSWebAssemblyInstance* targetInstance, FunctionSpaceIndex);
@@ -172,7 +161,7 @@ public:
 
     void clear(uint32_t);
     void set(uint32_t, JSValue);
-    JSValue get(uint32_t index);
+    WebAssemblyFunctionBase* get(uint32_t index);
 
     void registerInstance(JSWebAssemblyInstance&);
 
@@ -184,8 +173,13 @@ private:
     static Ref<FuncRefTable> createFixedSized(VM&, uint32_t size, Type wasmType);
 
     MallocPtr<Function, VMMalloc> m_importableFunctions;
+    // FIXME: It seems like we should be able to recover this from the Wasm::Callee + instance but there might be problems for JS
+    // wrapped functions. WasmToJSCallee's are currently a singleton, which would have to change.
+    MallocPtr<WriteBarrier<WebAssemblyFunctionBase>, VMMalloc> m_wrappers;
     JSWebAssemblyInstanceWeakCGSet m_instances;
 };
+
+static_assert(sizeof(FuncRefTable::Function) == sizeof(void*) * 4);
 
 } } // namespace JSC::Wasm
 


### PR DESCRIPTION
#### 8abf5256fdcb4497f2d77a65739784d270507c8b
<pre>
[Wasm] Reduce FuncRefTable entry size
<a href="https://bugs.webkit.org/show_bug.cgi?id=316305">https://bugs.webkit.org/show_bug.cgi?id=316305</a>
<a href="https://rdar.apple.com/178727001">rdar://178727001</a>

Reviewed by Yusuke Suzuki.

Previously, Wasm::FuncRefTable entries were 64 bytes:
┌───────────────────────────────────┬─────────────────────────────────────┬───────┐
│               Field               │                Type                 │ Bytes │
├───────────────────────────────────┼─────────────────────────────────────┼───────┤
│ m_function.boxedCallee            │ CalleeBits                          │ 8     │
├───────────────────────────────────┼─────────────────────────────────────┼───────┤
│ m_function.targetInstance         │ WriteBarrier&lt;JSWebAssemblyInstance&gt; │ 8     │
├───────────────────────────────────┼─────────────────────────────────────┼───────┤
│ m_function.entrypointLoadLocation │ raw ptr                             │ 8     │
├───────────────────────────────────┼─────────────────────────────────────┼───────┤
│ m_function.rtt                    │ raw ptr                             │ 8     │
├───────────────────────────────────┼─────────────────────────────────────┼───────┤
│ m_function.importFunctionStub     │ CodePtr&lt;&gt;                           │ 8     │
│                                   │                                     │       │
├───────────────────────────────────┼─────────────────────────────────────┼───────┤
│                                   │                                     │       │
│ m_function.importFunction         │ WriteBarrier&lt;JSObject&gt;              │ 8     │
│                                   │                                     │       │
│                                   │                                     │       │
├───────────────────────────────────┼─────────────────────────────────────┼───────┤
│ m_value                           │ WriteBarrier&lt;Unknown&gt;               │ 8     │
├───────────────────────────────────┼─────────────────────────────────────┼───────┤
│ m_padding                         │ void*                               │ 8     │
└───────────────────────────────────┴─────────────────────────────────────┴───────┘

However, only the first four entries were used by the JITs, which
correspond to a WasmToWasmImportableFunction. The importFunction and
m_value were actually the same thing and the importFunctionStub was unused.

Originally, I tried to have FuncRefTable::Function contain the m_value
inline but this meant the table entries were no longer a power of 2.
Using a multiply rather than a left shift appears to be a regression.

Instead this patch has two buffers. One for the WasmToWasmImportableFunction
contents and a second for the m_values (now called m_wrappers), which is
still needed for JS callbacks. Overall, this reduces each table entry
from 64-bytes to 40-bytes, a ~37% reduction.

No new tests, no behavior change. Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/314555@main">https://commits.webkit.org/314555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16dcfda2c8979737d51012066e71966ad79a6aca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123716 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f40340e2-cf11-4373-8a93-e33d2c6ecb10) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129412 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d0fff61-3328-4fee-9618-7049b7edaf58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109937 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/051bbb1c-3b10-4579-a7d1-7147f81eebb1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30771 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29471 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23649 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158618 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178042 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27355 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30943 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137764 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137683 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103417 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25333 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32978 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25931 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199140 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39219 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112294 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53454 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38616 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4017 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38861 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38759 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->