### PR TITLE
SVG: Do not apply text-decoration on elements with display:contents

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4635,7 +4635,6 @@ imported/w3c/web-platform-tests/css/css-sizing/responsive-iframe/responsive-ifra
 webkit.org/b/230041 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-color-selection-pseudo-01.html [ ImageOnlyFailure ]
 webkit.org/b/203528 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-linethrough-001.html [ ImageOnlyFailure ]
 webkit.org/b/203528 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-vertical-002.html [ ImageOnlyFailure ]
-webkit.org/b/233171 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-display-contents.html [ ImageOnlyFailure ]
 webkit.org/b/230291 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-skip-ink-005.html [ ImageOnlyFailure ]
 webkit.org/b/230291 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-skip-ink-upright-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-over-left-002.xht [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-display-contents-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-display-contents-002-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Decoration: line decorations and display: contents (block boxes)</title>
+<body>
+<!-- The underline propagates from the ancestor box; it is painted in the ancestor's color. -->
+<div style="text-decoration: underline; text-decoration-color: #44cc44;">
+ <div>Should have underline.</div>
+</div>
+
+<!-- No box contributes a decoration here. -->
+<div>
+ <div>Should have no decoration.</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-display-contents-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-display-contents-002-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Decoration: line decorations and display: contents (block boxes)</title>
+<body>
+<!-- The underline propagates from the ancestor box; it is painted in the ancestor's color. -->
+<div style="text-decoration: underline; text-decoration-color: #44cc44;">
+ <div>Should have underline.</div>
+</div>
+
+<!-- No box contributes a decoration here. -->
+<div>
+ <div>Should have no decoration.</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-display-contents-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-display-contents-002.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Decoration: line decorations and display: contents (block boxes)</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-decor/#line-decoration">
+<link rel="match" href="text-decoration-propagation-display-contents-002-ref.html">
+<!--
+Line decorations are propagated through the box tree, not through inheritance. A
+display: contents element generates no box, therefore:
+ - a line decoration specified on an ancestor box must still reach a descendant
+   box through the (boxless) display: contents element, but
+ - a line decoration specified on the display: contents element itself must not
+   reach its descendants.
+-->
+<body>
+<!-- The ancestor box's underline must propagate through the boxless wrapper to the inner block. -->
+<div style="text-decoration: underline; text-decoration-color: #44cc44;">
+ <div style="display: contents;">
+  <div>Should have underline.</div>
+ </div>
+</div>
+
+<!-- The display: contents element's own underline must not reach the inner block. -->
+<div style="display: contents; text-decoration: underline; text-decoration-color: red;">
+ <div>Should have no decoration.</div>
+</div>
+</body>

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -527,6 +527,15 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
         // https://drafts.csswg.org/css-ruby-1/#bidi
         if (style.display().isRubyContainerOrInternalRubyBox())
             style.setUnicodeBidi(forceBidiIsolationForRuby(style.unicodeBidi()));
+
+        // Line decorations propagate through the box tree, not through inheritance, so only a
+        // box-generating element folds its own text-decoration-line into the in-effect value.
+        if (shouldInheritTextDecorationsInEffect(style, m_element.get())) {
+            auto updatedTextDecorationLineInEffect = style.textDecorationLineInEffect();
+            updatedTextDecorationLineInEffect.addOrReplaceIfNotNone(style.textDecorationLine());
+            style.setTextDecorationLineInEffect(updatedTextDecorationLineInEffect);
+        } else
+            style.setTextDecorationLineInEffect(style.textDecorationLine());
     }
 
     auto hasAutoZIndex = [](const Style::ComputedStyle& style, const Style::ComputedStyle& parentBoxStyle, const Element* element) {
@@ -623,13 +632,6 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
         if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(element); htmlElement && htmlElement->isHiddenUntilFound())
             style.setAutoRevealsWhenFound();
     }
-
-    if (shouldInheritTextDecorationsInEffect(style, m_element.get())) {
-        auto updatedTextDecorationLineInEffect = style.textDecorationLineInEffect();
-        updatedTextDecorationLineInEffect.addOrReplaceIfNotNone(style.textDecorationLine());
-        style.setTextDecorationLineInEffect(updatedTextDecorationLineInEffect);
-    } else
-        style.setTextDecorationLineInEffect(style.textDecorationLine());
 
     bool overflowIsClipOrVisible = isOverflowClipOrVisible(style.overflowY()) && isOverflowClipOrVisible(style.overflowX());
 


### PR DESCRIPTION
#### f149be78a28fae1b717de0a0b10bf485945f5b5e
<pre>
SVG: Do not apply text-decoration on elements with display:contents
<a href="https://bugs.webkit.org/show_bug.cgi?id=233171">https://bugs.webkit.org/show_bug.cgi?id=233171</a>
<a href="https://rdar.apple.com/85691104">rdar://85691104</a>

Reviewed by Alan Baradlay.

Per the spec [1], line decorations are propagated through the box tree, not through
inheritance, and thus have no effect on descendants when specified on an element with
display: contents.

textDecorationLineInEffect is an inherited flag, so at adjustment time it already holds
the decorations contributed by ancestor boxes. Only a box-generating element should fold
its own text-decoration-line into that value, so do this in the else-if branch that
already gates such elements (display is neither contents nor none). A boxless element
then leaves the inherited in-effect value unchanged, while a decoration on an ancestor
box still reaches a descendant box through it, since each box-generating descendant
re-folds the inherited value. This covers the HTML &lt;span&gt;, SVG &lt;tspan&gt;, and SVG &lt;use&gt;
cases the test exercises.

Add a test covering that a line decoration on an ancestor box still propagates through a
display: contents element to a descendant box, while the display: contents element&apos;s own
decoration does not.

[1] <a href="https://drafts.csswg.org/css-text-decor/#line-decoration">https://drafts.csswg.org/css-text-decor/#line-decoration</a>

* LayoutTests/TestExpectations: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-display-contents-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-display-contents-002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-display-contents-002.html: Added.
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):

Canonical link: <a href="https://commits.webkit.org/314830@main">https://commits.webkit.org/314830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1891fa553a8fcd809045425d6f79d1bbf68fd6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124230 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f304cd2-bf77-4380-a3be-76cc6c729fa7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168838 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129846 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91454 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac65a504-3ce0-4c7f-ae25-1da8bf56e62d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110371 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b8710053-dd9f-4103-9e0f-7e2d31a653ae) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31221 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29926 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24756 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141195 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178558 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31456 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138214 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37275 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149521 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104093 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26386 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39731 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112805 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39127 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4485 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39372 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39271 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->