### PR TITLE
moveBefore() needs to invalidate tree based styles

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6101,10 +6101,8 @@ imported/w3c/web-platform-tests/trusted-types/should-trusted-type-policy-creatio
 
 # Needs moveBefore support
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-preserve-render.html [ Skip ]
-webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-as-flex-item.html [ Skip ]
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-option-recalc-style.html [ Skip ]
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/select-option-optgroup.html [ Skip ]
-webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/css-transition-trigger.html [ Skip ]
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/relevant-mutations.html [ Skip ]
 
 # Flaky crash.

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/continue-css-animation-left-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/continue-css-animation-left-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Node.moveBefore should preserve CSS animation state (left) assert_not_equals: got disallowed value "0px"
+PASS Node.moveBefore should preserve CSS animation state (left)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/continue-css-animation-transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/continue-css-animation-transform-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Node.moveBefore should preserve CSS animation state (transform) assert_not_equals: got disallowed value "none"
+PASS Node.moveBefore should preserve CSS animation state (transform)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/css-transition-trigger-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/css-transition-trigger-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Node.moveBefore should trigger CSS transition state (left) if needed Test timed out
+PASS Node.moveBefore should trigger CSS transition state (left) if needed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-selector-matching-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-selector-matching-expected.txt
@@ -1,4 +1,4 @@
 This text should be green
 
-FAIL moveBefore() should invalidate target when descendant selector changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS moveBefore() should invalidate target when descendant selector changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-size-query-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-size-query-expected.txt
@@ -1,4 +1,4 @@
 This text should be green
 
-FAIL moveBefore() between different size containers invalidates target assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS moveBefore() between different size containers invalidates target
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1522,6 +1522,11 @@ void Node::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemo
     }
 }
 
+void Node::movingSteps(bool, ContainerNode&)
+{
+    invalidateStyle(Style::Validity::SubtreeInvalid, Style::InvalidationMode::InsertedIntoAncestor);
+}
+
 void Node::updateShadowIncludingRootForSubtree()
 {
     SUPPRESS_UNCOUNTED_LOCAL for (auto* current = this; current; current = NodeTraversal::next(*current, this)) {

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -506,7 +506,7 @@ public:
     virtual void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree);
 
     // https://dom.spec.whatwg.org/#concept-node-move-ext
-    virtual void movingSteps(bool, ContainerNode&) { };
+    virtual void movingSteps(bool, ContainerNode&);
 
     void updateShadowIncludingRootForSubtree();
 


### PR DESCRIPTION
#### 5f6c6dcc515e4ffda76b737405e048cfb3b04f1e
<pre>
moveBefore() needs to invalidate tree based styles
<a href="https://bugs.webkit.org/show_bug.cgi?id=316310">https://bugs.webkit.org/show_bug.cgi?id=316310</a>

Reviewed by Ryosuke Niwa.

This updates Node::movingSteps() to trigger a style invalidation for
SubtreeInvalid. This causes numerous more tests to pass.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/continue-css-animation-left-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/continue-css-animation-transform-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/css-transition-trigger-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-selector-matching-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-size-query-expected.txt:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::movingSteps):
* Source/WebCore/dom/Node.h:
(WebCore::Node::movingSteps): Deleted.

Canonical link: <a href="https://commits.webkit.org/315405@main">https://commits.webkit.org/315405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e60e00270ef347a4a8a96775ad5b9292360334f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126540 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131467 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111971 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32909 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31620 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26859 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180765 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139913 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42404 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139757 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37641 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43093 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28112 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106864 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35042 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114860 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41596 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6200 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40993 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->