### PR TITLE
[JSC] Remove B3O0/O1 test modes from JSC stress tests

### DIFF
--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -696,8 +696,6 @@ BASE_OPTIONS = ["--validateOptions=true", "--useFTLJIT=false", "--useFunctionDot
 EAGER_OPTIONS = ["--validateOptions=true", "--thresholdForJITAfterWarmUp=10", "--thresholdForJITSoon=10", "--thresholdForOptimizeAfterWarmUp=20", "--thresholdForOptimizeAfterLongWarmUp=20", "--thresholdForOptimizeSoon=20", "--thresholdForFTLOptimizeAfterWarmUp=20", "--thresholdForFTLOptimizeSoon=20", "--thresholdForOMGOptimizeAfterWarmUp=20", "--thresholdForOMGOptimizeSoon=20", "--maximumEvalCacheableSourceLength=150000", "--useEagerCodeBlockJettisonTiming=true", "--repatchBufferingCountdown=0"]
 # NOTE: Tests rely on this using scribbleFreeCells.
 NO_CJIT_OPTIONS = ["--validateOptions=true", "--useConcurrentJIT=false", "--thresholdForJITAfterWarmUp=100", "--scribbleFreeCells=true"]
-B3O1_OPTIONS = ["--defaultB3OptLevel=1", "--useHandlerICInFTL=1", "--forceUnlinkedDFG=1"]
-B3O0_OPTIONS = ["--maxDFGNodesInBasicBlockForPreciseAnalysis=100", "--defaultB3OptLevel=0"]
 FTL_OPTIONS = ["--validateOptions=true", "--useFTLJIT=true"]
 FORCE_LLINT_EXIT_OPTIONS = ["--forceOSRExitToLLInt=true"]
 EXECUTABLE_FUZZER_OPTIONS = ["--useExecutableAllocationFuzz=true", "--fireExecutableAllocationFuzzRandomly=true"]
@@ -1195,19 +1193,6 @@ BASE_MODES = [
         NO_CJIT_OPTIONS
     ],
     [
-        "FTLNoCJITB3O0",
-        "ftl-no-cjit-b3o0",
-        [
-            "--useArrayAllocationProfiling=false",
-            "--forcePolyProto=true",
-            "--useRandomizingExecutableIslandAllocation=true",
-        ] +
-        FTL_OPTIONS +
-        NO_CJIT_OPTIONS +
-        B3O0_OPTIONS +
-        FORCE_LLINT_EXIT_OPTIONS
-    ],
-    [
         "FTLNoCJITValidate",
         "ftl-no-cjit-validate-sampling-profiler",
         [
@@ -1304,17 +1289,6 @@ BASE_MODES = [
         EXECUTABLE_FUZZER_OPTIONS
     ],
     [
-        "FTLEagerNoCJITB3O1",
-        "ftl-eager-no-cjit-b3o1",
-        [
-            "--validateGraph=true",
-        ] +
-        FTL_OPTIONS +
-        NO_CJIT_OPTIONS +
-        EAGER_OPTIONS +
-        B3O1_OPTIONS
-    ],
-    [
         "FTLEagerNoCJITOSRValidation",
         "ftl-eager-no-cjit-osr-validation",
         [
@@ -1356,6 +1330,8 @@ BASE_MODES = [
         "ftl-no-cjit-small-pool",
         [
             $buildType == "debug" ? "--jitMemoryReservationSize=4194304" : "--jitMemoryReservationSize=1048576",
+            "--maxDFGNodesInBasicBlockForPreciseAnalysis=100",
+            "--useArrayAllocationProfiling=false",
         ] +
         FTL_OPTIONS +
         NO_CJIT_OPTIONS
@@ -1631,12 +1607,8 @@ def defaultRunConfig(config, subsetOptions, *optionalTestSpecificOptions)
             return if $mode == :basic
 
             runFTLNoCJITValidateConfig(config, *optionalTestSpecificOptions)
-            runFTLNoCJITB3O0Config(config, *optionalTestSpecificOptions)
             runFTLNoCJITNoPutStackValidateConfig(config, *optionalTestSpecificOptions)
             runFTLNoCJITNoInlineValidateConfig(config, *optionalTestSpecificOptions)
-            if not subsetOptions.has_key?(:skipEager)
-                runFTLEagerNoCJITB3O1Config(config, *optionalTestSpecificOptions)
-            end
         end
     end
 end
@@ -1674,7 +1646,6 @@ def defaultSpotCheckNoMaximalFlush
     return if !$isFTLPlatform
     runFTLNoCJITOSRValidation
     runFTLNoCJITNoAccessInlining
-    runFTLNoCJITB3O0
 end
 
 def defaultSpotCheck
@@ -2218,10 +2189,6 @@ end
 
 def runLayoutTestFTLEagerNoCJIT
     runLayoutTest("ftl-eager-no-cjit", "--testTheFTL=true", *(FTL_OPTIONS + NO_CJIT_OPTIONS + EAGER_OPTIONS))
-end
-
-def runLayoutTestFTLEagerNoCJITB3O1
-    runLayoutTest("ftl-eager-no-cjit-b3o1", "--testTheFTL=true", *(FTL_OPTIONS + NO_CJIT_OPTIONS + EAGER_OPTIONS + B3O1_OPTIONS))
 end
 
 def noFTLRunLayoutTest


### PR DESCRIPTION
#### 963c64aac9edb49bc8d9bdcb72c37603ebb82557
<pre>
[JSC] Remove B3O0/O1 test modes from JSC stress tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=316324">https://bugs.webkit.org/show_bug.cgi?id=316324</a>
<a href="https://rdar.apple.com/178746557">rdar://178746557</a>

Reviewed by Yusuke Suzuki.

Drop the FTLNoCJITB3O0 (ftl-no-cjit-b3o0) and FTLEagerNoCJITB3O1
(ftl-eager-no-cjit-b3o1) testing modes along with their call sites,
the runLayoutTestFTLEagerNoCJITB3O1 helper, and the now-unused
B3O0_OPTIONS / B3O1_OPTIONS constants. B3-O0 and B3-O1 are no longer
used as part of a normal compiler pipeline, historically they were
used before modern BBQJIT. There is still coverage of O0 and O1 in
testb3.

To preserve coverage of the conservative DFG fallback paths introduced
in 213865@main relocate the two options that uniquely exercised them,
--maxDFGNodesInBasicBlockForPreciseAnalysis=100 and
--useArrayAllocationProfiling=false, into the FTLNoCJITSmallPool mode.
I moved the options to FTLNoCJITSmallPool as it is part of the default
run and is not a graph-validation mode, so the validation modes
continue to exercise the precise (default-threshold) DFG analysis
paths and are not downgraded to the conservative ones, which would
effectively reduce coverage.

Canonical link: <a href="https://commits.webkit.org/314570@main">https://commits.webkit.org/314570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a29d92b4797683320ec8432c291ab8159fc1a14b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166503 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/39993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123758 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ece44b85-05cf-449c-bac9-a1a08105d940) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129447 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a7a91257-2432-4dd7-9f0d-dca6bfc1dd1c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169462 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109972 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cdfc1b2d-9cd6-443d-8bee-cc82547825ca) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30805 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29513 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23691 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158660 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178084 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27397 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29016 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137802 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40063 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137720 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149107 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103469 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25343 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33016 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199182 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39261 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112336 "Build is in progress. Recent messages:") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53461 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38658 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4061 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38903 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38801 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->