### PR TITLE
[CMake] ICU build fix

### DIFF
--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -42,8 +42,8 @@ namespace TemporalCore {
 // and shared across call sites.
 static constexpr ASCIILiteral icuOpenTimeZoneFailed = "Failed to open ICU calendar for time zone"_s;
 static constexpr ASCIILiteral icuTimeZoneOffsetFailed = "Failed to get time zone offset from ICU"_s;
-static constexpr ASCIILiteral icuSetCalendarFailed = "Failed to set ICU calendar"_s;
-static constexpr ASCIILiteral icuCalendarArithmeticFailed = "Failed to perform ICU calendar arithmetic"_s;
+static constexpr ASCIILiteral icuTimeZoneSetCalendarFailed = "Failed to set ICU calendar"_s;
+static constexpr ASCIILiteral icuTimeZoneArithmeticFailed = "Failed to perform ICU calendar arithmetic"_s;
 static constexpr ASCIILiteral icuTransitionFailed = "Failed to get time zone transition date from ICU"_s;
 static constexpr ASCIILiteral epochNanosecondsOutOfRange = "Epoch nanoseconds out of valid Temporal range"_s;
 
@@ -195,13 +195,13 @@ static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds
         time.hour(), time.minute(), time.second(),
         &status);
     if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
+        return makeUnexpected(rangeError(icuTimeZoneSetCalendarFailed));
     ucal_set(calendar.get(), UCAL_MILLISECOND, time.millisecond());
 
     // ICU resolves the local time to one epoch (its "default" interpretation).
     double icuEpochMs = ucal_getMillis(calendar.get(), &status);
     if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        return makeUnexpected(rangeError(icuTimeZoneArithmeticFailed));
 
     auto icuOffsetMs = getOffsetMsAtEpoch(calendar.get(), icuEpochMs);
     if (!icuOffsetMs)
@@ -389,7 +389,7 @@ TemporalResult<std::optional<ISO8601::ExactTime>> getTimeZoneTransition(const Ti
         epochMs = static_cast<double>(exactTime.floorEpochMilliseconds());
     ucal_setMillis(calendar.get(), epochMs, &status);
     if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
+        return makeUnexpected(rangeError(icuTimeZoneSetCalendarFailed));
 
     UTimeZoneTransitionType transType = (direction == TransitionDirection::Next) ? UCAL_TZ_TRANSITION_NEXT : UCAL_TZ_TRANSITION_PREVIOUS;
 


### PR DESCRIPTION
#### 704f45b025cf198e2fc5dd47a2d67a59957b750e
<pre>
[CMake] ICU build fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=316375">https://bugs.webkit.org/show_bug.cgi?id=316375</a>
<a href="https://rdar.apple.com/178786644">rdar://178786644</a>

Reviewed by NOBODY (OOPS!).

Unreviewed, build fix.

* Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp: Use a more
specific name to avoid unified build conflict.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/704f45b025cf198e2fc5dd47a2d67a59957b750e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166625 "Failed to checkout and rebase branch from PR 66518") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/40115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33696 "Failed to checkout and rebase branch from PR 66518") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/40548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/40123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129546 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169584 "Failed to checkout and rebase branch from PR 66518") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31938 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110071 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/23814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158782 "Failed to checkout and rebase branch from PR 66518") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/27413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/178207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/27519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/29120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137908 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40185 "Failed to checkout and rebase branch from PR 66518") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137825 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40873 "Failed to checkout and rebase branch from PR 66518") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/149211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/103624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33113 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/199304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39384 "Failed to checkout and rebase branch from PR 66518") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/53534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38780 "Failed to checkout and rebase branch from PR 66518") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/4166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39025 "Failed to checkout and rebase branch from PR 66518") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38923 "Failed to checkout and rebase branch from PR 66518") | | | | 
<!--EWS-Status-Bubble-End-->