### PR TITLE
[JSC] Fix non-unified build due to incomplete use of class JSC::JSGlobalObject

### DIFF
--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
@@ -76,6 +76,11 @@ Structure* TemporalZonedDateTime::createStructure(VM& vm, JSGlobalObject* global
     return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
 }
 
+TemporalZonedDateTime* TemporalZonedDateTime::withExactTime(JSGlobalObject* globalObject, ISO8601::ExactTime epochNs) const
+{
+    return tryCreate(globalObject, globalObject->zonedDateTimeStructure(), epochNs, m_timeZone, String(m_timeZoneId), m_calendarID);
+}
+
 TemporalZonedDateTime::TemporalZonedDateTime(VM& vm, Structure* structure, ISO8601::ExactTime exactTime, TimeZone timeZone, String&& timeZoneId, CalendarID calendarID)
     : Base(vm, structure)
     , m_exactTime(exactTime)

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.h
@@ -71,10 +71,7 @@ public:
 
     static std::optional<ISO8601::ExactTime> getEpochNanosecondsFor(JSGlobalObject*, const TimeZone&, const ISO8601::PlainDate&, const ISO8601::PlainTime&, TemporalDisambiguation);
 
-    TemporalZonedDateTime* withExactTime(JSGlobalObject* globalObject, ISO8601::ExactTime epochNs) const
-    {
-        return tryCreate(globalObject, globalObject->zonedDateTimeStructure(), epochNs, m_timeZone, String(m_timeZoneId), m_calendarID);
-    }
+    TemporalZonedDateTime* withExactTime(JSGlobalObject*, ISO8601::ExactTime epochNs) const;
 
 private:
     TemporalZonedDateTime(VM&, Structure*, ISO8601::ExactTime, TimeZone, String&&, CalendarID);


### PR DESCRIPTION
#### ee637a607df2240cfb7133c7f2bf2f3e7bd94b7a
<pre>
[JSC] Fix non-unified build due to incomplete use of class JSC::JSGlobalObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=316381">https://bugs.webkit.org/show_bug.cgi?id=316381</a>

Reviewed by Keith Miller.

TemporalZonedDateTime::withExactTime() needs the full definition of JSGlobalObject.
Instead of pulling another header into TemporalZonedDateTime.h move the definition
to the cpp file that already includes the required headers.

* Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp:
(JSC::TemporalZonedDateTime::withExactTime const):
* Source/JavaScriptCore/runtime/TemporalZonedDateTime.h:

Canonical link: <a href="https://commits.webkit.org/314627@main">https://commits.webkit.org/314627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f27f23c99cef1d4df516a5d89e1ac27334ae0969

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123898 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129559 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110084 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30931 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29631 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23830 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158798 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178223 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27535 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31123 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137919 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137836 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149223 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103643 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25367 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26088 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199320 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39400 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112474 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53550 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38796 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4178 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39041 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->