### PR TITLE
MessagePorts a WebContent process already has should be invalidated if the Networking process disconnects

### DIFF
--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -95,6 +95,31 @@ void MessagePort::notifyMessageAvailable(const MessagePortIdentifier& identifier
     });
 }
 
+void MessagePort::notifyAllConnectionsClosed()
+{
+    ASSERT(isMainThread());
+    Vector<std::pair<ScriptExecutionContextIdentifier, ThreadSafeWeakPtr<MessagePort>>> entries;
+    {
+        Locker locker { allMessagePortsLock };
+        entries.reserveInitialCapacity(allMessagePorts().size());
+        for (auto& [identifier, weakPort] : allMessagePorts()) {
+            if (auto contextIdentifier = portToContextIdentifier().getOptional(identifier))
+                entries.append({ *contextIdentifier, weakPort });
+        }
+    }
+
+    for (auto& [contextIdentifier, weakPort] : entries) {
+        ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakPort = WTF::move(weakPort)](auto&) {
+            RefPtr port = weakPort.get();
+            if (!port || port->m_isDetached)
+                return;
+            port->m_isDetached = true;
+            port->m_entangled = false;
+            port->removeAllEventListeners();
+        });
+    }
+}
+
 Ref<MessagePort> MessagePort::create(ScriptExecutionContext& scriptExecutionContext, const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
 {
     Ref messagePort = adoptRef(*new MessagePort(scriptExecutionContext, local, remote));

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -81,6 +81,7 @@ public:
 
     WEBCORE_EXPORT static bool isMessagePortAliveForTesting(const MessagePortIdentifier&);
     WEBCORE_EXPORT static void notifyMessageAvailable(const MessagePortIdentifier&);
+    WEBCORE_EXPORT static void notifyAllConnectionsClosed();
 
     WEBCORE_EXPORT void messageAvailable();
     bool started() const { return m_started; }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -65,18 +65,23 @@ void WebMessagePortChannelProvider::createNewMessagePortChannel(const MessagePor
     m_inProcessPortMessages.add(port1, Vector<MessageWithMessagePorts> { });
     m_inProcessPortMessages.add(port2, Vector<MessageWithMessagePorts> { });
 
+    m_portsKnownToNetworkProcess.add(port1);
+    m_portsKnownToNetworkProcess.add(port2);
+
     protect(networkProcessConnection())->send(Messages::NetworkConnectionToWebProcess::CreateNewMessagePortChannel { port1, port2 }, 0);
 }
 
 void WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
 {
     m_inProcessPortMessages.add(local, Vector<MessageWithMessagePorts> { });
+    m_portsKnownToNetworkProcess.add(local);
 
     protect(networkProcessConnection())->send(Messages::NetworkConnectionToWebProcess::EntangleLocalPortInThisProcessToRemote { local, remote }, 0);
 }
 
 void WebMessagePortChannelProvider::messagePortDisentangled(const MessagePortIdentifier& port)
 {
+    m_portsKnownToNetworkProcess.remove(port);
     protect(networkProcessConnection())->send(Messages::NetworkConnectionToWebProcess::MessagePortDisentangled { port }, 0);
 }
 
@@ -92,14 +97,30 @@ void WebMessagePortChannelProvider::dropNonSerializableInProcessCache(WebCore::N
     m_nonSerializedDataRegistry.remove(identifier);
 }
 
+void WebMessagePortChannelProvider::networkProcessConnectionClosed()
+{
+    ASSERT(isMainRunLoop());
+
+    m_inProcessPortMessages.clear();
+    m_portsKnownToNetworkProcess.clear();
+    MessagePort::notifyAllConnectionsClosed();
+}
+
 void WebMessagePortChannelProvider::messagePortClosed(const MessagePortIdentifier& port)
 {
     m_inProcessPortMessages.remove(port);
+    m_portsKnownToNetworkProcess.remove(port);
     protect(networkProcessConnection())->send(Messages::NetworkConnectionToWebProcess::MessagePortClosed { port }, 0);
 }
 
 void WebMessagePortChannelProvider::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&& completionHandler)
 {
+    // This attempt to takeAllMessagesForPort might asynchronously have come from a worker thread while
+    // all ports were being detached due to disconnection from the networking process.
+    // Gracefully fail in this case.
+    if (!m_portsKnownToNetworkProcess.contains(port))
+        return completionHandler({ }, [] { });
+
     protect(networkProcessConnection())->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::TakeAllMessagesForPort { port }, [completionHandler = WTF::move(completionHandler), port](Vector<WebCore::MessageWithMessagePorts>&& messages, std::optional<MessageBatchIdentifier> messageBatchIdentifier) mutable {
         if (!messageBatchIdentifier)
             return completionHandler({ }, [] { }); // IPC failure.

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
@@ -31,6 +31,7 @@
 #include <WebCore/MessageWithMessagePorts.h>
 #include <WebCore/NonSerializedDataToken.h>
 #include <WebCore/SerializedScriptValue.h>
+#include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
@@ -42,6 +43,7 @@ public:
 
     void messagePortSentToRemote(const WebCore::MessagePortIdentifier&);
     void dropNonSerializableInProcessCache(WebCore::NonSerializedDataIdentifier);
+    void networkProcessConnectionClosed();
 
     // Don't do anything in ref() / deref() since this class is a singleton.
     void ref() const { }
@@ -64,6 +66,7 @@ private:
     // FIXME: this data registry currently only holds SharedArrayBuffer contents
     // but it should be generalized for other non-serializable types.
     HashMap<WebCore::NonSerializedDataIdentifier, std::unique_ptr<Vector<JSC::ArrayBufferContents>>> m_nonSerializedDataRegistry;
+    HashSet<WebCore::MessagePortIdentifier> m_portsKnownToNetworkProcess;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1462,6 +1462,7 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
     m_webLoaderStrategy->networkProcessCrashed();
     m_webSocketChannelManager.networkProcessCrashed();
     m_broadcastChannelRegistry->networkProcessCrashed();
+    WebMessagePortChannelProvider::singleton().networkProcessConnectionClosed();
 
 #if USE(LIBWEBRTC)
     if (m_libWebRTCNetwork)

--- a/Tools/TestWebKitAPI/Resources/cocoa/MessagePortSecurity.mm
+++ b/Tools/TestWebKitAPI/Resources/cocoa/MessagePortSecurity.mm
@@ -108,9 +108,7 @@ worker.port.postMessage('get-port');
 
 TEST(MessagePortSecurity, CrossProcessMessageTheftViaTakeAllMessagesForPort)
 {
-    using namespace TestWebKitAPI;
-
-    HTTPServer server({
+    TestWebKitAPI::HTTPServer server({
         { "/sender"_s, { senderBytes } },
         { "/receiver"_s, { receiverBytes } },
         { "/worker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, sharedWorkerBytes } },
@@ -216,3 +214,225 @@ TEST(MessagePortSecurity, CrossProcessMessageTheftViaTakeAllMessagesForPort)
 }
 
 #endif // ENABLE(IPC_TESTING_API)
+
+// When a WebContent process detaches from its Networking process, then reattaches to a new one,
+// then tries to use stale message ports... It triggers a message check in the new Networking process.
+// This test verifies that a WebContent process with "stale" message ports clears record of them,
+// so that we cannot trigger this message check under normal operation.
+TEST(MessagePortSecurity, MessagePortsSurviveNetworkProcessRestart)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/main"_s, { "<!doctype html><script>"
+            "window.channel = new MessageChannel();"
+            "window.channel.port2.onmessage = function(e) { alert('received-' + e.data); };"
+            "</script>"_s } },
+        { "/ping"_s, { "ok"_s } },
+    });
+
+    RetainPtr<TestNavigationDelegate> navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr<WKWebViewConfiguration> config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webView setNavigationDelegate:navDelegate.get()];
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView loadRequest:server.request("/main"_s)];
+    [navDelegate waitForDidFinishNavigation];
+
+    pid_t initialWebProcessPID = [webView _webProcessIdentifier];
+    pid_t initialNetworkProcessPID = [[webView configuration].websiteDataStore _networkProcessIdentifier];
+    EXPECT_TRUE(!!initialWebProcessPID);
+    EXPECT_TRUE(!!initialNetworkProcessPID);
+
+    [webView evaluateJavaScript:@"channel.port1.postMessage('first');" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "received-first");
+
+    // Killing the Networking process should cause the WebContent process to handle the disconnect,
+    // invalidating its current ports. This will help it avoid being killed by failing a MESSAGE_CHECK
+    // in the new Networking process.
+    [[webView configuration].websiteDataStore _terminateNetworkProcess];
+
+    // Force a new Networking process to fire up and connect.
+    NSString *fetchJS = [NSString stringWithFormat:
+        @"fetch('%@/ping').then(r => r.text()).catch(e => 'err')",
+        server.origin().createNSString().get()];
+    __block bool fetchSettled = false;
+    [webView evaluateJavaScript:fetchJS completionHandler:^(id, NSError *) {
+        fetchSettled = true;
+    }];
+    TestWebKitAPI::Util::run(&fetchSettled);
+
+    pid_t reestablishedNetworkProcessPID = [[webView configuration].websiteDataStore _networkProcessIdentifier];
+    EXPECT_NE(initialNetworkProcessPID, reestablishedNetworkProcessPID);
+
+    __block bool webContentTerminated = false;
+    navDelegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        webContentTerminated = true;
+    };
+
+    // Posting on a stale leftover port should be an instant no-op - The port has been invalidated.
+    __block bool unexpectedAlert = false;
+    uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *, WKFrameInfo *, void (^handler)(void)) {
+        unexpectedAlert = true;
+        handler();
+    };
+    [webView evaluateJavaScript:@"channel.port1.postMessage('stale');" completionHandler:nil];
+
+    // Let any in-flight tasks settle. If the bug is present (stale TakeAllMessagesForPort over the new
+    // connection), webContentTerminated would flip during this window when the MESSAGE_CHECK fails.
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    EXPECT_FALSE(webContentTerminated);
+    EXPECT_FALSE(unexpectedAlert);
+    EXPECT_EQ(initialWebProcessPID, [webView _webProcessIdentifier]);
+
+    // New MessageChannels should, of course, work again.
+    __block bool freshAlertReceived = false;
+    __block RetainPtr<NSString> freshAlertText;
+    uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *, void (^handler)(void)) {
+        freshAlertText = message;
+        freshAlertReceived = true;
+        handler();
+    };
+
+    [webView evaluateJavaScript:
+        @"window.fresh = new MessageChannel();"
+        "window.fresh.port2.onmessage = function(e) { alert('fresh-' + e.data); };"
+        "window.fresh.port1.postMessage('hello');"
+        completionHandler:nil];
+
+    TestWebKitAPI::Util::runFor(&freshAlertReceived, 5_s);
+    EXPECT_TRUE(freshAlertReceived);
+    if (freshAlertReceived)
+        EXPECT_WK_STREQ(freshAlertText.get(), "fresh-hello");
+    EXPECT_FALSE(webContentTerminated);
+}
+
+TEST(MessagePortSecurity, MessagePortsSurviveNetworkProcessRestartWithSiteIsolation)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/main"_s, { "<!doctype html><script>"
+            "window.channel = new MessageChannel();"
+            "</script>"_s } },
+        { "/ping"_s, { "ok"_s } },
+    });
+
+    RetainPtr<TestNavigationDelegate> navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr<WKWebViewConfiguration> config = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"SiteIsolationEnabled"]) {
+            [[config preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+
+    RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webView setNavigationDelegate:navDelegate.get()];
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView loadRequest:server.request("/main"_s)];
+    [navDelegate waitForDidFinishNavigation];
+
+    pid_t initialWebProcessPID = [webView _webProcessIdentifier];
+    pid_t initialNetworkProcessPID = [[webView configuration].websiteDataStore _networkProcessIdentifier];
+    EXPECT_TRUE(!!initialWebProcessPID);
+    EXPECT_TRUE(!!initialNetworkProcessPID);
+
+    [[webView configuration].websiteDataStore _terminateNetworkProcess];
+
+    NSString *fetchJS = [NSString stringWithFormat:
+        @"fetch('%@/ping').then(r => r.text()).catch(e => 'err')",
+        server.origin().createNSString().get()];
+    __block bool fetchSettled = false;
+    [webView evaluateJavaScript:fetchJS completionHandler:^(id, NSError *) {
+        fetchSettled = true;
+    }];
+    TestWebKitAPI::Util::run(&fetchSettled);
+
+    pid_t reestablishedNetworkProcessPID = [[webView configuration].websiteDataStore _networkProcessIdentifier];
+    EXPECT_NE(initialNetworkProcessPID, reestablishedNetworkProcessPID);
+
+    __block bool webContentTerminated = false;
+    navDelegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        webContentTerminated = true;
+    };
+
+    [webView evaluateJavaScript:@"channel.port2.start();" completionHandler:nil];
+
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    EXPECT_FALSE(webContentTerminated);
+    EXPECT_EQ(initialWebProcessPID, [webView _webProcessIdentifier]);
+}
+
+TEST(MessagePortSecurity, WorkerMessagePortsSurviveNetworkProcessRestart)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/main"_s, { "<!doctype html><script>"
+            "window.worker = new Worker('/worker.js');"
+            "window.channel = new MessageChannel();"
+            "window.worker.onmessage = function(e) { alert('worker-' + e.data); };"
+            "window.worker.postMessage('init', [window.channel.port2]);"
+            "</script>"_s } },
+        { "/worker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } },
+            "self.port = null;"
+            "self.onmessage = function(e) {"
+            "    if (e.data === 'init') {"
+            "        self.port = e.ports[0];"
+            // Intentionally don't start the port here. Starting it after the NetworkProcess
+            // restart is what exercises the racy TakeAllMessagesForPort path.
+            "        self.postMessage('ready');"
+            "    } else if (e.data === 'start-stale-port') {"
+            "        try {"
+            "            self.port.start();"
+            "            self.postMessage('start-ok');"
+            "        } catch (err) { self.postMessage('start-threw-' + err.message); }"
+            "    }"
+            "};"_s } },
+        { "/ping"_s, { "ok"_s } },
+    });
+
+    RetainPtr<TestNavigationDelegate> navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr<WKWebViewConfiguration> config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webView setNavigationDelegate:navDelegate.get()];
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView loadRequest:server.request("/main"_s)];
+    [navDelegate waitForDidFinishNavigation];
+
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "worker-ready");
+
+    pid_t initialWebProcessPID = [webView _webProcessIdentifier];
+    pid_t initialNetworkProcessPID = [[webView configuration].websiteDataStore _networkProcessIdentifier];
+
+    [[webView configuration].websiteDataStore _terminateNetworkProcess];
+
+    NSString *fetchJS = [NSString stringWithFormat:
+        @"fetch('%@/ping').then(r => r.text()).catch(e => 'err')",
+        server.origin().createNSString().get()];
+    __block bool fetchSettled = false;
+    [webView evaluateJavaScript:fetchJS completionHandler:^(id, NSError *) {
+        fetchSettled = true;
+    }];
+    TestWebKitAPI::Util::run(&fetchSettled);
+
+    pid_t reestablishedNetworkProcessPID = [[webView configuration].websiteDataStore _networkProcessIdentifier];
+    EXPECT_NE(initialNetworkProcessPID, reestablishedNetworkProcessPID);
+
+    __block bool webContentTerminated = false;
+    navDelegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        webContentTerminated = true;
+    };
+
+    [webView evaluateJavaScript:@"worker.postMessage('start-stale-port');" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "worker-start-ok");
+
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    EXPECT_FALSE(webContentTerminated);
+    EXPECT_EQ(initialWebProcessPID, [webView _webProcessIdentifier]);
+}


### PR DESCRIPTION
#### 67117c4975bb291a8775a61ee3c19dfe13e50690
<pre>
MessagePorts a WebContent process already has should be invalidated if the Networking process disconnects
<a href="https://rdar.apple.com/177440317">rdar://177440317</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315221">https://bugs.webkit.org/show_bug.cgi?id=315221</a>

Reviewed by Basuke Suzuki.

The scenario is:
1 - A MessageChannel is created, and therefore registered with the networking process.
2 - The Networking process disconnects (crash, jetsam, suspend, etc)
3 - A new Networking process is fired up and connects to the old WebContent process
4 - The WebContent process tries a message channel operation in the new Networking process on a port
    the new Networking process doesn&apos;t know about.

<a href="https://commits.webkit.org/305413.547@safari-7624-branch">https://commits.webkit.org/305413.547@safari-7624-branch</a> added more aggressive MESSAGE_CHECKs to the
networking process to protect against message port spoofs from compromised web content processes.

The above scenario is WebKit in normal operation and unfortunately triggering those MESSAGE_CHECKs

So this PR teaches web content processes to invalidate current message ports if the Networking process
goes away. It handles normal message port operation, worker use, and works with site isolation.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/MessagePortSecurity.mm

* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::notifyAllConnectionsClosed):
* Source/WebCore/dom/MessagePort.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp:
(WebKit::WebMessagePortChannelProvider::createNewMessagePortChannel):
(WebKit::WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote):
(WebKit::WebMessagePortChannelProvider::messagePortDisentangled):
(WebKit::WebMessagePortChannelProvider::networkProcessConnectionClosed):
(WebKit::WebMessagePortChannelProvider::messagePortClosed):
(WebKit::WebMessagePortChannelProvider::takeAllMessagesForPort):
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::networkProcessConnectionClosed):
* Tools/TestWebKitAPI/Resources/cocoa/MessagePortSecurity.mm:
((MessagePortSecurity, CrossProcessMessageTheftViaTakeAllMessagesForPort)):
((MessagePortSecurity, MessagePortsSurviveNetworkProcessRestart)):
((MessagePortSecurity, MessagePortsSurviveNetworkProcessRestartWithSiteIsolation)):
((MessagePortSecurity, WorkerMessagePortsSurviveNetworkProcessRestart)):

Originally-landed-as: 305413.972@safari-7624-branch (b90cdae5a91d). <a href="https://rdar.apple.com/178741244">rdar://178741244</a>
Canonical link: <a href="https://commits.webkit.org/314573@main">https://commits.webkit.org/314573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6160766bdc3952537bbc417b22ea8dd74bcd8da1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175550 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123757 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ad21338-bf91-4d97-9fd0-992bad3bd632) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129448 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1dd1d7e-2fab-40c8-bafc-32fcb69569a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169461 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109973 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27e0b59b-e278-49dc-922c-ebb176c22812) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29512 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23690 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178085 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30984 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137804 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40062 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137722 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37109 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103468 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25971 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112335 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38657 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4060 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38902 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38800 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->