### PR TITLE
[JSC] Fix opcode assert for Array.p.sort OSR exit

### DIFF
--- a/JSTests/stress/array-sort-nested-comparator-call-ignore-result.js
+++ b/JSTests/stress/array-sort-nested-comparator-call-ignore-result.js
@@ -1,0 +1,7 @@
+function test() {
+    var arr = [3, 4, /Ῠ/iu];
+    arr.sort(function() { arr.sort(function() {}); });
+}
+
+for (var i = 0; i < testLoopCount; ++i)
+    test();

--- a/JSTests/stress/array-sort-nested-comparator-tail-call.js
+++ b/JSTests/stress/array-sort-nested-comparator-tail-call.js
@@ -1,0 +1,7 @@
+function test() {
+    var arr = [3, 4, /Ῠ/iu];
+    return arr.sort(function() { arr.sort(function() {}); });
+}
+
+for (var i = 0; i < testLoopCount; ++i)
+    test();

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2838,17 +2838,17 @@ extern "C" UGPRPair SYSV_ABI llint_slow_path_array_sort_comparator_return(CallFr
     //      [ userDefinedComparator frame ]
     //
     //  After the comparator's baseline finishes we land here. We re-execute
-    //  op_call (sort) instead of advancing past it. This is safe because
+    //  the sort call instead of advancing past it. This is safe because
     //  ArraySortCommit (the only node that mutates the array) is downstream of
     //  the comparator in the DFG graph and has not yet run, and the spec allows
     //  Array.prototype.sort to invoke the comparator any number of times.
     LLINT_BEGIN_NO_SET_PC();
     UNUSED_PARAM(globalObject);
 
-    // reifyInlinedCallFrames stored CallSiteIndex(op_call_bc) in argumentCountIncludingThis's tag.
+    // reifyInlinedCallFrames stored CallSiteIndex of the sort call in argumentCountIncludingThis's tag.
     BytecodeIndex bytecodeIndex = callFrame->bytecodeIndex();
     auto pc = codeBlock->instructions().at(bytecodeIndex);
-    ASSERT_UNUSED(pc, pc->opcodeID() == op_call);
+    ASSERT_UNUSED(pc, pc->opcodeID() == op_call || pc->opcodeID() == op_call_ignore_result || pc->opcodeID() == op_tail_call);
     return dispatchToCurrentInstructionDuringExit(throwScope, codeBlock, pc);
 }
 


### PR DESCRIPTION
#### e7d51d19e065a727bcb67c2a434937ead382f722
<pre>
[JSC] Fix opcode assert for Array.p.sort OSR exit
<a href="https://bugs.webkit.org/show_bug.cgi?id=316296">https://bugs.webkit.org/show_bug.cgi?id=316296</a>
<a href="https://rdar.apple.com/178704991">rdar://178704991</a>

Reviewed by Yusuke Suzuki and Dan Hecht.

Array.prototype.sort, when inlined, bails back out to the callsite of the
entire sort() call. This call can be either op_call, op_call_ignore_result, or
op_tail_call, with identical inlining.

The OSR exit when resuming in LLInt currently narrowly asserts that the opcode
must be op_call. Relax this to also account for op_call_ignore_result and
op_tail_call.

* JSTests/stress/array-sort-nested-comparator-call-ignore-result.js: Added.
(test):
* JSTests/stress/array-sort-nested-comparator-tail-call.js: Added.
(test):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::llint_slow_path_array_sort_comparator_return):

Canonical link: <a href="https://commits.webkit.org/314643@main">https://commits.webkit.org/314643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18fa4e95b48cfc608ec64f7ef34b65bff55cc09f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123823 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f1499ad-745b-42e7-b400-9e39b7fa8ba7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129504 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6eeb5cfe-1e45-4aea-9fff-0252982f0ed9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110029 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9f4636e-9c63-4a0e-9bb2-d235bf6538a0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30871 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29569 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23756 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158724 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140842 "Found 1 new API test failure: TestWebKitAPI.WritingTools.CompositionWithMultipleChunks (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178149 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27461 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137859 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137777 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149161 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103541 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25374 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33072 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26026 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199246 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39325 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112400 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53480 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38722 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4116 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38967 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38865 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->