### PR TITLE
[JSC] Temporal conversion should use toIntegerWithTruncation

### DIFF
--- a/JSTests/stress/temporal-nan-fields.js
+++ b/JSTests/stress/temporal-nan-fields.js
@@ -1,0 +1,133 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldThrow(fn, type) {
+    let err;
+    try { fn(); } catch (e) { err = e; }
+    if (!(err instanceof type))
+        throw new Error(`Expected ${type.name} but got ${err}`);
+}
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`);
+}
+
+// Spec uses ToIntegerWithTruncation (throws on NaN/+/-Infinity) for year, eraYear, and time
+// fields; ToPositiveIntegerWithTruncation (also rejects ≤0) for month and day. Previously
+// JSC used toIntegerOrInfinity which silently maps NaN -> 0, letting NaN inputs slip through
+// across PlainDate/PlainTime/PlainMonthDay/PlainYearMonth/PlainDateTime/ZonedDateTime/Duration.
+
+// ---- PlainDate.from ----
+shouldThrow(() => Temporal.PlainDate.from({ year: NaN, month: 1, day: 1 }), RangeError);
+shouldThrow(() => Temporal.PlainDate.from({ year: 2024, month: NaN, day: 1 }), RangeError);
+shouldThrow(() => Temporal.PlainDate.from({ year: 2024, month: 1, day: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainDate.from({ era: "ce", eraYear: NaN, month: 1, day: 1, calendar: "gregory" }), RangeError);
+
+// ---- PlainDate.prototype.with ----
+{
+    const pd = Temporal.PlainDate.from("2024-01-15");
+    shouldThrow(() => pd.with({ year: NaN }), RangeError);
+    shouldThrow(() => pd.with({ month: NaN }), RangeError);
+    shouldThrow(() => pd.with({ day: NaN }), RangeError);
+}
+
+// ---- PlainDateTime.prototype.with ----
+{
+    const pdt = Temporal.PlainDateTime.from("2024-01-15T12:30:45");
+    shouldThrow(() => pdt.with({ year: NaN }), RangeError);
+    shouldThrow(() => pdt.with({ month: NaN }), RangeError);
+    shouldThrow(() => pdt.with({ day: NaN }), RangeError);
+    shouldThrow(() => pdt.with({ hour: NaN }), RangeError);
+    shouldThrow(() => pdt.with({ minute: NaN }), RangeError);
+    shouldThrow(() => pdt.with({ second: NaN }), RangeError);
+    shouldThrow(() => pdt.with({ millisecond: NaN }), RangeError);
+    shouldThrow(() => pdt.with({ microsecond: NaN }), RangeError);
+    shouldThrow(() => pdt.with({ nanosecond: NaN }), RangeError);
+    const jpdt = pdt.withCalendar("japanese");
+    shouldThrow(() => jpdt.with({ eraYear: NaN }), RangeError);
+}
+
+// ---- PlainTime.from / .with (all six time fields) ----
+shouldThrow(() => Temporal.PlainTime.from({ hour: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainTime.from({ minute: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainTime.from({ second: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainTime.from({ millisecond: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainTime.from({ microsecond: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainTime.from({ nanosecond: NaN }), RangeError);
+{
+    const pt = Temporal.PlainTime.from({ hour: 12 });
+    shouldThrow(() => pt.with({ hour: NaN }), RangeError);
+    shouldThrow(() => pt.with({ minute: NaN }), RangeError);
+    shouldThrow(() => pt.with({ second: NaN }), RangeError);
+    shouldThrow(() => pt.with({ millisecond: NaN }), RangeError);
+    shouldThrow(() => pt.with({ microsecond: NaN }), RangeError);
+    shouldThrow(() => pt.with({ nanosecond: NaN }), RangeError);
+}
+
+// ---- PlainMonthDay.from / .with ----
+shouldThrow(() => Temporal.PlainMonthDay.from({ month: NaN, day: 1 }), RangeError);
+shouldThrow(() => Temporal.PlainMonthDay.from({ month: 1, day: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainMonthDay.from({ era: "ce", eraYear: NaN, month: 1, day: 1, calendar: "gregory" }), RangeError);
+{
+    const pmd = Temporal.PlainMonthDay.from({ month: 5, day: 15 });
+    shouldThrow(() => pmd.with({ day: NaN }), RangeError);
+    shouldThrow(() => pmd.with({ month: NaN, day: 15 }), RangeError);
+    const jpmd = Temporal.PlainMonthDay.from({ monthCode: "M05", day: 15, calendar: "japanese" });
+    shouldThrow(() => jpmd.with({ eraYear: NaN }), RangeError);
+}
+
+// ---- PlainYearMonth.from / .with ----
+shouldThrow(() => Temporal.PlainYearMonth.from({ year: NaN, month: 1 }), RangeError);
+shouldThrow(() => Temporal.PlainYearMonth.from({ year: 2024, month: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainYearMonth.from({ era: "ce", eraYear: NaN, month: 1, calendar: "gregory" }), RangeError);
+{
+    const pym = Temporal.PlainYearMonth.from("2024-01");
+    shouldThrow(() => pym.with({ year: NaN }), RangeError);
+    shouldThrow(() => pym.with({ month: NaN }), RangeError);
+}
+
+// ---- ZonedDateTime.from / .with (calendar fields, time fields, era fields) ----
+shouldThrow(() => Temporal.ZonedDateTime.from({ year: NaN, month: 1, day: 1, timeZone: "UTC" }), RangeError);
+shouldThrow(() => Temporal.ZonedDateTime.from({ year: 2024, month: NaN, day: 1, timeZone: "UTC" }), RangeError);
+shouldThrow(() => Temporal.ZonedDateTime.from({ year: 2024, month: 1, day: NaN, timeZone: "UTC" }), RangeError);
+shouldThrow(() => Temporal.ZonedDateTime.from({ year: 2024, month: 1, day: 1, hour: NaN, timeZone: "UTC" }), RangeError);
+shouldThrow(() => Temporal.ZonedDateTime.from({ year: 2024, month: 1, day: 1, minute: NaN, timeZone: "UTC" }), RangeError);
+shouldThrow(() => Temporal.ZonedDateTime.from({ year: 2024, month: 1, day: 1, second: NaN, timeZone: "UTC" }), RangeError);
+shouldThrow(() => Temporal.ZonedDateTime.from({ year: 2024, month: 1, day: 1, millisecond: NaN, timeZone: "UTC" }), RangeError);
+shouldThrow(() => Temporal.ZonedDateTime.from({ year: 2024, month: 1, day: 1, microsecond: NaN, timeZone: "UTC" }), RangeError);
+shouldThrow(() => Temporal.ZonedDateTime.from({ year: 2024, month: 1, day: 1, nanosecond: NaN, timeZone: "UTC" }), RangeError);
+shouldThrow(() => Temporal.ZonedDateTime.from({ era: "ce", eraYear: NaN, month: 1, day: 1, calendar: "gregory", timeZone: "UTC" }), RangeError);
+{
+    const zdt = Temporal.ZonedDateTime.from({ year: 2024, month: 1, day: 1, timeZone: "UTC" });
+    shouldThrow(() => zdt.with({ year: NaN }), RangeError);
+    shouldThrow(() => zdt.with({ hour: NaN }), RangeError);
+    shouldThrow(() => zdt.with({ nanosecond: NaN }), RangeError);
+}
+
+// ---- Duration relativeTo: nested date object property reads via TemporalDuration.cpp ----
+{
+    const dur = Temporal.Duration.from({ days: 5 });
+    shouldThrow(() => dur.round({ largestUnit: "weeks", relativeTo: { year: NaN, month: 1, day: 1 } }), RangeError);
+    shouldThrow(() => dur.round({ largestUnit: "weeks", relativeTo: { year: 2024, month: NaN, day: 1 } }), RangeError);
+    shouldThrow(() => dur.round({ largestUnit: "weeks", relativeTo: { year: 2024, month: 1, day: NaN } }), RangeError);
+    shouldThrow(() => dur.round({ largestUnit: "weeks", relativeTo: { year: 2024, month: 1, day: 1, hour: NaN, timeZone: "UTC" } }), RangeError);
+    shouldThrow(() => dur.round({ largestUnit: "weeks", relativeTo: { year: 2024, month: 1, day: 1, nanosecond: NaN, timeZone: "UTC" } }), RangeError);
+    shouldThrow(() => dur.round({ largestUnit: "weeks", relativeTo: { era: "ce", eraYear: NaN, month: 1, day: 1, calendar: "gregory" } }), RangeError);
+}
+
+// ---- +/-Infinity continues to throw at the same sites ----
+shouldThrow(() => Temporal.PlainDate.from({ year: Infinity, month: 1, day: 1 }), RangeError);
+shouldThrow(() => Temporal.PlainTime.from({ hour: -Infinity }), RangeError);
+shouldThrow(() => Temporal.PlainYearMonth.from({ year: Infinity, month: 1 }), RangeError);
+shouldThrow(() => Temporal.ZonedDateTime.from({ year: 2024, month: 1, day: 1, nanosecond: Infinity, timeZone: "UTC" }), RangeError);
+
+// ---- Sanity: valid integer-like values still succeed (regression guard) ----
+shouldBe(Temporal.PlainDate.from({ year: 2024, month: 1, day: 1 }).toString(), "2024-01-01");
+shouldBe(Temporal.PlainTime.from({ hour: 1.7, minute: 2.9 }).toString(), "01:02:00");
+shouldBe(Temporal.PlainYearMonth.from({ year: 2024, month: 5 }).toString(), "2024-05");
+shouldBe(Temporal.PlainMonthDay.from({ month: 5, day: 15 }).toString(), "05-15");
+shouldBe(Temporal.PlainDateTime.from({ year: 2024, month: 1, day: 1 }).toString(), "2024-01-01T00:00:00");
+shouldBe(Temporal.ZonedDateTime.from({ year: 2024, month: 1, day: 1, timeZone: "UTC" }).toString(), "2024-01-01T00:00:00+00:00[UTC]");
+// Year 0 and negative year are valid (ToIntegerWithTruncation, not ToPositive).
+shouldBe(Temporal.PlainDate.from({ year: 0, month: 1, day: 1 }).year, 0);
+shouldBe(Temporal.PlainDate.from({ year: -1, month: 1, day: 1 }).year, -1);

--- a/JSTests/stress/temporal-plain-date-time-nan-fields.js
+++ b/JSTests/stress/temporal-plain-date-time-nan-fields.js
@@ -1,0 +1,51 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldThrow(fn, type) {
+    let err;
+    try { fn(); } catch (e) { err = e; }
+    if (!(err instanceof type))
+        throw new Error(`Expected ${type.name} but got ${err}`);
+}
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`);
+}
+
+// Spec uses ToIntegerWithTruncation for year, eraYear, and time fields. ToIntegerWithTruncation
+// throws RangeError on NaN/+Infinity/-Infinity. Previously, JSC used toIntegerOrInfinity which
+// silently maps NaN -> 0, letting NaN inputs slip through.
+shouldThrow(() => Temporal.PlainDateTime.from({ year: NaN, month: 1, day: 1 }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: 1, day: 1, hour: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: 1, day: 1, minute: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: 1, day: 1, second: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: 1, day: 1, millisecond: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: 1, day: 1, microsecond: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: 1, day: 1, nanosecond: NaN }), RangeError);
+
+// +/-Infinity continues to throw (was already covered by isFinite check).
+shouldThrow(() => Temporal.PlainDateTime.from({ year: Infinity, month: 1, day: 1 }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: -Infinity, month: 1, day: 1 }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: 1, day: 1, hour: Infinity }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: 1, day: 1, nanosecond: -Infinity }), RangeError);
+
+// eraYear with NaN throws (japanese calendar uses era/eraYear).
+shouldThrow(() => Temporal.PlainDateTime.from({ era: "reiwa", eraYear: NaN, month: 1, day: 1, calendar: "japanese" }), RangeError);
+
+// Day and month use ToPositiveIntegerWithTruncation: NaN/Infinity AND <=0 all throw,
+// regardless of overflow option. (Existing spec behavior, kept by this change.)
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: 1, day: NaN }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: NaN, day: 1 }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: 1, day: 0 }, { overflow: "constrain" }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: 0, day: 1 }, { overflow: "constrain" }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: 1, day: -5 }, { overflow: "constrain" }), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from({ year: 2024, month: -1, day: 1 }, { overflow: "constrain" }), RangeError);
+
+// Sanity: valid integer-like values still succeed.
+shouldBe(Temporal.PlainDateTime.from({ year: 2024, month: 1, day: 1 }).toString(), "2024-01-01T00:00:00");
+shouldBe(Temporal.PlainDateTime.from({ year: 2024, month: 1, day: 1, hour: 1.7, minute: 2.9 }).toString(), "2024-01-01T01:02:00");
+
+// Year=0 is valid (ToIntegerWithTruncation, not ToPositive).
+shouldBe(Temporal.PlainDateTime.from({ year: 0, month: 1, day: 1 }).year, 0);
+// Negative year is valid.
+shouldBe(Temporal.PlainDateTime.from({ year: -1, month: 1, day: 1 }).year, -1);

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -129,7 +129,7 @@ TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject(JSGlobalObject* glob
         JSValue dayProp = bag->get(globalObject, vm.propertyNames->day);
         RETURN_IF_EXCEPTION(scope, fields);
         if (!dayProp.isUndefined()) {
-            double d = dayProp.toIntegerOrInfinity(globalObject);
+            double d = dayProp.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, fields);
             if (!(d > 0 && std::isfinite(d))) [[unlikely]] {
                 throwRangeError(globalObject, scope, "day must be positive and finite"_s);
@@ -150,7 +150,7 @@ TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject(JSGlobalObject* glob
         JSValue eraYearProp = bag->get(globalObject, Identifier::fromString(vm, "eraYear"_s));
         RETURN_IF_EXCEPTION(scope, fields);
         if (!eraYearProp.isUndefined()) {
-            double ey = eraYearProp.toIntegerOrInfinity(globalObject);
+            double ey = eraYearProp.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, fields);
             if (!std::isfinite(ey)) [[unlikely]] {
                 throwRangeError(globalObject, scope, "eraYear must be finite"_s);
@@ -170,7 +170,7 @@ TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject(JSGlobalObject* glob
         JSValue monthProp = bag->get(globalObject, vm.propertyNames->month);
         RETURN_IF_EXCEPTION(scope, fields);
         if (!monthProp.isUndefined()) {
-            double m = monthProp.toIntegerOrInfinity(globalObject);
+            double m = monthProp.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, fields);
             if (!std::isfinite(m) || m < 1) [[unlikely]] {
                 throwRangeError(globalObject, scope, "month must be positive and finite"_s);
@@ -204,7 +204,7 @@ TemporalCore::CalendarFieldsIn readCalendarFieldsFromObject(JSGlobalObject* glob
         JSValue yearProp = bag->get(globalObject, vm.propertyNames->year);
         RETURN_IF_EXCEPTION(scope, fields);
         if (!yearProp.isUndefined()) {
-            double y = yearProp.toIntegerOrInfinity(globalObject);
+            double y = yearProp.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, fields);
             if (!std::isfinite(y)) [[unlikely]] {
                 throwRangeError(globalObject, scope, "year must be finite"_s);
@@ -259,7 +259,7 @@ ZonedDateTimeFields readZonedDateTimeFieldsFromObject(JSGlobalObject* globalObje
         JSValue v = bag->get(globalObject, vm.propertyNames->day);
         RETURN_IF_EXCEPTION(scope, result);
         if (!v.isUndefined()) {
-            double d = v.toIntegerOrInfinity(globalObject);
+            double d = v.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, result);
             if (!(d > 0 && std::isfinite(d))) [[unlikely]] {
                 throwRangeError(globalObject, scope, "day property must be positive and finite"_s);
@@ -284,7 +284,7 @@ ZonedDateTimeFields readZonedDateTimeFieldsFromObject(JSGlobalObject* globalObje
         JSValue eraYearVal = bag->get(globalObject, Identifier::fromString(vm, "eraYear"_s));
         RETURN_IF_EXCEPTION(scope, result);
         if (!eraYearVal.isUndefined()) {
-            double ey = eraYearVal.toIntegerOrInfinity(globalObject);
+            double ey = eraYearVal.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, result);
             if (!std::isfinite(ey)) [[unlikely]] {
                 throwRangeError(globalObject, scope, "eraYear property must be finite"_s);
@@ -306,7 +306,7 @@ ZonedDateTimeFields readZonedDateTimeFieldsFromObject(JSGlobalObject* globalObje
         RETURN_IF_EXCEPTION(scope, void());
         if (v.isUndefined())
             return;
-        double val = v.toIntegerOrInfinity(globalObject);
+        double val = v.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, void());
         if (!std::isfinite(val)) [[unlikely]] {
             throwRangeError(globalObject, scope, "Temporal time properties must be finite"_s);
@@ -331,7 +331,7 @@ ZonedDateTimeFields readZonedDateTimeFieldsFromObject(JSGlobalObject* globalObje
         JSValue v = bag->get(globalObject, vm.propertyNames->month);
         RETURN_IF_EXCEPTION(scope, result);
         if (!v.isUndefined()) {
-            double m = v.toIntegerOrInfinity(globalObject);
+            double m = v.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, result);
             if (!std::isfinite(m) || m <= 0) [[unlikely]] {
                 throwRangeError(globalObject, scope, "month property must be a positive finite integer"_s);
@@ -409,7 +409,7 @@ ZonedDateTimeFields readZonedDateTimeFieldsFromObject(JSGlobalObject* globalObje
         RETURN_IF_EXCEPTION(scope, result);
         if (!v.isUndefined()) {
             // Step 9.c: apply ~to-integer-with-truncation~.
-            double y = v.toIntegerOrInfinity(globalObject);
+            double y = v.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, result);
             if (!std::isfinite(y)) [[unlikely]] {
                 throwRangeError(globalObject, scope, "year property must be finite"_s);

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -322,7 +322,7 @@ static RelativeToRecord toRelativeTemporalObject(JSGlobalObject* globalObject, J
         RETURN_IF_EXCEPTION(scope, { });
         double day = 0;
         if (!dayProperty.isUndefined()) {
-            day = dayProperty.toIntegerOrInfinity(globalObject);
+            day = dayProperty.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (!(day > 0 && std::isfinite(day))) [[unlikely]] {
                 throwRangeError(globalObject, scope, "day property must be positive and finite"_s);
@@ -344,7 +344,7 @@ static RelativeToRecord toRelativeTemporalObject(JSGlobalObject* globalObject, J
             JSValue eraYearProperty = obj->get(globalObject, Identifier::fromString(vm, "eraYear"_s));
             RETURN_IF_EXCEPTION(scope, { });
             if (!eraYearProperty.isUndefined()) {
-                double ey = eraYearProperty.toIntegerOrInfinity(globalObject);
+                double ey = eraYearProperty.toIntegerWithTruncation(globalObject);
                 RETURN_IF_EXCEPTION(scope, { });
                 if (!std::isfinite(ey)) [[unlikely]] {
                     throwRangeError(globalObject, scope, "eraYear property must be finite"_s);
@@ -360,7 +360,7 @@ static RelativeToRecord toRelativeTemporalObject(JSGlobalObject* globalObject, J
             RETURN_IF_EXCEPTION(scope, 0);
             if (val.isUndefined())
                 return 0;
-            double d = val.toIntegerOrInfinity(globalObject);
+            double d = val.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, 0);
             if (!std::isfinite(d)) [[unlikely]] {
                 throwRangeError(globalObject, scope, "Temporal time properties must be finite"_s);
@@ -383,7 +383,7 @@ static RelativeToRecord toRelativeTemporalObject(JSGlobalObject* globalObject, J
         RETURN_IF_EXCEPTION(scope, { });
         double month = 0;
         if (!monthProperty.isUndefined()) {
-            month = monthProperty.toIntegerOrInfinity(globalObject);
+            month = monthProperty.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
         }
 
@@ -434,7 +434,7 @@ static RelativeToRecord toRelativeTemporalObject(JSGlobalObject* globalObject, J
         RETURN_IF_EXCEPTION(scope, { });
         double year = 0;
         if (!yearProperty.isUndefined()) {
-            year = yearProperty.toIntegerOrInfinity(globalObject);
+            year = yearProperty.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (!std::isfinite(year)) [[unlikely]] {
                 throwRangeError(globalObject, scope, "year property must be finite"_s);

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -439,7 +439,7 @@ TemporalPlainDate::mergeDateFields(JSGlobalObject* globalObject, JSObject* tempo
     JSValue dayProperty = temporalDateLike->get(globalObject, vm.propertyNames->day);
     RETURN_IF_EXCEPTION(scope, { });
     if (!dayProperty.isUndefined()) {
-        day = dayProperty.toIntegerOrInfinity(globalObject);
+        day = dayProperty.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
 
         if (day.value() <= 0 || !std::isfinite(day.value())) [[unlikely]] {
@@ -454,7 +454,7 @@ TemporalPlainDate::mergeDateFields(JSGlobalObject* globalObject, JSObject* tempo
     JSValue monthProperty = temporalDateLike->get(globalObject, vm.propertyNames->month);
     RETURN_IF_EXCEPTION(scope, { });
     if (!monthProperty.isUndefined()) {
-        month = monthProperty.toIntegerOrInfinity(globalObject);
+        month = monthProperty.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
 
         if (month.value() <= 0 || !std::isfinite(month.value())) [[unlikely]] {
@@ -479,7 +479,7 @@ TemporalPlainDate::mergeDateFields(JSGlobalObject* globalObject, JSObject* tempo
     JSValue yearProperty = temporalDateLike->get(globalObject, vm.propertyNames->year);
     RETURN_IF_EXCEPTION(scope, { });
     if (!yearProperty.isUndefined()) {
-        year = yearProperty.toIntegerOrInfinity(globalObject);
+        year = yearProperty.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
 
         if (!std::isfinite(year.value())) [[unlikely]] {
@@ -553,7 +553,7 @@ std::optional<int32_t> TemporalPlainDate::toDay(JSGlobalObject* globalObject, JS
     JSValue dayProperty = temporalDateLike->get(globalObject, vm.propertyNames->day);
     RETURN_IF_EXCEPTION(scope, { });
     if (!dayProperty.isUndefined()) {
-        double doubleDay = dayProperty.toIntegerOrInfinity(globalObject);
+        double doubleDay = dayProperty.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
 
         if (!std::isfinite(doubleDay)) [[unlikely]] {
@@ -579,7 +579,7 @@ std::optional<int32_t> TemporalPlainDate::toYear(JSGlobalObject* globalObject, J
     JSValue yearProperty = temporalDateLike->get(globalObject, vm.propertyNames->year);
     RETURN_IF_EXCEPTION(scope, { });
     if (!yearProperty.isUndefined()) {
-        double doubleYear = yearProperty.toIntegerOrInfinity(globalObject);
+        double doubleYear = yearProperty.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
 
         if (!std::isfinite(doubleYear)) [[unlikely]] {
@@ -605,7 +605,7 @@ TemporalPlainDate::toYearMonth(JSGlobalObject* globalObject, JSObject* temporalD
     JSValue monthProperty = temporalDateLike->get(globalObject, vm.propertyNames->month);
     RETURN_IF_EXCEPTION(scope, { });
     if (!monthProperty.isUndefined()) {
-        double doubleMonth = monthProperty.toIntegerOrInfinity(globalObject);
+        double doubleMonth = monthProperty.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
 
         if (!std::isfinite(doubleMonth)) [[unlikely]] {

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -169,7 +169,8 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
             throwTypeError(globalObject, scope, "day property must be present"_s);
             return { };
         }
-        double day = dayProperty.toIntegerOrInfinity(globalObject);
+        // Spec uses ToPositiveIntegerWithTruncation: rejects NaN/±Inf and any value ≤ 0.
+        double day = dayProperty.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
         if (!(day > 0 && std::isfinite(day))) [[unlikely]] {
             throwRangeError(globalObject, scope, "day property must be positive and finite"_s);
@@ -192,7 +193,7 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
             JSValue eraYearProperty = item->get(globalObject, Identifier::fromString(vm, "eraYear"_s));
             RETURN_IF_EXCEPTION(scope, { });
             if (!eraYearProperty.isUndefined()) {
-                double ey = eraYearProperty.toIntegerOrInfinity(globalObject);
+                double ey = eraYearProperty.toIntegerWithTruncation(globalObject);
                 RETURN_IF_EXCEPTION(scope, { });
                 if (!std::isfinite(ey)) [[unlikely]] {
                     throwRangeError(globalObject, scope, "eraYear property must be finite"_s);
@@ -207,7 +208,7 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
         auto readTimeField = [&](JSValue val, TemporalUnit unit) {
             if (val.isUndefined())
                 return;
-            double d = val.toIntegerOrInfinity(globalObject);
+            double d = val.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, void());
             if (!std::isfinite(d)) [[unlikely]] {
                 throwRangeError(globalObject, scope, "Temporal time properties must be finite"_s);
@@ -241,7 +242,7 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
         RETURN_IF_EXCEPTION(scope, { });
         double month = 0;
         if (!monthProperty.isUndefined()) {
-            month = monthProperty.toIntegerOrInfinity(globalObject);
+            month = monthProperty.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
         }
 
@@ -278,7 +279,7 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
             throwTypeError(globalObject, scope, "year property must be present"_s);
             return { };
         }
-        double year = yearProperty.isUndefined() ? 0 : yearProperty.toIntegerOrInfinity(globalObject);
+        double year = yearProperty.isUndefined() ? 0 : yearProperty.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
         if (!std::isfinite(year)) [[unlikely]] {
             throwRangeError(globalObject, scope, "year property must be finite"_s);
@@ -305,6 +306,7 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
             ASSERT(otherMonth);
             month = otherMonth->monthNumber;
         } else {
+            // Spec uses ToPositiveIntegerWithTruncation: rejects NaN/±Inf and any value ≤ 0.
             if (!(month > 0 && std::isfinite(month))) [[unlikely]] {
                 throwRangeError(globalObject, scope, "month property must be positive and finite"_s);
                 return { };

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -258,7 +258,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWith, (JSGlobalObject
         RETURN_IF_EXCEPTION(scope, 0.0);
         if (v.isUndefined())
             return std::numeric_limits<double>::quiet_NaN();
-        double dv = v.toIntegerOrInfinity(globalObject);
+        double dv = v.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, 0.0);
         if (!std::isfinite(dv)) [[unlikely]] {
             throwRangeError(globalObject, scope, "field value must be finite"_s);
@@ -273,7 +273,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWith, (JSGlobalObject
         JSValue v = fields->get(globalObject, vm.propertyNames->day);
         RETURN_IF_EXCEPTION(scope, { });
         if (!v.isUndefined()) {
-            double d = v.toIntegerOrInfinity(globalObject);
+            double d = v.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (!(d > 0 && std::isfinite(d))) [[unlikely]]
                 return throwVMRangeError(globalObject, scope, "day must be a positive finite integer"_s);
@@ -294,7 +294,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWith, (JSGlobalObject
         JSValue eraYearVal = fields->get(globalObject, Identifier::fromString(vm, "eraYear"_s));
         RETURN_IF_EXCEPTION(scope, { });
         if (!eraYearVal.isUndefined()) {
-            double ey = eraYearVal.toIntegerOrInfinity(globalObject);
+            double ey = eraYearVal.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (!std::isfinite(ey)) [[unlikely]]
                 return throwVMRangeError(globalObject, scope, "eraYear must be finite"_s);
@@ -320,7 +320,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWith, (JSGlobalObject
         JSValue v = fields->get(globalObject, vm.propertyNames->month);
         RETURN_IF_EXCEPTION(scope, { });
         if (!v.isUndefined()) {
-            double m = v.toIntegerOrInfinity(globalObject);
+            double m = v.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (!(m > 0 && std::isfinite(m))) [[unlikely]]
                 return throwVMRangeError(globalObject, scope, "month must be a positive finite integer"_s);
@@ -354,7 +354,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWith, (JSGlobalObject
         JSValue v = fields->get(globalObject, vm.propertyNames->year);
         RETURN_IF_EXCEPTION(scope, { });
         if (!v.isUndefined()) {
-            double y = v.toIntegerOrInfinity(globalObject);
+            double y = v.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (!std::isfinite(y)) [[unlikely]]
                 return throwVMRangeError(globalObject, scope, "year must be finite"_s);

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -208,7 +208,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToPlainDate, (JSGloba
         JSValue eraYearValue = asObject(itemValue)->get(globalObject, Identifier::fromString(vm, "eraYear"_s));
         RETURN_IF_EXCEPTION(scope, { });
         if (!eraYearValue.isUndefined()) {
-            double ey = eraYearValue.toIntegerOrInfinity(globalObject);
+            double ey = eraYearValue.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (!std::isfinite(ey)) [[unlikely]]
                 return throwVMRangeError(globalObject, scope, "eraYear property must be finite"_s);

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -397,7 +397,7 @@ ISO8601::Duration TemporalPlainTime::toTemporalTimeRecord(JSGlobalObject* global
             continue;
 
         hasRelevantProperty = true;
-        double integer = value.toIntegerOrInfinity(globalObject);
+        double integer = value.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
         if (!std::isfinite(integer)) [[unlikely]] {
             throwRangeError(globalObject, scope, "Temporal time properties must be finite"_s);
@@ -430,7 +430,7 @@ std::array<std::optional<double>, numberOfTemporalPlainTimeUnits> TemporalPlainT
 
         if (!value.isUndefined()) {
             hasAnyFields = true;
-            double doubleValue = value.toIntegerOrInfinity(globalObject);
+            double doubleValue = value.toIntegerWithTruncation(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             if (!std::isfinite(doubleValue)) [[unlikely]] {
                 throwRangeError(globalObject, scope, "Temporal time properties must be finite"_s);


### PR DESCRIPTION
#### 66267990831bf89c77fea8d45070f79c5160be55
<pre>
[JSC] Temporal conversion should use toIntegerWithTruncation
<a href="https://bugs.webkit.org/show_bug.cgi?id=316369">https://bugs.webkit.org/show_bug.cgi?id=316369</a>
<a href="https://rdar.apple.com/178782245">rdar://178782245</a>

Reviewed by Yijia Huang.

The spec requires using toIntegerWithTruncation instead of
toIntegerOrInfinity. Thus this patch replaces them all, and adding tests
for that.

Tests: JSTests/stress/temporal-nan-fields.js
       JSTests/stress/temporal-plain-date-time-nan-fields.js

* JSTests/stress/temporal-nan-fields.js: Added.
(shouldThrow):
(shouldBe):
(shouldThrow.Temporal.PlainDate.from):
(shouldThrow.Temporal.PlainTime.from):
(shouldThrow.Temporal.PlainMonthDay.from):
(shouldThrow.Temporal.PlainYearMonth.from):
(shouldThrow.Temporal.ZonedDateTime.from):
* JSTests/stress/temporal-plain-date-time-nan-fields.js: Added.
(shouldThrow):
(shouldBe):
* Source/JavaScriptCore/runtime/TemporalCalendar.cpp:
(JSC::readCalendarFieldsFromObject):
(JSC::readZonedDateTimeFieldsFromObject):
* Source/JavaScriptCore/runtime/TemporalDuration.cpp:
(JSC::toRelativeTemporalObject):
* Source/JavaScriptCore/runtime/TemporalPlainDate.cpp:
(JSC::TemporalPlainDate::mergeDateFields):
(JSC::TemporalPlainDate::toDay):
(JSC::TemporalPlainDate::toYear):
(JSC::TemporalPlainDate::toYearMonth):
* Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp:
(JSC::fromImpl):
* Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainTime.cpp:
(JSC::TemporalPlainTime::toTemporalTimeRecord):
(JSC::TemporalPlainTime::toPartialTime):

Canonical link: <a href="https://commits.webkit.org/314635@main">https://commits.webkit.org/314635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a62313a4d4f06465f471953f6c69555e2f602c7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123870 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129540 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23d5d0a5-5d35-4bdf-881d-0b626ec304a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110065 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de350485-66f0-41a5-9583-3e1d75a6c347) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30907 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29608 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23803 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158771 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140878 "Found 2 new API test failures: TestWebKitAPI.IndexedDB.IndexedDBPersistence, TestWebKitAPI.WritingTools.CompositionWithMultipleChunks (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178196 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27508 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31096 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137900 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137817 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149204 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103606 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25371 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33106 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26069 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199293 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112447 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53525 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38769 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4159 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39014 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38912 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->