### PR TITLE
[curl] Web Inspector: WebSocket response status code and status text are missing when handshake fails

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/inspector/handshake-error-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/inspector/handshake-error-expected.txt
@@ -1,0 +1,9 @@
+Tests WebSocket handshake errors.
+
+
+== Running test suite: WebSocket.HandshakeError
+-- Running test case: HandshakeError
+PASS: Resource should be a WebSocket.
+PASS: Should have correct status code.
+PASS: Should have correct status text.
+

--- a/LayoutTests/http/tests/websocket/tests/hybi/inspector/handshake-error.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/inspector/handshake-error.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../../inspector/resources/inspector-test.js"></script>
+<script>
+function createWebSocketConnection()
+{
+    new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/handshake-error");
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("WebSocket.HandshakeError");
+
+    suite.addTestCase({
+        name: "HandshakeError",
+        description: "Should capture WebSocket handshake errors.",
+        async test() {
+            let [resourceWasAddedEvent] = await Promise.all([
+                WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded),
+                InspectorTest.evaluateInPage(`createWebSocketConnection()`),
+            ]);
+            let {resource} = resourceWasAddedEvent.data;
+            InspectorTest.expectThat(resource instanceof WI.WebSocketResource, "Resource should be a WebSocket.");
+
+            await resource.awaitEvent(WI.Resource.Event.ResponseReceived);
+            InspectorTest.expectEqual(resource.statusCode, 403, "Should have correct status code.");
+            InspectorTest.expectEqual(resource.statusText, "Forbidden", "Should have correct status text.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests WebSocket handshake errors.</p>
+</body>
+</html>

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -326,26 +326,29 @@ URL WebSocketHandshake::httpURLForAuthenticationAndCookies() const
     return url;
 }
 
-// https://tools.ietf.org/html/rfc6455#section-4.1
-// "The HTTP version MUST be at least 1.1."
-static inline bool headerHasValidHTTPVersion(StringView httpStatusLine)
+struct HTTPVersion {
+    int major;
+    int minor;
+};
+
+static inline std::optional<HTTPVersion> readHTTPVersion(StringView httpStatusLine)
 {
     constexpr auto preamble = "HTTP/"_s;
     if (!httpStatusLine.startsWith(preamble))
-        return false;
+        return std::nullopt;
 
     // Check that there is a version number which should be at least three characters after "HTTP/"
     unsigned preambleLength = preamble.length();
     if (httpStatusLine.length() < preambleLength + 3)
-        return false;
+        return std::nullopt;
 
     auto dotPosition = httpStatusLine.find('.', preambleLength);
     if (dotPosition == notFound)
-        return false;
+        return std::nullopt;
 
     auto majorVersion = parseInteger<int>(httpStatusLine.substring(preambleLength, dotPosition - preambleLength));
     if (!majorVersion)
-        return false;
+        return std::nullopt;
 
     unsigned minorVersionLength;
     unsigned charactersLeftAfterDotPosition = httpStatusLine.length() - dotPosition;
@@ -355,9 +358,20 @@ static inline bool headerHasValidHTTPVersion(StringView httpStatusLine)
     }
     auto minorVersion = parseInteger<int>(httpStatusLine.substring(dotPosition + 1, minorVersionLength));
     if (!minorVersion)
-        return false;
+        return std::nullopt;
 
-    return (*majorVersion >= 1 && *minorVersion >= 1) || *majorVersion >= 2;
+    // Accept any well-formed HTTP/1.x or later status line. While a successful WebSocket
+    // upgrade requires HTTP/1.1 (enforced separately by the 101 status-code check in
+    // readStatusLine()), a failed handshake may legitimately come back as an HTTP/1.0
+    // error response (e.g. from a simple proxy or origin server). Rejecting HTTP/1.0 here
+    // would discard that response's status code and text instead of surfacing them.
+    if (*majorVersion < 1 || *minorVersion < 0)
+        return std::nullopt;
+
+    return { {
+        .major = *majorVersion,
+        .minor = *minorVersion,
+    } };
 }
 
 // Returns the header length (including "\r\n"), or -1 if we have not received enough data yet.
@@ -415,7 +429,8 @@ int WebSocketHandshake::readStatusLine(std::span<const uint8_t> header, int& sta
     }
 
     StringView httpStatusLine(byteCast<Latin1Character>(header.first(*firstSpaceIndex)));
-    if (!headerHasValidHTTPVersion(httpStatusLine)) {
+    auto httpVersion = readHTTPVersion(httpStatusLine);
+    if (!httpVersion) {
         m_failureReason = makeString("Invalid HTTP version string: "_s, httpStatusLine);
         return lineLength;
     }
@@ -432,6 +447,14 @@ int WebSocketHandshake::readStatusLine(std::span<const uint8_t> header, int& sta
 
     statusCode = parseInteger<int>(statusCodeString).value();
     statusText = String(byteCast<Latin1Character>(header.subspan(*secondSpaceIndex + 1, lineLength - *secondSpaceIndex - 3))); // Exclude "\r\n".
+
+    // https://tools.ietf.org/html/rfc6455#section-4.1
+    // "The HTTP version MUST be at least 1.1."
+    if (statusCode == 101 && (httpVersion->major < 1 || httpVersion->minor < 1)) {
+        m_failureReason = makeString("Invalid HTTP version string: "_s, httpStatusLine);
+        return lineLength;
+    }
+
     return lineLength;
 }
 

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -316,6 +316,10 @@ Expected<bool, String> WebSocketTask::validateOpeningHandshake()
 
     if (m_handshake->mode() != WebCore::WebSocketHandshake::Connected) {
         auto reason = m_handshake->failureReason();
+        if (!m_handshake->serverHandshakeResponse().isNull()) {
+            if (RefPtr channel = m_channel.get())
+                channel->didReceiveHandshakeResponse(WebCore::ResourceResponse(m_handshake->serverHandshakeResponse()));
+        }
         m_handshake = nullptr;
         return makeUnexpected(reason);
     }


### PR DESCRIPTION
#### b041edf32e2702d3474cc3c2e028ce20f12a8059
<pre>
[curl] Web Inspector: WebSocket response status code and status text are missing when handshake fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=316313">https://bugs.webkit.org/show_bug.cgi?id=316313</a>

Reviewed by Abrar Rahman Protyasha and Don Olmstead.

* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::validateOpeningHandshake):
Don&apos;t just drop the handshake if the server sends an error response as Web Inspector needs to be notified.

* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::readHTTPVersion): Renamed from `headerHasValidHTTPVersion`.
(WebCore::WebSocketHandshake::readStatusLine):
Move the check for `HTTP/1.1` to only if it&apos;s a successful `101` as a valid handshake failure could be `HTTP/1.0 404`.

* LayoutTests/http/tests/websocket/tests/hybi/inspector/handshake-error.html: Added.
* LayoutTests/http/tests/websocket/tests/hybi/inspector/handshake-error-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/314818@main">https://commits.webkit.org/314818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c44175ff80b1f12b3fb6c570b8178a21209cefa2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176361 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130149 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110666 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25100 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178904 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31801 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138540 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40881 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34393 "1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138430 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37268 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41569 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149814 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104621 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33678 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26690 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113154 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39470 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4788 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39615 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->