### PR TITLE
[WebXR|visionOS] Try shared MTLTexture before falling back to IOSurface

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/MetalSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/MetalSPI.h
@@ -67,13 +67,11 @@ typedef struct __IOSurface *IOSurfaceRef;
 - (mach_port_t)eventPort;
 @end
 
-#if !PLATFORM(IOS_FAMILY_SIMULATOR)
 @interface MTLSharedTextureHandle(Private)
 - (instancetype)initWithIOSurface:(IOSurfaceRef)ioSurface label:(NSString*)label;
 - (instancetype)initWithMachPort:(mach_port_t)machPort;
 - (mach_port_t)createMachPort;
 @end
-#endif
 
 WTF_EXTERN_C_BEGIN
 

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -545,11 +545,6 @@ GCGLExternalImage GraphicsContextGLCocoa::createExternalImage(ExternalImageSourc
         return tex;
     },
     [&](EGLImageSourceMTLSharedTextureHandle&& sharedTexture) -> RetainPtr<id> {
-#if PLATFORM(IOS_FAMILY_SIMULATOR)
-        UNUSED_VARIABLE(sharedTexture);
-        ASSERT_NOT_REACHED();
-        return nullptr;
-#else
         auto handle = adoptNS([[MTLSharedTextureHandle alloc] initWithMachPort:sharedTexture.handle.sendRight()]);
         if (!handle)
             return nullptr;
@@ -563,7 +558,6 @@ GCGLExternalImage GraphicsContextGLCocoa::createExternalImage(ExternalImageSourc
         RetainPtr<id> texture = adoptNS([mtlDevice newSharedTextureWithHandle:handle.get()]);
         return texture;
         // FIXME: Does the texture have the correct usage mode?
-#endif
     });
 
     if (!texture) {
@@ -574,12 +568,8 @@ GCGLExternalImage GraphicsContextGLCocoa::createExternalImage(ExternalImageSourc
     // Create an EGLImage out of the MTLTexture
     Vector<EGLint, 6> attributes;
     attributes.appendList({ EGL_METAL_TEXTURE_ARRAY_SLICE_ANGLE, layer });
-#if !PLATFORM(IOS_FAMILY_SIMULATOR)
     if (internalFormat)
         attributes.appendList({ EGL_TEXTURE_INTERNAL_FORMAT_ANGLE, static_cast<EGLint>(internalFormat) });
-#else
-    UNUSED_VARIABLE(internalFormat);
-#endif
     attributes.appendList({ EGL_NONE, EGL_NONE });
     auto eglImage = EGL_CreateImageKHR(platformDisplay(), EGL_NO_CONTEXT, EGL_METAL_TEXTURE_ANGLE, reinterpret_cast<EGLClientBuffer>(texture.get()), attributes.span().data());
     if (!eglImage) {

--- a/Source/WebGPU/WebGPU/MetalSPI.h
+++ b/Source/WebGPU/WebGPU/MetalSPI.h
@@ -85,7 +85,7 @@ constexpr MTLPixelFormat MTLPixelFormatYCBCR12_444_2P_PACKED_PQ = static_cast<MT
 - (kern_return_t)setOwnerWithIdentity:(mach_port_t)task_id_token;
 @end
 
-#if !PLATFORM(IOS_FAMILY_SIMULATOR) && !PLATFORM(WATCHOS)
+#if !PLATFORM(WATCHOS)
 @interface MTLSharedTextureHandle(Private)
 - (instancetype)initWithMachPort:(mach_port_t)machPort;
 @end

--- a/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
+++ b/Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm
@@ -45,7 +45,7 @@ constexpr size_t reusableTextureMaxCount = 3;
 
 static PlatformXR::FrameData::ExternalTexture makeMachSendRight(id<MTLTexture> texture)
 {
-#if !PLATFORM(IOS_FAMILY_SIMULATOR)
+#if !PLATFORM(IOS_SIMULATOR) || __VISION_OS_VERSION_MIN_REQUIRED >= 270000
     RetainPtr<MTLSharedTextureHandle> sharedTextureHandle = adoptNS([texture newSharedTextureHandle]);
     if (sharedTextureHandle)
         return { MachSendRight::adopt([sharedTextureHandle.get() createMachPort]), true };


### PR DESCRIPTION
#### 58b5768990e1c013032b721936d0a4b1c1b7a6d6
<pre>
[WebXR|visionOS] Try shared MTLTexture before falling back to IOSurface
<a href="https://bugs.webkit.org/show_bug.cgi?id=316380">https://bugs.webkit.org/show_bug.cgi?id=316380</a>
<a href="https://rdar.apple.com/178666073">rdar://178666073</a>

Reviewed by Mike Wyrzykowski.

When entering immersive VR mode on visionOS simulator only black is rendered
because the compositor surfaces passed as IOSurfaces return 0x0 dimensions.

To fix this, we know use the same logic as a visionOS device. Try to access the
compositor surfaces as shared MTLTextures before falling back to trying
IOSurface.

Tested by launching Safari in simulator and trying a WebXR immersive VR page.

* Source/WTF/wtf/PlatformUse.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::createExternalImage):
* Source/WebKit/UIProcess/XR/xros/PlatformXRCompositor.mm:
(makeMachSendRight):

Canonical link: <a href="https://commits.webkit.org/314780@main">https://commits.webkit.org/314780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5554f7a1bbf33a1c881ea1807353d114ca1fdf24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166837 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124095 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3b3d83e-2214-4bc0-9e11-388202500c7b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129731 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91360 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f30aec2-34f6-4c32-b984-d662977888ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110257 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c250b37-5fe6-47cb-a6c8-c9e39faeac66) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31108 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29807 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24621 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141081 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178423 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31320 "Found 2 new failures in css/SelectorChecker.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138097 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138010 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37237 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149400 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103883 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33288 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26265 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39596 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112670 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38992 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4358 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39237 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39135 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->