### PR TITLE
[Site Isolation] Enable MultiProcessBackForwardCache in WebKitTestRunner when Site Isolation is enabled

### DIFF
--- a/LayoutTests/fast/events/site-isolation/event-timing-back-forward-cache-duration-expected.txt
+++ b/LayoutTests/fast/events/site-isolation/event-timing-back-forward-cache-duration-expected.txt
@@ -1,0 +1,10 @@
+Tests that event timing entries do not have inflated durations after back-forward cache restore.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Event timing entries have reasonable durations after back-forward restore
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Navigate

--- a/LayoutTests/fast/events/site-isolation/event-timing-back-forward-cache-duration.html
+++ b/LayoutTests/fast/events/site-isolation/event-timing-back-forward-cache-duration.html
@@ -1,0 +1,72 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<a id="link" href="../resources/go-back-after-delay.html" style="display:block; width:100px; height:100px;">Navigate</a>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+description("Tests that event timing entries do not have inflated durations after back-forward cache restore.");
+window.jsTestIsAsync = true;
+
+const collectedEntries = [];
+const observer = new PerformanceObserver(list => {
+    for (const entry of list.getEntries()) {
+        collectedEntries.push({
+            name: entry.name,
+            duration: entry.duration,
+        });
+    }
+});
+observer.observe({ type: 'event', durationThreshold: 16 });
+
+const link = document.getElementById('link');
+link.addEventListener('click', () => {
+    const target = performance.now() + 20;
+    while (performance.now() < target);
+}, { once: true });
+
+window.addEventListener("pageshow", function(event) {
+    if (!event.persisted)
+        return;
+
+    // Wait for any remaining entries to be dispatched after restoration.
+    requestAnimationFrame(async () => {
+        await new Promise(r => setTimeout(r, 0));
+        await new Promise(r => requestAnimationFrame(r));
+        await new Promise(r => setTimeout(r, 0));
+
+        let hasClickEntry = false;
+        let hasInflatedDuration = false;
+        for (const entry of collectedEntries) {
+            if (entry.name === 'click')
+                hasClickEntry = true;
+            if (entry.duration >= 1500) {
+                testFailed("'" + entry.name + "' entry has inflated duration: " + entry.duration + "ms");
+                hasInflatedDuration = true;
+            }
+        }
+        if (!hasClickEntry)
+            testFailed("No 'click' event timing entry collected");
+        else if (!hasInflatedDuration)
+            testPassed("Event timing entries have reasonable durations after back-forward restore");
+        finishJSTest();
+    });
+});
+
+window.addEventListener("pagehide", function(event) {
+    if (!event.persisted) {
+        testFailed("Page did not enter the page cache");
+        finishJSTest();
+    }
+});
+
+window.addEventListener('load', async function() {
+    // Click the link to generate event timing entries and navigate via
+    // the link's default action. The navigation happens as part of click
+    // event dispatch, so no rendering update can drain entries beforehand.
+    await UIHelper.activateElement(link);
+});
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1339,6 +1339,10 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
     RefPtr relatedPage = pageConfiguration->relatedPage();
     bool siteIsolationEnabled = protect(pageConfiguration->preferences())->siteIsolationEnabled();
     if (siteIsolationEnabled) {
+        // These preferences are coupled to Site Isolation here. WebKitTestRunner must
+        // mirror this in TestController::featuresImpliedBySiteIsolation().
+        // FIXME: Find a single shared definition so the product and the test harness
+        // cannot drift out of sync.
         Ref<WebPreferences> preferences = pageConfiguration->preferences();
         preferences->setUseUIProcessForBackForwardItemLoading(true);
         preferences->setMultiProcessBackForwardCacheEnabled(true);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2033,7 +2033,23 @@ TestOptions TestController::testOptionsForTest(const TestCommand& command) const
     merge(features, featureFromAdditionalHeaderOption(command, TestOptions::keyTypeMapping()));
     merge(features, platformSpecificFeatureOverridesDefaultsForTest(command));
 
+    auto siteIsolation = features.boolWebPreferenceFeatures.find("SiteIsolationEnabled");
+    if (siteIsolation != features.boolWebPreferenceFeatures.end() && siteIsolation->second)
+        merge(features, featuresImpliedBySiteIsolation());
+
     return TestOptions { features };
+}
+
+// Mirror WebProcessPool::createWebPage, which unconditionally enables this under Site
+// Isolation. Merged last so it matches that override and survives WebKitTestRunner's
+// per-test preference reset; a test cannot run Site Isolation with it off, as in production.
+// FIXME: Also couple UseUIProcessForBackForwardItemLoading; it currently surfaces a
+// nested-frame form-state restoration failure.
+TestFeatures TestController::featuresImpliedBySiteIsolation() const
+{
+    TestFeatures implied;
+    implied.boolWebPreferenceFeatures.insert_or_assign("MultiProcessBackForwardCacheEnabled", true);
+    return implied;
 }
 
 void TestController::updateWebViewSizeForTest(const TestInvocation& test)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -543,6 +543,7 @@ private:
     TestOptions testOptionsForTest(const TestCommand&) const;
     TestFeatures platformSpecificFeatureDefaultsForTest(const TestCommand&) const;
     TestFeatures platformSpecificFeatureOverridesDefaultsForTest(const TestCommand&) const;
+    TestFeatures featuresImpliedBySiteIsolation() const;
 
     void updateWebViewSizeForTest(const TestInvocation&);
     void updateWindowScaleForTest(PlatformWebView*, const TestInvocation&);


### PR DESCRIPTION
#### 49a03a1fa5d5841b91c77cb285f1e929b20125c1
<pre>
[Site Isolation] Enable MultiProcessBackForwardCache in WebKitTestRunner when Site Isolation is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=316344">https://bugs.webkit.org/show_bug.cgi?id=316344</a>
<a href="https://rdar.apple.com/178760818">rdar://178760818</a>

Reviewed by Sihui Liu.

Under Site Isolation, WebProcessPool::createWebPage enables MultiProcessBackForwardCache
(and UseUIProcessForBackForwardItemLoading) automatically at page creation. WebKitTestRunner
applies a full preference set per test in resetPreferencesToConsistentValues
(WKPreferencesResetTestRunnerOverrides resets unspecified preferences to their defaults),
which clobbers that runtime flip. As a result BFCache-under-Site-Isolation tests ran with
MultiProcessBackForwardCacheEnabled=false, so BackForwardCache::addIfCacheable&apos;s guard
(siteIsolationEnabled() &amp;&amp; !multiProcessBackForwardCacheEnabled()) rejected caching and
back/forward restore failed.

Mirror the product coupling in the test runner: when SiteIsolationEnabled is resolved true
for a test, also enable MultiProcessBackForwardCacheEnabled. The coupling is applied last in
testOptionsForTest so it matches the product&apos;s unconditional enable under Site Isolation.

UseUIProcessForBackForwardItemLoading is intentionally not coupled yet; enabling it surfaces a
separate nested-frame form-state restoration failure (tracked by the FIXME in TestController).

Add a same-origin Site-Isolation copy of fast/events/event-timing-back-forward-cache-duration
as a regression guard for the coupling. It exercises the same-site, no-cross-site-iframe
BFCache path under Site Isolation; the cross-process iframe path is not covered here.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage): Note the coupling must stay in sync with
WebKitTestRunner and add a FIXME to share a single definition.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::testOptionsForTest): Merge the Site-Isolation-implied features.
(WTR::TestController::featuresImpliedBySiteIsolation): Added.
* Tools/WebKitTestRunner/TestController.h:
* LayoutTests/fast/events/site-isolation/event-timing-back-forward-cache-duration.html: Added.
* LayoutTests/fast/events/site-isolation/event-timing-back-forward-cache-duration-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/314591@main">https://commits.webkit.org/314591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/626b5d3787d07b36ab5697831e834ca205ed55ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175596 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129486 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169507 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110011 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9bf6959c-90ae-43ee-a10c-b703b9dd1657) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23737 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178130 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31030 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29057 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137841 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137759 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37117 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103521 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33053 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39306 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112381 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38703 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4103 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38948 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38846 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->