### PR TITLE
Cherry pick 305413.672@safari-7624-branch (4fcd36e3a363)

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -305,6 +305,7 @@ Ref<WebProcessProxy> WebProcessProxy::create(WebProcessPool& processPool, Websit
 Ref<WebProcessProxy> WebProcessProxy::createForRemoteWorkers(RemoteWorkerType workerType, WebProcessPool& processPool, Site&& site, WebsiteDataStore& websiteDataStore, CrossOriginMode crossOriginMode, LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity)
 {
     Ref proxy = adoptRef(*new WebProcessProxy(processPool, &websiteDataStore, IsPrewarmed::No, crossOriginMode, lockdownMode, enhancedSecurity));
+    proxy->m_committedSites.add(site);
     proxy->m_site = WTF::move(site);
     proxy->enableRemoteWorkers(workerType, processPool.userContentControllerForRemoteWorkers());
     proxy->connect();
@@ -977,7 +978,8 @@ void WebProcessProxy::sendPageCloseMessage(std::optional<WebPageProxyIdentifier>
 bool WebProcessProxy::hasCommittedClientOrigin(const WebCore::ClientOrigin& clientOrigin) const
 {
     if (isRunningWorkers()) {
-        ASSERT(m_site);
+        if (!m_site)
+            return m_committedSites.contains(Site { clientOrigin.topOrigin }) && m_committedSites.contains(Site { clientOrigin.clientOrigin });
         return Site { clientOrigin.topOrigin } == *m_site && Site { clientOrigin.clientOrigin } == *m_site;
     }
     return m_committedClientOrigins.contains(clientOrigin);
@@ -2347,6 +2349,7 @@ void WebProcessProxy::didStartProvisionalLoadForMainFrame(const URL& url)
         ASSERT((m_site && *m_site == site) || m_site.error() == SiteState::SharedProcess);
     else {
         // Associate the process with this site.
+        m_committedSites.add(site);
         m_site = WTF::move(site);
     }
 }
@@ -2360,6 +2363,7 @@ void WebProcessProxy::didStartUsingProcessForSiteIsolation(const std::optional<W
         return;
     }
     ASSERT(m_site ? (m_site.value().isEmpty() || m_site.value() == *site || !m_hasCommittedAnyProvisionalLoads) : (m_site.error() == SiteState::NotYetSpecified || m_site.error() == SiteState::MultipleSites));
+    m_committedSites.add(*site);
     m_site = *site;
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -846,6 +846,7 @@ private:
 #endif
 
     Expected<WebCore::Site, SiteState> m_site { std::unexpected<SiteState> { SiteState::NotYetSpecified } };
+    HashSet<WebCore::Site> m_committedSites;
     std::optional<WebCore::Site> m_sharedProcessMainFrameSite;
     HashSet<WebCore::RegistrableDomain> m_sharedProcessDomains;
     std::pair<LoadedWebArchive, HashSet<WebCore::RegistrableDomain>> m_allowedFirstPartiesForCookies { LoadedWebArchive::No, { } };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm
@@ -34,8 +34,20 @@
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKFeature.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
+#import <wtf/text/MakeString.h>
 
 namespace TestWebKitAPI {
+
+static void enableWebLocksAPI(WKWebViewConfiguration *configuration)
+{
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            return;
+        }
+    }
+}
 
 enum class ShouldUseSameProcess : bool { No, Yes };
 
@@ -46,12 +58,7 @@ static void runSnapshotAcrossPagesTest(ShouldUseSameProcess shouldUseSameProcess
     });
 
     RetainPtr configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
-            [[configuration1 preferences] _setEnabled:YES forFeature:feature];
-            break;
-        }
-    }
+    enableWebLocksAPI(configuration1.get());
 
     RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
     [webView1 synchronouslyLoadRequest:server.request()];
@@ -71,12 +78,7 @@ static void runSnapshotAcrossPagesTest(ShouldUseSameProcess shouldUseSameProcess
 
     RetainPtr configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration2.get().processPool = [configuration1 processPool];
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
-            [[configuration2 preferences] _setEnabled:YES forFeature:feature];
-            break;
-        }
-    }
+    enableWebLocksAPI(configuration2.get());
     if (shouldUseSameProcess == ShouldUseSameProcess::Yes) {
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         configuration2.get()._relatedWebView = webView1.get();
@@ -142,12 +144,7 @@ static void runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess shouldUseSam
     });
 
     RetainPtr configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
-            [[configuration1 preferences] _setEnabled:YES forFeature:feature];
-            break;
-        }
-    }
+    enableWebLocksAPI(configuration1.get());
 
     RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
     [webView1 synchronouslyLoadRequest:server.request()];
@@ -167,12 +164,7 @@ static void runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess shouldUseSam
 
     RetainPtr configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration2.get().processPool = [configuration1 processPool];
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
-            [[configuration2 preferences] _setEnabled:YES forFeature:feature];
-            break;
-        }
-    }
+    enableWebLocksAPI(configuration2.get());
     if (shouldUseSameProcess == ShouldUseSameProcess::Yes) {
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         configuration2.get()._relatedWebView = webView1.get();
@@ -242,6 +234,45 @@ TEST(WebLocks, LockRequestWaitingOnAnotherPageInOtherProcess)
 TEST(WebLocks, LockRequestWaitingOnAnotherPageInSameProcess)
 {
     runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess::Yes);
+}
+
+TEST(WebLocks, ServiceWorkerLockRequestAfterCrossSiteNavigationInSameProcess)
+{
+    TestWebKitAPI::HTTPServer server1({ }, TestWebKitAPI::HTTPServer::Protocol::Http);
+    TestWebKitAPI::HTTPServer server2({ }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto swScript = "self.addEventListener('message', event => { event.waitUntil(new Promise(() => {})); event.source.postMessage('processing'); function loop() { navigator.locks.request('sw-lock', () => {}).then(loop); } loop(); });"_s;
+    auto page2HTML = "<script>webkit.messageHandlers.testHandler.postMessage('LOADED');</script>"_s;
+    auto page1HTML = makeString(
+        "<script>"
+        "navigator.serviceWorker.register('/sw.js').then(() => navigator.serviceWorker.ready).then(reg => {"
+        "    navigator.serviceWorker.onmessage = () => { window.location = 'http://localhost:"_s, server2.port(), "/'; };"
+        "    reg.active.postMessage('start');"
+        "});"
+        "</script>"_s);
+
+    server1.addResponse("/sw.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, swScript });
+    server1.addResponse("/"_s, { page1HTML });
+    server2.addResponse("/"_s, { page2HTML });
+
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    processPoolConfiguration.get().processSwapsOnNavigation = NO;
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get().processPool = processPool.get();
+    enableWebLocksAPI(configuration.get());
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    __block bool done = false;
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        EXPECT_WK_STREQ(message, @"LOADED");
+        done = true;
+    }];
+
+    [webView synchronouslyLoadRequest:server1.request()];
+    TestWebKitAPI::Util::run(&done);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### f8acb9cb819c1f8ae56c81b5e5076403a6b12a5b
<pre>
Cherry pick 305413.672@safari-7624-branch (4fcd36e3a363)
<a href="https://bugs.webkit.org/show_bug.cgi?id=316322">https://bugs.webkit.org/show_bug.cgi?id=316322</a>
<a href="https://rdar.apple.com/178745136">rdar://178745136</a>

    REGRESSION(305413.548@safari-7624-branch): Crash in WebProcessProxy::hasCommittedClientOrigin
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312335">https://bugs.webkit.org/show_bug.cgi?id=312335</a>
    <a href="https://rdar.apple.com/174679141">rdar://174679141</a>

    Reviewed by Chris Dumez.

    WebProcessProxy::hasCommittedClientOrigin has a code path for processes running workers (isRunningWorkers())
    that dereferences m_site as in *m_site. m_site is a WTF::Expected&lt;WebCore::Site, SiteState&gt; — when it holds
    the error value SiteState::MultipleSites, operator*() accesses the non-existent value member, throwing
    std::bad_variant_access. This propagates uncaught to the Objective-C run loop boundary, triggering std::terminate().

    The three conditions that must hold simultaneously for this crash to occur:
      1. isRunningWorkers() is true — a service worker is running inside a web content process (not a dedicated worker
         process), so m_serviceWorkerInformation is set.
      2. m_site holds MultipleSites — a cross-site navigation occurred in that same web content process (no process swap),
         so didStartProvisionalLoadForMainFrame set m_site = makeUnexpected(SiteState::MultipleSites).
      3. A RequestLock IPC from the service worker arrives after condition 2 — the service worker&apos;s termination is
         deferred (terminateRemoteWorkerContextConnectionWhenPossible instead of the old disableRemoteWorkers), so
         isRunningWorkers() remains true during a window where the worker can still send IPCs.

    Fixed the bug by adding a HashSet&lt;WebCore::Site&gt; m_committedSites to WebProcessProxy, populated whenever m_site is
    assigned a valid Site (in createForRemoteWorkers, didStartProvisionalLoadForMainFrame, and
    didStartUsingProcessForSiteIsolation). In hasCommittedClientOrigin, when isRunningWorkers() is true but m_site does
    not holds a value (it&apos;s MultipleSites), the check falls back to m_committedSites instead of dereferencing m_site
    in an error state. This correctly validates the worker&apos;s origin against the sites the process has legitimately
    committed — rather than crashing or incorrectly rejecting a legitimate lock request and killing the web process.

    Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WebLocks.mm

    * Source/WebKit/UIProcess/WebProcessProxy.cpp:
    (WebKit::WebProcessProxy::createForRemoteWorkers):
    (WebKit::WebProcessProxy::hasCommittedClientOrigin const):
    (WebKit::WebProcessProxy::didStartProvisionalLoadForMainFrame):
    (WebKit::WebProcessProxy::didStartUsingProcessForSiteIsolation):
    * Source/WebKit/UIProcess/WebProcessProxy.h:
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/WebLocks.mm:
    (TestWebKitAPI::enableWebLocksAPI):
    (TestWebKitAPI::runSnapshotAcrossPagesTest):
    (TestWebKitAPI::runLockRequestWaitingOnAnotherPage):
    (TestWebKitAPI::TEST(WebLocks, ServiceWorkerLockRequestAfterCrossSiteNavigationInSameProcess)):

Originally-landed-as: 305413.672@safari-7624-branch (4fcd36e3a363). <a href="https://rdar.apple.com/174679141">rdar://174679141</a>
Canonical link: <a href="https://commits.webkit.org/314616@main">https://commits.webkit.org/314616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a7969f020c9c8c8bd8ef2302cf5386d8e44955e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123754 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129445 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36426b27-8e81-4672-a285-7bcbe8837f45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109970 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30802 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29508 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23687 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178080 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30981 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29013 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137806 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137719 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149104 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103465 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33015 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25969 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39257 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112332 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38654 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4058 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38899 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38797 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->