### PR TITLE
[JSC] Make Temporal ICU error handling more strict

### DIFF
--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -37,6 +37,14 @@
 namespace JSC {
 namespace TemporalCore {
 
+// Shared error messages for ICU failure paths. ICU errors are not user-actionable
+// — they indicate ICU resource exhaustion or internal failure — so the messages
+// are intentionally generic and shared across call sites.
+static constexpr ASCIILiteral icuOpenCalendarFailed = "Failed to open ICU calendar"_s;
+static constexpr ASCIILiteral icuSetCalendarFailed = "Failed to set ICU calendar"_s;
+static constexpr ASCIILiteral icuReadCalendarFailed = "Failed to read calendar fields from ICU"_s;
+static constexpr ASCIILiteral icuCalendarArithmeticFailed = "Failed to perform ICU calendar arithmetic"_s;
+
 CalendarID calendarIDFromString(StringView identifier)
 {
     const auto& calendars = intlAvailableCalendars();
@@ -66,13 +74,19 @@ static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> openCalendar(CalendarI
     auto locale = buildICULocale(str);
     UErrorCode status = U_ZERO_ERROR;
     auto cal = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(ucal_open(u"UTC", 3, locale.data(), UCAL_DEFAULT, &status));
-    if (U_FAILURE(status))
+    if (U_FAILURE(status)) [[unlikely]]
         return nullptr;
     // Set to ExactTime::minValue in ms — the minimum representable Temporal instant — making ICU
     // use proleptic Gregorian for all valid dates (effectively -infinity for our purposes).
-    if (calendarId == gregoryCalendarID() || calendarIsISO(calendarId) || calendarId == japaneseCalendarID() || calendarId == buddhistCalendarID() || calendarId == rocCalendarID()) {
+    // ucal_setGregorianChange is only supported on the base Gregorian calendar; ICU returns
+    // U_UNSUPPORTED_ERROR for derived calendars (Japanese, Buddhist, ROC). Those derived
+    // calendars already use proleptic-Gregorian arithmetic in the years Temporal cares about,
+    // so calling ucal_setGregorianChange would be a no-op and we skip it.
+    if (calendarId == gregoryCalendarID() || calendarIsISO(calendarId)) {
         const double prolepticGregorianChangeMs = -8.64e15; // ExactTime::minValue / nsPerMillisecond
         ucal_setGregorianChange(cal.get(), prolepticGregorianChangeMs, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return nullptr;
     }
     return cal;
 }
@@ -97,8 +111,10 @@ int32_t lunarCalendarExtendedYearFor1972(CalendarID calendarId)
     static constexpr double iso1972Feb15EpochMs = 66960000000.0;
     UErrorCode status = U_ZERO_ERROR;
     ucal_setMillis(cal.get(), iso1972Feb15EpochMs, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return cached = 1972; // fallback: assume ISO-proleptic
     int32_t extYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
-    if (U_FAILURE(status))
+    if (U_FAILURE(status)) [[unlikely]]
         return cached = 1972; // fallback: assume ISO-proleptic
     // Return the raw EXTENDED_YEAR: 1972 on ISO-proleptic ICU,
     // epoch-based year (whatever the current ICU uses) on older Apple ICU.
@@ -128,22 +144,14 @@ static std::optional<ISO8601::PlainDate> isoDateFromCalendarChecked(UCalendar* c
 {
     UErrorCode status = U_ZERO_ERROR;
     double epochMs = ucal_getMillis(cal, &status);
-    if (U_FAILURE(status))
+    if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
     WTF::Int64Milliseconds msWT(static_cast<int64_t>(epochMs));
     int32_t days = WTF::msToDays(msWT);
     auto [year, month, day] = WTF::yearMonthDayFromDays(days);
-    if (!ISO8601::isYearWithinLimits(year))
+    if (!ISO8601::isYearWithinLimits(year)) [[unlikely]]
         return std::nullopt;
     return ISO8601::PlainDate(year, static_cast<uint8_t>(month + 1), static_cast<uint8_t>(day));
-}
-
-// isoDateFromCalendar — internal: unchecked variant of isoDateFromCalendarChecked; callers assert validity
-static ISO8601::PlainDate isoDateFromCalendar(UCalendar* cal)
-{
-    auto result = isoDateFromCalendarChecked(cal);
-    ASSERT(result);
-    return *result;
 }
 
 // Japanese era table — start years are historically fixed calendar facts.
@@ -162,11 +170,11 @@ static constexpr auto japaneseEras = WTF::toArray<JapaneseEra>({
 
 // japaneseEraStartYear — no spec AO, no ICU4X equivalent (ICU4X keys on EraStartDate directly).
 // Bridges ICU4C's UCAL_ERA integer to a Gregorian start year for lookup in japaneseEras[].
-static int32_t japaneseEraStartYear(int32_t icuEraCode)
+static std::optional<int32_t> japaneseEraStartYear(int32_t icuEraCode)
 {
     auto cal = openCalendar(japaneseCalendarID());
     if (!cal)
-        return INT32_MIN;
+        return std::nullopt;
     UErrorCode status = U_ZERO_ERROR;
     ucal_set(cal.get(), UCAL_ERA, icuEraCode);
     // YEAR=2: YEAR=1/January doesn't exist for eras starting mid-year (e.g. Showa on Dec 25).
@@ -174,24 +182,24 @@ static int32_t japaneseEraStartYear(int32_t icuEraCode)
     ucal_set(cal.get(), UCAL_MONTH, UCAL_JANUARY);
     ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
     int32_t extYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
-    if (U_FAILURE(status))
-        return INT32_MIN;
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
     return extYear - 1; // EXTENDED_YEAR of YEAR=2/Jan 1 is eraStartYear+1.
 }
 
 // japaneseEraCode — inverse of japaneseEraStartYear: derives the ICU era integer from a known era start year.
-static int32_t japaneseEraCode(int32_t startYear)
+static std::optional<int32_t> japaneseEraCode(int32_t startYear)
 {
     auto cal = openCalendar(japaneseCalendarID());
     if (!cal)
-        return -1;
+        return std::nullopt;
     UErrorCode status = U_ZERO_ERROR;
     ucal_set(cal.get(), UCAL_EXTENDED_YEAR, startYear + 1); // startYear+1/Jan 1 is always within the era.
     ucal_set(cal.get(), UCAL_MONTH, UCAL_JANUARY);
     ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
     int32_t eraCode = ucal_get(cal.get(), UCAL_ERA, &status);
-    if (U_FAILURE(status))
-        return -1;
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
     return eraCode;
 }
 
@@ -209,12 +217,14 @@ static std::optional<String> mapICUEraToTemporalEra(CalendarID calendarId, int32
     if (calendarId == buddhistCalendarID())
         return "be"_s;
     if (calendarId == japaneseCalendarID()) {
-        int32_t startYear = japaneseEraStartYear(icuEra);
+        auto startYear = japaneseEraStartYear(icuEra);
+        if (!startYear) [[unlikely]]
+            return std::nullopt;
         for (auto& e : japaneseEras) {
-            if (startYear == e.startYear)
+            if (*startYear == e.startYear)
                 return String(e.name);
         }
-        return startYear > 0 ? "ce"_s : "bce"_s;
+        return *startYear > 0 ? "ce"_s : "bce"_s;
     }
     if (calendarId == rocCalendarID())
         return !icuEra ? "broc"_s : "roc"_s;
@@ -236,19 +246,23 @@ static std::optional<String> mapICUEraToTemporalEra(CalendarID calendarId, int32
 // computeMonthCode — internal: computes monthCode string from ICU calendar state (e.g. "M05L" for Hebrew Adar I)
 // icu4x: components/calendar/src/cal/hebrew.rs (Hebrew special case)
 // icu4x: components/calendar/src/cal/chinese_based.rs (Chinese/Dangi IS_LEAP_MONTH)
-static String computeMonthCode(UCalendar* cal, CalendarID calendarId)
+static std::optional<String> computeMonthCode(UCalendar* cal, CalendarID calendarId)
 {
     UErrorCode status = U_ZERO_ERROR;
     int32_t ucalMonth = ucal_get(cal, UCAL_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
 
     if (calendarId == hebrewCalendarID()) {
         // ICU4C Hebrew never sets IS_LEAP_MONTH=1. Instead, leap years have 13 slots
         // (maxMonth=12, UCAL_MONTH 0-12) and non-leap years have 12 slots (maxMonth=11).
         // Leap year slot 5 = Adar I (M05L); non-leap slot 5 = Adar (M06).
         int32_t maxMonth = ucal_getLimit(cal, UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
         bool isLeapYear = (maxMonth == 12);
         if (isLeapYear && ucalMonth == 5)
-            return "M05L"_s;
+            return String("M05L"_s);
         int32_t codeNum;
         if (isLeapYear && ucalMonth >= 6)
             codeNum = ucalMonth; // leap post-Adar-I: M06-M12 for slots 6-12
@@ -260,24 +274,31 @@ static String computeMonthCode(UCalendar* cal, CalendarID calendarId)
     // Chinese/Dangi: IS_LEAP_MONTH distinguishes leap months on the same UCAL_MONTH slot.
     int32_t month = ucalMonth + 1;
     int32_t isLeap = ucal_get(cal, UCAL_IS_LEAP_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
     if (isLeap)
         return makeString("M"_s, month < 10 ? "0"_s : ""_s, month, "L"_s);
-    ASSERT(U_SUCCESS(status));
     return makeString("M"_s, month < 10 ? "0"_s : ""_s, month);
 }
 
 // computeOrdinalMonth — internal: returns 1-based ordinal month position in year, counting leap months for lunisolar
 // icu4x: components/calendar/src/date.rs Date::month().ordinal
-static uint8_t computeOrdinalMonth(UCalendar* cal, CalendarID calendarId)
+static std::optional<uint8_t> computeOrdinalMonth(UCalendar* cal, CalendarID calendarId)
 {
     UErrorCode status = U_ZERO_ERROR;
     int32_t month = ucal_get(cal, UCAL_MONTH, &status) + 1;
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
     if (!calendarIsLunisolar(calendarId))
         return static_cast<uint8_t>(month); // For lunisolar: the ordinal month includes leap months.
     // UCAL_MONTH gives the underlying month index (leap months share same index).
     // Count how many months from start of year to current position.
     int32_t isLeap = ucal_get(cal, UCAL_IS_LEAP_MONTH, &status); // Save current state.
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
     double savedMs = ucal_getMillis(cal, &status); // Go to the first day of the calendar year.
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
     ucal_set(cal, UCAL_MONTH, 0);
     ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
     ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
@@ -288,16 +309,23 @@ static uint8_t computeOrdinalMonth(UCalendar* cal, CalendarID calendarId)
     for (int i = 0; i < 15; i++) {
         // max 13 months + safety
         int32_t curMonth = ucal_get(cal, UCAL_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
         int32_t curLeap = ucal_get(cal, UCAL_IS_LEAP_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
         if (curMonth == targetMonth && curLeap == targetIsLeap)
             break;
         ucal_add(cal, UCAL_MONTH, 1, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
         ordinal++;
     }
 
     // Restore calendar state.
     ucal_setMillis(cal, savedMs, &status);
-    ASSERT(U_SUCCESS(status));
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
     return static_cast<uint8_t>(ordinal);
 }
 
@@ -305,12 +333,17 @@ static uint8_t computeOrdinalMonth(UCalendar* cal, CalendarID calendarId)
 // For non-Japanese calendars, era indices are 0/1 and fixed by the calendar system — hardcoded mapping suffices.
 // For Japanese, japaneseEraCode derives the integer via ICU4C dynamically using the era's historically-fixed start year.
 // Era strings match icu4x extended_year_from_era_year_unchecked (gregorian.rs, japanese.rs, coptic.rs, ethiopian.rs, hebrew.rs, persian.rs, indian.rs, roc.rs).
-static int32_t mapTemporalEraToICUEra(CalendarID calendarId, StringView era)
+static std::optional<int32_t> mapTemporalEraToICUEra(CalendarID calendarId, StringView era)
 {
-    if (calendarId == gregoryCalendarID())
-        return era == "bce"_s ? 0 : (era == "ce"_s ? 1 : -1);
+    if (calendarId == gregoryCalendarID()) {
+        if (era == "bce"_s)
+            return 0;
+        if (era == "ce"_s)
+            return 1;
+        return std::nullopt;
+    }
     if (calendarId == buddhistCalendarID())
-        return era == "be"_s ? 0 : -1;
+        return era == "be"_s ? std::optional<int32_t>(0) : std::nullopt;
     if (calendarId == japaneseCalendarID()) {
         for (auto& e : japaneseEras) {
             if (era == StringView(e.name))
@@ -318,53 +351,83 @@ static int32_t mapTemporalEraToICUEra(CalendarID calendarId, StringView era)
         }
         if (era == "ce"_s)
             return 0;
-        return -1;
+        return std::nullopt;
     }
-    if (calendarId == rocCalendarID())
-        return era == "broc"_s ? 0 : (era == "roc"_s ? 1 : -1);
-    if (calendarId == copticCalendarID() || calendarId == ethiopicCalendarID())
-        return era == "bce"_s ? 0 : (era == "ce"_s ? 1 : -1);
+    if (calendarId == rocCalendarID()) {
+        if (era == "broc"_s)
+            return 0;
+        if (era == "roc"_s)
+            return 1;
+        return std::nullopt;
+    }
+    if (calendarId == copticCalendarID() || calendarId == ethiopicCalendarID()) {
+        if (era == "bce"_s)
+            return 0;
+        if (era == "ce"_s)
+            return 1;
+        return std::nullopt;
+    }
     if (calendarId == ethioaaCalendarID())
-        return era == "aa"_s ? 0 : -1;
+        return era == "aa"_s ? std::optional<int32_t>(0) : std::nullopt;
     if (calendarId == hebrewCalendarID())
-        return era == "am"_s ? 0 : -1;
+        return era == "am"_s ? std::optional<int32_t>(0) : std::nullopt;
     if (calendarId == indianCalendarID())
-        return era == "saka"_s ? 0 : -1;
+        return era == "saka"_s ? std::optional<int32_t>(0) : std::nullopt;
     if (calendarId == persianCalendarID())
-        return era == "ap"_s ? 0 : -1;
+        return era == "ap"_s ? std::optional<int32_t>(0) : std::nullopt;
     if (calendarIsIslamic(calendarId))
-        return era == "ah"_s ? 0 : -1;
-    return -1;
+        return era == "ah"_s ? std::optional<int32_t>(0) : std::nullopt;
+    return std::nullopt;
 }
 
 // isoToCalendarFields — no single temporal_rs equivalent; aggregates Calendar::year/month/month_code/day/era into one ICU pass.
 TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
-    if (!setCalendarToISODate(cal.get(), isoDate))
-        return makeUnexpected(rangeError("Failed to set ICU calendar to ISO date"_s));
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
+    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
 
     UErrorCode status = U_ZERO_ERROR;
     CalendarFields fields;
     // NOTE: ROC UCAL_EXTENDED_YEAR may return Gregorian year on some ICU versions; handled below.
     fields.year = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
     if (calendarId == rocCalendarID()) {
         int32_t era = ucal_get(cal.get(), UCAL_ERA, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         int32_t eraYear = ucal_get(cal.get(), UCAL_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         fields.year = !era ? -(eraYear - 1) : eraYear;
     }
-    fields.month = computeOrdinalMonth(cal.get(), calendarId);
+    auto ordinalMonth = computeOrdinalMonth(cal.get(), calendarId);
+    if (!ordinalMonth) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    fields.month = *ordinalMonth;
     fields.day = static_cast<uint8_t>(ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status));
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
     fields.isLeapMonth = !!ucal_get(cal.get(), UCAL_IS_LEAP_MONTH, &status);
-    fields.monthCode = computeMonthCode(cal.get(), calendarId);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    auto monthCode = computeMonthCode(cal.get(), calendarId);
+    if (!monthCode) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    fields.monthCode = WTF::move(*monthCode);
 
     if (calendarHasEras(calendarId)) {
         int32_t icuEra = ucal_get(cal.get(), UCAL_ERA, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         fields.era = mapICUEraToTemporalEra(calendarId, icuEra);
         // NOTE: Japanese dates before 1873 use "ce"/"bce" per spec, not ICU era names.
         fields.eraYear = ucal_get(cal.get(), UCAL_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         if (calendarId == japaneseCalendarID()) {
             if (isoDate.year() < 1873) {
                 fields.era = isoDate.year() > 0 ? "ce"_s : "bce"_s;
@@ -374,8 +437,6 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
         }
     }
 
-    if (U_FAILURE(status))
-        return makeUnexpected(rangeError("Failed to read calendar fields from ICU"_s));
     return fields;
 }
 
@@ -389,18 +450,27 @@ TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::Plain
 {
     // 1. Return the extended year of isoDate in calendarId.
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
-    if (!setCalendarToISODate(cal.get(), isoDate))
-        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
+
+    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
+
     UErrorCode status = U_ZERO_ERROR;
     // NOTE: ROC UCAL_EXTENDED_YEAR may return Gregorian year on some ICU versions; compute from era+year.
     if (calendarId == rocCalendarID()) {
         int32_t era = ucal_get(cal.get(), UCAL_ERA, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         int32_t eraYear = ucal_get(cal.get(), UCAL_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         return !era ? -(eraYear - 1) : eraYear;
     }
-    return ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+    auto result = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    return result;
 }
 
 // calendarMonth — temporal_rs: Calendar::month (src/builtins/core/calendar.rs)
@@ -416,11 +486,14 @@ TemporalResult<uint8_t> calendarMonth(CalendarID calendarId, const ISO8601::Plai
     if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
         return isoDate.month();
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
-    if (!setCalendarToISODate(cal.get(), isoDate))
-        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
-    return computeOrdinalMonth(cal.get(), calendarId);
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
+    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
+    auto ordinal = computeOrdinalMonth(cal.get(), calendarId);
+    if (!ordinal) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    return *ordinal;
 }
 
 // calendarMonthCode — temporal_rs: Calendar::month_code (src/builtins/core/calendar.rs)
@@ -436,11 +509,14 @@ TemporalResult<String> calendarMonthCode(CalendarID calendarId, const ISO8601::P
     if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
         return ISO8601::monthCode(isoDate.month());
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
-    if (!setCalendarToISODate(cal.get(), isoDate))
-        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
-    return computeMonthCode(cal.get(), calendarId);
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
+    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
+    auto code = computeMonthCode(cal.get(), calendarId);
+    if (!code) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    return WTF::move(*code);
 }
 
 // calendarDay — temporal_rs: Calendar::day (src/builtins/core/calendar.rs)
@@ -456,12 +532,15 @@ TemporalResult<uint8_t> calendarDay(CalendarID calendarId, const ISO8601::PlainD
     if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
         return isoDate.day();
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
-    if (!setCalendarToISODate(cal.get(), isoDate))
-        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
+    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
     UErrorCode status = U_ZERO_ERROR;
-    return static_cast<uint8_t>(ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status));
+    int32_t day = ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    return static_cast<uint8_t>(day);
 }
 
 // calendarEra — temporal_rs: Calendar::era (src/builtins/core/calendar.rs)
@@ -478,14 +557,14 @@ TemporalResult<std::optional<String>> calendarEra(CalendarID calendarId, const I
     // 2. Return the era string for isoDate in calendarId (e.g. "ce", "bce", "reiwa").
     // NOTE: Japanese dates before 1873 use "ce"/"bce" per spec, not ICU era names.
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
-    if (!setCalendarToISODate(cal.get(), isoDate))
-        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
+    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
     UErrorCode status = U_ZERO_ERROR;
     int32_t icuEra = ucal_get(cal.get(), UCAL_ERA, &status);
-    if (U_FAILURE(status))
-        return makeUnexpected(rangeError("Failed to get era from ICU"_s));
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
     if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
         return std::optional<String>(isoDate.year() > 0 ? String("ce"_s) : String("bce"_s));
     return mapICUEraToTemporalEra(calendarId, icuEra);
@@ -505,19 +584,21 @@ TemporalResult<std::optional<int32_t>> calendarEraYear(CalendarID calendarId, co
     // 2. Return the era year (year within the current era) of isoDate in calendarId.
     // NOTE: Japanese "ce"/"bce" fallback: eraYear is the Gregorian year.
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
-    if (!setCalendarToISODate(cal.get(), isoDate))
-        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
+    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
     UErrorCode status = U_ZERO_ERROR;
     int32_t eraYear = ucal_get(cal.get(), UCAL_YEAR, &status);
-    if (U_FAILURE(status))
-        return makeUnexpected(rangeError("Failed to get era year from ICU"_s));
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
     if (calendarId == japaneseCalendarID()) {
         if (isoDate.year() < 1873)
             eraYear = isoDate.year() > 0 ? isoDate.year() : (1 - isoDate.year());
         else {
             int32_t icuEra = ucal_get(cal.get(), UCAL_ERA, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
             auto era = mapICUEraToTemporalEra(calendarId, icuEra);
             if (era && *era == "ce"_s)
                 eraYear = isoDate.year();
@@ -536,12 +617,15 @@ TemporalResult<int32_t> calendarDaysInMonth(CalendarID calendarId, const ISO8601
 {
     // 1. Return the number of days in the month containing isoDate in calendarId.
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
-    if (!setCalendarToISODate(cal.get(), isoDate))
-        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
+    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
     UErrorCode status = U_ZERO_ERROR;
-    return ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+    auto result = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    return result;
 }
 
 // calendarDaysInYear — temporal_rs: Calendar::days_in_year (src/builtins/core/calendar.rs)
@@ -554,12 +638,15 @@ TemporalResult<int32_t> calendarDaysInYear(CalendarID calendarId, const ISO8601:
 {
     // 1. Return the number of days in the year containing isoDate in calendarId.
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
-    if (!setCalendarToISODate(cal.get(), isoDate))
-        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
+    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
     UErrorCode status = U_ZERO_ERROR;
-    return ucal_getLimit(cal.get(), UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
+    int32_t result = ucal_getLimit(cal.get(), UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    return result;
 }
 
 // calendarMonthsInYear — temporal_rs: Calendar::months_in_year (src/builtins/core/calendar.rs)
@@ -573,36 +660,43 @@ TemporalResult<int32_t> calendarMonthsInYear(CalendarID calendarId, const ISO860
     // 1. Return the number of months in the year containing isoDate in calendarId.
     // NOTE: Lunisolar calendars may have 12 or 13 months; requires walking all months.
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
-    if (!setCalendarToISODate(cal.get(), isoDate))
-        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
+    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
     UErrorCode status = U_ZERO_ERROR;
 
     if (calendarIsLunisolar(calendarId)) {
         // For lunisolar calendars, count months by walking from month 1 to end of year.
-        // Save current state.
-        double savedMs = ucal_getMillis(cal.get(), &status);
-        int32_t savedYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status); // Go to first day of first month.
+        // cal is local; mutating it has no observable effect outside this function.
+        int32_t savedYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         ucal_set(cal.get(), UCAL_MONTH, 0);
         ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 0);
         ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
         ucal_getMillis(cal.get(), &status); // resolve
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
         int32_t count = 1;
         for (int i = 0; i < 14; i++) {
             ucal_add(cal.get(), UCAL_MONTH, 1, &status);
-            if (U_FAILURE(status))
-                break;
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
             int32_t curYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
             if (curYear != savedYear)
                 break;
             count++;
         }
-        ucal_setMillis(cal.get(), savedMs, &status);
         return count;
     }
 
-    return ucal_getLimit(cal.get(), UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status) + 1;
+    int32_t result = ucal_getLimit(cal.get(), UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status) + 1;
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    return result;
 }
 
 // calendarInLeapYear — temporal_rs: Calendar::in_leap_year (src/builtins/core/calendar.rs)
@@ -618,51 +712,61 @@ TemporalResult<bool> calendarInLeapYear(CalendarID calendarId, const ISO8601::Pl
     // NOTE: Lunisolar calendars: leap = 13 months in year. Others: leap = extra days in year.
     if (calendarIsLunisolar(calendarId)) {
         auto months = calendarMonthsInYear(calendarId, isoDate);
-        if (!months)
+        if (!months) [[unlikely]]
             return makeUnexpected(months.error());
         return *months > 12;
     }
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
-    if (!setCalendarToISODate(cal.get(), isoDate))
-        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
+    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
     UErrorCode status = U_ZERO_ERROR;
     int32_t actualMax = ucal_getLimit(cal.get(), UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
     int32_t leastMax = ucal_getLimit(cal.get(), UCAL_DAY_OF_YEAR, UCAL_LEAST_MAXIMUM, &status);
-    if (U_FAILURE(status))
-        return makeUnexpected(rangeError("Failed to query leap year from ICU"_s));
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
     return actualMax > leastMax;
 }
 
 // setCalendarToMonthCode — internal: sets ICU calendar to the first day of the month matching monthCode in the current year.
 // icu4x: ArithmeticDate::from_input_year_month_code_day (components/calendar/src/calendar_arithmetic.rs)
 // Returns: 1 = found exact, 0 = constrained (month code doesn't exist in year), -1 = error
-static int setCalendarToMonthCode(UCalendar* cal, CalendarID calendarId, const String& monthCode, UErrorCode& status)
+static std::optional<int> setCalendarToMonthCode(UCalendar* cal, CalendarID calendarId, const String& monthCode)
 {
     auto parsed = ISO8601::parseMonthCode(monthCode);
     if (!parsed)
-        return -1;
+        return std::nullopt;
 
+    UErrorCode status = U_ZERO_ERROR;
     if (calendarId == hebrewCalendarID()) {
         // Hebrew: walk months in the target year to find the matching month code.
         // NOTE: UCAL_ACTUAL_MAXIMUM is unreliable for Hebrew; walk is correct and safe.
         int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
         ucal_set(cal, UCAL_MONTH, 0);
         ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
         ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
         ucal_getMillis(cal, &status);
-        if (U_FAILURE(status))
-            return -1;
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
 
         for (int i = 0; i < 15; i++) {
-            String curCode = computeMonthCode(cal, calendarId);
-            if (curCode == monthCode)
+            auto curCode = computeMonthCode(cal, calendarId);
+            if (!curCode) [[unlikely]]
+                return std::nullopt;
+            if (*curCode == monthCode)
                 return 1; // exact match
             ucal_add(cal, UCAL_MONTH, 1, &status);
-            if (U_FAILURE(status))
-                return -1;
-            if (ucal_get(cal, UCAL_EXTENDED_YEAR, &status) != savedYear) {
+            if (U_FAILURE(status)) [[unlikely]]
+                return std::nullopt;
+            int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return std::nullopt;
+            if (curYear != savedYear) {
                 // Month code doesn't exist in this year.
                 // For M05L (Adar I), constrain to M06 (Adar, slot 5 in non-leap year).
                 ucal_set(cal, UCAL_EXTENDED_YEAR, savedYear);
@@ -672,32 +776,41 @@ static int setCalendarToMonthCode(UCalendar* cal, CalendarID calendarId, const S
                 return 0; // constrained
             }
         }
-        return -1;
+        return std::nullopt;
     }
 
     // Chinese/Dangi: walk months from start of year to find matching month code.
     int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
     ucal_set(cal, UCAL_MONTH, 0);
     ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
     ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
     ucal_getMillis(cal, &status);
-    if (U_FAILURE(status))
-        return -1;
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
 
     for (int i = 0; i < 14; i++) {
-        String curCode = computeMonthCode(cal, calendarId);
-        if (curCode == monthCode)
+        auto curCode = computeMonthCode(cal, calendarId);
+        if (!curCode) [[unlikely]]
+            return std::nullopt;
+        if (*curCode == monthCode)
             return 1; // exact match
         ucal_add(cal, UCAL_MONTH, 1, &status);
-        if (U_FAILURE(status))
-            return -1;
-        if (ucal_get(cal, UCAL_EXTENDED_YEAR, &status) != savedYear) {
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        if (curYear != savedYear) {
             // Month code doesn't exist in this year — constrain to last month.
             ucal_add(cal, UCAL_MONTH, -1, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return std::nullopt;
             return 0; // constrained
         }
     }
-    return -1;
+    return std::nullopt;
 }
 
 // compareSurpassesLexicographic — icu4x: compare_surpasses_lexicographic (components/calendar/src/calendar_arithmetic.rs)
@@ -742,14 +855,20 @@ static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& mo
     ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 0);
     ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
     ucal_getMillis(cal.get(), &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return 1;
 
     int32_t savedYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return 1;
     int32_t lastOrdinal = 1;
     for (int i = 0; i < 14; i++) {
-        String curCode = computeMonthCode(cal.get(), calendarId);
-        if (curCode == monthCode)
+        auto curCode = computeMonthCode(cal.get(), calendarId);
+        if (!curCode) [[unlikely]]
+            return lastOrdinal;
+        if (*curCode == monthCode)
             return i + 1;
-        if (codePointCompare(curCode, monthCode) > 0) {
+        if (codePointCompare(*curCode, monthCode) > 0) {
             // Hebrew M05L (Adar I) constrains FORWARD to M06 (Adar) in non-leap years.
             // icu4x components/calendar/src/cal/hebrew.rs ordinal_from_month: M05L -> ordinal 6 with Overflow::Constrain.
             // All other calendars constrain backward to the previous existing month.
@@ -759,7 +878,12 @@ static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& mo
         }
         lastOrdinal = i + 1;
         ucal_add(cal.get(), UCAL_MONTH, 1, &status);
-        if (U_FAILURE(status) || ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status) != savedYear)
+        if (U_FAILURE(status)) [[unlikely]]
+            return lastOrdinal;
+        int32_t curYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return lastOrdinal;
+        if (curYear != savedYear)
             return lastOrdinal;
     }
     return lastOrdinal;
@@ -810,70 +934,91 @@ TemporalResult<ISO8601::PlainDate> calendarDateAdd(CalendarID calendarId, const 
         return v >= INT32_MIN && v <= INT32_MAX;
     };
     int64_t totalDays64 = duration.days() + 7LL * duration.weeks();
-    if (!fitsInt32(duration.years()) || !fitsInt32(duration.months()) || !fitsInt32(totalDays64))
+    if (!fitsInt32(duration.years()) || !fitsInt32(duration.months()) || !fitsInt32(totalDays64)) [[unlikely]]
         return makeUnexpected(rangeError("duration is out of the representable range"_s));
 
     // 4. Open ICU calendar for calendarId.
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
     // 5. Set ICU calendar to isoDate.
-    if (!setCalendarToISODate(cal.get(), isoDate))
-        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
 
     // 6. Let origMonthCode and origDay be the source month code and day (preserved across year addition per icu4x).
     UErrorCode status = U_ZERO_ERROR;
-    String origMonthCode = computeMonthCode(cal.get(), calendarId);
+    auto origMonthCodeOpt = computeMonthCode(cal.get(), calendarId);
+    if (!origMonthCodeOpt) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    String origMonthCode = WTF::move(*origMonthCodeOpt);
     int32_t originalDay = ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
     // 7. If duration.[[Years]] ≠ 0, add years; for lunisolar, re-resolve the original month code in the new year.
     if (duration.years()) {
         ucal_add(cal.get(), UCAL_EXTENDED_YEAR, clampTo<int32_t>(duration.years()), &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
         if (calendarIsLunisolar(calendarId)) {
-            int foundState = setCalendarToMonthCode(cal.get(), calendarId, origMonthCode, status);
-            if (foundState < 0)
+            auto foundState = setCalendarToMonthCode(cal.get(), calendarId, origMonthCode);
+            if (!foundState) [[unlikely]]
                 return makeUnexpected(rangeError("Failed to resolve month code after year addition"_s));
             //    a. If overflow is ~reject~ and month code doesn't exist in new year, throw RangeError.
-            if (!foundState && overflow == TemporalOverflow::Reject)
+            if (!foundState.value() && overflow == TemporalOverflow::Reject) [[unlikely]]
                 return makeUnexpected(rangeError("month code does not exist in the target year (overflow: reject)"_s));
         }
     }
 
     // 8. If duration.[[Months]] ≠ 0, add months.
-    if (duration.months())
+    if (duration.months()) {
         ucal_add(cal.get(), UCAL_MONTH, clampTo<int32_t>(duration.months()), &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+    }
     // 9. Clamp or reject the day to the new month's maximum.
     // NOTE: ucal_add already clamps for constrain. For reject, check if day was reduced.
     // Do NOT use ucal_set(DAY_OF_MONTH) after ucal_add — causes ICU state corruption on lunisolar calendars.
     int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-    if (overflow == TemporalOverflow::Reject && originalDay > maxDay)
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    if (overflow == TemporalOverflow::Reject && originalDay > maxDay) [[unlikely]]
         return makeUnexpected(rangeError("day is out of range for the resulting month (overflow: reject)"_s));
     int32_t curDay = ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+
     if (curDay != originalDay && originalDay <= maxDay) {
         ucal_add(cal.get(), UCAL_DAY_OF_MONTH, originalDay - curDay, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
     } else if (originalDay > maxDay) {
         int32_t adj = maxDay - curDay;
-        if (adj)
+        if (adj) {
             ucal_add(cal.get(), UCAL_DAY_OF_MONTH, adj, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        }
     }
 
     // 10. Add totalDays.
-    int32_t totalDays = static_cast<int32_t>(totalDays64);
-    if (totalDays)
-        ucal_add(cal.get(), UCAL_DAY_OF_MONTH, totalDays, &status);
-
     // 11. If result is outside representable range, throw RangeError.
-    if (U_FAILURE(status))
-        return makeUnexpected(rangeError("Calendar date addition failed"_s));
+    int32_t totalDays = static_cast<int32_t>(totalDays64);
+    if (totalDays) {
+        ucal_add(cal.get(), UCAL_DAY_OF_MONTH, totalDays, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+    }
 
     // 12. Return result.
     auto result = isoDateFromCalendarChecked(cal.get());
-    if (!result)
+    if (!result) [[unlikely]]
         return makeUnexpected(rangeError("Result of calendar date addition is outside representable range"_s));
     return *result;
 }
 
 // surpassesMonths — icu4x: SurpassesChecker::surpasses_months (components/calendar/src/calendar_arithmetic.rs)
-static bool surpassesMonths(
+// Returns nullopt on ICU failure
+static std::optional<bool> surpassesMonths(
     UCalendar* trialCal,
     CalendarID calendarId,
     int32_t sign,
@@ -881,23 +1026,38 @@ static bool surpassesMonths(
     int32_t targetYear,
     const String& targetMonthCode,
     int32_t targetOrdinalMonth,
-    int32_t targetDay,
-    UErrorCode& status)
+    int32_t targetDay)
 {
+    UErrorCode status = U_ZERO_ERROR;
     ucal_add(trialCal, UCAL_MONTH, sign, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
     int32_t trialYear = ucal_get(trialCal, UCAL_EXTENDED_YEAR, &status);
-    String trialMonthCode = computeMonthCode(trialCal, calendarId);
-    return nonISODateSurpasses(calendarId, sign, trialYear, trialMonthCode, sourceDay, 0, targetYear, targetMonthCode, targetOrdinalMonth, targetDay);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    auto trialMonthCode = computeMonthCode(trialCal, calendarId);
+    if (!trialMonthCode) [[unlikely]]
+        return std::nullopt;
+    return nonISODateSurpasses(calendarId, sign, trialYear, *trialMonthCode, sourceDay, 0, targetYear, targetMonthCode, targetOrdinalMonth, targetDay);
 }
 
 // setMonths — icu4x: SurpassesChecker::set_months (components/calendar/src/calendar_arithmetic.rs)
-static void setMonths(UCalendar* cal, int32_t sourceDay, UErrorCode& status)
+static std::optional<bool> setMonths(UCalendar* cal, int32_t sourceDay)
 {
+    UErrorCode status = U_ZERO_ERROR;
     int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
     int32_t regulatedDay = std::min(sourceDay, maxDay);
     int32_t currentDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
-    if (currentDay != regulatedDay)
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    if (currentDay != regulatedDay) {
         ucal_add(cal, UCAL_DAY_OF_MONTH, regulatedDay - currentDay, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+    }
+    return true;
 }
 
 // calendarDateUntil — temporal_rs: Calendar::date_until (src/builtins/core/calendar.rs)
@@ -923,15 +1083,19 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
     // 3. Open ICU calendars for both endpoints one and two.
     auto cal1 = openCalendar(calendarId);
     auto cal2 = openCalendar(calendarId);
-    if (!cal1 || !cal2)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
-    if (!setCalendarToISODate(cal1.get(), one) || !setCalendarToISODate(cal2.get(), two))
-        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    if (!cal1 || !cal2) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
+    if (!setCalendarToISODate(cal1.get(), one) || !setCalendarToISODate(cal2.get(), two)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
 
     // 4. Let sign be +1 if one < two, -1 if one > two, 0 if equal. Return zero duration if sign = 0.
     UErrorCode status = U_ZERO_ERROR;
     double epochMs1 = ucal_getMillis(cal1.get(), &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
     double epochMs2 = ucal_getMillis(cal2.get(), &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
     int32_t sign;
     if (epochMs1 < epochMs2)
         sign = 1;
@@ -941,12 +1105,29 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
         return ISO8601::Duration { };
     // 5. Read source (one) and target (two) calendar fields: year, monthCode, day, ordinalMonth.
     int32_t sourceYear = ucal_get(cal1.get(), UCAL_EXTENDED_YEAR, &status);
-    String sourceMonthCode = computeMonthCode(cal1.get(), calendarId);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    auto sourceMonthCodeOpt = computeMonthCode(cal1.get(), calendarId);
+    if (!sourceMonthCodeOpt) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    String sourceMonthCode = WTF::move(*sourceMonthCodeOpt);
     int32_t sourceDay = ucal_get(cal1.get(), UCAL_DAY_OF_MONTH, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
     int32_t targetYear = ucal_get(cal2.get(), UCAL_EXTENDED_YEAR, &status);
-    String targetMonthCode = computeMonthCode(cal2.get(), calendarId);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    auto targetMonthCodeOpt = computeMonthCode(cal2.get(), calendarId);
+    if (!targetMonthCodeOpt) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    String targetMonthCode = WTF::move(*targetMonthCodeOpt);
     int32_t targetDay = ucal_get(cal2.get(), UCAL_DAY_OF_MONTH, &status);
-    int32_t targetOrdinalMonth = computeOrdinalMonth(cal2.get(), calendarId);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    auto targetOrdinalMonthOpt = computeOrdinalMonth(cal2.get(), calendarId);
+    if (!targetOrdinalMonthOpt) [[unlikely]]
+        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    int32_t targetOrdinalMonth = *targetOrdinalMonthOpt;
     // NOTE: min_years fast-forward: pre-guess year delta that doesn't surpass (icu4x optimization).
     int32_t yearDiff = targetYear - sourceYear;
     int32_t minYears = !yearDiff ? 0 : yearDiff - sign;
@@ -971,9 +1152,10 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
                 ISO8601::Duration yearDur;
                 yearDur.setYears(static_cast<int64_t>(years));
                 auto advanced = calendarDateAdd(calendarId, one, yearDur, TemporalOverflow::Constrain);
-                if (!advanced)
+                if (!advanced) [[unlikely]]
                     return makeUnexpected(advanced.error());
-                setCalendarToISODate(cal1.get(), *advanced);
+                if (!setCalendarToISODate(cal1.get(), *advanced)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuSetCalendarFailed));
             }
         }
 
@@ -983,23 +1165,35 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
             int32_t candidateMonths = sign;
             //    c. Set cal1 to (one + years) with day=1 for clamping-free month advancement.
             double startMs = ucal_getMillis(cal1.get(), &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
             ucal_set(cal1.get(), UCAL_DAY_OF_MONTH, 1);
             ucal_getMillis(cal1.get(), &status); // force ICU state resolution
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
 
-            auto monthDoesNotSurpass = [&] {
-                return !surpassesMonths(cal1.get(), calendarId, sign, sourceDay, targetYear, targetMonthCode, targetOrdinalMonth, targetDay, status);
-            };
-            while (monthDoesNotSurpass()) {
+            for (;;) {
+                auto surpasses = surpassesMonths(cal1.get(), calendarId, sign, sourceDay, targetYear, targetMonthCode, targetOrdinalMonth, targetDay);
+                if (!surpasses) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                if (*surpasses)
+                    break;
                 months = candidateMonths;
                 candidateMonths += sign;
             }
 
             // Restore cal1 to (one + years), apply total months in one ucal_add (avoids undo asymmetry).
             ucal_setMillis(cal1.get(), startMs, &status);
-            if (months)
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuSetCalendarFailed));
+            if (months) {
                 ucal_add(cal1.get(), UCAL_MONTH, months, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            }
             //    c. Apply regulated day = min(sourceDay, end_of_month) via setMonths.
-            setMonths(cal1.get(), sourceDay, status);
+            if (!setMonths(cal1.get(), sourceDay)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
             //    d. If largestUnit is ~month~, clear years (months were counted from one + years=0).
             if (largestUnit == TemporalUnit::Month)
                 years = 0;
@@ -1009,13 +1203,18 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
     // 7. Compute remaining days from the epoch ms difference between cal1 and two.
     const double msPerDay = 86'400'000.0; // nsPerDay / nsPerMillisecond
     if (largestUnit == TemporalUnit::Week) {
-        double dayDiff = (epochMs2 - ucal_getMillis(cal1.get(), &status)) / msPerDay;
+        double endMs = ucal_getMillis(cal1.get(), &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        double dayDiff = (epochMs2 - endMs) / msPerDay;
         //    a. If largestUnit is ~week~, extract weeks = floor(daysDiff / 7) and remaining days.
         weeks = static_cast<int32_t>(std::trunc(dayDiff / ISO8601::daysPerWeek));
     }
 
     // 8. Return Duration { years, months, weeks, days }.
     double finalMs1 = ucal_getMillis(cal1.get(), &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
     double daysDiff = std::trunc((epochMs2 - finalMs1) / msPerDay);
     if (largestUnit == TemporalUnit::Week)
         daysDiff = std::trunc(std::fmod(daysDiff, static_cast<double>(ISO8601::daysPerWeek)));
@@ -1258,8 +1457,8 @@ int32_t ecmaReferenceYear(CalendarID calendarId, uint8_t monthNumber, bool isLea
 TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId, std::optional<int32_t> year, uint8_t month, uint8_t day, std::optional<StringView> era, std::optional<int32_t> eraYear, std::optional<ParsedMonthCode> monthCode, TemporalOverflow overflow)
 {
     auto cal = openCalendar(calendarId);
-    if (!cal)
-        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!cal) [[unlikely]]
+        return makeUnexpected(rangeError(icuOpenCalendarFailed));
 
     UErrorCode status = U_ZERO_ERROR;
     ucal_clear(cal.get());
@@ -1272,21 +1471,21 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
             int32_t isoYear = *era == "bce"_s ? (1 - *eraYear) : *eraYear; // For Japanese "ce"/"bce" eras, the year IS the ISO year — bypass ICU to avoid
             // Julian/Gregorian calendar switch issues for pre-1582 dates. Apply overflow.
             // year.has_value() means user-provided; check for consistency (NonISOResolveFields step).
-            if (year && *year != isoYear)
+            if (year && *year != isoYear) [[unlikely]]
                 return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));
             uint8_t resolvedDay = day;
             uint8_t daysInMo = static_cast<uint8_t>(ISO8601::daysInMonth(isoYear, month));
             if (day > daysInMo) {
-                if (overflow == TemporalOverflow::Reject)
+                if (overflow == TemporalOverflow::Reject) [[unlikely]]
                     return makeUnexpected(rangeError("Day is out of range for the given month"_s));
                 resolvedDay = daysInMo;
             }
             return ISO8601::PlainDate(isoYear, month, resolvedDay);
         }
-        int32_t icuEra = mapTemporalEraToICUEra(calendarId, *era);
-        if (icuEra < 0)
+        auto icuEra = mapTemporalEraToICUEra(calendarId, *era);
+        if (!icuEra) [[unlikely]]
             return makeUnexpected(rangeError("era is not valid for this calendar"_s));
-        ucal_set(cal.get(), UCAL_ERA, icuEra);
+        ucal_set(cal.get(), UCAL_ERA, *icuEra);
         ucal_set(cal.get(), UCAL_YEAR, *eraYear);
     } else if (calendarId == rocCalendarID()) {
         // ROC: convert temporal year to era+eraYear for ICU.
@@ -1303,10 +1502,9 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
 
     if (monthCode) {
         // Month codes > M13 are always invalid. M13 is only valid for Coptic/Ethiopian.
-        if (monthCode->monthNumber > 13)
+        if (monthCode->monthNumber > 13) [[unlikely]]
             return makeUnexpected(rangeError("month is out of range"_s));
-        if (monthCode->monthNumber == 13
-            && calendarId != copticCalendarID() && calendarId != ethiopicCalendarID() && calendarId != ethioaaCalendarID())
+        if (monthCode->monthNumber == 13 && calendarId != copticCalendarID() && calendarId != ethiopicCalendarID() && calendarId != ethioaaCalendarID()) [[unlikely]]
             return makeUnexpected(rangeError("month is out of range"_s));
 
         if (calendarIsLunisolar(calendarId)) {
@@ -1317,19 +1515,25 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
             ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 0);
             ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
             ucal_getMillis(cal.get(), &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
 
             String targetCode = makeString("M"_s, monthCode->monthNumber < 10 ? "0"_s : ""_s,
                 monthCode->monthNumber, monthCode->isLeapMonth ? "L"_s : ""_s);
             int32_t savedYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
             bool found = false;
             for (int i = 0; i < 14; i++) {
-                String curCode = computeMonthCode(cal.get(), calendarId);
-                if (curCode == targetCode) {
+                auto curCode = computeMonthCode(cal.get(), calendarId);
+                if (!curCode) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
+                if (*curCode == targetCode) {
                     found = true;
                     break;
                 }
                 // For constrain: if we've passed the target code, stop at previous.
-                if (codePointCompare(curCode, targetCode) > 0) {
+                if (codePointCompare(*curCode, targetCode) > 0) {
                     // Leap month doesn't exist — constrain to previous month.
                     if (overflow == TemporalOverflow::Constrain && monthCode->isLeapMonth) {
                         if (calendarId == hebrewCalendarID()) {
@@ -1338,29 +1542,40 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                         } else {
                             // Chinese/Dangi: M01L->M01, revert one step.
                             ucal_add(cal.get(), UCAL_MONTH, -1, &status);
+                            if (U_FAILURE(status)) [[unlikely]]
+                                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
                             found = true;
                         }
                     }
                     break;
                 }
                 ucal_add(cal.get(), UCAL_MONTH, 1, &status);
-                if (U_FAILURE(status) || ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status) != savedYear) {
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                int32_t curYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
+                if (curYear != savedYear) {
                     ucal_add(cal.get(), UCAL_MONTH, -1, &status);
+                    if (U_FAILURE(status)) [[unlikely]]
+                        return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
                     break;
                 }
             }
-            if (!found && overflow == TemporalOverflow::Reject)
+            if (!found && overflow == TemporalOverflow::Reject) [[unlikely]]
                 return makeUnexpected(rangeError("monthCode does not exist in this calendar year"_s)); // Clamp day via ucal_add.
             int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
             uint8_t clampedDay = day;
             if (day > maxDay) {
-                if (overflow == TemporalOverflow::Reject)
+                if (overflow == TemporalOverflow::Reject) [[unlikely]]
                     return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
                 clampedDay = static_cast<uint8_t>(maxDay);
             }
             if (clampedDay > 1)
                 ucal_add(cal.get(), UCAL_DAY_OF_MONTH, clampedDay - 1, &status);
-        } else if (calendarId == hebrewCalendarID()) {
+        } else if (calendarId == hebrewCalendarID()) [[unlikely]] {
             // Hebrew non-lunisolar path — shouldn't reach here since Hebrew IS lunisolar.
             ASSERT_NOT_REACHED();
             return makeUnexpected(rangeError("unexpected hebrew non-lunisolar path"_s));
@@ -1372,11 +1587,15 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                 ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 1);
             ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
             ucal_getMillis(cal.get(), &status); // force resolution of year+month
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
 
             // Now check maxDay for the resolved month.
             int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
             if (day > maxDay) {
-                if (overflow == TemporalOverflow::Reject)
+                if (overflow == TemporalOverflow::Reject) [[unlikely]]
                     return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
                 ucal_set(cal.get(), UCAL_DAY_OF_MONTH, maxDay);
             } else if (day > 1)
@@ -1389,19 +1608,29 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
         ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 0);
         ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
         ucal_getMillis(cal.get(), &status);
-        if (U_FAILURE(status))
+        if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError("Failed to resolve lunisolar calendar"_s)); // Use a separate calendar to count months in year.
         auto countCal = openCalendar(calendarId);
-        if (!countCal)
+        if (!countCal) [[unlikely]]
             return makeUnexpected(rangeError("Failed to open counting calendar"_s));
-        ucal_setMillis(countCal.get(), ucal_getMillis(cal.get(), &status), &status);
+        double calMs = ucal_getMillis(cal.get(), &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        ucal_setMillis(countCal.get(), calMs, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
         int32_t savedYear = ucal_get(countCal.get(), UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         int32_t monthsInYear = 1;
         for (int i = 0; i < 14; i++) {
             ucal_add(countCal.get(), UCAL_MONTH, 1, &status);
-            if (U_FAILURE(status))
-                break;
-            if (ucal_get(countCal.get(), UCAL_EXTENDED_YEAR, &status) != savedYear)
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            int32_t curYear = ucal_get(countCal.get(), UCAL_EXTENDED_YEAR, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            if (curYear != savedYear)
                 break;
             monthsInYear++;
         }
@@ -1409,7 +1638,7 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
         // Clamp or reject month against monthsInYear.
         uint8_t resolvedMonth = month;
         if (month > monthsInYear) {
-            if (overflow == TemporalOverflow::Reject)
+            if (overflow == TemporalOverflow::Reject) [[unlikely]]
                 return makeUnexpected(rangeError("month is out of range for this calendar year"_s));
             resolvedMonth = static_cast<uint8_t>(monthsInYear);
         }
@@ -1417,37 +1646,46 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
         // Advance the original calendar to the target month.
         if (resolvedMonth > 1) {
             ucal_add(cal.get(), UCAL_MONTH, resolvedMonth - 1, &status);
-            if (U_FAILURE(status))
+            if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError("Failed to resolve lunisolar month"_s));
         }
 
         // Clamp day to daysInMonth if constrain.
         int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         uint8_t resolvedDay = day;
         if (day > maxDay) {
-            if (overflow == TemporalOverflow::Reject)
+            if (overflow == TemporalOverflow::Reject) [[unlikely]]
                 return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
             resolvedDay = static_cast<uint8_t>(maxDay);
         }
         // Use ucal_add (not ucal_set) to advance within the month — avoids
         // ICU's lazy-field resolution resetting the month position.
-        if (resolvedDay > 1)
+        if (resolvedDay > 1) {
             ucal_add(cal.get(), UCAL_DAY_OF_MONTH, resolvedDay - 1, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        }
     } else {
         // Non-lunisolar: clamp month to calendar max.
         int32_t maxMonth = ucal_getLimit(cal.get(), UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status) + 1;
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         uint8_t resolvedMonth = month;
         if (month > maxMonth) {
-            if (overflow == TemporalOverflow::Reject)
+            if (overflow == TemporalOverflow::Reject) [[unlikely]]
                 return makeUnexpected(rangeError("month is out of range for this calendar"_s));
             resolvedMonth = static_cast<uint8_t>(maxMonth);
         }
         ucal_set(cal.get(), UCAL_MONTH, resolvedMonth - 1); // Resolve to get actual max day for this month.
         ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
         int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
         uint8_t resolvedDay = day;
         if (day > maxDay) {
-            if (overflow == TemporalOverflow::Reject)
+            if (overflow == TemporalOverflow::Reject) [[unlikely]]
                 return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
             resolvedDay = static_cast<uint8_t>(maxDay);
         }
@@ -1456,7 +1694,7 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
 
     if (overflow == TemporalOverflow::Reject) {
         int32_t resolvedDay = ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status);
-        if (U_FAILURE(status))
+        if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError("Failed to resolve calendar date"_s));
         if (monthCode) {
             if (calendarIsLunisolar(calendarId)) {
@@ -1464,13 +1702,17 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                 // M05L at slot 5 gives UCAL_MONTH+1=6, and ICU4C never sets IS_LEAP_MONTH).
                 // Use computeMonthCode to verify the actual month — the walk already positioned
                 // the calendar at the target month, so we only need to verify the day.
-                if (resolvedDay != static_cast<int32_t>(day))
+                if (resolvedDay != static_cast<int32_t>(day)) [[unlikely]]
                     return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
             } else {
                 int32_t resolvedMonth = ucal_get(cal.get(), UCAL_MONTH, &status) + 1;
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
                 int32_t resolvedLeap = ucal_get(cal.get(), UCAL_IS_LEAP_MONTH, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
                 bool leapMismatch = monthCode->isLeapMonth && !resolvedLeap;
-                if (resolvedDay != static_cast<int32_t>(day) || resolvedMonth != static_cast<int32_t>(monthCode->monthNumber) || leapMismatch)
+                if (resolvedDay != static_cast<int32_t>(day) || resolvedMonth != static_cast<int32_t>(monthCode->monthNumber) || leapMismatch) [[unlikely]]
                     return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
             }
         }
@@ -1480,17 +1722,19 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
     // flag and lands on the non-leap version of the month, which is the correct constrain
     // behavior. No explicit fallback is needed.
 
-    ISO8601::PlainDate resolved = isoDateFromCalendar(cal.get());
+    auto resolved = isoDateFromCalendarChecked(cal.get());
+    if (!resolved) [[unlikely]]
+        return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
 
     // NonISOResolveFields: when era+eraYear and year are all non-unset, they must identify
     // the same year. year == nullopt means the caller did not have a user-provided year.
     if (tookEraPath && year) {
-        auto resolvedTemporalYear = calendarYear(calendarId, resolved);
-        if (resolvedTemporalYear && *resolvedTemporalYear != *year)
+        auto resolvedTemporalYear = calendarYear(calendarId, *resolved);
+        if (resolvedTemporalYear && *resolvedTemporalYear != *year) [[unlikely]]
             return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));
     }
 
-    return resolved;
+    return *resolved;
 }
 
 } // namespace TemporalCore

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -37,6 +37,16 @@
 namespace JSC {
 namespace TemporalCore {
 
+// Shared error messages for ICU failure paths in the time-zone bridge. ICU
+// errors are not user-actionable, so the messages are intentionally generic
+// and shared across call sites.
+static constexpr ASCIILiteral icuOpenTimeZoneFailed = "Failed to open ICU calendar for time zone"_s;
+static constexpr ASCIILiteral icuTimeZoneOffsetFailed = "Failed to get time zone offset from ICU"_s;
+static constexpr ASCIILiteral icuSetCalendarFailed = "Failed to set ICU calendar"_s;
+static constexpr ASCIILiteral icuCalendarArithmeticFailed = "Failed to perform ICU calendar arithmetic"_s;
+static constexpr ASCIILiteral icuTransitionFailed = "Failed to get time zone transition date from ICU"_s;
+static constexpr ASCIILiteral epochNanosecondsOutOfRange = "Epoch nanoseconds out of valid Temporal range"_s;
+
 // openCalendarForTimeZone — internal: opens ICU UCalendar for a named (IANA) timezone
 static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> openCalendarForTimeZone(const TimeZone& timeZone)
 {
@@ -47,7 +57,7 @@ static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> openCalendarForTimeZon
     UErrorCode status = U_ZERO_ERROR;
     auto calendar = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(
         ucal_open(upconverted, view.length(), "", UCAL_DEFAULT, &status));
-    if (U_FAILURE(status))
+    if (U_FAILURE(status)) [[unlikely]]
         return nullptr;
     return calendar;
 }
@@ -57,13 +67,13 @@ static std::optional<int32_t> getOffsetMsAtEpoch(UCalendar* cal, double epochMs)
 {
     UErrorCode status = U_ZERO_ERROR;
     ucal_setMillis(cal, epochMs, &status);
-    if (U_FAILURE(status))
+    if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
     int32_t rawOffset = ucal_get(cal, UCAL_ZONE_OFFSET, &status);
-    if (U_FAILURE(status))
+    if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
     int32_t dstOffset = ucal_get(cal, UCAL_DST_OFFSET, &status);
-    if (U_FAILURE(status))
+    if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
     return rawOffset + dstOffset;
 }
@@ -126,12 +136,12 @@ TemporalResult<int64_t> getOffsetNanosecondsFor(const TimeZone& timeZone, ISO860
     //        cache on VM would eliminate this overhead for named timezones.
     auto calendar = openCalendarForTimeZone(timeZone);
     if (!calendar)
-        return makeUnexpected(rangeError("Failed to open ICU calendar for time zone"_s));
+        return makeUnexpected(rangeError(icuOpenTimeZoneFailed));
 
     double epochMs = static_cast<double>(exactTime.floorEpochMilliseconds());
     auto offsetMs = getOffsetMsAtEpoch(calendar.get(), epochMs);
     if (!offsetMs)
-        return makeUnexpected(rangeError("Failed to get time zone offset from ICU"_s));
+        return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
 
     constexpr int64_t nsPerMs = 1'000'000; // nsPerMillisecond
     return static_cast<int64_t>(*offsetMs) * nsPerMs;
@@ -167,7 +177,7 @@ static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds
 
     auto calendar = openCalendarForTimeZone(timeZone);
     if (!calendar)
-        return makeUnexpected(rangeError("Failed to open ICU calendar for time zone"_s));
+        return makeUnexpected(rangeError(icuOpenTimeZoneFailed));
 
     // Compute the "naive" local epoch — the local datetime treated as UTC, used for gap/fold detection.
     double localMs = isoDateTimeToLocalMs(date, time);
@@ -184,18 +194,18 @@ static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds
         date.year(), static_cast<int32_t>(date.month()) - 1, date.day(),
         time.hour(), time.minute(), time.second(),
         &status);
-    if (U_FAILURE(status))
-        return makeUnexpected(rangeError("Failed to set date/time on ICU calendar"_s));
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
     ucal_set(calendar.get(), UCAL_MILLISECOND, time.millisecond());
 
     // ICU resolves the local time to one epoch (its "default" interpretation).
     double icuEpochMs = ucal_getMillis(calendar.get(), &status);
-    if (U_FAILURE(status))
-        return makeUnexpected(rangeError("Failed to get epoch ms from ICU calendar"_s));
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
 
     auto icuOffsetMs = getOffsetMsAtEpoch(calendar.get(), icuEpochMs);
     if (!icuOffsetMs)
-        return makeUnexpected(rangeError("Failed to get time zone offset from ICU"_s));
+        return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
 
     // If icuEpoch + offset ≠ localMs the local time is in a DST gap (spring-forward).
     bool icuValid = (icuEpochMs + static_cast<double>(*icuOffsetMs) == localMs);
@@ -209,10 +219,16 @@ static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds
         // beforeNs = pre-transition offset (find via previous transition or 1-day probe fallback).
         int64_t beforeNs = afterNs;
         {
-            UErrorCode s = U_ZERO_ERROR;
-            ucal_setMillis(calendar.get(), icuEpochMs, &s);
+            ucal_setMillis(calendar.get(), icuEpochMs, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
+
             UDate transitionMs = 0;
-            if (!U_FAILURE(s) && ucal_getTimeZoneTransitionDate(calendar.get(), UCAL_TZ_TRANSITION_PREVIOUS, &transitionMs, &s) && !U_FAILURE(s)) {
+            auto result = ucal_getTimeZoneTransitionDate(calendar.get(), UCAL_TZ_TRANSITION_PREVIOUS, &transitionMs, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
+
+            if (result) {
                 auto preOffset = getOffsetMsAtEpoch(calendar.get(), transitionMs - 1.0);
                 if (preOffset)
                     beforeNs = static_cast<int64_t>(*preOffset) * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
@@ -236,14 +252,15 @@ static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds
     std::optional<ISO8601::ExactTime> secondCandidate;
 
     auto tryFoldFromTransition = [&](UTimeZoneTransitionType transType) -> bool {
-        UErrorCode s = U_ZERO_ERROR;
-        ucal_setMillis(calendar.get(), icuEpochMs, &s);
-        if (U_FAILURE(s))
+        UErrorCode status = U_ZERO_ERROR;
+        ucal_setMillis(calendar.get(), icuEpochMs, &status);
+        if (U_FAILURE(status)) [[unlikely]]
             return false;
         UDate transitionMs = 0;
-        if (!ucal_getTimeZoneTransitionDate(calendar.get(), transType, &transitionMs, &s))
+        auto result = ucal_getTimeZoneTransitionDate(calendar.get(), transType, &transitionMs, &status);
+        if (U_FAILURE(status)) [[unlikely]]
             return false;
-        if (U_FAILURE(s))
+        if (!result)
             return false;
         if (std::abs(transitionMs - icuEpochMs) > maxFoldWindowMs)
             return false;
@@ -269,14 +286,15 @@ static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds
     // ICU quirk: retry from 1ms later to catch transition-boundary fold case.
     if (!secondCandidate) {
         auto tryFoldFromOffset = [&](double probeEpochMs) -> bool {
-            UErrorCode s = U_ZERO_ERROR;
-            ucal_setMillis(calendar.get(), probeEpochMs, &s);
-            if (U_FAILURE(s))
+            UErrorCode status = U_ZERO_ERROR;
+            ucal_setMillis(calendar.get(), probeEpochMs, &status);
+            if (U_FAILURE(status)) [[unlikely]]
                 return false;
             UDate transitionMs = 0;
-            if (!ucal_getTimeZoneTransitionDate(calendar.get(), UCAL_TZ_TRANSITION_PREVIOUS, &transitionMs, &s))
+            auto result = ucal_getTimeZoneTransitionDate(calendar.get(), UCAL_TZ_TRANSITION_PREVIOUS, &transitionMs, &status);
+            if (U_FAILURE(status)) [[unlikely]]
                 return false;
-            if (U_FAILURE(s))
+            if (!result)
                 return false;
             if (std::abs(transitionMs - icuEpochMs) > maxFoldWindowMs)
                 return false;
@@ -321,7 +339,7 @@ TemporalResult<PossibleEpochNanoseconds> getPossibleEpochNanosecondsFor(const Ti
         auto base = ISO8601::ExactTime::fromEpochMilliseconds(static_cast<int64_t>(epochMs));
         ISO8601::ExactTime exactTime(base.epochNanoseconds() + subMs);
         if (!exactTime.isValid())
-            return makeUnexpected(rangeError("Epoch nanoseconds out of valid Temporal range"_s));
+            return makeUnexpected(rangeError(epochNanosecondsOutOfRange));
         return PossibleEpochNanoseconds { exactTime };
     }
 
@@ -334,7 +352,7 @@ TemporalResult<PossibleEpochNanoseconds> getPossibleEpochNanosecondsFor(const Ti
     //    a. If IsValidEpochNanoseconds(epochNanoseconds) is false, throw a RangeError.
     for (auto& candidate : epochCandidates(*possible)) {
         if (!candidate.isValid())
-            return makeUnexpected(rangeError("Epoch nanoseconds out of valid Temporal range"_s));
+            return makeUnexpected(rangeError(epochNanosecondsOutOfRange));
     }
 
     // 5. Return possibleEpochNanoseconds.
@@ -353,7 +371,7 @@ TemporalResult<std::optional<ISO8601::ExactTime>> getTimeZoneTransition(const Ti
     // 2. Open ICU calendar for timeZone.
     auto calendar = openCalendarForTimeZone(timeZone);
     if (!calendar)
-        return makeUnexpected(rangeError("Failed to open ICU calendar for time zone"_s));
+        return makeUnexpected(rangeError(icuOpenTimeZoneFailed));
 
     UErrorCode status = U_ZERO_ERROR;
     // 3. Let epochMs be floor(exactTime) for Next; ceil(exactTime) for Previous (sub-ms epochs round up per spec).
@@ -370,8 +388,8 @@ TemporalResult<std::optional<ISO8601::ExactTime>> getTimeZoneTransition(const Ti
     } else
         epochMs = static_cast<double>(exactTime.floorEpochMilliseconds());
     ucal_setMillis(calendar.get(), epochMs, &status);
-    if (U_FAILURE(status))
-        return makeUnexpected(rangeError("Failed to set epoch on ICU calendar"_s));
+    if (U_FAILURE(status)) [[unlikely]]
+        return makeUnexpected(rangeError(icuSetCalendarFailed));
 
     UTimeZoneTransitionType transType = (direction == TransitionDirection::Next) ? UCAL_TZ_TRANSITION_NEXT : UCAL_TZ_TRANSITION_PREVIOUS;
 
@@ -383,8 +401,8 @@ TemporalResult<std::optional<ISO8601::ExactTime>> getTimeZoneTransition(const Ti
         UDate transitionMs = 0;
         bool hasTransition = ucal_getTimeZoneTransitionDate(
             calendar.get(), transType, &transitionMs, &status);
-        if (U_FAILURE(status))
-            return makeUnexpected(rangeError("Failed to get time zone transition date from ICU"_s));
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuTransitionFailed));
 
         //    b. If no transition, return null.
         if (!hasTransition)
@@ -410,7 +428,7 @@ TemporalResult<std::optional<ISO8601::ExactTime>> getTimeZoneTransition(const Ti
         int32_t offsetAfter = ucal_get(cal2.get(), UCAL_ZONE_OFFSET, &s2) + ucal_get(cal2.get(), UCAL_DST_OFFSET, &s2);
         // NOTE: check s2 before comparing offsets — if any ucal call above failed, both
         // offsetBefore and offsetAfter would be 0 (equal), silently skipping a real transition.
-        if (U_FAILURE(s2))
+        if (U_FAILURE(s2)) [[unlikely]]
             return std::optional<ISO8601::ExactTime> { transition }; // fallback: treat as real transition
         if (offsetBefore != offsetAfter)
             return std::optional<ISO8601::ExactTime> { transition };
@@ -418,6 +436,8 @@ TemporalResult<std::optional<ISO8601::ExactTime>> getTimeZoneTransition(const Ti
         //    e. Otherwise, advance past this transition and continue.
         // Offset didn't change — skip and find the next/previous real transition.
         ucal_setMillis(calendar.get(), direction == TransitionDirection::Previous ? beforeMs : transitionMs + 1.0, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuTransitionFailed));
     }
     return std::optional<ISO8601::ExactTime> { std::nullopt }; // no real transition found
 }


### PR DESCRIPTION
#### 178eab31123551f0736f9c33263b9d71310cecb3
<pre>
[JSC] Make Temporal ICU error handling more strict
<a href="https://bugs.webkit.org/show_bug.cgi?id=316346">https://bugs.webkit.org/show_bug.cgi?id=316346</a>
<a href="https://rdar.apple.com/178762591">rdar://178762591</a>

Reviewed by Yijia Huang.

This patch makes ICU error handling stricter by inserting U_FAILURE
check for each ICU call when it takes status. Also using std::optional
etc to make error result more explicit.

* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
(JSC::TemporalCore::openCalendar):
(JSC::TemporalCore::lunarCalendarExtendedYearFor1972):
(JSC::TemporalCore::isoDateFromCalendarChecked):
(JSC::TemporalCore::japaneseEraStartYear):
(JSC::TemporalCore::japaneseEraCode):
(JSC::TemporalCore::mapICUEraToTemporalEra):
(JSC::TemporalCore::computeMonthCode):
(JSC::TemporalCore::computeOrdinalMonth):
(JSC::TemporalCore::mapTemporalEraToICUEra):
(JSC::TemporalCore::isoToCalendarFields):
(JSC::TemporalCore::calendarYear):
(JSC::TemporalCore::calendarMonth):
(JSC::TemporalCore::calendarMonthCode):
(JSC::TemporalCore::calendarDay):
(JSC::TemporalCore::calendarEra):
(JSC::TemporalCore::calendarEraYear):
(JSC::TemporalCore::calendarDaysInMonth):
(JSC::TemporalCore::calendarDaysInYear):
(JSC::TemporalCore::calendarMonthsInYear):
(JSC::TemporalCore::calendarInLeapYear):
(JSC::TemporalCore::setCalendarToMonthCode):
(JSC::TemporalCore::resolveMonthCodeToOrdinal):
(JSC::TemporalCore::calendarDateAdd):
(JSC::TemporalCore::surpassesMonths):
(JSC::TemporalCore::setMonths):
(JSC::TemporalCore::calendarDateUntil):
(JSC::TemporalCore::calendarDateFromFields):
(JSC::TemporalCore::isoDateFromCalendar): Deleted.
* Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp:
(JSC::TemporalCore::openCalendarForTimeZone):
(JSC::TemporalCore::getOffsetMsAtEpoch):
(JSC::TemporalCore::getOffsetNanosecondsFor):
(JSC::TemporalCore::getNamedTimeZoneEpochNanoseconds):
(JSC::TemporalCore::getPossibleEpochNanosecondsFor):
(JSC::TemporalCore::getTimeZoneTransition):

Canonical link: <a href="https://commits.webkit.org/314604@main">https://commits.webkit.org/314604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8730097a8808cbd57416eb4327560dff4462cfcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175628 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129513 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169539 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110038 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23769 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158737 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178162 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27474 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31062 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137871 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137788 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149171 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103561 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25357 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33080 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26036 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199259 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39338 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112413 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53493 "Found 2 new JSC stress test failures: stress/temporal-plain-date-time-with-era-calendar.js.bytecode-cache, stress/temporal-plain-date-time-with-era-calendar.js.default (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38735 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4126 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38980 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38878 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->