### PR TITLE
[CURL] Report handshake response to the inspector when WebSocket upgrade is rejected

### DIFF
--- a/LayoutTests/http/tests/inspector/network/websocket-handshake-response-rejected-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/websocket-handshake-response-rejected-expected.txt
@@ -1,0 +1,8 @@
+Tests for rejected WebSocket handshake response status reporting.
+
+
+== Running test suite: Resource.WebSocket.RejectedHandshake
+-- Running test case: Resource.WebSocket.RejectedHandshake.ResponseStatus
+PASS: Response status should be 403.
+PASS: Response status text should be 'Forbidden'.
+

--- a/LayoutTests/http/tests/inspector/network/websocket-handshake-response-rejected.html
+++ b/LayoutTests/http/tests/inspector/network/websocket-handshake-response-rejected.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/inspector-test.js"></script>
+<script>
+function createRejectedWebSocket() {
+    let ws = new WebSocket("ws://localhost:8880/websocket/tests/hybi/websocket-reject");
+    ws.addEventListener('error', () => ws.close());
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Resource.WebSocket.RejectedHandshake");
+
+    suite.addTestCase({
+        name: "Resource.WebSocket.RejectedHandshake.ResponseStatus",
+        description: "Check that a rejected WebSocket upgrade reports the server's HTTP status code.",
+        test(resolve, reject) {
+            WI.Resource.awaitEvent(WI.Resource.Event.ResponseReceived)
+            .then((event) => {
+                let resource = event.target;
+                InspectorTest.expectEqual(resource.statusCode, 403, "Response status should be 403.");
+                InspectorTest.expectEqual(resource.statusText, "Forbidden", "Response status text should be 'Forbidden'.");
+            })
+            .then(resolve, reject);
+
+            InspectorTest.evaluateInPage(`createRejectedWebSocket()`)
+            .catch(reject);
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Tests for rejected WebSocket handshake response status reporting.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/websocket/tests/hybi/websocket-reject_wsh.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/websocket-reject_wsh.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+from pywebsocket3 import handshake
+
+
+def web_socket_do_extra_handshake(request):
+    request.connection.write(b'HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n')
+    raise handshake.AbortedByUserException('Reject the connection')
+
+
+def web_socket_transfer_data(request):
+    pass


### PR DESCRIPTION
#### ff2dc9130c208aa401c42672124bc5abd534300f
<pre>
[CURL] Report handshake response to the inspector when WebSocket upgrade is rejected
<a href="https://bugs.webkit.org/show_bug.cgi?id=316315">https://bugs.webkit.org/show_bug.cgi?id=316315</a>

Reviewed by NOBODY (OOPS!).

Test: http/tests/inspector/network/websocket-handshake-response-rejected.html

* LayoutTests/http/tests/inspector/network/websocket-handshake-response-rejected-expected.txt: Added.
* LayoutTests/http/tests/inspector/network/websocket-handshake-response-rejected.html: Added.
* LayoutTests/http/tests/websocket/tests/hybi/websocket-reject_wsh.py: Added.
(web_socket_do_extra_handshake):
(web_socket_transfer_data):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff2dc9130c208aa401c42672124bc5abd534300f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123739 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/40421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129429 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169443 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31814 "") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109954 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30791 "") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29493 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23672 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140762 "") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178065 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30966 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137783 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137702 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40732 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149078 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103450 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32999 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25943 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39242 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38639 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4032 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38884 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38782 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->