### PR TITLE
[WPE] Touch-driven scrolling should not wait for the main-thread touch ack on pages with no touch handlers

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9357,6 +9357,9 @@ void Document::didAddTouchEventHandler(Node& handler)
         return;
     }
 
+    if (RefPtr page = this->page())
+        page->chrome().client().touchEventHandlersChanged(!m_touchEventTargets.isEmptyIgnoringNullReferences());
+
     if (!shouldUseTouchEventRegions())
         return;
 
@@ -9374,6 +9377,11 @@ void Document::didRemoveTouchEventHandler(Node& handler, EventHandlerRemoval rem
 
     if (auto* parent = parentDocument())
         parent->didRemoveTouchEventHandler(*this, removalMode);
+
+    if (!parentDocument()) {
+        if (RefPtr page = this->page())
+            page->chrome().client().touchEventHandlersChanged(!m_touchEventTargets.isEmptyIgnoringNullReferences());
+    }
 
     if (!shouldUseTouchEventRegions())
         return;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -605,6 +605,7 @@ public:
     virtual std::optional<ScrollbarOverlayStyle> preferredScrollbarOverlayStyle() { return std::nullopt; }
 
     virtual void wheelEventHandlersChanged(bool hasHandlers) = 0;
+    virtual void touchEventHandlersChanged(bool hasHandlers) { UNUSED_PARAM(hasHandlers); }
         
     virtual bool isSVGImageChromeClient() const { return false; }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4896,10 +4896,15 @@ void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent
     }
 #else
     UNUSED_PARAM(touchStartEvent);
-    internals().touchEventTracking.touchForceChangedTracking = TrackingType::Synchronous;
-    internals().touchEventTracking.touchStartTracking = TrackingType::Synchronous;
-    internals().touchEventTracking.touchMoveTracking = TrackingType::Synchronous;
-    internals().touchEventTracking.touchEndTracking = TrackingType::Synchronous;
+#if ENABLE(WPE_PLATFORM)
+    auto trackingType = m_hasActiveTouchEventHandlers ? TrackingType::Synchronous : TrackingType::NotTracking;
+#else
+    auto trackingType = TrackingType::Synchronous;
+#endif
+    internals().touchEventTracking.touchForceChangedTracking = trackingType;
+    internals().touchEventTracking.touchStartTracking = trackingType;
+    internals().touchEventTracking.touchMoveTracking = trackingType;
+    internals().touchEventTracking.touchEndTracking = trackingType;
 #endif // PLATFORM(COCOA)
 }
 
@@ -5164,8 +5169,17 @@ void WebPageProxy::handleTouchEvent(IPC::Connection* connection, const NativeWeb
 
     updateTouchEventTracking(event);
 
-    if (touchEventTrackingType(event) == TrackingType::NotTracking)
+    if (touchEventTrackingType(event) == TrackingType::NotTracking) {
+#if ENABLE(WPE_PLATFORM)
+        if (RefPtr pageClient = this->pageClient())
+            pageClient->doneWithTouchEvent(event, false);
+        if (event.allTouchPointsAreReleased()) {
+            internals().touchEventTracking.reset();
+            didReleaseAllTouchPoints();
+        }
+#endif
         return;
+    }
 
     // If the page is suspended, which should be the case during panning, pinching
     // and animation on the page itself (kinetic scrolling, tap to zoom) etc, then
@@ -10679,6 +10693,11 @@ void WebPageProxy::setHasActiveAnimatedScrolls(bool isRunning)
 #if HAVE(DISPLAY_LINK)
     updateDisplayLinkFrequency();
 #endif
+}
+
+void WebPageProxy::setHasActiveTouchEventHandlers(bool hasHandlers)
+{
+    m_hasActiveTouchEventHandlers = hasHandlers;
 }
 
 #if USE(COORDINATED_GRAPHICS) && HAVE(DISPLAY_LINK)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1090,6 +1090,7 @@ public:
     void setNeedsScrollGeometryUpdates(bool);
 
     void setHasActiveAnimatedScrolls(bool isRunning);
+    void setHasActiveTouchEventHandlers(bool hasHandlers);
 #if USE(COORDINATED_GRAPHICS) && HAVE(DISPLAY_LINK)
     void setHasActiveAnimatedScrollsForAsyncScrolling(DisplayLinkObserverID, bool isRunning);
 #endif
@@ -3938,6 +3939,7 @@ private:
     bool m_isPerformingDOMPrintOperation { false };
 
     bool m_hasUpdatedRenderingAfterDidCommitLoad { true };
+    bool m_hasActiveTouchEventHandlers { false };
 
     bool m_hasActiveAnimatedScroll { false };
     bool m_registeredForFullSpeedUpdates { false };

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -72,6 +72,7 @@ messages -> WebPageProxy {
     RunBeforeUnloadConfirmPanel(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, String message) -> (bool shouldClose) Synchronous
     PageDidScroll(WebCore::IntPoint scrollOffset)
     SetHasActiveAnimatedScrolls(bool hasActiveAnimatedScrolls)
+    SetHasActiveTouchEventHandlers(bool hasHandlers)
 #if USE(COORDINATED_GRAPHICS) && HAVE(DISPLAY_LINK)
     SetHasActiveAnimatedScrollsForAsyncScrolling(WebKit::DisplayLinkObserverID observerID, bool hasActiveAnimatedScrolls)
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1765,6 +1765,12 @@ void WebChromeClient::wheelEventHandlersChanged(bool hasHandlers)
         page->wheelEventHandlersChanged(hasHandlers);
 }
 
+void WebChromeClient::touchEventHandlersChanged(bool hasHandlers)
+{
+    if (RefPtr page = m_page.get())
+        page->touchEventHandlersChanged(hasHandlers);
+}
+
 void WebChromeClient::enableSuddenTermination()
 {
     if (RefPtr page = m_page.get())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -399,6 +399,7 @@ private:
 #endif
     
     void wheelEventHandlersChanged(bool) final;
+    void touchEventHandlersChanged(bool) final;
 
     void didAddHeaderLayer(WebCore::GraphicsLayer&) final;
     void didAddFooterLayer(WebCore::GraphicsLayer&) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7305,6 +7305,15 @@ void WebPage::wheelEventHandlersChanged(bool hasHandlers)
     recomputeShortCircuitHorizontalWheelEventsState();
 }
 
+void WebPage::touchEventHandlersChanged(bool hasHandlers)
+{
+    if (m_hasTouchEventHandlers == hasHandlers)
+        return;
+
+    m_hasTouchEventHandlers = hasHandlers;
+    send(Messages::WebPageProxy::SetHasActiveTouchEventHandlers(hasHandlers));
+}
+
 static bool hasEnabledHorizontalScrollbar(ScrollableArea* scrollableArea)
 {
     RefPtr scrollbar = scrollableArea->horizontalScrollbar();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1530,6 +1530,7 @@ public:
     std::pair<WebCore::HandleUserInputEventResult, OptionSet<WebCore::EventHandling>> wheelEvent(const WebCore::FrameIdentifier&, const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>);
 
     void wheelEventHandlersChanged(bool);
+    void touchEventHandlersChanged(bool);
     void recomputeShortCircuitHorizontalWheelEventsState();
     bool pageContainsAnyHorizontalScrollbars() const;
 
@@ -3045,6 +3046,7 @@ private:
     WebCore::RectEdges<bool> m_cachedMainFramePinnedState { true, true, true, true };
     bool m_canShortCircuitHorizontalWheelEvents { true };
     bool m_hasWheelEventHandlers { false };
+    bool m_hasTouchEventHandlers { false };
 
     unsigned m_cachedPageCount { 0 };
 


### PR DESCRIPTION
#### 29e784b40f44dfe5f13d8e8be387d80286975e3e
<pre>
[WPE] Touch-driven scrolling should not wait for the main-thread touch ack on pages with no touch handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=316398">https://bugs.webkit.org/show_bug.cgi?id=316398</a>

Reviewed by NOBODY (OOPS!).

On WPE the scroll gesture synthesized from touch input is driven from
PageClientImpl::doneWithTouchEvent(), i.e. only after the web process has
acknowledged the touch event. Because WPE has no per-point touch event regions,
WebPageProxy::updateTouchEventTracking() unconditionally tracks every touch as
TrackingType::Synchronous, so every touch is sent to the web process and the
gesture waits for the reply even when the page has no touch handlers. When the
web process main thread is busy (e.g. a long-running scroll handler) the acks are
delayed, the synthesized wheel events arrive in bursts, and dragging instead of
scrolling smoothly.

Add a page-level has-touch event handlers signal, and use it on WPE to track
touch synchronously only when the page actually has touch handlers. When it does
not, leave the touch NotTracking and drive the gesture directly on touch arrival
in WebPageProxy::handleTouchEvent(), so scrolling is no longer waiting on the
main-thread ack. Pages that do have touch handlers keep the existing synchronous,
so preventDefault() is still honoured.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::didAddTouchEventHandler):
(WebCore::Document::didRemoveTouchEventHandler):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::touchEventHandlersChanged):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateTouchEventTracking):
(WebKit::WebPageProxy::handleTouchEvent):
(WebKit::WebPageProxy::setHasActiveTouchEventHandlers):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::touchEventHandlersChanged):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::touchEventHandlersChanged):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29e784b40f44dfe5f13d8e8be387d80286975e3e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123946 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40187 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129608 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91278 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30977 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29678 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23878 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178271 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31171 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137968 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40249 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33825 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137885 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149272 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103713 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33171 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26137 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112522 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38844 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4227 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->