### PR TITLE
[Yarr] YarrInterpreter Greedy backtracking should finish its parentheses by trying up to max count

### DIFF
--- a/JSTests/stress/regexp-greedy-varcount-reextend-after-content-backtrack.js
+++ b/JSTests/stress/regexp-greedy-varcount-reextend-after-content-backtrack.js
@@ -1,0 +1,56 @@
+// Regression test: after popping iterations below quantityMinCount and using
+// parenthesesDoBacktrack to find a new content distribution, the interpreter
+// must re-run the greedy extension loop up to quantityMaxCount. The new
+// distribution leaves the input at a different position, so the iteration
+// counts in (min, max] are an unexplored branch — silently skipping them led
+// to short matches and corrupted captures.
+//
+// All cases below force the YARR interpreter (lookbehind / backreference, or
+// --useRegExpJIT=0) and should match V8 behavior.
+
+function eq(actual, expected, label) {
+    if (actual === expected)
+        return;
+    if (Array.isArray(actual) && Array.isArray(expected) && actual.length === expected.length) {
+        let allEq = true;
+        for (let i = 0; i < actual.length; ++i) {
+            if (actual[i] !== expected[i]) {
+                allEq = false;
+                break;
+            }
+        }
+        if (allEq)
+            return;
+    }
+    throw new Error("FAIL " + label + ": got " + JSON.stringify(actual) + ", expected " + JSON.stringify(expected));
+}
+
+function check(re, input, expectedArr, expectedIndex, label) {
+    const m = re.exec(input);
+    if (expectedArr === null) {
+        if (m !== null)
+            throw new Error("FAIL " + label + ": got " + JSON.stringify(m) + ", expected null");
+        return;
+    }
+    if (m === null)
+        throw new Error("FAIL " + label + ": got null, expected " + JSON.stringify(expectedArr));
+    eq(Array.from(m), expectedArr, label + " (groups)");
+    eq(m.index, expectedIndex, label + " (index)");
+}
+
+// Greedy variable-count parens, anchored, multi-alt forces a content backtrack
+// that drops below min (=2). After refilling to min, the third iteration must
+// be re-attempted to satisfy `$` at end of input.
+check(/(?<=^)(a|aa|b){2,3}$/, "aaba", ["aaba", "a"], 0, "lookbehind aaba");
+
+// Same shape but with a backreference to force the interpreter, exercising the
+// capture restoration on backtrack as well.
+check(/((\w.)?\2+|c){2,}(.)+(..)/, "cbcbcbbb", ["cbcbcbbb", "c", undefined, "b", "bb"], 0, "backref cbcbcbbb");
+
+// A lookbehind variant that used to return null because the third iteration
+// was never attempted after the first iteration backtracked from "aa" to "a".
+check(/(?<=^)(aa|a){2,3}$/, "aaa", ["aaa", "a"], 0, "lookbehind aaa");
+
+// Min reachable only after redistributing earlier iterations across alts;
+// then max must still be reachable by extending the greedy tail.
+check(/(?<=^)(a|aa|b){2,4}b$/, "aaab", ["aaab", "a"], 0, "lookbehind reach max via extend");

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -1150,7 +1150,7 @@ public:
         while (backTrack->matchAmount) {
             ParenthesesDisjunctionContext* context = backTrack->lastContext;
 
-            JSRegExpResult result = matchDisjunction(term.atom.parenthesesDisjunction, context->getDisjunctionContext(), true);
+            JSRegExpResult result = matchDisjunction(term.atom.parenthesesDisjunction, context->getDisjunctionContext(), /* btrack= */ true);
             if (result == JSRegExpResult::Match)
                 return JSRegExpResult::Match;
 
@@ -1447,23 +1447,9 @@ public:
         }
 
         case QuantifierType::Greedy: {
-            while (backTrack->matchAmount < term.atom.quantityMaxCount) {
-                ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                if (!context) [[unlikely]]
-                    return JSRegExpResult::ErrorNoMemory;
-                JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext());
-                if (result == JSRegExpResult::Match)
-                    appendParenthesesDisjunctionContext(backTrack, context);
-                else {
-                    resetMatches(term, context);
-                    freeParenthesesDisjunctionContext(context);
-
-                    if (result != JSRegExpResult::NoMatch)
-                        return result;
-
-                    break;
-                }
-            }
+            JSRegExpResult result = extendParenthesesContextsToMaxCount(term, backTrack, disjunctionBody);
+            if (result != JSRegExpResult::Match)
+                return result;
 
             if (backTrack->matchAmount) {
                 ParenthesesDisjunctionContext* context = backTrack->lastContext;
@@ -1500,38 +1486,20 @@ public:
         switch (term.atom.quantityType) {
         case QuantifierType::FixedCount: {
             ASSERT(backTrack->matchAmount == term.atom.quantityMaxCount);
+            ASSERT(term.atom.quantityMinCount == term.atom.quantityMaxCount);
 
-            ParenthesesDisjunctionContext* context = nullptr;
             JSRegExpResult result = parenthesesDoBacktrack(term, backTrack);
-
             if (result != JSRegExpResult::Match)
                 return result;
 
-            // While we haven't yet reached our fixed limit,
-            while (backTrack->matchAmount < term.atom.quantityMaxCount) {
-                // Try to do a match, and it it succeeds, add it to the list.
-                context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                if (!context) [[unlikely]]
-                    return JSRegExpResult::ErrorNoMemory;
-                result = matchDisjunction(disjunctionBody, context->getDisjunctionContext());
-
-                if (result == JSRegExpResult::Match)
-                    appendParenthesesDisjunctionContext(backTrack, context);
-                else {
-                    // The match failed; try to find an alternate point to carry on from.
-                    resetMatches(term, context);
-                    freeParenthesesDisjunctionContext(context);
-
-                    if (result != JSRegExpResult::NoMatch)
-                        return result;
-                    JSRegExpResult backtrackResult = parenthesesDoBacktrack(term, backTrack);
-                    if (backtrackResult != JSRegExpResult::Match)
-                        return backtrackResult;
-                }
-            }
+            // For FixedCount min == max, so refilling to min refills to max; the
+            // helper handles the inner content-backtrack-on-failure loop too.
+            result = refillParenthesesContextsToMinCount(term, backTrack, disjunctionBody);
+            if (result != JSRegExpResult::Match)
+                return result;
 
             ASSERT(backTrack->matchAmount == term.atom.quantityMaxCount);
-            context = backTrack->lastContext;
+            ParenthesesDisjunctionContext* context = backTrack->lastContext;
             recordParenthesesMatch(term, context);
             return JSRegExpResult::Match;
         }
@@ -1545,26 +1513,12 @@ public:
             // non-empty; a mandatory iteration (count <= min) may match zero-length, so
             // retry its content allowing an empty match in that case.
             JSRegExpResult result = (backTrack->matchAmount <= term.atom.quantityMinCount)
-                ? matchDisjunction(disjunctionBody, context->getDisjunctionContext(), true)
-                : matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(), true);
+                ? matchDisjunction(disjunctionBody, context->getDisjunctionContext(), /* btrack= */ true)
+                : matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(), /* btrack= */ true);
             if (result == JSRegExpResult::Match) {
-                while (backTrack->matchAmount < term.atom.quantityMaxCount) {
-                    ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                    if (!context) [[unlikely]]
-                        return JSRegExpResult::ErrorNoMemory;
-                    JSRegExpResult parenthesesResult = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext());
-                    if (parenthesesResult == JSRegExpResult::Match)
-                        appendParenthesesDisjunctionContext(backTrack, context);
-                    else {
-                        resetMatches(term, context);
-                        freeParenthesesDisjunctionContext(context);
-
-                        if (parenthesesResult != JSRegExpResult::NoMatch)
-                            return parenthesesResult;
-
-                        break;
-                    }
-                }
+                result = extendParenthesesContextsToMaxCount(term, backTrack, disjunctionBody);
+                if (result != JSRegExpResult::Match)
+                    return result;
             } else {
                 resetMatches(term, context);
                 popParenthesesDisjunctionContext(backTrack);
@@ -1591,6 +1545,11 @@ public:
                     result = refillParenthesesContextsToMinCount(term, backTrack, disjunctionBody);
                     if (result != JSRegExpResult::Match)
                         return result;
+
+                    // And now we should expand the matching up to max count, then we can say Greedy is fully backtracked.
+                    result = extendParenthesesContextsToMaxCount(term, backTrack, disjunctionBody);
+                    if (result != JSRegExpResult::Match)
+                        return result;
                 }
             }
 
@@ -1607,7 +1566,7 @@ public:
                 ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
                 if (!context) [[unlikely]]
                     return JSRegExpResult::ErrorNoMemory;
-                JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext());
+                JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(), /* btrack= */ false);
                 if (result == JSRegExpResult::Match) {
                     appendParenthesesDisjunctionContext(backTrack, context);
                     recordParenthesesMatch(term, context);
@@ -1627,8 +1586,8 @@ public:
                 // Mandatory iterations (count <= min) may match zero-length; only extra
                 // iterations must be non-empty (RepeatMatcher).
                 JSRegExpResult result = (backTrack->matchAmount <= term.atom.quantityMinCount)
-                    ? matchDisjunction(disjunctionBody, context->getDisjunctionContext(), true)
-                    : matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(), true);
+                    ? matchDisjunction(disjunctionBody, context->getDisjunctionContext(), /* btrack= */ true)
+                    : matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(), /* btrack= */ true);
                 if (result == JSRegExpResult::Match) {
                     // A successful content backtrack may have left us below the mandatory
                     // minimum (we popped iterations above while searching for an alternative).
@@ -1671,7 +1630,7 @@ public:
             ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
             if (!context) [[unlikely]]
                 return JSRegExpResult::ErrorNoMemory;
-            JSRegExpResult result = matchDisjunction(disjunctionBody, context->getDisjunctionContext());
+            JSRegExpResult result = matchDisjunction(disjunctionBody, context->getDisjunctionContext(), /* btrack= */ false);
             if (result == JSRegExpResult::Match) {
                 appendParenthesesDisjunctionContext(backTrack, context);
                 continue;
@@ -1683,6 +1642,28 @@ public:
             result = parenthesesDoBacktrack(term, backTrack);
             if (result != JSRegExpResult::Match)
                 return result;
+        }
+        return JSRegExpResult::Match;
+    }
+
+    // Greedy extension appends as many additional iterations as possible up
+    // to quantityMaxCount, each required to match at least one character.
+    JSRegExpResult extendParenthesesContextsToMaxCount(ByteTerm& term, BackTrackInfoParentheses* backTrack, ByteDisjunction* disjunctionBody)
+    {
+        while (backTrack->matchAmount < term.atom.quantityMaxCount) {
+            ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
+            if (!context) [[unlikely]]
+                return JSRegExpResult::ErrorNoMemory;
+            JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(), /* btrack= */ false);
+            if (result == JSRegExpResult::Match) {
+                appendParenthesesDisjunctionContext(backTrack, context);
+                continue;
+            }
+            resetMatches(term, context);
+            freeParenthesesDisjunctionContext(context);
+            if (result != JSRegExpResult::NoMatch)
+                return result;
+            break;
         }
         return JSRegExpResult::Match;
     }
@@ -1768,7 +1749,7 @@ public:
     } \
 }
 
-    JSRegExpResult matchDisjunction(ByteDisjunction* disjunction, DisjunctionContext* context, bool btrack = false)
+    JSRegExpResult matchDisjunction(ByteDisjunction* disjunction, DisjunctionContext* context, bool btrack)
     {
         if (!isSafeToRecurse()) [[unlikely]]
             return JSRegExpResult::ErrorNoMemory;
@@ -2220,13 +2201,13 @@ public:
         return JSRegExpResult::ErrorNoMatch;
     }
 
-    JSRegExpResult matchNonZeroDisjunction(ByteDisjunction* disjunction, DisjunctionContext* context, bool btrack = false)
+    JSRegExpResult matchNonZeroDisjunction(ByteDisjunction* disjunction, DisjunctionContext* context, bool btrack)
     {
         JSRegExpResult result = matchDisjunction(disjunction, context, btrack);
 
         if (result == JSRegExpResult::Match) {
             while (context->matchBegin == context->matchEnd) {
-                result = matchDisjunction(disjunction, context, true);
+                result = matchDisjunction(disjunction, context, /* btrack= */ true);
                 if (result != JSRegExpResult::Match)
                     return result;
             }
@@ -2261,7 +2242,7 @@ public:
 
         dataLogLnIf(verbose, "  Interpret input: ", input, "\n  Matching");
 
-        JSRegExpResult result = matchDisjunction(pattern->m_body.get(), context, false);
+        JSRegExpResult result = matchDisjunction(pattern->m_body.get(), context, /* btrack= */ false);
         if (result == JSRegExpResult::Match) {
             output[0] = context->matchBegin;
             output[1] = context->matchEnd;


### PR DESCRIPTION
#### 5fe4838cb7d14f80f57579bac4759e6d2bdcf34f
<pre>
[Yarr] YarrInterpreter Greedy backtracking should finish its parentheses by trying up to max count
<a href="https://bugs.webkit.org/show_bug.cgi?id=316378">https://bugs.webkit.org/show_bug.cgi?id=316378</a>
<a href="https://rdar.apple.com/178787974">rdar://178787974</a>

Reviewed by Yijia Huang.

In Greedy Parentheses backtracking,

1. We do content-backtracking first. If it works, then we say it is
   matched and return from the backtracking (continue to the subsequent
   pattern). If it matches, then this iteration is completed. So we
   should attempt to expand Greedy iterations as much as possible, then
   we say this is matched and continue going to the subsequent pattern.
2. Otherwise, we need to restore the previous iteration&apos;s state since
   this iteration failed. Then we do content-backtracking in this popped
   iteration if we are not reaching to min count. If succeeds, then
   refill up to min count, and then expand up to max count. And then
   saying Greedy backtracking is completed.
3. If content-backtracking failed, we need to repeatedly pop the
   iteration and try backtracking again. If it failed completely, then
   we need to say that this parentheses is completely failed.

We were missing expand-to-max-count in (2). So we are saying the
parentheses completion as non-greedy manner. We need to expand it as it
is greedy.

Test: JSTests/stress/regexp-greedy-varcount-reextend-after-content-backtrack.js

* JSTests/stress/regexp-greedy-varcount-reextend-after-content-backtrack.js: Added.
(eq):
(check):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::parenthesesDoBacktrack):
(JSC::Yarr::Interpreter::matchParentheses):
(JSC::Yarr::Interpreter::backtrackParentheses):
(JSC::Yarr::Interpreter::refillParenthesesContextsToMinCount):
(JSC::Yarr::Interpreter::extendParenthesesContextsToMaxCount):
(JSC::Yarr::Interpreter::matchDisjunction):
(JSC::Yarr::Interpreter::matchNonZeroDisjunction):

Canonical link: <a href="https://commits.webkit.org/314655@main">https://commits.webkit.org/314655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49a25e7bd801a6c661177a5afae8b2401c5a95a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123889 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129554 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110079 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30921 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29624 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23821 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158789 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178214 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27526 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31114 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137915 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137832 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149214 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103632 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25380 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33121 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26079 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199311 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39391 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112465 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53543 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38787 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4169 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39032 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38930 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->