### PR TITLE
[GTK][WPE] Skia Compositor: compositing debug borders are not painted properly

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -428,11 +428,6 @@ bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& damage
     context.mode = PaintMode::Paint;
     recursivePaint(canvas, context);
 
-    if (hasDebugIndicators()) {
-        context.mode = PaintMode::DebugIndicators;
-        recursivePaint(canvas, context);
-    }
-
     recursiveCleanUpAfterPaint();
 
 #if ENABLE(DAMAGE_TRACKING)
@@ -480,8 +475,7 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
 #if ENABLE(DAMAGE_TRACKING)
         collectFrameDamage(canvas, context, transform);
 #endif
-    } else
-        paintDebugIndicators(canvas, context);
+    }
 
     canvas.restore();
 }
@@ -566,8 +560,16 @@ void SkiaCompositingLayer::collectFrameDamage(SkCanvas& canvas, PaintContext& co
 
 #endif
 
-void SkiaCompositingLayer::paintDebugIndicators(SkCanvas& canvas, PaintContext&)
+void SkiaCompositingLayer::paintDebugIndicators(SkCanvas& canvas, PaintContext& context)
 {
+    if (m_size.isEmpty() || !m_visible || !m_contentsVisible || !hasVisualContent())
+        return;
+
+    TransformationMatrix transform(context.accumulatedReplicaTransform);
+    transform.multiply(m_transforms.combined);
+    SkAutoCanvasRestore autoRestore(&canvas, true);
+    canvas.concat(SkM44(transform));
+
     if (m_debugBorder) {
         SkPaint borderPaint;
         borderPaint.setStyle(SkPaint::kStroke_Style);
@@ -613,7 +615,7 @@ void SkiaCompositingLayer::paintDebugIndicators(SkCanvas& canvas, PaintContext&)
         m_repaintCountOverlay.baselineOffset = -textBounds.fTop + padding;
     }
 
-    SkAutoCanvasRestore autoRestore(&canvas, true);
+    SkAutoCanvasRestore overlayRestore(&canvas, true);
     canvas.resetMatrix();
 
     SkPaint backgroundPaint;
@@ -972,12 +974,16 @@ void SkiaCompositingLayer::recursivePaint(SkCanvas& canvas, PaintContext& contex
 
     SetForScope scopedOpacity(context.opacity, context.opacity * opacity());
 
-    if (m_preserves3D) {
+    if (m_preserves3D)
         paintWith3DRenderingContext(canvas, context);
-        return;
-    }
+    else
+        paintWithOpacity(canvas, context);
 
-    paintWithOpacity(canvas, context);
+    // Drawn after the layer's own content, filters and masks have been composited
+    // into the parent, but still in tree order, so layers painted on top (e.g. a
+    // modal) occlude the indicators of the layers they cover.
+    if (context.mode == PaintMode::Paint && hasDebugIndicators())
+        paintDebugIndicators(canvas, context);
 }
 
 void SkiaCompositingLayer::computeOverlapRegions(ComputeOverlapRegionData& data, const TransformationMatrix& accumulatedReplicaTransform, IncludesReplica includesReplica)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -123,9 +123,8 @@ private:
 
     bool computeTransformsAndAnimations(const TransformationMatrix& parentTransform, const TransformationMatrix& futureParentTransform, MonotonicTime);
 
-    enum class PaintMode : uint8_t {
+    enum class PaintMode : bool {
         Paint,
-        DebugIndicators,
     };
 
     struct PaintContext {


### PR DESCRIPTION
#### 7e67352d773dac9253ee2516fe90b131bb411580
<pre>
[GTK][WPE] Skia Compositor: compositing debug borders are not painted properly
<a href="https://bugs.webkit.org/show_bug.cgi?id=316330">https://bugs.webkit.org/show_bug.cgi?id=316330</a>

Reviewed by Carlos Garcia Campos.

Enabling &quot;Show compositing borders&quot; in Web Inspector had no visible effect on
the page in the Skia compositor: borders only showed in the Layers panel preview
(a separate inspector snapshot path).

SkiaCompositingLayer::paint() ran a follow-up tree walk in PaintMode::DebugIndicators
to draw layer borders and repaint counters, but that walk only happened when the
scene root layer itself carried indicators (hasDebugIndicators()), which it never
does, so the pass was always skipped. Even when forced to run, that design draws
only strokes after all content has been painted, so a border belonging to a layer
hidden behind an opaque layer (e.g. a modal dialog) bleeds through on top of it.

Drop the separate DebugIndicators pass and instead draw the indicators inline in
the single Paint walk, at the tail of recursivePaint() - after the layer&apos;s own
content, filters and masks have been composited into the parent, but still in tree
order. Layers painted on top then occlude the indicators of the layers they cover,
while the indicators still sit above each layer&apos;s own effects.

paintDebugIndicators() now establishes the layer transform itself (it previously
relied on paintSelf() having concatenated it) and keeps paintSelf()&apos;s visibility
guard so the set of layers that get a border is unchanged. PaintMode loses its now
unused DebugIndicators value - the remaining single-value mode plumbing is kept as
preparation for the planned SkNoDrawCanvas damage walk.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paint):
(WebCore::SkiaCompositingLayer::paintSelf):
(WebCore::SkiaCompositingLayer::paintDebugIndicators):
(WebCore::SkiaCompositingLayer::recursivePaint):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:

Canonical link: <a href="https://commits.webkit.org/314621@main">https://commits.webkit.org/314621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/161176a7fab255b29b39562c2ccc7804d8ebb1a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175559 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129458 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109983 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30817 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29519 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23699 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178093 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30993 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137813 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137730 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149115 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103479 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25365 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33025 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25980 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39269 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112344 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38666 "Built successfully") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Site-Isolation-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->