### PR TITLE
[macOS iOS] imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/modulepreload-referrerpolicy.html is a flaky text failure.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/modulepreload-referrerpolicy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/modulepreload-referrerpolicy.html
@@ -20,6 +20,7 @@
 -->
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script>
 // Initialize the window.referrers object that will be used by echo-referrer.py
 window.referrers = {};
@@ -27,11 +28,6 @@ window.referrers = {};
 </head>
 <body>
 <script>
-// Helper function to create a unique ID for each test
-function generateUniqueId() {
-  return Date.now() + Math.floor(Math.random() * 1000);
-}
-
 // Helper function to create a modulepreload element with a given referrer policy
 function createModulePreload(url, referrerPolicy = null) {
   const link = document.createElement('link');
@@ -55,7 +51,7 @@ function waitForPreload(link) {
 
 // Test default referrer policy behavior
 promise_test(async t => {
-  const uid = generateUniqueId();
+  const uid = token();
   const url = `/preload/resources/echo-referrer.py?uid=${uid}`;
 
   // First import to establish baseline
@@ -78,7 +74,7 @@ promise_test(async t => {
 
 // Test explicit no-referrer policy
 promise_test(async t => {
-  const uid = generateUniqueId();
+  const uid = token();
   const url = `/preload/resources/echo-referrer.py?uid=${uid}`;
 
   // Create modulepreload with no-referrer policy
@@ -98,7 +94,7 @@ promise_test(async t => {
 
 // Test origin referrer policy
 promise_test(async t => {
-  const uid = generateUniqueId();
+  const uid = token();
   const url = `/preload/resources/echo-referrer.py?uid=${uid}`;
 
   // Create modulepreload with origin policy
@@ -118,7 +114,7 @@ promise_test(async t => {
 
 // Test same-origin referrer policy
 promise_test(async t => {
-  const uid = generateUniqueId();
+  const uid = token();
   const url = `/preload/resources/echo-referrer.py?uid=${uid}`;
 
   // Create modulepreload with same-origin policy
@@ -138,7 +134,7 @@ promise_test(async t => {
 
 // Test strict-origin referrer policy
 promise_test(async t => {
-  const uid = generateUniqueId();
+  const uid = token();
   const url = `/preload/resources/echo-referrer.py?uid=${uid}`;
 
   // Create modulepreload with strict-origin policy
@@ -158,7 +154,7 @@ promise_test(async t => {
 
 // Test strict-origin-when-cross-origin referrer policy
 promise_test(async t => {
-  const uid = generateUniqueId();
+  const uid = token();
   const url = `/preload/resources/echo-referrer.py?uid=${uid}`;
 
   // Create modulepreload with strict-origin-when-cross-origin policy
@@ -178,7 +174,7 @@ promise_test(async t => {
 
 // Test unsafe-url referrer policy
 promise_test(async t => {
-  const uid = generateUniqueId();
+  const uid = token();
   const url = `/preload/resources/echo-referrer.py?uid=${uid}`;
 
   // Create modulepreload with unsafe-url policy

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8348,8 +8348,6 @@ webkit.org/b/312496 fast/forms/select/base/select-pagedown-pageup-vertical.html 
 
 webkit.org/b/312499 imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/form.html [ Pass Failure ]
 
-webkit.org/b/309173 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/modulepreload-referrerpolicy.html [ Pass Failure ]
-
 webkit.org/b/309019 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-programmatic-scroll.html?include=root-scrollBy-auto [ Pass Failure ]
 
 webkit.org/b/308658 compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2269,8 +2269,6 @@ webkit.org/b/311759 [ Release arm64 ] imported/w3c/web-platform-tests/event-timi
 
 webkit.org/b/308325 [ Debug ] http/wpt/cache-storage/cache-in-stopped-context.html [ Pass Failure ]
 
-webkit.org/b/309173 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/modulepreload-referrerpolicy.html [ Pass Failure ]
-
 webkit.org/b/308326 [ Debug ] imported/w3c/web-platform-tests/fetch/api/basic/error-after-response.any.html [ Pass Failure ]
 
 webkit.org/b/308586 imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html [ Pass Failure ]


### PR DESCRIPTION
#### 165f8228e9298ea53e333879be0fb75bb4c8c408
<pre>
[macOS iOS] imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/modulepreload-referrerpolicy.html is a flaky text failure.
<a href="https://rdar.apple.com/171730851">rdar://171730851</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309173">https://bugs.webkit.org/show_bug.cgi?id=309173</a>

Reviewed by NOBODY (OOPS!).

This test is flaky because it uses generateUniqueId() which uses `Date.now() + Math.floor(Math.random() * 1000)`.
Because the 7 promise_tests in this file run concurrently and generate their UIDs in synchronous code within the
same millisecond, the time component is identical and causes collisions.

Changed `LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/modulepreload-referrerpolicy.html`:

1. Added `&lt;script src=&quot;/common/utils.js&quot;&gt;&lt;/script&gt;` to load WPT&apos;s standard `token()` helper.
2. Removed the local `generateUniqueId()` function (returned `Date.now() + Math.floor(Math.random() * 1000)`
   — only ~10 bits of effective entropy across the 7 concurrent `promise_test` blocks that all evaluate within
   the same millisecond).
3. Replaced all 7 `generateUniqueId()` callsites with `token()`, which produces a 122-bit
   UUID — collision probability is negligible.

This eliminates the cross-test contamination through `window.referrers[uid]` that caused the strict-origin
assertion to flake with `location.href` (a sibling test&apos;s expected value) instead of `location.origin + &quot;/&quot;`.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/modulepreload-referrerpolicy.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/165f8228e9298ea53e333879be0fb75bb4c8c408

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123746 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129437 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91163 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109962 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30809 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29501 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23679 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178072 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137790 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137709 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103457 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33005 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25953 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39249 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38646 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4042 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38891 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38789 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->