### PR TITLE
Map nextslide and previousslide MediaSession actions to nexttrack and previoustrack platform commands

### DIFF
--- a/LayoutTests/media/media-session/actionHandlerInternalMappings-expected.txt
+++ b/LayoutTests/media/media-session/actionHandlerInternalMappings-expected.txt
@@ -20,6 +20,27 @@ ACTION: stop
 Command: StopCommand
 ACTION: seekto
 Command: SeekToPlaybackPositionCommand
+ACTION: previousslide
+Command: PreviousTrackCommand
+ACTION: nextslide
+Command: NextTrackCommand
+Test that removing one of a pair sharing a platform command keeps the command, and removing both clears it
+Register nexttrack and nextslide, then remove nexttrack
+EXPECTED (internals.platformSupportedCommands().includes("NextTrackCommand") == 'true') OK
+Remove nextslide
+EXPECTED (internals.platformSupportedCommands().includes("NextTrackCommand") == 'false') OK
+Register nexttrack and nextslide, then remove nextslide
+EXPECTED (internals.platformSupportedCommands().includes("NextTrackCommand") == 'true') OK
+Remove nexttrack
+EXPECTED (internals.platformSupportedCommands().includes("NextTrackCommand") == 'false') OK
+Register previoustrack and previousslide, then remove previoustrack
+EXPECTED (internals.platformSupportedCommands().includes("PreviousTrackCommand") == 'true') OK
+Remove previousslide
+EXPECTED (internals.platformSupportedCommands().includes("PreviousTrackCommand") == 'false') OK
+Register previoustrack and previousslide, then remove previousslide
+EXPECTED (internals.platformSupportedCommands().includes("PreviousTrackCommand") == 'true') OK
+Remove previoustrack
+EXPECTED (internals.platformSupportedCommands().includes("PreviousTrackCommand") == 'false') OK
 Iterate over all possible actions
 Command: SkipForwardCommand
 Command: SkipBackwardCommand

--- a/LayoutTests/media/media-session/actionHandlerInternalMappings.html
+++ b/LayoutTests/media/media-session/actionHandlerInternalMappings.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ MediaSessionExtendedActionsEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -6,7 +7,7 @@
     <script src="../media-file.js"></script>
     <script>
 
-    const mediaSessionActions = [ "play", "pause", "seekbackward", "seekforward", "previoustrack", "nexttrack", "skipad", "stop", "seekto" ];
+    const mediaSessionActions = [ "play", "pause", "seekbackward", "seekforward", "previoustrack", "nexttrack", "skipad", "stop", "seekto", "previousslide", "nextslide" ];
     async function runTest() {
         if (!window.internals) {
             failTest('This test requires Internals');
@@ -25,6 +26,44 @@
             internals.platformSupportedCommands().forEach(value => consoleWrite(`Command: ${value}`));
             navigator.mediaSession.setActionHandler(value, null);
         });
+
+        consoleWrite('Test that removing one of a pair sharing a platform command keeps the command, and removing both clears it');
+
+        consoleWrite('Register nexttrack and nextslide, then remove nexttrack');
+        navigator.mediaSession.setActionHandler('nexttrack', actionDetails => { });
+        navigator.mediaSession.setActionHandler('nextslide', actionDetails => { });
+        navigator.mediaSession.setActionHandler('nexttrack', null);
+        testExpected('internals.platformSupportedCommands().includes("NextTrackCommand")', true);
+        consoleWrite('Remove nextslide');
+        navigator.mediaSession.setActionHandler('nextslide', null);
+        testExpected('internals.platformSupportedCommands().includes("NextTrackCommand")', false);
+
+        consoleWrite('Register nexttrack and nextslide, then remove nextslide');
+        navigator.mediaSession.setActionHandler('nexttrack', actionDetails => { });
+        navigator.mediaSession.setActionHandler('nextslide', actionDetails => { });
+        navigator.mediaSession.setActionHandler('nextslide', null);
+        testExpected('internals.platformSupportedCommands().includes("NextTrackCommand")', true);
+        consoleWrite('Remove nexttrack');
+        navigator.mediaSession.setActionHandler('nexttrack', null);
+        testExpected('internals.platformSupportedCommands().includes("NextTrackCommand")', false);
+
+        consoleWrite('Register previoustrack and previousslide, then remove previoustrack');
+        navigator.mediaSession.setActionHandler('previoustrack', actionDetails => { });
+        navigator.mediaSession.setActionHandler('previousslide', actionDetails => { });
+        navigator.mediaSession.setActionHandler('previoustrack', null);
+        testExpected('internals.platformSupportedCommands().includes("PreviousTrackCommand")', true);
+        consoleWrite('Remove previousslide');
+        navigator.mediaSession.setActionHandler('previousslide', null);
+        testExpected('internals.platformSupportedCommands().includes("PreviousTrackCommand")', false);
+
+        consoleWrite('Register previoustrack and previousslide, then remove previousslide');
+        navigator.mediaSession.setActionHandler('previoustrack', actionDetails => { });
+        navigator.mediaSession.setActionHandler('previousslide', actionDetails => { });
+        navigator.mediaSession.setActionHandler('previousslide', null);
+        testExpected('internals.platformSupportedCommands().includes("PreviousTrackCommand")', true);
+        consoleWrite('Remove previoustrack');
+        navigator.mediaSession.setActionHandler('previoustrack', null);
+        testExpected('internals.platformSupportedCommands().includes("PreviousTrackCommand")', false);
 
         consoleWrite('Iterate over all possible actions');
         mediaSessionActions.forEach(value => {

--- a/LayoutTests/media/media-session/mock-actionHandlers-expected.txt
+++ b/LayoutTests/media/media-session/mock-actionHandlers-expected.txt
@@ -35,5 +35,21 @@ EXPECTED (actionDetails === '{"action":"seekto","seekTime":1}') OK
 RUN(internals.sendMediaSessionAction(navigator.mediaSession, {action: "seekto", seekTime: 1, fastSeek: true}))
 ACTION: seekto
 EXPECTED (actionDetails === '{"action":"seekto","seekTime":1,"fastSeek":true}') OK
+Test that nexttrack handler takes priority over nextslide when both are registered
+RUN(internals.sendMediaSessionAction(navigator.mediaSession, {action: "nexttrack"}))
+ACTION: nexttrack
+EXPECTED (actionDetails === '{"action":"nexttrack"}') OK
+Test that nexttrack falls back to nextslide handler when only nextslide is registered
+RUN(internals.sendMediaSessionAction(navigator.mediaSession, {action: "nexttrack"}))
+ACTION: nextslide
+EXPECTED (actionDetails === '{"action":"nextslide"}') OK
+Test that previoustrack handler takes priority over previousslide when both are registered
+RUN(internals.sendMediaSessionAction(navigator.mediaSession, {action: "previoustrack"}))
+ACTION: previoustrack
+EXPECTED (actionDetails === '{"action":"previoustrack"}') OK
+Test that previoustrack falls back to previousslide handler when only previousslide is registered
+RUN(internals.sendMediaSessionAction(navigator.mediaSession, {action: "previoustrack"}))
+ACTION: previousslide
+EXPECTED (actionDetails === '{"action":"previousslide"}') OK
 END OF TEST
 

--- a/LayoutTests/media/media-session/mock-actionHandlers.html
+++ b/LayoutTests/media/media-session/mock-actionHandlers.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ MediaSessionExtendedActionsEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -26,7 +27,7 @@
             return;
         }
 
-        let actions = ["play", "pause", "seekbackward", "seekforward", "previoustrack", "nexttrack", "skipad", "stop", "seekto"];
+        let actions = ["play", "pause", "seekbackward", "seekforward", "previoustrack", "nexttrack", "skipad", "stop", "seekto", "previousslide", "nextslide"];
 
         for (action of actions) {
             navigator.mediaSession.setActionHandler(action, actionDetails => {
@@ -72,6 +73,24 @@
 
         run('internals.sendMediaSessionAction(navigator.mediaSession, {action: "seekto", seekTime: 1, fastSeek: true})');
         testExpectedActionDetails('actionDetails', {action: 'seekto', seekTime: 1, fastSeek: true});
+
+        consoleWrite('Test that nexttrack handler takes priority over nextslide when both are registered');
+        run('internals.sendMediaSessionAction(navigator.mediaSession, {action: "nexttrack"})');
+        testExpectedActionDetails('actionDetails', {action: 'nexttrack'});
+
+        consoleWrite('Test that nexttrack falls back to nextslide handler when only nextslide is registered');
+        navigator.mediaSession.setActionHandler('nexttrack', null);
+        run('internals.sendMediaSessionAction(navigator.mediaSession, {action: "nexttrack"})');
+        testExpectedActionDetails('actionDetails', {action: 'nextslide'});
+
+        consoleWrite('Test that previoustrack handler takes priority over previousslide when both are registered');
+        run('internals.sendMediaSessionAction(navigator.mediaSession, {action: "previoustrack"})');
+        testExpectedActionDetails('actionDetails', {action: 'previoustrack'});
+
+        consoleWrite('Test that previoustrack falls back to previousslide handler when only previousslide is registered');
+        navigator.mediaSession.setActionHandler('previoustrack', null);
+        run('internals.sendMediaSessionAction(navigator.mediaSession, {action: "previoustrack"})');
+        testExpectedActionDetails('actionDetails', {action: 'previousslide'});
 
         endTest();
     }, {once: true});

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -87,6 +87,8 @@ static PlatformMediaSession::RemoteControlCommandType platformCommandForMediaSes
         { MediaSessionAction::Skipad, PlatformMediaSession::RemoteControlCommandType::NextTrackCommand },
         { MediaSessionAction::Stop, PlatformMediaSession::RemoteControlCommandType::StopCommand },
         { MediaSessionAction::Seekto, PlatformMediaSession::RemoteControlCommandType::SeekToPlaybackPositionCommand },
+        { MediaSessionAction::Previousslide, PlatformMediaSession::RemoteControlCommandType::PreviousTrackCommand },
+        { MediaSessionAction::Nextslide, PlatformMediaSession::RemoteControlCommandType::NextTrackCommand },
     }) };
     return map.get(action, PlatformMediaSession::RemoteControlCommandType::NoCommand);
 }
@@ -128,10 +130,14 @@ static std::optional<std::pair<PlatformMediaSession::RemoteControlCommandType, P
         argument.time = actionDetails.seekTime;
         argument.fastSeek = actionDetails.fastSeek;
         break;
+    case MediaSessionAction::Previousslide:
+        command = PlatformMediaSession::RemoteControlCommandType::PreviousTrackCommand;
+        break;
+    case MediaSessionAction::Nextslide:
+        command = PlatformMediaSession::RemoteControlCommandType::NextTrackCommand;
+        break;
     case MediaSessionAction::Settrack:
     case MediaSessionAction::Hangup:
-    case MediaSessionAction::Previousslide:
-    case MediaSessionAction::Nextslide:
     case MediaSessionAction::Enterpictureinpicture:
         // Not supported at present.
         break;
@@ -321,16 +327,27 @@ ExceptionOr<void> MediaSession::setActionHandler(MediaSessionAction action, RefP
             }
         }
     } else {
-        bool containedAction;
+        bool containedAction = false;
+        bool anotherActionNeedsCommand = false;
+        auto platformCommand = platformCommandForMediaSessionAction(action);
         {
             Locker lock { m_actionHandlersLock };
             containedAction = m_actionHandlers.remove(action);
+            if (containedAction) {
+                for (auto registeredAction : m_actionHandlers.keys()) {
+                    if (platformCommandForMediaSessionAction(registeredAction) == platformCommand) {
+                        anotherActionNeedsCommand = true;
+                        break;
+                    }
+                }
+            }
         }
 
         if (sessionManager) {
             if (containedAction)
                 ALWAYS_LOG(LOGIDENTIFIER, "removing ", action);
-            sessionManager->removeSupportedCommand(platformCommandForMediaSessionAction(action));
+            if (!anotherActionNeedsCommand)
+                sessionManager->removeSupportedCommand(platformCommand);
         }
     }
 
@@ -364,16 +381,28 @@ bool MediaSession::hasActionHandler(const MediaSessionAction action) const
 bool MediaSession::callActionHandler(const MediaSessionActionDetails& actionDetails, TriggerGestureIndicator triggerGestureIndicator)
 {
     RefPtr<MediaSessionActionHandler> handler;
+    MediaSessionActionDetails effectiveActionDetails = actionDetails;
     {
         Locker lock { m_actionHandlersLock };
         handler = m_actionHandlers.get(actionDetails.action);
+        if (!handler) {
+            if (actionDetails.action == MediaSessionAction::Nexttrack) {
+                handler = m_actionHandlers.get(MediaSessionAction::Nextslide);
+                if (handler)
+                    effectiveActionDetails.action = MediaSessionAction::Nextslide;
+            } else if (actionDetails.action == MediaSessionAction::Previoustrack) {
+                handler = m_actionHandlers.get(MediaSessionAction::Previousslide);
+                if (handler)
+                    effectiveActionDetails.action = MediaSessionAction::Previousslide;
+            }
+        }
     }
 
     if (handler) {
         std::optional<UserGestureIndicator> maybeGestureIndicator;
         if (triggerGestureIndicator == TriggerGestureIndicator::Yes)
             maybeGestureIndicator.emplace(IsProcessingUserGesture::Yes, document());
-        handler->invoke(actionDetails);
+        handler->invoke(effectiveActionDetails);
         return true;
     }
     auto element = activeMediaElement();


### PR DESCRIPTION
#### 2c1df6e3a6860de63f209bd7d9f2276a1089ca3e
<pre>
Map nextslide and previousslide MediaSession actions to nexttrack and previoustrack platform commands
<a href="https://rdar.apple.com/178744268">rdar://178744268</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316320">https://bugs.webkit.org/show_bug.cgi?id=316320</a>

Reviewed by Youenn Fablet.

When a site registers only a nextslide or previousslide handler,
pressing the next/previous track button should invoke those handlers.
This patch maps `nextslide` and `previousslide` to `NextTrackCommand` and
`PreviousTrackCommand` respectively, and adds a fallback in `callActionHandler`
so that when `nexttrack` or `previoustrack` arrives from the OS and
no direct handler is registered, the corresponding slide handler is invoked instead.

The deregistration path also avoids removing a shared platform command
when another action mapping to the same command is still registered.

New tests have been added to `actionHandlerInternalMappings` and
`mock-actionHandlers` to cover the fallback behavior and shared command deregistration.

* LayoutTests/media/media-session/actionHandlerInternalMappings-expected.txt:
* LayoutTests/media/media-session/actionHandlerInternalMappings.html:
* LayoutTests/media/media-session/mock-actionHandlers-expected.txt:
* LayoutTests/media/media-session/mock-actionHandlers.html:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::platformCommandForMediaSessionAction):
(WebCore::MediaSession::setActionHandler):
(WebCore::MediaSession::callActionHandler):

Canonical link: <a href="https://commits.webkit.org/314839@main">https://commits.webkit.org/314839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9590d70aac616b3ac3909dc1487454fd6bc9e179

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176057 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168875 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129877 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91483 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110402 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31253 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29958 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24794 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141228 "Found 2 new API test failures: TestWebKitAPI.CopyHTML.SanitizationPreservesCharacterSetInSelectedText, TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178595 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31493 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138245 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138156 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149551 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/104159 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25469 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33427 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26416 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39768 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112842 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39164 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4517 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->