### PR TITLE
[writing-mode] Incorrect computed style value when body's value propagated to document element

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5182,7 +5182,6 @@ webkit.org/b/214291 imported/w3c/web-platform-tests/css/css-writing-modes/wm-pro
 webkit.org/b/214291 imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-047.html [ ImageOnlyFailure ]
 webkit.org/b/214291 imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-049.html [ ImageOnlyFailure ]
 webkit.org/b/214291 imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-054.html [ ImageOnlyFailure ]
-webkit.org/b/299202 imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-writing-mode.html [ Failure ]
 
 # New failures after updating WPT import of css/css-text on 2020-07
 webkit.org/b/214299 imported/w3c/web-platform-tests/css/css-ui/appearance-menulist-button-002.tentative.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-style-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Body writing-mode propagation does not change the document element's computed writing-mode
+PASS Body direction propagation does not change the document element's computed direction
+PASS Document element pseudo-element computed style is unaffected by body propagation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-style.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Propagating writing-mode/direction from body does not change the document element's computed style</title>
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#principal-flow">
+<meta name="assert" content="Propagation of writing-mode and direction from the body to the document element only affects used values, not computed values, so getComputedStyle reports the document element's own values, and a pseudo-element of the document element keeps its own values.">
+<style>
+/* A pseudo-element on the document element that sets its own values. The
+   propagation from <body> must not leak into the pseudo-element's computed
+   style. */
+html::before {
+    content: "x";
+    writing-mode: sideways-rl;
+    direction: rtl;
+}
+</style>
+</head>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const html = document.documentElement;
+const body = document.body;
+
+function cleanup() {
+    html.style.removeProperty("writing-mode");
+    html.style.removeProperty("direction");
+    body.style.removeProperty("writing-mode");
+    body.style.removeProperty("direction");
+}
+
+test(function(t) {
+    t.add_cleanup(cleanup);
+    // The body's value is propagated to the document element's used value, but the
+    // computed value reported by getComputedStyle must stay the document element's own.
+    html.style.writingMode = "vertical-lr";
+    body.style.writingMode = "horizontal-tb";
+    assert_equals(getComputedStyle(html).writingMode, "vertical-lr",
+        "document element keeps its own computed writing-mode");
+    assert_equals(getComputedStyle(body).writingMode, "horizontal-tb",
+        "body keeps its own computed writing-mode");
+}, "Body writing-mode propagation does not change the document element's computed writing-mode");
+
+test(function(t) {
+    t.add_cleanup(cleanup);
+    html.style.direction = "ltr";
+    body.style.direction = "rtl";
+    assert_equals(getComputedStyle(html).direction, "ltr",
+        "document element keeps its own computed direction");
+    assert_equals(getComputedStyle(body).direction, "rtl",
+        "body keeps its own computed direction");
+}, "Body direction propagation does not change the document element's computed direction");
+
+test(function(t) {
+    t.add_cleanup(cleanup);
+    // Regression guard: the document-element special case must not capture the
+    // document element's pseudo-elements, which carry their own values.
+    html.style.writingMode = "vertical-lr";
+    html.style.direction = "ltr";
+    body.style.writingMode = "vertical-rl";
+    body.style.direction = "rtl";
+    const before = getComputedStyle(html, "::before");
+    assert_equals(before.writingMode, "sideways-rl",
+        "::before on the document element reports its own writing-mode");
+    assert_equals(before.direction, "rtl",
+        "::before on the document element reports its own direction");
+}, "Document element pseudo-element computed style is unaffected by body propagation");
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -352,6 +352,7 @@ enum class ScheduleLocationChangeResult : uint8_t;
 enum class ScrollEventType : bool;
 enum class ShouldOpenExternalURLsPolicy : uint8_t;
 enum class StyleColorOptions : uint8_t;
+enum class StyleWritingMode : uint8_t;
 enum class ViolationReportType : uint8_t;
 enum class VisibilityState : bool;
 
@@ -623,6 +624,16 @@ public:
     void setDocumentElementLanguage(const AtomString&);
     TextDirection documentElementTextDirection() const { return m_documentElementTextDirection; }
     void setDocumentElementTextDirection(TextDirection textDirection) { m_documentElementTextDirection = textDirection; }
+
+    // The computed (not used) writing-mode and direction of the document element. These can differ from the
+    // values on the document element's render style: when those properties are propagated from the body, only
+    // the used values on the document element are affected, not the computed values (see
+    // Style::Adjuster::propagateToDocumentElementAndInitialContainingBlock and
+    // https://drafts.csswg.org/css-writing-modes-4/#principal-flow). getComputedStyle must report these.
+    StyleWritingMode documentElementComputedWritingMode() const { return m_documentElementComputedWritingMode; }
+    void setDocumentElementComputedWritingMode(StyleWritingMode writingMode) { m_documentElementComputedWritingMode = writingMode; }
+    TextDirection documentElementComputedTextDirection() const { return m_documentElementComputedTextDirection; }
+    void setDocumentElementComputedTextDirection(TextDirection direction) { m_documentElementComputedTextDirection = direction; }
 
     void addElementWithLangAttrMatchingDocumentElement(Element&);
     void removeElementWithLangAttrMatchingDocumentElement(Element&);
@@ -2697,6 +2708,8 @@ private:
     DocumentClasses m_documentClasses;
 
     TextDirection m_documentElementTextDirection;
+    StyleWritingMode m_documentElementComputedWritingMode { };
+    TextDirection m_documentElementComputedTextDirection { };
 
     DesignMode m_designMode { DesignMode::Off };
     BackForwardCacheState m_backForwardCacheState { NotInBackForwardCache };

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1172,7 +1172,7 @@ void Adjuster::adjustColumnStylesForPaginationMode(Style::ComputedStyle& style, 
     }
 }
 
-void Adjuster::propagateToDocumentElementAndInitialContainingBlock(Update& update, const Document& document)
+void Adjuster::propagateToDocumentElementAndInitialContainingBlock(Update& update, Document& document)
 {
     RefPtr body = document.body();
     auto* bodyStyle = body ? update.elementStyle(*body) : nullptr;
@@ -1180,6 +1180,17 @@ void Adjuster::propagateToDocumentElementAndInitialContainingBlock(Update& updat
 
     if (!documentElementStyle)
         return;
+
+    // https://drafts.csswg.org/css-writing-modes-4/#principal-flow
+    // Propagation from the body only affects the used values of writing-mode and direction on the document
+    // element, not their computed values. Remember the document element's own computed values here, before
+    // they are overwritten below, so that getComputedStyle() can report them.
+    document.setDocumentElementComputedWritingMode(documentElementStyle->hasExplicitlySetWritingMode()
+        ? documentElementStyle->writingMode().computedWritingMode()
+        : ComputedStyle::initialWritingMode());
+    document.setDocumentElementComputedTextDirection(documentElementStyle->hasExplicitlySetDirection()
+        ? documentElementStyle->writingMode().computedTextDirection()
+        : ComputedStyle::initialDirection());
 
     // https://drafts.csswg.org/css-contain-2/#contain-property
     // "Additionally, when any containments are active on either the HTML html or body elements, propagation of

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -60,7 +60,7 @@ public:
     static void adjustSVGElementStyle(Style::ComputedStyle&, const SVGElement&);
     static bool adjustEventListenerRegionTypesForRootStyle(Style::ComputedStyle&, const Document&);
     static void adjustColumnStylesForPaginationMode(Style::ComputedStyle&, PaginationMode);
-    static void propagateToDocumentElementAndInitialContainingBlock(Update&, const Document&);
+    static void propagateToDocumentElementAndInitialContainingBlock(Update&, Document&);
     static std::unique_ptr<Style::ComputedStyle> restoreUsedDocumentElementStyleToComputed(const Style::ComputedStyle&);
 
 #if ENABLE(TEXT_AUTOSIZING)

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -685,8 +685,10 @@ template<CSSPropertyID> struct PropertyExtractorAdaptor;
 template<> struct PropertyExtractorAdaptor<CSSPropertyDirection> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
-        if (state.element.ptr() == state.element->document().documentElement() && !state.style.hasExplicitlySetDirection())
-            return functor(Style::ComputedStyle::initialDirection());
+        // Propagation from the body affects only the used value of direction on the document element, so report
+        // its computed value here. https://drafts.csswg.org/css-writing-modes-4/#principal-flow
+        if (!state.pseudoElementIdentifier && state.element.ptr() == state.element->document().documentElement())
+            return functor(state.element->document().documentElementComputedTextDirection());
         return functor(state.style.writingMode().computedTextDirection());
     }
 };
@@ -694,8 +696,10 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyDirection> {
 template<> struct PropertyExtractorAdaptor<CSSPropertyWritingMode> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
-        if (state.element.ptr() == state.element->document().documentElement() && !state.style.hasExplicitlySetWritingMode())
-            return functor(Style::ComputedStyle::initialWritingMode());
+        // Propagation from the body affects only the used value of writing-mode on the document element, so
+        // report its computed value here. https://drafts.csswg.org/css-writing-modes-4/#principal-flow
+        if (!state.pseudoElementIdentifier && state.element.ptr() == state.element->document().documentElement())
+            return functor(state.element->document().documentElementComputedWritingMode());
         return functor(state.style.writingMode().computedWritingMode());
     }
 };


### PR DESCRIPTION
#### a0aa49214799e95d3713dfa0db7374a5586c6db2
<pre>
[writing-mode] Incorrect computed style value when body&apos;s value propagated to document element
<a href="https://bugs.webkit.org/show_bug.cgi?id=299202">https://bugs.webkit.org/show_bug.cgi?id=299202</a>
<a href="https://rdar.apple.com/160959541">rdar://160959541</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per <a href="https://drafts.csswg.org/css-writing-modes-4/#principal-flow">https://drafts.csswg.org/css-writing-modes-4/#principal-flow</a>, when the
writing-mode and direction of the document element are propagated from the
body element, the propagation affects only the *used* values on the document
element, not its *computed* values:

    &quot;Note that this does not affect the computed values of writing-mode,
    direction, or text-orientation of the root element itself.&quot;

We correctly apply the propagated value to the document element&apos;s render
style (its used value, needed for layout, scrolling and page progression),
but getComputedStyle() reads that render style directly and so reported the
propagated value instead of the document element&apos;s own computed value. When
the html and body elements specified different writing modes, the document
element&apos;s own computed value was lost entirely once it was overwritten.

Remember the document element&apos;s own computed writing-mode and direction on
the Document before the used value overwrites them in
propagateToDocumentElementAndInitialContainingBlock(), and report those
stored values from the computed-style extractor for the document element
(but not its pseudo-elements, which keep their own values - added test here).

Test: imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-style.html

* LayoutTests/TestExpectations: Remove [ Failure ] Expectation
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-style.html: Added.
* Source/WebCore/dom/Document.h:
(WebCore::Document::documentElementComputedWritingMode const):
(WebCore::Document::setDocumentElementComputedWritingMode):
(WebCore::Document::documentElementComputedTextDirection const):
(WebCore::Document::setDocumentElementComputedTextDirection):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::propagateToDocumentElementAndInitialContainingBlock):
* Source/WebCore/style/StyleAdjuster.h:
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::PropertyExtractorAdaptor&lt;CSSPropertyDirection&gt;::computedValue const):
(WebCore::Style::PropertyExtractorAdaptor&lt;CSSPropertyWritingMode&gt;::computedValue const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0aa49214799e95d3713dfa0db7374a5586c6db2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123890 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129557 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91238 "3 flakes 4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110082 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30926 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29627 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23822 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140897 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178215 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31115 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137918 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137835 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149221 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103633 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33125 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26086 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39392 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112466 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38788 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4176 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39033 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38931 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->