### PR TITLE
tumblr.com: Saving .gifv image adds .html to end of filename

### DIFF
--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -34,6 +34,7 @@
 #include <WebCore/NavigationAction.h>
 #include <WebCore/Node.h>
 #include <WebCore/RenderImage.h>
+#include <WebCore/ResourceResponse.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/Text.h>
 #include <wtf/URL.h>
@@ -81,8 +82,8 @@ static String imageSuggestedFilenameFromHitTestResult(const HitTestResult& hitTe
         return nullString();
 
     auto url = hitTestResult.absoluteImageURL();
-    auto filename = webFrame->suggestedFilenameForResourceWithURL(url);
-    auto mimeType = webFrame->mimeTypeForResourceWithURL(url);
+    auto filename = webFrame->suggestedFilenameForResourceWithURL(url, WebFrame::ResourceType::Image);
+    auto mimeType = webFrame->mimeTypeForResourceWithURL(url, WebFrame::ResourceType::Image);
     return MIMETypeRegistry::correctExtensionForMIMEType(filename, mimeType);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1221,7 +1221,7 @@ String WebFrame::provisionalURL() const
     return provisionalDocumentLoader->url().string();
 }
 
-String WebFrame::suggestedFilenameForResourceWithURL(const URL& url) const
+String WebFrame::suggestedFilenameForResourceWithURL(const URL& url, ResourceType resourceType) const
 {
     RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
     if (!localFrame)
@@ -1231,11 +1231,12 @@ String WebFrame::suggestedFilenameForResourceWithURL(const URL& url) const
     if (!loader)
         return String();
 
-    // First, try the main resource.
-    if (loader->url() == url)
-        return loader->response().suggestedFilename();
+    if (loader->url() == url) {
+        const auto& mimeType = loader->response().mimeType();
+        if (resourceType != ResourceType::Image || mimeType.startsWithIgnoringASCIICase("image/"_s))
+            return loader->response().suggestedFilename();
+    }
 
-    // Next, try subresources.
     RefPtr<ArchiveResource> resource = loader->subresource(url);
     if (resource)
         return resource->response().suggestedFilename();
@@ -1243,7 +1244,7 @@ String WebFrame::suggestedFilenameForResourceWithURL(const URL& url) const
     return String();
 }
 
-String WebFrame::mimeTypeForResourceWithURL(const URL& url) const
+String WebFrame::mimeTypeForResourceWithURL(const URL& url, ResourceType resourceType) const
 {
     RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
     if (!localFrame)
@@ -1253,11 +1254,12 @@ String WebFrame::mimeTypeForResourceWithURL(const URL& url) const
     if (!loader)
         return String();
 
-    // First, try the main resource.
-    if (loader->url() == url)
-        return loader->response().mimeType();
+    if (loader->url() == url) {
+        const auto& mimeType = loader->response().mimeType();
+        if (resourceType != ResourceType::Image || mimeType.startsWithIgnoringASCIICase("image/"_s))
+            return mimeType;
+    }
 
-    // Next, try subresources.
     RefPtr<ArchiveResource> resource = loader->subresource(url);
     if (resource)
         return resource->mimeType();

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -224,8 +224,9 @@ public:
     bool allowsFollowingLink(const URL&) const;
 
     String provisionalURL() const;
-    String suggestedFilenameForResourceWithURL(const URL&) const;
-    String mimeTypeForResourceWithURL(const URL&) const;
+    enum class ResourceType : uint8_t { Generic, Image };
+    String suggestedFilenameForResourceWithURL(const URL&, ResourceType = ResourceType::Generic) const;
+    String mimeTypeForResourceWithURL(const URL&, ResourceType = ResourceType::Generic) const;
 
     void setTextDirection(const String&);
     void updateFrameRectFromRemote(WebCore::IntRect);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
@@ -27,6 +27,7 @@
 
 #if PLATFORM(MAC)
 
+#import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/mac/AppKitSPI.h"
 #import "InstanceMethodSwizzler.h"
 #import "Helpers/cocoa/PasteboardUtilities.h"
@@ -756,6 +757,66 @@ TEST(ContextMenuTests, HitTestResultImageSuggestedFilename)
     [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
     [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
     Util::run(&gotProposedMenu);
+}
+
+static RetainPtr<NSString> imageSuggestedFilenameFromCollidingImageURL(HashMap<String, String> imageResponseHeaders)
+{
+    using namespace TestWebKitAPI;
+
+    RetainPtr imageData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
+
+    HTTPServer server([imageData, imageResponseHeaders](Connection connection) {
+        connection.receiveHTTPRequest([connection, imageData, imageResponseHeaders](Vector<char>&&) {
+            connection.send(HTTPResponse({ { "Content-Type"_s, "text/html"_s } },
+                "<img id='collision' src='collision.gifv' style='width:300px;height:300px'>"_s).serialize(), [connection, imageData, imageResponseHeaders] {
+                connection.receiveHTTPRequest([connection, imageData, imageResponseHeaders](Vector<char>&&) {
+                    HashMap<String, String> headers = imageResponseHeaders;
+                    connection.send(HTTPResponse(WTF::move(headers), imageData).serialize());
+                });
+            });
+        });
+    });
+
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
+    __block bool gotProposedMenu = false;
+    __block RetainPtr<NSString> capturedFilename;
+    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
+        EXPECT_NOT_NULL(elementInfo.hitTestResult);
+        capturedFilename = elementInfo.hitTestResult.imageSuggestedFilename;
+        completion(nil);
+        gotProposedMenu = true;
+    }];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView setUIDelegate:delegate];
+    RetainPtr collisionURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/collision.gifv", server.port()]];
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:collisionURL]];
+
+    auto midpoint = [webView getElementMidpoint:@"#collision"].value();
+    [webView mouseDownAtPoint:midpoint simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:midpoint withFlags:0 eventType:NSEventTypeRightMouseUp];
+    Util::run(&gotProposedMenu);
+
+    return capturedFilename;
+}
+
+TEST(ContextMenuTests, HitTestResultImageSuggestedFilenameWhenURLCollidesWithMainResource)
+{
+    RetainPtr filename = imageSuggestedFilenameFromCollidingImageURL({
+        { "Content-Type"_s, "image/png"_s },
+        { "Content-Disposition"_s, "inline; filename=\"collision.png\""_s },
+    });
+    EXPECT_FALSE([filename hasSuffix:@".html"]);
+    EXPECT_TRUE([filename hasSuffix:@".png"]);
+}
+
+TEST(ContextMenuTests, HitTestResultImageSuggestedFilenameWhenURLCollidesAndNoContentDisposition)
+{
+    RetainPtr filename = imageSuggestedFilenameFromCollidingImageURL({
+        { "Content-Type"_s, "image/png"_s },
+    });
+    EXPECT_FALSE([filename hasSuffix:@".html"]);
+    EXPECT_GT([filename length], 0u);
 }
 
 TEST(ContextMenuTests, HitTestResultLinkWithInvalidURL)


### PR DESCRIPTION
#### d5d7c2176bc747df9090acab2eac8193424b4273
<pre>
tumblr.com: Saving .gifv image adds .html to end of filename
<a href="https://bugs.webkit.org/show_bug.cgi?id=316350">https://bugs.webkit.org/show_bug.cgi?id=316350</a>
<a href="https://rdar.apple.com/70161124">rdar://70161124</a>

Reviewed by Sammy Gill.

The problem: when an &lt;img&gt;&apos;s url coincides with the main document url,
Save Image suggests a filename with the wrong extension
(e.g., tumblr_inline_*.gifv.html). WebFrame::suggestedFilenameForResourceWithURL
and mimeTypeForResourceWithURL short-circuit to the document loader&apos;s
response when the image url equals the document url, so an &lt;img&gt; on an
HTML interstitial gets the document&apos;s text/html MIME instead of the
image&apos;s image/* MIME. NSURLResponse.suggestedFilename then appends .html
to the url-derived filename, and MIMETypeRegistry::correctExtensionForMIMEType
can&apos;t recover when the url extension is unregistered.

The fix: add a WebFrame::ResourceType { Generic, Image } hint and thread it
through suggestedFilenameForResourceWithURL and mimeTypeForResourceWithURL.
When the caller passes ResourceType::Image, the main resource short circuit
skips itself if the document&apos;s MIME is non-image (the contradiction the bug
hinges on), and the methods fall through to CachedResourceLoader::cachedResource
to find the actual image&apos;s response. WebHitTestResultData no longer reaches
into the render tree from Source/WebKit/Shared/.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm

* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::imageSuggestedFilenameFromHitTestResult):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::suggestedFilenameForResourceWithURL const):
(WebKit::WebFrame::mimeTypeForResourceWithURL const):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm:
(TestWebKitAPI::imageSuggestedFilenameFromCollidingImageURL):
(TestWebKitAPI::TEST(ContextMenuTests, HitTestResultImageSuggestedFilenameWhenURLCollidesWithMainResource)):
(TestWebKitAPI::TEST(ContextMenuTests, HitTestResultImageSuggestedFilenameWhenURLCollidesAndNoContentDisposition)):

Canonical link: <a href="https://commits.webkit.org/315059@main">https://commits.webkit.org/315059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dced01ed08b2e9128a61cb00bc190b2452d514e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176677 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125301 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bfd81866-3e54-47d9-ab56-4d15652fa419) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130416 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91678 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb858161-79e9-456b-8bfa-6b933f985360) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110933 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/974b3a2e-9284-4a4f-bfd8-d039174aac03) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31815 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30611 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25410 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179217 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32258 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138818 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34670 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138703 "") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37428 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41877 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105037 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33958 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26977 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40381 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113627 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39778 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5078 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40029 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39923 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->