### PR TITLE
[CMake] Skip configure-time compiler and stdlib probes on Apple platforms

### DIFF
--- a/Source/ThirdParty/gtest/CMakeLists.txt
+++ b/Source/ThirdParty/gtest/CMakeLists.txt
@@ -34,9 +34,11 @@ endif ()
 
 target_include_directories(gtest PRIVATE ${GTEST_INCLUDE_DIRECTORIES})
 
-WEBKIT_ADD_TARGET_CXX_FLAGS(gtest -Wno-undef
-                                  -Wno-stringop-truncation
-                                  -Wno-suggest-attribute=format)
+WEBKIT_ADD_TARGET_CXX_FLAGS(gtest -Wno-undef)
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    WEBKIT_ADD_TARGET_CXX_FLAGS(gtest -Wno-stringop-truncation
+                                      -Wno-suggest-attribute=format)
+endif ()
 
 if (CMAKE_USE_PTHREADS_INIT)
     target_link_libraries(gtest PRIVATE ${CMAKE_THREAD_LIBS_INIT})

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -138,56 +138,19 @@
 #define HAVE_MISSING_U8STRING 1
 #endif
 
-/* FIXME: Remove after CMake build enabled on Darwin */
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
+#if OS(DARWIN)
 #define HAVE_ERRNO_H 1
-#endif
-
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
 #define HAVE_LANGINFO_H 1
-#endif
-
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
 #define HAVE_LOCALTIME_R 1
-#endif
-
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
 #define HAVE_MMAP 1
-#endif
-
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
 #define HAVE_REGEX_H 1
-#endif
-
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
 #define HAVE_SIGNAL_H 1
-#endif
-
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
 #define HAVE_STAT_BIRTHTIME 1
-#endif
-
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
 #define HAVE_SYS_PARAM_H 1
-#endif
-
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
 #define HAVE_SYS_TIME_H 1
-#endif
-
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
 #define HAVE_TM_GMTOFF 1
-#endif
-
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
 #define HAVE_TM_ZONE 1
-#endif
-
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
 #define HAVE_TIMEGM 1
-#endif
-
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
 #define HAVE_PTHREAD_MAIN_NP 1
 #endif
 
@@ -228,7 +191,7 @@
 #define HAVE_READLINE 1
 #endif
 
-#if OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
+#if OS(DARWIN)
 #define HAVE_SYS_TIMEB_H 1
 #endif
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2211,7 +2211,7 @@ if (ENABLE_XSLT)
     list(APPEND WebCore_LIBRARIES LibXslt::LibXslt)
 endif ()
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
     check_function_exists(shm_open SHM_OPEN_EXISTS)
     if (NOT SHM_OPEN_EXISTS)
         set(CMAKE_REQUIRED_LIBRARIES rt)

--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -59,6 +59,8 @@ endif ()
 find_package(ICU 70.1 REQUIRED COMPONENTS data i18n uc)
 find_package(LibXml2 2.8.0 REQUIRED)
 find_package(LibXslt 1.1.13 REQUIRED)
+set(CMAKE_HAVE_PTHREAD_H 1 CACHE INTERNAL "")
+set(CMAKE_HAVE_LIBC_PTHREAD 1 CACHE INTERNAL "")
 find_package(Threads REQUIRED)
 
 # Strip ${SDK}/usr/include from these imported targets; reachable via -isysroot.

--- a/Source/cmake/OptionsCommon.cmake
+++ b/Source/cmake/OptionsCommon.cmake
@@ -227,33 +227,38 @@ set(CXX_STDLIB_TEST_SOURCE "
     #error Clang needed for libc++
     #endif
 ")
-check_cxx_source_compiles("${CXX_STDLIB_TEST_SOURCE}" CXX_STDLIB_IS_LIBCPP)
-if (CXX_STDLIB_IS_LIBCPP)
-    set(CXX_STDLIB_TEST_SOURCE "
-        #include <utility>
-        #if _LIBCPP_VERSION >= 190000
-        int main() { }
-        #else
-        #error libc++ is older than 19.x
-        #endif
-    ")
-    check_cxx_source_compiles("${CXX_STDLIB_TEST_SOURCE}" CXX_STDLIB_IS_LIBCPP_19_OR_NEWER)
-    if (CXX_STDLIB_IS_LIBCPP_19_OR_NEWER)
-        set(CXX_STDLIB_VARIANT "LIBCPP 19+")
-        set(CXX_STDLIB_ASSERTIONS_MACRO _LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE)
-    else ()
-        set(CXX_STDLIB_VARIANT "LIBCPP <19")
-        set(CXX_STDLIB_ASSERTIONS_MACRO _LIBCPP_ENABLE_ASSERTIONS=1)
-    endif ()
+if (APPLE)
+    set(CXX_STDLIB_VARIANT "LIBCPP 19+")
+    set(CXX_STDLIB_ASSERTIONS_MACRO _LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE)
 else ()
-    set(CXX_STDLIB_TEST_SOURCE "
-    #include <utility>
-    int main() { return _GLIBCXX_RELEASE; }
-    ")
-    check_cxx_source_compiles("${CXX_STDLIB_TEST_SOURCE}" CXX_STDLIB_IS_GLIBCXX)
-    if (CXX_STDLIB_IS_GLIBCXX)
-        set(CXX_STDLIB_VARIANT "GLIBCXX")
-        set(CXX_STDLIB_ASSERTIONS_MACRO _GLIBCXX_ASSERTIONS=1)
+    check_cxx_source_compiles("${CXX_STDLIB_TEST_SOURCE}" CXX_STDLIB_IS_LIBCPP)
+    if (CXX_STDLIB_IS_LIBCPP)
+        set(CXX_STDLIB_TEST_SOURCE "
+            #include <utility>
+            #if _LIBCPP_VERSION >= 190000
+            int main() { }
+            #else
+            #error libc++ is older than 19.x
+            #endif
+        ")
+        check_cxx_source_compiles("${CXX_STDLIB_TEST_SOURCE}" CXX_STDLIB_IS_LIBCPP_19_OR_NEWER)
+        if (CXX_STDLIB_IS_LIBCPP_19_OR_NEWER)
+            set(CXX_STDLIB_VARIANT "LIBCPP 19+")
+            set(CXX_STDLIB_ASSERTIONS_MACRO _LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE)
+        else ()
+            set(CXX_STDLIB_VARIANT "LIBCPP <19")
+            set(CXX_STDLIB_ASSERTIONS_MACRO _LIBCPP_ENABLE_ASSERTIONS=1)
+        endif ()
+    else ()
+        set(CXX_STDLIB_TEST_SOURCE "
+        #include <utility>
+        int main() { return _GLIBCXX_RELEASE; }
+        ")
+        check_cxx_source_compiles("${CXX_STDLIB_TEST_SOURCE}" CXX_STDLIB_IS_GLIBCXX)
+        if (CXX_STDLIB_IS_GLIBCXX)
+            set(CXX_STDLIB_VARIANT "GLIBCXX")
+            set(CXX_STDLIB_ASSERTIONS_MACRO _GLIBCXX_ASSERTIONS=1)
+        endif ()
     endif ()
 endif ()
 message(STATUS "C++ standard library in use: ${CXX_STDLIB_VARIANT}")
@@ -296,57 +301,59 @@ elseif (NOT ENABLE_ASSERTS)
     WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-DASSERT_ENABLED=0)
 endif ()
 
-# Check whether features.h header exists.
-# Including glibc's one defines __GLIBC__, that is used in Platform.h
-WEBKIT_CHECK_HAVE_INCLUDE(HAVE_FEATURES_H features.h)
+if (NOT APPLE)
+    # Check whether features.h header exists.
+    # Including glibc's one defines __GLIBC__, that is used in Platform.h
+    WEBKIT_CHECK_HAVE_INCLUDE(HAVE_FEATURES_H features.h)
 
-# Check for headers
-WEBKIT_CHECK_HAVE_INCLUDE(HAVE_ERRNO_H errno.h)
-WEBKIT_CHECK_HAVE_INCLUDE(HAVE_LANGINFO_H langinfo.h)
-WEBKIT_CHECK_HAVE_INCLUDE(HAVE_MMAP sys/mman.h)
-WEBKIT_CHECK_HAVE_INCLUDE(HAVE_PTHREAD_NP_H pthread_np.h)
-WEBKIT_CHECK_HAVE_INCLUDE(HAVE_SYS_PARAM_H sys/param.h)
-WEBKIT_CHECK_HAVE_INCLUDE(HAVE_SYS_TIME_H sys/time.h)
-WEBKIT_CHECK_HAVE_INCLUDE(HAVE_SYS_TIMEB_H sys/timeb.h)
-WEBKIT_CHECK_HAVE_INCLUDE(HAVE_LINUX_MEMFD_H linux/memfd.h)
+    # Check for headers
+    WEBKIT_CHECK_HAVE_INCLUDE(HAVE_ERRNO_H errno.h)
+    WEBKIT_CHECK_HAVE_INCLUDE(HAVE_LANGINFO_H langinfo.h)
+    WEBKIT_CHECK_HAVE_INCLUDE(HAVE_MMAP sys/mman.h)
+    WEBKIT_CHECK_HAVE_INCLUDE(HAVE_PTHREAD_NP_H pthread_np.h)
+    WEBKIT_CHECK_HAVE_INCLUDE(HAVE_SYS_PARAM_H sys/param.h)
+    WEBKIT_CHECK_HAVE_INCLUDE(HAVE_SYS_TIME_H sys/time.h)
+    WEBKIT_CHECK_HAVE_INCLUDE(HAVE_SYS_TIMEB_H sys/timeb.h)
+    WEBKIT_CHECK_HAVE_INCLUDE(HAVE_LINUX_MEMFD_H linux/memfd.h)
 
-# Check for functions
-# _GNU_SOURCE=1 is required to expose statx
-list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE=1")
-WEBKIT_CHECK_HAVE_FUNCTION(HAVE_ALIGNED_MALLOC _aligned_malloc malloc.h)
-WEBKIT_CHECK_HAVE_FUNCTION(HAVE_LOCALTIME_R localtime_r time.h)
-WEBKIT_CHECK_HAVE_FUNCTION(HAVE_MALLOC_TRIM malloc_trim malloc.h)
-WEBKIT_CHECK_HAVE_FUNCTION(HAVE_STATX statx sys/stat.h)
-WEBKIT_CHECK_HAVE_FUNCTION(HAVE_TIMEGM timegm time.h)
-WEBKIT_CHECK_HAVE_FUNCTION(HAVE_TIMERFD timerfd_create sys/timerfd.h)
-WEBKIT_CHECK_HAVE_FUNCTION(HAVE_VASPRINTF vasprintf stdio.h)
+    # Check for functions
+    # _GNU_SOURCE=1 is required to expose statx
+    list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE=1")
+    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_ALIGNED_MALLOC _aligned_malloc malloc.h)
+    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_LOCALTIME_R localtime_r time.h)
+    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_MALLOC_TRIM malloc_trim malloc.h)
+    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_STATX statx sys/stat.h)
+    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_TIMEGM timegm time.h)
+    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_TIMERFD timerfd_create sys/timerfd.h)
+    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_VASPRINTF vasprintf stdio.h)
 
-# Check for symbols
-WEBKIT_CHECK_HAVE_SYMBOL(HAVE_REGEX_H regexec regex.h)
-if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin"))
-    WEBKIT_CHECK_HAVE_SYMBOL(HAVE_PTHREAD_MAIN_NP pthread_main_np pthread_np.h)
-endif ()
-WEBKIT_CHECK_HAVE_SYMBOL(HAVE_MAP_ALIGNED MAP_ALIGNED sys/mman.h)
-WEBKIT_CHECK_HAVE_SYMBOL(HAVE_SHM_ANON SHM_ANON sys/mman.h)
-WEBKIT_CHECK_HAVE_SYMBOL(HAVE_TIMINGSAFE_BCMP timingsafe_bcmp string.h)
-# Windows has signal.h but is missing symbols that are used in calls to signal.
-WEBKIT_CHECK_HAVE_SYMBOL(HAVE_SIGNAL_H SIGTRAP signal.h)
+    # Check for symbols
+    WEBKIT_CHECK_HAVE_SYMBOL(HAVE_REGEX_H regexec regex.h)
+    if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin"))
+        WEBKIT_CHECK_HAVE_SYMBOL(HAVE_PTHREAD_MAIN_NP pthread_main_np pthread_np.h)
+    endif ()
+    WEBKIT_CHECK_HAVE_SYMBOL(HAVE_MAP_ALIGNED MAP_ALIGNED sys/mman.h)
+    WEBKIT_CHECK_HAVE_SYMBOL(HAVE_SHM_ANON SHM_ANON sys/mman.h)
+    WEBKIT_CHECK_HAVE_SYMBOL(HAVE_TIMINGSAFE_BCMP timingsafe_bcmp string.h)
+    # Windows has signal.h but is missing symbols that are used in calls to signal.
+    WEBKIT_CHECK_HAVE_SYMBOL(HAVE_SIGNAL_H SIGTRAP signal.h)
 
-# Check for struct members
-WEBKIT_CHECK_HAVE_STRUCT(HAVE_STAT_BIRTHTIME "struct stat" st_birthtime sys/stat.h)
-WEBKIT_CHECK_HAVE_STRUCT(HAVE_TM_GMTOFF "struct tm" tm_gmtoff time.h)
-WEBKIT_CHECK_HAVE_STRUCT(HAVE_TM_ZONE "struct tm" tm_zone time.h)
+    # Check for struct members
+    WEBKIT_CHECK_HAVE_STRUCT(HAVE_STAT_BIRTHTIME "struct stat" st_birthtime sys/stat.h)
+    WEBKIT_CHECK_HAVE_STRUCT(HAVE_TM_GMTOFF "struct tm" tm_gmtoff time.h)
+    WEBKIT_CHECK_HAVE_STRUCT(HAVE_TM_ZONE "struct tm" tm_zone time.h)
 
-# Check for int types
-check_type_size("__int128_t" INT128_VALUE)
+    # Check for int types
+    check_type_size("__int128_t" INT128_VALUE)
 
-if (HAVE_INT128_VALUE)
-  SET_AND_EXPOSE_TO_BUILD(HAVE_INT128_T INT128_VALUE)
-endif ()
+    if (HAVE_INT128_VALUE)
+      SET_AND_EXPOSE_TO_BUILD(HAVE_INT128_T INT128_VALUE)
+    endif ()
 
-# Check which filesystem implementation is available if any
-if (STD_FILESYSTEM_IS_AVAILABLE)
-    SET_AND_EXPOSE_TO_BUILD(HAVE_STD_FILESYSTEM TRUE)
-elseif (STD_EXPERIMENTAL_FILESYSTEM_IS_AVAILABLE)
-    SET_AND_EXPOSE_TO_BUILD(HAVE_STD_EXPERIMENTAL_FILESYSTEM TRUE)
+    # Check which filesystem implementation is available if any
+    if (STD_FILESYSTEM_IS_AVAILABLE)
+        SET_AND_EXPOSE_TO_BUILD(HAVE_STD_FILESYSTEM TRUE)
+    elseif (STD_EXPERIMENTAL_FILESYSTEM_IS_AVAILABLE)
+        SET_AND_EXPOSE_TO_BUILD(HAVE_STD_EXPERIMENTAL_FILESYSTEM TRUE)
+    endif ()
 endif ()

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -8,7 +8,9 @@ function(WEBKIT_CHECK_COMPILER_FLAGS _compiler _result)
         # If an equals (=) character is present in a variable name, it will
         # not be cached correctly, and the check will be retried ad nauseam.
         string(REPLACE "=" "__" _cachevar "${_compiler}_COMPILER_SUPPORTS_${_flag}")
-        if (${_compiler} STREQUAL CXX)
+        if (CMAKE_${_compiler}_COMPILER_ID STREQUAL "AppleClang")
+            set(${_cachevar} TRUE)
+        elseif (${_compiler} STREQUAL CXX)
             check_cxx_compiler_flag("${_flag}" "${_cachevar}")
         elseif (${_compiler} STREQUAL C)
             check_c_compiler_flag("${_flag}" "${_cachevar}")
@@ -168,7 +170,7 @@ if (DEVELOPER_MODE AND DEVELOPER_MODE_FATAL_WARNINGS)
         set(FATAL_WARNINGS_FLAG -Werror)
     endif ()
 
-    check_cxx_compiler_flag(${FATAL_WARNINGS_FLAG} CXX_COMPILER_SUPPORTS_WERROR)
+    WEBKIT_CHECK_COMPILER_FLAGS(CXX CXX_COMPILER_SUPPORTS_WERROR ${FATAL_WARNINGS_FLAG})
     if (CXX_COMPILER_SUPPORTS_WERROR)
         set(DEVELOPER_MODE_CXX_FLAGS ${FATAL_WARNINGS_FLAG})
     endif ()
@@ -180,7 +182,7 @@ if (DEVELOPER_MODE OR ARM)
 endif ()
 
 if (COMPILER_IS_GCC_OR_CLANG)
-    if (COMPILER_IS_CLANG OR (DEVELOPER_MODE AND NOT ARM))
+    if (NOT APPLE AND (COMPILER_IS_CLANG OR (DEVELOPER_MODE AND NOT ARM)))
         # Split debug information in ".debug_types" / ".debug_info" sections - this leads
         # to a smaller overall size of the debug information, and avoids linker relocation
         # errors on e.g. aarch64 (relocation R_AARCH64_ABS32 out of range: 4312197985 is not in [-2147483648, 4294967295])
@@ -228,13 +230,16 @@ if (COMPILER_IS_GCC_OR_CLANG)
                                          -Wundef)
 
     # Warnings to be disabled
-    # FIXME: We should probably not be disabling -Wno-maybe-uninitialized?
     WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Qunused-arguments
-                                         -Wno-maybe-uninitialized
                                          -Wno-parentheses-equality
                                          -Wno-misleading-indentation
                                          -Wno-psabi
                                          -Wno-nullability-completeness)
+
+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        # FIXME: We should probably not be disabling -Wno-maybe-uninitialized?
+        WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-maybe-uninitialized)
+    endif ()
 
     # FIXME: Remove once Clang 18 does no longer need to be supported for the GTK and WPE ports
     if ((CMAKE_CXX_COMPILER_ID STREQUAL Clang) AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19))
@@ -458,7 +463,7 @@ if (COMPILER_IS_GCC_OR_CLANG)
    set(CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES} ${SYSTEM_INCLUDE_DIRS})
 endif ()
 
-if (COMPILER_IS_GCC_OR_CLANG)
+if (COMPILER_IS_GCC_OR_CLANG AND NOT APPLE)
     set(ATOMIC_TEST_SOURCE [=[
 #include <atomic>
 #include <optional>
@@ -586,7 +591,7 @@ int main() {
     cmake_pop_check_state()
 endif ()
 
-if (NOT WTF_PLATFORM_COCOA)
+if (NOT APPLE)
   set(FLOAT16_TEST_SOURCE "
 int main() {
   _Float16 f;

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -1220,8 +1220,9 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         endif ()
         # -emit-clang-header-min-access was added in Swift 6.3. Please simplify
         # this once that becomes mandatory.
-        include(CheckCompilerFlag)
-        check_compiler_flag(Swift "-emit-clang-header-min-access internal" CAN_USE_EMIT_CLANG_HEADER_MIN_ACCESS)
+        if (CMAKE_Swift_COMPILER_VERSION VERSION_GREATER_EQUAL 6.3)
+            set(CAN_USE_EMIT_CLANG_HEADER_MIN_ACCESS TRUE)
+        endif ()
         # Always create the SwiftCxxHeader placeholder so external callers
         # (e.g. Source/WebKit/CMakeLists.txt's deferred add_dependencies) can
         # reference it even when ${_target}_SWIFT_TYPECHECK_SOURCES is empty


### PR DESCRIPTION
#### 2b6dc2f38e1d232e4d669a18231f039f89b4ccb8
<pre>
[CMake] Skip configure-time compiler and stdlib probes on Apple platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=316357">https://bugs.webkit.org/show_bug.cgi?id=316357</a>
<a href="https://rdar.apple.com/178772829">rdar://178772829</a>

Reviewed by Elliott Williams, Brandon Stewart, and Keith Miller.

Saves 28s (7%) on a clean build.

CMake supports autoconf-like behavior for fine-grained detection of compiler
and standard library features across open source ecosystems. But all that work
is unnecessary on Apple platforms, where we use a consistent SDK + toolchain
pairing, and also unnecessary in WebKit, where we set platform policy using
Platform.h, HAVE(), USE(), etc.

* Source/ThirdParty/gtest/CMakeLists.txt: Limit GCC-only flags to GCC builds.

* Source/WTF/wtf/PlatformHave.h: Drop the !defined(BUILDING_WITH_CMAKE)
guard and build the same way Xcode builds on Darwin.

* Source/WebCore/CMakeLists.txt: Skip checking for shm_open, since we know
libSystem supports it, and even if we did want to do feature detection, we
wouldn&apos;t do it at the CMake level.

* Source/cmake/OptionsCocoa.cmake: Skip checking pthread, since we know we have
it.

* Source/cmake/OptionsCommon.cmake: Skip checking libcpp and libc, since we
know we have them.

* Source/cmake/WebKitCompilerFlags.cmake: Skip checking for whether the compiler
supports our flags, since we only use flags the compiler supports.

* Source/cmake/WebKitMacros.cmake: Check Swift compiler version instead of
launching the Swift compiler, since the answers will match.

Canonical link: <a href="https://commits.webkit.org/314603@main">https://commits.webkit.org/314603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9007bfffb9df8a0fad803fbc63161e3b2c8e10d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175638 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168456 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40088 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/129529 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169549 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31913 "Exiting early after 10 failures. 20 tests run. 1 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110054 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23779 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158747 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178172 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27484 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29094 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137886 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137803 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149185 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103573 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25356 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33096 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199269 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39348 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112423 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/53499 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38745 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4140 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38990 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38888 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->