### PR TITLE
CSP sandbox does not prevent cross-document view transition state transfer

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-csp-sandbox-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-csp-sandbox-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Cross-document view transition is blocked when new document has CSP sandbox without allow-same-origin
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-csp-sandbox.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-csp-sandbox.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>View Transitions: CSP sandbox without allow-same-origin must block cross-document view transition</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-2/">
+<link rel="author" href="mailto:roberto_rodriguez2@apple.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/common.js"></script>
+<script>
+assertViewTransitionOnNavigationImplemented();
+
+promise_test(async t => {
+    const result = await new Promise((resolve, reject) => {
+        window.addEventListener("message", event => resolve(event.data));
+        const popup = window.open("resources/csp-sandbox-old.html");
+        t.add_cleanup(() => popup.close());
+        t.step_timeout(() => reject("Timed out waiting for postMessage"), 10000);
+    });
+
+    assert_false(result.hasViewTransition,
+        "CSP-sandboxed document (opaque origin) must not receive an inbound cross-document view transition");
+    assert_equals(result.keyframes.length, 0,
+        "No keyframe data from the previous page should be accessible");
+}, "Cross-document view transition is blocked when new document has CSP sandbox without allow-same-origin");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/csp-sandbox-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/csp-sandbox-new.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+@view-transition { navigation: auto; }
+.target { view-transition-name: target; width: 10px; height: 10px; background: transparent; }
+</style>
+<div class="target"></div>
+<script>
+addEventListener("pagereveal", event => {
+    const hasViewTransition = !!(event && event.viewTransition);
+    function report() {
+        const keyframes = [];
+        for (const animation of document.getAnimations()) {
+            if (animation.effect && typeof animation.effect.getKeyframes === "function") {
+                const animationKeyframes = animation.effect.getKeyframes();
+                if (animationKeyframes.length > 0)
+                    keyframes.push({ pseudo: animation.effect.pseudoElement || null, frames: animationKeyframes });
+            }
+        }
+        if (window.opener)
+            window.opener.postMessage({ hasViewTransition, keyframes }, "*");
+    }
+    if (hasViewTransition)
+        event.viewTransition.ready.then(report).catch(report);
+    else
+        report();
+});
+setTimeout(() => {
+    if (window.opener)
+        window.opener.postMessage({ hasViewTransition: false, keyframes: [] }, "*");
+}, 3000);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/csp-sandbox-new.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/csp-sandbox-new.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/csp-sandbox-old.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/csp-sandbox-old.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+@view-transition { navigation: auto; }
+.target {
+    view-transition-name: target;
+    width: 480px;
+    height: 270px;
+    transform: rotate(7deg);
+    background: red;
+}
+</style>
+<div class="target">SENSITIVE</div>
+<script>
+onload = () => requestAnimationFrame(() => requestAnimationFrame(() => {
+    location.replace("csp-sandbox-new.html");
+}));
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8952,6 +8952,7 @@ void Document::dispatchPageswapEvent(CanTriggerCrossDocumentViewTransition canTr
         // Store it on the old, and we'll call transferViewTransitionParams soon.
         m_inboundViewTransitionParams = oldViewTransition->takeViewTransitionParams().moveToUniquePtr();
         m_inboundViewTransitionParams->startTime = startTime;
+        m_inboundViewTransitionParams->oldDocumentOrigin = &securityOrigin();
     }
 }
 

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -120,6 +120,12 @@ RefPtr<ViewTransition> ViewTransition::resolveInboundCrossDocumentViewTransition
     if (MonotonicTime::now() - inboundViewTransitionParams->startTime > defaultTimeout)
         return nullptr;
 
+    // Re-check against the new document's final origin, which may differ from the URL-derived
+    // origin used by DocumentLoader::navigationCanTriggerCrossDocumentViewTransition.
+    if (!inboundViewTransitionParams->oldDocumentOrigin
+        || !inboundViewTransitionParams->oldDocumentOrigin->isSameOriginAs(document.securityOrigin()))
+        return nullptr;
+
     if (document.activeViewTransition())
         return nullptr;
 

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -55,7 +55,6 @@ class DOMPromise;
 class DeferredPromise;
 class RenderLayerModelObject;
 class RenderViewTransitionCapture;
-class RenderLayerModelObject;
 class ViewTransitionTypeSet;
 template<typename> class ExceptionOr;
 
@@ -169,6 +168,7 @@ public:
     FloatSize initialLargeViewportSize;
     float initialPageZoom;
     MonotonicTime startTime;
+    RefPtr<SecurityOrigin> oldDocumentOrigin;
 };
 
 class ViewTransition : public RefCounted<ViewTransition>, public VisibilityChangeClient, public ActiveDOMObject {


### PR DESCRIPTION
#### cc6b337ba1540c4c071c16103cd2c0fdb8e32564
<pre>
CSP sandbox does not prevent cross-document view transition state transfer
<a href="https://bugs.webkit.org/show_bug.cgi?id=314705">https://bugs.webkit.org/show_bug.cgi?id=314705</a>
<a href="https://rdar.apple.com/175369822">rdar://175369822</a>

Reviewed by Tim Nguyen.

A navigation to a same-origin URL that responds with Content-Security-Policy: sandbox
(but without allow-same-origin) still receives the full inbound cross-document view
transition. The same-origin check runs before CSP headers are applied and is never
re-evaluated. The previous page&apos;s captured element names, geometry, and rendered content
get transfered to the sandboxed document.

Store the old document&apos;s SecurityOrigin in ViewTransitionParams at pageswap capture time.
Re-check same-origin in resolveInboundCrossDocumentViewTransition, which runs during
Document::reveal() after CSP headers have been applied and the new document&apos;s final origin
is established. If the origins no longer match, the transition is rejected and no state is
transferred.

Test: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-csp-sandbox.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-csp-sandbox-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-csp-sandbox.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/csp-sandbox-new.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/csp-sandbox-new.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/csp-sandbox-old.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::dispatchPageswapEvent):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::resolveInboundCrossDocumentViewTransition):
* Source/WebCore/dom/ViewTransition.h:

Originally-landed-as: 305413.920@safari-7624-branch (5002f3bd2e07). <a href="https://rdar.apple.com/175369822">rdar://175369822</a>
Canonical link: <a href="https://commits.webkit.org/314585@main">https://commits.webkit.org/314585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e9f34819a14e695927081bd259a03c3829cb7a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166536 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175584 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77fd77fe-681e-4525-b983-79a0feebfd0f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129477 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97ea06ff-a442-45f2-9cac-84e899d8a17e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169495 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110002 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/450354f2-c6ae-4f0c-8316-d5e127678014) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23725 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178118 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31018 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137833 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137751 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37116 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149134 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103508 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33044 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39294 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38691 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4088 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38936 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38834 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->