### PR TITLE
Crash in WebPushD::Connection::connectionReceivedEvent() from XPC reestablishment after webpushd interruption

### DIFF
--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -75,22 +75,27 @@ void ConnectionToMachService<Traits>::initializeConnectionIfNeeded() const
     // FIXME: This is a false positive. <rdar://164843889>
     SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptOSObject(xpc_connection_create_mach_service(m_machServiceName.data(), mainDispatchQueueSingleton(), 0));
     xpc_connection_set_event_handler(m_connection.get(), [weakThis = WeakPtr { *this }](xpc_object_t event) {
-        if (!weakThis)
+        // Promote `weakThis` to a stack-local strong reference before doing anything else.
+        // Clearing m_connection below may release the last strong reference to the
+        // xpc_connection (and thus to this very event-handler block), which would free
+        // the captured `weakThis` while we are still executing inside the block.
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis)
             return;
         if (event == XPC_ERROR_CONNECTION_INVALID) {
 #if HAVE(XPC_CONNECTION_COPY_INVALIDATION_REASON)
-            auto reason = std::unique_ptr<char[]>(xpc_connection_copy_invalidation_reason(weakThis->m_connection.get()));
-            WTFLogAlways("Failed to connect to mach service %s, reason: %s", weakThis->m_machServiceName.data(), reason.get());
+            auto reason = std::unique_ptr<char[]>(xpc_connection_copy_invalidation_reason(protectedThis->m_connection.get()));
+            WTFLogAlways("Failed to connect to mach service %s, reason: %s", protectedThis->m_machServiceName.data(), reason.get());
 #else
-            WTFLogAlways("Failed to connect to mach service %s, likely because it is not registered with launchd", weakThis->m_machServiceName.data());
+            WTFLogAlways("Failed to connect to mach service %s, likely because it is not registered with launchd", protectedThis->m_machServiceName.data());
 #endif
         }
         if (event == XPC_ERROR_CONNECTION_INTERRUPTED) {
-            logMachServiceInterrupted(weakThis->m_machServiceName);
+            logMachServiceInterrupted(protectedThis->m_machServiceName);
             // Daemon crashed, we will need to make a new connection to a new instance of the daemon.
-            weakThis->m_connection = nullptr;
+            protectedThis->m_connection = nullptr;
         }
-        weakThis->connectionReceivedEvent(event);
+        protectedThis->connectionReceivedEvent(event);
     });
     xpc_connection_activate(m_connection.get());
 


### PR DESCRIPTION
#### f204a8b967f7a64657e51c1db88c1e08b3450334
<pre>
Crash in WebPushD::Connection::connectionReceivedEvent() from XPC reestablishment after webpushd interruption
<a href="https://bugs.webkit.org/show_bug.cgi?id=316362">https://bugs.webkit.org/show_bug.cgi?id=316362</a>
<a href="https://rdar.apple.com/178675392">rdar://178675392</a>

Reviewed by Brady Eidson.

When webpushd is interrupted, libxpc fires our event handler block with
XPC_ERROR_CONNECTION_INTERRUPTED. The handler clears m_connection, which
can drop the last strong reference to the xpc_connection_t and trigger
its teardown — including release of the very event-handler block we are
currently executing inside. Releasing the block frees the heap-allocated
captures (the `weakThis` WeakPtr), so the trailing
`weakThis-&gt;connectionReceivedEvent(event)` call reads garbage from freed
block memory and dispatches a virtual call through a corrupt vtable,
which faults with a PAC failure on arm64e.

This was observed as repeated NetworkProcess crashes during Safari
automation runs, with stacks of the form:
```
      WebKit:        WebPushD::Connection::connectionReceivedEvent + 0
      libxpc.dylib:  _xpc_connection_call_event_handler
      libxpc.dylib:  _xpc_connection_reestablish
      libxpc.dylib:  do_mach_notify_port_destroyed
      ...
```
  and accompanied in the log by:
```
      libxpc: Re-initialization successful; calling out to event handler
              with XPC_ERROR_CONNECTION_INTERRUPTED
      WebKit: Connection to mach service com.apple.webkit.webpushd.service
              is interrupted
      libxpc: invalidated after the last release of the connection object
```

Promote `weakThis` to a stack-local RefPtr at the top of the lambda and
use it for the rest of the body. The strong reference lives on the
lambda&apos;s stack rather than in the block&apos;s captures, so it keeps the
Daemon::Connection alive across `m_connection = nullptr` even when
that release tears down the block underneath us. The fix also covers
the PrivateClickMeasurement connection, which shares this lambda.

* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::initializeConnectionIfNeeded const):

Canonical link: <a href="https://commits.webkit.org/314611@main">https://commits.webkit.org/314611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50e0fc08c9bd519cde8326ed6df0c0950f0c96a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166605 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175653 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123861 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129534 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110059 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23794 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178187 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31087 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137895 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137812 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37131 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149195 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103593 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33100 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26060 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39364 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112438 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38760 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4150 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39005 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38903 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->