### PR TITLE
font-synthesis: Avoid synthetic oblique for variable fonts in @font-face

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4343,7 +4343,6 @@ webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-variation
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-variation-settings-descriptor-03.html [ ImageOnlyFailure ]
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-variation-settings-descriptor-04.html [ ImageOnlyFailure ]
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/matching/font-weight-search-direction.html [ ImageOnlyFailure ]
-webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/synthetic-oblique-out-of-capabilities-range.html [ ImageOnlyFailure ]
 webkit.org/b/207711 [ Debug ] fast/selectors/slow-style-sharing-with-long-cousin-list.html [ Slow ]
 webkit.org/b/208368 imported/w3c/web-platform-tests/wasm/jsapi/constructor/instantiate-bad-imports.any.worker.html [ Failure Pass ]
 webkit.org/b/209720 fast/css-grid-layout/grid-align-baseline-vertical.html [ Failure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2794,7 +2794,6 @@ webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-synthesis
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-variation-settings-descriptor-01.html [ ImageOnlyFailure ]
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-variation-settings-descriptor-03.html [ ImageOnlyFailure ]
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-variation-settings-descriptor-04.html [ ImageOnlyFailure ]
-webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/synthetic-oblique-out-of-capabilities-range.html [ ImageOnlyFailure ]
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/variations/variable-avar2-warp.html [ ImageOnlyFailure ]
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/variations/variable-gpos-avar2.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1148,7 +1148,6 @@ webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-synthesis
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-variation-settings-descriptor-01.html [ ImageOnlyFailure ]
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-variation-settings-descriptor-03.html [ ImageOnlyFailure ]
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/font-variation-settings-descriptor-04.html [ ImageOnlyFailure ]
-webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/synthetic-oblique-out-of-capabilities-range.html [ ImageOnlyFailure ]
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/variations/variable-avar2-warp.html [ ImageOnlyFailure ]
 webkit.org/b/315568 imported/w3c/web-platform-tests/css/css-fonts/variations/variable-gpos-avar2.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -220,7 +220,7 @@ RefPtr<Font> CSSFontFaceSource::font(const FontDescription& fontDescription, boo
         if (m_immediateSource) {
             if (!m_immediateFontCustomPlatformData)
                 return nullptr;
-            return Font::create(CachedFont::platformDataFromCustomData(Ref { *m_immediateFontCustomPlatformData }, fontDescription, syntheticItalic, fontCreationContext), Font::Origin::Remote);
+            return Font::create(CachedFont::platformDataFromCustomData(Ref { *m_immediateFontCustomPlatformData }, fontDescription, fontCreationContext), Font::Origin::Remote);
         }
 
         // We're local. Just return a Font from the normal cache.
@@ -238,7 +238,7 @@ RefPtr<Font> CSSFontFaceSource::font(const FontDescription& fontDescription, boo
         ASSERT_UNUSED(success, success);
 
         ASSERT(status() == Status::Success);
-        auto result = m_fontRequest->createFont(fontDescription, syntheticItalic, fontCreationContext);
+        auto result = m_fontRequest->createFont(fontDescription, fontCreationContext);
         ASSERT(result);
         return result;
     }
@@ -250,7 +250,7 @@ RefPtr<Font> CSSFontFaceSource::font(const FontDescription& fontDescription, boo
         return nullptr;
     if (!m_inDocumentCustomPlatformData)
         return nullptr;
-    return Font::create(Ref { *m_inDocumentCustomPlatformData }->fontPlatformData(fontDescription, syntheticItalic, fontCreationContext), Font::Origin::Remote);
+    return Font::create(Ref { *m_inDocumentCustomPlatformData }->fontPlatformData(fontDescription, fontCreationContext), Font::Origin::Remote);
 }
 
 bool CSSFontFaceSource::isSVGFontFaceSource() const

--- a/Source/WebCore/loader/FontLoadRequest.h
+++ b/Source/WebCore/loader/FontLoadRequest.h
@@ -57,7 +57,7 @@ public:
     virtual bool errorOccurred() const = 0;
 
     virtual bool ensureCustomFontData() = 0;
-    virtual RefPtr<Font> createFont(const FontDescription&, bool syntheticItalic, const FontCreationContext&) = 0;
+    virtual RefPtr<Font> createFont(const FontDescription&, const FontCreationContext&) = 0;
 
     virtual void setClient(FontLoadRequestClient*) = 0;
 

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -216,21 +216,21 @@ RefPtr<FontCustomPlatformData> CachedFont::createCustomFontDataSafeFontParser(Sh
     return FontCustomPlatformData::createMemorySafe(*buffer, itemInCollection);
 }
 
-RefPtr<Font> CachedFont::createFont(const FontDescription& fontDescription, bool syntheticItalic, const FontCreationContext& fontCreationContext)
+RefPtr<Font> CachedFont::createFont(const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)
 {
-    return Font::create(platformDataFromCustomData(fontDescription, syntheticItalic, fontCreationContext), Font::Origin::Remote);
+    return Font::create(platformDataFromCustomData(fontDescription, fontCreationContext), Font::Origin::Remote);
 }
 
-FontPlatformData CachedFont::platformDataFromCustomData(const FontDescription& fontDescription, bool italic, const FontCreationContext& fontCreationContext)
+FontPlatformData CachedFont::platformDataFromCustomData(const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)
 {
     RefPtr fontCustomPlatformData = m_fontCustomPlatformData;
     ASSERT(fontCustomPlatformData);
-    return platformDataFromCustomData(*fontCustomPlatformData, fontDescription, italic, fontCreationContext);
+    return platformDataFromCustomData(*fontCustomPlatformData, fontDescription, fontCreationContext);
 }
 
-FontPlatformData CachedFont::platformDataFromCustomData(FontCustomPlatformData& fontCustomPlatformData, const FontDescription& fontDescription, bool italic, const FontCreationContext& fontCreationContext)
+FontPlatformData CachedFont::platformDataFromCustomData(FontCustomPlatformData& fontCustomPlatformData, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)
 {
-    return fontCustomPlatformData.fontPlatformData(fontDescription, italic, fontCreationContext);
+    return fontCustomPlatformData.fontPlatformData(fontDescription, fontCreationContext);
 }
 
 void CachedFont::allClientsRemoved()

--- a/Source/WebCore/loader/cache/CachedFont.h
+++ b/Source/WebCore/loader/cache/CachedFont.h
@@ -57,14 +57,14 @@ public:
 
     virtual bool ensureCustomFontData();
     static RefPtr<FontCustomPlatformData> createCustomFontData(SharedBuffer&, const String& itemInCollection, bool& wrapping, DownloadableBinaryFontTrustedTypes);
-    static FontPlatformData platformDataFromCustomData(FontCustomPlatformData&, const FontDescription&, bool italic, const FontCreationContext&);
+    static FontPlatformData platformDataFromCustomData(FontCustomPlatformData&, const FontDescription&, const FontCreationContext&);
 
-    virtual RefPtr<Font> createFont(const FontDescription&, bool syntheticItalic, const FontCreationContext&);
+    virtual RefPtr<Font> createFont(const FontDescription&, const FontCreationContext&);
 
     bool didRefuseToParseCustomFontWithSafeFontParser() const { return m_didRefuseToParseCustomFont; }
 
 protected:
-    FontPlatformData platformDataFromCustomData(const FontDescription&, bool italic, const FontCreationContext&);
+    FontPlatformData platformDataFromCustomData(const FontDescription&, const FontCreationContext&);
 
     bool ensureCustomFontData(SharedBuffer* data);
 

--- a/Source/WebCore/loader/cache/CachedFontLoadRequest.h
+++ b/Source/WebCore/loader/cache/CachedFontLoadRequest.h
@@ -84,9 +84,9 @@ private:
         return result;
     }
 
-    RefPtr<Font> createFont(const FontDescription& description, bool syntheticItalic, const FontCreationContext& fontCreationContext) final
+    RefPtr<Font> createFont(const FontDescription& description, const FontCreationContext& fontCreationContext) final
     {
-        return protect(m_font)->createFont(description, syntheticItalic, fontCreationContext);
+        return protect(m_font)->createFont(description, fontCreationContext);
     }
 
     void setClient(FontLoadRequestClient* client) final

--- a/Source/WebCore/loader/cache/CachedSVGFont.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGFont.cpp
@@ -30,6 +30,7 @@
 #include "CookieJar.h"
 #include "ElementChildIteratorInlines.h"
 #include "FontCreationContext.h"
+#include "FontCustomPlatformData.h"
 #include "FontDescription.h"
 #include "FontPlatformData.h"
 #include "ParserContentPolicy.h"
@@ -59,17 +60,17 @@ CachedSVGFont::CachedSVGFont(CachedResourceRequest&& request, CachedSVGFont& res
 
 CachedSVGFont::~CachedSVGFont() = default;
 
-RefPtr<Font> CachedSVGFont::createFont(const FontDescription& fontDescription, bool syntheticItalic, const FontCreationContext& fontCreationContext)
+RefPtr<Font> CachedSVGFont::createFont(const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)
 {
     ASSERT(firstFontFace());
-    return CachedFont::createFont(fontDescription, syntheticItalic, fontCreationContext);
+    return CachedFont::createFont(fontDescription, fontCreationContext);
 }
 
-FontPlatformData CachedSVGFont::platformDataFromCustomData(const FontDescription& fontDescription, bool italic, const FontCreationContext& fontCreationContext)
+FontPlatformData CachedSVGFont::platformDataFromCustomData(const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)
 {
     if (m_externalSVGDocument)
-        return FontPlatformData(fontDescription.computedSize(), false, italic); // FIXME: Why are we creating a bogus font here?
-    return CachedFont::platformDataFromCustomData(fontDescription, italic, fontCreationContext);
+        return FontPlatformData(fontDescription.computedSize(), computeSyntheticBold(false, fontDescription, fontCreationContext), computeSyntheticItalic(false, fontDescription, fontCreationContext)); // FIXME: Why are we creating a bogus font here?
+    return CachedFont::platformDataFromCustomData(fontDescription, fontCreationContext);
 }
 
 bool CachedSVGFont::ensureCustomFontData()

--- a/Source/WebCore/loader/cache/CachedSVGFont.h
+++ b/Source/WebCore/loader/cache/CachedSVGFont.h
@@ -41,10 +41,10 @@ public:
     virtual ~CachedSVGFont();
 
     bool ensureCustomFontData() final;
-    RefPtr<Font> createFont(const FontDescription&, bool syntheticItalic, const FontCreationContext&) final;
+    RefPtr<Font> createFont(const FontDescription&, const FontCreationContext&) final;
 
 private:
-    FontPlatformData platformDataFromCustomData(const FontDescription&, bool italic, const FontCreationContext&);
+    FontPlatformData platformDataFromCustomData(const FontDescription&, const FontCreationContext&);
 
     SVGFontElement* NODELETE getSVGFontById(const AtomString&) const;
 

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -77,14 +77,14 @@ Ref<Font> Font::create(const FontPlatformData& platformData, Origin origin, IsIn
     return adoptRef(*new Font(platformData, origin, interstitial, visibility, orientationFallback, identifier));
 }
 
-Ref<Font> Font::create(Ref<SharedBuffer>&& fontFaceData, Font::Origin origin, float fontSize, bool, bool syntheticItalic, DownloadableBinaryFontTrustedTypes trustedType)
+Ref<Font> Font::create(Ref<SharedBuffer>&& fontFaceData, Font::Origin origin, float fontSize, bool, bool, DownloadableBinaryFontTrustedTypes trustedType)
 {
     bool wrapping;
     auto customFontData = CachedFont::createCustomFontData(fontFaceData.get(), { }, wrapping, trustedType);
     FontDescription description;
     description.setComputedSize(fontSize);
     // FIXME: Why doesn't this pass in any meaningful data for the last few arguments?
-    auto platformData = CachedFont::platformDataFromCustomData(*customFontData, description, syntheticItalic, { });
+    auto platformData = CachedFont::platformDataFromCustomData(*customFontData, description, { });
     return Font::create(WTF::move(platformData), origin);
 }
 

--- a/Source/WebCore/platform/graphics/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontCustomPlatformData.h
@@ -90,8 +90,7 @@ public:
 #endif
     WEBCORE_EXPORT ~FontCustomPlatformData();
 
-    FontPlatformData fontPlatformData(const FontDescription&, bool italic, const FontCreationContext&);
-
+    FontPlatformData fontPlatformData(const FontDescription&, const FontCreationContext&);
 
     WEBCORE_EXPORT FontCustomPlatformSerializedData NODELETE serializedData() const;
     WEBCORE_EXPORT static std::optional<Ref<FontCustomPlatformData>> tryMakeFromSerializationData(FontCustomPlatformSerializedData&&, bool);
@@ -125,6 +124,20 @@ inline bool computeSyntheticBold(bool hasWeightVariationAxis, const FontDescript
     return fontDescription.hasAutoFontSynthesisWeight()
         && isFontWeightBold(fontDescription.weight())
         && !isFontWeightBold(declaredWeightMax);
+}
+
+inline bool computeSyntheticItalic(bool hasSlopeVariationAxis, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)
+{
+    auto explicitlyDeclaredSlope = fontCreationContext.fontFaceCapabilities().slope;
+    // No explicit font-style descriptor (auto): the variable font's slnt/ital axis handles slope, so don't synthesize.
+    if (hasSlopeVariationAxis && !explicitlyDeclaredSlope)
+        return false;
+    auto declaredSlopeMax = explicitlyDeclaredSlope
+        .transform([](auto range) { return range.maximum; })
+        .value_or(normalItalicValue());
+    return fontDescription.allowsItalicOrObliqueFontSynthesisStyle()
+        && isItalic(fontDescription.fontStyleSlope())
+        && !isItalic(declaredSlopeMax);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 
 FontCustomPlatformData::~FontCustomPlatformData() = default;
 
-FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription& fontDescription, bool italic, const FontCreationContext& fontCreationContext)
+FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)
 {
     auto size = fontDescription.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
     UnrealizedCoreTextFont unrealizedFont = { RetainPtr { fontDescriptor } };
@@ -55,8 +55,12 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     auto font = preparePlatformFont(WTF::move(unrealizedFont), fontDescription, fontCreationContext);
     ASSERT(font);
 
-    bool hasWeightVariationAxis = defaultVariationValues(font.get(), ShouldLocalizeAxisNames::No).contains(FontVariationAxisTag::wght);
-    FontPlatformData platformData(font.get(), size, computeSyntheticBold(hasWeightVariationAxis, fontDescription, fontCreationContext), italic, orientation, widthVariant, fontDescription.textRenderingMode(), this);
+    auto variationAxes = defaultVariationValues(font.get(), ShouldLocalizeAxisNames::No);
+    bool hasWeightVariationAxis = variationAxes.contains(FontVariationAxisTag::wght);
+    bool hasSlopeVariationAxis = variationAxes.contains(FontVariationAxisTag::slnt) || variationAxes.contains(FontVariationAxisTag::ital);
+    bool syntheticBold = computeSyntheticBold(hasWeightVariationAxis, fontDescription, fontCreationContext);
+    bool syntheticItalic = computeSyntheticItalic(hasSlopeVariationAxis, fontDescription, fontCreationContext);
+    FontPlatformData platformData(font.get(), size, syntheticBold, syntheticItalic, orientation, widthVariant, fontDescription.textRenderingMode(), this);
 
     platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
     return platformData;

--- a/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
@@ -80,7 +80,7 @@ static RefPtr<FcPattern> defaultFontconfigOptions()
     return adoptRef(FcPatternDuplicate(pattern));
 }
 
-FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription& description, bool italic, const FontCreationContext& fontCreationContext)
+FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription& description, const FontCreationContext& fontCreationContext)
 {
     auto* freeTypeFace = static_cast<FT_Face>(cairo_font_face_get_user_data(m_fontFace.get(), &freeTypeFaceKey));
     ASSERT(freeTypeFace);
@@ -102,14 +102,17 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     if (!variants.isEmpty())
         FcPatternAddString(pattern.get(), FC_FONT_VARIATIONS, reinterpret_cast<const FcChar8*>(variants.utf8().data()));
     auto defaultValues = defaultVariationValues(freeTypeFace, ShouldLocalizeAxisNames::No);
-    bool hasWeightVariationAxis = defaultValues.contains({ { 'w', 'g', 'h', 't' } });
+    bool hasWeightVariationAxis = defaultValues.contains(FontVariationAxisTag::wght);
+    bool hasSlopeVariationAxis = defaultValues.contains(FontVariationAxisTag::slnt) || defaultValues.contains(FontVariationAxisTag::ital);
 #else
     bool hasWeightVariationAxis = false;
+    bool hasSlopeVariationAxis = false;
 #endif
     bool syntheticBold = computeSyntheticBold(hasWeightVariationAxis, description, fontCreationContext);
+    bool syntheticItalic = computeSyntheticItalic(hasSlopeVariationAxis, description, fontCreationContext);
 
     auto size = description.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
-    FontPlatformData platformData(m_fontFace.get(), WTF::move(pattern), size, freeTypeFace->face_flags & FT_FACE_FLAG_FIXED_WIDTH, syntheticBold, italic, description.orientation());
+    FontPlatformData platformData(m_fontFace.get(), WTF::move(pattern), size, freeTypeFace->face_flags & FT_FACE_FLAG_FIXED_WIDTH, syntheticBold, syntheticItalic, description.orientation());
 
     platformData.updateSizeWithFontSizeAdjust(description.fontSizeAdjust(), description.computedSize());
     return platformData;

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -44,12 +44,13 @@ FontCustomPlatformData::FontCustomPlatformData(sk_sp<SkTypeface>&& typeface, Fon
 
 FontCustomPlatformData::~FontCustomPlatformData() = default;
 
-FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription& description, bool italic, const FontCreationContext& fontCreationContext)
+FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription& description, const FontCreationContext& fontCreationContext)
 {
     sk_sp<SkTypeface> typeface = m_typeface;
 
     auto defaultValues = defaultFontVariationValues(*typeface);
-    bool hasWeightVariationAxis = defaultValues.contains({ { 'w', 'g', 'h', 't' } });
+    bool hasWeightVariationAxis = defaultValues.contains(FontVariationAxisTag::wght);
+    bool hasSlopeVariationAxis = defaultValues.contains(FontVariationAxisTag::slnt) || defaultValues.contains(FontVariationAxisTag::ital);
     if (!defaultValues.isEmpty()) {
         Vector<SkFontArguments::VariationPosition::Coordinate> variationsToBeApplied;
         auto applyVariation = [&](const FontTag& tag, float value) {
@@ -97,7 +98,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     auto size = description.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
     auto features = FontCache::computeFeatures(description, fontCreationContext);
 
-    FontPlatformData platformData(WTF::move(typeface), size, computeSyntheticBold(hasWeightVariationAxis, description, fontCreationContext), italic, description.orientation(), description.widthVariant(), description.textRenderingMode(), WTF::move(features), this);
+    FontPlatformData platformData(WTF::move(typeface), size, computeSyntheticBold(hasWeightVariationAxis, description, fontCreationContext), computeSyntheticItalic(hasSlopeVariationAxis, description, fontCreationContext), description.orientation(), description.widthVariant(), description.textRenderingMode(), WTF::move(features), this);
     platformData.updateSizeWithFontSizeAdjust(description.fontSizeAdjust(), description.computedSize());
     return platformData;
 }

--- a/Source/WebCore/platform/graphics/win/cairo/FontCustomPlatformDataWinCairo.cpp
+++ b/Source/WebCore/platform/graphics/win/cairo/FontCustomPlatformDataWinCairo.cpp
@@ -31,11 +31,12 @@ namespace WebCore {
 
 cairo_font_face_t* createCairoDWriteFontFace(HFONT);
 
-FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription& fontDescription, bool italic, const FontCreationContext& fontCreationContext)
+FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)
 {
     auto size = fontDescription.computedSize();
 
     bool syntheticBold = computeSyntheticBold(false, fontDescription, fontCreationContext);
+    bool syntheticItalic = computeSyntheticItalic(false, fontDescription, fontCreationContext);
 
     LOGFONT logFont;
     memset(&logFont, 0, sizeof(LOGFONT));
@@ -51,14 +52,14 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     logFont.lfOutPrecision = OUT_TT_ONLY_PRECIS;
     logFont.lfQuality = CLEARTYPE_QUALITY;
     logFont.lfPitchAndFamily = DEFAULT_PITCH | FF_DONTCARE;
-    logFont.lfItalic = italic;
+    logFont.lfItalic = syntheticItalic;
     logFont.lfWeight = syntheticBold ? 700 : 400;
 
     auto hfont = adoptGDIObject(::CreateFontIndirect(&logFont));
 
     cairo_font_face_t* fontFace = createCairoDWriteFontFace(hfont.get());
 
-    FontPlatformData fontPlatformData(WTF::move(hfont), fontFace, size, syntheticBold, italic, this);
+    FontPlatformData fontPlatformData(WTF::move(hfont), fontFace, size, syntheticBold, syntheticItalic, this);
 
     cairo_font_face_destroy(fontFace);
 

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -112,11 +112,11 @@ bool WorkerFontLoadRequest::ensureCustomFontData()
     return m_fontCustomPlatformData.get();
 }
 
-RefPtr<Font> WorkerFontLoadRequest::createFont(const FontDescription& fontDescription, bool syntheticItalic, const FontCreationContext& fontCreationContext)
+RefPtr<Font> WorkerFontLoadRequest::createFont(const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)
 {
     ASSERT(m_fontCustomPlatformData);
     ASSERT(m_context);
-    return Font::create(m_fontCustomPlatformData->fontPlatformData(fontDescription, syntheticItalic, fontCreationContext), Font::Origin::Remote);
+    return Font::create(m_fontCustomPlatformData->fontPlatformData(fontDescription, fontCreationContext), Font::Origin::Remote);
 }
 
 void WorkerFontLoadRequest::setClient(FontLoadRequestClient* client)

--- a/Source/WebCore/workers/WorkerFontLoadRequest.h
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.h
@@ -62,7 +62,7 @@ private:
     bool errorOccurred() const final { return m_errorOccurred; }
 
     bool ensureCustomFontData() final;
-    RefPtr<Font> createFont(const FontDescription&, bool syntheticItalic, const FontCreationContext&) final;
+    RefPtr<Font> createFont(const FontDescription&, const FontCreationContext&) final;
 
     void setClient(FontLoadRequestClient*) final;
 


### PR DESCRIPTION
#### 06d88499f9e6ae4b4d107b185b7a2e2273840bc6
<pre>
font-synthesis: Avoid synthetic oblique for variable fonts in @font-face
<a href="https://bugs.webkit.org/show_bug.cgi?id=316289">https://bugs.webkit.org/show_bug.cgi?id=316289</a>
<a href="https://rdar.apple.com/178698772">rdar://178698772</a>

Reviewed by Brent Fulgham.

Same as <a href="https://commits.webkit.org/314814@main">https://commits.webkit.org/314814@main</a> but for the oblique/italic axis:
a variable font with a slnt or ital axis already produces the closest available
slope, so synthetic obliquing on top is wrong. Only suppress synthesis when the
font-style descriptor is auto, letting the variable axis own the slope. Also fix
CachedSVGFont to compute synthetic bold/italic instead of hardcoding them false.

Spec: <a href="https://drafts.csswg.org/css-fonts-4/#font-prop-desc">https://drafts.csswg.org/css-fonts-4/#font-prop-desc</a>
Resolution: <a href="https://github.com/w3c/csswg-drafts/issues/7999">https://github.com/w3c/csswg-drafts/issues/7999</a>

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/css/CSSFontFaceSource.cpp:
(WebCore::CSSFontFaceSource::font):
* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::createFont):
(WebCore::CachedFont::platformDataFromCustomData):
* Source/WebCore/loader/cache/CachedFont.h:
* Source/WebCore/loader/cache/CachedSVGFont.cpp:
(WebCore::CachedSVGFont::platformDataFromCustomData):
* Source/WebCore/loader/cache/CachedSVGFont.h:
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::Font::create):
* Source/WebCore/platform/graphics/FontCustomPlatformData.h:
(WebCore::computeSyntheticItalic):
* Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp:
(WebCore::fontHasSlopeVariationAxis):
(WebCore::FontCustomPlatformData::fontPlatformData):
* Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):
* Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):
* Source/WebCore/platform/graphics/win/cairo/FontCustomPlatformDataWinCairo.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):
* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
(WebCore::WorkerFontLoadRequest::createFont):
* Source/WebCore/workers/WorkerFontLoadRequest.h:

Canonical link: <a href="https://commits.webkit.org/315345@main">https://commits.webkit.org/315345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5924594c1cada2cc8c56f2966f95d1dc739a65a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126472 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4546ae0d-90ad-4599-bfbd-80f0186cfb37) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131401 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/58eea2eb-8a4b-4b29-938a-cb94d52c7e03) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33855 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111905 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2c891395-afd4-4b9b-ae72-65edc07a829f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26791 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180697 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139851 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139695 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37611 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43025 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106771 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34970 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114792 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41528 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6135 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40925 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41179 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41070 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->