### PR TITLE
Extend bounds check validation to include all IRO facts

### DIFF
--- a/JSTests/stress/integer-range-optimization-fact-poison-arithabs-crashes.js
+++ b/JSTests/stress/integer-range-optimization-fact-poison-arithabs-crashes.js
@@ -1,0 +1,19 @@
+//@ mustCrashWith!(:trap, "Bounds Check Elimination error found")
+//@ skip if $hostOS == "windows"
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// Drives IRO's ArithAbs -> Identity transform: the inserted range assertion
+// must catch a value outside the poisoned [min, max].
+function poisoned(x) {
+    let y = $vm.iroFactPoison(x | 0, 0, 0);
+    return Math.abs(y);
+}
+noInline(poisoned);
+
+for (let i = 0; i < testLoopCount; ++i)
+    poisoned(0);
+
+poisoned(-1);
+
+throw new Error("Should have crashed before reaching here");

--- a/JSTests/stress/integer-range-optimization-fact-poison-checkinbounds-crashes.js
+++ b/JSTests/stress/integer-range-optimization-fact-poison-checkinbounds-crashes.js
@@ -1,0 +1,22 @@
+//@ mustCrashWith!(:trap, "Bounds Check Elimination error found")
+//@ skip if $hostOS == "windows"
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// Drives the GetByVal-on-Undecided-array transform (converts to `undefined`
+// once IRO proves the index is non-negative). The inserted range assertion
+// must catch a negative runtime index.
+const undecided = new Array(8);
+
+function poisoned(x) {
+    let i = $vm.iroFactPoison(x | 0, 0, 1000);
+    return undecided[i];
+}
+noInline(poisoned);
+
+for (let i = 0; i < testLoopCount; ++i)
+    poisoned(0);
+
+poisoned(-1);
+
+throw new Error("Should have crashed before reaching here");

--- a/JSTests/stress/integer-range-optimization-fact-poison-crashes.js
+++ b/JSTests/stress/integer-range-optimization-fact-poison-crashes.js
@@ -1,0 +1,20 @@
+//@ mustCrashWith!(:trap, "Bounds Check Elimination error found")
+//@ skip if $hostOS == "windows"
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// Lie to IRO via iroFactPoison, then call with a non-conforming value. The
+// AssertInBounds emitted at the IROFactPoison site must catch the lie.
+
+function poisoned(x) {
+    let y = $vm.iroFactPoison(x | 0, 0, 0);
+    return y + 5;
+}
+noInline(poisoned);
+
+for (let i = 0; i < testLoopCount; ++i)
+    poisoned(0);
+
+poisoned(1000);
+
+throw new Error("Should have crashed before reaching here");

--- a/JSTests/stress/integer-range-optimization-fact-poison-loop-crashes.js
+++ b/JSTests/stress/integer-range-optimization-fact-poison-loop-crashes.js
@@ -1,0 +1,24 @@
+//@ mustCrashWith!(:trap, "Bounds Check Elimination error found")
+//@ skip if $hostOS == "windows"
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// Exposes the inserted AssertInBounds to LICM / CSE / DCE: the consumer is
+// in-loop, so any post-IRO pass silently dropping a NodeMustGenerate
+// AssertInBounds would make this test stop crashing.
+function poisoned(start) {
+    let acc = 0;
+    for (let i = 0; i < 100; ++i) {
+        let y = $vm.iroFactPoison(start | 0, 0, 0);
+        acc = acc + y + 5;
+    }
+    return acc;
+}
+noInline(poisoned);
+
+for (let i = 0; i < testLoopCount; ++i)
+    poisoned(0);
+
+poisoned(1000);
+
+throw new Error("Should have crashed before reaching here");

--- a/JSTests/stress/integer-range-optimization-fact-poison-misuse-arity-crashes.js
+++ b/JSTests/stress/integer-range-optimization-fact-poison-misuse-arity-crashes.js
@@ -1,0 +1,16 @@
+//@ mustCrashWith!(:trap, "$vm.iroFactPoison requires 3 arguments")
+//@ skip if $hostOS == "windows"
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// Too-few-args misuse - parser-side RELEASE_ASSERT must fire.
+
+function misuse(x) {
+    return $vm.iroFactPoison(x | 0);
+}
+noInline(misuse);
+
+for (let i = 0; i < testLoopCount; ++i)
+    misuse(i);
+
+throw new Error("Should have crashed before reaching here");

--- a/JSTests/stress/integer-range-optimization-fact-poison-misuse-bad-args-crashes.js
+++ b/JSTests/stress/integer-range-optimization-fact-poison-misuse-bad-args-crashes.js
@@ -1,0 +1,16 @@
+//@ mustCrashWith!(:trap, "iroFactPoison: bound must be a numeric constant")
+//@ skip if $hostOS == "windows"
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// Non-numeric bound - parser-side RELEASE_ASSERT must fire.
+
+function misuse(x) {
+    return $vm.iroFactPoison(x | 0, "low", "high");
+}
+noInline(misuse);
+
+for (let i = 0; i < testLoopCount; ++i)
+    misuse(i);
+
+throw new Error("Should have crashed before reaching here");

--- a/JSTests/stress/integer-range-optimization-fact-poison-misuse-fractional-crashes.js
+++ b/JSTests/stress/integer-range-optimization-fact-poison-misuse-fractional-crashes.js
@@ -1,0 +1,16 @@
+//@ mustCrashWith!(:trap, "iroFactPoison: bound must be an integer in int32 range")
+//@ skip if $hostOS == "windows"
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// Non-integer bound - parser-side RELEASE_ASSERT must fire.
+
+function misuse(x) {
+    return $vm.iroFactPoison(x | 0, 0, 1.5);
+}
+noInline(misuse);
+
+for (let i = 0; i < testLoopCount; ++i)
+    misuse(i);
+
+throw new Error("Should have crashed before reaching here");

--- a/JSTests/stress/integer-range-optimization-fact-poison-negative-range-crashes.js
+++ b/JSTests/stress/integer-range-optimization-fact-poison-negative-range-crashes.js
@@ -1,0 +1,18 @@
+//@ mustCrashWith!(:trap, "Bounds Check Elimination error found")
+//@ skip if $hostOS == "windows"
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// Signed-negative range - the assertion must use signed comparison.
+function poisoned(x) {
+    let y = $vm.iroFactPoison(x | 0, -10, -1);
+    return y + 1;
+}
+noInline(poisoned);
+
+for (let i = 0; i < testLoopCount; ++i)
+    poisoned(-3);
+
+poisoned(5);
+
+throw new Error("Should have crashed before reaching here");

--- a/JSTests/stress/integer-range-optimization-fact-poison-removed-checkinbounds.js
+++ b/JSTests/stress/integer-range-optimization-fact-poison-removed-checkinbounds.js
@@ -1,0 +1,26 @@
+//@ mustCrashWith!(:trap, "Bounds Check Elimination error found")
+//@ skip if $hostOS == "windows"
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// Two CheckInBounds in one function: the second is eliminable once the first
+// adds `i > -1` / `i < length` facts and the poison adds a [0, 32] range.
+// Even after that elimination, the validator must catch a runtime value
+// outside the poisoned range.
+const arr = new Array(64);
+for (let i = 0; i < arr.length; ++i) arr[i] = i;
+
+function probe(x) {
+    let i = $vm.iroFactPoison(x | 0, 0, 32);
+    let a = arr[i];
+    let b = arr[i];
+    return a + b;
+}
+noInline(probe);
+
+for (let i = 0; i < testLoopCount; ++i)
+    probe(0);
+
+probe(99999);
+
+throw new Error("Should have crashed before reaching here");

--- a/JSTests/stress/integer-range-optimization-fact-poison-truthful.js
+++ b/JSTests/stress/integer-range-optimization-fact-poison-truthful.js
@@ -1,0 +1,93 @@
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// Truthful counterpart of the various *-crashes tests: every IRO transform
+// that consults a poisoned range fact must FTL-compile cleanly and return
+// correct values when the claim holds.
+//
+// Each function sticky-records whether FTL ever compiled it via $vm.ftlTrue().
+// Without that check, a harness/loop-count regression that prevents FTL from
+// engaging would make this whole file pass vacuously: IROFactPoison collapses
+// to Identity outside FTL, so no assertion path runs.
+
+const ftlTrue = $vm.ftlTrue;
+
+let didFTLCompile = {
+    viaArithAdd: 0,
+    viaArithSub: 0,
+    viaArithMul: 0,
+    viaArithAbs: 0,
+    viaCheckInBounds: 0,
+};
+
+function assert(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(label + ": expected " + expected + ", got " + actual);
+}
+
+function viaArithAdd(x) {
+    didFTLCompile.viaArithAdd |= ftlTrue();
+    return $vm.iroFactPoison(x | 0, 0, 100) + 5;
+}
+noInline(viaArithAdd);
+
+function viaArithSub(x) {
+    didFTLCompile.viaArithSub |= ftlTrue();
+    return 200 - $vm.iroFactPoison(x | 0, 0, 100);
+}
+noInline(viaArithSub);
+
+function viaArithMul(x) {
+    didFTLCompile.viaArithMul |= ftlTrue();
+    return $vm.iroFactPoison(x | 0, 0, 100) * 3;
+}
+noInline(viaArithMul);
+
+function viaArithAbs(x) {
+    didFTLCompile.viaArithAbs |= ftlTrue();
+    return Math.abs($vm.iroFactPoison(x | 0, 0, 100));
+}
+noInline(viaArithAbs);
+
+const array = new Array(128);
+for (let i = 0; i < array.length; ++i)
+    array[i] = i * 2;
+function viaCheckInBounds(x) {
+    didFTLCompile.viaCheckInBounds |= ftlTrue();
+    let i = $vm.iroFactPoison(x | 0, 0, 127);
+    return array[i];
+}
+noInline(viaCheckInBounds);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    viaArithAdd(7);
+    viaArithSub(7);
+    viaArithMul(7);
+    viaArithAbs(7);
+    viaCheckInBounds(7);
+}
+
+assert(viaArithAdd(7), 12, "viaArithAdd");
+assert(viaArithAdd(0), 5, "viaArithAdd boundary low");
+assert(viaArithAdd(100), 105, "viaArithAdd boundary high");
+
+assert(viaArithSub(7), 193, "viaArithSub");
+assert(viaArithSub(0), 200, "viaArithSub boundary low");
+assert(viaArithSub(100), 100, "viaArithSub boundary high");
+
+assert(viaArithMul(7), 21, "viaArithMul");
+assert(viaArithMul(0), 0, "viaArithMul boundary low");
+assert(viaArithMul(100), 300, "viaArithMul boundary high");
+
+assert(viaArithAbs(7), 7, "viaArithAbs");
+assert(viaArithAbs(0), 0, "viaArithAbs boundary low");
+assert(viaArithAbs(100), 100, "viaArithAbs boundary high");
+
+assert(viaCheckInBounds(7), 14, "viaCheckInBounds");
+assert(viaCheckInBounds(0), 0, "viaCheckInBounds boundary low");
+assert(viaCheckInBounds(127), 254, "viaCheckInBounds boundary high");
+
+for (const name of ["viaArithAdd", "viaArithSub", "viaArithMul", "viaArithAbs", "viaCheckInBounds"]) {
+    if (!didFTLCompile[name])
+        throw new Error(name + " never reached FTL - IRO assertion paths untested, coverage is vacuous");
+}

--- a/JSTests/stress/integer-range-optimization-validator-adversarial-int32-invariant.js
+++ b/JSTests/stress/integer-range-optimization-validator-adversarial-int32-invariant.js
@@ -1,0 +1,215 @@
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// Adversarial: try every way I can think of to land a non-Int32 value on an
+// AssertInBounds edge. IRO and its validator are Int32-only at every
+// consumption site - see the RELEASE_ASSERT at the entry of rangeFor() and the
+// hasDoubleResult()/hasInt52Result() skips in insertSingleRelationshipAssertion
+// and the inner insertOffset/Upper/LowerBoundAssertion helpers. If any of those
+// trip, this test crashes; if no invariant breaks, it returns correct results.
+
+const ftlTrue = $vm.ftlTrue;
+// Pre-seed every key with Int32 0, and use `|= ftlTrue()` rather than the
+// `if (ftlTrue()) ... = true` branch form. The branch form gives DFG a profile
+// where the true arm is never taken (DFG sees ftlTrue()===0), so the FTL
+// version OSR-exits with InadequateCoverage the moment the true arm executes
+// and the AssertInBounds path is never actually run. The bitwise-OR form
+// avoids both the cold-arm OSR exit and the object-Structure transition that
+// would otherwise invalidate sibling FTL-compiled callees.
+let didFTLCompile = {
+    uint32Direct: 0,
+    phiIntDouble: 0,
+    toLengthOnUint32: 0,
+    truncatedArith: 0,
+    poisonTruncatedU32: 0,
+    uint32AsIndex: 0,
+    divThenTrunc: 0,
+    nested: 0,
+};
+
+function assert(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(label + ": expected " + expected + ", got " + actual);
+}
+
+// ============================================================================
+// (1) Uint32Array values exceeding INT32_MAX produce an Int52-result (with
+//     enableInt52) or Double-result GetByVal. IRO records `result > -1` against
+//     that node. The fact is dead in IRO (no consumer can query it), and the
+//     comprehensive validator must skip emitting an AssertInBounds for it.
+// ============================================================================
+const u32 = new Uint32Array(8);
+for (let i = 0; i < u32.length; ++i) u32[i] = 0xFFFFFFF0 + i;
+
+function uint32Direct(arr, i) {
+    didFTLCompile.uint32Direct |= ftlTrue();
+    let v = arr[i & 7];
+    return v + 1;            // ArithAdd not Int32Use here; IRO does not touch
+}
+noInline(uint32Direct);
+
+// ============================================================================
+// (2) Phi merging Int32 and Double in a tight loop. The Phi is Double-result;
+//     IRO's setEquivalence in Upsilon/Phi places facts on the Phi's projections.
+//     The validator must skip those (Shadow drop + Double-result skip).
+// ============================================================================
+function phiIntDouble(n, useDouble) {
+    didFTLCompile.phiIntDouble |= ftlTrue();
+    let x = 0;
+    for (let i = 0; i < n; ++i)
+        x = useDouble ? x + 0.5 : x + 1;
+    return x;
+}
+noInline(phiIntDouble);
+
+// ============================================================================
+// (3) ToLength's executeNode calls provablyNonNegative(child) on an arbitrary
+//     useKind (only != UntypedUse). When the child is Double with a `>-1` fact
+//     (e.g. from Uint32Array), ToLength adds `result_int32 == child_double` -
+//     a mixed-type relationship the validator must skip on the RHS check.
+// ============================================================================
+function toLengthOnUint32(arr, i) {
+    didFTLCompile.toLengthOnUint32 |= ftlTrue();
+    let v = arr[i & 7];
+    // Pass v as the length of an array-like; slice invokes ToLength on .length
+    // unconditionally (step 2 of Array.prototype.slice). The explicit `(0, 0)`
+    // bounds skip the materialization loop so the call doesn't try to allocate
+    // a 4-billion-element result when v exceeds INT32_MAX.
+    return Array.prototype.slice.call({length: v}, 0, 0).length;
+}
+noInline(toLengthOnUint32);
+
+// ============================================================================
+// (4) Truncate a non-Int32 value to Int32 with `| 0`, then run an IRO-
+//     optimizable ArithAdd. The truncation IS Int32-result; the ArithAdd is
+//     IRO-optimizable; facts come from the BitOr (Int32 LHS) - never from the
+//     original Int52/Double producer. The chain reaches AssertInBounds via
+//     the per-site insertRangeAssertion at the ArithAdd.
+// ============================================================================
+function truncatedArith(arr, i) {
+    didFTLCompile.truncatedArith |= ftlTrue();
+    let v = arr[i & 7];
+    let t = v | 0;
+    return t + 1;
+}
+noInline(truncatedArith);
+
+// ============================================================================
+// (5) iroFactPoison on a truncated Uint32 value. Tests the IROFactPoison ->
+//     Int32Use fixup + the per-site insertFactPoisonRangeAssertion. The claim
+//     is on the truncation, not the original.
+//     For arr[0..7] = 0xFFFFFFF0..0xFFFFFFF7, `| 0` yields -16..-9.
+// ============================================================================
+function poisonTruncatedU32(arr, i) {
+    didFTLCompile.poisonTruncatedU32 |= ftlTrue();
+    let t = arr[i & 7] | 0;
+    return $vm.iroFactPoison(t, -16, -9);
+}
+noInline(poisonTruncatedU32);
+
+// ============================================================================
+// (6) Uint32 value flowing into CheckInBounds. The index requires Int32 at
+//     the bounds check, so a conversion node sits between the Double producer
+//     and CheckInBounds. The CheckInBounds children are Int32 - the per-site
+//     var-var assertion must fire only on Int32-result endpoints.
+//
+// u32Mixed contains both small valid indices (slots 0..3) and values that
+// exceed INT32_MAX (slots 4..7). The GetByVal observes both and predicts
+// Double, so v is Double-result; data[v] requires Int32 so a Double->Int32
+// conversion is inserted before CheckInBounds. With small v in [0, 64) hot,
+// the data[v] block survives profile-driven cold-block elimination and IRO
+// proves `v < data.length` along that path, triggering the var-var
+// assertion insertion at the CheckInBounds.
+// ============================================================================
+const dataArr = new Array(64);
+for (let i = 0; i < dataArr.length; ++i) dataArr[i] = i;
+
+const u32Mixed = new Uint32Array(8);
+for (let i = 0; i < 4; ++i) u32Mixed[i] = i;
+for (let i = 4; i < 8; ++i) u32Mixed[i] = 0xFFFFFFF0 + i;
+
+function uint32AsIndex(uintArr, data, i) {
+    didFTLCompile.uint32AsIndex |= ftlTrue();
+    let v = uintArr[i & 7];
+    if (v >= 0 && v < data.length)
+        return data[v];
+    return -1;
+}
+noInline(uint32AsIndex);
+
+// ============================================================================
+// (7) Double producer (ArithDiv) feeding into Int32-typed arithmetic via
+//     truncation. Confirms the validator does not pull facts from the Div node.
+// ============================================================================
+function divThenTrunc(n, k) {
+    didFTLCompile.divThenTrunc |= ftlTrue();
+    let q = n / k;           // ArithDiv, Double-result
+    let t = q | 0;           // Int32-result
+    return t + 1;            // IRO-optimizable
+}
+noInline(divThenTrunc);
+
+// ============================================================================
+// (8) Direct test of comprehensive validator at non-trivial CFG: nested loops
+//     with conditional branches that add many relationships into m_relationships.
+//     Each iteration explores every fact path; the comprehensive walker emits
+//     assertions at every exitOK node in every block.
+// ============================================================================
+function nested(arr, n) {
+    didFTLCompile.nested |= ftlTrue();
+    let total = 0;
+    for (let i = 0; i < n; ++i) {
+        if (i >= 0 && i < arr.length) {
+            for (let j = 0; j < n; ++j) {
+                if (j > i)
+                    total += arr[j] - arr[i];
+            }
+        }
+    }
+    return total;
+}
+noInline(nested);
+
+// Drive enough iterations to trigger FTL compilation of every function. Each
+// function only needs warmup to reach FTL; extra iterations re-run the same
+// compiled code at no added validator coverage. Don't cap below testLoopCount
+// - with 8 hot callees and a Debug build, FTL tier-up needs the full budget.
+const iterations = testLoopCount;
+let sum = 0;
+for (let i = 0; i < iterations; ++i) {
+    sum += uint32Direct(u32, i);
+    sum += phiIntDouble(4, i & 1);
+    sum += toLengthOnUint32(u32, i);
+    sum += truncatedArith(u32, i);
+    sum += poisonTruncatedU32(u32, i);
+    sum += uint32AsIndex(u32Mixed, dataArr, i);
+    sum += divThenTrunc(100 + i, 3);
+    sum += nested(dataArr, 8);
+}
+
+if (!Number.isFinite(sum))
+    throw new Error("non-finite sum: " + sum);
+
+// Spot-check exact values: any silent miscompile would change these.
+assert(uint32Direct(u32, 0), 0xFFFFFFF0 + 1, "uint32Direct[0]");
+assert(uint32Direct(u32, 7), 0xFFFFFFF7 + 1, "uint32Direct[7]");
+assert(truncatedArith(u32, 0), (0xFFFFFFF0 | 0) + 1, "truncatedArith[0]");
+assert(truncatedArith(u32, 7), (0xFFFFFFF7 | 0) + 1, "truncatedArith[7]");
+assert(poisonTruncatedU32(u32, 0), 0xFFFFFFF0 | 0, "poisonTruncatedU32[0]");
+assert(poisonTruncatedU32(u32, 7), 0xFFFFFFF7 | 0, "poisonTruncatedU32[7]");
+assert(uint32AsIndex(u32Mixed, dataArr, 0), 0, "uint32AsIndex valid index");
+assert(uint32AsIndex(u32Mixed, dataArr, 3), 3, "uint32AsIndex valid index high");
+assert(uint32AsIndex(u32Mixed, dataArr, 4), -1, "uint32AsIndex out-of-range Double");
+assert(divThenTrunc(100, 3), (100 / 3 | 0) + 1, "divThenTrunc 100/3");
+assert(nested(dataArr, 4), 10, "nested[0..3]");
+
+// And one truthful intermediate: phiIntDouble with both branches active.
+assert(phiIntDouble(4, false), 4, "phiIntDouble all-int");
+assert(phiIntDouble(4, true), 2, "phiIntDouble all-double");
+
+for (const name of ["uint32Direct", "phiIntDouble", "toLengthOnUint32",
+                    "truncatedArith", "poisonTruncatedU32", "uint32AsIndex",
+                    "divThenTrunc", "nested"]) {
+    if (!didFTLCompile[name])
+        throw new Error(name + " never reached FTL - adversarial invariant untested for this case");
+}

--- a/JSTests/stress/integer-range-optimization-validator-boxed-relationship.js
+++ b/JSTests/stress/integer-range-optimization-validator-boxed-relationship.js
@@ -1,0 +1,24 @@
+//@ runDefault
+
+// IRO can record an integer-range relationship for a value whose DFG node is not int32-typed.
+// A for-of loop over an array gives the iterator index such a relationship while its node is a
+// boxed Phi with an imprecise prediction. Validating that fact must reference the operand in its
+// own representation and check the bound only when it is an int32 at runtime, never assuming a raw
+// int32. This must run cleanly under --validateIntegerRangeOptimization.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " (expected " + expected + ")");
+}
+
+function sumOf(arr) {
+    var sum = 0;
+    for (var v of arr)
+        sum += v;
+    return sum;
+}
+noInline(sumOf);
+
+var arr = [1, 2, 3, 4, 5];
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(sumOf(arr), 15);

--- a/JSTests/stress/integer-range-optimization-validator-checkinbounds-boundary-truthful.js
+++ b/JSTests/stress/integer-range-optimization-validator-checkinbounds-boundary-truthful.js
@@ -1,0 +1,33 @@
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+const ftlTrue = $vm.ftlTrue;
+// Use `|= ftlTrue()` not `if (ftlTrue()) ... = true`. The branch form gives DFG
+// a profile where the true arm is never taken (DFG sees ftlTrue()===0), so FTL
+// OSR-exits at the first true return and the AssertInBounds path never runs.
+let didFTLCompile = 0;
+
+const arr = new Array(64);
+for (let i = 0; i < arr.length; ++i)
+    arr[i] = i * 2;
+
+function probe(x) {
+    didFTLCompile |= ftlTrue();
+    let i = x | 0;
+    if (i < 0 || i >= arr.length) return -1;
+    return arr[i];
+}
+noInline(probe);
+
+for (let i = 0; i < testLoopCount; ++i)
+    probe(0);
+
+if (probe(63) !== 126)
+    throw new Error("expected 126 at boundary, got " + probe(63));
+if (probe(0) !== 0)
+    throw new Error("expected 0 at low boundary, got " + probe(0));
+if (probe(64) !== -1)
+    throw new Error("expected -1 past boundary, got " + probe(64));
+
+if (!didFTLCompile)
+    throw new Error("probe never reached FTL - CheckInBounds var-var assertion path untested");

--- a/JSTests/stress/integer-range-optimization-validator-handles-extreme-offsets.js
+++ b/JSTests/stress/integer-range-optimization-validator-handles-extreme-offsets.js
@@ -1,0 +1,103 @@
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// IRO can produce Relationships whose (kind, offset) need arithmetic
+// outside int32 to lower - Equal at INT32_MIN/MAX (offset+/-1 overflows)
+// and GreaterThan at INT32_MIN (-offset overflows). Two known sources:
+//   1. filterConstant promoting a more-vague relationship into Equal at
+//      the difference of two extreme constants (e.g. INT32_MAX - 0).
+//   2. IROFactPoison directly constructing GreaterThan(node, m_zero,
+//      minValue - 1) when minValue == INT32_MIN + 1.
+// The validator stores AssertInBounds offsets as int64 and does all
+// arithmetic in int64, so these encode cleanly without special cases.
+// This test drives both sources and verifies FTL compiles + runs them
+// correctly. Coverage is non-vacuous as long as each case reaches FTL.
+
+const INT32_MIN = -2147483648;
+const INT32_MAX =  2147483647;
+const ftlTrue = $vm.ftlTrue;
+
+let didFTLCompile = {
+    filterConstantPromotesToEqMax: 0,
+    filterConstantPromotesToEqMin: 0,
+    iroFactPoisonMinPlusOne: 0,
+    iroFactPoisonMaxMinusOne: 0,
+};
+
+function assert(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(label + ": expected " + expected + ", got " + actual);
+}
+
+// (1) filterConstant.NotEqual(Equal at int32 limit): establish x ===
+// INT32_LIMIT first (records Equal(x, LIMIT_const, 0)), then introduce
+// x !== 0. setOneSide refines the NotEqual against the existing Equal
+// and would produce Equal(x, 0_const, LIMIT) if not guarded.
+function filterConstantPromotesToEqMax(x) {
+    didFTLCompile.filterConstantPromotesToEqMax |= ftlTrue();
+    if (x === INT32_MAX) {
+        if (x !== 0)
+            return 1;
+        return 2;
+    }
+    return 0;
+}
+noInline(filterConstantPromotesToEqMax);
+
+function filterConstantPromotesToEqMin(x) {
+    didFTLCompile.filterConstantPromotesToEqMin |= ftlTrue();
+    if (x === INT32_MIN) {
+        if (x !== 0)
+            return 1;
+        return 2;
+    }
+    return 0;
+}
+noInline(filterConstantPromotesToEqMin);
+
+// (2) IROFactPoison with minValue == INT32_MIN + 1 builds
+// GreaterThan(node, m_zero, INT32_MIN) directly; setOneSide must drop it.
+// The symmetric maxValue == INT32_MAX - 1 case produces LessThan(node,
+// m_zero, INT32_MAX), which is fine to store - kept here so future
+// changes that incidentally tighten LessThan also stay tested.
+function iroFactPoisonMinPlusOne(x) {
+    didFTLCompile.iroFactPoisonMinPlusOne |= ftlTrue();
+    return $vm.iroFactPoison(x | 0, -2147483647, 2147483647);
+}
+noInline(iroFactPoisonMinPlusOne);
+
+function iroFactPoisonMaxMinusOne(x) {
+    didFTLCompile.iroFactPoisonMaxMinusOne |= ftlTrue();
+    return $vm.iroFactPoison(x | 0, -2147483648, 2147483646);
+}
+noInline(iroFactPoisonMaxMinusOne);
+
+// Keep both branches of `x === INT32_LIMIT` hot so FTL compiles each
+// function with the inner block live (which is where filterConstant is
+// asked to refine NotEqual against an existing Equal at the extreme).
+for (let i = 0; i < testLoopCount; ++i) {
+    filterConstantPromotesToEqMax(INT32_MAX);
+    filterConstantPromotesToEqMax(INT32_MAX);
+    filterConstantPromotesToEqMax(i & 1);
+    filterConstantPromotesToEqMin(INT32_MIN);
+    filterConstantPromotesToEqMin(INT32_MIN);
+    filterConstantPromotesToEqMin(i & 1);
+    iroFactPoisonMinPlusOne(0);
+    iroFactPoisonMinPlusOne(-2147483647);
+    iroFactPoisonMaxMinusOne(0);
+    iroFactPoisonMaxMinusOne(2147483646);
+}
+
+assert(filterConstantPromotesToEqMax(INT32_MAX), 1, "filterConstantPromotesToEqMax(INT32_MAX)");
+assert(filterConstantPromotesToEqMax(0), 0, "filterConstantPromotesToEqMax(0)");
+assert(filterConstantPromotesToEqMin(INT32_MIN), 1, "filterConstantPromotesToEqMin(INT32_MIN)");
+assert(filterConstantPromotesToEqMin(0), 0, "filterConstantPromotesToEqMin(0)");
+assert(iroFactPoisonMinPlusOne(0), 0, "iroFactPoisonMinPlusOne(0)");
+assert(iroFactPoisonMinPlusOne(-2147483647), -2147483647, "iroFactPoisonMinPlusOne(INT32_MIN+1)");
+assert(iroFactPoisonMaxMinusOne(0), 0, "iroFactPoisonMaxMinusOne(0)");
+assert(iroFactPoisonMaxMinusOne(2147483646), 2147483646, "iroFactPoisonMaxMinusOne(INT32_MAX-1)");
+
+for (const name of Object.keys(didFTLCompile)) {
+    if (!didFTLCompile[name])
+        throw new Error(name + " never reached FTL - setOneSide extreme-offset rejection untested for this path");
+}

--- a/JSTests/stress/integer-range-optimization-validator-int32-boundary-relationships.js
+++ b/JSTests/stress/integer-range-optimization-validator-int32-boundary-relationships.js
@@ -1,0 +1,250 @@
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// IRO must never produce a Relationship whose encoded offset reshapes outside
+// int32 when fed to AssertInBounds - e.g. GreaterThan with offset == INT32_MIN
+// (would need -offset = INT32_MAX + 1), or Equal with offset == INT32_MAX or
+// INT32_MIN (would need offset +/- 1 to fit). Relationship's construction paths
+// (flipped, inverse, addToOffset, mergeConstant) use sumOverflows to bail on
+// these. The validator's insertSingleRelationshipAssertion RELEASE_ASSERTs via
+// fitsInt32() on every derived offset, so any IRO leak crashes here.
+//
+// This test drives comparisons and arithmetic against the int32 limits through
+// FTL with the validator enabled. If any pattern coaxes IRO into a boundary
+// relationship, the validator crashes; if no invariant breaks, results match
+// the expected values.
+
+const ftlTrue = $vm.ftlTrue;
+// Pre-seed every key with Int32 0, and use `|= ftlTrue()` rather than the
+// `if (ftlTrue()) ... = true` branch form. Branching on ftlTrue() gives DFG a
+// profile where the true arm is never taken (DFG sees ftlTrue()===0), so the
+// FTL version OSR-exits with InadequateCoverage the moment the true arm
+// executes and the AssertInBounds path is never actually run. The
+// bitwise-OR form keeps FTL resident through the loop and avoids the
+// object-Structure transition that would invalidate sibling FTL-compiled
+// callees.
+let didFTLCompile = {
+    eqMax: 0, eqMin: 0,
+    ltMax: 0, gtMin: 0, ltMin: 0, gtMax: 0,
+    neMax: 0, neMin: 0,
+    subNearMax: 0, subNearMin: 0,
+    loopDownFromMax: 0,
+    twoSidedAtMax: 0, twoSidedAtMin: 0,
+};
+
+function assert(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(label + ": expected " + expected + ", got " + actual);
+}
+
+const INT32_MIN = -2147483648;
+const INT32_MAX =  2147483647;
+
+// ============================================================================
+// (1) Direct equality with each int32 limit. Forms Relationship(x, m_zero,
+//     Equal, INT32_MAX) / (..., INT32_MIN). If IRO recorded these, the
+//     validator would try fitsInt32(INT32_MAX + 1) -> RELEASE_ASSERT.
+// ============================================================================
+function eqMax(x) {
+    didFTLCompile.eqMax |= ftlTrue();
+    if (x === INT32_MAX) return 1;
+    return 0;
+}
+noInline(eqMax);
+
+function eqMin(x) {
+    didFTLCompile.eqMin |= ftlTrue();
+    if (x === INT32_MIN) return 1;
+    return 0;
+}
+noInline(eqMin);
+
+// ============================================================================
+// (2) Strict inequality with each limit. LessThan with offset == INT32_MIN or
+//     GreaterThan with offset == INT32_MAX would be unsatisfiable; LessThan
+//     with offset == INT32_MAX or GreaterThan with offset == INT32_MIN are
+//     boundary-but-trivial. IRO's inverse() path (LessThan->GreaterThan and
+//     vice-versa) bails on these via sumOverflows.
+// ============================================================================
+function ltMax(x) {
+    didFTLCompile.ltMax |= ftlTrue();
+    if (x < INT32_MAX) return 1;
+    return 0;
+}
+noInline(ltMax);
+
+function gtMin(x) {
+    didFTLCompile.gtMin |= ftlTrue();
+    if (x > INT32_MIN) return 1;
+    return 0;
+}
+noInline(gtMin);
+
+function ltMin(x) {
+    didFTLCompile.ltMin |= ftlTrue();
+    if (x < INT32_MIN) return 1;       // unsatisfiable for int32 x
+    return 0;
+}
+noInline(ltMin);
+
+function gtMax(x) {
+    didFTLCompile.gtMax |= ftlTrue();
+    if (x > INT32_MAX) return 1;       // unsatisfiable for int32 x
+    return 0;
+}
+noInline(gtMax);
+
+// ============================================================================
+// (3) NotEqual at each limit. Encodes as a single AssertInBounds with offset
+//     == INT32_MIN/MAX; fitsInt32(offset) passes (int32-stored) but the
+//     reshape into NotEqual must not derive offset+/-1.
+// ============================================================================
+function neMax(x) {
+    didFTLCompile.neMax |= ftlTrue();
+    if (x !== INT32_MAX) return 1;
+    return 0;
+}
+noInline(neMax);
+
+function neMin(x) {
+    didFTLCompile.neMin |= ftlTrue();
+    if (x !== INT32_MIN) return 1;
+    return 0;
+}
+noInline(neMin);
+
+// ============================================================================
+// (4) Comparisons after a checked subtraction by a constant near the limit.
+//     ArithSub here is overflow-checked, so the result is int32; IRO will
+//     try to relate `(x - k)` to its operands with a non-trivial offset that
+//     could pile up near the boundary if it weren't carefully bounded.
+// ============================================================================
+function subNearMax(x) {
+    didFTLCompile.subNearMax |= ftlTrue();
+    let d = x - (INT32_MAX - 3);
+    if (d >= 0 && d < 8) return d;
+    return -1;
+}
+noInline(subNearMax);
+
+function subNearMin(x) {
+    didFTLCompile.subNearMin |= ftlTrue();
+    let d = x - (INT32_MIN + 3);
+    if (d >= 0 && d < 8) return d;
+    return -1;
+}
+noInline(subNearMin);
+
+// ============================================================================
+// (5) Loop counting down from a value near INT32_MAX. The loop induction
+//     variable accumulates IRO facts each round; if any incremental
+//     setEquivalence/addToOffset crossed the int32 boundary, the validator
+//     would catch it on the next iteration.
+// ============================================================================
+function loopDownFromMax(start, count) {
+    didFTLCompile.loopDownFromMax |= ftlTrue();
+    let i = start;
+    let total = 0;
+    for (let k = 0; k < count; ++k) {
+        if (i > INT32_MIN + 8)
+            total += 1;
+        i -= 1;
+    }
+    return total;
+}
+noInline(loopDownFromMax);
+
+// ============================================================================
+// (6) Two-sided range guard at the int32 limits - forms both a LessThan and
+//     GreaterThan fact against the same node, exercising the Equal-expansion
+//     path that derives both offset+1 and -offset+1 from rel.offset().
+// ============================================================================
+function twoSidedAtMax(x) {
+    didFTLCompile.twoSidedAtMax |= ftlTrue();
+    if (x > INT32_MAX - 4 && x < INT32_MAX)
+        return x - (INT32_MAX - 4);
+    return -1;
+}
+noInline(twoSidedAtMax);
+
+function twoSidedAtMin(x) {
+    didFTLCompile.twoSidedAtMin |= ftlTrue();
+    if (x > INT32_MIN && x < INT32_MIN + 4)
+        return x - INT32_MIN;
+    return -1;
+}
+noInline(twoSidedAtMin);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    eqMax(i | 0);
+    eqMax(INT32_MAX);
+    eqMin(i | 0);
+    eqMin(INT32_MIN);
+
+    ltMax(INT32_MAX - 1);
+    ltMax(INT32_MAX);
+    gtMin(INT32_MIN + 1);
+    gtMin(INT32_MIN);
+    ltMin(0);
+    ltMin(INT32_MIN);
+    gtMax(0);
+    gtMax(INT32_MAX);
+
+    neMax(INT32_MAX);
+    neMax(0);
+    neMin(INT32_MIN);
+    neMin(0);
+
+    subNearMax(INT32_MAX - 2);
+    subNearMax(0);
+    subNearMin(INT32_MIN + 2);
+    subNearMin(0);
+
+    loopDownFromMax(INT32_MAX, 4);
+    loopDownFromMax(INT32_MIN + 16, 4);
+
+    twoSidedAtMax(INT32_MAX - 2);
+    twoSidedAtMax(0);
+    twoSidedAtMin(INT32_MIN + 2);
+    twoSidedAtMin(0);
+}
+
+assert(eqMax(INT32_MAX), 1, "eqMax(INT32_MAX)");
+assert(eqMax(0), 0, "eqMax(0)");
+assert(eqMin(INT32_MIN), 1, "eqMin(INT32_MIN)");
+assert(eqMin(0), 0, "eqMin(0)");
+
+assert(ltMax(INT32_MAX), 0, "ltMax(INT32_MAX)");
+assert(ltMax(0), 1, "ltMax(0)");
+assert(gtMin(INT32_MIN), 0, "gtMin(INT32_MIN)");
+assert(gtMin(0), 1, "gtMin(0)");
+assert(ltMin(INT32_MIN), 0, "ltMin(INT32_MIN)");
+assert(ltMin(0), 0, "ltMin(0)");
+assert(gtMax(INT32_MAX), 0, "gtMax(INT32_MAX)");
+assert(gtMax(0), 0, "gtMax(0)");
+
+assert(neMax(INT32_MAX), 0, "neMax(INT32_MAX)");
+assert(neMax(0), 1, "neMax(0)");
+assert(neMin(INT32_MIN), 0, "neMin(INT32_MIN)");
+assert(neMin(0), 1, "neMin(0)");
+
+assert(subNearMax(INT32_MAX - 3), 0, "subNearMax low");
+assert(subNearMax(INT32_MAX), 3, "subNearMax high in range");
+assert(subNearMax(0), -1, "subNearMax under range");
+assert(subNearMin(INT32_MIN + 3), 0, "subNearMin low in range");
+assert(subNearMin(INT32_MIN), -1, "subNearMin under range");
+assert(subNearMin(0), -1, "subNearMin over range");
+
+assert(twoSidedAtMax(INT32_MAX - 2), 2, "twoSidedAtMax inside");
+assert(twoSidedAtMax(INT32_MAX), -1, "twoSidedAtMax outside high");
+assert(twoSidedAtMax(0), -1, "twoSidedAtMax outside low");
+assert(twoSidedAtMin(INT32_MIN + 2), 2, "twoSidedAtMin inside");
+assert(twoSidedAtMin(INT32_MIN), -1, "twoSidedAtMin outside low");
+assert(twoSidedAtMin(0), -1, "twoSidedAtMin outside high");
+
+for (const name of ["eqMax", "eqMin", "ltMax", "gtMin", "ltMin", "gtMax",
+                    "neMax", "neMin", "subNearMax", "subNearMin",
+                    "loopDownFromMax", "twoSidedAtMax", "twoSidedAtMin"]) {
+    if (!didFTLCompile[name])
+        throw new Error(name + " never reached FTL - int32 boundary relationship path untested for this case");
+}

--- a/JSTests/stress/integer-range-optimization-validator-notequal-truthful.js
+++ b/JSTests/stress/integer-range-optimization-validator-notequal-truthful.js
@@ -1,0 +1,36 @@
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// The false arm of `x === 5` gives IRO a `x != 5` fact; combined with a
+// poisoned range, the validator emits AssertInBounds for both fact kinds.
+// All facts hold - FTL compiles cleanly and results are correct.
+
+const ftlTrue = $vm.ftlTrue;
+// Use `|= ftlTrue()` not `if (ftlTrue()) ... = true`. The branch form gives DFG
+// a profile where the true arm is never taken (DFG sees ftlTrue()===0), so FTL
+// OSR-exits at the first true return and the AssertInBounds path never runs.
+let didFTLCompile = 0;
+
+function assert(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(label + ": expected " + expected + ", got " + actual);
+}
+
+function viaNotEqual(x) {
+    didFTLCompile |= ftlTrue();
+    if (x === 5)
+        return -1;
+    return $vm.iroFactPoison(x | 0, 0, 100) + 1;
+}
+noInline(viaNotEqual);
+
+for (let i = 0; i < testLoopCount; ++i)
+    viaNotEqual(i % 4 === 0 ? 5 : (i & 63));
+
+assert(viaNotEqual(5), -1, "viaNotEqual sentinel");
+assert(viaNotEqual(0), 1, "viaNotEqual low");
+assert(viaNotEqual(7), 8, "viaNotEqual normal");
+assert(viaNotEqual(100), 101, "viaNotEqual high");
+
+if (!didFTLCompile)
+    throw new Error("viaNotEqual never reached FTL - NotEqual assertion path untested");

--- a/JSTests/stress/integer-range-optimization-validator-tolength-non-int32.js
+++ b/JSTests/stress/integer-range-optimization-validator-tolength-non-int32.js
@@ -1,0 +1,28 @@
+//@ skip if !$jitTests
+//@ runFTLNoCJIT("--useDollarVM=true", "--validateIntegerRangeOptimization=true")
+
+// Array.prototype.some is implemented in JS and calls @toLength on the
+// length. With length = 2^60, ToLength's child is a non-Int32 node. IRO's
+// ToLength case must skip such children so the validator's Int32 invariant
+// holds; otherwise insertSingleRelationshipAssertion's RELEASE_ASSERT fires.
+
+const ftlTrue = $vm.ftlTrue;
+let didFTLCompile = 0;
+
+const BIG = Math.pow(2, 60);
+const evil = { 0: 'x', length: BIG };
+const isX = v => v === 'x';
+
+function doSome(arr, predicate) {
+    didFTLCompile |= ftlTrue();
+    return Array.prototype.some.call(arr, predicate);
+}
+noInline(doSome);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    if (doSome(evil, isX) !== true)
+        throw new Error("doSome should have returned true at iteration " + i);
+}
+
+if (!didFTLCompile)
+    throw new Error("doSome never reached FTL - ToLength on Int52/Double length path untested");

--- a/JSTests/stress/test-harness-must-crash.js
+++ b/JSTests/stress/test-harness-must-crash.js
@@ -1,0 +1,4 @@
+//@ mustCrashWith!(:trap, "AAAAAHHHH")
+//@ runFTLNoCJIT
+
+$vm.crash("AAAAAHHHH");

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -5350,6 +5350,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case AssertInBounds:
         break;
 
+
+    case IROFactPoison:
     case CheckInBounds: {
         // We claim we result in Int32. It's not really important what our result is (though we
         // don't want to claim we may result in the empty value), other nodes with data flow edges

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -4018,6 +4018,43 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case IROFactPoisonIntrinsic: {
+            RELEASE_ASSERT(Options::validateIntegerRangeOptimization());
+            if (argumentCountIncludingThis != 4) {
+                dataLogLn("$vm.iroFactPoison requires 3 arguments: (value, asMin, asMax)");
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+            Node* minNode = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
+            Node* maxNode = get(virtualRegisterForArgumentIncludingThis(3, registerOffset));
+
+            auto readBound = [] (Node* boundNode) -> int32_t {
+                if (!boundNode->isConstant() || !boundNode->constant()->value().isNumber()) {
+                    dataLogLn("iroFactPoison: bound must be a numeric constant");
+                    RELEASE_ASSERT_NOT_REACHED();
+                }
+                if (!boundNode->constant()->value().isInt32AsAnyInt()) {
+                    dataLogLn("iroFactPoison: bound must be an integer in int32 range");
+                    RELEASE_ASSERT_NOT_REACHED();
+                }
+                return boundNode->constant()->value().asInt32AsAnyInt();
+            };
+            int32_t minValue = readBound(minNode);
+            int32_t maxValue = readBound(maxNode);
+            if (minValue > maxValue) {
+                dataLogLn("iroFactPoison: asMin > asMax, fact range is empty");
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+
+            insertChecks();
+            VirtualRegister operand = virtualRegisterForArgumentIncludingThis(1, registerOffset);
+            setResult(addToGraph(
+                IROFactPoison,
+                OpInfo(static_cast<uint32_t>(minValue)),
+                OpInfo(static_cast<uint32_t>(maxValue)),
+                get(operand)));
+            return CallOptimizationResult::Inlined;
+        }
+
         case JSMapGetIntrinsic: {
             if (argumentCountIncludingThis < 2 || !is64Bit())
                 return CallOptimizationResult::DidNothing;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -205,6 +205,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
 
     case Identity:
     case IdentityWithProfile:
+    case IROFactPoison:
     case Phantom:
     case Check:
     case CheckVarargs:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -184,6 +184,7 @@ bool doesGC(Graph& graph, Node* node)
     case PutCellButterflySlot:
     case ArraySortCommit:
     case AssertInBounds:
+    case IROFactPoison:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case ConstantStoragePointer:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2772,6 +2772,20 @@ private:
             break;
         }
 
+        case IROFactPoison: {
+            RELEASE_ASSERT(Options::validateIntegerRangeOptimization());
+            // Only the FTL IRO phase consumes this; collapse elsewhere so later
+            // phases don't have to know about it.
+            if (!m_graph.m_plan.isFTL()) {
+                node->convertToIdentity();
+                break;
+            }
+            RELEASE_ASSERT_WITH_MESSAGE(isInt32Speculation(node->child1()->prediction()),
+                "iroFactPoison: input must be Int32-predicted; values IRO cannot consume cannot be meaningfully poisoned");
+            fixEdge<Int32Use>(node->child1());
+            break;
+        }
+
         case GetArrayLength: {
             ArrayMode arrayMode = node->arrayMode().refine(m_graph, node, node->child1()->prediction(), ArrayMode::unusedIndexSpeculatedType);
             // We don't know how to handle generic and we only emit this in the Parser when we have checked the value is an Array/TypedArray.

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1291,7 +1291,10 @@ public:
                 }
             }
         }
-        
+
+        if (Options::validateIntegerRangeOptimization()) [[unlikely]]
+            insertTestingValidation();
+
         // Now we transform the code based on the results computed in the previous loop.
         changed = false;
         for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
@@ -1299,11 +1302,18 @@ public:
             for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
                 Node* node = block->at(nodeIndex);
                 dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "Transformation: at ", node, ": ", listDump(sortedRelationships()));
-                
+
                 // This ends up being pretty awkward to write because we need to decide if we
                 // optimize by using the relationships before the operation, but we need to
                 // call executeNode() before we optimize.
                 switch (node->op()) {
+                case IROFactPoison: {
+                    insertRangeAssertion(nodeIndex, node->origin, node->child1().node(), node->iroFactPoisonMin(), node->iroFactPoisonMax());
+                    executeNode(block->at(nodeIndex));
+                    node->convertToIdentity();
+                    changed = true;
+                    continue;
+                }
                 case ArithAbs: {
                     if (node->child1().useKind() != Int32Use)
                         break;
@@ -1312,6 +1322,8 @@ public:
                     if (!range)
                         break;
                     auto [minValue, maxValue] = range.value();
+
+                    insertRangeAssertion(nodeIndex, node->origin, node->child1().node(), minValue, maxValue);
 
                     executeNode(block->at(nodeIndex));
 
@@ -1346,11 +1358,13 @@ public:
                     if (!leftRange)
                         break;
                     auto [leftMinValue, leftMaxValue] = leftRange.value();
+                    insertRangeAssertion(nodeIndex, node->origin, node->child1().node(), leftMinValue, leftMaxValue);
 
                     auto rightRange = rangeFor(node->child2().node());
                     if (!rightRange)
                         break;
                     auto [rightMinValue, rightMaxValue] = rightRange.value();
+                    insertRangeAssertion(nodeIndex, node->origin, node->child2().node(), rightMinValue, rightMaxValue);
 
                     dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "    leftMinValue = ", leftMinValue, ", leftMaxValue = ", leftMaxValue, ", rightMinValue = ", rightMinValue, ", rightMaxValue = ", rightMaxValue);
 
@@ -1384,11 +1398,13 @@ public:
                     if (!leftRange)
                         break;
                     auto [leftMinValue, leftMaxValue] = leftRange.value();
+                    insertRangeAssertion(nodeIndex, node->origin, node->child1().node(), leftMinValue, leftMaxValue);
 
                     auto rightRange = rangeFor(node->child2().node());
                     if (!rightRange)
                         break;
                     auto [rightMinValue, rightMaxValue] = rightRange.value();
+                    insertRangeAssertion(nodeIndex, node->origin, node->child2().node(), rightMinValue, rightMaxValue);
 
                     dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "    leftMinValue = ", leftMinValue, ", leftMaxValue = ", leftMaxValue, ", rightMinValue = ", rightMinValue, ", rightMaxValue = ", rightMaxValue);
 
@@ -1422,11 +1438,13 @@ public:
                     if (!leftRange)
                         break;
                     auto [leftMinValue, leftMaxValue] = leftRange.value();
+                    insertRangeAssertion(nodeIndex, node->origin, node->child1().node(), leftMinValue, leftMaxValue);
 
                     auto rightRange = rangeFor(node->child2().node());
                     if (!rightRange)
                         break;
                     auto [rightMinValue, rightMaxValue] = rightRange.value();
+                    insertRangeAssertion(nodeIndex, node->origin, node->child2().node(), rightMinValue, rightMaxValue);
 
                     dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "    leftMinValue = ", leftMinValue, ", leftMaxValue = ", leftMaxValue, ", rightMinValue = ", rightMinValue, ", rightMaxValue = ", rightMaxValue);
 
@@ -1512,6 +1530,7 @@ public:
                     for (Relationship relationship : iter->value)
                         minValue = std::max(minValue, relationship.minValueOfLeft());
 
+                    insertRangeAssertion(nodeIndex, node->origin, m_graph.varArgChild(node, 1).node(), minValue, std::numeric_limits<int32_t>::max());
                     if (minValue < 0)
                         break;
 
@@ -1524,11 +1543,12 @@ public:
                 default:
                     break;
                 }
-                
+
                 executeNode(block->at(nodeIndex));
             }
+            m_insertionSet.execute(block);
         }
-        
+
         return changed;
     }
 
@@ -1687,7 +1707,8 @@ private:
         }
 
         case ToLength: {
-            if (node->child1().useKind() == UntypedUse)
+            // FIXME
+            if (node->child1().useKind() != Int32Use)
                 break;
             // Consider b = ToLength(a)
             // If a < 0, then b == 0; b >= a
@@ -1753,7 +1774,9 @@ private:
                 case Array::Int32Array:
                     break;
                 case Array::Uint32Array:
-                    setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -1));
+                // FIXME
+                    if (node->hasInt32Result())
+                        setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -1));
                     break;
                 default:
                     break;
@@ -1777,9 +1800,121 @@ private:
                 node);
             break;
         }
-            
+
+        case IROFactPoison: {
+            RELEASE_ASSERT(Options::validateIntegerRangeOptimization());
+            int32_t minValue = node->iroFactPoisonMin();
+            int32_t maxValue = node->iroFactPoisonMax();
+            if (minValue > std::numeric_limits<int32_t>::min())
+                setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, minValue - 1));
+            if (maxValue < std::numeric_limits<int32_t>::max())
+                setRelationship(Relationship(node, m_zero, Relationship::LessThan, maxValue + 1));
+            break;
+        }
+
         default:
             break;
+        }
+    }
+
+    static Edge validatorEdgeFor(Node* n)
+    {
+        if (n->hasInt32Result() || n->isInt32Constant())
+            return Edge(n, KnownInt32Use);
+        return Edge(n, UntypedUse);
+    }
+
+    void insertOffsetAssertion(unsigned nodeIndex, NodeOrigin origin, Node* leftNode, Node* rightNode, int64_t offset, Node::AssertInBoundsCompare compare)
+    {
+        // AssertInBounds offsets are derived from int32 IRO offsets via ±1
+        // or negation, so they fit in [INT32_MIN-1, INT32_MAX+1]. Anything
+        // wider would indicate the caller is computing the offset wrong.
+        RELEASE_ASSERT(offset >= int64_t { std::numeric_limits<int32_t>::min() } - 1
+            && offset <= int64_t { std::numeric_limits<int32_t>::max() } + 1);
+        m_insertionSet.insertNode(
+            nodeIndex, SpecNone, AssertInBounds, origin,
+            OpInfo(static_cast<uint32_t>(compare)),
+            OpInfo(static_cast<uint64_t>(offset)),
+            validatorEdgeFor(leftNode), validatorEdgeFor(rightNode));
+    }
+
+    void insertRangeAssertion(unsigned nodeIndex, NodeOrigin origin, Node* checkedValue, int32_t minValue, int32_t maxValue)
+    {
+        if (!Options::validateIntegerRangeOptimization()) [[likely]]
+            return;
+        if (maxValue < std::numeric_limits<int32_t>::max()) {
+            // checkedValue < maxValue + 1 <=> checkedValue < m_zero + (maxValue + 1).
+            insertOffsetAssertion(nodeIndex, origin, checkedValue, m_zero, int64_t { maxValue } + 1, Node::AssertInBoundsCompareLessThan);
+        }
+        if (minValue > std::numeric_limits<int32_t>::min()) {
+            // checkedValue > minValue - 1 <=> m_zero < checkedValue + (1 - minValue).
+            insertOffsetAssertion(nodeIndex, origin, m_zero, checkedValue, 1 - int64_t { minValue }, Node::AssertInBoundsCompareLessThan);
+        }
+    }
+
+    void insertSingleRelationshipAssertion(unsigned nodeIndex, NodeOrigin origin, const Relationship& rel)
+    {
+        if (rel.left().kind() != NodeFlowProjection::Primary)
+            return;
+        if (rel.right().kind() != NodeFlowProjection::Primary)
+            return;
+        Node* left = rel.left().node();
+        Node* right = rel.right().node();
+        RELEASE_ASSERT(left && right);
+        int64_t offset = rel.offset();
+
+        // A zero-offset equality over a non-int32 operand (e.g. two boxed values
+        // proven identical) carries no integer bound, but IRO will still use it
+        // to substitute one operand for the other. Validate value sameness in
+        // that case rather than an int32 bound, so we neither skip it nor crash
+        // on a legitimate non-integer equivalence.
+        auto isInt32Rep = [] (Node* n) { return n->hasInt32Result() || n->isInt32Constant(); };
+        if (rel.kind() == Relationship::Equal && !offset && (!isInt32Rep(left) || !isInt32Rep(right))) {
+            m_insertionSet.insertNode(
+                nodeIndex, SpecNone, AssertInBounds, origin,
+                OpInfo(static_cast<uint32_t>(Node::AssertInBoundsCompareIdentical)),
+                OpInfo(static_cast<uint64_t>(0)),
+                Edge(left, UntypedUse), Edge(right, UntypedUse));
+            return;
+        }
+
+        switch (rel.kind()) {
+        case Relationship::LessThan:
+            // left < right + offset
+            insertOffsetAssertion(nodeIndex, origin, left, right, offset, Node::AssertInBoundsCompareLessThan);
+            return;
+        case Relationship::GreaterThan:
+            // left > right + offset  <=>  right < left + (-offset)
+            insertOffsetAssertion(nodeIndex, origin, right, left, -offset, Node::AssertInBoundsCompareLessThan);
+            return;
+        case Relationship::Equal:
+            // left == right + offset  <=>  left < right + (offset+1) AND right < left + (1-offset)
+            insertOffsetAssertion(nodeIndex, origin, left, right, offset + 1, Node::AssertInBoundsCompareLessThan);
+            insertOffsetAssertion(nodeIndex, origin, right, left, 1 - offset, Node::AssertInBoundsCompareLessThan);
+            return;
+        case Relationship::NotEqual:
+            insertOffsetAssertion(nodeIndex, origin, left, right, offset, Node::AssertInBoundsCompareNotEqual);
+            return;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    void insertTestingValidation()
+    {
+        for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
+            m_relationships = m_relationshipsAtHead[block];
+            for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
+                Node* node = block->at(nodeIndex);
+                NodeOrigin originForInsertion = node->origin;
+                if (nodeIndex > 0)
+                    originForInsertion = block->at(nodeIndex - 1)->origin.forInsertingAfter(m_graph, block->at(nodeIndex - 1));
+                for (auto& entry : m_relationships) {
+                    for (const Relationship& rel : entry.value)
+                        insertSingleRelationshipAssertion(nodeIndex, originForInsertion, rel);
+                }
+                executeNode(node);
+            }
+            m_insertionSet.execute(block);
         }
     }
 

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1821,12 +1821,29 @@ private:
     {
         if (n->hasInt32Result() || n->isInt32Constant())
             return Edge(n, KnownInt32Use);
+        if (n->hasDoubleResult())
+            return Edge(n, DoubleRepUse);
+        if (n->hasInt52Result())
+            return Edge(n, Int52RepUse);
         return Edge(n, UntypedUse);
+    }
+
+    // An offset relationship (anything other than a zero-offset equality) is sound
+    // only when the operand's runtime value is an int32, because IRO combines it
+    // with int32 offset arithmetic. A non-int32 double can hold AnyIntAsDouble
+    // values outside int32 range, so such a relationship cannot be carried over it.
+    static bool canCarryOffsetRelationship(Node* n)
+    {
+        return n->hasInt32Result() || n->isInt32Constant();
     }
 
     void insertOffsetAssertion(unsigned nodeIndex, NodeOrigin origin, Node* leftNode, Node* rightNode, int64_t offset, Node::AssertInBoundsCompare compare)
     {
-        // AssertInBounds offsets are derived from int32 IRO offsets via ±1
+        // An offset relationship is reasoned about with int32 arithmetic, so it is
+        // only meaningful over int32 operands. IRO never forms such a relationship
+        // over a non-int32 operand; a violation here means that invariant broke.
+        RELEASE_ASSERT(canCarryOffsetRelationship(leftNode) && canCarryOffsetRelationship(rightNode));
+        // AssertInBounds offsets are derived from int32 IRO offsets via +/-1
         // or negation, so they fit in [INT32_MIN-1, INT32_MAX+1]. Anything
         // wider would indicate the caller is computing the offset wrong.
         RELEASE_ASSERT(offset >= int64_t { std::numeric_limits<int32_t>::min() } - 1
@@ -1863,18 +1880,23 @@ private:
         RELEASE_ASSERT(left && right);
         int64_t offset = rel.offset();
 
-        // A zero-offset equality over a non-int32 operand (e.g. two boxed values
-        // proven identical) carries no integer bound, but IRO will still use it
-        // to substitute one operand for the other. Validate value sameness in
-        // that case rather than an int32 bound, so we neither skip it nor crash
-        // on a legitimate non-integer equivalence.
-        auto isInt32Rep = [] (Node* n) { return n->hasInt32Result() || n->isInt32Constant(); };
-        if (rel.kind() == Relationship::Equal && !offset && (!isInt32Rep(left) || !isInt32Rep(right))) {
+        // A zero-offset equality asserts value identity, which holds in any
+        // representation, so validate it directly when an operand is not int32.
+        // This avoids the int32 offset arithmetic of the relational decomposition
+        // below, which is sound only over int32 operands. A Double/Int52 operand
+        // is compared as a double (the values are integer-valued); otherwise the
+        // operands are compared as JSValues, which also boxes an int32 side.
+        if (rel.kind() == Relationship::Equal && !offset
+            && (!canCarryOffsetRelationship(left) || !canCarryOffsetRelationship(right))) {
+            bool asDouble = left->hasDoubleResult() || left->hasInt52Result()
+                || right->hasDoubleResult() || right->hasInt52Result();
+            Edge leftEdge = asDouble ? validatorEdgeFor(left) : Edge(left, UntypedUse);
+            Edge rightEdge = asDouble ? validatorEdgeFor(right) : Edge(right, UntypedUse);
             m_insertionSet.insertNode(
                 nodeIndex, SpecNone, AssertInBounds, origin,
                 OpInfo(static_cast<uint32_t>(Node::AssertInBoundsCompareIdentical)),
                 OpInfo(static_cast<uint64_t>(0)),
-                Edge(left, UntypedUse), Edge(right, UntypedUse));
+                leftEdge, rightEdge);
             return;
         }
 
@@ -1962,6 +1984,18 @@ private:
     void setRelationship(
         RelationshipMap& relationshipMap, Relationship relationship, unsigned timeToLive = 1)
     {
+        // Only zero-offset equalities may involve a non-int32 operand. Every other
+        // relationship carries an integer offset combined with int32 arithmetic,
+        // which is unsound over a double operand whose value can fall outside int32
+        // range. Refusing to track those keeps facts that future rules build on
+        // int32-safe; equalities are exempt because they assert value identity
+        // (representation-independent) and are only consumed against an int32 side.
+        bool zeroOffsetEqual = relationship.kind() == Relationship::Equal && !relationship.offset();
+        if (!zeroOffsetEqual
+            && (!canCarryOffsetRelationship(relationship.left().node())
+                || !canCarryOffsetRelationship(relationship.right().node())))
+            return;
+
         setOneSide(relationshipMap, relationship, timeToLive);
         setOneSide(relationshipMap, relationship.flipped(), timeToLive);
     }

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -132,6 +132,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case LogShadowChickenTail:
     case PerformPromiseThen:
     case PerformPromiseThenOneHandler:
+    case AssertInBounds:
         break;
 
     case Switch: {

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -2211,6 +2211,39 @@ public:
         return m_opInfo.as<uint32_t>();
     }
 
+    enum AssertInBoundsCompare : uint32_t {
+        AssertInBoundsCompareBelow = 0, // unsigned <
+        AssertInBoundsCompareLessThan = 1, // signed <
+        AssertInBoundsCompareNotEqual = 2, // signed !=
+        AssertInBoundsCompareIdentical = 3, // same JSValue; for equalities over non-int32 operands
+    };
+
+    AssertInBoundsCompare assertInBoundsCompare() const
+    {
+        RELEASE_ASSERT(op() == AssertInBounds);
+        return static_cast<AssertInBoundsCompare>(m_opInfo.as<uint32_t>());
+    }
+    int64_t assertInBoundsOffset() const
+    {
+        RELEASE_ASSERT(op() == AssertInBounds);
+        int64_t offset = static_cast<int64_t>(m_opInfo2.as<uint64_t>());
+        RELEASE_ASSERT(offset >= int64_t { std::numeric_limits<int32_t>::min() } - 1
+            && offset <= int64_t { std::numeric_limits<int32_t>::max() } + 1);
+        return offset;
+    }
+
+    int32_t iroFactPoisonMin() const
+    {
+        RELEASE_ASSERT(op() == IROFactPoison);
+        return static_cast<int32_t>(m_opInfo.as<uint32_t>());
+    }
+
+    int32_t iroFactPoisonMax() const
+    {
+        RELEASE_ASSERT(op() == IROFactPoison);
+        return static_cast<int32_t>(m_opInfo2.as<uint32_t>());
+    }
+
     SpeculatedType catchLocalPrediction()
     {
         ASSERT(op() == ExtractCatchLocal);

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -312,6 +312,7 @@ namespace JSC { namespace DFG {
     macro(AssertNotEmpty, NodeMustGenerate) \
     macro(CheckBadValue, NodeMustGenerate) \
     macro(AssertInBounds, NodeMustGenerate) \
+    macro(IROFactPoison, NodeResultInt32) \
     macro(CheckInBounds, NodeMustGenerate | NodeResultJS) \
     macro(CheckInBoundsInt52, NodeMustGenerate | NodeResultJS) \
     macro(CheckIdent, NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1542,6 +1542,11 @@ private:
             break;
         }
 
+        case IROFactPoison: {
+            setPrediction(SpecInt32Only);
+            break;
+        }
+
         case GetScope:
         case GetEvalScope:
             setPrediction(SpecObjectOther);

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -300,6 +300,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case ExtractOSREntryLocal:
     case ExtractCatchLocal:
     case AssertInBounds:
+    case IROFactPoison:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case ConstantStoragePointer:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -4522,6 +4522,7 @@ void SpeculativeJIT::compile(Node* node)
     case FiatInt52:
     case Int52Constant:
     case AssertInBounds:
+    case IROFactPoison:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case ArithIMul:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -6793,6 +6793,7 @@ void SpeculativeJIT::compile(Node* node)
     case Upsilon:
     case ExtractOSREntryLocal:
     case AssertInBounds:
+    case IROFactPoison:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case ArithIMul:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -220,6 +220,7 @@ inline CapabilityLevel canCompile(DFG::Node* node)
     case ToBoolean:
     case LogicalNot:
     case AssertInBounds:
+    case IROFactPoison:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case ConstantStoragePointer:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -6317,11 +6317,34 @@ IGNORE_CLANG_WARNINGS_END
         RELEASE_ASSERT(Options::validateBoundsCheckElimination() || Options::validateIntegerRangeOptimization());
 
         if (m_node->assertInBoundsCompare() == Node::AssertInBoundsCompareIdentical) {
-            LValue left = lowJSValue(m_node->child1());
-            LValue right = lowJSValue(m_node->child2());
+            // Value identity for a zero-offset equality. Double/Int52 operands have
+            // no JSValue form, so when either side is one, compare both as doubles
+            // (the operands are integer-valued); otherwise compare JSValues, which
+            // also covers a boxed value against an int32.
+            auto isDoubleOrInt52 = [] (Edge edge) {
+                return edge.useKind() == DoubleRepUse || edge.useKind() == Int52RepUse;
+            };
+            LValue same;
+            if (isDoubleOrInt52(m_node->child1()) || isDoubleOrInt52(m_node->child2())) {
+                auto lowAsDouble = [&] (Edge edge) -> LValue {
+                    switch (edge.useKind()) {
+                    case DoubleRepUse:
+                        return lowDouble(edge);
+                    case Int52RepUse:
+                        return m_out.intToDouble(lowStrictInt52(edge));
+                    case KnownInt32Use:
+                        return m_out.intToDouble(lowInt32(edge));
+                    default:
+                        RELEASE_ASSERT_NOT_REACHED();
+                        return nullptr;
+                    }
+                };
+                same = m_out.doubleEqual(lowAsDouble(m_node->child1()), lowAsDouble(m_node->child2()));
+            } else
+                same = m_out.equal(lowJSValue(m_node->child1()), lowJSValue(m_node->child2()));
             LBasicBlock notSameCase = m_out.newBlock();
             LBasicBlock continuation = m_out.newBlock();
-            m_out.branch(m_out.equal(left, right), usually(continuation), rarely(notSameCase));
+            m_out.branch(same, usually(continuation), rarely(notSameCase));
             LBasicBlock lastNext = m_out.appendTo(notSameCase, continuation);
             m_out.trap();
             m_out.appendTo(continuation, lastNext);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -6314,16 +6314,81 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileAssertInBounds()
     {
-        ASSERT(Options::validateBoundsCheckElimination());
-        LValue index = lowInt32(m_node->child1());
-        LValue bounds = lowInt32(m_node->child2());
+        RELEASE_ASSERT(Options::validateBoundsCheckElimination() || Options::validateIntegerRangeOptimization());
 
+        if (m_node->assertInBoundsCompare() == Node::AssertInBoundsCompareIdentical) {
+            LValue left = lowJSValue(m_node->child1());
+            LValue right = lowJSValue(m_node->child2());
+            LBasicBlock notSameCase = m_out.newBlock();
+            LBasicBlock continuation = m_out.newBlock();
+            m_out.branch(m_out.equal(left, right), usually(continuation), rarely(notSameCase));
+            LBasicBlock lastNext = m_out.appendTo(notSameCase, continuation);
+            m_out.trap();
+            m_out.appendTo(continuation, lastNext);
+            return;
+        }
+
+        // Each operand is referenced in its own representation. An int32 operand
+        // is compared directly. A boxed operand is loaded as a JSValue: if it is
+        // an int32 at runtime it is compared like any other, but if it is
+        // anything else we crash (invalid relationship)
+        LValue nonInt32Operand = m_out.booleanFalse;
+        auto lowOperand = [&] (Edge edge) -> LValue {
+            if (edge.useKind() != UntypedUse)
+                return lowInt32(edge);
+            LValue jsValue = lowJSValue(edge);
+            nonInt32Operand = m_out.bitOr(nonInt32Operand, isNotInt32(jsValue));
+            return unboxInt32(jsValue);
+        };
+        LValue index = lowOperand(m_node->child1());
+        LValue bounds = lowOperand(m_node->child2());
+        int64_t offset = m_node->assertInBoundsOffset();
+        RELEASE_ASSERT(offset >= static_cast<int64_t>(INT32_MIN) - 1 && offset <= static_cast<int64_t>(INT32_MAX) + 1);
+
+        LValue inBounds;
+        Node::AssertInBoundsCompare compare = m_node->assertInBoundsCompare();
+        if (compare == Node::AssertInBoundsCompareNotEqual) {
+            LValue limit = offset
+                ? m_out.add(m_out.signExt32To64(bounds), m_out.constInt64(offset))
+                : m_out.signExt32To64(bounds);
+            inBounds = m_out.notEqual(m_out.signExt32To64(index), limit);
+        } else if (!offset) {
+            inBounds = (compare == Node::AssertInBoundsCompareLessThan)
+                ? m_out.lessThan(index, bounds)
+                : m_out.below(index, bounds);
+        } else {
+            LValue offsetExt = m_out.constInt64(offset);
+            if (compare == Node::AssertInBoundsCompareLessThan) {
+                LValue indexExt = m_out.signExt32To64(index);
+                LValue boundsExt = m_out.signExt32To64(bounds);
+                LValue limit = m_out.add(boundsExt, offsetExt);
+                inBounds = m_out.lessThan(indexExt, limit);
+            } else {
+                LValue indexExt = m_out.zeroExt(index, Int64);
+                LValue boundsExt = m_out.zeroExt(bounds, Int64);
+                LValue limit = m_out.add(boundsExt, offsetExt);
+                inBounds = m_out.below(indexExt, limit);
+            }
+        }
+
+        LBasicBlock nonInt32Case = m_out.newBlock();
+        LBasicBlock boundsCheckCase = m_out.newBlock();
         LBasicBlock outOfBoundsCase = m_out.newBlock();
         LBasicBlock continuation = m_out.newBlock();
-        m_out.branch(m_out.below(index, bounds), usually(continuation), rarely(outOfBoundsCase));
 
-        LBasicBlock lastNext = m_out.appendTo(outOfBoundsCase, continuation);
-        vmCall(Void, operationReportBoundsCheckEliminationErrorAndCrash,
+        // A non-int32 operand reached the validator. Trap to surface it rather
+        // than skipping, since the relationship will be consulted for further
+        // implications without re-checking int32-ness at the use site.
+        m_out.branch(nonInt32Operand, rarely(nonInt32Case), usually(boundsCheckCase));
+
+        LBasicBlock lastNext = m_out.appendTo(nonInt32Case, boundsCheckCase);
+        m_out.trap();
+
+        m_out.appendTo(boundsCheckCase, outOfBoundsCase);
+        m_out.branch(inBounds, usually(continuation), rarely(outOfBoundsCase));
+
+        m_out.appendTo(outOfBoundsCase, continuation);
+        m_out.call(Void, m_out.operation(operationReportBoundsCheckEliminationErrorAndCrash),
             m_out.constIntPtr(std::bit_cast<intptr_t>(codeBlock())),
             m_out.constInt32(m_node->index()),
             m_out.constInt32(m_node->child1()->index()),
@@ -6333,6 +6398,7 @@ IGNORE_CLANG_WARNINGS_END
 
         m_out.appendTo(continuation, lastNext);
     }
+
 
     void compileCheckInBounds()
     {

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -962,7 +962,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompileFTLLazySlowPath, void*, (CallF
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION_WITH_ATTRIBUTES(operationReportBoundsCheckEliminationErrorAndCrash, NO_RETURN_DUE_TO_CRASH, void, (intptr_t codeBlockAsIntPtr, int32_t nodeIndex, int32_t child1Index, int32_t child2Index, int32_t checkedIndex, int32_t bounds))
 {
     CodeBlock* codeBlock = std::bit_cast<CodeBlock*>(codeBlockAsIntPtr);
-    dataLogLn("Bounds Check Eimination error found @ D@", nodeIndex, ": AssertInBounds(index D@", child1Index, ": ", checkedIndex, ", bounds D@", child2Index, " ", bounds, ") in ", codeBlock);
+    dataLogLn("Bounds Check Elimination error found @ D@", nodeIndex, ": AssertInBounds(index D@", child1Index, ": ", checkedIndex, ", bounds D@", child2Index, " ", bounds, ") in ", codeBlock);
     CRASH();
 }
 

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4164,10 +4164,21 @@ void CommandLine::parseArguments(int argc, char** argv, int start)
         }
         if (!strcmp(arg, "--signal-expected")) {
 #if OS(UNIX)
+            // Keep in sync with getFailCondition in jsc-stress-test-writer-default.rb.
             SignalAction (*exit)(Signal, SigInfo&, PlatformRegisters&) = [] (Signal signal, SigInfo&, PlatformRegisters&) {
-                dataLogLn("Signal handler for ", ScopedEnumDump(signal), " hit. Exiting with status 137");
-                // Deliberate exit with a SIGKILL code greater than 130.
-                terminateProcess(137);
+                int status = 137;
+                switch (signal) {
+                case Signal::AccessFault:
+                    status = 138;
+                    break;
+                case Signal::FloatingPoint:
+                    status = 139;
+                    break;
+                default:
+                    break;
+                }
+                dataLogLn("Signal handler for ", ScopedEnumDump(signal), " hit. Exiting with status ", status);
+                terminateProcess(status);
                 return SignalAction::ForceDefault;
             };
 

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -259,6 +259,7 @@ namespace JSC {
     macro(SetInt32HeapPredictionIntrinsic) \
     macro(CheckInt32Intrinsic) \
     macro(FiatInt52Intrinsic) \
+    macro(IROFactPoisonIntrinsic) \
     \
     /* These are used for $vm performance debugging features. */ \
     macro(CPUMfenceIntrinsic) \

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -468,6 +468,7 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Bool, validateDFGClobberize, false, Normal, "Emits code in the DFG/FTL to validate the Clobberize phase"_s) \
     v(Bool, validateBoundsCheckElimination, false, Normal, "Emits code in the DFG/FTL to validate bounds check elimination"_s) \
+    v(Bool, validateIntegerRangeOptimization, false, Normal, "Emits code in the FTL to validate facts learned by IntegerRangeOptimizationPhase"_s) \
     v(Bool, validateDFGMayExit, ASSERT_ENABLED, Normal, "Emits code in the DFG/FTL to validate the MayExit phase"_s) \
     \
     v(Bool, validateVMEntryCalleeSaves, false, Configurable, "Causes vmEntryToJavaScript to validate VMEntry callee saves are properly restored"_s) \
@@ -725,6 +726,7 @@ enum OptionEquivalence {
     v(maximumFTLCandidateInstructionCount, maximumFTLCandidateBytecodeCost, SameOption) \
     v(maximumInliningCallerSize, maximumInliningCallerBytecodeCost, SameOption) \
     v(validateBCE, validateBoundsCheckElimination, SameOption) \
+    v(validateIRO, validateIntegerRangeOptimization, SameOption) \
 
 
 enum ExperimentalOptionFlags {

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2117,6 +2117,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionBreakpoint);
 static JSC_DECLARE_HOST_FUNCTION(functionExit);
 static JSC_DECLARE_HOST_FUNCTION(functionDFGTrue);
 static JSC_DECLARE_HOST_FUNCTION(functionFTLTrue);
+static JSC_DECLARE_HOST_FUNCTION(functionIROFactPoison);
 static JSC_DECLARE_HOST_FUNCTION(functionOMGTrue);
 static JSC_DECLARE_HOST_FUNCTION(functionCpuMfence);
 static JSC_DECLARE_HOST_FUNCTION(functionCpuRdtsc);
@@ -2339,6 +2340,15 @@ JSC_DEFINE_HOST_FUNCTION(functionFTLTrue, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
     return JSValue::encode(jsBoolean(false));
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionIROFactPoison, (JSGlobalObject*, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    RELEASE_ASSERT(Options::validateIntegerRangeOptimization());
+    if (callFrame->argumentCount() < 1)
+        return JSValue::encode(jsUndefined());
+    return JSValue::encode(callFrame->uncheckedArgument(0));
 }
 
 // Returns true if the calling frame is an OMG frame.
@@ -4427,6 +4437,7 @@ void JSDollarVM::finishCreation(VM& vm)
 
     putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "dfgTrue"_s), 0, functionDFGTrue, ImplementationVisibility::Public, DFGTrueIntrinsic, jsDollarVMPropertyAttributes);
     putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "ftlTrue"_s), 0, functionFTLTrue, ImplementationVisibility::Public, FTLTrueIntrinsic, jsDollarVMPropertyAttributes);
+    putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "iroFactPoison"_s), 3, functionIROFactPoison, ImplementationVisibility::Public, IROFactPoisonIntrinsic, jsDollarVMPropertyAttributes);
     putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "omgTrue"_s), 0, functionOMGTrue, ImplementationVisibility::Public, NoIntrinsic, jsDollarVMPropertyAttributes);
 
     putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "cpuMfence"_s), 0, functionCpuMfence, ImplementationVisibility::Public, CPUMfenceIntrinsic, jsDollarVMPropertyAttributes);

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -705,7 +705,7 @@ class BasePlan
     attr_accessor :retryParameters
 
     @@index = 0
-    def initialize(directory, arguments, family, name, outputHandler, errorHandler, retryParameters, expectCrash)
+    def initialize(directory, arguments, family, name, outputHandler, errorHandler, retryParameters, expectCrash, expectCrashMessage = nil)
         @directory = directory
         @arguments = argumentsMapper(arguments)
         @family = family
@@ -713,6 +713,7 @@ class BasePlan
         @outputHandler = outputHandler
         @errorHandler = errorHandler
         @expectCrash = expectCrash
+        @expectCrashMessage = expectCrashMessage
         # A plan for which @retryParameters is not nil is being
         # treated as potentially flaky.
         @retryParameters = retryParameters
@@ -727,11 +728,14 @@ class BasePlan
         if $runCommandOptions[:mustCrash]
             outputHandler = noisyOutputHandler
         end
-        self.new(directory, arguments, family, name, outputHandler, errorHandler, $runCommandOptions[:flaky], $runCommandOptions[:mustCrash])
+        self.new(directory, arguments, family, name, outputHandler, errorHandler, $runCommandOptions[:flaky], $runCommandOptions[:mustCrash], $runCommandOptions[:mustCrashMessage])
     end
 
     def expectCrash
         @expectCrash
+    end
+    def expectCrashMessage
+        @expectCrashMessage
     end
     def argumentsMapper(args)
         args
@@ -961,7 +965,18 @@ end
 
 def mustCrash!
     $testSpecificRequiredOptions += ["--signal-expected"]
-    $runCommandOptions[:mustCrash] = true
+    $runCommandOptions[:mustCrash] = :any
+end
+
+#   :trap — IllegalInstruction / Breakpoint / Abort (CRASH/RELEASE_ASSERT/abort).
+#   :segv — SIGSEGV / SIGBUS.
+#   :fpe  — SIGFPE.
+def mustCrashWith!(kind, message = nil)
+    raise "mustCrashWith! requires :trap, :segv, or :fpe (got #{kind.inspect})" unless %i[trap segv fpe].include?(kind)
+    raise "mustCrashWith! message must be a String or nil" unless message.nil? || message.is_a?(String)
+    $testSpecificRequiredOptions += ["--signal-expected"]
+    $runCommandOptions[:mustCrash] = kind
+    $runCommandOptions[:mustCrashMessage] = message
 end
 
 def serial!

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -968,9 +968,9 @@ def mustCrash!
     $runCommandOptions[:mustCrash] = :any
 end
 
-#   :trap — IllegalInstruction / Breakpoint / Abort (CRASH/RELEASE_ASSERT/abort).
-#   :segv — SIGSEGV / SIGBUS.
-#   :fpe  — SIGFPE.
+#   :trap - IllegalInstruction / Breakpoint / Abort (CRASH/RELEASE_ASSERT/abort).
+#   :segv - SIGSEGV / SIGBUS.
+#   :fpe  - SIGFPE.
 def mustCrashWith!(kind, message = nil)
     raise "mustCrashWith! requires :trap, :segv, or :fpe (got #{kind.inspect})" unless %i[trap segv fpe].include?(kind)
     raise "mustCrashWith! message must be a String or nil" unless message.nil? || message.is_a?(String)
@@ -1251,6 +1251,15 @@ BASE_MODES = [
         "ftl-no-cjit-osr-validation",
         [
             "--validateFTLOSRExitLiveness=true",
+        ] +
+        FTL_OPTIONS +
+        NO_CJIT_OPTIONS
+    ],
+    [
+        "FTLNoCJITIROValidate",
+        "ftl-no-cjit-iro-validate",
+        [
+            "--validateIntegerRangeOptimization=true",
         ] +
         FTL_OPTIONS +
         NO_CJIT_OPTIONS
@@ -1624,6 +1633,7 @@ def defaultRunConfig(config, subsetOptions, *optionalTestSpecificOptions)
             runFTLNoCJITValidateConfig(config, *optionalTestSpecificOptions)
             runFTLNoCJITNoPutStackValidateConfig(config, *optionalTestSpecificOptions)
             runFTLNoCJITNoInlineValidateConfig(config, *optionalTestSpecificOptions)
+            runFTLNoCJITIROValidateConfig(config, *optionalTestSpecificOptions)
         end
     end
 end

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
@@ -50,10 +50,15 @@ def noisyOutputHandler
 end
 
 def getFailCondition(plan)
-    # jsc shell's expected crashes are configured to return with an error > 130.
-    # So, if we're expecting a crash and the exitCode is less or equal to 130, the test
-    # is not exiting due to an expected crash, and it should be considered a test failure.
-    plan.expectCrash ? "-le 130" : "-ne 0"
+    # Status codes assigned by jsc.cpp's --signal-expected handler — keep in sync.
+    case plan.expectCrash
+    when :any then "-le 130"
+    when :trap then "-ne 137"
+    when :segv then "-ne 138"
+    when :fpe then "-ne 139"
+    when false, nil then "-ne 0"
+    else raise "Unknown expectCrash value: #{plan.expectCrash.inspect}"
+    end
 end
 
 def getAndTestExitCode(plan, condition)
@@ -71,6 +76,16 @@ def simpleErrorHandler
         outp.puts "then"
         outp.puts "    (echo ERROR: Unexpected exit code: $exitCode) | " + redirectAndPrefixCommand(plan.name)
         outp.puts "    " + plan.failCommand
+        if plan.expectCrashMessage
+            outputFilename = Shellwords.shellescape((Pathname("..") + (plan.name + ".out")).to_s)
+            messagePattern = Shellwords.shellescape(plan.expectCrashMessage)
+            diagnostic = Shellwords.shellescape(
+                "ERROR: Crashed as expected, but stdout/stderr did not contain expected message: #{plan.expectCrashMessage}")
+            outp.puts "elif ! grep -q -F -- #{messagePattern} #{outputFilename}"
+            outp.puts "then"
+            outp.puts "    (cat #{outputFilename} && echo #{diagnostic}) | " + redirectAndPrefixCommand(plan.name)
+            outp.puts "    " + plan.failCommand
+        end
         outp.puts "else"
         outp.puts "    " + plan.successCommand
         outp.puts "fi"

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
@@ -50,7 +50,7 @@ def noisyOutputHandler
 end
 
 def getFailCondition(plan)
-    # Status codes assigned by jsc.cpp's --signal-expected handler — keep in sync.
+    # Status codes assigned by jsc.cpp's --signal-expected handler - keep in sync.
     case plan.expectCrash
     when :any then "-le 130"
     when :trap then "-ne 137"

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb
@@ -65,6 +65,20 @@ def noisyOutputHandler
     }
 end
 
+# Ruby expression that evaluates to true iff `status` matches the plan's
+# expected exit. Keep in sync with getFailCondition in
+# jsc-stress-test-writer-default.rb and the --signal-expected handler in jsc.cpp.
+def successCheckFor(plan)
+    case plan.expectCrash
+    when :any then "((status.exitstatus || 0) > 130)"
+    when :trap then "(status.exitstatus == 137)"
+    when :segv then "(status.exitstatus == 138)"
+    when :fpe then "(status.exitstatus == 139)"
+    when false, nil then "status.success?"
+    else raise "Unknown expectCrash value: #{plan.expectCrash.inspect}"
+    end
+end
+
 # Error handler for tests that fail exactly when they return non-zero exit status.
 # This is useful when a test is expected to fail.
 def simpleErrorHandler
@@ -73,6 +87,12 @@ def simpleErrorHandler
         outp.puts "if !success(status)\n"
         outp.puts "    print " + prefixString("\"ERROR: Unexpected exit code \#{status.exitstatus}\\n\"", plan.name) + "\n"
         outp.puts "        " + plan.failCommand
+        if plan.expectCrashMessage
+            outp.puts "elsif !out.include?(#{plan.expectCrashMessage.inspect})\n"
+            outp.puts "    print " + prefixString("out", plan.name) + "\n"
+            outp.puts "    print " + prefixString("\"ERROR: Crashed as expected, but stdout/stderr did not contain expected message: #{plan.expectCrashMessage}\\n\"", plan.name) + "\n"
+            outp.puts "    " + plan.failCommand
+        end
         outp.puts "else\n"
         outp.puts "    " + plan.successCommand
         outp.puts "end\n"
@@ -284,7 +304,7 @@ class Plan < BasePlan
         script += "    <<-END_OF_SCRIPT\n"
         script += "        require 'open3'\n"
         script += "        def success(status)\n"
-        script += "            status.success?\n"
+        script += "            #{successCheckFor(self)}\n"
         script += "        end\n"
         script += "        script_location = File.expand_path(File.dirname(__FILE__))\n"
         script += "        Dir.chdir(\"\\\#{script_location}"
@@ -360,7 +380,7 @@ class Plan < BasePlan
             outp.puts "require 'open3'"
             outp.puts "require 'fileutils'"
             outp.puts "def success(status)"
-            outp.puts "   status.success?"
+            outp.puts "   #{successCheckFor(self)}"
             outp.puts "end"
 
             cmd = shellCommand


### PR DESCRIPTION
#### b8d053ff45128ece6f19caec8e343cc4b5ff4f7c
<pre>
Extend bounds check validation to include all IRO facts
<a href="https://bugs.webkit.org/show_bug.cgi?id=316343">https://bugs.webkit.org/show_bug.cgi?id=316343</a>

Reviewed by NOBODY (OOPS!).

AssertInBounds is extended to validate every IRO fact (the original
testing mode is left in, since these facts are very heavy)

We add some generated tests to confirm that these assertions can
be hit and are not removed by later phases.

Finally, we add a new bulitin that lets us inject bad IRO facts.
This is helpful for writing tests without relying on a particular
setup that might change after future optimizations.

This is added as a new testing mode to the test suite only for EWS,
this part can be removed before this patch lands.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5814553ebdb0e1744a8e418b2af3e0b2a63d5f5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180131 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128466 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133178 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93977 "16 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173712 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35006 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33327 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28811 "Built successfully") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2043 "Found 14 new JSC stress test failures: stress/ai-needs-to-model-spreads-effects.js.ftl-no-cjit-iro-validate, stress/array-sort-inline-full.js.ftl-no-cjit-iro-validate, stress/generator-fib-ftl-and-object.js.ftl-no-cjit-iro-validate, stress/generator-fib-ftl.js.ftl-no-cjit-iro-validate, stress/integer-range-optimization-fact-poison-arithabs-crashes.js.misc-ftl-no-cjit, stress/integer-range-optimization-fact-poison-checkinbounds-crashes.js.misc-ftl-no-cjit, stress/integer-range-optimization-fact-poison-crashes.js.misc-ftl-no-cjit, stress/integer-range-optimization-fact-poison-loop-crashes.js.misc-ftl-no-cjit, stress/integer-range-optimization-fact-poison-negative-range-crashes.js.misc-ftl-no-cjit, stress/integer-range-optimization-fact-poison-removed-checkinbounds.js.misc-ftl-no-cjit ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182716 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32008 "Found 14 new JSC stress test failures: stress/ai-needs-to-model-spreads-effects.js.ftl-no-cjit-iro-validate, stress/array-sort-inline-full.js.ftl-no-cjit-iro-validate, stress/generator-fib-ftl-and-object.js.ftl-no-cjit-iro-validate, stress/generator-fib-ftl.js.ftl-no-cjit-iro-validate, stress/integer-range-optimization-fact-poison-arithabs-crashes.js.misc-ftl-no-cjit, stress/integer-range-optimization-fact-poison-checkinbounds-crashes.js.misc-ftl-no-cjit, stress/integer-range-optimization-fact-poison-crashes.js.misc-ftl-no-cjit, stress/integer-range-optimization-fact-poison-loop-crashes.js.misc-ftl-no-cjit, stress/integer-range-optimization-fact-poison-negative-range-crashes.js.misc-ftl-no-cjit, stress/integer-range-optimization-fact-poison-removed-checkinbounds.js.misc-ftl-no-cjit ... (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37503 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141636 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44334 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141452 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45023 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30004 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109704 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36721 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116912 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203432 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43534 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8106 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54479 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42938 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43179 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->