### PR TITLE
Variant WPT with a . in the params cause a failure

### DIFF
--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -594,14 +594,8 @@ class Port(object):
         if self.test_isfile(test_name) or self.test_isdir(test_name):
             return True
         if '?' in test_name or '#' in test_name:
-            fs = self._filesystem
-            ext_parts = fs.splitext(test_name)
-            test_name = ext_parts[0]
-            if len(ext_parts) > 1 and '?' in ext_parts[1]:
-                test_name += ext_parts[1].split('?')[0]
-            if len(ext_parts) > 1 and '#' in ext_parts[1]:
-                test_name += ext_parts[1].split('#')[0]
-            return self.test_isfile(test_name)
+            (base_name, variant) = Port.test_name_and_variant(test_name)
+            return self.test_isfile(base_name)
         return False
 
     def split_test(self, test_name):

--- a/Tools/Scripts/webkitpy/port/base_unittest.py
+++ b/Tools/Scripts/webkitpy/port/base_unittest.py
@@ -261,6 +261,7 @@ class PortTest(unittest.TestCase):
         self.assertTrue(port.test_exists('passes/text.html'))
         self.assertFalse(port.test_exists('passes/does_not_exist.html'))
         self.assertTrue(port.test_exists('variant/variant.any.html?1-100'))
+        self.assertTrue(port.test_exists('variant/variant.any.html?val=2.3'))
 
     def test_test_isfile(self):
         port = self.make_port(with_tests=True)


### PR DESCRIPTION
#### 72d07dd3a9ddf086d361a7ca83e48d64676596cc
<pre>
Variant WPT with a . in the params cause a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=316341">https://bugs.webkit.org/show_bug.cgi?id=316341</a>
<a href="https://rdar.apple.com/178763669">rdar://178763669</a>

Reviewed by Sam Sneddon and Simon Fraser.

test_exists() used splitext() to strip the variant from a test name
before checking if the file exists, but splitext() splits on the last
dot in the string — so a variant containing a decimal value like 2.3
causes the split to land inside the variant instead of at the file
extension, making the style checker reject valid TestExpectations
entries. Fix by using test_name_and_variant() which correctly
partitions on the first ? or #, and add . to sanitized_variant()&apos;s
regex so decimal dots don&apos;t appear in expected output filenames.

* Tools/Scripts/webkitpy/port/base.py:
(Port.test_exists):
* Tools/Scripts/webkitpy/port/base_unittest.py:
(PortTest.test_test_exists):

Canonical link: <a href="https://commits.webkit.org/314642@main">https://commits.webkit.org/314642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b7e5ab40409b81c334f9f8fab0913be0cc2a0b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175625 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129509 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110034 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/165897 "Found 2 webkitpy test failures: webkitscmpy.test.land_unittest.TestLand.test_svn, webkitscmpy.test.land_unittest.TestLandBitBucket.test_no_reviewer") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30877 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29575 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23766 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178159 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29077 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137865 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137783 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37152 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40825 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149168 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/103558 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33076 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26033 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39335 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38732 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4123 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38977 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38875 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->