### PR TITLE
[JSC] `FreeList::forEach` interval assert should be bounded by `MarkedBlock::blockSize`

### DIFF
--- a/Source/JavaScriptCore/heap/FreeListInlines.h
+++ b/Source/JavaScriptCore/heap/FreeListInlines.h
@@ -60,7 +60,7 @@ void FreeList::forEach(const Func& func) const
     FreeCell* cell = nextInterval();
     char* intervalStart = m_intervalStart;
     char* intervalEnd = m_intervalEnd;
-    ASSERT(intervalEnd - intervalStart < (ptrdiff_t)(16 * KB));
+    ASSERT(intervalEnd - intervalStart < (ptrdiff_t)MarkedBlock::blockSize);
 
     while (true) {
         for (; intervalStart < intervalEnd; intervalStart += m_cellSize)


### PR DESCRIPTION
#### 4d73bc11dd6c1f369b4e4b2e4457305d673605cc
<pre>
[JSC] `FreeList::forEach` interval assert should be bounded by `MarkedBlock::blockSize`
<a href="https://bugs.webkit.org/show_bug.cgi?id=316385">https://bugs.webkit.org/show_bug.cgi?id=316385</a>

Reviewed by Yusuke Suzuki.

FreeList::forEach asserts that a free-list interval is smaller than a
hardcoded 16 KB. The actual invariant is that an interval never spans
more than one MarkedBlock payload, and MarkedBlock::blockSize is
std::max(16 * KB, CeilingOnPageSize), which is 64 KB on platforms where
CeilingOnPageSize is 64 KB (e.g. USE(64KB_PAGE_BLOCK), used by Linux
distributions with 64 KiB pages such as RHEL on ARM64). On such
platforms, sweeping an empty block creates a single interval spanning
the whole payload, so the assertion fires spuriously on the first
MarkedBlock::Handle::stopAllocating in any ASSERT_ENABLED build.

Bound the assertion by MarkedBlock::blockSize instead. On platforms
where blockSize is 16 KB this compiles to the identical check.

* Source/JavaScriptCore/heap/FreeListInlines.h:
(JSC::FreeList::forEach const):

Canonical link: <a href="https://commits.webkit.org/314688@main">https://commits.webkit.org/314688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b09bdf60ed96aa53b05ed09bccd47d70968ed0fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175693 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123902 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40143 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129564 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91243 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110089 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30934 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29635 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23834 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158802 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178227 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27539 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31127 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137925 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137842 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37174 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103648 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33130 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26093 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199324 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112478 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53555 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38800 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4183 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39045 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->