### PR TITLE
Remove some unused member variables

### DIFF
--- a/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.h
@@ -98,7 +98,6 @@ private:
     HashMap<CallbackIdentifier, StringCallback> m_stringCallbacks;
     HashMap<CallbackIdentifier, ResolveGlobalIdentifierCallback> m_resolveGlobalIdentifierCallbacks;
     HashMap<CallbackIdentifier, StreamCallback> m_streamCallbacks;
-    HashMap<FileSystemSyncAccessHandleIdentifier, Function<void()>> m_accessHandleInvalidationHandlers;
     HashMap<FileSystemSyncAccessHandleIdentifier, WeakPtr<FileSystemSyncAccessHandle>> m_syncAccessHandles;
 };
 

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.h
@@ -121,8 +121,6 @@ private:
     HashMap<IDBDatabaseConnectionIdentifier, WeakPtr<UniqueIDBDatabaseConnection>> m_databaseConnections;
     HashMap<IDBResourceIdentifier, WeakPtr<UniqueIDBDatabaseTransaction>> m_transactions;
 
-    HashMap<uint64_t, Function<void ()>> m_deleteDatabaseCompletionHandlers;
-
     String m_databaseDirectoryPath;
 
     SpaceRequester m_spaceRequester;

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
@@ -43,7 +43,6 @@ namespace WebCore {
 
 class Document;
 class HTMLCanvasElement;
-class Image;
 
 class CanvasCaptureMediaStreamTrack final : public MediaStreamTrack {
     WTF_MAKE_TZONE_ALLOCATED(CanvasCaptureMediaStreamTrack);
@@ -100,7 +99,6 @@ private:
         Timer m_captureCanvasTimer;
         std::optional<RealtimeMediaSourceSettings> m_currentSettings;
         WeakPtr<HTMLCanvasElement, WeakPtrImplWithEventTargetData> m_canvas;
-        RefPtr<Image> m_currentImage;
 #if USE(GSTREAMER)
         GRefPtr<GstClock> m_clock;
 #endif

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -222,8 +222,6 @@ private:
     using SSRC = unsigned;
     HashMap<SSRC, RefPtr<GStreamerIncomingTrackProcessor>> m_trackProcessors;
 
-    Vector<String> m_pendingIncomingMediaStreamIDs;
-
     bool m_shouldIgnoreNegotiationNeededSignal { false };
 
     Vector<RefPtr<MediaStreamTrackPrivate>> m_pendingIncomingTracks;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -56,7 +56,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 namespace webrtc {
 class CreateSessionDescriptionObserver;
 class DataChannelInterface;
-class MediaStreamInterface;
 class PeerConnectionObserver;
 class SessionDescriptionInterface;
 class SetSessionDescriptionObserver;
@@ -202,8 +201,6 @@ private:
 
     bool m_isInitiator { false };
     Timer m_statsLogTimer;
-
-    MemoryCompactRobinHoodHashMap<String, Ref<webrtc::MediaStreamInterface>> m_localStreams;
 
     const std::unique_ptr<LibWebRTCProvider::SuspendableSocketFactory> m_rtcSocketFactory;
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
@@ -123,7 +123,6 @@ private:
     bool m_isLocalDescriptionSet { false };
     bool m_isRemoteDescriptionSet { false };
 
-    Vector<std::unique_ptr<webrtc::IceCandidate>> m_pendingCandidates;
     Vector<Ref<RTCRtpReceiver>> m_pendingReceivers;
 
     HashMap<String, String> m_trackIds;

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -114,8 +114,6 @@ private:
     CallbackMap m_callbackMap;
 
     using PromiseVector = Vector<Ref<DeferredPromise>>;
-    PromiseVector m_availabilityPromises;
-    PromiseVector m_cancelAvailabilityPromises;
     PromiseVector m_promptPromises;
     State m_state { State::Disconnected };
     bool m_available { false };

--- a/Source/WebCore/Modules/webxr/XRInputSourceEvent.h
+++ b/Source/WebCore/Modules/webxr/XRInputSourceEvent.h
@@ -55,7 +55,6 @@ private:
 
     const Ref<WebXRFrame> m_frame;
     const Ref<WebXRInputSource> m_inputSource;
-    std::optional<int> m_buttonIndex;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSRegisteredCounterStyle.h
+++ b/Source/WebCore/css/CSSRegisteredCounterStyle.h
@@ -122,8 +122,6 @@ private:
     bool m_predefinedCounterStyle { false };
     CSSCounterStyleDescriptors::Name m_fallbackName;
     WeakPtr<const CSSRegisteredCounterStyle> m_fallbackReference { nullptr };
-    WeakPtr<const CSSRegisteredCounterStyle> m_extendsReference { nullptr };
     bool m_isFallingBack { false };
-    bool m_isExtendedUnresolved { true };
 };
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2647,7 +2647,6 @@ private:
     std::unique_ptr<SleepDisabler> m_sleepDisabler;
 
 #if ENABLE(MEDIA_STREAM)
-    String m_idHashSalt;
     size_t m_activeMediaElementsWithMediaStreamCount { 0 };
     HashSet<Ref<RealtimeMediaSource>> m_captureSources;
     bool m_isUpdatingCaptureAccordingToMutedState { false };
@@ -2770,9 +2769,7 @@ private:
 
     bool m_hasStyleWithViewportUnits { false };
     bool m_needsDOMWindowResizeEvent { false };
-    bool m_hasDeferredDOMWindowResizeEvent { false };
     bool m_needsVisualViewportResizeEvent { false };
-    bool m_hasDeferredVisualViewportResizeEvent { false };
     bool m_needsVisualViewportScrollEvent { false };
     bool m_isTimerThrottlingEnabled { false };
     bool m_isSuspended { false };
@@ -2794,7 +2791,6 @@ private:
 
     bool m_updateTitleTaskScheduled { false };
 
-    bool m_isRunningUserScripts { false };
     bool m_shouldPreventEnteringBackForwardCacheForTesting { false };
     bool m_hasLoadedThirdPartyScript { false };
     bool m_hasLoadedThirdPartyFrame { false };

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -157,7 +157,6 @@ private:
     bool m_hasRelevantLoadEventsListener : 1 { false };
     ScriptType m_scriptType : bitWidthOfScriptType { ScriptType::Classic };
     AtomString m_characterEncoding;
-    AtomString m_fallbackCharacterEncoding;
     RefPtr<LoadableScript> m_loadableScript;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#preparation-time-document

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1340,7 +1340,6 @@ private:
     bool m_havePreparedToPlay : 1;
     bool m_parsingInProgress : 1;
     bool m_elementIsHidden : 1;
-    bool m_elementWasRemovedFromDOM : 1;
     bool m_receivedLayoutSizeChanged : 1;
     bool m_hasEverNotifiedAboutPlaying : 1;
 
@@ -1415,7 +1414,6 @@ private:
     const Ref<WTF::Observer<WebCoreOpaqueRoot()>> m_opaqueRootProvider;
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    bool m_hasNeedkeyListener { false };
     RefPtr<WebKitMediaKeys> m_webKitMediaKeys;
 #endif
 

--- a/Source/WebCore/html/track/AudioTrack.h
+++ b/Source/WebCore/html/track/AudioTrack.h
@@ -37,7 +37,6 @@ namespace WebCore {
 
 class AudioTrackClient;
 class AudioTrackConfiguration;
-class AudioTrackList;
 
 class AudioTrack final : public MediaTrackBase, private AudioTrackPrivateClient {
     WTF_MAKE_TZONE_ALLOCATED(AudioTrack);
@@ -97,7 +96,6 @@ private:
     ASCIILiteral logClassName() const final { return "AudioTrack"_s; }
 #endif
 
-    WeakPtr<AudioTrackList> m_audioTrackList;
     WeakHashSet<AudioTrackClient> m_clients;
     Ref<AudioTrackPrivate> m_private;
     bool m_enabled { false };

--- a/Source/WebCore/html/track/VideoTrack.h
+++ b/Source/WebCore/html/track/VideoTrack.h
@@ -39,7 +39,6 @@ class MediaDescription;
 class VideoTrack;
 class VideoTrackClient;
 class VideoTrackConfiguration;
-class VideoTrackList;
 class VideoTrackPrivate;
 
 class VideoTrack final : public MediaTrackBase, private VideoTrackPrivateClient {
@@ -101,7 +100,6 @@ private:
     ASCIILiteral logClassName() const final { return "VideoTrack"_s; }
 #endif
 
-    WeakPtr<VideoTrackList> m_videoTrackList;
     WeakHashSet<VideoTrackClient> m_clients;
     Ref<VideoTrackPrivate> m_private;
     const Ref<VideoTrackConfiguration> m_configuration;

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
@@ -71,7 +71,6 @@ private:
     unsigned indexForNewlyConnectedDevice();
 
     bool m_shouldMakeGamepadsVisible { false };
-    size_t m_initialGamepadsCount { 0 };
     Vector<WeakPtr<PlatformGamepad>> m_gamepadVector;
 
     // We create our own Gamepad type - to wrap both HID and GameController gamepads -
@@ -103,7 +102,6 @@ private:
     };
 
     WeakHashMap<PlatformGamepad, std::unique_ptr<PlatformGamepadWrapper>> m_gamepadMap;
-    bool m_hidImportComplete { false };
     bool m_usesOnlyHIDProvider { false };
 };
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -419,8 +419,6 @@ protected:
     HashSet<CString> m_allRequestableExtensions;
     HashSet<CString> m_allEnabledRequestableExtensions;
     HashSet<CString> m_extensions;
-    bool m_webglColorBufferFloatRGB { false };
-    bool m_webglColorBufferFloatRGBA { false };
     GCGLuint m_texture { 0 };
     GCGLuint m_fbo { 0 };
     GCGLuint m_depthStencilBuffer { 0 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -53,7 +53,6 @@ OBJC_CLASS NSArray;
 OBJC_CLASS NSMutableDictionary;
 OBJC_CLASS WebCoreAVFLoaderDelegate;
 OBJC_CLASS WebCoreAVFMovieObserver;
-OBJC_CLASS WebCoreAVFPullDelegate;
 
 typedef struct CGImage *CGImageRef;
 typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
@@ -437,7 +436,6 @@ private:
 
     RetainPtr<AVAssetImageGenerator> m_imageGenerator;
     RefPtr<QueuedVideoOutput> m_videoOutput;
-    RetainPtr<WebCoreAVFPullDelegate> m_videoOutputDelegate;
     RetainPtr<CVPixelBufferRef> m_lastPixelBuffer;
     RefPtr<NativeImage> m_lastImage;
     std::unique_ptr<ImageRotationSessionVT> m_imageRotationSession;
@@ -448,7 +446,6 @@ private:
     HashMap<RetainPtr<AVAssetResourceLoadingRequest>, Ref<WebCoreAVFResourceLoader>> m_resourceLoaderMap;
     const RetainPtr<WebCoreAVFLoaderDelegate> m_loaderDelegate;
     MemoryCompactRobinHoodHashMap<String, RetainPtr<AVAssetResourceLoadingRequest>> m_keyURIToRequestMap;
-    MemoryCompactRobinHoodHashMap<String, RetainPtr<AVAssetResourceLoadingRequest>> m_sessionIDToRequestMap;
 
     RetainPtr<AVPlayerItemLegibleOutput> m_legibleOutput;
 
@@ -520,7 +517,6 @@ private:
     bool m_cachedCanPlayFastForward { false };
     bool m_cachedCanPlayFastReverse { false };
     mutable bool m_cachedAssetIsLoaded { false };
-    mutable bool m_cachedTracksAreLoaded { false };
     mutable std::optional<bool> m_cachedAssetIsPlayable;
     mutable std::optional<bool> m_cachedTracksArePlayable;
     mutable std::optional<bool> m_cachedAssetIsHLS;
@@ -529,13 +525,11 @@ private:
     bool m_preservesPitch { true };
     bool m_shouldObserveTimeControlStatus { false };
     bool m_isInFullscreenOrPictureInPicture { false };
-    mutable std::optional<bool> m_tracksArePlayable;
     bool m_automaticallyWaitsToMinimizeStalling { false };
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     mutable bool m_allowsWirelessVideoPlayback { true };
     bool m_shouldPlayToPlaybackTarget { false };
 #endif
-    bool m_haveProcessedChapterTracks { false };
     bool m_waitForVideoOutputMediaDataWillChangeTimedOut { false };
     bool m_haveBeenAskedToPaint { false };
     uint64_t m_sampleCount { 0 };

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -349,7 +349,6 @@ private:
     bool NODELETE isEnabledVideoTrackID(TrackID) const;
     bool NODELETE hasSelectedVideo() const;
     std::optional<TrackID> m_enabledVideoTrackID WTF_GUARDED_BY_CAPABILITY(runningQueue());
-    std::atomic<uint32_t> m_abortCalled { 0 };
     size_t m_contentLength WTF_GUARDED_BY_CAPABILITY(mainThread) { 0 };
     size_t m_contentReceived WTF_GUARDED_BY_CAPABILITY(mainThread) { 0 };
     uint32_t m_pendingAppends WTF_GUARDED_BY_CAPABILITY(runningQueue()) { 0 };

--- a/Source/WebCore/platform/network/ResourceHandleInternal.h
+++ b/Source/WebCore/platform/network/ResourceHandleInternal.h
@@ -116,11 +116,7 @@ public:
     bool m_shouldContentSniff;
     bool m_failsTAOCheck { false };
     bool m_hasCrossOriginRedirect { false };
-    bool m_isCrossOrigin { false };
     bool m_isMainFrameNavigation { false };
-#if PLATFORM(COCOA)
-    bool m_startWhenScheduled { false };
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -277,9 +277,6 @@ private:
     HashMap<RegistrableDomain, std::pair<IsLoggedIn, std::optional<WebCore::LoginStatus>>> m_loginStatus;
     HashMap<WebPageProxyIdentifier, HashSet<std::pair<TopFrameDomain, SubFrameDomain>>> m_domainsGrantedStorageAccessPermissionInPage;
 
-    bool m_hasScheduledProcessStats { false };
-    bool m_firstNetworkProcessCreated { false };
-
     struct StorageAccessRequestRecordValue {
         Markable<WebPageProxyIdentifier> webPageProxyID;
         Markable<WallTime> lastRequestTime;

--- a/Source/WebKit/NetworkProcess/Downloads/Download.h
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.h
@@ -49,7 +49,6 @@ OBJC_CLASS NSURLSessionDownloadTask;
 
 namespace WebCore {
 class AuthenticationChallenge;
-class BlobDataFileReference;
 class Credential;
 class ResourceError;
 class ResourceRequest;
@@ -128,7 +127,6 @@ private:
     DownloadID m_downloadID;
     const Ref<DownloadManager::Client> m_client;
 
-    Vector<Ref<WebCore::BlobDataFileReference>> m_blobFileReferences;
     RefPtr<SandboxExtension> m_sandboxExtension;
 
     const RefPtr<NetworkDataTask> m_download;
@@ -149,7 +147,6 @@ private:
     IgnoreDidFailCallback m_ignoreDidFailCallback { IgnoreDidFailCallback::No };
     DownloadMonitor m_monitor { *this };
     unsigned m_testSpeedMultiplier { 1 };
-    CompletionHandler<void(std::span<const uint8_t>)> m_cancelCompletionHandler;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -324,8 +324,6 @@ private:
     size_t m_bytesTransferredOverNetwork { 0 };
 #endif
 
-    unsigned m_retrievedDerivedDataCount { 0 };
-
     WebCore::Timer m_bufferingTimer;
     RefPtr<NetworkCache::Cache> m_cache;
     WebCore::SharedBufferBuilder m_bufferedDataForCache;

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -358,7 +358,6 @@ void WebProcessProxy::platformInitialize()
 WebProcessProxy::~WebProcessProxy()
 {
     RELEASE_ASSERT(isMainThreadOrCheckDisabled());
-    ASSERT(m_pageURLRetainCountMap.isEmpty());
     WEBPROCESSPROXY_RELEASE_LOG(Process, "destructor:");
 
     // ~AuxiliaryProcessProxy() replies to pending messages after our members are gone; a reply

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -845,8 +845,6 @@ private:
     bool m_hasSentMessageToUnblockAccessibilityServer { false };
 #endif
 
-    HashMap<String, uint64_t> m_pageURLRetainCountMap;
-
     Expected<WebCore::Site, SiteState> m_site { std::unexpected<SiteState> { SiteState::NotYetSpecified } };
     std::optional<WebCore::Site> m_sharedProcessMainFrameSite;
     HashSet<WebCore::RegistrableDomain> m_sharedProcessDomains;


### PR DESCRIPTION
#### 809fc2216abc27beeb8d695eee583e0ff7d5513c
<pre>
Remove some unused member variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=316328">https://bugs.webkit.org/show_bug.cgi?id=316328</a>
<a href="https://rdar.apple.com/178750331">rdar://178750331</a>

Reviewed by Charlie Wolfe.

I&apos;m learning how to use some new tools.  Some of them even show signs of
intelligence, albeit artificial.  They can look through a lot of code
and find unused member variables relatively quickly, so let&apos;s take that
assistance and save a tiny bit of memory.

* Source/WebCore/Modules/filesystem/WorkerFileSystemStorageConnection.h:
* Source/WebCore/Modules/indexeddb/server/IDBServer.h:
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
* Source/WebCore/Modules/webxr/XRInputSourceEvent.h:
* Source/WebCore/css/CSSRegisteredCounterStyle.h:
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/track/AudioTrack.h:
* Source/WebCore/html/track/VideoTrack.h:
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/network/ResourceHandleInternal.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Downloads/Download.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::~WebProcessProxy):
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/314582@main">https://commits.webkit.org/314582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8203966f0732db8d6017e7dc70ba49e087bf88bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175566 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123773 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ebb6930b-2bcf-4810-8310-eac612bb93c3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129464 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f5af3c3-2d05-4e77-93f0-abf70fe6184b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169477 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109989 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a42ce389-0808-4754-82e5-3f6a970ec915) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29526 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23706 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178100 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31000 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137821 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137739 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149126 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103486 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25349 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33033 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112351 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38673 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4080 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38918 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->