### PR TITLE
[Site Isolation] Bots no longer run API tests with Site Isolation after switching to use --additional-header

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -369,7 +369,7 @@
                   },
                   { "name": "Apple-Tahoe-Debug-WK2-Site-Isolation-Tree-Tests", "factory": "TestAllButJSCFactory",
                   "platform": "mac-tahoe", "configuration": "debug", "architectures": ["x86_64", "arm64"],
-                  "additionalArguments": ["--no-retry-failures", "--additional-header=SiteIsolationEnabled=true", "--additional-expectations=LayoutTests/platform/mac-site-isolation/TestExpectations"],
+                  "additionalArguments": ["--no-retry-failures", "--site-isolation-enabled-by-default"],
                   "workernames": ["bot10011", "bot10012", "bot10013", "bot10014"]
                   },
                   { "name": "Apple-Sequoia-Release-Build", "factory": "BuildFactory",
@@ -385,7 +385,7 @@
                   },
                   { "name": "Apple-Sequoia-Release-WK2-Site-Isolation-Tree-Tests", "factory": "TestLayoutAndAPIOnlyFactory",
                   "platform": "mac-sequoia", "configuration": "release", "architectures": ["x86_64", "arm64"],
-                  "additionalArguments": ["--no-retry-failures", "--additional-header=SiteIsolationEnabled=true", "--additional-expectations=LayoutTests/platform/mac-site-isolation/TestExpectations"],
+                  "additionalArguments": ["--no-retry-failures", "--site-isolation-enabled-by-default"],
                   "workernames": ["bot10005", "bot10006", "bot10007", "bot10008"]
                   },
                   { "name": "Apple-Sequoia-Release-WK1-Tests", "factory": "TestWebKit1AllButJSCFactory",
@@ -472,7 +472,7 @@
                   },
                   { "name": "Apple-iOS-26-Simulator-Release-WK2-Site-Isolation-Tree-Tests", "factory": "TestLayoutAndAPIOnlyFactory",
                   "platform": "ios-simulator-26", "configuration": "release", "architectures": ["x86_64", "arm64"], "device_model": "iphone",
-                  "additionalArguments": ["--no-retry-failures", "--site-isolation", "--child-processes=6"],
+                  "additionalArguments": ["--no-retry-failures", "--site-isolation-enabled-by-default", "--child-processes=6"],
                   "workernames": ["bot2002", "bot2003"]
                   },
                   {

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -929,7 +929,7 @@ class RunWebKitTests(shell.Test, CustomFlagsMixin, ShellMixin):
 
         # Up the timeout limit for site isolation queues to 300
         # FIXME: We should remove the need for these timeouts altogether. (webkit.org/b/303404)
-        if additionalArguments and '--site-isolation' in additionalArguments:
+        if additionalArguments and '--site-isolation-enabled-by-default' in additionalArguments:
             idx = self.command.index('--exit-after-n-crashes-or-timeouts')
             self.command[idx + 1] = '300'
 
@@ -1051,7 +1051,7 @@ class RunWorldLeaksTests(RunWebKitTests):
 
 class RunAPITests(TestWithFailureCount, CustomFlagsMixin, ShellMixin):
     name = "run-api-tests"
-    VALID_ADDITIONAL_ARGUMENTS_LIST = ["--remote-layer-tree", "--use-gpu-process", "--child-processes", "--site-isolation", "--wpe-legacy-api"]
+    VALID_ADDITIONAL_ARGUMENTS_LIST = ["--remote-layer-tree", "--use-gpu-process", "--child-processes", "--site-isolation-enabled-by-default", "--wpe-legacy-api"]
     description = ["api tests running"]
     descriptionDone = ["api-tests"]
     jsonFileName = "api_test_results.json"

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -988,14 +988,14 @@ class TestRunWebKitTests(BuildStepMixinAdditions, unittest.TestCase):
         self.configureStep()
         self.setProperty('fullPlatform', 'mac-highsierra')
         self.setProperty('configuration', 'debug')
-        self.setProperty('additionalArguments', ['--site-isolation'])
+        self.setProperty('additionalArguments', ['--site-isolation-enabled-by-default'])
         self.expectRemoteCommands(
             ExpectShell(
                 workdir='wkdir',
                 timeout=10800,
                 log_environ=False,
                 command=['/bin/bash', '--posix', '-o', 'pipefail', '-c',
-                         f'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --builder-name iOS-14-Simulator-WK2-Tests-EWS --build-number 101 --buildbot-worker ews100 --buildbot-master {CURRENT_HOSTNAME} --exit-after-n-crashes-or-timeouts 300 --exit-after-n-failures 500 --debug --report {RESULTS_WEBKIT_URL} --results-directory layout-test-results --debug-rwt-logging --site-isolation 2>&1 | python3 Tools/Scripts/filter-test-logs layout'],
+                         f'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --builder-name iOS-14-Simulator-WK2-Tests-EWS --build-number 101 --buildbot-worker ews100 --buildbot-master {CURRENT_HOSTNAME} --exit-after-n-crashes-or-timeouts 300 --exit-after-n-failures 500 --debug --report {RESULTS_WEBKIT_URL} --results-directory layout-test-results --debug-rwt-logging --site-isolation-enabled-by-default 2>&1 | python3 Tools/Scripts/filter-test-logs layout'],
                 env={'RESULTS_SERVER_API_KEY': 'test-api-key'}
             ).exit(0)
         )
@@ -1290,8 +1290,8 @@ class TestRunAPITests(BuildStepMixinAdditions, unittest.TestCase):
         return self.successTest('mac', 'mac-highsierra', 'release', expected_command)
 
     def test_success_mac_additional_arguments(self):
-        additional_arguments = ['--no-retry-failures', '--site-isolation']
-        expected_command = f'python3 Tools/Scripts/run-api-tests --timestamps --no-build --json-output={self.jsonFileName} --release --verbose --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org --site-isolation'
+        additional_arguments = ['--no-retry-failures', '--site-isolation-enabled-by-default']
+        expected_command = f'python3 Tools/Scripts/run-api-tests --timestamps --no-build --json-output={self.jsonFileName} --release --verbose --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org --site-isolation-enabled-by-default'
         return self.successTest('mac', 'mac-highsierra', 'release', expected_command, additional_arguments)
 
     def test_success_gtk(self):

--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -368,7 +368,7 @@
       "factory": "macOSSiteIsolationFactory", "platform": "mac-sequoia",
       "configuration": "release",
       "triggered_by": ["macos-sequoia-release-build-ews"],
-      "additionalArguments": ["imported/w3c/web-platform-tests", "--additional-header=SiteIsolationEnabled=true", "--additional-expectations=LayoutTests/platform/mac-site-isolation/TestExpectations", "--exclude-tests", "imported/w3c/web-platform-tests/css"],
+      "additionalArguments": ["imported/w3c/web-platform-tests", "--site-isolation-enabled-by-default", "--exclude-tests", "imported/w3c/web-platform-tests/css"],
       "workernames": ["ews2011", "ews2012", "ews2013", "ews2014", "ews2015"]
     },
     {

--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -68,9 +68,9 @@ def main(argv, stdout, stderr):
         return print_expectations(port, options, args, stderr)
 
     # Add site-isolation results report flavor for API tests when ran
-    if options.site_isolation:
+    if options.site_isolation_enabled_by_default:
         if options.result_report_flavor:
-            raise RuntimeError('--site-isolation implicitly sets the result flavor, this should not be overridden')
+            raise RuntimeError('--site-isolation-enabled-by-default implicitly sets the result flavor, this should not be overridden')
         options.result_report_flavor = 'site-isolation'
 
     try:
@@ -133,6 +133,10 @@ def run(port, options, args, logging_stream):
 
     try:
         stream = MeteredStream(logging_stream, options.verbose, logger=logger, number_of_columns=port.host.platform.terminal_width(), print_timestamps=options.timestamps)
+
+        if options.site_isolation_enabled_by_default:
+            _log.info('Enabling site isolation by default')
+
         manager = Manager(port, options, stream)
 
         result = manager.run(args, json_output=options.json_output)
@@ -209,7 +213,7 @@ def parse_args(args):
         optparse.make_option('--test-parallel-safety', type='string', action='append', default=[],
                              help='Run specified test(s) constantly in parallel against all allowlist tests to test parallel safety'),
 
-        optparse.make_option('--site-isolation', action='store_true', default=False,
+        optparse.make_option('--site-isolation-enabled-by-default', action='store_true', default=False,
                              help='Enable Site Isolation'),
         optparse.make_option('--remote-layer-tree', action='store_true', default=False,
                              help='Use the remote layer tree drawing model (macOS WebKit2 only)'),

--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -132,8 +132,8 @@ class Runner(object):
             args.append('--force')
         if (port.get_option('remote_layer_tree')):
             args.append('--remote-layer-tree')
-        if (port.get_option('site_isolation')):
-            args.append('--site-isolation')
+        if (port.get_option('site_isolation_enabled_by_default')):
+            args.append('--site-isolation-enabled-by-default')
         if (port.get_option('no_remote_layer_tree')):
             args.append('--no-remote-layer-tree')
         if (port.get_option('use_gpu_process')):

--- a/Tools/TestWebKitAPI/Runner/TestWebKitAPI.swift
+++ b/Tools/TestWebKitAPI/Runner/TestWebKitAPI.swift
@@ -58,7 +58,7 @@ struct TestWebKitAPI {
                 argumentDefaults["WebKit2GPUProcessForDOMRendering"] = true
             case "--no-use-gpu-process":
                 argumentDefaults["WebKit2GPUProcessForDOMRendering"] = false
-            case "--site-isolation":
+            case "--site-isolation-enabled-by-default":
                 Self.forceSiteIsolationForTesting()
             default:
                 break

--- a/Tools/TestWebKitAPI/generic/main.mm
+++ b/Tools/TestWebKitAPI/generic/main.mm
@@ -142,7 +142,7 @@ std::vector<std::string> translateArgv(int argc, char** argv)
             continue;
         }
 
-        if (token == "--site-isolation") {
+        if (token == "--site-isolation-enabled-by-default") {
             forceSiteIsolation();
             continue;
         }


### PR DESCRIPTION
#### 1a27ef7f3b4246c19184a9d326932e973eabb18a
<pre>
[Site Isolation] Bots no longer run API tests with Site Isolation after switching to use --additional-header
<a href="https://bugs.webkit.org/show_bug.cgi?id=316358">https://bugs.webkit.org/show_bug.cgi?id=316358</a>
<a href="https://rdar.apple.com/178773623">rdar://178773623</a>

Reviewed by Jonathan Bedard.

When CI bots were updated to use --additional-header=SiteIsolationEnabled=true to enable Site Isolation for layout
tests, the corresponding --site-isolation flag was dropped from additionalArguments (314188@main). This flag was the
only way to enable Site Isolation for run-api-tests, so API tests silently stopped running under Site Isolation.

Fix this by renaming --site-isolation to --site-isolation-enabled-by-default in run-api-tests and its test binaries
(TestWebKitAPI/generic/main.mm and TestWebKitAPI/Runner/TestWebKitAPI.swift), matching the flag already used by
run-webkit-tests for the same purpose. Update CI bots to pass --site-isolation-enabled-by-default, replacing the
now-redundant --additional-header=SiteIsolationEnabled=true and --additional-expectations flags (run-webkit-tests
handles those automatically when --site-isolation-enabled-by-default is set).

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/steps.py:
(RunWebKitTests.run):
(RunAPITests):
* Tools/CISupport/build-webkit-org/steps_unittest.py:
* Tools/Scripts/run-api-tests:
(main):
(run):
(parse_args):
* Tools/Scripts/webkitpy/api_tests/runner.py:
(Runner.command_for_port):
* Tools/TestWebKitAPI/Runner/TestWebKitAPI.swift:
(TestWebKitAPI.handleArguments(_:)):
* Tools/TestWebKitAPI/generic/main.mm:

Canonical link: <a href="https://commits.webkit.org/314667@main">https://commits.webkit.org/314667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8ccc809b1e21612ffaddc9150c7dc6111ff753d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175844 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/887b65df-9138-42c9-8f3e-32f9a130b456) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129692 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdc76966-e3bd-479a-88a3-4aff6fd1c15b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169755 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110218 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac33f5e4-83dc-447e-a8be-217826cc7ade) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/166119 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178382 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138058 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/166198 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40356 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137971 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37164 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149356 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103842 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33253 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39555 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38951 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4313 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39196 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39094 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->