### PR TITLE
[Site Isolation] Add back dumpResourceLoadCallbacks to x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html

### DIFF
--- a/LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html
+++ b/LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpResourceLoadCallbacks=true ] -->
 <script>
     if (window.testRunner) {
         testRunner.dumpAsText();
@@ -17,6 +18,7 @@
                 console.log(e);
             console.log("FAIL: Could not read contentWindow.location.href");
         }
+        testRunner.clearMemoryCache();
         testRunner.notifyDone();
     }
 </script>

--- a/LayoutTests/platform/wk2/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny-expected.txt
+++ b/LayoutTests/platform/wk2/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny-expected.txt
@@ -9,3 +9,9 @@ There should be content in the iframe below
 Frame: '<!--frame1-->'
 --------
 PASS: This should show up even though the parent is not in the same origin because we should be ignoring the meta tag.
+http://127.0.0.1:8000/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html, main document URL http://127.0.0.1:8000/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html, http method GET> redirectResponse (null)
+http://127.0.0.1:8000/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html, http status code 200>
+http://127.0.0.1:8000/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html - didFinishLoading
+http://localhost:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-parent-same-origin-deny.html - willSendRequest <NSURLRequest URL http://localhost:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-parent-same-origin-deny.html, main document URL http://127.0.0.1:8000/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html, http method GET> redirectResponse (null)
+http://localhost:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-parent-same-origin-deny.html - didReceiveResponse <NSURLResponse http://localhost:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-parent-same-origin-deny.html, http status code 200>
+http://localhost:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-parent-same-origin-deny.html - didFinishLoading

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -1254,6 +1254,11 @@ void Storage::clear(String&& type, WallTime modifiedSinceTime, CompletionHandler
     ASSERT(RunLoop::isMain());
     LOG(NetworkCacheStorage, "(NetworkProcess) clearing cache");
 
+    // Cancel queued writes that haven't been dispatched yet; otherwise they materialize on disk
+    // after clear() returns and resurrect cache entries the caller intended to delete.
+    m_writeOperationDispatchTimer.stop();
+    m_pendingWriteOperations.clear();
+
     if (m_recordFilter)
         m_recordFilter->clear();
     if (m_blobFilter)


### PR DESCRIPTION
#### dfb41fe0a07275b58635f5793d5146654dee307a
<pre>
[Site Isolation] Add back dumpResourceLoadCallbacks to x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=316323">https://bugs.webkit.org/show_bug.cgi?id=316323</a>
<a href="https://rdar.apple.com/178745935">rdar://178745935</a>

Reviewed by NOBODY (OOPS!).

Previously, in <a href="https://commits.webkit.org/312174@main">https://commits.webkit.org/312174@main</a>, I removed
logging of events triggered by dumpResourceLoadCallbacks.

At that time, I removed the JS call to testRunner.dumpResourceLoadCallbacks()
and tried to lift it from the InjectedBundle, it started to produce different
test results with site isolation enabled vs disabled. This was because the
resource load messages were getting interleaved with non resource load messages.
With <a href="https://commits.webkit.org/312174@main">https://commits.webkit.org/312174@main</a>, I decided to outright remove the
dumpResourceLoadCallbacks logs altogether to make the output consistent with
pre site isolation.

In <a href="https://commits.webkit.org/313704@main">https://commits.webkit.org/313704@main</a>, Alex lifted the JS function from
the InjectedBundle to a webkit-test-runner test header attribute. To solve
the interleaved message issue, he collected all the resource load logs and
flushed them at the end of the test output. This way, they don&apos;t get
interleaved with non resource load messages.

This test and other resource callback tests are failing in stress modes
where they pass the first time (with the full resource loading log
messages), then fail on subsequent runs. This was because the resources
were being loaded from cache on the subsequent runs after the first.

To make the tests more deterministic in stress runs, Alex cleared the
disk cache between tests in <a href="https://commits.webkit.org/314790@main.">https://commits.webkit.org/314790@main.</a>
That change called WKWebsiteDataStoreRemoveNetworkCache, which routes
to NetworkCache::Storage::clear().
However, Storage::clear() did not cancel writes that had been queued
via Storage::store() but had not yet been dispatched
(Storage::store doesn&apos;t perform the actual disk write until a 1s timer fires).
As a result, clear() would delete files on disk while leaving pending writes
queued, and those pending writes would then materialize on disk after
clear() returned, resurrecting cache entries which were previously deleted.
Subsequent test iterations would then hit the resurrected entry.

This patch updates Storage::clear() to also stop the dispatch timer and
drop m_pendingWriteOperations, so the in-memory cache state is fully
cleared before the on-disk traversal begins.

The test additionally calls testRunner.clearMemoryCache() before
notifyDone() to evict the in-process WebCore::MemoryCache across all
WebProcesses (broadcast via UIProcess), since that cache is separate
from NetworkCache::Storage.

* LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html:
* LayoutTests/platform/wk2/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny-expected.txt:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::clear):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfb41fe0a07275b58635f5793d5146654dee307a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127785 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/750c7cc1-0f36-40b7-8bb7-beaf326890cf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132564 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93410 "14 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32256760-84e9-4a27-9075-ad61b62d3111) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113066 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ebe74d4f-f01a-4a4c-aa4c-463507080f96) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34354 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32705 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28131 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1417 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144837 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182032 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141016 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43652 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140845 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44341 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29382 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108692 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36115 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116222 "Found 125 new failures in runtime/IndexingType.cpp, layout/formattingContexts/inline/InlineFormattingContext.cpp, css/SelectorFilter.cpp, rendering/RenderFlexibleBox.h, Modules/speech/SpeechRecognitionResultList.cpp, bytecode/CheckPrivateBrandStatus.cpp, dfg/DFGFixupPhase.cpp, html/canvas/WebGLTransformFeedback.cpp, Modules/webauthn/apdu/ApduCommand.cpp, platform/audio/AudioBus.cpp ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42852 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7481 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42244 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42498 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->