### PR TITLE
Cherry pick 305413.913@safari-7624-branch (58357344684a)

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -977,12 +977,16 @@ void WebProcessProxy::sendPageCloseMessage(std::optional<WebPageProxyIdentifier>
 
 bool WebProcessProxy::hasCommittedClientOrigin(const WebCore::ClientOrigin& clientOrigin) const
 {
+    if (m_committedClientOrigins.contains(clientOrigin))
+        return true;
+
     if (isRunningWorkers()) {
         if (!m_site)
             return m_committedSites.contains(Site { clientOrigin.topOrigin }) && m_committedSites.contains(Site { clientOrigin.clientOrigin });
         return Site { clientOrigin.topOrigin } == *m_site && Site { clientOrigin.clientOrigin } == *m_site;
     }
-    return m_committedClientOrigins.contains(clientOrigin);
+
+    return false;
 }
 
 void WebProcessProxy::didCommitLoadClientOrigin(WebCore::ClientOrigin&& clientOrigin)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm
@@ -28,6 +28,7 @@
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
+#import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "Helpers/Utilities.h"
 #import <WebKit/WKPreferencesPrivate.h>
@@ -273,6 +274,91 @@ TEST(WebLocks, ServiceWorkerLockRequestAfterCrossSiteNavigationInSameProcess)
 
     [webView synchronouslyLoadRequest:server1.request()];
     TestWebKitAPI::Util::run(&done);
+}
+
+TEST(WebLocks, CrossSiteIframeUsingLocksInServiceWorkerHostingProcess)
+{
+    TestWebKitAPI::HTTPServer server1({ }, TestWebKitAPI::HTTPServer::Protocol::Http);
+    TestWebKitAPI::HTTPServer server2({ }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto swScript =
+        "self.addEventListener('install', e => self.skipWaiting());"
+        "self.addEventListener('activate', e => e.waitUntil(self.clients.claim()));"_s;
+
+    // navigator.locks.request calls WebLockRegistryProxy::requestLock.
+    auto iframeHTML =
+        "<script>"
+        "  navigator.locks.request('iframe-lock', () => new Promise(() => {}));"
+        "  parent.postMessage('IFRAME_READY', '*');"
+        "</script>"_s;
+
+    auto pageHTML = makeString(
+        "<script>"
+        "  window.addEventListener('message', e => {"
+        "    if (e.data === 'IFRAME_READY')"
+        "      webkit.messageHandlers.testHandler.postMessage('IFRAME_READY');"
+        "  });"
+        "  navigator.serviceWorker.register('/sw.js')"
+        "    .then(() => navigator.serviceWorker.ready)"
+        "    .then(() => {"
+        "      const f = document.createElement('iframe');"
+        "      f.id = 'subframe';"
+        "      f.src = 'http://localhost:"_s, server2.port(), "/iframe';"
+        "      document.body.appendChild(f);"
+        "    });"
+        "</script>"_s);
+
+    server1.addResponse("/"_s, { pageHTML });
+    server1.addResponse("/sw.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, swScript });
+    server2.addResponse("/iframe"_s, { iframeHTML });
+
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    processPoolConfiguration.get().processSwapsOnNavigation = NO;
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get().processPool = processPool.get();
+    enableWebLocksAPI(configuration.get());
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    __block bool done = false;
+    __block bool webProcessTerminated = false;
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    navigationDelegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        webProcessTerminated = true;
+        done = true;
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        if ([message isEqualToString:@"IFRAME_READY"])
+            done = true;
+    }];
+
+    [webView loadRequest:server1.request()];
+    TestWebKitAPI::Util::run(&done);
+
+    // Wait long enough for webContentProcessDidTerminate to fire.
+    TestWebKitAPI::Util::runFor(0.1_s);
+    EXPECT_FALSE(webProcessTerminated);
+
+    // If the WebProcess was terminated by requestLock's MESSAGE_CHECK, we
+    // have already failed and don't need to check clientIsGoingAway.
+    if (webProcessTerminated)
+        return;
+
+    // Detaching the iframe will call WebLockRegistryProxy::clientIsGoingAway.
+    __block bool detachDone = false;
+    [webView evaluateJavaScript:@"document.getElementById('subframe').remove(); 1" completionHandler:^(id, NSError *error) {
+        EXPECT_NULL(error);
+        detachDone = true;
+    }];
+    TestWebKitAPI::Util::run(&detachDone);
+
+    // Wait long enough for webContentProcessDidTerminate to fire.
+    TestWebKitAPI::Util::runFor(0.1_s);
+    EXPECT_FALSE(webProcessTerminated);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 89f18277fe742a66605ffb4401a3732ae4bff55b
<pre>
Cherry pick 305413.913@safari-7624-branch (58357344684a)
<a href="https://bugs.webkit.org/show_bug.cgi?id=316377">https://bugs.webkit.org/show_bug.cgi?id=316377</a>
<a href="https://rdar.apple.com/178787581">rdar://178787581</a>

    Webpage reloaded because a problem occurred (Invalid message WebLockRegistryProxy::clientIsGoingAway)
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314863">https://bugs.webkit.org/show_bug.cgi?id=314863</a>
    <a href="https://rdar.apple.com/177020691">rdar://177020691</a>

    Reviewed by Chris Dumez.

    In <a href="https://bugs.webkit.org/show_bug.cgi?id=310289">https://bugs.webkit.org/show_bug.cgi?id=310289</a>, we added message checks to
    various WebLock IPCs in the UI process to validate the ClientOrigin sent by
    the web process. Now, on various sites, the web page is often being reloaded
    because &quot;an error occurred&quot;. We are hitting this message check:

    MESSAGE_CHECK(m_process-&gt;hasCommittedClientOrigin(clientOrigin));
    in WebLockRegistryProxy::clientIsGoingAway().

    Suppose we have a web process in which the main frame (mainframe.com) has a
    service or shared worker in the same process and also a cross-site iframe
    (iframe.com). Then the iframe is torn down resulting in the
    WebLockRegistryProxy::clientIsGoingAway() IPC being sent. In this IPC, we
    have a message check that calls WebProcessProxy::hasCommittedClientOrigin()
    to confirm if this web process has committed a load of this ClientOrigin
    before (in this case, the iframe&apos;s ClientOrigin).

    We have indeed committed a load for this iframe&apos;s ClientOrigin and it will
    indeed show up in m_committedClientOrigins. But currently, since the web
    process has a running worker, we don&apos;t check m_committedClientOrigins at all.
    This web process has m_site (the main frame&apos;s site mainframe.com), So we simply
    check if this iframe&apos;s ClientOrigin&apos;s topOrigin (mainframe.com) and clientOrigin
    (iframe.com) both match m_site. Since the clientOrigin does not,
    hasCommittedClientOrigin() returns false, and the message check terminates the
    web process.

    We fix this by ensuring that hasCommittedClientOrigin() first checks
    m_committedClientOrigins. Only if it does not find the ClientOrigin there, will
    it check the isRunningWorkers() case.

    This same message check appears in another WebLock IPC (requestLock). This new
    test checks that the message check there passes as well:
    TEST(WebLocks, CrossSiteIframeUsingLocksInServiceWorkerHostingProcess).

    * Source/WebKit/UIProcess/WebProcessProxy.cpp:
    (WebKit::WebProcessProxy::hasCommittedClientOrigin const):
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/WebLocks.mm:
    (TestWebKitAPI::TEST(WebLocks, CrossSiteIframeUsingLocksInServiceWorkerHostingProcess)):

Originally-landed-as: 305413.913@safari-7624-branch (58357344684a). <a href="https://rdar.apple.com/177020691">rdar://177020691</a>
Canonical link: <a href="https://commits.webkit.org/314641@main">https://commits.webkit.org/314641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b78bad36d312543f891e9e96139f7d5563f000aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175679 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123888 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129553 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110078 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30922 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29623 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23820 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178213 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137914 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137831 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149213 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103631 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25373 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26078 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39390 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112464 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38786 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4168 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39031 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38929 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->