### PR TITLE
MutationObserver.observe() incorrectly throws when attributeOldValue or characterDataOldValue is present with value false

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/MutationObserver-sanity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/MutationObserver-sanity-expected.txt
@@ -12,4 +12,7 @@ PASS Should throw if attributeFilter is present and attributes is false
 PASS Should not throw if attributeFilter is present and attributes is true
 PASS Should throw if characterDataOldValue is true and characterData is false
 PASS Should not throw if characterDataOldValue is true and characterData is true
+PASS Should not throw if attributeOldValue is false and attributes is omitted
+PASS Should not throw if characterDataOldValue is false and characterData is omitted
+PASS attributeOldValue:false (present) auto-enables attribute observation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/MutationObserver-sanity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/MutationObserver-sanity.html
@@ -92,4 +92,29 @@
       m.disconnect();
   }, "Should not throw if characterDataOldValue is true and characterData is true");
 
+  test(() => {
+      var m = new MutationObserver(() => {});
+      m.observe(document, { attributeOldValue: false });
+      m.disconnect();
+  }, "Should not throw if attributeOldValue is false and attributes is omitted");
+
+  test(() => {
+      var m = new MutationObserver(() => {});
+      m.observe(document, { characterDataOldValue: false });
+      m.disconnect();
+  }, "Should not throw if characterDataOldValue is false and characterData is omitted");
+
+  async_test(t => {
+      var target = document.createElement("div");
+      var m = new MutationObserver(t.step_func_done(records => {
+          assert_equals(records.length, 1);
+          assert_equals(records[0].type, "attributes");
+          assert_equals(records[0].attributeName, "data-x");
+          assert_equals(records[0].oldValue, null);
+          m.disconnect();
+      }));
+      m.observe(target, { attributeOldValue: false });
+      target.setAttribute("data-x", "1");
+  }, "attributeOldValue:false (present) auto-enables attribute observation");
+
 </script>

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -100,10 +100,10 @@ ExceptionOr<void> MutationObserver::observe(Node& node, const Init& init)
         options.add(OptionType::AttributeFilter);
     }
 
-    if (init.attributes ? init.attributes.value() : options.containsAny({ OptionType::AttributeFilter, OptionType::AttributeOldValue }))
+    if (init.attributes ? init.attributes.value() : (init.attributeOldValue.has_value() || init.attributeFilter.has_value()))
         options.add(OptionType::Attributes);
 
-    if (init.characterData ? init.characterData.value() : options.contains(OptionType::CharacterDataOldValue))
+    if (init.characterData ? init.characterData.value() : init.characterDataOldValue.has_value())
         options.add(OptionType::CharacterData);
 
     if (!validateOptions(options))


### PR DESCRIPTION
#### a811f8d9e6ff1508488ef0fb8b117105dbfe0390
<pre>
MutationObserver.observe() incorrectly throws when attributeOldValue or characterDataOldValue is present with value false
<a href="https://bugs.webkit.org/show_bug.cgi?id=316382">https://bugs.webkit.org/show_bug.cgi?id=316382</a>

Reviewed by Ryosuke Niwa.

Per <a href="https://dom.spec.whatwg.org/#dom-mutationobserver-observe">https://dom.spec.whatwg.org/#dom-mutationobserver-observe</a>, if either
attributeOldValue or attributeFilter is *present* in the init dictionary
and attributes is omitted, attributes is set to true. The same applies to
characterDataOldValue and characterData. &quot;Present&quot; here means the
dictionary key was provided, regardless of its value.

WebKit was conflating presence with truthiness: AttributeOldValue /
CharacterDataOldValue option flags were only added when the value was
true, and the auto-set step keyed off those flags rather than off
presence. As a result, observe(node, { attributeOldValue: false }) — and
likewise for characterDataOldValue: false — incorrectly threw a
TypeError instead of registering an attribute observer with no
old-value delivery.

Use std::optional::has_value() to test presence in the auto-set step,
matching Blink &amp; Gecko&apos;s behavior and the spec.

Test: imported/w3c/web-platform-tests/dom/nodes/MutationObserver-sanity.html

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/MutationObserver-sanity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/MutationObserver-sanity.html:
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::observe):

Canonical link: <a href="https://commits.webkit.org/314623@main">https://commits.webkit.org/314623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/787d63f7b93a502677a49bd4107ff09232954e17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175690 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123899 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d3ebeb7-012c-424f-bbeb-c3abb74b8b82) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129560 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62f20467-ba84-4266-807c-51442de07dbc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110085 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/596eae4c-5fc6-4aac-ac34-b123612f972b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30932 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29628 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23831 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178224 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31124 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137920 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33775 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137837 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37141 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149224 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103645 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26089 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112475 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38797 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4179 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39042 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38940 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->