### PR TITLE
[curl] Web Inspector: WebSocket request headers are missing

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/inspector/before-load-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/inspector/before-load-expected.txt
@@ -8,9 +8,14 @@ PASS: Resource should be a WebSocket.
 PASS: Resource URL should be "ws://127.0.0.1:8880/websocket/tests/hybi/inspector/echo".
 PASS: Resource status code should be 101.
 PASS: Resource status text should be "Switching Protocols".
-PASS: Resource should have request headers.
-PASS: Resource should have response headers.
-Resource readyState should be Symbol(open).
+PASS: Resource should have request header Connection.
+PASS: Resource should have request header Sec-Websocket-Key.
+PASS: Resource should have request header Sec-Websocket-Version.
+PASS: Resource should have request header Upgrade.
+PASS: Resource should have response header Connection.
+PASS: Resource should have response header sec-websocket-accept.
+PASS: Resource should have response header Upgrade.
+PASS: Resource should be open.
 PASS: Frame data should be 'Hello World!'
 PASS: Frame outgoing should be 'true'
 PASS: Frame data should be 'Hello World!'

--- a/LayoutTests/http/tests/websocket/tests/hybi/inspector/before-load.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/inspector/before-load.html
@@ -58,9 +58,14 @@ function test()
             InspectorTest.expectEqual(webSocketResource.url, url, `Resource URL should be "${url}".`);
             InspectorTest.expectEqual(webSocketResource.statusCode, 101, "Resource status code should be 101.");
             InspectorTest.expectEqual(webSocketResource.statusText, "Switching Protocols", "Resource status text should be \"Switching Protocols\".");
-            InspectorTest.expectThat(!isEmptyObject(webSocketResource.requestHeaders), "Resource should have request headers.");
-            InspectorTest.expectThat(!isEmptyObject(webSocketResource.responseHeaders), "Resource should have response headers.");
-            InspectorTest.log(`Resource readyState should be ${String(webSocketResource.readyState)}.`);
+            InspectorTest.expectThat(webSocketResource.requestHeaders.valueForCaseInsensitiveKey("Connection"), "Resource should have request header Connection.");
+            InspectorTest.expectThat(webSocketResource.requestHeaders.valueForCaseInsensitiveKey("Sec-Websocket-Key"), "Resource should have request header Sec-Websocket-Key.");
+            InspectorTest.expectThat(webSocketResource.requestHeaders.valueForCaseInsensitiveKey("Sec-Websocket-Version"), "Resource should have request header Sec-Websocket-Version.");
+            InspectorTest.expectEqual(webSocketResource.requestHeaders.valueForCaseInsensitiveKey("Upgrade"), "websocket", "Resource should have request header Upgrade.");
+            InspectorTest.expectThat(webSocketResource.responseHeaders.valueForCaseInsensitiveKey("Connection"), "Resource should have response header Connection.");
+            InspectorTest.expectThat(webSocketResource.responseHeaders.valueForCaseInsensitiveKey("sec-websocket-accept"), "Resource should have response header sec-websocket-accept.");
+            InspectorTest.expectEqual(webSocketResource.responseHeaders.valueForCaseInsensitiveKey("Upgrade"), "websocket", "Resource should have response header Upgrade.");
+            InspectorTest.expectEqual(webSocketResource.readyState, WI.WebSocketResource.ReadyState.Open, "Resource should be open.");
 
             let expectedFrames = [
                 {

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -197,6 +197,7 @@ ResourceRequest WebSocketHandshake::clientHandshakeRequest(NOESCAPE const Functi
     auto extensions = m_extensionDispatcher.createHeaderValue();
     ResourceRequest request { URL { m_url } };
     request.setHTTPMethod("GET"_s);
+    request.setHTTPHeaderField(HTTPHeaderName::Upgrade, "websocket"_s);
     request.setHTTPHeaderField(HTTPHeaderName::Connection, "Upgrade"_s);
     request.setHTTPHeaderField(HTTPHeaderName::Host, hostName(m_url, m_secure));
     request.setHTTPHeaderField(HTTPHeaderName::Origin, m_clientOrigin);

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -62,7 +62,6 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifi
         localhostAlias = WebCore::CurlStream::LocalhostAlias::Enable;
 
     m_streamID = m_scheduler.createStream(request.url(), *this, WebCore::CurlStream::ServerTrustEvaluation::Enable, localhostAlias);
-    channel.didSendHandshakeRequest(WebCore::ResourceRequest(m_request));
 }
 
 WebSocketTask::~WebSocketTask()
@@ -127,16 +126,17 @@ void WebSocketTask::didOpen(WebCore::CurlStreamID)
     m_handshake->reset();
     m_handshake->addExtensionProcessor(m_deflateFramer.createExtensionProcessor());
 
-    CString cookieHeader;
-
+    String cookieHeaderField;
     if (m_request.allowCookies()) {
         if (CheckedPtr storageSession = networkSession() ? networkSession()->networkStorageSession() : nullptr) {
             auto includeSecureCookies = m_request.url().protocolIs("wss"_s) ? WebCore::IncludeSecureCookies::Yes : WebCore::IncludeSecureCookies::No;
-            auto cookieHeaderField = storageSession->cookieRequestHeaderFieldValue(m_request.firstPartyForCookies(), WebCore::SameSiteInfo::create(m_request), m_request.url(), std::nullopt, std::nullopt, includeSecureCookies, WebCore::ApplyTrackingPrevention::Yes, WebCore::ShouldRelaxThirdPartyCookieBlocking::No, WebCore::IsKnownCrossSiteTracker::No).first;
-            if (!cookieHeaderField.isEmpty())
-                cookieHeader = makeString("Cookie: "_s, cookieHeaderField, "\r\n"_s).utf8();
+            cookieHeaderField = storageSession->cookieRequestHeaderFieldValue(m_request.firstPartyForCookies(), WebCore::SameSiteInfo::create(m_request), m_request.url(), std::nullopt, std::nullopt, includeSecureCookies, WebCore::ApplyTrackingPrevention::Yes, WebCore::ShouldRelaxThirdPartyCookieBlocking::No, WebCore::IsKnownCrossSiteTracker::No).first;
         }
     }
+
+    CString cookieHeader;
+    if (!cookieHeaderField.isEmpty())
+        cookieHeader = makeString("Cookie: "_s, cookieHeaderField, "\r\n"_s).utf8();
 
     auto originalMessage = m_handshake->clientHandshakeMessage();
     auto handshakeMessageLength = originalMessage.length() + cookieHeader.length();
@@ -149,6 +149,15 @@ void WebSocketTask::didOpen(WebCore::CurlStreamID)
     }
 
     m_scheduler.send(m_streamID, WTF::move(handshakeMessage), handshakeMessageLength);
+
+    // Web Inspector needs the method and headers from the handshake.
+    auto handshakeRequest = m_handshake->clientHandshakeRequest([&cookieHeaderField] (const URL&) {
+        return cookieHeaderField;
+    });
+    auto inspectorRequest = m_request;
+    inspectorRequest.setHTTPMethod(handshakeRequest.httpMethod());
+    inspectorRequest.setHTTPHeaderFields(handshakeRequest.httpHeaderFields());
+    protect(m_channel)->didSendHandshakeRequest(WTF::move(inspectorRequest));
 }
 
 void WebSocketTask::didReceiveData(WebCore::CurlStreamID, const WebCore::SharedBuffer& buffer)


### PR DESCRIPTION
#### 51ffbadc9899c40f5ef05029e71ff6bd20671156
<pre>
[curl] Web Inspector: WebSocket request headers are missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=316312">https://bugs.webkit.org/show_bug.cgi?id=316312</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::WebSocketTask):
(WebKit::WebSocketTask::didOpen):
Don&apos;t notify Web Inspector that the handshake has been sent until it&apos;s actually been sent.
Also make sure that the handshake copies from the initial network request all the info needed by Web Inspector (e.g. method, request headers, etc.).

* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::WebSocketHandshake::clientHandshakeRequest const):
Add missing header to match `WebSocketHandshake::clientHandshakeMessage`.

* LayoutTests/http/tests/websocket/tests/hybi/inspector/before-load.html:
* LayoutTests/http/tests/websocket/tests/hybi/inspector/before-load-expected.txt:

Canonical link: <a href="https://commits.webkit.org/314678@main">https://commits.webkit.org/314678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92163903be718428fc5bb347c3fa80c7c0ab90da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175892 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129737 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169803 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110263 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178430 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138104 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40404 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138017 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37168 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41092 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149406 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103890 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33294 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39603 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112677 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38999 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4364 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->