### PR TITLE
[Site Isolation] Do not reconstruct top document sync data on provisional page load commit

### DIFF
--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1314,7 +1314,7 @@ void LocalFrame::documentURLOrOriginDidChange()
     RefPtr page = this->page();
     RefPtr document = this->document();
     if (page && document)
-        page->setMainFrameURLAndOrigin(document->url(), protect(document->securityOrigin()));
+        page->localTopDocumentURLOrOriginDidChange(document->url(), protect(document->securityOrigin()));
 }
 
 void LocalFrame::dispatchLoadEventToParent()

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -870,26 +870,21 @@ void Page::setMainFrame(Ref<Frame>&& frame)
     chrome().client().mainFrameDidChange();
 }
 
-void Page::setMainFrameURLAndOrigin(const URL& url, RefPtr<SecurityOrigin>&& origin)
+void Page::localTopDocumentURLOrOriginDidChange(const URL& url, RefPtr<SecurityOrigin>&& origin)
 {
-    // This URL and SecurityOrigin is relevant to this Page only if it is not
-    // directly hosting the local main frame.
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
-    if (!localFrame) {
-        m_topDocumentSyncData->documentURL = url;
-
-        if (!origin)
-            origin = SecurityOrigin::create(url);
-        m_topDocumentSyncData->documentSecurityOrigin = WTF::move(origin);
-
-        return;
-    }
-
     if (!settings().siteIsolationEnabled())
         return;
 
     // If this page is hosting the local main frame, make sure the url and origin
     // match what we expect, then broadcast them out to other processes.
+    // m_topDocumentSyncData may have been replaced by updateTopDocumentSyncData while the page was
+    // suspended in bfcache. Re-establish it from the local document if there is a mismatch.
+    if (url != m_topDocumentSyncData->documentURL) {
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get())) {
+            if (RefPtr document = localFrame->document())
+                m_topDocumentSyncData = document->syncData();
+        }
+    }
     RELEASE_ASSERT(url == m_topDocumentSyncData->documentURL);
     if (!origin)
         RELEASE_ASSERT(!m_topDocumentSyncData->documentSecurityOrigin);

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -431,7 +431,7 @@ public:
     SecurityOrigin& mainFrameOrigin() const;
     WEBCORE_EXPORT RefPtr<Frame> findFrameByPath(const Vector<uint64_t>& path) const;
 
-    WEBCORE_EXPORT void setMainFrameURLAndOrigin(const URL&, RefPtr<SecurityOrigin>&&);
+    WEBCORE_EXPORT void localTopDocumentURLOrOriginDidChange(const URL&, RefPtr<SecurityOrigin>&&);
 #if ENABLE(DOM_AUDIO_SESSION)
     void setAudioSessionType(DOMAudioSessionType);
     DOMAudioSessionType NODELETE audioSessionType() const;

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -46,6 +46,7 @@
 #include <WebCore/ContentSecurityPolicy.h>
 #include <WebCore/CornerRadii.h>
 #include <WebCore/DestinationColorSpace.h>
+#include <WebCore/DocumentSyncData.h>
 #include <WebCore/FloatSize.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/HighlightVisibility.h>
@@ -105,7 +106,7 @@ enum class AccessibilityMode : uint8_t;
 namespace WebKit {
 
 struct RemotePageParameters {
-    URL initialMainDocumentURL;
+    Ref<WebCore::DocumentSyncData> topDocumentSyncData;
     FrameTreeCreationParameters frameTreeParameters;
     std::optional<WebsitePoliciesData> websitePoliciesData;
 };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -311,7 +311,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 }
 
 [Nested] struct WebKit::RemotePageParameters {
-    URL initialMainDocumentURL;
+    Ref<WebCore::DocumentSyncData> topDocumentSyncData;
     WebKit::FrameTreeCreationParameters frameTreeParameters;
     std::optional<WebKit::WebsitePoliciesData> websitePoliciesData;
 }

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -292,7 +292,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
     auto creationParameters = page->creationParametersForProvisionalPage(process, *drawingArea, mainFrame->frameID());
     if (preferences->siteIsolationEnabled() && !isRestoringFromBFCache) {
         creationParameters.remotePageParameters = RemotePageParameters {
-            m_request.url(),
+            page->topDocumentSyncData(),
             mainFrame->frameTreeCreationParameters(),
             websitePolicies ? std::optional(websitePolicies->dataForProcess(process)) : std::nullopt
         };
@@ -728,12 +728,20 @@ void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::D
 #endif
         || decoder.messageName() == Messages::WebPageProxy::AddMessageToConsoleForTesting::name()
         || decoder.messageName() == Messages::WebPageProxy::HandleMessage::name()
-        || decoder.messageName() == Messages::WebPageProxy::BroadcastDocumentSyncData::name()
-        || decoder.messageName() == Messages::WebPageProxy::BroadcastAllDocumentSyncData::name()
         )
     {
         if (RefPtr page = m_page.get())
             page->didReceiveMessage(connection, decoder);
+        return;
+    }
+
+    if (decoder.messageName() == Messages::WebPageProxy::BroadcastDocumentSyncData::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::BroadcastDocumentSyncData>(connection, decoder, this, &ProvisionalPageProxy::broadcastDocumentSyncData);
+        return;
+    }
+
+    if (decoder.messageName() == Messages::WebPageProxy::BroadcastAllDocumentSyncData::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::BroadcastAllDocumentSyncData>(connection, decoder, this, &ProvisionalPageProxy::broadcastAllDocumentSyncData);
         return;
     }
 
@@ -917,6 +925,22 @@ void ProvisionalPageProxy::updateFrameProcess()
 {
     if (auto mainFrame = m_mainFrame)
         m_frameProcess = mainFrame->frameProcess();
+}
+
+RefPtr<DocumentSyncData> ProvisionalPageProxy::topDocumentSyncData() const
+{
+    return m_topDocumentSyncData;
+}
+
+void ProvisionalPageProxy::broadcastDocumentSyncData(IPC::Connection&, const DocumentSyncSerializationData& data)
+{
+    if (RefPtr topDocumentSyncData = m_topDocumentSyncData)
+        topDocumentSyncData->update(data);
+}
+
+void ProvisionalPageProxy::broadcastAllDocumentSyncData(IPC::Connection&, Ref<DocumentSyncData>&& data)
+{
+    m_topDocumentSyncData = WTF::move(data);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -54,12 +54,14 @@ class FormDataReference;
 }
 
 namespace WebCore {
+class DocumentSyncData;
 class RegistrableDomain;
 class ResourceRequest;
 enum class CrossOriginOpenerPolicyValue : uint8_t;
 enum class RestoredFromBackForwardCache : bool;
 enum class ShouldTreatAsContinuingLoad : uint8_t;
 struct BackForwardItemIdentifierType;
+struct DocumentSyncSerializationData;
 using BackForwardItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardItemIdentifierType>>;
 }
 
@@ -152,6 +154,8 @@ public:
 
     bool needsCookieAccessAddedInNetworkProcess() const { return m_needsCookieAccessAddedInNetworkProcess; }
 
+    RefPtr<WebCore::DocumentSyncData> topDocumentSyncData() const;
+
     API::WebsitePolicies* mainFrameWebsitePolicies() const { return m_mainFrameWebsitePolicies.get(); }
 
     WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() LIFETIME_BOUND { return m_messageReceiverRegistration; }
@@ -173,6 +177,8 @@ private:
 
     void decidePolicyForNavigationActionAsync(IPC::Connection&, NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
     void decidePolicyForResponse(FrameInfoData&&, std::optional<WebCore::NavigationIdentifier>, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, String&& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&&);
+    void broadcastDocumentSyncData(IPC::Connection&, const WebCore::DocumentSyncSerializationData&);
+    void broadcastAllDocumentSyncData(IPC::Connection&, Ref<WebCore::DocumentSyncData>&&);
     void didChangeProvisionalURLForFrame(WebCore::FrameIdentifier, std::optional<WebCore::NavigationIdentifier>, URL&&);
     void didPerformServerRedirect(String&& sourceURLString, String&& destinationURLString, WebCore::FrameIdentifier);
     void didReceiveServerRedirectForProvisionalLoadForFrame(WebCore::FrameIdentifier, std::optional<WebCore::NavigationIdentifier>, WebCore::ResourceRequest&&, const UserData&);
@@ -237,6 +243,7 @@ private:
     URL m_provisionalLoadURL;
     WebPageProxyMessageReceiverRegistration m_messageReceiverRegistration;
     RefPtr<API::WebsitePolicies> m_mainFrameWebsitePolicies;
+    RefPtr<WebCore::DocumentSyncData> m_topDocumentSyncData;
 
 #if PLATFORM(COCOA)
     Vector<uint8_t> m_accessibilityToken;

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -209,7 +209,7 @@ void RemotePageProxy::injectPageIntoNewProcess()
         Messages::WebProcess::CreateWebPage(
             m_webPageID,
             page->creationParametersForRemotePage(m_process, drawingArea.get(), RemotePageParameters {
-                page->pageLoadState().url(),
+                page->topDocumentSyncData(),
                 protect(page->mainFrame())->frameTreeCreationParameters(),
                 websitePolicies ? std::make_optional(websitePolicies->dataForProcess(m_process)) : std::nullopt
             })
@@ -362,7 +362,7 @@ void RemotePageProxy::setDrawingArea(DrawingAreaProxy* drawingArea)
         Messages::WebProcess::CreateWebPage(
             m_webPageID,
             page->creationParametersForRemotePage(m_process, *drawingArea, RemotePageParameters {
-                page->pageLoadState().url(),
+                page->topDocumentSyncData(),
                 mainFrame->frameTreeCreationParameters(),
                 websitePolicies ? std::make_optional(websitePolicies->dataForProcess(m_process)) : std::nullopt
             })

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -918,6 +918,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 #endif
     , m_visitedLinkStore(configuration->visitedLinkStore())
     , m_websiteDataStore(configuration->websiteDataStore())
+    , m_topDocumentSyncData(WebCore::DocumentSyncData::create())
     , m_userAgent(standardUserAgent())
     , m_overrideContentSecurityPolicy { configuration->overrideContentSecurityPolicy() }
     , m_openedMainFrameName { configuration->openedMainFrameName() }
@@ -1618,6 +1619,9 @@ void WebPageProxy::swapToProvisionalPage(Ref<ProvisionalPageProxy>&& provisional
     m_mainFrame = provisionalPage->mainFrame();
     ASSERT(!m_drawingArea);
     setDrawingArea(provisionalPage->takeDrawingArea());
+
+    if (RefPtr provisionalTopData = provisionalPage->topDocumentSyncData())
+        m_topDocumentSyncData = provisionalTopData.releaseNonNull();
 
     // FIXME: Think about what to do if the provisional page didn't get its browsing context group from the SuspendedPageProxy.
     // We do need to clear it at some point for navigations that aren't from back/forward navigations. Probably in the same place as PSON?
@@ -5978,11 +5982,14 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
     // frozen in the cache, not transitioning to "remote."
     if (!didSuspendPreviousPage && provisionalPage->deferredRemoteTransitionSite()) {
         ASSERT(oldMainFrameID);
-        auto topDocumentSyncData = DocumentSyncData::create();
-        topDocumentSyncData->documentURL = request.url();
-        topDocumentSyncData->documentSecurityOrigin = SecurityOrigin::create(request.url());
-        setTopDocumentSyncData(topDocumentSyncData.copyRef());
-        protect(legacyMainFrameProcess())->send(Messages::WebPage::LoadDidCommitInAnotherProcess(*oldMainFrameID, provisionalPage->process().coreProcessIdentifier(), std::nullopt, WTF::move(topDocumentSyncData)), webPageIDInMainFrameProcess());
+        RefPtr<DocumentSyncData> topDocumentSyncData = provisionalPage->topDocumentSyncData();
+        if (!topDocumentSyncData) {
+            auto fallback = DocumentSyncData::create();
+            fallback->documentURL = request.url();
+            fallback->documentSecurityOrigin = SecurityOrigin::create(request.url());
+            topDocumentSyncData = WTF::move(fallback);
+        }
+        protect(legacyMainFrameProcess())->send(Messages::WebPage::LoadDidCommitInAnotherProcess(*oldMainFrameID, provisionalPage->process().coreProcessIdentifier(), std::nullopt, topDocumentSyncData.releaseNonNull()), webPageIDInMainFrameProcess());
         protect(m_browsingContextGroup)->transitionPageToRemotePage(*this, *provisionalPage->deferredRemoteTransitionSite());
     }
 
@@ -8630,14 +8637,18 @@ void WebPageProxy::setTopDocumentSyncData(Ref<WebCore::DocumentSyncData>&& data)
     m_topDocumentSyncData = WTF::move(data);
 }
 
+Ref<WebCore::DocumentSyncData> WebPageProxy::topDocumentSyncData() const
+{
+    return m_topDocumentSyncData.copyRef();
+}
+
 void WebPageProxy::broadcastDocumentSyncData(IPC::Connection& connection, const WebCore::DocumentSyncSerializationData& data)
 {
     Ref process = WebProcessProxy::fromConnection(connection);
     if (process.ptr() != &legacyMainFrameProcess())
         return;
 
-    if (RefPtr topDocumentSyncData = m_topDocumentSyncData)
-        topDocumentSyncData->update(data);
+    m_topDocumentSyncData->update(data);
     forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         if (webProcess == process)
             return;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -774,6 +774,7 @@ public:
 
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
     void setTopDocumentSyncData(Ref<WebCore::DocumentSyncData>&&);
+    Ref<WebCore::DocumentSyncData> topDocumentSyncData() const;
     WebFrameProxy* focusedFrame() const { return m_focusedFrame.get(); }
     WebFrameProxy* focusedOrMainFrame() const { return m_focusedFrame ? m_focusedFrame.get() : m_mainFrame.get(); }
 
@@ -3779,7 +3780,7 @@ private:
 #endif
 
     RefPtr<WebFrameProxy> m_mainFrame;
-    RefPtr<WebCore::DocumentSyncData> m_topDocumentSyncData;
+    Ref<WebCore::DocumentSyncData> m_topDocumentSyncData;
     RefPtr<WebFrameProxy> m_focusedFrame;
 
     String m_userAgent;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1037,9 +1037,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         for (auto& childParameters : remotePageParameters->frameTreeParameters.children)
             constructFrameTree(m_mainFrame.get(), childParameters);
 
-        // Use the origin from FrameTreeSyncData so Page::mainFrameOrigin() reflects the inherited origin.
-        RefPtr<SecurityOrigin> mainFrameOrigin = dynamicDowncast<RemoteFrame>(page->mainFrame()) ? protect(page->mainFrame())->frameDocumentSecurityOrigin() : nullptr;
-        page->setMainFrameURLAndOrigin(remotePageParameters->initialMainDocumentURL, WTF::move(mainFrameOrigin));
+        page->updateTopDocumentSyncData(remotePageParameters->topDocumentSyncData.copyRef());
 
         if (auto websitePolicies = remotePageParameters->websitePoliciesData) {
             if (auto* remoteMainFrameClient = m_mainFrame->remoteFrameClient())
@@ -8906,11 +8904,9 @@ void WebPage::restoreWithFrameItem(BackForwardFrameItemIdentifier identifier, st
         return completionHandler(false);
     }
 
-    // Re-establish the authoritative main-frame URL/origin before restoring. It must come from the
-    // UIProcess, not a local read here: the cross-site top-document broadcast races ahead of this
-    // restore, so this process's top URL is still the stale cross-site value.
+    // FIXME: m_topDocumentSyncData should be stored with cache entry so that web process does not need to pull from UI process.
     if (mainFrameURLAndOrigin)
-        page->setMainFrameURLAndOrigin(mainFrameURLAndOrigin->first, mainFrameURLAndOrigin->second.securityOrigin());
+        page->localTopDocumentURLOrOriginDidChange(mainFrameURLAndOrigin->first, mainFrameURLAndOrigin->second.securityOrigin());
 
     m_isSuspended = false;
     unfreezeLayerTree(LayerTreeFreezeReason::PageSuspended);


### PR DESCRIPTION
#### eced20abcdc617a8201a4c7f34a887fa55998eb7
<pre>
[Site Isolation] Do not reconstruct top document sync data on provisional page load commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=316371">https://bugs.webkit.org/show_bug.cgi?id=316371</a>
<a href="https://rdar.apple.com/178783039">rdar://178783039</a>

Reviewed by NOBODY (OOPS!).

In current implementation, UI process doesn&apos;t keep track of top document sync data of provisional page -- it only
tracks that of the current page with WebPageProxy::m_topDocumentSyncData. And when provisional page replaces current
page (provisional load is committed), top document sync data is reconstructed with url and origin, discarding any state
the provisional page has broadcast.

To ensure states are preserved during process swap, this patch introduces ProvisionalPageProxy::m_topDocumentSyncData,
and uses it to cache updates sent from provisional page&apos;s process. When provisional load is committed, UI process will
replace WebPageProxy::m_topDocumentSyncData with ProvisionalPageProxy::m_topDocumentSyncData.

Also, UI process now includes top document sync data in RemotePageParameters, so that web process can initialize
Page::m_topDocumentSyncData properly, instead of just filling in url.

With this change, Page::setMainFrameURLAndOrigin() should only be called when an update is local -- if the update is
remote (i.e. main frame / top document is in a different process), the change be encoded in DocumentSyncData or
DocumentSyncSerializationData and update states via Page::updateTopDocumentSyncData. So, this patch renames
setMainFrameURLAndOrigin to localTopDocumentURLOrOriginDidChange for clarity. There is still one exception case
WebPage::restoreWithFrameItem that uses localTopDocumentURLOrOriginDidChange to overwrite top document url, and that
will be fixed when we store top doc sync data in cache entry.

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::documentURLOrOriginDidChange):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::localTopDocumentURLOrOriginDidChange):
(WebCore::Page::setMainFrameURLAndOrigin): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::initializeWebPage):
(WebKit::ProvisionalPageProxy::didReceiveMessage):
(WebKit::ProvisionalPageProxy::topDocumentSyncData const):
(WebKit::ProvisionalPageProxy::broadcastDocumentSyncData):
(WebKit::ProvisionalPageProxy::broadcastAllDocumentSyncData):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::injectPageIntoNewProcess):
(WebKit::RemotePageProxy::setDrawingArea):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::WebPageProxy):
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::commitProvisionalPage):
(WebKit::WebPageProxy::topDocumentSyncData const):
(WebKit::WebPageProxy::broadcastDocumentSyncData):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_allowsImmersiveEnvironments):
(WebKit::WebPage::restoreWithFrameItem):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eced20abcdc617a8201a4c7f34a887fa55998eb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127391 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab215db7-f64a-47e0-b3d0-4b2b82aac7fe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132227 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93140 "9 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/413a66b4-0ef1-4f05-a619-5782258a4a18) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112730 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc4ad4fb-1330-49f5-ac26-3ec963622cc9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34324 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32364 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27735 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181637 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34345 "Found 1 new failure in UIProcess/WebPageProxy.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140674 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43257 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140509 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43946 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28983 "Too many flaky failures: http/tests/contentextensions/text-track-blocked.html, http/tests/media/now-playing-info-private-browsing.html, http/tests/misc/object-image-error-with-onload.html, http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, http/tests/security/cached-cross-origin-shared-css-stylesheet.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/object-redirect-blocked2.html, http/tests/security/mixedContent/insecure-script-in-data-iframe-in-main-frame-blocked.html, http/tests/site-isolation/frame-index.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108192 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35777 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115711 "Found 1 new failure in UIProcess/WebPageProxy.cpp") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42456 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7076 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41849 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41992 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->