### PR TITLE
<object> elements loading images are incorrectly blocked by img-src CSP directive

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-allowed-img-src-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-allowed-img-src-none-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Violation report status OK.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-allowed-img-src-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-allowed-img-src-none.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <!--
+      Content-Security-Policy:
+        object-src 'self';
+        img-src 'none';
+        script-src 'self' 'unsafe-inline';
+        report-uri /reporting/resources/report.py?op=put&reportID={{$id}}
+    -->
+</head>
+
+<body>
+    <object type="image/png" data="/content-security-policy/support/pass.png"></object>
+    <!--
+      Per CSP3 section 6.1.9, object-src is the only directive that governs
+      object and embed elements, even when loading image content. img-src
+      must not be applied to object elements.
+    -->
+    <script src='../support/checkReport.sub.js?reportExists=false'></script>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-allowed-img-src-none.html.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-allowed-img-src-none.html.sub.headers
@@ -1,0 +1,2 @@
+Set-Cookie: object-src-url-allowed-img-src-none={{$id:uuid()}}; Path=/content-security-policy/object-src/
+Content-Security-Policy: object-src 'self'; img-src 'none'; script-src 'self' 'unsafe-inline'; report-uri /reporting/resources/report.py?op=put&reportID={{$id}}

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Violation report status OK.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <!--
+      Content-Security-Policy:
+        object-src 'self';
+        img-src 'none';
+        script-src 'self' 'unsafe-inline';
+        report-uri /reporting/resources/report.py?op=put&reportID={{$id}}
+    -->
+</head>
+
+<body>
+    <embed height="40" width="40" type="image/png"
+           src="/content-security-policy/support/pass.png"></embed>
+    <!--
+      Per CSP3 section 6.1.9, object-src is the only directive that governs
+      object and embed elements, even when loading image content. img-src
+      must not be applied to embed elements.
+    -->
+    <script src='../support/checkReport.sub.js?reportExists=false'></script>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none.html.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none.html.sub.headers
@@ -1,0 +1,2 @@
+Set-Cookie: object-src-url-embed-allowed-img-src-none={{$id:uuid()}}; Path=/content-security-policy/object-src/
+Content-Security-Policy: object-src 'self'; img-src 'none'; script-src 'self' 'unsafe-inline'; report-uri /reporting/resources/report.py?op=put&reportID={{$id}}

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -514,10 +514,9 @@ bool CachedResourceLoader::allowedByContentSecurityPolicy(CachedResource::Type t
         contentSecurityPolicy->setIsReportingToConsoleEnabled(true);
     });
 
-    // All content loaded through embed or object elements goes through object-src: https://www.w3.org/TR/CSP3/#directive-object-src.
-    if (options.loadedFromPluginElement == LoadedFromPluginElement::Yes
-        && !contentSecurityPolicy->allowObjectFromSource(url, document->currentParserSourcePosition(), redirectResponseReceived, preRedirectURL))
-        return false;
+    // Only object-src governs object/embed elements, regardless of resource type (CSP3 §6.1.9).
+    if (options.loadedFromPluginElement == LoadedFromPluginElement::Yes)
+        return contentSecurityPolicy->allowObjectFromSource(url, document->currentParserSourcePosition(), redirectResponseReceived, preRedirectURL);
 
     switch (type) {
 #if ENABLE(XSLT)


### PR DESCRIPTION
#### 1a1efe9cf4e6709cfaba6f7f637105d331283a5f
<pre>
&lt;object&gt; elements loading images are incorrectly blocked by img-src CSP directive
<a href="https://bugs.webkit.org/show_bug.cgi?id=316356">https://bugs.webkit.org/show_bug.cgi?id=316356</a>
<a href="https://rdar.apple.com/178772677">rdar://178772677</a>

Reviewed by Ryan Reno and Anne van Kesteren.

When an &lt;object&gt; element loads image content, the resource is checked against both object-src
and img-src. A page with object-src *; img-src &apos;none&apos; incorrectly blocks images in object tags.
Per the spec, object-src is the only directive that should apply.

Fix by short-circuiting the content security policy check for plugin elements so that only object-src
is evaluated. The subsequent type-based directive lookup no longer runs for resources loaded by object
or embed tags.

Test: imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-allowed-img-src-none.html
      imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none.html

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-allowed-img-src-none-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-allowed-img-src-none.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-allowed-img-src-none.html.sub.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-embed-allowed-img-src-none.html.sub.headers: Added.
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::allowedByContentSecurityPolicy const):

Canonical link: <a href="https://commits.webkit.org/314668@main">https://commits.webkit.org/314668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9752945ce5ee439e3cd61927e6ffdf7d75642bf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123994 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bcfe321f-7a2c-49c8-a015-6b6d5a1384e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129649 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3cf1f89e-8bb6-405d-98ef-f3a23a5c584c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110174 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23990323-e658-489a-80b3-3935b4a59b13) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31017 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29717 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141028 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178319 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31219 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138015 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137925 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37167 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149313 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103782 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33206 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26178 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39496 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112570 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38892 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4268 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39137 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->