### PR TITLE
FontTaggedSettings: Replace repeated OpenType variation axis literals with named constants

### DIFF
--- a/Source/WebCore/platform/graphics/FontTaggedSettings.h
+++ b/Source/WebCore/platform/graphics/FontTaggedSettings.h
@@ -47,6 +47,19 @@ inline FontTag fontFeatureTag(std::span<const char, 5> nullTerminatedString)
     return { nullTerminatedString[0], nullTerminatedString[1], nullTerminatedString[2], nullTerminatedString[3] };
 }
 
+namespace FontVariationAxisTag {
+inline constexpr FontTag ital = { { 'i', 't', 'a', 'l' } };
+inline constexpr FontTag opsz = { { 'o', 'p', 's', 'z' } };
+inline constexpr FontTag slnt = { { 's', 'l', 'n', 't' } };
+inline constexpr FontTag wdth = { { 'w', 'd', 't', 'h' } };
+inline constexpr FontTag wght = { { 'w', 'g', 'h', 't' } };
+} // namespace FontVariationAxisTag
+
+inline constexpr uint32_t fontVariationAxisTagValue(FontTag tag)
+{
+    return (static_cast<uint8_t>(tag[0]) << 24) | (static_cast<uint8_t>(tag[1]) << 16) | (static_cast<uint8_t>(tag[2]) << 8) | static_cast<uint8_t>(tag[3]);
+}
+
 inline void add(Hasher& hasher, std::array<char, 4> array)
 {
     uint32_t integer = (static_cast<uint8_t>(array[0]) << 24) | (static_cast<uint8_t>(array[1]) << 16) | (static_cast<uint8_t>(array[2]) << 8) | static_cast<uint8_t>(array[3]);

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -352,11 +352,11 @@ static VariationCapabilities variationCapabilitiesForFontDescriptor(CTFontDescri
         uint32_t rawAxisIdentifier = 0;
         Boolean success = CFNumberGetValue(axisIdentifier.get(), kCFNumberSInt32Type, &rawAxisIdentifier);
         ASSERT_UNUSED(success, success);
-        if (rawAxisIdentifier == 0x77676874) // 'wght'
+        if (rawAxisIdentifier == fontVariationAxisTagValue(FontVariationAxisTag::wght))
             result.weight = extractVariationBounds(axis.get());
-        else if (rawAxisIdentifier == 0x77647468) // 'wdth'
+        else if (rawAxisIdentifier == fontVariationAxisTagValue(FontVariationAxisTag::wdth))
             result.width = extractVariationBounds(axis.get());
-        else if (rawAxisIdentifier == 0x736C6E74) // 'slnt'
+        else if (rawAxisIdentifier == fontVariationAxisTagValue(FontVariationAxisTag::slnt))
             result.slope = extractVariationBounds(axis.get());
     }
 

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
@@ -86,7 +86,7 @@ void UnrealizedCoreTextFont::addAttributesForOpticalSizing(CFMutableDictionaryRe
     case OpticalSizingType::JustVariation:
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=252592 We should never be enabling just the opsz variation without also enabling trak.
         // We should delete this and use the OpticalSizingType::Everything path instead.
-        variationsToBeApplied.set({ { 'o', 'p', 's', 'z' } }, size);
+        variationsToBeApplied.set(FontVariationAxisTag::opsz, size);
         break;
     case OpticalSizingType::Everything:
         CFDictionarySetValue(attributes, kCTFontOpticalSizeAttribute, CFSTR("auto"));
@@ -226,12 +226,12 @@ void UnrealizedCoreTextFont::modifyFromContext(CFMutableDictionaryRef attributes
 
     // The system font is somewhat magical. Don't mess with its variations.
     if (applyTraitsVariations == ApplyTraitsVariations::Yes) {
-        variationsToBeApplied.set({ { 'w', 'g', 'h', 't' } }, weight);
-        variationsToBeApplied.set({ { 'w', 'd', 't', 'h' } }, width);
+        variationsToBeApplied.set(FontVariationAxisTag::wght, weight);
+        variationsToBeApplied.set(FontVariationAxisTag::wdth, width);
         if (fontStyleAxis == FontStyleAxis::ital)
-            variationsToBeApplied.set({ { 'i', 't', 'a', 'l' } }, 1);
+            variationsToBeApplied.set(FontVariationAxisTag::ital, 1);
         else
-            variationsToBeApplied.set({ { 's', 'l', 'n', 't' } }, -slope);
+            variationsToBeApplied.set(FontVariationAxisTag::slnt, -slope);
     }
 
     // FIXME: Implement font-named-instance
@@ -351,22 +351,22 @@ RetainPtr<CTFontRef> UnrealizedCoreTextFont::realize() const
     // Once rdar://problem/105483251 is solved, we can delete this section.
     if (m_applyTraitsVariations == ApplyTraitsVariations::Yes && FontInterrogation(font.get()).variationType == FontInterrogation::VariationType::TrueTypeGX) {
         auto variationValues = defaultVariationValues(font.get(), ShouldLocalizeAxisNames::No);
-        if (variationValues.contains({ { 'w', 'g', 'h', 't' } })
-            || variationValues.contains({ { 'w', 'd', 't', 'h' } })
-            || variationValues.contains({ { 'i', 't', 'a', 'l' } })
-            || variationValues.contains({ { 's', 'l', 'n', 't' } })) {
+        if (variationValues.contains(FontVariationAxisTag::wght)
+            || variationValues.contains(FontVariationAxisTag::wdth)
+            || variationValues.contains(FontVariationAxisTag::ital)
+            || variationValues.contains(FontVariationAxisTag::slnt)) {
             VariationsMap variationsToBeApplied;
 
             auto weight = denormalizeGXWeight(m_weight);
             auto width = denormalizeVariationWidth(m_width);
             auto slope = denormalizeSlope(m_slope);
 
-            variationsToBeApplied.set({ { 'w', 'g', 'h', 't' } }, weight);
-            variationsToBeApplied.set({ { 'w', 'd', 't', 'h' } }, width);
+            variationsToBeApplied.set(FontVariationAxisTag::wght, weight);
+            variationsToBeApplied.set(FontVariationAxisTag::wdth, width);
             if (m_fontStyleAxis == FontStyleAxis::ital)
-                variationsToBeApplied.set({ { 'i', 't', 'a', 'l' } }, 1);
+                variationsToBeApplied.set(FontVariationAxisTag::ital, 1);
             else
-                variationsToBeApplied.set({ { 's', 'l', 'n', 't' } }, -slope);
+                variationsToBeApplied.set(FontVariationAxisTag::slnt, -slope);
 
             RetainPtr attributes = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -571,12 +571,12 @@ String buildVariationSettings(FT_Face face, const FontDescription& fontDescripti
     if (auto slopeValue = fontCreationContext.fontFaceCapabilities().slope)
         slope = std::max(std::min(slope, static_cast<float>(slopeValue->maximum)), static_cast<float>(slopeValue->minimum));
 
-    variationsToBeApplied.set({ { 'w', 'g', 'h', 't' } }, weight);
-    variationsToBeApplied.set({ { 'w', 'd', 't', 'h' } }, width);
+    variationsToBeApplied.set(FontVariationAxisTag::wght, weight);
+    variationsToBeApplied.set(FontVariationAxisTag::wdth, width);
     if (fontStyleAxis == FontStyleAxis::ital)
-        variationsToBeApplied.set({ { 'i', 't', 'a', 'l' } }, 1);
+        variationsToBeApplied.set(FontVariationAxisTag::ital, 1);
     else
-        variationsToBeApplied.set({ { 's', 'l', 'n', 't' } }, slope);
+        variationsToBeApplied.set(FontVariationAxisTag::slnt, slope);
 
     auto applyVariation = [&](const FontTag& tag, float value) {
         auto iterator = defaultValues.find(tag);

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -63,21 +63,21 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
         float weight = description.weight();
         if (auto weightValue = fontCreationContext.fontFaceCapabilities().weight)
             weight = std::max(std::min(weight, static_cast<float>(weightValue->maximum)), static_cast<float>(weightValue->minimum));
-        applyVariation({ { 'w', 'g', 'h', 't' } }, weight);
+        applyVariation(FontVariationAxisTag::wght, weight);
 
         float width = description.width();
         if (auto widthValue = fontCreationContext.fontFaceCapabilities().width)
             width = std::max(std::min(width, static_cast<float>(widthValue->maximum)), static_cast<float>(widthValue->minimum));
-        applyVariation({ { 'w', 'd', 't', 'h' } }, width);
+        applyVariation(FontVariationAxisTag::wdth, width);
 
         if (description.fontStyleAxis() == FontStyleAxis::ital)
-            applyVariation({ { 'i', 't', 'a', 'l' } }, 1);
+            applyVariation(FontVariationAxisTag::ital, 1);
         else {
             float slope = description.fontStyleSlope().value_or(normalItalicValue());
             if (auto slopeValue = fontCreationContext.fontFaceCapabilities().slope)
                 slope = std::max(std::min(slope, static_cast<float>(slopeValue->maximum)), static_cast<float>(slopeValue->minimum));
             // The 'slnt' axis is positive counter-clockwise; a CSS oblique angle is positive clockwise.
-            applyVariation({ { 's', 'l', 'n', 't' } }, -slope);
+            applyVariation(FontVariationAxisTag::slnt, -slope);
         }
 
         // FIXME: optical sizing.


### PR DESCRIPTION
#### 6b33c34721e82d9829c4b1dd593e8461c23624a2
<pre>
FontTaggedSettings: Replace repeated OpenType variation axis literals with named constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=316290">https://bugs.webkit.org/show_bug.cgi?id=316290</a>
<a href="https://rdar.apple.com/178702902">rdar://178702902</a>

Reviewed by Sammy Gill.

Replace magic numbers and repeated char-array literals for OpenType variation axis tags with
named constants in FontTaggedSettings.h, where FontTag is already defined.

* Source/WebCore/platform/graphics/FontTaggedSettings.h:
(WebCore::FontVariationAxisTag::ital):
(WebCore::FontVariationAxisTag::opsz):
(WebCore::FontVariationAxisTag::slnt):
(WebCore::FontVariationAxisTag::wdth):
(WebCore::FontVariationAxisTag::wght):
(WebCore::fontVariationAxisTagValue):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::variationCapabilitiesForFontDescriptor):
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp:
(WebCore::UnrealizedCoreTextFont::addAttributesForOpticalSizing):
(WebCore::UnrealizedCoreTextFont::modifyFromContext):
* Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp:
(WebCore::buildVariationSettings):
* Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):

Canonical link: <a href="https://commits.webkit.org/314575@main">https://commits.webkit.org/314575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a53849eb62c1208ac92eec8eb5d60941013d89b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175549 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123756 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6e9244e-5f7c-43c7-8ce3-06fed89094d3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129449 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78b77d11-d16e-40cf-aec3-5a5eff2068f7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169460 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149610 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109974 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3fa8bb6b-f94a-403f-94fa-8c817af13b98) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30804 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29511 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23689 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178082 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30983 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137803 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137721 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37110 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149105 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103467 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33019 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25970 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39259 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112334 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38656 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4059 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38901 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38799 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->