### PR TITLE
[WPE] Add documentation to the enums of the new platform API

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -89,8 +89,9 @@ struct _WPEDisplayClass
  * WPEDisplayError:
  * @WPE_DISPLAY_ERROR_NOT_SUPPORTED: Operation not supported
  * @WPE_DISPLAY_ERROR_CONNECTION_FAILED: Failed to connect to the native system
+ * @WPE_DISPLAY_ERROR_CONNECTION_LOST: The connection to the native system was lost
  *
- * #WPEDisplay errors
+ * [class@Display] errors.
  */
 typedef enum {
     WPE_DISPLAY_ERROR_NOT_SUPPORTED,

--- a/Source/WebKit/WPEPlatform/wpe/WPEEvent.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEEvent.h
@@ -42,21 +42,21 @@ typedef struct _WPEEvent WPEEvent;
 
 /**
  * WPEEventType:
- * @WPE_EVENT_NONE:
- * @WPE_EVENT_POINTER_DOWN:
- * @WPE_EVENT_POINTER_UP:
- * @WPE_EVENT_POINTER_MOVE:
- * @WPE_EVENT_POINTER_ENTER:
- * @WPE_EVENT_POINTER_LEAVE:
- * @WPE_EVENT_SCROLL:
- * @WPE_EVENT_KEYBOARD_KEY_DOWN:
- * @WPE_EVENT_KEYBOARD_KEY_UP:
- * @WPE_EVENT_TOUCH_DOWN:
- * @WPE_EVENT_TOUCH_UP:
- * @WPE_EVENT_TOUCH_MOVE:
- * @WPE_EVENT_TOUCH_CANCEL:
+ * @WPE_EVENT_NONE: no event.
+ * @WPE_EVENT_POINTER_DOWN: a pointer button was pressed.
+ * @WPE_EVENT_POINTER_UP: a pointer button was released.
+ * @WPE_EVENT_POINTER_MOVE: the pointer moved.
+ * @WPE_EVENT_POINTER_ENTER: the pointer entered the view.
+ * @WPE_EVENT_POINTER_LEAVE: the pointer left the view.
+ * @WPE_EVENT_SCROLL: the pointer scroll (axis) was operated.
+ * @WPE_EVENT_KEYBOARD_KEY_DOWN: a keyboard key was pressed.
+ * @WPE_EVENT_KEYBOARD_KEY_UP: a keyboard key was released.
+ * @WPE_EVENT_TOUCH_DOWN: a new touch point appeared.
+ * @WPE_EVENT_TOUCH_UP: a touch point was removed.
+ * @WPE_EVENT_TOUCH_MOVE: a touch point moved.
+ * @WPE_EVENT_TOUCH_CANCEL: a touch point was cancelled.
  *
- * The type of a #WPEEvent
+ * The type of a [struct@Event].
  */
 typedef enum {
     WPE_EVENT_NONE,
@@ -80,12 +80,13 @@ typedef enum {
 
 /**
  * WPEInputSource:
- * @WPE_INPUT_SOURCE_MOUSE:
- * @WPE_INPUT_SOURCE_PEN:
- * @WPE_INPUT_SOURCE_KEYBOARD:
- * @WPE_INPUT_SOURCE_TOUCHSCREEN:
- * @WPE_INPUT_SOURCE_TOUCHPAD:
- * @WPE_INPUT_SOURCE_TRACKPOINT:
+ * @WPE_INPUT_SOURCE_MOUSE: the event came from a mouse.
+ * @WPE_INPUT_SOURCE_PEN: the event came from a pen or stylus.
+ * @WPE_INPUT_SOURCE_KEYBOARD: the event came from a keyboard.
+ * @WPE_INPUT_SOURCE_TOUCHSCREEN: the event came from a touchscreen.
+ * @WPE_INPUT_SOURCE_TOUCHPAD: the event came from a touchpad.
+ * @WPE_INPUT_SOURCE_TRACKPOINT: the event came from a trackpoint.
+ * @WPE_INPUT_SOURCE_TABLET_PAD: the event came from a tablet pad.
  *
  * The type of a device input source.
  */

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepad.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepad.h
@@ -55,25 +55,26 @@ struct _WPEGamepadClass
 
 /**
  * WPEGamepadButton:
- * @WPE_GAMEPAD_BUTTON_RIGHT_CLUSTER_BOTTOM:
- * @WPE_GAMEPAD_BUTTON_RIGHT_CLUSTER_RIGHT:
- * @WPE_GAMEPAD_BUTTON_RIGHT_CLUSTER_LEFT:
- * @WPE_GAMEPAD_BUTTON_RIGHT_CLUSTER_TOP:
- * @WPE_GAMEPAD_BUTTON_LEFT_SHOULDER_FRONT:
- * @WPE_GAMEPAD_BUTTON_RIGHT_SHOULDER_FRONT:
- * @WPE_GAMEPAD_BUTTON_LEFT_SHOULDER_BACK:
- * @WPE_GAMEPAD_BUTTON_RIGHT_SHOULDER_BACK:
- * @WPE_GAMEPAD_BUTTON_CENTER_CLUSTER_LEFT:
- * @WPE_GAMEPAD_BUTTON_CENTER_CLUSTER_RIGHT:
- * @WPE_GAMEPAD_BUTTON_LEFT_THUMB:
- * @WPE_GAMEPAD_BUTTON_RIGHT_THUMB:
- * @WPE_GAMEPAD_BUTTON_LEFT_CLUSTER_TOP:
- * @WPE_GAMEPAD_BUTTON_LEFT_CLUSTER_BOTTOM:
- * @WPE_GAMEPAD_BUTTON_LEFT_CLUSTER_LEFT:
- * @WPE_GAMEPAD_BUTTON_LEFT_CLUSTER_RIGHT:
- * @WPE_GAMEPAD_BUTTON_CENTER_CLUSTER_CENTER:
+ * @WPE_GAMEPAD_BUTTON_RIGHT_CLUSTER_BOTTOM: bottom button in the right cluster.
+ * @WPE_GAMEPAD_BUTTON_RIGHT_CLUSTER_RIGHT: right button in the right cluster.
+ * @WPE_GAMEPAD_BUTTON_RIGHT_CLUSTER_LEFT: left button in the right cluster.
+ * @WPE_GAMEPAD_BUTTON_RIGHT_CLUSTER_TOP: top button in the right cluster.
+ * @WPE_GAMEPAD_BUTTON_LEFT_SHOULDER_FRONT: top left front button.
+ * @WPE_GAMEPAD_BUTTON_RIGHT_SHOULDER_FRONT: top right front button.
+ * @WPE_GAMEPAD_BUTTON_LEFT_SHOULDER_BACK: bottom left front button.
+ * @WPE_GAMEPAD_BUTTON_RIGHT_SHOULDER_BACK: bottom right front button.
+ * @WPE_GAMEPAD_BUTTON_CENTER_CLUSTER_LEFT: left button in the center cluster.
+ * @WPE_GAMEPAD_BUTTON_CENTER_CLUSTER_RIGHT: right button in the center cluster.
+ * @WPE_GAMEPAD_BUTTON_LEFT_THUMB: left stick pressed button.
+ * @WPE_GAMEPAD_BUTTON_RIGHT_THUMB: right stick pressed button.
+ * @WPE_GAMEPAD_BUTTON_LEFT_CLUSTER_TOP: top button in the left cluster.
+ * @WPE_GAMEPAD_BUTTON_LEFT_CLUSTER_BOTTOM: bottom button in the left cluster.
+ * @WPE_GAMEPAD_BUTTON_LEFT_CLUSTER_LEFT: left button in the left cluster.
+ * @WPE_GAMEPAD_BUTTON_LEFT_CLUSTER_RIGHT: right button in the left cluster.
+ * @WPE_GAMEPAD_BUTTON_CENTER_CLUSTER_CENTER: center button in the center cluster.
  *
- * Available buttons in a #WPEGamepad
+ * Available buttons in a [class@Gamepad], following the W3C standard gamepad
+ * mapping.
  */
 typedef enum {
     WPE_GAMEPAD_BUTTON_RIGHT_CLUSTER_BOTTOM,
@@ -97,12 +98,13 @@ typedef enum {
 
 /**
  * WPEGamepadAxis:
- * @WPE_GAMEPAD_AXIS_LEFT_X:
- * @WPE_GAMEPAD_AXIS_LEFT_Y:
- * @WPE_GAMEPAD_AXIS_RIGHT_X:
- * @WPE_GAMEPAD_AXIS_RIGHT_Y:
+ * @WPE_GAMEPAD_AXIS_LEFT_X: horizontal axis for the left stick (negative left/positive right).
+ * @WPE_GAMEPAD_AXIS_LEFT_Y: vertical axis for the left stick (negative up/positive down).
+ * @WPE_GAMEPAD_AXIS_RIGHT_X: horizontal axis for the right stick (negative left/positive right).
+ * @WPE_GAMEPAD_AXIS_RIGHT_Y: vertical axis for the right stick (negative up/positive down).
  *
- * Available axis in a #WPEGamepad
+ * Available axes in a [class@Gamepad], following the W3C standard gamepad
+ * mapping.
  */
 typedef enum {
     WPE_GAMEPAD_AXIS_LEFT_X,

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.h
@@ -41,7 +41,7 @@ G_BEGIN_DECLS
  * @WPE_SETTINGS_ERROR_ALREADY_REGISTERED: Key has already been registered
  * @WPE_SETTINGS_ERROR_INVALID_VALUE: Failed to parse a value from a keyfile
  *
- * #WPESettings errors
+ * [class@Settings] errors.
  */
 typedef enum {
     WPE_SETTINGS_ERROR_INCORRECT_TYPE,
@@ -100,10 +100,12 @@ WPE_API GQuark wpe_settings_error_quark(void);
 
 /**
  * WPESettingsHintingStyle:
- * @WPE_SETTINGS_HINTING_STYLE_NONE
- * @WPE_SETTINGS_HINTING_STYLE_SLIGHT
- * @WPE_SETTINGS_HINTING_STYLE_MEDIUM
- * @WPE_SETTINGS_HINTING_STYLE_FULL
+ * @WPE_SETTINGS_HINTING_STYLE_NONE: do not apply font hinting.
+ * @WPE_SETTINGS_HINTING_STYLE_SLIGHT: apply a small amount of font hinting.
+ * @WPE_SETTINGS_HINTING_STYLE_MEDIUM: apply a moderate amount of font hinting.
+ * @WPE_SETTINGS_HINTING_STYLE_FULL: apply the maximum amount of font hinting.
+ *
+ * The style of hinting to apply to fonts.
  */
 typedef enum {
     WPE_SETTINGS_HINTING_STYLE_NONE,
@@ -125,10 +127,13 @@ typedef enum {
 
 /**
  * WPESettingsSubpixelLayout:
- * @WPE_SETTINGS_SUBPIXEL_LAYOUT_RGB
- * @WPE_SETTINGS_SUBPIXEL_LAYOUT_BGR
- * @WPE_SETTINGS_SUBPIXEL_LAYOUT_VRGB
- * @WPE_SETTINGS_SUBPIXEL_LAYOUT_VBGR
+ * @WPE_SETTINGS_SUBPIXEL_LAYOUT_RGB: horizontal subpixels ordered red, green, blue.
+ * @WPE_SETTINGS_SUBPIXEL_LAYOUT_BGR: horizontal subpixels ordered blue, green, red.
+ * @WPE_SETTINGS_SUBPIXEL_LAYOUT_VRGB: vertical subpixels ordered red, green, blue.
+ * @WPE_SETTINGS_SUBPIXEL_LAYOUT_VBGR: vertical subpixels ordered blue, green, red.
+ *
+ * The order of the subpixels that compose a pixel, used for subpixel font
+ * rendering.
  */
 typedef enum {
     WPE_SETTINGS_SUBPIXEL_LAYOUT_RGB,


### PR DESCRIPTION
#### faa76e244ce08dd0edd1d16e74ab6769d2828407
<pre>
[WPE] Add documentation to the enums of the new platform API
<a href="https://bugs.webkit.org/show_bug.cgi?id=316403">https://bugs.webkit.org/show_bug.cgi?id=316403</a>

Reviewed by Carlos Garcia Campos.

Also normalize the references to use the gi-docgen format.

* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:
* Source/WebKit/WPEPlatform/wpe/WPEEvent.h:
* Source/WebKit/WPEPlatform/wpe/WPEGamepad.h:
* Source/WebKit/WPEPlatform/wpe/WPESettings.h:

Canonical link: <a href="https://commits.webkit.org/314630@main">https://commits.webkit.org/314630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bfb4cec98e7889f6bfd3e09aba6afaf548c5b1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123948 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40189 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/129607 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110132 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23880 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140947 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178273 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31173 "Found 8 new failures in wtf/StdLibExtras.h, Modules/streams/ReadableStreamBYOBReader.cpp, rendering/StyledMarkedText.cpp, testing/Internals.cpp, rendering/RenderFlexibleBox.h, css/parser/CSSParserTokenRange.cpp, rendering/TextDecorationPainter.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29180 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/137967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40251 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137884 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40939 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149271 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103717 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25368 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33170 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39450 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112524 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38846 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4226 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39091 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->