### PR TITLE
Masonry fieldset legend passes isSubgrid() despite being excluded from parent grid

### DIFF
--- a/LayoutTests/fast/css-grid-layout/masonry-span-exceeds-grid-axis-tracks-crash-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/masonry-span-exceeds-grid-axis-tracks-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/fast/css-grid-layout/masonry-span-exceeds-grid-axis-tracks-crash.html
+++ b/LayoutTests/fast/css-grid-layout/masonry-span-exceeds-grid-axis-tracks-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+.outer {
+    display: grid-lanes;
+    grid-template-rows: 10px;
+}
+.inner {
+    display: grid-lanes;
+    grid-template-rows: subgrid;
+}
+.item {
+    grid-row: span 10;
+}
+</style>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<p>This test passes if it does not crash.</p>
+<div class="outer"><div class="inner"><div class="item"></div></div></div>

--- a/LayoutTests/fast/css-grid-layout/masonry-subgrid-excluded-legend-crash-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/masonry-subgrid-excluded-legend-crash-expected.txt
@@ -1,0 +1,4 @@
+This test passes if it does not crash.
+
+
+

--- a/LayoutTests/fast/css-grid-layout/masonry-subgrid-excluded-legend-crash.html
+++ b/LayoutTests/fast/css-grid-layout/masonry-subgrid-excluded-legend-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+*:not(style):not(script) {
+    display: grid-lanes;
+    grid-template-rows: subgrid repeat(auto-fill, []) repeat(4, []);
+}
+</style>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<p>This test passes if it does not crash.</p>
+<fieldset><legend><div></div></legend></fieldset>

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -216,7 +216,7 @@ LayoutUnit GridMasonryLayout::maxRunningPositionForSpan(unsigned startLine, unsi
 
 GridArea GridMasonryLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& item)
 {
-    auto itemSpanLength = Style::GridPositionsResolver::spanSizeForAutoPlacedItem(item, gridAxisDirection());
+    auto itemSpanLength = std::min<unsigned>(Style::GridPositionsResolver::spanSizeForAutoPlacedItem(item, gridAxisDirection()), m_gridAxisTracksCount);
     auto gridAxisLines = m_gridAxisTracksCount + 1;
 
     // Get flow-tolerance from the masonry container's style

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2180,6 +2180,8 @@ bool RenderGrid::isSubgrid(Style::GridTrackSizingDirection direction) const
     // https://drafts.csswg.org/css-grid-2/#subgrid-listing
     if (establishesIndependentFormattingContextIgnoringDisplayType(style()))
         return false;
+    if (isExcludedFromNormalLayout())
+        return false;
     if (!style().gridTemplateList(direction).subgrid)
         return false;
     auto* renderGrid = dynamicDowncast<RenderGrid>(parent());


### PR DESCRIPTION
#### ca8c809f1e71553a22215a67fe9be1d05114e6d6
<pre>
Masonry fieldset legend passes isSubgrid() despite being excluded from parent grid
<a href="https://bugs.webkit.org/show_bug.cgi?id=313505">https://bugs.webkit.org/show_bug.cgi?id=313505</a>
<a href="https://rdar.apple.com/175165115">rdar://175165115</a>

Reviewed by Elika Etemad.

RenderGrid::isSubgrid() does not check isExcludedFromNormalLayout(). A fieldset legend styled with
grid-template-rows: subgrid is excluded from the fieldset&apos;s grid item placement but still passes all
subgrid checks. When the legend&apos;s layout queries the parent grid for its span, the legend is not found
and hits ASSERT(m_gridItemArea.contains(item)) in debug builds and causes an unsigned underflow in
gridAreaForIndefiniteGridAxisItem in release builds.

Return false from isSubgrid() for excluded elements. Clamp the item span to the grid-axis track count in
gridAreaForIndefiniteGridAxisItem() per CSS Grid Level 3 §4.4, which bounds placement to existing grid-axis
tracks.

Tests: fast/css-grid-layout/masonry-span-exceeds-grid-axis-tracks-crash.html
       fast/css-grid-layout/masonry-subgrid-excluded-legend-crash.html

* LayoutTests/fast/css-grid-layout/masonry-span-exceeds-grid-axis-tracks-crash-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/masonry-span-exceeds-grid-axis-tracks-crash.html: Added.
* LayoutTests/fast/css-grid-layout/masonry-subgrid-excluded-legend-crash-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/masonry-subgrid-excluded-legend-crash.html: Added.
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::gridAreaForIndefiniteGridAxisItem):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::isSubgrid const):

Originally-landed-as: 305413.808@safari-7624-branch (b39e5f1bf872). <a href="https://rdar.apple.com/175165115">rdar://175165115</a>
Canonical link: <a href="https://commits.webkit.org/314580@main">https://commits.webkit.org/314580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/412322ab12654c875ac9d2d1d5630b6bbe4f1758

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175560 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123767 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b8d9f4a-b3d6-4e0c-9dbd-77e876e4007d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129455 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1344c16e-739e-45b3-a1f2-c1edd7ffbf22) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169471 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109980 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d30096cc-7e8b-4039-9ae6-3d765e970f50) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29521 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23700 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178094 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137814 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137731 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37113 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149121 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103480 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33027 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39270 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112345 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38667 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4075 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38912 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38810 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->