### PR TITLE
[JSC] `ISO8601::parseDate` reads past the end of the buffer for short invalid strings

### DIFF
--- a/JSTests/stress/temporal-iso8601-parse-bounds.js
+++ b/JSTests/stress/temporal-iso8601-parse-bounds.js
@@ -1,0 +1,88 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected ${expected} but got ${actual}`);
+}
+
+function shouldThrowRangeError(fn, msg) {
+    let thrown = null;
+    try { fn(); } catch (e) { thrown = e; }
+    if (!thrown)
+        throw new Error(`${msg}: expected RangeError but nothing was thrown`);
+    if (!(thrown instanceof RangeError))
+        throw new Error(`${msg}: expected RangeError but got ${thrown}`);
+}
+
+// ISO8601::parseDate() used to read past the end of the buffer for short
+// truncated strings: month/day length guards only applied to the Date format.
+// All of these must throw RangeError instead of crashing.
+{
+    const crashers = [
+        ["PlainDate", "0"],
+        ["PlainDate", "1"],
+        ["PlainDate", "12"],
+        ["PlainDate", "123"],
+        ["PlainDate", "12-"],
+        ["Instant", "1"],
+        ["PlainTime", "1"],
+        ["PlainDateTime", "12"],
+        ["PlainMonthDay", "1"],
+        ["PlainMonthDay", "12"],
+        ["PlainMonthDay", "12-"],
+        ["PlainMonthDay", "121"],
+        ["PlainMonthDay", "--1"],
+        ["PlainMonthDay", "--12"],
+        ["PlainMonthDay", "--12-"],
+        ["PlainMonthDay", "--121"],
+        ["PlainMonthDay", "02-2"],
+        ["PlainMonthDay", "2024-01"],
+        ["PlainMonthDay", "202401"],
+        ["PlainMonthDay", "2021-12"],
+        ["PlainMonthDay", "2024-05"],
+        ["PlainYearMonth", "2024-0"],
+        ["PlainYearMonth", "2024-01-"],
+        ["PlainYearMonth", "2024-01-1"],
+        ["PlainYearMonth", "202401-"],
+        ["PlainYearMonth", "2024011"],
+        ["PlainYearMonth", "12-1"],
+        ["ZonedDateTime", "1"],
+        ["ZonedDateTime", "12"],
+        ["PlainDate", "2024-0"],
+        ["PlainDate", "2024-01-"],
+        ["PlainDate", "2024-01-1"],
+        ["PlainDate", "1976111"],
+        ["PlainDate", "19761"],
+    ];
+    for (const [type, string] of crashers)
+        shouldThrowRangeError(() => Temporal[type].from(string), `${type}.from(${JSON.stringify(string)})`);
+}
+
+// Valid strings must keep working.
+{
+    shouldBe(Temporal.PlainDate.from("2024-01-15").toString(), "2024-01-15", "PlainDate hyphenated");
+    shouldBe(Temporal.PlainDate.from("20240115").toString(), "2024-01-15", "PlainDate compact");
+    shouldBe(Temporal.PlainDate.from("+002024-01-15").toString(), "2024-01-15", "PlainDate extended year");
+    shouldBe(Temporal.PlainDate.from("2024-01-15T12:30").toString(), "2024-01-15", "PlainDate with time");
+    shouldBe(Temporal.PlainDate.from("2024-01-01[u-ca=iso8601]").toString(), "2024-01-01", "calendar annotation");
+
+    shouldBe(Temporal.PlainYearMonth.from("2024-01").toString(), "2024-01", "YearMonth hyphenated");
+    shouldBe(Temporal.PlainYearMonth.from("202401").toString(), "2024-01", "YearMonth compact");
+    shouldBe(Temporal.PlainYearMonth.from("2024-01[u-ca=iso8601]").toString(), "2024-01", "YearMonth annotated");
+    shouldBe(Temporal.PlainYearMonth.from("19761118").toString(), "1976-11", "YearMonth compact full date");
+    shouldBe(Temporal.PlainYearMonth.from("1976-11-18").toString(), "1976-11", "YearMonth full date");
+    shouldBe(Temporal.PlainYearMonth.from("1976-11-18T15:23:30").toString(), "1976-11", "YearMonth full datetime");
+    shouldBe(Temporal.PlainYearMonth.from("19761118T15:23").toString(), "1976-11", "YearMonth compact datetime");
+
+    shouldBe(Temporal.PlainMonthDay.from("12-14").toString(), "12-14", "MonthDay hyphenated");
+    shouldBe(Temporal.PlainMonthDay.from("1214").toString(), "12-14", "MonthDay compact");
+    shouldBe(Temporal.PlainMonthDay.from("--12-14").toString(), "12-14", "MonthDay double hyphen");
+    shouldBe(Temporal.PlainMonthDay.from("--1214").toString(), "12-14", "MonthDay double hyphen compact");
+    shouldBe(Temporal.PlainMonthDay.from("1130[u-ca=iso8601]").toString(), "11-30", "MonthDay annotated");
+    shouldBe(Temporal.PlainMonthDay.from("1118[+01:00]").toString(), "11-18", "MonthDay timezone annotation");
+    shouldBe(Temporal.PlainMonthDay.from("1976-11-18").toString(), "11-18", "MonthDay full date");
+    shouldBe(Temporal.PlainMonthDay.from("1976-11-18T15:23:30").toString(), "11-18", "MonthDay full datetime");
+
+    shouldBe(Temporal.PlainDateTime.from("2024-01-15T12:30").toString(), "2024-01-15T12:30:00", "PlainDateTime");
+    shouldBe(Temporal.ZonedDateTime.from("2024-01-15T12:30[UTC]").toString(), "2024-01-15T12:30:00+00:00[UTC]", "ZonedDateTime");
+}

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -1114,16 +1114,12 @@ static std::optional<PlainDate> NODELETE parseDate(StringParsingBuffer<Character
         if (*buffer == '-') {
             splitByHyphen = true;
             buffer.advance();
-            if (buffer.lengthRemaining() < 5 && format == TemporalDateFormat::Date)
-                return std::nullopt;
-        } else {
-            if (buffer.lengthRemaining() < 4 && format == TemporalDateFormat::Date)
-                return std::nullopt;
         }
     }
-    // We ensured that buffer has enough length for month and day. We do not need to check length.
 
     unsigned month = 0;
+    if (buffer.lengthRemaining() < 2)
+        return std::nullopt;
     auto firstMonthCharacter = *buffer;
     if (firstMonthCharacter == '0' || firstMonthCharacter == '1') {
         buffer.advance();
@@ -1147,17 +1143,22 @@ static std::optional<PlainDate> NODELETE parseDate(StringParsingBuffer<Character
         return PlainDate(year, month, 1);
     }
 
+    if (buffer.atEnd())
+        return std::nullopt;
+
+    bool consumedDaySeparator = false;
     if (*buffer == '-') {
-        if (splitByHyphen || format != TemporalDateFormat::Date)
+        if (splitByHyphen || format != TemporalDateFormat::Date) {
             buffer.advance();
-        else
+            consumedDaySeparator = true;
+        } else
             return std::nullopt;
     } else if (splitByHyphen)
         return std::nullopt;
 
     unsigned day = 0;
-    auto firstDayCharacter = *buffer;
-    if (firstDayCharacter >= '0' && firstDayCharacter <= '3') {
+    if (buffer.lengthRemaining() >= 2 && *buffer >= '0' && *buffer <= '3') {
+        auto firstDayCharacter = *buffer;
         buffer.advance();
         auto secondDayCharacter = *buffer;
         if (!isASCIIDigit(secondDayCharacter))
@@ -1166,7 +1167,7 @@ static std::optional<PlainDate> NODELETE parseDate(StringParsingBuffer<Character
         if (!day || day > daysInMonth(year, month))
             return std::nullopt;
         buffer.advance();
-    } else if (format != TemporalDateFormat::YearMonth)
+    } else if (consumedDaySeparator || format != TemporalDateFormat::YearMonth)
         return std::nullopt;
 
     // PlainDate represents out-of-range years using outOfRangeYear


### PR DESCRIPTION
#### d58bad697e50a0bda1ff67669bb4cf9e1f78662e
<pre>
[JSC] `ISO8601::parseDate` reads past the end of the buffer for short invalid strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=316366">https://bugs.webkit.org/show_bug.cgi?id=316366</a>

Reviewed by Yusuke Suzuki.

The month/day length guards in parseDate only applied to the Date format, so
short truncated strings like &quot;0&quot;, &quot;2024-01-&quot; or &quot;2024-05&quot; reached unchecked
buffer dereferences via PlainYearMonth/PlainMonthDay parsing (and via the
year-less month parsing path for all formats), crashing Release builds with a
span bounds trap. Check the remaining length at every month/day read
regardless of format, and require a day to follow a consumed day separator so
trailing-hyphen strings are rejected instead of read out of bounds.

Test: JSTests/stress/temporal-iso8601-parse-bounds.js

* JSTests/stress/temporal-iso8601-parse-bounds.js: Added.
(shouldBe):
(throw.new.Error):
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::parseDate):

Canonical link: <a href="https://commits.webkit.org/314612@main">https://commits.webkit.org/314612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f127128aee54c2e85c803f722b8985d3ce420495

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175657 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123865 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129537 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110062 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23798 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158766 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178191 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27503 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31091 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137901 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137818 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37132 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149198 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103601 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33109 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26063 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199288 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39368 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112442 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53506 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38764 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4153 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39009 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->