### PR TITLE
Unreviewed, very partial revert of 314479@main since it introduced crashes

### DIFF
--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
@@ -50,8 +50,6 @@ Connection::Connection(CString&& machServiceName, WebPushDaemonConnectionConfigu
     LOG(Push, "Creating WebPushD connection to mach service: %s", this->machServiceName().data());
 }
 
-Connection::~Connection() = default;
-
 } // namespace WebKit::WebPushD
 
 #endif // ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
@@ -79,7 +79,6 @@ public:
 
 private:
     Connection(CString&& machServiceName, WebPushDaemonConnectionConfiguration&&);
-    ~Connection();
 
     void newConnectionWasInitialized() const final;
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### ca2b840961169ced5cbb7de7bbf7f1ac5f8887aa
<pre>
Unreviewed, very partial revert of <a href="https://commits.webkit.org/314479@main">314479@main</a> since it introduced crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=316390">https://bugs.webkit.org/show_bug.cgi?id=316390</a>
<a href="https://rdar.apple.com/178728999">rdar://178728999</a>

It introduced crashes in WebKit::Daemon::ConnectionToMachService&lt;WebKit::WebPushD::ConnectionTraits&gt;::initializeConnectionIfNeeded()
with non-CMake builds.

* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp:
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca2b840961169ced5cbb7de7bbf7f1ac5f8887aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123914 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129576 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110101 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30945 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29646 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23846 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140916 "Found 2 new API test failures: TestWebKitAPI.HSTS.Preconnect, TestWebKitAPI.WritingTools.CompositionWithMultipleChunks (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178239 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31139 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137936 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137853 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149239 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103664 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33139 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26104 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39416 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112490 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38812 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4194 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39057 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38955 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->