### PR TITLE
Fix -Wunused-parameter warnings in TestWebKitAPI plug-ins

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleParametersPlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleParametersPlugIn.mm
@@ -63,7 +63,7 @@ static NSString * const testParameter2 = @"TestParameter2";
 #if WK_HAVE_C_SPI
     WKBundlePageLoaderClientV6 loaderClient = { };
     loaderClient.base.version = 6;
-    loaderClient.willLoadDataRequest = [] (WKBundlePageRef page, WKURLRequestRef, WKDataRef, WKStringRef, WKStringRef, WKURLRef, WKTypeRef userData, const void*) {
+    loaderClient.willLoadDataRequest = [] (WKBundlePageRef, WKURLRequestRef, WKDataRef, WKStringRef, WKStringRef, WKURLRef, WKTypeRef userData, const void*) {
         id data = WKObjCTypeWrapperGetObject((WKObjCTypeWrapperRef)userData);
         RELEASE_ASSERT([data isKindOfClass:NSData.class]);
     };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSHandlePlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSHandlePlugIn.mm
@@ -59,7 +59,7 @@ static WKWebProcessPlugInBrowserContextController *globalBrowserContextControlle
     [world allowJSHandleCreation];
 }
 
-static JSValueRef javaScriptFunction(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+static JSValueRef javaScriptFunction(JSContextRef context, JSObjectRef, JSObjectRef, size_t argumentCount, const JSValueRef arguments[], JSValueRef*)
 {
     if (argumentCount == 1) {
         JSContext *jsContext = [JSContext contextWithJSGlobalContextRef:JSContextGetGlobalContext(context)];


### PR DESCRIPTION
#### 551711b33c5c2c2778fe5a5aed9ee61d68fe839b
<pre>
Fix -Wunused-parameter warnings in TestWebKitAPI plug-ins
<a href="https://bugs.webkit.org/show_bug.cgi?id=316321">https://bugs.webkit.org/show_bug.cgi?id=316321</a>
<a href="https://rdar.apple.com/178744875">rdar://178744875</a>

Reviewed by Brandon Stewart.

Drop the names of unused parameters in BundleParametersPlugIn.mm and
JSHandlePlugIn.mm to silence -Wunused-parameter warnings.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleParametersPlugIn.mm:
(-[BundleParametersPlugIn webProcessPlugIn:didCreateBrowserContextController:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSHandlePlugIn.mm:
(javaScriptFunction):

Canonical link: <a href="https://commits.webkit.org/314568@main">https://commits.webkit.org/314568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a96b8027851c96b660b76c4ab747b864070f727a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166498 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/39988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175546 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129444 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169457 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109969 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a73f22b-c30b-4fbc-a107-96623fc6e18f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23686 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178079 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137799 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40058 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33657 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137717 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37106 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149101 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103464 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33011 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25966 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39256 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38653 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4055 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38898 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38796 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->