### PR TITLE
[WPE] Add documentation summaries for WPE Platform implementation classes

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
@@ -52,6 +52,16 @@
 /**
  * WPEDisplayDRM:
  *
+ * A [class@WPEPlatform.Display] implementation for DRM/KMS.
+ *
+ * [class@DisplayDRM] is the built-in [class@WPEPlatform.Display]
+ * implementation that drives the screen directly through DRM/KMS, without a
+ * windowing system. Use [ctor@DisplayDRM.new] to create a new instance and
+ * [method@DisplayDRM.connect] to connect to a particular DRM device by name.
+ * [method@DisplayDRM.get_device] gives access to the underlying `gbm_device`,
+ * while [method@DisplayDRM.supports_atomic] and
+ * [method@DisplayDRM.supports_modifiers] report the capabilities of the
+ * device.
  */
 struct _WPEDisplayDRMPrivate {
     std::unique_ptr<WPE::DRM::Session> session;

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp
@@ -37,6 +37,11 @@
 /**
  * WPEScreenDRM:
  *
+ * A [class@WPEPlatform.Screen] implementation for DRM/KMS.
+ *
+ * [class@ScreenDRM] is the [class@WPEPlatform.Screen] implementation used by
+ * [class@DisplayDRM]. Each instance represents a DRM connector and its
+ * associated mode.
  */
 struct _WPEScreenDRMPrivate {
     std::unique_ptr<WPE::DRM::Crtc> crtc;

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp
@@ -33,6 +33,11 @@
 /**
  * WPEToplevelDRM:
  *
+ * A [class@WPEPlatform.Toplevel] implementation for DRM/KMS.
+ *
+ * [class@ToplevelDRM] is the [class@WPEPlatform.Toplevel] implementation used
+ * by [class@DisplayDRM]. It is always fullscreen, covering the whole screen
+ * managed by the DRM device.
  */
 struct _WPEToplevelDRMPrivate {
 };

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
@@ -52,6 +52,11 @@ enum class UpdateFlags : uint8_t {
 /**
  * WPEViewDRM:
  *
+ * A [class@WPEPlatform.View] implementation for DRM/KMS.
+ *
+ * [class@ViewDRM] is the [class@WPEPlatform.View] implementation used by
+ * [class@DisplayDRM]. It displays the web view contents by scanning out
+ * buffers directly to the DRM device.
  */
 struct _WPEViewDRMPrivate {
     Seconds refreshDuration;

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
@@ -52,6 +52,14 @@
 /**
  * WPEDisplayHeadless:
  *
+ * A headless [class@WPEPlatform.Display] implementation.
+ *
+ * [class@DisplayHeadless] is the built-in [class@WPEPlatform.Display]
+ * implementation that does not connect to any native display. It renders to
+ * offscreen buffers and is useful for testing or for running web content
+ * without showing it on screen. Use [ctor@DisplayHeadless.new] to create a
+ * new instance, or [ctor@DisplayHeadless.new_for_device] to back it by a
+ * specific DRM device.
  */
 struct _WPEDisplayHeadlessPrivate {
     std::optional<GRefPtr<WPEDRMDevice>> drmDevice;

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp
@@ -31,6 +31,11 @@
 /**
  * WPEToplevelHeadless:
  *
+ * A headless [class@WPEPlatform.Toplevel] implementation.
+ *
+ * [class@ToplevelHeadless] is the [class@WPEPlatform.Toplevel] implementation
+ * used by [class@DisplayHeadless]. It has no native window and only tracks its
+ * state, since there is no compositor or display to manage it.
  */
 struct _WPEToplevelHeadlessPrivate {
 };

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
@@ -34,6 +34,12 @@
 /**
  * WPEViewHeadless:
  *
+ * A headless [class@WPEPlatform.View] implementation.
+ *
+ * [class@ViewHeadless] is the [class@WPEPlatform.View] implementation used by
+ * [class@DisplayHeadless]. It does not display buffers on any native surface;
+ * instead it notifies that each buffer has been rendered, driving the
+ * rendering loop without producing visible output.
  */
 struct _WPEViewHeadlessPrivate {
     GRefPtr<WPEBuffer> pendingBuffer;

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWayland.cpp
@@ -40,6 +40,11 @@
 /**
  * WPEClipboardWayland:
  *
+ * A [class@WPEPlatform.Clipboard] implementation for Wayland.
+ *
+ * [class@ClipboardWayland] is the [class@WPEPlatform.Clipboard] implementation
+ * used by [class@DisplayWayland]. It integrates with the Wayland data device
+ * protocol to share clipboard contents with other Wayland clients.
  */
 struct _WPEClipboardWaylandPrivate {
     struct wl_data_device* wlDataDevice;

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -73,6 +73,16 @@
 /**
  * WPEDisplayWayland:
  *
+ * A [class@WPEPlatform.Display] implementation for Wayland.
+ *
+ * [class@DisplayWayland] is the built-in [class@WPEPlatform.Display]
+ * implementation for the Wayland windowing system. Use
+ * [ctor@DisplayWayland.new] to create a new instance and
+ * [method@DisplayWayland.connect] to connect to a particular Wayland display
+ * by name. The underlying Wayland objects can be accessed with
+ * [method@DisplayWayland.get_wl_display],
+ * [method@DisplayWayland.get_wl_compositor] and
+ * [method@DisplayWayland.get_wl_shm].
  */
 struct _WPEDisplayWaylandPrivate {
     struct wl_display* wlDisplay;

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEScreenWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEScreenWayland.cpp
@@ -31,6 +31,11 @@
 /**
  * WPEScreenWayland:
  *
+ * A [class@WPEPlatform.Screen] implementation for Wayland.
+ *
+ * [class@ScreenWayland] is the [class@WPEPlatform.Screen] implementation used
+ * by [class@DisplayWayland]. Each instance represents a `wl_output`, which can
+ * be accessed with [method@ScreenWayland.get_wl_output].
  */
 struct _WPEScreenWaylandPrivate {
     struct wl_output* wlOutput;

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
@@ -221,6 +221,11 @@ struct DMABufFeedback {
 /**
  * WPEToplevelWayland:
  *
+ * A [class@WPEPlatform.Toplevel] implementation for Wayland.
+ *
+ * [class@ToplevelWayland] is the [class@WPEPlatform.Toplevel] implementation
+ * used by [class@DisplayWayland]. It is backed by an `xdg_toplevel` and its
+ * Wayland surface can be accessed with [method@ToplevelWayland.get_wl_surface].
  */
 struct _WPEToplevelWaylandPrivate {
     struct wl_surface* wlSurface;

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -86,6 +86,11 @@ private:
 /**
  * WPEViewWayland:
  *
+ * A [class@WPEPlatform.View] implementation for Wayland.
+ *
+ * [class@ViewWayland] is the [class@WPEPlatform.View] implementation used by
+ * [class@DisplayWayland]. It renders the web view contents into a Wayland
+ * surface, which can be accessed with [method@ViewWayland.get_wl_surface].
  */
 struct _WPEViewWaylandPrivate {
     GRefPtr<WPEBuffer> buffer;


### PR DESCRIPTION
#### 0f783ccc0a9e0bbd876828d5d30aff0cc3f08ef5
<pre>
[WPE] Add documentation summaries for WPE Platform implementation classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=316400">https://bugs.webkit.org/show_bug.cgi?id=316400</a>

Reviewed by Carlos Garcia Campos.

Cross-linking will need to be reviewed later.

* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp:
* Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp:
* Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp:
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
* Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp:
* Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp:
* Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWayland.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEScreenWayland.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:

Canonical link: <a href="https://commits.webkit.org/314631@main">https://commits.webkit.org/314631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb2737f89ddb8c4378104b18802302240e308615

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123939 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40180 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129599 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91271 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110124 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29671 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23871 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178264 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31164 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137959 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137876 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149263 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103706 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25369 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33163 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26128 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39441 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112515 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38837 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4218 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39082 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38980 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->