### PR TITLE
REGRESSION: Layout Test webgl/many-contexts.html is a flaky timeout on Mojave+

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1370,8 +1370,6 @@ fast/text/design-system-ui-16.html [ Pass ]
 # See bug 232916; this test can't pass as we do not support mid-stream resolution change.
 webkit.org/b/231084 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/resize-during-playback.html [ Skip ]
 
-webkit.org/b/198867 webgl/many-contexts.html [ Skip ]
-
 webkit.org/b/203171 inspector/layers/layers-for-node.html [ Pass Failure ]
 
 webkit.org/b/203357 [ Debug ] imported/w3c/web-platform-tests/css/css-transitions/event-dispatch.tentative.html [ Pass Failure ]


### PR DESCRIPTION
#### 80e617e1181ff9f168fbddc18be7ed5f6364b3d0
<pre>
REGRESSION: Layout Test webgl/many-contexts.html is a flaky timeout on Mojave+
<a href="https://bugs.webkit.org/show_bug.cgi?id=198867">https://bugs.webkit.org/show_bug.cgi?id=198867</a>
<a href="https://rdar.apple.com/51810342">rdar://51810342</a>

Reviewed by Dan Glastonbury.

Re-enable the test, it may have been old OS issue that
caused the test to be slow.

* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/314793@main">https://commits.webkit.org/314793@main</a>
</pre>
