### PR TITLE
Relayout during live resize on visionOS can cause webpage UI to shift and misposition

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -314,8 +314,18 @@ struct PerWebProcessState {
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
     std::optional<CGFloat> lastResizedViewWidth;
     RetainPtr<NSDate> lastResizeTimestamp;
+    std::optional<WebKit::TransactionID> transactionIDForEndLiveResize;
+    BOOL waitingForEndLiveResizePresentationUpdate { NO };
+    BOOL resizeAnimationViewIsUpdating { NO };
 #endif
 };
+
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+struct LiveResizeSnapshotState {
+    RetainPtr<UIView> snapshotView;
+    CGFloat initialWidth { 0 };
+};
+#endif
 
 #endif // PLATFORM(IOS_FAMILY)
 
@@ -460,7 +470,7 @@ struct PerWebProcessState {
     UIEdgeInsets _animatedResizeOldObscuredInsets;
     RetainPtr<UIView> _resizeAnimationView;
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-    RetainPtr<UIView> _liveResizeSnapshotContainerView;
+    std::optional<std::pair<WebKit::TransactionID, LiveResizeSnapshotState>> _liveResizeSnapshotState;
 #endif
     CGFloat _lastAdjustmentForScroller;
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -888,6 +888,11 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
     [self _destroyResizeAnimationView];
     [_contentView setHidden:NO];
 
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+    if (_liveResizeSnapshotState)
+        [self _removeLiveSnapshotState];
+#endif
+
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
     [self _invalidateResizeAssertions];
 #endif
@@ -1190,6 +1195,20 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
 
         _perProcessState.lastTransactionID = transactionID;
 
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+        auto transactionIDForEndLiveResize = _perProcessState.transactionIDForEndLiveResize;
+        if (transactionIDForEndLiveResize && transactionID.greaterThanOrEqualSameProcess(*transactionIDForEndLiveResize)) {
+            _perProcessState.waitingForEndLiveResizePresentationUpdate = YES;
+            _perProcessState.transactionIDForEndLiveResize = std::nullopt;
+            [self _doAfterNextPresentationUpdate:makeBlockPtr([weakSelf = WeakObjCPtr<WKWebView>(self)] {
+                RetainPtr strongSelf = weakSelf.get();
+                if (!strongSelf)
+                    return;
+                strongSelf->_perProcessState.waitingForEndLiveResizePresentationUpdate = NO;
+            }).get()];
+        }
+#endif
+
 #if HAVE(LIQUID_GLASS)
         bool isEnteringStableState = !std::exchange(_perProcessState.lastTransactionWasInStableState, mainFrameCommitData.isInStableState);
 #endif
@@ -1238,6 +1257,12 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
 
         if (_perProcessState.liveResizeParameters)
             return;
+
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=317005
+        if (_perProcessState.transactionIDForEndLiveResize || _perProcessState.waitingForEndLiveResizePresentationUpdate)
+            return;
+#endif
 
         if (_resizeAnimationView)
             WKWEBVIEW_RELEASE_LOG("%p -[WKWebView _didCommitLayerTree:] - dynamicViewportUpdateMode is NotResizing, but still have a live resizeAnimationView (unpaired begin/endAnimatedResize?)", self);
@@ -2586,6 +2611,11 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
     [self _rescheduleEndLiveResizeTimer];
 
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+    if (_perProcessState.transactionIDForEndLiveResize || _perProcessState.waitingForEndLiveResizePresentationUpdate)
+        return;
+#endif
+
     if (_perProcessState.liveResizeParameters)
         return;
 
@@ -2670,10 +2700,10 @@ static CGFloat liveResizeMinimumWidthDifference()
             auto strongSelf = weakSelf.get();
             [strongSelf _endLiveResize];
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-        if (!didEndLiveResizeImmediately)
-            [strongSelf _resetResponsiveResizeState];
+            if (!didEndLiveResizeImmediately)
+                [strongSelf _resetResponsiveResizeState];
 #else
-        UNUSED_PARAM(didEndLiveResizeImmediately);
+            UNUSED_PARAM(didEndLiveResizeImmediately);
 #endif
         }).get()];
 }
@@ -2691,15 +2721,37 @@ static CGFloat liveResizeMinimumWidthDifference()
 
     [_resizeAnimationView setTransform:transform];
 
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+    if (_perProcessState.resizeAnimationViewIsUpdating && _liveResizeSnapshotState) {
+        _perProcessState.resizeAnimationViewIsUpdating = NO;
+        auto snapshotTransactionID = _liveResizeSnapshotState->first;
+        [self _doAfterNextPresentationUpdate:makeBlockPtr([weakSelf = WeakObjCPtr<WKWebView>(self), snapshotTransactionID] {
+            RetainPtr strongSelf = weakSelf.get();
+            if (!strongSelf || !strongSelf->_liveResizeSnapshotState || strongSelf->_liveResizeSnapshotState->first != snapshotTransactionID)
+                return;
+            [strongSelf _removeLiveSnapshotState];
+        }).get()];
+    }
+#endif
+
 #if HAVE(LIQUID_GLASS)
     [self _updateFixedColorExtensionViewFrames];
 #endif
+}
 
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-    if (_liveResizeSnapshotContainerView)
-        [_liveResizeSnapshotContainerView setTransform:transform];
-#endif
+- (void)_updateLiveSnapshotTransform
+{
+    CGFloat snapshotScale = self.bounds.size.width / _liveResizeSnapshotState->second.initialWidth;
+    [_liveResizeSnapshotState->second.snapshotView setTransform:CGAffineTransformMakeScale(snapshotScale, snapshotScale)];
 }
+
+- (void)_removeLiveSnapshotState
+{
+    [_liveResizeSnapshotState->second.snapshotView removeFromSuperview];
+    _liveResizeSnapshotState = std::nullopt;
+}
+#endif
 
 #endif // HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
 
@@ -2757,7 +2809,16 @@ static CGFloat liveResizeMinimumWidthDifference()
         [self _updateLiveResizeTransform];
 #endif
 
-    if (!self._shouldDeferGeometryUpdates) {
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+    if (_liveResizeSnapshotState)
+        [self _updateLiveSnapshotTransform];
+#endif
+
+    if (!self._shouldDeferGeometryUpdates
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+        && !_perProcessState.transactionIDForEndLiveResize && !_perProcessState.waitingForEndLiveResizePresentationUpdate
+#endif
+    ) {
         if (!_overriddenLayoutParameters) {
             [self _dispatchSetViewLayoutSize:[self activeViewLayoutSize:self.bounds]];
             _page->setDefaultUnobscuredSize(WebCore::FloatSize(bounds.size));
@@ -3264,6 +3325,11 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
     if (_resizeAnimationView)
         return;
 
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+    if (_liveResizeSnapshotState)
+        _perProcessState.resizeAnimationViewIsUpdating = YES;
+#endif
+
     NSUInteger indexOfContentView = [[_scrollView subviews] indexOfObject:_contentView.get()];
     _resizeAnimationView = adoptNS([[UIView alloc] init]);
     [_resizeAnimationView layer].name = @"ResizeAnimation";
@@ -3727,6 +3793,7 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     [self _ensureResizeAnimationView];
 }
 
+// FIXME: https://bugs.webkit.org/show_bug.cgi?id=317000
 - (void)_endLiveResize
 {
     WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _endLiveResize]", self, _page->identifier().toUInt64());
@@ -3737,22 +3804,31 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     [_endLiveResizeTimer invalidate];
     _endLiveResizeTimer = nil;
 
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+    if (_liveResizeSnapshotState)
+        [self _removeLiveSnapshotState];
+
+    if (RefPtr drawingArea = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(_page->drawingArea()))
+        _perProcessState.transactionIDForEndLiveResize = drawingArea->nextMainFrameLayerTreeTransactionID();
+
+    if (!_perProcessState.transactionIDForEndLiveResize)
+        return;
+#endif
+
     RetainPtr liveResizeSnapshotView = [self snapshotViewAfterScreenUpdates:NO];
     [liveResizeSnapshotView setFrame:self.bounds];
 
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-    _liveResizeSnapshotContainerView = adoptNS([[UIView alloc] initWithFrame:self.bounds]);
-    [_liveResizeSnapshotContainerView layer].anchorPoint = CGPointZero;
-    [_liveResizeSnapshotContainerView layer].position = CGPointZero;
-    [_liveResizeSnapshotContainerView addSubview:liveResizeSnapshotView.get()];
-    [self addSubview:_liveResizeSnapshotContainerView.get()];
-#else
+    [liveResizeSnapshotView layer].anchorPoint = CGPointZero;
+    [liveResizeSnapshotView layer].position = CGPointZero;
     [self addSubview:liveResizeSnapshotView.get()];
-#endif
+    auto transactionIDForEndLiveResize = *_perProcessState.transactionIDForEndLiveResize;
+    _liveResizeSnapshotState = { { transactionIDForEndLiveResize, { liveResizeSnapshotView, self.bounds.size.width } } };
 
-#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
     _perProcessState.lastResizeTimestamp = [NSDate now];
     _perProcessState.lastResizedViewWidth = self.bounds.size.width;
+#else
+    [self addSubview:liveResizeSnapshotView.get()];
 #endif
 
     _perProcessState.liveResizeParameters = std::nullopt;
@@ -3761,34 +3837,30 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     [self _destroyResizeAnimationView];
     [self _didStopDeferringGeometryUpdates];
 
+#if !ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
     [self _doAfterNextVisibleContentRectUpdate:makeBlockPtr([liveResizeSnapshotView, weakSelf = WeakObjCPtr<WKWebView>(self)] mutable {
         RetainPtr strongSelf = weakSelf.get();
-        [strongSelf _doAfterNextPresentationUpdate:makeBlockPtr([liveResizeSnapshotView, weakSelf] {
-#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-            UNUSED_PARAM(liveResizeSnapshotView);
-            RetainPtr strongSelf = weakSelf.get();
-            if (!strongSelf)
-                return;
-            [strongSelf->_liveResizeSnapshotContainerView removeFromSuperview];
-            strongSelf->_liveResizeSnapshotContainerView = nil;
-#else
-            UNUSED_PARAM(weakSelf);
+        [strongSelf _doAfterNextPresentationUpdate:makeBlockPtr([liveResizeSnapshotView] {
             [liveResizeSnapshotView removeFromSuperview];
-#endif
         }).get()];
     }).get()];
+#endif
 
-    // Ensure that the live resize snapshot is eventually removed, even if the webpage is unresponsive.
-    RunLoop::mainSingleton().dispatchAfter(1_s, [liveResizeSnapshotView, weakSelf = WeakObjCPtr<WKWebView>(self)] {
+    RunLoop::mainSingleton().dispatchAfter(1_s, [
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-        UNUSED_PARAM(liveResizeSnapshotView);
-        RetainPtr strongSelf = weakSelf.get();
-        if (!strongSelf)
-            return;
-        [strongSelf->_liveResizeSnapshotContainerView removeFromSuperview];
-        strongSelf->_liveResizeSnapshotContainerView = nil;
+        weakSelf = WeakObjCPtr<WKWebView>(self), transactionIDForEndLiveResize
 #else
-        UNUSED_PARAM(weakSelf);
+        liveResizeSnapshotView
+#endif
+    ] {
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+        RetainPtr strongSelf = weakSelf.get();
+        if (!strongSelf || !strongSelf->_liveResizeSnapshotState || strongSelf->_liveResizeSnapshotState->first != transactionIDForEndLiveResize)
+            return;
+        [strongSelf _removeLiveSnapshotState];
+        strongSelf->_perProcessState.transactionIDForEndLiveResize = std::nullopt;
+        strongSelf->_perProcessState.waitingForEndLiveResizePresentationUpdate = NO;
+#else
         [liveResizeSnapshotView removeFromSuperview];
 #endif
     });


### PR DESCRIPTION
#### 40f08476d98a53903891d3b7dc91509cfc071cea
<pre>
Relayout during live resize on visionOS can cause webpage UI to shift and misposition
<a href="https://bugs.webkit.org/show_bug.cgi?id=316388">https://bugs.webkit.org/show_bug.cgi?id=316388</a>
<a href="https://rdar.apple.com/175530464">rdar://175530464</a>

Reviewed by Abrar Rahman Protyasha and Simon Fraser.

This PR updates the existing live resize mechanisms for visionOS when the user is
resizing the window. Previously, in 312437@main, we introduced a more responsive
update heuristic such that the WKWebView will relayout its content more frequently
during live resize. This however would cause synchronization issues where the webview
would try to commit updates into its layer tree while simultaneously supplying new
liveResizeParameters to the web process. It also introduced issues where the snapshot,
which was intended to cover the web content during the relayout, would snapshot the
content while updates were committing, making the resize transition buggy.

This patch addresses these issues by introducing the following changes:
1. The perProcessState now maintains a transactionIDForEndLiveResize which corresponds to
the last transactionID sent to the Web Process to dispatch the resize update. We pause
subsequent dispatches until the Web Process commits the changes to the layer tree with the
same or greater transactionID.

2. We introduce a LiveResizeSnapshotState that maintains the snapshot instance and the width
it was captured. We store that as a tuple keyed by the transactionID. When a relayout is dispatched,
we store the transactionID and the snapshotView in the state variable, until the layer tree has
committed all its changes and the next resizeAnimationView has been created. This ensures we only
maintain one snapshot and that the snapshot does not get removed before the relayout has completed.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
Introduce the following new variables:
- transactionIDForEndLiveResize — set when the UI Process ends a resize cycle and dispatch new
layout to web process. Marks which commit the UI Process is waiting for.
- waitingForEndLiveResizePresentationUpdate — set when the matching commit arrives after the commit
has been presented, enabling the next live resize update.
- resizeAnimationViewIsUpdating — set when a new animation view is created while a snapshot exists.
Indicates the animation view needs to render before the snapshot can be removed.
- _liveResizeSnapshotState — holds the snapshot view and its initial width for scaling.
Optional pair of {TransactionID, {snapshotView, initialWidth}}.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _processWillSwapOrDidExit]):
(-[WKWebView _didCommitLayerTree:mainFrameData:pageData:transactionID:]):
Checks whether the transactionID is same or greater than the stored transactionIDForEndLiveResize. If true,
we will reset waitingForEndLiveResizePresentationUpdate after the next presentation update so that live resize
can dispatch again.

(-[WKWebView _beginAutomaticLiveResizeIfNeeded]):
Guard live resize updates based on transactionID and whether we are waiting for a presentation update or not.

(-[WKWebView _rescheduleEndLiveResizeTimer]):
(-[WKWebView _updateLiveResizeTransform]):
(-[WKWebView _updateLiveSnapshotTransform]):
(-[WKWebView _removeLiveSnapshotState]):
(-[WKWebView _frameOrBoundsMayHaveChanged]):
(-[WKWebView _ensureResizeAnimationView]):
Update when we add and remove the live snapshot view such that it is captured before the resize dispatch and removed
only after the resizeAnimationView for the next resize update has been set.

(-[WKWebView _endLiveResize]):
Create the new snapshot view and update the new state variables. We also remove the early removal of the snapshot
and defer that until the updated layer tree corresponding to transactionIDForEndLiveResize has been returned.

Canonical link: <a href="https://commits.webkit.org/315206@main">https://commits.webkit.org/315206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f916c44c76f22f50abe4000392288b2f14ac0264

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41768 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35366 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125913 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130900 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92011 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171171 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111412 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32353 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31058 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26236 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142339 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180140 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32863 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30574 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139337 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139200 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37524 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42469 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105843 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34487 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27537 "Unexpected infrastructure issue, retrying build") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40973 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114229 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40370 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5629 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40621 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->