### PR TITLE
[JSC][Temporal] `PlainDate` add/subtract with a huge day count fails a day-range assertion

### DIFF
--- a/JSTests/stress/temporal-plaindate-add-huge-days-out-of-range.js
+++ b/JSTests/stress/temporal-plaindate-add-huge-days-out-of-range.js
@@ -1,0 +1,24 @@
+//@ requireOptions("--useTemporal=1")
+
+// Adding/subtracting a huge number of days must throw RangeError instead of
+// crashing (Debug ASSERT: day >= 1 && day <= 31 in ExactTime::fromISOPartsAndOffset).
+
+function shouldThrow(func, errorType) {
+    let threw = false;
+    try { func(); } catch (e) {
+        threw = true;
+        if (!(e instanceof errorType))
+            throw new Error(`Expected ${errorType.name} but got ${e.constructor.name}: ${e.message}`);
+    }
+    if (!threw)
+        throw new Error(`Expected ${errorType.name} but no exception was thrown`);
+}
+
+shouldThrow(() => new Temporal.PlainDate(2024, 1, 1).subtract({ days: 149645246 }), RangeError);
+shouldThrow(() => new Temporal.PlainDate(2024, 1, 1).subtract({ days: 2000000000 }), RangeError);
+shouldThrow(() => new Temporal.PlainDate(2024, 1, 1).add({ days: 149645246 }), RangeError);
+shouldThrow(() => new Temporal.PlainDate(2024, 1, 1).add({ days: 2000000000 }), RangeError);
+
+shouldThrow(() => {
+    Temporal.Duration.from({ hours: -4294967295 }).round({ smallestUnit: "years", roundingMode: "halfEven", relativeTo: "2020-02-29" });
+}, RangeError);

--- a/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
@@ -76,7 +76,7 @@ ISO8601::PlainDate balanceISODate(int32_t year, int32_t month, int64_t day)
     // 3. Return CreateISODateRecord(EpochTimeToEpochYear(ms), EpochTimeToMonthInYear(ms) + 1, EpochTimeToDate(ms)).
     auto [y, m, d] = WTF::yearMonthDayFromDays(static_cast<int32_t>(daysToUse));
     if (!ISO8601::isYearWithinLimits(y)) [[unlikely]]
-        return ISO8601::PlainDate { ISO8601::outOfRangeYear, static_cast<unsigned>(m + 1), static_cast<unsigned>(d) };
+        return ISO8601::PlainDate { ISO8601::outOfRangeYear, 1, 1 };
     return ISO8601::PlainDate { y, static_cast<unsigned>(m + 1), static_cast<unsigned>(d) };
 }
 


### PR DESCRIPTION
#### 2c290815d4218ecc5a71fdb0eea444bedeb08755
<pre>
[JSC][Temporal] `PlainDate` add/subtract with a huge day count fails a day-range assertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=316368">https://bugs.webkit.org/show_bug.cgi?id=316368</a>

Reviewed by Yusuke Suzuki.

balanceISODate returns the outOfRangeYear sentinel with the raw month/day
from WTF::yearMonthDayFromDays. Once the balanced date lands far enough past
the supported range (roughly 1.4e8 days from the epoch), that day falls
outside [1, 31], and isDateTimeWithinLimits hits the day-range assertion in
ExactTime::fromISOPartsAndOffset on Debug builds (Release correctly throws
RangeError). The out-of-range path now returns the fully-normalized
{ outOfRangeYear, 1, 1 } sentinel, matching the other out-of-range paths.

    new Temporal.PlainDate(2024, 1, 1).subtract({ days: 149645246 });
    // Expected: RangeError
    // Actual (Debug): ASSERTION FAILED: day &gt;= 1 &amp;&amp; day &lt;= 31

Test: JSTests/stress/temporal-plaindate-add-huge-days-out-of-range.js

* JSTests/stress/temporal-plaindate-add-huge-days-out-of-range.js: Added.
(shouldThrow):
* Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp:
(JSC::TemporalCore::balanceISODate):

Canonical link: <a href="https://commits.webkit.org/314613@main">https://commits.webkit.org/314613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64243cc757a5daa2d0142033d72bc2a36ad1843f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175660 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129538 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110063 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29606 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23801 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158769 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178194 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27506 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31094 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137899 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137816 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37133 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40860 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149203 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103604 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33104 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26068 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199291 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39371 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112445 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/53520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38767 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4158 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->