### PR TITLE
ANGLE: DrawBuffersAnyFormat tests fail with MSAA, RG16, AMD

### DIFF
--- a/Source/ThirdParty/ANGLE/include/platform/autogen/FeaturesMtl_autogen.h
+++ b/Source/ThirdParty/ANGLE/include/platform/autogen/FeaturesMtl_autogen.h
@@ -182,6 +182,12 @@ struct FeaturesMtl : FeatureSetBase
         &members,
     };
 
+    FeatureInfo clearMsaaRg16UnormWithDrawWorkaround = {
+        "clearMsaaRg16UnormWithDrawWorkaround",
+        FeatureCategory::MetalWorkarounds,
+        &members,
+    };
+
     FeatureInfo copyIOSurfaceToNonIOSurfaceForReadOptimization = {
         "copyIOSurfaceToNonIOSurfaceForReadOptimization",
         FeatureCategory::MetalWorkarounds,

--- a/Source/ThirdParty/ANGLE/include/platform/mtl_features.json
+++ b/Source/ThirdParty/ANGLE/include/platform/mtl_features.json
@@ -201,6 +201,16 @@
             "issue": "http://anglebug.com/42265518"
         },
         {
+            "name": "clear_msaa_rg16_unorm_with_draw_workaround",
+            "category": "Workarounds",
+            "description": [
+                "AMD Metal driver silently drops MTLLoadActionClear for MSAA RG16Unorm color ",
+                "attachments at certain attachment indices. Force such clears through a ",
+                "draw-call-based clear path instead of the load-action path."
+            ],
+            "issue": "rdar://178796612"
+        },
+        {
             "name": "copy_IOSurface_to_non_IOSurface_for_read_optimization",
             "category": "Workarounds",
             "description": [

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm
@@ -1266,6 +1266,8 @@ void DisplayMtl::initializeFeatures()
     ANGLE_FEATURE_CONDITION((&mFeatures), writeHelperSampleMask, supportsAppleGPUFamily(1));
 
     ANGLE_FEATURE_CONDITION((&mFeatures), multisampleColorFormatShaderReadWorkaround, isAMD());
+    // At least for Radeon 5500M. See rdar://178796612.
+    ANGLE_FEATURE_CONDITION((&mFeatures), clearMsaaRg16UnormWithDrawWorkaround, isAMD());
     ANGLE_FEATURE_CONDITION((&mFeatures), copyIOSurfaceToNonIOSurfaceForReadOptimization,
                             isIntel() || isAMD());
     ANGLE_FEATURE_CONDITION((&mFeatures), copyTextureToBufferForReadOptimization, isAMD());

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.h
@@ -160,6 +160,9 @@ class FramebufferMtl : public FramebufferImpl
                                 gl::DrawBufferMask clearColorBuffers,
                                 const mtl::ClearRectParams &clearOpts);
 
+    bool needsRG16UnormMSAAClearWorkaround(const ContextMtl *contextMtl,
+                                           gl::DrawBufferMask clearColorBuffers) const;
+
     // Initialize load store options for a render pass's first start (i.e. not render pass resuming
     // from interruptions such as those caused by a conversion compute pass)
     void setLoadStoreActionOnRenderPassFirstStart(mtl::RenderPassAttachmentDesc *attachmentOut,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
@@ -1482,12 +1482,36 @@ angle::Result FramebufferMtl::clearImpl(const gl::Context *context,
     if (clearOpts.clearArea == renderArea &&
         (!clearOpts.clearColor.valid() || allBuffersUnmasked) &&
         (!clearOpts.clearStencil.valid() ||
-         (stencilMask & mtl::kStencilMaskAll) == mtl::kStencilMaskAll))
+         (stencilMask & mtl::kStencilMaskAll) == mtl::kStencilMaskAll) &&
+        !needsRG16UnormMSAAClearWorkaround(contextMtl, clearColorBuffers))
     {
         return clearWithLoadOp(context, clearColorBuffers, clearOpts);
     }
 
     return clearWithDraw(context, clearColorBuffers, clearOpts);
+}
+
+bool FramebufferMtl::needsRG16UnormMSAAClearWorkaround(const ContextMtl *contextMtl,
+                                                       gl::DrawBufferMask clearColorBuffers) const
+{
+    if (!contextMtl->getDisplay()->getFeatures().clearMsaaRg16UnormWithDrawWorkaround.enabled)
+    {
+        return false;
+    }
+    for (size_t i : clearColorBuffers)
+    {
+        if (i >= mColorRenderTargets.size())
+        {
+            break;
+        }
+        const RenderTargetMtl *rt = mColorRenderTargets[i];
+        if (rt && rt->getRenderSamples() > 1 &&
+            rt->getFormat().metalFormat == MTLPixelFormatRG16Unorm)
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 angle::Result FramebufferMtl::invalidateImpl(const gl::Context *context,

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawBuffersTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawBuffersTest.cpp
@@ -1922,19 +1922,24 @@ constexpr GLenum kDrawBuffersAnyFormatMSAAColorFormats[] = {
     GL_RGBX8_ANGLE,
 };
 
+#if ANGLE_PLATFORM_IOS_FAMILY
 constexpr GLint kDrawBuffersAnyFormatMaxTestedSampleCount = 4;
-
-struct DrawBuffersAnyFormatExpectationPerSampleResult
-{
-    GLint sampleCount;                  // 0 = single-sampled
-    GLint firstFailingDrawBufferCount;  // Count where FRAMEBUFFER_UNSUPPORTED starts.
-};
+#else
+constexpr GLint kDrawBuffersAnyFormatMaxTestedSampleCount = 8;
+#endif
 
 struct DrawBuffersAnyFormatExpectation
 {
     const char *deviceNameSubstring;
     GLenum colorFormat;
-    DrawBuffersAnyFormatExpectationPerSampleResult sampleCounts[3];
+    // First draw-buffer count at which the FBO becomes FRAMEBUFFER_UNSUPPORTED.
+    // Single-sampled (samples == 0) and MSAA paths are tracked separately because
+    // MSAA samples multiply the per-pixel byte budget. The MSAA value applies to
+    // every MSAA sample count tested by this suite.
+    //   0 -- FBO is expected FRAMEBUFFER_UNSUPPORTED at every count
+    //   9 -- FBO is expected FRAMEBUFFER_COMPLETE at every count
+    GLint firstFailingDrawBufferCountAliased;
+    GLint firstFailingDrawBufferCountMSAA;
 };
 
 // Per-known device results for framebuffer-completeness for the
@@ -1945,60 +1950,56 @@ struct DrawBuffersAnyFormatExpectation
 // For this (color format, sampleCount), the FBO is expected to
 // become FRAMEBUFFER_UNSUPPORTED at firstFailingDrawBufferCount
 // and remain unsupported for larger counts.
-//
-// firstFailingDrawBufferCount:
-//   0 -- FBO is expected FRAMEBUFFER_UNSUPPORTED at every count
-//   9 -- FBO is expected FRAMEBUFFER_COMPLETE at every count
 constexpr DrawBuffersAnyFormatExpectation kDrawBuffersAnyFormatExpectedFramebufferIncomplete[] = {
 #if ANGLE_PLATFORM_MACOS
     // Force expectations by having one result: all framebuffers are complete.
-    {"Apple", GL_RGBA32F, {{0, 9}, {2, 9}, {4, 9}}},
+    {"", GL_RGBA32F, 9, 9},
 #elif ANGLE_PLATFORM_IOS_FAMILY_SIMULATOR
     // Simulator uses a 32-byte color tile budget but its emulated
     // pixelBytes don't match a real Apple GPU.  Many "small" formats
     // come out oversized.
-    {"Apple iOS simulator GPU", GL_R11F_G11F_B10F, {{0, 5}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_RG32F, {{0, 5}, {2, 0}, {4, 0}}},
-    {"Apple iOS simulator GPU", GL_RG32I, {{0, 5}, {2, 0}, {4, 0}}},
-    {"Apple iOS simulator GPU", GL_RG32UI, {{0, 5}, {2, 0}, {4, 0}}},
-    {"Apple iOS simulator GPU", GL_RGB10_A2, {{0, 5}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_RGB10_A2UI, {{0, 9}, {2, 0}, {4, 0}}},
-    {"Apple iOS simulator GPU", GL_RGB565, {{0, 9}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_RGB5_A1, {{0, 9}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_RGB8, {{0, 9}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_RGB16F, {{0, 5}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_RGBA16F, {{0, 5}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_RGBA16I, {{0, 5}, {2, 0}, {4, 0}}},
-    {"Apple iOS simulator GPU", GL_RGBA16UI, {{0, 5}, {2, 0}, {4, 0}}},
-    {"Apple iOS simulator GPU", GL_RGBA32F, {{0, 3}, {2, 0}, {4, 0}}},
-    {"Apple iOS simulator GPU", GL_RGBA32I, {{0, 3}, {2, 0}, {4, 0}}},
-    {"Apple iOS simulator GPU", GL_RGBA32UI, {{0, 3}, {2, 0}, {4, 0}}},
-    {"Apple iOS simulator GPU", GL_RGBA4, {{0, 9}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_RGBA8, {{0, 9}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_RGBA8_SNORM, {{0, 9}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_RGBA16_EXT, {{0, 5}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_RGBA16_SNORM_EXT, {{0, 5}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_SRGB8_ALPHA8, {{0, 9}, {2, 5}, {4, 5}}},
-    {"Apple iOS simulator GPU", GL_BGRA8_EXT, {{0, 9}, {2, 5}, {4, 5}}},
+    {"Apple iOS simulator GPU", GL_R11F_G11F_B10F, 5, 5},
+    {"Apple iOS simulator GPU", GL_RG32F, 5, 0},
+    {"Apple iOS simulator GPU", GL_RG32I, 5, 0},
+    {"Apple iOS simulator GPU", GL_RG32UI, 5, 0},
+    {"Apple iOS simulator GPU", GL_RGB10_A2, 5, 5},
+    {"Apple iOS simulator GPU", GL_RGB10_A2UI, 9, 0},
+    {"Apple iOS simulator GPU", GL_RGB565, 9, 5},
+    {"Apple iOS simulator GPU", GL_RGB5_A1, 9, 5},
+    {"Apple iOS simulator GPU", GL_RGB8, 9, 5},
+    {"Apple iOS simulator GPU", GL_RGB16F, 5, 5},
+    {"Apple iOS simulator GPU", GL_RGBA16F, 5, 5},
+    {"Apple iOS simulator GPU", GL_RGBA16I, 5, 0},
+    {"Apple iOS simulator GPU", GL_RGBA16UI, 5, 0},
+    {"Apple iOS simulator GPU", GL_RGBA32F, 3, 0},
+    {"Apple iOS simulator GPU", GL_RGBA32I, 3, 0},
+    {"Apple iOS simulator GPU", GL_RGBA32UI, 3, 0},
+    {"Apple iOS simulator GPU", GL_RGBA4, 9, 5},
+    {"Apple iOS simulator GPU", GL_RGBA8, 9, 5},
+    {"Apple iOS simulator GPU", GL_RGBA8_SNORM, 9, 5},
+    {"Apple iOS simulator GPU", GL_RGBA16_EXT, 5, 5},
+    {"Apple iOS simulator GPU", GL_RGBA16_SNORM_EXT, 5, 5},
+    {"Apple iOS simulator GPU", GL_SRGB8_ALPHA8, 9, 5},
+    {"Apple iOS simulator GPU", GL_BGRA8_EXT, 9, 5},
 #elif ANGLE_PLATFORM_IOS_FAMILY
     // Apple A12*, Apple5, 64 bytes of implicit image block size.
-    {"Apple A12", GL_RGBA32F, {{0, 5}, {2, 5}, {4, 5}}},
-    {"Apple A12", GL_RGBA32I, {{0, 5}, {2, 0}, {4, 0}}},
-    {"Apple A12", GL_RGBA32UI, {{0, 5}, {2, 0}, {4, 0}}},
+    {"Apple A12", GL_RGBA32F, 5, 5},
+    {"Apple A12", GL_RGBA32I, 5, 0},
+    {"Apple A12", GL_RGBA32UI, 5, 0},
 
     // Apple A13*, Apple6, 64 bytes of implicit image block size.
-    {"Apple A13", GL_RGBA32F, {{0, 5}, {2, 5}, {4, 5}}},
-    {"Apple A13", GL_RGBA32I, {{0, 5}, {2, 0}, {4, 0}}},
-    {"Apple A13", GL_RGBA32UI, {{0, 5}, {2, 0}, {4, 0}}},
+    {"Apple A13", GL_RGBA32F, 5, 5},
+    {"Apple A13", GL_RGBA32I, 5, 0},
+    {"Apple A13", GL_RGBA32UI, 5, 0},
 
     // Force expect success, Apple7+, 128 bytes of implicit image block size.
-    {"Apple A14", GL_RGBA32F, {{0, 9}, {2, 9}, {4, 9}}},
-    {"Apple A15", GL_RGBA32F, {{0, 9}, {2, 9}, {4, 9}}},
-    {"Apple A16", GL_RGBA32F, {{0, 9}, {2, 9}, {4, 9}}},
-    {"Apple A17", GL_RGBA32F, {{0, 9}, {2, 9}, {4, 9}}},
-    {"Apple A18", GL_RGBA32F, {{0, 9}, {2, 9}, {4, 9}}},
-    {"Apple A19", GL_RGBA32F, {{0, 9}, {2, 9}, {4, 9}}},
-    {"Apple M", GL_RGBA32F, {{0, 9}, {2, 9}, {4, 9}}},
+    {"Apple A14", GL_RGBA32F, 9, 9},
+    {"Apple A15", GL_RGBA32F, 9, 9},
+    {"Apple A16", GL_RGBA32F, 9, 9},
+    {"Apple A17", GL_RGBA32F, 9, 9},
+    {"Apple A18", GL_RGBA32F, 9, 9},
+    {"Apple A19", GL_RGBA32F, 9, 9},
+    {"Apple M", GL_RGBA32F, 9, 9},
 #endif
 };
 
@@ -2606,14 +2607,8 @@ testing::AssertionResult DrawBuffersAnyFormatTestES3::verifyKnownDeviceExpectedF
         {
             continue;
         }
-        for (const DrawBuffersAnyFormatExpectationPerSampleResult &r : e.sampleCounts)
-        {
-            if (r.sampleCount == samples())
-            {
-                expectedFirstFailingBufferCount = r.firstFailingDrawBufferCount;
-                break;
-            }
-        }
+        expectedFirstFailingBufferCount = (samples() == 0) ? e.firstFailingDrawBufferCountAliased
+                                                           : e.firstFailingDrawBufferCountMSAA;
     }
     if (hasExpectation)
     {
@@ -2634,9 +2629,9 @@ testing::AssertionResult DrawBuffersAnyFormatTestES3::verifyKnownDeviceExpectedF
     // ((true)) to log a candidate row to add to the expectations table.
     if (status != GL_FRAMEBUFFER_COMPLETE && ((false)))
     {
-        printf("DrawBuffersAnyFormat incomplete: {\"%s\", %s, {..., {%d, %d}, ...}},\n",
+        printf("DrawBuffersAnyFormat incomplete: {\"%s\", %s, /* %s n=%d */},\n",
                deviceName.c_str(), gl::GLenumToString(gl::GLESEnum::AllEnums, colorFormat()),
-               samples(), numAttachments);
+               samples() == 0 ? "Aliased" : "MSAA", numAttachments);
     }
     return testing::AssertionSuccess();
 }
@@ -2893,5 +2888,21 @@ INSTANTIATE_TEST_SUITE_P(
         testing::ValuesIn(kDrawBuffersAnyFormatMSAAColorFormats),
         testing::ValuesIn(kDrawBuffersAnyFormatDepthStencilFormats),
         testing::Values(false),  // renderbuffers only; ES 3.0 has no MSAA textures
-        testing::Values<GLint>(2, kDrawBuffersAnyFormatMaxTestedSampleCount)),
+        testing::Values<GLint>(2, 4)),
     DrawBuffersAnyFormatVariationsTestPrint);
+
+#if !ANGLE_PLATFORM_IOS_FAMILY
+// List MSAA8 in its own instantiation, so it's easier to understand that it's frequently
+// skipped.
+INSTANTIATE_TEST_SUITE_P(
+    MSAA8,
+    DrawBuffersAnyFormatTestES3,
+    testing::Combine(
+        testing::ValuesIn(::angle::FilterTestParams(kDrawBuffersAnyFormatPlatforms,
+                                                    ArraySize(kDrawBuffersAnyFormatPlatforms))),
+        testing::ValuesIn(kDrawBuffersAnyFormatMSAAColorFormats),
+        testing::ValuesIn(kDrawBuffersAnyFormatDepthStencilFormats),
+        testing::Values(false),  // renderbuffers only; ES 3.0 has no MSAA textures
+        testing::Values<GLint>(kDrawBuffersAnyFormatMaxTestedSampleCount)),
+    DrawBuffersAnyFormatVariationsTestPrint);
+#endif

--- a/Source/ThirdParty/ANGLE/util/autogen/angle_features_autogen.cpp
+++ b/Source/ThirdParty/ANGLE/util/autogen/angle_features_autogen.cpp
@@ -75,6 +75,7 @@ constexpr PackedEnumMap<Feature, const char *> kFeatureNames = {{
     {Feature::ClampPointSize, "clampPointSize"},
     {Feature::ClBestUniformFitWGS, "clBestUniformFitWGS"},
     {Feature::ClDumpVkSpirv, "clDumpVkSpirv"},
+    {Feature::ClearMsaaRg16UnormWithDrawWorkaround, "clearMsaaRg16UnormWithDrawWorkaround"},
     {Feature::ClearsWithGapsNeedFlush, "clearsWithGapsNeedFlush"},
     {Feature::ClipCullDistanceBrokenWithPassthroughShaders, "clipCullDistanceBrokenWithPassthroughShaders"},
     {Feature::ClipSrcRegionForBlitFramebuffer, "clipSrcRegionForBlitFramebuffer"},

--- a/Source/ThirdParty/ANGLE/util/autogen/angle_features_autogen.h
+++ b/Source/ThirdParty/ANGLE/util/autogen/angle_features_autogen.h
@@ -75,6 +75,7 @@ enum class Feature
     ClampPointSize,
     ClBestUniformFitWGS,
     ClDumpVkSpirv,
+    ClearMsaaRg16UnormWithDrawWorkaround,
     ClearsWithGapsNeedFlush,
     ClipCullDistanceBrokenWithPassthroughShaders,
     ClipSrcRegionForBlitFramebuffer,


### PR DESCRIPTION
#### 4e06d306cde23dd84205b20a52e9e6c79cf5f169
<pre>
ANGLE: DrawBuffersAnyFormat tests fail with MSAA, RG16, AMD
<a href="https://bugs.webkit.org/show_bug.cgi?id=316392">https://bugs.webkit.org/show_bug.cgi?id=316392</a>
<a href="https://rdar.apple.com/178807945">rdar://178807945</a>

Reviewed by Dan Glastonbury.

Appears that AMD, at least Radeon 5500M Metal driver has problems with
RG16Unorm pixel format and multisampling. The render pass clear operation
does not clear all the attachments.

Workaround by clearing with a draw.
Change the test to test also 8 sample variants, as AMD/Intel support those.
Change the test to assume all MSAA variants have the same completeness
limit, as they do.

Fixes:
MSAA/DrawBuffersAnyFormatTestES3.ClearIterativeAttachmentCount/ES3_Metal__GL_RG16_EXT_*_MSAA*

* Source/ThirdParty/ANGLE/include/platform/autogen/FeaturesMtl_autogen.h:
* Source/ThirdParty/ANGLE/include/platform/mtl_features.json:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm:
(rx::DisplayMtl::initializeFeatures):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm:
(rx::FramebufferMtl::clearImpl):
(rx::FramebufferMtl::needsRG16UnormMSAAClearWorkaround const):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawBuffersTest.cpp:
* Source/ThirdParty/ANGLE/util/autogen/angle_features_autogen.cpp:
* Source/ThirdParty/ANGLE/util/autogen/angle_features_autogen.h:

Canonical link: <a href="https://commits.webkit.org/315009@main">https://commits.webkit.org/315009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a7bcf495fb68a13800811a2b33c619d4ff1eea5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176882 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41334 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36d7f9c2-afb5-43ec-90a2-3410aec169d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170783 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/33022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111084 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68a9fdfb-f0b6-4e1a-83e9-fdce0fd5d456) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25614 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179424 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30222 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41393 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138870 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37394 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42081 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105306 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34145 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40585 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39982 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5278 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40233 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->