### PR TITLE
[JSC][Temporal] `round`, `until` and `since` crash with `std::bad_variant_access` on `smallestUnit: "auto"`

### DIFF
--- a/JSTests/stress/temporal-smallest-unit-auto-rejected.js
+++ b/JSTests/stress/temporal-smallest-unit-auto-rejected.js
@@ -1,0 +1,80 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+function shouldThrow(func, errorType) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+
+    if (!(error instanceof errorType))
+        throw new Error(`Expected ${errorType.name} but got ${error}`);
+}
+
+const instant1 = Temporal.Instant.fromEpochMilliseconds(0);
+const instant2 = Temporal.Instant.fromEpochMilliseconds(3600 * 1000);
+const time1 = Temporal.PlainTime.from("01:00");
+const time2 = Temporal.PlainTime.from("02:00");
+const date1 = Temporal.PlainDate.from("2000-01-01");
+const date2 = Temporal.PlainDate.from("2001-03-04");
+const dateTime1 = Temporal.PlainDateTime.from("2000-01-01T00:00");
+const dateTime2 = Temporal.PlainDateTime.from("2001-03-04T05:06");
+const yearMonth1 = Temporal.PlainYearMonth.from("2000-01");
+const yearMonth2 = Temporal.PlainYearMonth.from("2001-03");
+const zoned1 = new Temporal.ZonedDateTime(0n, "UTC");
+const zoned2 = new Temporal.ZonedDateTime(3600_000_000_000n, "UTC");
+const duration = Temporal.Duration.from({ hours: 1 });
+
+// smallestUnit: "auto" must throw a RangeError, not crash, in every consumer.
+// https://tc39.es/proposal-temporal/#sec-temporal-gettemporalunitvaluedoption
+// https://tc39.es/proposal-temporal/#sec-temporal-validatetemporalunitvalue
+
+// round with options object
+shouldThrow(() => instant1.round({ smallestUnit: "auto" }), RangeError);
+shouldThrow(() => time1.round({ smallestUnit: "auto" }), RangeError);
+shouldThrow(() => dateTime1.round({ smallestUnit: "auto" }), RangeError);
+shouldThrow(() => zoned1.round({ smallestUnit: "auto" }), RangeError);
+shouldThrow(() => duration.round({ smallestUnit: "auto" }), RangeError);
+
+// round with string shorthand
+shouldThrow(() => instant1.round("auto"), RangeError);
+shouldThrow(() => time1.round("auto"), RangeError);
+shouldThrow(() => dateTime1.round("auto"), RangeError);
+shouldThrow(() => zoned1.round("auto"), RangeError);
+shouldThrow(() => duration.round("auto"), RangeError);
+
+// until / since (GetDifferenceSettings)
+shouldThrow(() => instant1.until(instant2, { smallestUnit: "auto" }), RangeError);
+shouldThrow(() => instant1.since(instant2, { smallestUnit: "auto" }), RangeError);
+shouldThrow(() => time1.until(time2, { smallestUnit: "auto" }), RangeError);
+shouldThrow(() => time1.since(time2, { smallestUnit: "auto" }), RangeError);
+shouldThrow(() => date1.until(date2, { smallestUnit: "auto" }), RangeError);
+shouldThrow(() => date1.since(date2, { smallestUnit: "auto" }), RangeError);
+shouldThrow(() => dateTime1.until(dateTime2, { smallestUnit: "auto" }), RangeError);
+shouldThrow(() => dateTime1.since(dateTime2, { smallestUnit: "auto" }), RangeError);
+shouldThrow(() => yearMonth1.until(yearMonth2, { smallestUnit: "auto" }), RangeError);
+shouldThrow(() => yearMonth1.since(yearMonth2, { smallestUnit: "auto" }), RangeError);
+shouldThrow(() => zoned1.until(zoned2, { smallestUnit: "auto" }), RangeError);
+shouldThrow(() => zoned1.since(zoned2, { smallestUnit: "auto" }), RangeError);
+
+// toString
+shouldThrow(() => instant1.toString({ smallestUnit: "auto" }), RangeError);
+shouldThrow(() => time1.toString({ smallestUnit: "auto" }), RangeError);
+shouldThrow(() => dateTime1.toString({ smallestUnit: "auto" }), RangeError);
+shouldThrow(() => zoned1.toString({ smallestUnit: "auto" }), RangeError);
+shouldThrow(() => duration.toString({ smallestUnit: "auto" }), RangeError);
+
+// largestUnit: "auto" remains valid where the spec allows it.
+shouldBe(instant1.until(instant2, { largestUnit: "auto" }).toString(), "PT3600S");
+shouldBe(time1.until(time2, { largestUnit: "auto" }).toString(), "PT1H");
+shouldBe(date1.until(date2, { largestUnit: "auto" }).toString(), "P428D");
+shouldBe(duration.round({ largestUnit: "auto" }).toString(), "PT1H");
+
+// largestUnit: "auto" is rejected where the spec does not allow it.
+shouldThrow(() => duration.total({ unit: "auto" }), RangeError);

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -918,7 +918,8 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
     if (!smallest) {
         auto smallestUnitMaybeAuto = getTemporalUnitValuedOption(globalObject, options, vm.propertyNames->smallestUnit);
         RETURN_IF_EXCEPTION(scope, { });
-        ASSERT(std::holds_alternative<std::optional<TemporalUnit>>(smallestUnitMaybeAuto));
+        validateTemporalUnitValue(globalObject, smallestUnitMaybeAuto, UnitGroup::DateTime, AllowedUnit::None, "smallestUnit"_s);
+        RETURN_IF_EXCEPTION(scope, { });
         auto smallestUnitOptional = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
         if (smallestUnitOptional)
             smallest = smallestUnitOptional.value();

--- a/Source/JavaScriptCore/runtime/TemporalInstant.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.cpp
@@ -305,9 +305,10 @@ ISO8601::ExactTime TemporalInstant::round(JSGlobalObject* globalObject, JSValue 
 
     if (!smallest) {
         auto smallestUnitMaybeAuto = getTemporalUnitValuedOption(globalObject, options, vm.propertyNames->smallestUnit);
-        ASSERT(std::holds_alternative<std::optional<TemporalUnit>>(smallestUnitMaybeAuto));
-        smallest = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
         RETURN_IF_EXCEPTION(scope, { });
+        validateTemporalUnitValue(globalObject, smallestUnitMaybeAuto, UnitGroup::Time, AllowedUnit::None, "smallestUnit"_s);
+        RETURN_IF_EXCEPTION(scope, { });
+        smallest = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
     }
 
     if (!smallest) [[unlikely]] {

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -288,8 +288,12 @@ void validateTemporalUnitValue(JSGlobalObject* globalObject, Variant<TemporalAut
 
     if (isAbsentUnit(unit))
         return;
-    if (extraValue == AllowedUnit::Auto && std::holds_alternative<TemporalAuto>(unit))
+    if (std::holds_alternative<TemporalAuto>(unit)) {
+        if (extraValue == AllowedUnit::Auto)
+            return;
+        throwRangeError(globalObject, scope, makeString(valueName, " is a disallowed unit"_s));
         return;
+    }
     TemporalUnit actualUnit = std::get<std::optional<TemporalUnit>>(unit).value();
     if (extraValue == AllowedUnit::Day && actualUnit == TemporalUnit::Day)
         return;
@@ -333,8 +337,6 @@ std::tuple<TemporalUnit, TemporalUnit, RoundingMode, double> extractDifferenceOp
     RETURN_IF_EXCEPTION(scope, { });
     Variant<TemporalAuto, std::optional<TemporalUnit>> smallestUnitMaybeAuto = getTemporalUnitValuedOption(globalObject, options, vm.propertyNames->smallestUnit);
     RETURN_IF_EXCEPTION(scope, { });
-    ASSERT(std::holds_alternative<std::optional<TemporalUnit>>(smallestUnitMaybeAuto));
-    auto smallestUnitOptional = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
 
     validateTemporalUnitValue(globalObject, largestUnitMaybeAuto, unitGroup, AllowedUnit::Auto, "largestUnit"_s);
     RETURN_IF_EXCEPTION(scope, { });
@@ -356,6 +358,7 @@ std::tuple<TemporalUnit, TemporalUnit, RoundingMode, double> extractDifferenceOp
 
     validateTemporalUnitValue(globalObject, smallestUnitMaybeAuto, unitGroup, AllowedUnit::None, "smallestUnit"_s);
     RETURN_IF_EXCEPTION(scope, { });
+    auto smallestUnitOptional = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
 
     auto smallestUnit = smallestUnitOptional.value_or(fallbackSmallestUnit);
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -735,7 +735,8 @@ TemporalPlainDateTime* TemporalPlainDateTime::round(JSGlobalObject* globalObject
     if (!smallest) {
         auto smallestUnitMaybeAuto = getTemporalUnitValuedOption(globalObject, options, vm.propertyNames->smallestUnit);
         RETURN_IF_EXCEPTION(scope, { });
-        ASSERT(std::holds_alternative<std::optional<TemporalUnit>>(smallestUnitMaybeAuto));
+        validateTemporalUnitValue(globalObject, smallestUnitMaybeAuto, UnitGroup::Time, AllowedUnit::Day, "smallestUnit"_s);
+        RETURN_IF_EXCEPTION(scope, { });
         smallest = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
         if (!smallest) [[unlikely]] {
             throwRangeError(globalObject, scope, "Cannot round without a smallestUnit option"_s);

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -264,7 +264,8 @@ ISO8601::PlainTime TemporalPlainTime::round(JSGlobalObject* globalObject, JSValu
     if (!smallest) {
         auto smallestMaybeAuto = getTemporalUnitValuedOption(globalObject, options, vm.propertyNames->smallestUnit);
         RETURN_IF_EXCEPTION(scope, { });
-        ASSERT(std::holds_alternative<std::optional<TemporalUnit>>(smallestMaybeAuto));
+        validateTemporalUnitValue(globalObject, smallestMaybeAuto, UnitGroup::Time, AllowedUnit::None, "smallestUnit"_s);
+        RETURN_IF_EXCEPTION(scope, { });
         smallest = std::get<std::optional<TemporalUnit>>(smallestMaybeAuto);
     }
     if (!smallest) [[unlikely]] {

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
@@ -446,17 +446,16 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncRound, (JSGlobalObjec
     RETURN_IF_EXCEPTION(scope, { });
     auto smallestUnitMaybeAuto = getTemporalUnitValuedOption(globalObject, options, vm.propertyNames->smallestUnit);
     RETURN_IF_EXCEPTION(scope, { });
-    ASSERT(std::holds_alternative<std::optional<TemporalUnit>>(smallestUnitMaybeAuto));
-    auto smallestOpt = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
 
     // Step 10: ValidateTemporalUnitValue(smallestUnit, ~time~, « ~day~ »). ~required~ → error if absent.
+    validateTemporalUnitValue(globalObject, smallestUnitMaybeAuto, UnitGroup::Time, AllowedUnit::Day, "smallestUnit"_s);
+    RETURN_IF_EXCEPTION(scope, { });
+    auto smallestOpt = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
     if (!smallestOpt) [[unlikely]] {
         throwRangeError(globalObject, scope, "ZonedDateTime.round requires a smallestUnit option"_s);
         return { };
     }
     TemporalUnit smallestUnit = smallestOpt.value();
-    validateTemporalUnitValue(globalObject, smallestUnit, UnitGroup::Time, AllowedUnit::Day, "smallestUnit"_s);
-    RETURN_IF_EXCEPTION(scope, { });
 
     // Steps 11-13: Compute maximum increment and ValidateTemporalRoundingIncrement.
     if (smallestUnit == TemporalUnit::Day)


### PR DESCRIPTION
#### 74bdc2491f893bd64bbd31c39e5842ec3a3be692
<pre>
[JSC][Temporal] `round`, `until` and `since` crash with `std::bad_variant_access` on `smallestUnit: &quot;auto&quot;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=316373">https://bugs.webkit.org/show_bug.cgi?id=316373</a>

Reviewed by NOBODY (OOPS!).

getTemporalUnitValuedOption() returns Variant&lt;TemporalAuto, std::optional&lt;TemporalUnit&gt;&gt;,
and the string &quot;auto&quot; yields the TemporalAuto alternative for any unit option. Several
consumers of smallestUnit assumed the std::optional&lt;TemporalUnit&gt; alternative with only
a debug ASSERT guarding the std::get, so release builds aborted with an uncaught
std::bad_variant_access:

    Temporal.Duration.from({ hours: 1 }).round({ smallestUnit: &quot;auto&quot; });  // crash
    Temporal.PlainTime.from(&quot;01:00&quot;).until(&quot;02:00&quot;, { smallestUnit: &quot;auto&quot; });  // crash
    new Temporal.ZonedDateTime(0n, &quot;UTC&quot;).round(&quot;auto&quot;);  // crash

validateTemporalUnitValue() had the same flaw when passed an auto-valued variant in a
context where auto is not allowed.

Per ValidateTemporalUnitValue[1], &quot;auto&quot; must be rejected with a RangeError wherever
it is not an allowed extra value. Teach validateTemporalUnitValue() to handle the
TemporalAuto alternative, and make every consumer validate the variant before
extracting the unit: extractDifferenceOptions() (until/since of all Temporal types)
and the round() implementations of Instant, PlainTime, PlainDateTime, ZonedDateTime,
and Duration. ZonedDateTime.round&apos;s now-redundant post-extraction validation is
removed. This also matches the validation order of GetDifferenceSettings[2]
(largestUnit before smallestUnit).

[1]: <a href="https://tc39.es/proposal-temporal/#sec-temporal-validatetemporalunitvalue">https://tc39.es/proposal-temporal/#sec-temporal-validatetemporalunitvalue</a>
[2]: <a href="https://tc39.es/proposal-temporal/#sec-temporal-getdifferencesettings">https://tc39.es/proposal-temporal/#sec-temporal-getdifferencesettings</a>

Test: JSTests/stress/temporal-smallest-unit-auto-rejected.js

* JSTests/stress/temporal-smallest-unit-auto-rejected.js: Added.
(shouldBe):
(shouldThrow):
* Source/JavaScriptCore/runtime/TemporalDuration.cpp:
(JSC::TemporalDuration::round const):
* Source/JavaScriptCore/runtime/TemporalInstant.cpp:
* Source/JavaScriptCore/runtime/TemporalObject.cpp:
(JSC::validateTemporalUnitValue):
(JSC::extractDifferenceOptions):
* Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp:
(JSC::TemporalPlainDateTime::round):
* Source/JavaScriptCore/runtime/TemporalPlainTime.cpp:
(JSC::TemporalPlainTime::round const):
* Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74bdc2491f893bd64bbd31c39e5842ec3a3be692

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123878 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129545 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91230 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110070 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30917 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29615 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23810 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158778 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140888 "Found 1 new API test failure: TestWebKitAPI.HSTS.Preconnect (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178203 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27515 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31103 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29118 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137906 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137823 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149209 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103617 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33115 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26074 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199300 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39380 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112454 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53531 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38776 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4164 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39021 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->