### PR TITLE
Add mustCrash JS testing mode for testing validation options

### DIFF
--- a/JSTests/stress/test-harness-must-crash.js
+++ b/JSTests/stress/test-harness-must-crash.js
@@ -1,0 +1,4 @@
+//@ mustCrashWith!(:trap, "AAAAAHHHH")
+//@ runFTLNoCJIT
+
+$vm.crash("AAAAAHHHH");

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4164,10 +4164,21 @@ void CommandLine::parseArguments(int argc, char** argv, int start)
         }
         if (!strcmp(arg, "--signal-expected")) {
 #if OS(UNIX)
+            // Keep in sync with getFailCondition in jsc-stress-test-writer-default.rb.
             SignalAction (*exit)(Signal, SigInfo&, PlatformRegisters&) = [] (Signal signal, SigInfo&, PlatformRegisters&) {
-                dataLogLn("Signal handler for ", ScopedEnumDump(signal), " hit. Exiting with status 137");
-                // Deliberate exit with a SIGKILL code greater than 130.
-                terminateProcess(137);
+                int status = 137;
+                switch (signal) {
+                case Signal::AccessFault:
+                    status = 138;
+                    break;
+                case Signal::FloatingPoint:
+                    status = 139;
+                    break;
+                default:
+                    break;
+                }
+                dataLogLn("Signal handler for ", ScopedEnumDump(signal), " hit. Exiting with status ", status);
+                terminateProcess(status);
                 return SignalAction::ForceDefault;
             };
 

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -707,7 +707,7 @@ class BasePlan
     attr_accessor :retryParameters
 
     @@index = 0
-    def initialize(directory, arguments, family, name, outputHandler, errorHandler, retryParameters, expectCrash)
+    def initialize(directory, arguments, family, name, outputHandler, errorHandler, retryParameters, expectCrash, expectCrashMessage = nil)
         @directory = directory
         @arguments = argumentsMapper(arguments)
         @family = family
@@ -715,6 +715,7 @@ class BasePlan
         @outputHandler = outputHandler
         @errorHandler = errorHandler
         @expectCrash = expectCrash
+        @expectCrashMessage = expectCrashMessage
         # A plan for which @retryParameters is not nil is being
         # treated as potentially flaky.
         @retryParameters = retryParameters
@@ -729,11 +730,14 @@ class BasePlan
         if $runCommandOptions[:mustCrash]
             outputHandler = noisyOutputHandler
         end
-        self.new(directory, arguments, family, name, outputHandler, errorHandler, $runCommandOptions[:flaky], $runCommandOptions[:mustCrash])
+        self.new(directory, arguments, family, name, outputHandler, errorHandler, $runCommandOptions[:flaky], $runCommandOptions[:mustCrash], $runCommandOptions[:mustCrashMessage])
     end
 
     def expectCrash
         @expectCrash
+    end
+    def expectCrashMessage
+        @expectCrashMessage
     end
     def argumentsMapper(args)
         args
@@ -963,7 +967,18 @@ end
 
 def mustCrash!
     $testSpecificRequiredOptions += ["--signal-expected"]
-    $runCommandOptions[:mustCrash] = true
+    $runCommandOptions[:mustCrash] = :any
+end
+
+#   :trap — IllegalInstruction / Breakpoint / Abort (CRASH/RELEASE_ASSERT/abort).
+#   :segv — SIGSEGV / SIGBUS.
+#   :fpe  — SIGFPE.
+def mustCrashWith!(kind, message = nil)
+    raise "mustCrashWith! requires :trap, :segv, or :fpe (got #{kind.inspect})" unless %i[trap segv fpe].include?(kind)
+    raise "mustCrashWith! message must be a String or nil" unless message.nil? || message.is_a?(String)
+    $testSpecificRequiredOptions += ["--signal-expected"]
+    $runCommandOptions[:mustCrash] = kind
+    $runCommandOptions[:mustCrashMessage] = message
 end
 
 def serial!

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
@@ -50,10 +50,15 @@ def noisyOutputHandler
 end
 
 def getFailCondition(plan)
-    # jsc shell's expected crashes are configured to return with an error > 130.
-    # So, if we're expecting a crash and the exitCode is less or equal to 130, the test
-    # is not exiting due to an expected crash, and it should be considered a test failure.
-    plan.expectCrash ? "-le 130" : "-ne 0"
+    # Status codes assigned by jsc.cpp's --signal-expected handler — keep in sync.
+    case plan.expectCrash
+    when :any then "-le 130"
+    when :trap then "-ne 137"
+    when :segv then "-ne 138"
+    when :fpe then "-ne 139"
+    when false, nil then "-ne 0"
+    else raise "Unknown expectCrash value: #{plan.expectCrash.inspect}"
+    end
 end
 
 def getAndTestExitCode(plan, condition)
@@ -71,6 +76,16 @@ def simpleErrorHandler
         outp.puts "then"
         outp.puts "    (echo ERROR: Unexpected exit code: $exitCode) | " + redirectAndPrefixCommand(plan.name)
         outp.puts "    " + plan.failCommand
+        if plan.expectCrashMessage
+            outputFilename = Shellwords.shellescape((Pathname("..") + (plan.name + ".out")).to_s)
+            messagePattern = Shellwords.shellescape(plan.expectCrashMessage)
+            diagnostic = Shellwords.shellescape(
+                "ERROR: Crashed as expected, but stdout/stderr did not contain expected message: #{plan.expectCrashMessage}")
+            outp.puts "elif ! grep -q -F -- #{messagePattern} #{outputFilename}"
+            outp.puts "then"
+            outp.puts "    (cat #{outputFilename} && echo #{diagnostic}) | " + redirectAndPrefixCommand(plan.name)
+            outp.puts "    " + plan.failCommand
+        end
         outp.puts "else"
         outp.puts "    " + plan.successCommand
         outp.puts "fi"

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb
@@ -65,6 +65,20 @@ def noisyOutputHandler
     }
 end
 
+# Ruby expression that evaluates to true iff `status` matches the plan's
+# expected exit. Keep in sync with getFailCondition in
+# jsc-stress-test-writer-default.rb and the --signal-expected handler in jsc.cpp.
+def successCheckFor(plan)
+    case plan.expectCrash
+    when :any then "((status.exitstatus || 0) > 130)"
+    when :trap then "(status.exitstatus == 137)"
+    when :segv then "(status.exitstatus == 138)"
+    when :fpe then "(status.exitstatus == 139)"
+    when false, nil then "status.success?"
+    else raise "Unknown expectCrash value: #{plan.expectCrash.inspect}"
+    end
+end
+
 # Error handler for tests that fail exactly when they return non-zero exit status.
 # This is useful when a test is expected to fail.
 def simpleErrorHandler
@@ -73,6 +87,12 @@ def simpleErrorHandler
         outp.puts "if !success(status)\n"
         outp.puts "    print " + prefixString("\"ERROR: Unexpected exit code \#{status.exitstatus}\\n\"", plan.name) + "\n"
         outp.puts "        " + plan.failCommand
+        if plan.expectCrashMessage
+            outp.puts "elsif !out.include?(#{plan.expectCrashMessage.inspect})\n"
+            outp.puts "    print " + prefixString("out", plan.name) + "\n"
+            outp.puts "    print " + prefixString("\"ERROR: Crashed as expected, but stdout/stderr did not contain expected message: #{plan.expectCrashMessage}\\n\"", plan.name) + "\n"
+            outp.puts "    " + plan.failCommand
+        end
         outp.puts "else\n"
         outp.puts "    " + plan.successCommand
         outp.puts "end\n"
@@ -284,7 +304,7 @@ class Plan < BasePlan
         script += "    <<-END_OF_SCRIPT\n"
         script += "        require 'open3'\n"
         script += "        def success(status)\n"
-        script += "            status.success?\n"
+        script += "            #{successCheckFor(self)}\n"
         script += "        end\n"
         script += "        script_location = File.expand_path(File.dirname(__FILE__))\n"
         script += "        Dir.chdir(\"\\\#{script_location}"
@@ -360,7 +380,7 @@ class Plan < BasePlan
             outp.puts "require 'open3'"
             outp.puts "require 'fileutils'"
             outp.puts "def success(status)"
-            outp.puts "   status.success?"
+            outp.puts "   #{successCheckFor(self)}"
             outp.puts "end"
 
             cmd = shellCommand


### PR DESCRIPTION
#### 737778ec5f5c8a8245d78fd1ea89d4d63eb352d9
<pre>
Add mustCrash JS testing mode for testing validation options
<a href="https://bugs.webkit.org/show_bug.cgi?id=316327">https://bugs.webkit.org/show_bug.cgi?id=316327</a>

Reviewed by NOBODY (OOPS!).

We add a new mustCrash JSTest helper; this lets us confirm that
new validation modes that we add can successfully catch the edge
cases they are designed for.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/737778ec5f5c8a8245d78fd1ea89d4d63eb352d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175557 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123764 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129456 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91177 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149616 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109981 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30829 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29520 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23697 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158666 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178091 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27403 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137807 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137724 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149111 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103477 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33023 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25976 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199188 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112342 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53462 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38664 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4065 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38909 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->