### PR TITLE
Debounce screen properties updates

### DIFF
--- a/Source/WebCore/platform/PlatformScreen.cpp
+++ b/Source/WebCore/platform/PlatformScreen.cpp
@@ -31,8 +31,11 @@
 #include "ScreenProperties.h"
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(ScreenProperties);
 
 static Lock& platformScreenLock()
 {

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/ContentsFormat.h>
 #include <WebCore/ScreenProperties.h>
+#include <memory>
 #include <wtf/Forward.h>
 #include <wtf/Platform.h>
 #include <wtf/ThreadSafeRefCounted.h>

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -30,6 +30,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Platform.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -90,6 +91,8 @@ struct ScreenData {
 using ScreenDataMap = HashMap<PlatformDisplayID, ScreenData>;
 
 struct ScreenProperties {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_EXPORT(ScreenProperties, WEBCORE_EXPORT);
+
     PlatformDisplayID primaryDisplayID { 0 };
     ScreenDataMap screenDataMap;
 #if HAVE(SUPPORT_HDR_DISPLAY)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -858,7 +858,7 @@ void WebProcessPool::registerNotificationObservers()
     }];
 
     m_accessibilityDisplayOptionsNotificationObserver = [retainPtr([NSWorkspace.sharedWorkspace notificationCenter]) addObserverForName:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
-        screenPropertiesChanged();
+        screenPropertiesChanged("NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification"_s);
     }];
 
     m_scrollerStyleNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSPreferredScrollerStyleDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
@@ -878,7 +878,7 @@ void WebProcessPool::registerNotificationObservers()
     }];
 
     m_didChangeScreenParametersNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidChangeScreenParametersNotification object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
-        screenPropertiesChanged();
+        screenPropertiesChanged("NSApplicationDidChangeScreenParametersNotification"_s);
     }];
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
     m_didBeginSuppressingHighDynamicRange = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
@@ -1287,7 +1287,85 @@ void WebProcessPool::notifyPreferencesChanged(const String& domain, const String
 }
 #endif // ENABLE(CFPREFS_DIRECT_MODE)
 
-void WebProcessPool::screenPropertiesChanged()
+void WebProcessPool::sendScreenPropertiesChangedToAllProcesses(const WebCore::ScreenProperties& screenProperties, ASCIILiteral reason)
+{
+    static constexpr Seconds excessiveUpdateWindow { 60_s };
+    static constexpr unsigned excessiveUpdateThreshold = 600;
+
+    auto now = ApproximateTime::now();
+    if (now - m_screenPropertiesUpdateReasonsTime > excessiveUpdateWindow) {
+        if (m_logScreenPropertiesUpdateReasonsTimer.isActive()) {
+            // Drain any pending log first so we don't drop counts that were about to be reported.
+            m_logScreenPropertiesUpdateReasonsTimer.stop();
+            logScreenPropertiesUpdateReasonsTimerFired();
+        } else {
+            m_screenPropertiesUpdateReasons.clear();
+            m_screenPropertiesUpdateCount = 0;
+            m_screenPropertiesUpdateReasonsTime = now;
+        }
+    }
+    m_screenPropertiesUpdateReasons.add(reason);
+    ++m_screenPropertiesUpdateCount;
+
+    if (m_screenPropertiesUpdateCount > excessiveUpdateThreshold && !m_logScreenPropertiesUpdateReasonsTimer.isActive())
+        m_logScreenPropertiesUpdateReasonsTimer.startOneShot(excessiveUpdateWindow - (now - m_screenPropertiesUpdateReasonsTime));
+
+    static constexpr Seconds debounceInterval { 1_s };
+
+    if (m_screenPropertiesUpdateTimer.isActive()) {
+        ASSERT(m_pendingScreenProperties);
+        *m_pendingScreenProperties = screenProperties;
+        return;
+    }
+
+    auto elapsed = now - m_lastScreenPropertiesSendTime;
+    if (elapsed >= debounceInterval) {
+        m_lastScreenPropertiesSendTime = now;
+        dispatchScreenPropertiesChangedToAllProcesses(screenProperties);
+        return;
+    }
+
+    m_pendingScreenProperties = makeUnique<WebCore::ScreenProperties>(screenProperties);
+    m_screenPropertiesUpdateTimer.startOneShot(debounceInterval - elapsed);
+}
+
+void WebProcessPool::logScreenPropertiesUpdateReasonsTimerFired()
+{
+    ASCIILiteral mostCommonReason;
+    unsigned mostCommonCount = 0;
+    for (const auto& entry : m_screenPropertiesUpdateReasons) {
+        if (entry.value > mostCommonCount) {
+            mostCommonCount = entry.value;
+            mostCommonReason = entry.key;
+        }
+    }
+    auto elapsed = ApproximateTime::now() - m_screenPropertiesUpdateReasonsTime;
+    WEBPROCESSPOOL_RELEASE_LOG(DisplayLink, "Excessive screen property updates: %u updates over %.1f seconds, most common reason: %" PUBLIC_LOG_STRING " (%u times)", m_screenPropertiesUpdateCount, elapsed.seconds(), mostCommonReason.characters(), mostCommonCount);
+
+    m_screenPropertiesUpdateReasons.clear();
+    m_screenPropertiesUpdateCount = 0;
+    m_screenPropertiesUpdateReasonsTime = ApproximateTime::now();
+}
+
+void WebProcessPool::screenPropertiesUpdateTimerFired()
+{
+    ASSERT(m_pendingScreenProperties);
+    auto pendingProperties = std::exchange(m_pendingScreenProperties, nullptr);
+    m_lastScreenPropertiesSendTime = ApproximateTime::now();
+    dispatchScreenPropertiesChangedToAllProcesses(*pendingProperties);
+}
+
+void WebProcessPool::dispatchScreenPropertiesChangedToAllProcesses(const WebCore::ScreenProperties& screenProperties)
+{
+    sendToAllProcesses(Messages::WebProcess::SetScreenProperties(screenProperties));
+
+#if PLATFORM(MAC) && ENABLE(GPU_PROCESS)
+    if (RefPtr gpuProcess = this->gpuProcess())
+        gpuProcess->setScreenProperties(screenProperties);
+#endif
+}
+
+void WebProcessPool::screenPropertiesChanged(ASCIILiteral reason)
 {
     auto screenProperties = WebCore::collectScreenProperties();
 #if HAVE(SUPPORT_HDR_DISPLAY)
@@ -1300,26 +1378,17 @@ void WebProcessPool::screenPropertiesChanged()
         }
     }
 #endif
-    sendToAllProcesses(Messages::WebProcess::SetScreenProperties(screenProperties));
 
-#if PLATFORM(MAC) && ENABLE(GPU_PROCESS)
-    if (RefPtr gpuProcess = this->gpuProcess())
-        gpuProcess->setScreenProperties(screenProperties);
-#endif
+    sendScreenPropertiesChangedToAllProcesses(screenProperties, reason);
 }
 
 #if PLATFORM(MAC)
 void WebProcessPool::displayPropertiesChanged(const WebCore::ScreenProperties& screenProperties, WebCore::PlatformDisplayID displayID, CGDisplayChangeSummaryFlags flags)
 {
-    sendToAllProcesses(Messages::WebProcess::SetScreenProperties(screenProperties));
-
     if (auto* displayLink = displayLinks().existingDisplayLinkForDisplay(displayID))
         displayLink->displayPropertiesChanged();
 
-#if ENABLE(GPU_PROCESS)
-    if (RefPtr gpuProcess = this->gpuProcess())
-        gpuProcess->setScreenProperties(screenProperties);
-#endif
+    sendScreenPropertiesChangedToAllProcesses(screenProperties, "displayPropertiesChanged"_s);
 }
 
 static void displayReconfigurationCallBack(CGDirectDisplayID displayID, CGDisplayChangeSummaryFlags flags, void *userInfo)
@@ -1346,7 +1415,7 @@ static void webProcessPoolHighDynamicRangeDidChangeCallback(CFNotificationCenter
     RunLoop::mainSingleton().dispatch([] {
         auto properties = WebCore::collectScreenProperties();
         for (auto& pool : WebProcessPool::allProcessPools())
-            pool->sendToAllProcesses(Messages::WebProcess::SetScreenProperties(properties));
+            pool->sendScreenPropertiesChangedToAllProcesses(properties, "ShouldPlayHDRVideoChanged"_s);
     });
 }
 
@@ -1387,7 +1456,7 @@ void WebProcessPool::registerHighDynamicRangeChangeCallback()
     static NeverDestroyed<LowPowerModeNotifier> notifier { [](bool) {
         auto properties = WebCore::collectScreenProperties();
         for (auto& pool : WebProcessPool::allProcessPools())
-            pool->sendToAllProcesses(Messages::WebProcess::SetScreenProperties(properties));
+            pool->sendScreenPropertiesChangedToAllProcesses(properties, "LowPowerModeNotifier"_s);
     } };
 }
 #endif // PLATFORM(IOS) || PLATFORM(VISION)
@@ -1400,7 +1469,7 @@ void WebProcessPool::didRefreshDisplay()
     float headroom = currentEDRHeadroomForDisplay(screen->primaryScreenDisplayID());
     if (m_currentEDRHeadroom != headroom) {
         m_currentEDRHeadroom = headroom;
-        screenPropertiesChanged();
+        screenPropertiesChanged("didRefreshDisplayEDRHeadroomChanged"_s);
     }
 #endif
 }
@@ -1413,7 +1482,7 @@ void WebProcessPool::suppressEDR(bool suppressEDR)
         return;
 
     m_suppressEDR = suppressEDR;
-    screenPropertiesChanged();
+    screenPropertiesChanged("suppressEDR"_s);
 #else
     UNUSED_PARAM(m_suppressEDR);
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6493,7 +6493,7 @@ void WebPageProxy::accessibilitySettingsDidChange()
 
 #if PLATFORM(COCOA)
     // Also update screen properties which encodes invert colors.
-    protect(legacyMainFrameProcess().processPool())->screenPropertiesChanged();
+    protect(legacyMainFrameProcess().processPool())->screenPropertiesChanged("accessibilitySettingsDidChange"_s);
 #endif
     send(Messages::WebPage::AccessibilitySettingsDidChange());
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -109,6 +109,7 @@
 #include <WebCore/ProcessWarming.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceRequest.h>
+#include <WebCore/ScreenProperties.h>
 #include <WebCore/SecurityPolicy.h>
 #include <WebCore/Site.h>
 #include <algorithm>
@@ -267,6 +268,10 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
     , m_resourceMonitorRuleListRefreshTimer(RunLoop::mainSingleton(), "WebProcessPool::ResourceMonitorRuleListRefreshTimer"_s, this, &WebProcessPool::loadOrUpdateResourceMonitorRuleList)
+#endif
+#if PLATFORM(COCOA)
+    , m_screenPropertiesUpdateTimer(RunLoop::mainSingleton(), "WebProcessPool::ScreenPropertiesUpdateTimer"_s, this, &WebProcessPool::screenPropertiesUpdateTimerFired)
+    , m_logScreenPropertiesUpdateReasonsTimer(RunLoop::mainSingleton(), "WebProcessPool::LogScreenPropertiesUpdateReasonsTimer"_s, this, &WebProcessPool::logScreenPropertiesUpdateReasonsTimerFired)
 #endif
 #if ENABLE(IPC_TESTING_API)
     , m_ipcTester(IPCTester::create())

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -41,9 +41,11 @@
 #include "WebsiteDataStore.h"
 #include <WebCore/ProcessIdentifier.h>
 #include <pal/SessionID.h>
+#include <wtf/ApproximateTime.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
+#include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/MemoryPressureHandler.h>
@@ -101,6 +103,7 @@ enum class GamepadHapticEffectType : uint8_t;
 enum class ProcessSwapDisposition : uint8_t;
 struct GamepadEffectParameters;
 struct MockMediaDevice;
+struct ScreenProperties;
 #if PLATFORM(COCOA)
 class PowerSourceNotifier;
 #endif
@@ -251,7 +254,8 @@ public:
     void handleMemoryPressureWarning(Critical);
 
 #if PLATFORM(COCOA)
-    void screenPropertiesChanged();
+    void sendScreenPropertiesChangedToAllProcesses(const WebCore::ScreenProperties&, ASCIILiteral reason);
+    void screenPropertiesChanged(ASCIILiteral reason);
 #endif
 
 #if PLATFORM(MAC)
@@ -740,6 +744,12 @@ private:
 #endif
     void clearAudibleActivity();
 
+#if PLATFORM(COCOA)
+    void dispatchScreenPropertiesChangedToAllProcesses(const WebCore::ScreenProperties&);
+    void screenPropertiesUpdateTimerFired();
+    void logScreenPropertiesUpdateReasonsTimerFired();
+#endif
+
 #if PLATFORM(IOS_FAMILY)
     static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef, void* observer, CFStringRef, const void*, CFDictionaryRef);
     void initializeHardwareKeyboardAvailability();
@@ -1020,6 +1030,15 @@ private:
     std::optional<HashMap<String, Vector<String>>> m_userInstalledFontFamilyMap;
     std::optional<Vector<URL>> m_sandboxExtensionURLs;
     HashMap<String, bool> m_mediaSourceTypesSupported;
+
+    ApproximateTime m_lastScreenPropertiesSendTime;
+    RunLoop::Timer m_screenPropertiesUpdateTimer;
+    std::unique_ptr<WebCore::ScreenProperties> m_pendingScreenProperties;
+
+    ApproximateTime m_screenPropertiesUpdateReasonsTime;
+    HashCountedSet<ASCIILiteral> m_screenPropertiesUpdateReasons;
+    unsigned m_screenPropertiesUpdateCount { 0 };
+    RunLoop::Timer m_logScreenPropertiesUpdateReasonsTimer;
 #endif
 
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2323,7 +2323,7 @@ void WebViewImpl::windowWillClose()
 
 void WebViewImpl::screenDidChangeColorSpace()
 {
-    protect(m_page->configuration().processPool())->screenPropertiesChanged();
+    protect(m_page->configuration().processPool())->screenPropertiesChanged("screenDidChangeColorSpace"_s);
 }
 
 void WebViewImpl::applicationShouldSuppressHDR(bool suppress)


### PR DESCRIPTION
#### 79d48cd76aca9a259093fc8df53abe972a7b382d
<pre>
Debounce screen properties updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=316316">https://bugs.webkit.org/show_bug.cgi?id=316316</a>
<a href="https://rdar.apple.com/177953568">rdar://177953568</a>

Reviewed by Per Arne Vollan.

We&apos;ve seen instances in logs where we are IPC&apos;ing a large number of screen properties updates (more
than 2000 in a minute). This is surprising because we don&apos;t expect screen properties to change
frequently.

Debounce screen properties updates to at most one per second. Additionally, add logging to help
better understand why there are sometimes an excessive number of screen updates (in this patch, we
log if we get more than 600 updates per minute).

* Source/WebCore/platform/PlatformScreen.cpp:
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::sendScreenPropertiesChangedToAllProcesses):
(WebKit::WebProcessPool::logScreenPropertiesUpdateReasonsTimerFired):
(WebKit::WebProcessPool::screenPropertiesUpdateTimerFired):
(WebKit::WebProcessPool::dispatchScreenPropertiesChangedToAllProcesses):
(WebKit::WebProcessPool::screenPropertiesChanged):
(WebKit::WebProcessPool::displayPropertiesChanged):
(WebKit::webProcessPoolHighDynamicRangeDidChangeCallback):
(WebKit::WebProcessPool::registerHighDynamicRangeChangeCallback):
(WebKit::WebProcessPool::didRefreshDisplay):
(WebKit::WebProcessPool::suppressEDR):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::accessibilitySettingsDidChange):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::screenDidChangeColorSpace):

Canonical link: <a href="https://commits.webkit.org/314702@main">https://commits.webkit.org/314702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51f3fdf649c2de6d00dfc71d2992329f33b88df3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124141 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80b8d630-f72e-4311-91e5-f6ea106667a6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129771 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6dd89507-542a-4838-bcde-25ac9987c281) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110297 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f19eb2b0-c181-4ad6-8d36-050aafc59d0d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31151 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29850 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24667 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141124 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178469 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31366 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138140 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138052 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37183 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149447 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103948 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33327 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26312 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112716 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39038 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4406 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39182 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->