### PR TITLE
[Site Isolation] Fix nested-frame form state restoration with UseUIProcessForBackForwardItemLoading

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3023,6 +3023,10 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
         if (!provisionalDocumentLoader->isLoadingInAPISense() || provisionalDocumentLoader->isStopping()) {
             FRAMELOADER_RELEASE_LOG(ResourceLoading, "checkLoadCompleteForThisFrame: Failed provisional load (isTimeout = %d, isCancellation = %d, errorCode = %d, httpsFirstApplicable = %d)", error.isTimeout(), error.isCancellation(), error.errorCode(), isHTTPSFirstApplicable);
 
+            // Provisional load failed before didBeginDocument() could clear the async-wait state;
+            // clear it here so this frame stops blocking its parent's completion.
+            clearAsyncBackForwardNavigationState();
+
             if (loadWillContinueInAnotherProcess == LoadWillContinueInAnotherProcess::No) {
                 auto willInternallyHandleFailure = (error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::NoRecovery || (error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::HTTPFallback && (!isHTTPSFirstApplicable || isHTTPFallbackInProgressOrUpgradeDisabled()))) ? WillInternallyHandleFailure::No : WillInternallyHandleFailure::Yes;
 
@@ -4777,12 +4781,6 @@ void FrameLoader::cancelPendingAsyncBackForwardNavigation()
     Ref frame = m_frame.get();
     if (RefPtr parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent()))
         parentFrame->loader().checkCompleted();
-}
-
-bool FrameLoader::shouldProceedWithAsyncBackForwardNavigation()
-{
-    auto state = std::exchange(m_asyncBackForwardNavigationState, AsyncBackForwardNavigationState::None);
-    return state != AsyncBackForwardNavigationState::Cancelled;
 }
 
 void FrameLoader::loadRequestedHistoryItem(FrameLoadType loadType, PolicyAlreadyDecided policyAlreadyDecided)

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -364,7 +364,8 @@ public:
 
     WEBCORE_EXPORT void NODELETE setPendingAsyncBackForwardNavigation();
     WEBCORE_EXPORT void cancelPendingAsyncBackForwardNavigation();
-    WEBCORE_EXPORT bool NODELETE shouldProceedWithAsyncBackForwardNavigation();
+    bool asyncBackForwardNavigationWasCancelled() const { return m_asyncBackForwardNavigationState == AsyncBackForwardNavigationState::Cancelled; }
+    void clearAsyncBackForwardNavigationState() { m_asyncBackForwardNavigationState = AsyncBackForwardNavigationState::None; }
     bool isWaitingForAsyncBackForwardNavigation() const { return m_asyncBackForwardNavigationState != AsyncBackForwardNavigationState::None; }
 
     void setRequiredCookiesVersion(uint64_t version) { m_requiredCookiesVersion = version; }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1248,12 +1248,15 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationActi
                 return;
             }
 
-            // The async wait is over — UIProcess has resolved the HistoryItem
-            // and the actual loading begins via normal DocumentLoader mechanisms.
-            // Clear the async state so that frame completion tracking behaves
-            // identically to the non-flag path.
-            if (localFrame->loader().shouldProceedWithAsyncBackForwardNavigation())
-                localFrame->loader().loadRequestedHistoryItem(loadType, PolicyAlreadyDecided::Yes);
+            if (localFrame->loader().asyncBackForwardNavigationWasCancelled()) {
+                localFrame->loader().clearAsyncBackForwardNavigationState();
+                return;
+            }
+
+            // Keep the async-wait state set across the load: the freshly created child still
+            // reports isComplete() until its document begins, so clearing it here would let the
+            // parent fire its load event early. didBeginDocument() clears it once loading starts.
+            localFrame->loader().loadRequestedHistoryItem(loadType, PolicyAlreadyDecided::Yes);
         }
     );
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2661,7 +2661,9 @@ void WebPage::goToBackForwardItem(GoToBackForwardItemParameters&& parameters)
         targetFrame = historyItemFrame.releaseNonNull();
 
     if (RefPtr targetLocalFrame = targetFrame->provisionalFrame() ? targetFrame->provisionalFrame() : targetFrame->coreLocalFrame()) {
-        if (!targetLocalFrame->loader().shouldProceedWithAsyncBackForwardNavigation()) {
+        bool wasCancelled = targetLocalFrame->loader().asyncBackForwardNavigationWasCancelled();
+        targetLocalFrame->loader().clearAsyncBackForwardNavigationState();
+        if (wasCancelled) {
             WEBPAGE_RELEASE_LOG(Loading, "goToBackForwardItem: Skipping because pending async back/forward traversal was cancelled");
             return;
         }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2040,15 +2040,14 @@ TestOptions TestController::testOptionsForTest(const TestCommand& command) const
     return TestOptions { features };
 }
 
-// Mirror WebProcessPool::createWebPage, which unconditionally enables this under Site
+// Mirror WebProcessPool::createWebPage, which unconditionally enables these under Site
 // Isolation. Merged last so it matches that override and survives WebKitTestRunner's
-// per-test preference reset; a test cannot run Site Isolation with it off, as in production.
-// FIXME: Also couple UseUIProcessForBackForwardItemLoading; it currently surfaces a
-// nested-frame form-state restoration failure.
+// per-test preference reset; a test cannot run Site Isolation with them off, as in production.
 TestFeatures TestController::featuresImpliedBySiteIsolation() const
 {
     TestFeatures implied;
     implied.boolWebPreferenceFeatures.insert_or_assign("MultiProcessBackForwardCacheEnabled", true);
+    implied.boolWebPreferenceFeatures.insert_or_assign("UseUIProcessForBackForwardItemLoading", true);
     return implied;
 }
 


### PR DESCRIPTION
#### 1cff9b97d6800ad6c1bc9a5e14b9ea9ba41e5842
<pre>
[Site Isolation] Fix nested-frame form state restoration with UseUIProcessForBackForwardItemLoading
<a href="https://bugs.webkit.org/show_bug.cgi?id=316345">https://bugs.webkit.org/show_bug.cgi?id=316345</a>
<a href="https://rdar.apple.com/178762633">rdar://178762633</a>

Reviewed by Sihui Liu.

Under UseUIProcessForBackForwardItemLoading a child frame&apos;s back/forward load is delegated to
the UIProcess asynchronously (FrameLoader::loadURLIntoChildFrame -&gt;
LocalFrameLoaderClient::dispatchBackForwardItemLoading). To keep the parent frame from firing
its load event before the child finishes, the child&apos;s FrameLoader is put into an async-wait
state (setPendingAsyncBackForwardNavigation); LocalFrame::preventsParentFromBeingComplete()
returns true while that state is set, so checkCompleted()/allChildrenAreComplete() hold the
parent.

The bug: the UIProcess policy-decision completion handler cleared the async-wait state
(shouldProceedWithAsyncBackForwardNavigation) before starting the provisional load. A freshly
created child is still on its initial empty document, so isComplete() is true, and starting the
provisional load does not flip isComplete() to false until the new document begins. Clearing the
wait state first therefore opened a window where the child neither waits nor loads, letting the
parent fire its load event before the child was restored — losing nested-frame form state
(iframe.contentDocument observed as null).

Fix: clear the async-wait state at the points where the frame becomes genuinely not-complete,
not in the policy callback. The success path already clears it in FrameLoader::didBeginDocument()
atomically with isComplete() becoming false; clear it on the provisional-load-failure terminal in
checkLoadCompleteForThisFrame() too (otherwise a failed load would leave the frame holding its
parent forever). The policy callback now just starts the load while still Pending, so the parent
keeps being held until one of those terminals runs. Replace the peek-and-clear
shouldProceedWithAsyncBackForwardNavigation() with explicit asyncBackForwardNavigationWasCancelled()
and clearAsyncBackForwardNavigationState() primitives at the two call sites.

Also couple UseUIProcessForBackForwardItemLoading to SiteIsolationEnabled in WebKitTestRunner
(the deferred half of bug 316344), mirroring WebProcessPool::createWebPage, so test runs match
production. This is what exercises the path above: the existing
fast/loader/site-isolation/form-state-restore-with-frames.html now runs with the flag on and
deterministically reproduced the failure before this fix.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkLoadCompleteForThisFrame): Clear the async-wait state on the
provisional-load-failure terminal.
(WebCore::FrameLoader::shouldProceedWithAsyncBackForwardNavigation): Deleted.
* Source/WebCore/loader/FrameLoader.h:
(WebCore::FrameLoader::asyncBackForwardNavigationWasCancelled const): Added.
(WebCore::FrameLoader::clearAsyncBackForwardNavigationState): Added.
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationAction): Start the
load while still Pending; clear only on cancellation.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::goToBackForwardItem): Use the explicit cancelled/clear primitives.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::featuresImpliedBySiteIsolation): Also enable
UseUIProcessForBackForwardItemLoading under Site Isolation.

Canonical link: <a href="https://commits.webkit.org/314648@main">https://commits.webkit.org/314648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0082881d0d2de151b92e49ac2c6884b65db97bdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123854 "Built successfully") | ⏳ 🛠 ios-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168464 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129526 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e001842-9c97-44ae-b90f-47558833849e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110051 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/600f489c-1737-40b6-bc5e-d3719ab844df) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30893 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29594 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23787 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140864 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178180 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31080 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29097 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137889 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137806 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37155 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149188 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103581 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33094 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26053 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39357 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112431 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38753 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4143 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38896 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->