### PR TITLE
[JSC][Temporal] Month code `"M00L"` and unvalidated `PlainMonthDay` reference years reach assertions

### DIFF
--- a/JSTests/stress/temporal-month-code-m00l-rejected.js
+++ b/JSTests/stress/temporal-month-code-m00l-rejected.js
@@ -1,0 +1,47 @@
+//@ requireOptions("--useTemporal=1")
+
+function assert(cond, msg) {
+    if (!cond) throw new Error("FAIL: " + msg);
+}
+
+function shouldThrowRangeError(fn, msg) {
+    let thrown = null;
+    try {
+        fn();
+    } catch (e) {
+        thrown = e;
+    }
+    assert(thrown instanceof RangeError, msg + " (got: " + thrown + ")");
+}
+
+const overflows = [undefined, { overflow: "constrain" }, { overflow: "reject" }];
+
+for (const options of overflows) {
+    const tag = " (options: " + JSON.stringify(options) + ")";
+    shouldThrowRangeError(() => Temporal.PlainDate.from({ calendar: "chinese", year: 2024, monthCode: "M00L", day: 1 }, options),
+        "PlainDate chinese M00L should throw RangeError" + tag);
+    shouldThrowRangeError(() => Temporal.PlainDate.from({ calendar: "hebrew", year: 5784, monthCode: "M00L", day: 1 }, options),
+        "PlainDate hebrew M00L should throw RangeError" + tag);
+    shouldThrowRangeError(() => Temporal.PlainDateTime.from({ year: 2024, monthCode: "M00L", day: 1, calendar: "chinese" }, options),
+        "PlainDateTime chinese M00L should throw RangeError" + tag);
+    shouldThrowRangeError(() => Temporal.PlainDateTime.from({ year: 2016, monthCode: "M00L", day: 1, calendar: "japanese" }, options),
+        "PlainDateTime japanese M00L should throw RangeError" + tag);
+    shouldThrowRangeError(() => Temporal.PlainDate.from({ year: 2024, monthCode: "M00L", day: 1 }, options),
+        "PlainDate iso8601 M00L should throw RangeError" + tag);
+}
+shouldThrowRangeError(() => Temporal.PlainMonthDay.from({ calendar: "chinese", monthCode: "M00L", day: 1 }),
+    "PlainMonthDay chinese M00L should throw RangeError");
+shouldThrowRangeError(() => Temporal.PlainYearMonth.from({ calendar: "chinese", year: 2024, monthCode: "M00L" }),
+    "PlainYearMonth chinese M00L should throw RangeError");
+shouldThrowRangeError(() => Temporal.PlainDate.from("2024-03-10[u-ca=chinese]").with({ monthCode: "M00L" }),
+    "PlainDate.with chinese M00L should throw RangeError");
+
+{
+    const constrained = Temporal.PlainDate.from({ calendar: "chinese", year: 2024, monthCode: "M01L", day: 1 });
+    assert(constrained.monthCode === "M01", "chinese M01L should constrain to M01, got " + constrained.monthCode);
+    assert(constrained.year === 2024, "chinese M01L constrain should stay in year 2024, got " + constrained.year);
+    const leapYear = Temporal.PlainDate.from({ calendar: "hebrew", year: 5779, monthCode: "M05L", day: 1 });
+    assert(leapYear.monthCode === "M05L", "hebrew M05L in leap year 5779 should resolve to M05L, got " + leapYear.monthCode);
+    const commonYear = Temporal.PlainDate.from({ calendar: "hebrew", year: 5781, monthCode: "M05L", day: 1 });
+    assert(commonYear.monthCode === "M06", "hebrew M05L in common year 5781 should constrain to M06, got " + commonYear.monthCode);
+}

--- a/JSTests/stress/temporal-plainmonthday-constructor-reference-year-range.js
+++ b/JSTests/stress/temporal-plainmonthday-constructor-reference-year-range.js
@@ -1,0 +1,45 @@
+//@ requireOptions("--useTemporal=1")
+
+function assert(cond, msg) {
+    if (!cond) throw new Error("FAIL: " + msg);
+}
+
+function shouldThrowRangeError(fn, msg) {
+    let thrown = null;
+    try {
+        fn();
+    } catch (e) {
+        thrown = e;
+    }
+    assert(thrown instanceof RangeError, msg + " (got: " + thrown + ")");
+}
+
+shouldThrowRangeError(() => new Temporal.PlainMonthDay(7, 15, "iso8601", 2 ** 32 + 1972),
+    "2**32 + 1972 should throw RangeError");
+shouldThrowRangeError(() => new Temporal.PlainMonthDay(2, 29, "iso8601", 2 ** 53),
+    "2**53 should throw RangeError");
+shouldThrowRangeError(() => new Temporal.PlainMonthDay(7, 15, "iso8601", -(2 ** 53)),
+    "-2**53 should throw RangeError");
+shouldThrowRangeError(() => new Temporal.PlainMonthDay(7, 15, "iso8601", 1e9),
+    "1e9 should throw RangeError");
+shouldThrowRangeError(() => new Temporal.PlainMonthDay(7, 15, "iso8601", -1e9),
+    "-1e9 should throw RangeError");
+
+shouldThrowRangeError(() => new Temporal.PlainMonthDay(7, 15, "iso8601", 275761),
+    "275761 should throw RangeError");
+shouldThrowRangeError(() => new Temporal.PlainMonthDay(7, 15, "iso8601", -271822),
+    "-271822 should throw RangeError");
+
+assert(new Temporal.PlainMonthDay(7, 15, "iso8601", 275760).toString() === "07-15",
+    "reference year 275760 (July is within limits) should be accepted");
+assert(new Temporal.PlainMonthDay(7, 15, "iso8601", -271821).toString() === "07-15",
+    "reference year -271821 (July is within limits) should be accepted");
+assert(new Temporal.PlainMonthDay(7, 15, "iso8601", 2000).toString() === "07-15",
+    "reference year 2000 should be accepted");
+assert(new Temporal.PlainMonthDay(2, 29).toString() === "02-29",
+    "default reference year 1972 should accept Feb 29");
+
+shouldThrowRangeError(() => new Temporal.PlainMonthDay(2, 29, "iso8601", 1973),
+    "Feb 29 in non-leap reference year should throw RangeError");
+shouldThrowRangeError(() => new Temporal.PlainMonthDay(2, 30),
+    "Feb 30 should throw RangeError");

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -83,6 +83,10 @@ static void calendarResolveFields(JSGlobalObject* globalObject, std::optional<in
         return;
     }
     if (monthCode) {
+        if (!monthCode->monthNumber) [[unlikely]] {
+            throwRangeError(globalObject, scope, "monthCode is not valid for this calendar"_s);
+            return;
+        }
         if (isISO) {
             if (monthCode->isLeapMonth) [[unlikely]] {
                 throwRangeError(globalObject, scope, "iso8601 calendar does not have leap months"_s);

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
@@ -142,7 +142,17 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainMonthDay, (JSGlobalObject* global
     }
 
     // Steps 9-11: IsValidISODate + CreateISODateRecord + CreateTemporalMonthDay.
-    auto* result = TemporalPlainMonthDay::tryCreateIfValid(globalObject, structure, ISO8601::PlainDate(referenceYear, isoMonth, isoDay));
+    if (!ISO8601::isValidISODate(referenceYear, isoMonth, isoDay)) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay: not a valid ISO date"_s);
+
+    if (!ISO8601::isYearWithinLimits(referenceYear)) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, "reference year is out of range"_s);
+    if (!isInBounds<int32_t>(isoMonth)) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, "month is out of range"_s);
+    if (!isInBounds<int32_t>(isoDay)) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, "day is out of range"_s);
+
+    auto* result = TemporalPlainMonthDay::tryCreateIfValid(globalObject, structure, ISO8601::PlainDate(static_cast<int32_t>(referenceYear), static_cast<unsigned>(isoMonth), static_cast<unsigned>(isoDay)));
     RETURN_IF_EXCEPTION(scope, { });
     if (result && calId != iso8601CalendarID())
         result->setCalendarID(calId);

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -1501,6 +1501,8 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
         ucal_set(cal.get(), UCAL_EXTENDED_YEAR, year.value_or(0));
 
     if (monthCode) {
+        if (!monthCode->monthNumber)
+            return makeUnexpected(rangeError("monthCode is not valid for this calendar"_s));
         // Month codes > M13 are always invalid. M13 is only valid for Coptic/Ethiopian.
         if (monthCode->monthNumber > 13) [[unlikely]]
             return makeUnexpected(rangeError("month is out of range"_s));


### PR DESCRIPTION
#### d4dd322f9d78944a81eb36d1ad9b5282712b86cc
<pre>
[JSC][Temporal] Month code `&quot;M00L&quot;` and unvalidated `PlainMonthDay` reference years reach assertions
<a href="https://bugs.webkit.org/show_bug.cgi?id=316367">https://bugs.webkit.org/show_bug.cgi?id=316367</a>

Reviewed by NOBODY (OOPS!).

Fix two crash bugs in Temporal:

1. &quot;M00L&quot; parses as month number 0 with the leap flag, and non-ISO
   calendar resolution did not reject it, so month = 0 reached
   ASSERT(month &gt; 0) in isoDateFromFields on Debug builds. On Release
   builds the lunisolar month walk stepped past the start of the year,
   silently resolving Chinese &quot;M00L&quot; to M12 of the previous year:

       Temporal.PlainDateTime.from({ year: 2024, monthCode: &quot;M00L&quot;, day: 1, calendar: &quot;chinese&quot; })
       // before: Debug ASSERT; Release 2024-01-11T00:00:00[u-ca=chinese]
       //         (chinese 2023 M12); after: RangeError

   No calendar has a leap month before its first month, so month number 0
   is never valid. Reject it in calendarResolveFields (before the month
   is resolved) and in calendarDateFromFields (covering the
   dateFromFields / yearMonthFromFields / monthDayFromFields paths).

2. The Temporal.PlainMonthDay constructor narrowed the referenceISOYear
   argument to int32 before validating its range, failing an assertion
   in ISO8601::PlainDate on Debug builds and creating observably broken
   out-of-range objects on Release builds:

       new Temporal.PlainMonthDay(7, 15, &quot;iso8601&quot;, 2 ** 32 + 1972)
       // before: succeeds with saturated internal reference year; after: RangeError

   Validate the range before narrowing, like the Temporal.PlainYearMonth
   constructor does.

Tests: JSTests/stress/temporal-month-code-m00l-rejected.js
       JSTests/stress/temporal-plainmonthday-constructor-reference-year-range.js

* JSTests/stress/temporal-month-code-m00l-rejected.js: Added.
(assert):
(shouldThrowRangeError):
(shouldThrowRangeError.Temporal.PlainDate.from.string_appeared_here.with):
* JSTests/stress/temporal-plainmonthday-constructor-reference-year-range.js: Added.
(assert):
(shouldThrowRangeError):
* Source/JavaScriptCore/runtime/TemporalCalendar.cpp:
(JSC::calendarResolveFields):
* Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
(JSC::TemporalCore::calendarDateFromFields):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4dd322f9d78944a81eb36d1ad9b5282712b86cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33682 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175659 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123867 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40109 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/175659 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91225 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149707 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/175659 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30911 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29605 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23800 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158768 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178193 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27505 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31093 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137897 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137814 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149202 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103603 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33103 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26067 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199290 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112444 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53517 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38766 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4157 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->