### PR TITLE
REGRESSION(314479@main): Crash in WebPushD::Connection::connectionReceivedEvent() due to xpc_object_t ODR violation

### DIFF
--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -36,7 +36,16 @@
 #import "WebPushDaemonConstants.h"
 #import <wtf/darwin/XPCExtras.h>
 
-namespace WebKit::WebPushD { 
+namespace WebKit::WebPushD {
+
+// This destructor must be defined in this .mm file (and not in WebPushDaemonConnection.cpp).
+// As the first non-pure non-inline virtual, it is the key function for Connection, and the
+// vtable is emitted in the same translation unit. WebPushDaemonConnection.h's ConnectionToMachService
+// base declares connectionReceivedEvent(xpc_object_t), and xpc_object_t resolves to OS_xpc_object*
+// in .mm TUs but to void* in .cpp TUs (gated on __OBJC__ via <os/object.h>). Emitting the vtable
+// from a .cpp TU would sign its slot with the void* discriminator, causing arm64e PAC failures at
+// every .mm call site. See https://bugs.webkit.org/show_bug.cgi?id=316390.
+Connection::~Connection() = default;
 
 void Connection::newConnectionWasInitialized() const
 {

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
@@ -50,8 +50,6 @@ Connection::Connection(CString&& machServiceName, WebPushDaemonConnectionConfigu
     LOG(Push, "Creating WebPushD connection to mach service: %s", this->machServiceName().data());
 }
 
-Connection::~Connection() = default;
-
 } // namespace WebKit::WebPushD
 
 #endif // ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
@@ -79,7 +79,9 @@ public:
 
 private:
     Connection(CString&& machServiceName, WebPushDaemonConnectionConfiguration&&);
+#if PLATFORM(COCOA)
     ~Connection();
+#endif
 
     void newConnectionWasInitialized() const final;
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### ada15a6825207b391c7a11274907fb454ff9826d
<pre>
REGRESSION(314479@main): Crash in WebPushD::Connection::connectionReceivedEvent() due to xpc_object_t ODR violation
<a href="https://bugs.webkit.org/show_bug.cgi?id=316390">https://bugs.webkit.org/show_bug.cgi?id=316390</a>
<a href="https://rdar.apple.com/178728999">rdar://178728999</a>

Reviewed by Cameron McCormack.

NetworkProcess crashes on arm64e with EXC_ARM_PAC_FAIL on the virtual
dispatch to WebPushD::Connection::connectionReceivedEvent() inside the
xpc_connection_set_event_handler lambda in DaemonConnectionCocoa.mm.

Root cause is an ODR violation on xpc_object_t. &lt;wtf/spi/darwin/XPCSPI.h&gt;
ultimately reaches &lt;os/object.h&gt;, which gates OS_OBJECT_USE_OBJC on
__OBJC__:

  - In .mm TUs, OS_OBJECT_USE_OBJC = 1 and xpc_object_t resolves to
    OS_xpc_object* (an Objective-C class).
  - In .cpp TUs, OS_OBJECT_USE_OBJC = 0 and xpc_object_t resolves to
    void*.

Because Daemon::ConnectionToMachService&lt;Traits&gt;::connectionReceivedEvent
takes xpc_object_t in its declaration, and WebPushDaemonConnection.h is
consumed by both a .cpp TU (WebPushDaemonConnection.cpp) and a .mm TU
(DaemonConnectionCocoa.mm), the two TUs disagree on the virtual&apos;s type:

  .cpp:  ...connectionReceivedEventEPv
  .mm:   ...connectionReceivedEventEPU24objcproto13OS_xpc_object8NSObject

On arm64e, vtable function pointers are PAC-signed at vtable-emission
time with a discriminator derived from the function&apos;s mangled name. The
two TUs therefore produce vtables whose slot for connectionReceivedEvent
is signed with different discriminators, while .mm call sites always
expect the ObjC discriminator.

Before 314479@main, WebPushD::Connection had no out-of-line virtual, so
its vtable was emitted linkonce_odr from every TU that needed it; the
linker resolved to the .mm-emitted copy and .mm call sites authenticated
correctly. 314479@main out-of-lined the destructor as a workaround for
<a href="https://rdar.apple.com/176736350">rdar://176736350</a>, making the dtor the key function and forcing a single
strong-external vtable emission from WebPushDaemonConnection.cpp -- the
.cpp TU with the wrong (void*) discriminator. Every .mm call site now
PAC-fails on dispatch.

PCM::Connection is not affected: its key function is the out-of-line
newConnectionWasInitialized(), defined on Cocoa in
PrivateClickMeasurementConnectionCocoa.mm. That TU is already an .mm,
so the vtable already emits with the ObjC discriminator.

Fix by gating the destructor declaration on PLATFORM(COCOA) and moving
its definition from WebPushDaemonConnection.cpp to
WebPushDaemonConnectionCocoa.mm. The destructor remains the key
function, so the vtable is now emitted in a .mm TU where xpc_object_t
resolves to OS_xpc_object*, the slot is signed with the ObjC
discriminator, and .mm call sites authenticate cleanly.
ENABLE_WEB_PUSH_NOTIFICATIONS is Cocoa-only (PlatformEnableCocoa.h), so
gating the destructor on PLATFORM(COCOA) is a no-op for non-Cocoa ports.

* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
(WebKit::WebPushD::Connection::~Connection): Defined here, with a comment
explaining why it must live in a .mm TU.
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp:
Removed the destructor definition.
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h:
Gate the destructor declaration on PLATFORM(COCOA).

Canonical link: <a href="https://commits.webkit.org/314624@main">https://commits.webkit.org/314624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb7a41842a4943d89919ed2231ef6ef47e07f1b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123927 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129586 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110111 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23859 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140927 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178252 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31152 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137947 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137864 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37142 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149251 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103686 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33150 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26116 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39429 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112503 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38825 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4206 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39070 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38968 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->