### PR TITLE
[CMake] Select toolchain/deployment from SDK before project() is called

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,82 +8,13 @@
 
 cmake_minimum_required(VERSION 3.20)
 
-if (PORT STREQUAL "IOS")
-    set(CMAKE_SYSTEM_NAME iOS)
-    if (CMAKE_IOS_SIMULATOR)
-        set(_sdk_name "iphonesimulator.internal")
-        set(_sdk_name_fallback "iphonesimulator")
-    else ()
-        set(_sdk_name "iphoneos.internal")
-        set(_sdk_name_fallback "iphoneos")
-    endif ()
-    execute_process(COMMAND xcrun --sdk ${_sdk_name} --show-sdk-path
-        OUTPUT_VARIABLE _ios_sysroot
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        RESULT_VARIABLE _internal_sdk_result
-        ERROR_QUIET)
-    if (NOT _internal_sdk_result EQUAL 0 OR NOT _ios_sysroot)
-        set(_ios_sysroot "")
-        if (CMAKE_OSX_SYSROOT AND EXISTS "${CMAKE_OSX_SYSROOT}")
-            set(_ios_sysroot "${CMAKE_OSX_SYSROOT}")
-        elseif (DEFINED ENV{SDKROOT} AND EXISTS "$ENV{SDKROOT}" AND "$ENV{SDKROOT}" MATCHES "iPhone")
-            set(_ios_sysroot "$ENV{SDKROOT}")
-        else ()
-            execute_process(COMMAND xcrun --sdk ${_sdk_name_fallback} --show-sdk-path
-                OUTPUT_VARIABLE _ios_sysroot
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-                ERROR_QUIET)
-        endif ()
-    endif ()
-    if (_ios_sysroot)
-        set(CMAKE_OSX_SYSROOT "${_ios_sysroot}" CACHE PATH "iOS SDK path" FORCE)
-    endif ()
-    unset(_sdk_name)
-    unset(_sdk_name_fallback)
-    unset(_internal_sdk_result)
-    unset(_ios_sysroot)
-
-    if (NOT CMAKE_OSX_ARCHITECTURES)
-        if (CMAKE_OSX_SYSROOT MATCHES "\\.Internal\\.sdk$" AND NOT CMAKE_OSX_SYSROOT MATCHES "[Ss]imulator")
-            execute_process(COMMAND uname -m
-                OUTPUT_VARIABLE _host_arch
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-            if (_host_arch STREQUAL "arm64")
-                set(CMAKE_OSX_ARCHITECTURES "arm64e" CACHE STRING "Target architecture" FORCE)
-                message(STATUS "iOS: arm64e enabled (internal device SDK detected)")
-            endif ()
-        else ()
-            set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "Target architecture" FORCE)
-        endif ()
-    endif ()
-
-    if (NOT CMAKE_OSX_DEPLOYMENT_TARGET)
-        set(CMAKE_OSX_DEPLOYMENT_TARGET "18.0" CACHE STRING "Minimum iOS version" FORCE)
-    endif ()
-
-    if (NOT CMAKE_SYSTEM_PROCESSOR)
-        set(CMAKE_SYSTEM_PROCESSOR "aarch64" CACHE STRING "Target processor" FORCE)
-    endif ()
-endif ()
-
-if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_SYSTEM_NAME STREQUAL "iOS" AND NOT CMAKE_OSX_SYSROOT)
-    # Set CMAKE_OSX_SYSROOT before the project() call below. project() runs ABI
-    # detection tests whose results are cached; having the wrong sysroot there
-    # would cause those cached results to refer to a different SDK than actual
-    # builds use. OptionsMac.cmake (which sets this via WEBKIT_XCRUN) is loaded
-    # only after project() via include(WebKitCommon), so it is too late.
-    # WEBKIT_XCRUN is also unavailable here because WebKitXcrun.cmake is
-    # included by OptionsMac.cmake.
-    execute_process(COMMAND xcrun --sdk macosx --show-sdk-path
-        OUTPUT_VARIABLE _macos_sysroot
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        RESULT_VARIABLE _xcrun_result
-        ERROR_QUIET)
-    if (_xcrun_result EQUAL 0 AND _macos_sysroot)
-        set(CMAKE_OSX_SYSROOT "${_macos_sysroot}" CACHE PATH "macOS SDK path" FORCE)
-    endif ()
-    unset(_macos_sysroot)
-    unset(_xcrun_result)
+# Resolve SDK / toolchain / deployment target / arch before project() runs:
+# project() runs ABI detection tests against CMAKE_OSX_SYSROOT, picks compilers
+# from PATH, and consumes CMAKE_OSX_DEPLOYMENT_TARGET.
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/Source/cmake")
+if (APPLE)
+    include(WebKitXcrun)
+    WEBKIT_RESOLVE_SDK_AND_TOOLCHAIN()
 endif ()
 
 project(WebKit LANGUAGES C CXX)
@@ -91,7 +22,6 @@ project(WebKit LANGUAGES C CXX)
 # -----------------------------------------------------------------------------
 # Common configuration
 #------------------------------------------------------------------------------
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/Source/cmake")
 include(WebKitCommon)
 
 # -----------------------------------------------------------------------------

--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -1,3 +1,10 @@
+# Enable Objective-C / Objective-C++ so .m/.mm sources use the OBJC/OBJCXX
+# compile rules and $<COMPILE_LANGUAGE:OBJC/OBJCXX> generator expressions
+# match. Without this CMake compiles .mm as CXX, CMAKE_OBJCXX_FLAGS are
+# ignored, and WEBKIT_ADD_PREFIX_HEADER produces no OBJCXX precompiled
+# header for .mm sources.
+enable_language(OBJC OBJCXX)
+
 set(_wka_found FALSE)
 set(_wka_cmake_paths
     "${CMAKE_SOURCE_DIR}/../Internal/WebKit"
@@ -68,7 +75,9 @@ foreach (_t SQLite::SQLite3 LibXml2::LibXml2 LibXslt::LibXslt LibXslt::LibExslt)
     endif ()
 endforeach ()
 
-string(REGEX MATCH "^[0-9]+" _sdk_major "${_sdk_version}")
+string(REGEX REPLACE "\\.internal$" "" _sdk_prefix "${WEBKIT_SDK}")
+string(REGEX MATCH "^[0-9]+" _sdk_major "${WEBKIT_SDK_VERSION}")
+string(REGEX MATCH "^[0-9]+\\.[0-9]+" _sdk_major_minor "${WEBKIT_SDK_VERSION}")
 set(_additions_candidates
     "${CMAKE_SOURCE_DIR}/WebKitLibraries/SDKs/${_sdk_prefix}${_sdk_major}.0-additions.sdk/usr/local/include"
     "${CMAKE_SOURCE_DIR}/WebKitLibraries/SDKs/${_sdk_prefix}${_sdk_major_minor}-additions.sdk/usr/local/include"
@@ -101,7 +110,6 @@ endif ()
 if (NOT _additions_found)
     message(WARNING "No SDK additions overlay found -- API_UNAVAILABLE classes (AVAudioSession etc.) will fail to compile")
 endif ()
-unset(_sdk_version)
 unset(_sdk_major)
 unset(_sdk_major_minor)
 unset(_sdk_prefix)
@@ -139,7 +147,7 @@ add_compile_options(
     "$<$<COMPILE_LANGUAGE:C,CXX>:-fvisibility-inlines-hidden>"
 )
 
-if (CMAKE_OSX_SYSROOT MATCHES "\\.Internal\\.sdk$")
+if (USE_APPLE_INTERNAL_SDK)
     add_compile_definitions(OS_UNFAIR_LOCK_INLINE=1)
 endif ()
 

--- a/Source/cmake/OptionsIOS.cmake
+++ b/Source/cmake/OptionsIOS.cmake
@@ -104,36 +104,13 @@ WEBKIT_OPTION_END()
 # FIXME: Needs WebCore_Private Swift module. https://bugs.webkit.org/show_bug.cgi?id=312083
 SET_AND_EXPOSE_TO_BUILD(ENABLE_BACK_FORWARD_LIST_SWIFT OFF)
 
-include(WebKitXcrun)
 if (CMAKE_IOS_SIMULATOR OR CMAKE_OSX_SYSROOT MATCHES "[Ss]imulator")
-    WEBKIT_RESOLVE_SDK(iphonesimulator.internal iphonesimulator)
     set(WEBKIT_PLATFORM_NAME "iPhoneSimulator")
-    set(_sdk_prefix "iphonesimulator")
 else ()
-    WEBKIT_RESOLVE_SDK(iphoneos.internal iphoneos)
     set(WEBKIT_PLATFORM_NAME "iPhoneOS")
-    set(_sdk_prefix "iphoneos")
-endif ()
-string(REGEX MATCH "^[0-9]+\\.[0-9]+" _sdk_major_minor "${_sdk_version}")
-if (_sdk_major_minor AND (NOT CMAKE_OSX_DEPLOYMENT_TARGET OR CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS _sdk_major_minor))
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "${_sdk_major_minor}" CACHE STRING "Minimum iOS version" FORCE)
-    message(WARNING "Deployment target auto-set to SDK version: ${CMAKE_OSX_DEPLOYMENT_TARGET} (SPI header guards require this)")
-endif ()
-
-# Resolve the real clang once and pin it for the lifetime of this build tree.
-# This is a build speed optimization, and also a defense against tearing between
-# resolved toolchain and resolved SDK path / version.
-WEBKIT_XCRUN(_clang -f clang)
-if (EXISTS "${_clang}")
-    set(CMAKE_C_COMPILER "${_clang}")
-    set(CMAKE_CXX_COMPILER "${_clang}++")
-    set(CMAKE_OBJC_COMPILER "${_clang}")
-    set(CMAKE_OBJCXX_COMPILER "${_clang}++")
 endif ()
 
 include(OptionsCocoa)
-
-enable_language(OBJC OBJCXX)
 
 find_package(ZLIB REQUIRED)
 
@@ -169,7 +146,7 @@ if (CMAKE_OSX_SYSROOT)
     set(WEBKIT_PRIVATE_FRAMEWORKS_COMPILE_FLAG "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks>")
 endif ()
 
-if (CMAKE_OSX_SYSROOT MATCHES "\\.Internal\\.sdk$")
+if (USE_APPLE_INTERNAL_SDK)
     add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:-DUSE_APPLE_INTERNAL_SDK>")
     add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DUSE_APPLE_INTERNAL_SDK>")
 endif ()

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -1,12 +1,5 @@
 include(WebKitVersion)
 
-# Enable Objective-C / Objective-C++ so .m/.mm sources use the OBJC/OBJCXX
-# compile rules and $<COMPILE_LANGUAGE:OBJC/OBJCXX> generator expressions
-# match. Without this CMake compiles .mm as CXX, CMAKE_OBJCXX_FLAGS are
-# ignored, and WEBKIT_ADD_PREFIX_HEADER produces no OBJCXX precompiled
-# header for .mm sources.
-enable_language(OBJC OBJCXX)
-
 WEBKIT_OPTION_BEGIN()
 # Private options shared with other WebKit ports. Add options here only if
 # we need a value different from the default defined in WebKitFeatures.cmake.
@@ -136,32 +129,6 @@ WEBKIT_OPTION_END()
 # rdar://177360289
 SET_AND_EXPOSE_TO_BUILD(ENABLE_BACK_FORWARD_LIST_SWIFT ON)
 
-# -----------------------------------------------------------------------------
-# Toolchain / SDK resolution
-# -----------------------------------------------------------------------------
-include(WebKitXcrun)
-WEBKIT_RESOLVE_SDK(macosx)
-
-# Resolve the real clang once and pin it for the lifetime of this build tree.
-# This is a build speed optimization, and also a defense against tearing between
-# resolved toolchain and resolved SDK path / version.
-WEBKIT_XCRUN(_clang -f clang)
-if (EXISTS "${_clang}")
-    set(CMAKE_C_COMPILER "${_clang}")
-    set(CMAKE_CXX_COMPILER "${_clang}++")
-    set(CMAKE_OBJC_COMPILER "${_clang}")
-    set(CMAKE_OBJCXX_COMPILER "${_clang}++")
-endif ()
-
-# Deployment target must match SDK version -- PlatformHave.h SPI guards depend on
-# __MAC_OS_X_VERSION_MIN_REQUIRED. Auto-bump if the preset floor is below the SDK.
-string(REGEX MATCH "^[0-9]+\\.[0-9]+" _sdk_major_minor "${_sdk_version}")
-if (_sdk_major_minor AND (NOT CMAKE_OSX_DEPLOYMENT_TARGET OR CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS _sdk_major_minor))
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "${_sdk_major_minor}" CACHE STRING "Minimum macOS version" FORCE)
-    message(WARNING "Deployment target auto-set to SDK version: ${CMAKE_OSX_DEPLOYMENT_TARGET} (SPI header guards require this)")
-endif ()
-
-set(_sdk_prefix "macosx")
 set(WEBKIT_PLATFORM_NAME "MacOSX")
 
 include(OptionsCocoa)

--- a/Source/cmake/WebKitXcrun.cmake
+++ b/Source/cmake/WebKitXcrun.cmake
@@ -3,32 +3,176 @@
 # Always pass --sdk to xcrun explicitly -- otherwise, toolchain and SDK
 # are not guaranteed to match.
 
-# Sets WEBKIT_SDK and _sdk_version in the caller's scope.
+# Sets WEBKIT_SDK and WEBKIT_SDK_VERSION as cache vars. Cache (not
+# PARENT_SCOPE) so values survive when invoked from inside another function
+# (e.g. WEBKIT_RESOLVE_SDK_AND_TOOLCHAIN).
 function(WEBKIT_RESOLVE_SDK)
     foreach (_sdk IN LISTS ARGN)
         execute_process(COMMAND xcrun --sdk ${_sdk} --show-sdk-version
-            OUTPUT_VARIABLE _sdk_version
+            OUTPUT_VARIABLE _xcrun_sdk_version
             RESULT_VARIABLE _sdk_result
             OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_QUIET)
-        if (_sdk_result EQUAL 0 AND _sdk_version)
-            set(WEBKIT_SDK "${_sdk}" PARENT_SCOPE)
-            set(_sdk_version "${_sdk_version}" PARENT_SCOPE)
-            return ()
+        if (_sdk_result EQUAL 0 AND _xcrun_sdk_version)
+            set(WEBKIT_SDK "${_sdk}" CACHE STRING "Resolved Apple SDK name" FORCE)
+            set(WEBKIT_SDK_VERSION "${_xcrun_sdk_version}" CACHE STRING "Resolved Apple SDK version" FORCE)
+            return()
         endif ()
     endforeach ()
     message(FATAL_ERROR "xcrun could not locate any SDK in: ${ARGN}")
 endfunction()
 
-# Runs `xcrun --sdk ${WEBKIT_SDK} <args>` and capture stdout in OUTPUT_VAR
-# (in the caller's scope).
+# Resolve a tool path via `xcrun <args>` (typically `-f <tool>`) and cache it.
+# SDKROOT is in the env (set by WEBKIT_RESOLVE_SDK_AND_TOOLCHAIN), so xcrun's
+# tool resolution follows the SDK's preferred toolchain. Caching prevents
+# re-running xcrun on every reconfigure (matching find_program semantics).
 function(WEBKIT_XCRUN OUTPUT_VAR)
-    if (NOT WEBKIT_SDK)
-        message(FATAL_ERROR "WEBKIT_XCRUN called before WEBKIT_RESOLVE_SDK")
+    if (NOT DEFINED ENV{SDKROOT})
+        message(FATAL_ERROR "WEBKIT_XCRUN called before SDKROOT was set in env (call WEBKIT_RESOLVE_SDK_AND_TOOLCHAIN first)")
     endif ()
-    execute_process(COMMAND xcrun --sdk ${WEBKIT_SDK} ${ARGN}
+    if (DEFINED CACHE{${OUTPUT_VAR}})
+        return()
+    endif ()
+    execute_process(COMMAND xcrun ${ARGN}
         OUTPUT_VARIABLE _out
         OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_QUIET)
-    set(${OUTPUT_VAR} "${_out}" PARENT_SCOPE)
+    set(${OUTPUT_VAR} "${_out}" CACHE FILEPATH "Path resolved via xcrun")
+endfunction()
+
+# Resolve the Apple SDK, toolchain, deployment target, and architecture for
+# the current PORT, before project() runs (project() runs ABI detection tests
+# against CMAKE_OSX_SYSROOT, picks the compiler from PATH, and consumes
+# CMAKE_OSX_DEPLOYMENT_TARGET).
+#
+# All outputs are CACHE so the function can call WEBKIT_RESOLVE_SDK without
+# manual PARENT_SCOPE plumbing through nested function calls.
+#
+# Deployment-target policy (precedent: 305611@main): when the sysroot is a
+# macOS SDK, use max(host macOS version, SDK version) so PlatformHave.h SPI
+# guards keyed off __MAC_OS_X_VERSION_MIN_REQUIRED activate; on iOS we pin to
+# a hardcoded floor.
+function(WEBKIT_RESOLVE_SDK_AND_TOOLCHAIN)
+    if (PORT STREQUAL "Mac")
+        # FIXME: add macosx.internal here when the internal-SDK Mac build is green.
+        WEBKIT_RESOLVE_SDK(macosx)
+        set(_target_key "macosx")
+    elseif (PORT STREQUAL "IOS")
+        if (CMAKE_IOS_SIMULATOR OR CMAKE_OSX_SYSROOT MATCHES "[Ss]imulator")
+            WEBKIT_RESOLVE_SDK(iphonesimulator.internal iphonesimulator)
+            set(_target_key "iphonesimulator")
+        else ()
+            WEBKIT_RESOLVE_SDK(iphoneos.internal iphoneos)
+            set(_target_key "iphoneos")
+        endif ()
+    else ()
+        return()
+    endif ()
+
+    string(REGEX MATCH "^[0-9]+\\.[0-9]+" _sdk_major_minor "${WEBKIT_SDK_VERSION}")
+
+    if (NOT CMAKE_OSX_SYSROOT)
+        execute_process(COMMAND xcrun --sdk ${WEBKIT_SDK} --show-sdk-path
+            OUTPUT_VARIABLE _sysroot_path
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET)
+        if (NOT _sysroot_path)
+            message(FATAL_ERROR "Unable to determine SDK root path for ${WEBKIT_SDK}")
+        endif ()
+        set(CMAKE_OSX_SYSROOT "${_sysroot_path}" CACHE PATH "SDK path" FORCE)
+    endif ()
+
+    # Internal-SDK detection. The Internal SDK changes both arch policy
+    # (arm64e on Mac) and SPI surface (compile flags in OptionsCocoa, Swift
+    # define in OptionsIOS). Detect both name-form (auto-resolved
+    # iphoneos.internal) and path-form (user-supplied iPhoneOS26.6.Internal.sdk).
+    if (WEBKIT_SDK MATCHES "\\.internal$" OR CMAKE_OSX_SYSROOT MATCHES "\\.Internal\\.sdk$")
+        set(USE_APPLE_INTERNAL_SDK ON CACHE BOOL "Apple-internal SDK is in use" FORCE)
+    else ()
+        set(USE_APPLE_INTERNAL_SDK OFF CACHE BOOL "Apple-internal SDK is in use" FORCE)
+    endif ()
+
+    # Steer all subsequent xcrun-based tool resolution to the SDK's preferred
+    # toolchain by setting SDKROOT, and prepend the toolchain's bin to PATH so
+    # CMake's find_program-based discovery (CMAKE_AR / CMAKE_RANLIB /
+    # CMAKE_LINKER / etc.) lands on toolchain binaries instead of /usr/bin
+    # stubs.
+    set(ENV{SDKROOT} "${CMAKE_OSX_SYSROOT}")
+    execute_process(COMMAND xcrun --sdk "${CMAKE_OSX_SYSROOT}" --show-toolchain-path
+        OUTPUT_VARIABLE _toolchain_path
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET)
+    if (_toolchain_path AND EXISTS "${_toolchain_path}/usr/bin")
+        set(ENV{PATH} "${_toolchain_path}/usr/bin:$ENV{PATH}")
+        message(STATUS "Using platform toolchain (prepending PATH): ${_toolchain_path}")
+    endif ()
+
+    if (NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+        if (PORT STREQUAL "Mac")
+            set(_target "${_sdk_major_minor}")
+            execute_process(COMMAND sw_vers -productVersion
+                OUTPUT_VARIABLE _host_version
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET)
+            string(REGEX MATCH "^[0-9]+\\.[0-9]+" _host_major_minor "${_host_version}")
+            if (_host_major_minor AND _host_major_minor VERSION_GREATER _target)
+                set(_target "${_host_major_minor}")
+            endif ()
+            if (_target)
+                set(CMAKE_OSX_DEPLOYMENT_TARGET "${_target}" CACHE STRING "Minimum deployment target" FORCE)
+            endif ()
+        elseif (PORT STREQUAL "IOS")
+            set(CMAKE_OSX_DEPLOYMENT_TARGET "18.0" CACHE STRING "Minimum deployment target" FORCE)
+        endif ()
+    endif ()
+
+    # Pick the default architecture from the SDK's own metadata
+    # (SDKSettings.json's SupportedTargets[<target>].Archs), filtered by host
+    # arch. The SDK lists archs in its own preferred order (e.g. internal
+    # iphoneos lists arm64e first), so the filtered Archs[0] usually does the
+    # right thing. Mac is the exception: macosx.internal still lists arm64
+    # before arm64e, but WebKit's policy is to build internal Mac binaries as
+    # arm64e -- preserve that as an explicit override.
+    if (NOT CMAKE_OSX_ARCHITECTURES)
+        execute_process(COMMAND uname -m
+            OUTPUT_VARIABLE _host_arch
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        set(_pick "")
+        set(_sdk_settings "${CMAKE_OSX_SYSROOT}/SDKSettings.json")
+        if (EXISTS "${_sdk_settings}")
+            file(READ "${_sdk_settings}" _sdk_settings_json)
+            string(JSON _archs_count ERROR_VARIABLE _err
+                LENGTH "${_sdk_settings_json}" SupportedTargets ${_target_key} Archs)
+            if (NOT _err AND _archs_count GREATER 0)
+                set(_compat_archs)
+                math(EXPR _last "${_archs_count} - 1")
+                foreach (_i RANGE 0 ${_last})
+                    string(JSON _arch GET "${_sdk_settings_json}"
+                        SupportedTargets ${_target_key} Archs ${_i})
+                    if ((_host_arch STREQUAL "arm64" AND _arch MATCHES "^arm64") OR
+                        (_host_arch STREQUAL "x86_64" AND _arch MATCHES "^x86_64"))
+                        list(APPEND _compat_archs "${_arch}")
+                    endif ()
+                endforeach ()
+                if (USE_APPLE_INTERNAL_SDK AND "arm64e" IN_LIST _compat_archs)
+                    set(_pick "arm64e")
+                elseif (_compat_archs)
+                    list(GET _compat_archs 0 _pick)
+                endif ()
+            endif ()
+        endif ()
+        if (NOT _pick)
+            message(FATAL_ERROR "Could not determine default architecture from ${_sdk_settings} for target '${_target_key}' on ${_host_arch} host. Set CMAKE_OSX_ARCHITECTURES explicitly.")
+        endif ()
+        set(CMAKE_OSX_ARCHITECTURES "${_pick}" CACHE STRING "Target architecture" FORCE)
+    endif ()
+
+    if (PORT STREQUAL "IOS")
+        # CMake's cross-compile setup reads CMAKE_SYSTEM_NAME from the
+        # directory scope, not the cache, so use PARENT_SCOPE here.
+        set(CMAKE_SYSTEM_NAME iOS PARENT_SCOPE)
+        if (NOT CMAKE_SYSTEM_PROCESSOR)
+            set(CMAKE_SYSTEM_PROCESSOR "aarch64" CACHE STRING "Target processor" FORCE)
+        endif ()
+    endif ()
 endfunction()


### PR DESCRIPTION
#### 53ca7bcb3d760d6c55aef67c6414696a274c2f42
<pre>
[CMake] Select toolchain/deployment from SDK before project() is called
<a href="https://bugs.webkit.org/show_bug.cgi?id=316338">https://bugs.webkit.org/show_bug.cgi?id=316338</a>
<a href="https://rdar.apple.com/178756061">rdar://178756061</a>

Reviewed by NOBODY (OOPS!).

WIP, ignore below.

When CMAKE_OSX_SYSROOT names an Apple SDK, derive the matching
platform toolchain and the deployment target before the project()
call. This matches what xcodebuild does: an internal SDK is paired
with a versioned OSX&lt;ver&gt;.xctoolchain (newer linker), not XcodeDefault.

Both pieces must run pre-project() because that is the call that locks
in the C/C++ compiler binary for the configure run, and it consumes
CMAKE_OSX_DEPLOYMENT_TARGET for its own ABI-detection try_compile
tests. Setting either of them later -- e.g., from a port-specific
options file pulled in via include(WebKitCommon) -- is too late: the
cache values reflect the new toolchain/target, but project() has
already generated its build system using the old ones. The previous
post-project() compiler set in OptionsMac.cmake only ever shadowed the
locked-in cache value, and the post-project() deployment-target bump
would force the value back up to the SDK after our helpers ran.

The pre-project() work goes through two new helpers in
WebKitXcrun.cmake that take a sysroot path directly:

    WEBKIT_PIN_COMPILERS_FROM_SYSROOT asks `xcrun --show-toolchain-path`
    for the SDK&apos;s preferred toolchain and pins CMAKE_C_COMPILER and
    CMAKE_CXX_COMPILER from it. xcrun encodes the full SDK -&gt; toolchain
    mapping, so this works for every Apple platform without path parsing.

    WEBKIT_PIN_DEPLOYMENT_TARGET_FROM_SYSROOT pins
    CMAKE_OSX_DEPLOYMENT_TARGET. For macOS targets it uses the build
    host&apos;s macOS version (typical case is build-and-run on the same
    machine). For other Apple ports it falls back to the SDK version.
    Both branches are no-ops if the deployment target is already set.

Both helpers call execute_process directly rather than the existing
WEBKIT_XCRUN helper. WEBKIT_XCRUN&apos;s contract requires
WEBKIT_RESOLVE_SDK to have populated WEBKIT_SDK first from a list of
short SDK names; these helpers run pre-project() with a user-supplied
sysroot path, before any port-specific module that would call
WEBKIT_RESOLVE_SDK has been loaded.

To make the helpers reachable from the top of CMakeLists.txt,
CMAKE_MODULE_PATH and include(WebKitXcrun) are hoisted above the
project() call. WebKitXcrun.cmake has no project()-derived state, so
loading it early is safe.

The matching post-project() auto-bump of CMAKE_OSX_DEPLOYMENT_TARGET
in OptionsMac.cmake is removed -- the pre-project() helper now owns
that decision, and leaving the bump in place would force the
deployment target back up to the SDK version on every macOS configure.

* CMakeLists.txt:
* Source/cmake/OptionsCocoa.cmake:
* Source/cmake/OptionsIOS.cmake:
* Source/cmake/OptionsMac.cmake:
* Source/cmake/WebKitXcrun.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53ca7bcb3d760d6c55aef67c6414696a274c2f42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166825 "Failed to checkout and rebase branch from PR 66483") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40315 "Failed to checkout and rebase branch from PR 66483") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33896 "Failed to checkout and rebase branch from PR 66483") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175873 "Failed to checkout and rebase branch from PR 66483") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124083 "Failed to checkout and rebase branch from PR 66483") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40748 "Failed to checkout and rebase branch from PR 66483") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40323 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/175873 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/124083 "Failed to checkout and rebase branch from PR 66483") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169784 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/40748 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/33896 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/175873 "Failed to checkout and rebase branch from PR 66483") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/40748 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/40323 "Failed to checkout and rebase branch from PR 66483") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24609 "Failed to checkout and rebase branch from PR 66483") | | 
| [❌ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158982 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/40748 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/33896 "Failed to checkout and rebase branch from PR 66483") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178411 "Failed to checkout and rebase branch from PR 66483") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27719 "Failed to checkout and rebase branch from PR 66483") | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/33896 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/178411 "Failed to checkout and rebase branch from PR 66483") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40385 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/40323 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/178411 "Failed to checkout and rebase branch from PR 66483") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41073 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/33896 "Failed to checkout and rebase branch from PR 66483") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103871 "Failed to checkout and rebase branch from PR 66483") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/41073 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/33896 "Failed to checkout and rebase branch from PR 66483") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199504 "Failed to checkout and rebase branch from PR 66483") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39584 "Failed to checkout and rebase branch from PR 66483") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/199504 "Failed to checkout and rebase branch from PR 66483") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38980 "Failed to checkout and rebase branch from PR 66483") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/33896 "Failed to checkout and rebase branch from PR 66483") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39225 "Failed to checkout and rebase branch from PR 66483") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39123 "Failed to checkout and rebase branch from PR 66483") | | | | 
<!--EWS-Status-Bubble-End-->