### PR TITLE
`<select>` Incorrectly displayed when all options deleted while popup menu is activated

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-options-removed-while-popup-open-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-options-removed-while-popup-open-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Select popup closes when all options are removed while popup is open
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-options-removed-while-popup-open.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-options-removed-while-popup-open.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>Select popup should close when there is no option</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<select id="sel">
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+</select>
+
+<script>
+promise_test(async t => {
+    const sel = document.getElementById("sel");
+
+    await test_driver.bless("open select popup");
+    sel.showPicker();
+    assert_true(sel.matches(":open"), "select should be open after showPicker");
+
+    sel.options.length = 0;
+    assert_false(sel.matches(":open"), "select popup should close when all options are removed");
+}, "Select popup closes when all options are removed while popup is open");
+</script>

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -739,6 +739,15 @@ void HTMLSelectElement::childrenChanged(const ChildChange& change)
     updateValidity();
     m_lastOnChangeSelection.clear();
 
+    if (listItems().isEmpty()) {
+        if (usesBaseAppearancePicker())
+            hidePickerPopoverElement();
+#if !PLATFORM(IOS_FAMILY)
+        else if (m_popupIsVisible)
+            hidePopup();
+#endif
+    }
+
     HTMLFormControlElement::childrenChanged(change);
 
     invalidateButtonText();


### PR DESCRIPTION
#### 993226ad5675e4891e79ddd81ed688ef351c4df6
<pre>
`&lt;select&gt;` Incorrectly displayed when all options deleted while popup menu is activated
<a href="https://bugs.webkit.org/show_bug.cgi?id=68386">https://bugs.webkit.org/show_bug.cgi?id=68386</a>

Reviewed by NOBODY (OOPS!).

If all the options are deleted from a &lt;select&gt; while it is activated and its popup
menu is displayed, The popup menu should go away.

WebKit behavior is different from other browsers, this patch fix it.

The popup close code path for IOS_FAMILY should use openPickerForUserInteraction(),
since m_popup is not defined for iOS.

Test:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-options-removed-while-popup-open-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-options-removed-while-popup-open.html: Added.
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::childrenChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/993226ad5675e4891e79ddd81ed688ef351c4df6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47616 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41397 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131551 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47298 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135061 "Found 5 new test failures: fast/forms/basic-selects.html fast/forms/select/menulist-disabled-option.html fast/forms/select/option-selecting.html imported/w3c/web-platform-tests/html/select/options-length-too-large.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/selected-index.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95282 "1 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176641 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38488 "Found 2 new test failures: fast/forms/basic-selects.html fast/forms/select/menulist-disabled-option.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/41397 "") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115539 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37129 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-options-removed-while-popup-open.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/selected-index.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35491 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31741 "Built successfully") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/41397 "") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147553 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/41397 "") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185683 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38720 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39691 "Found 5 new test failures: fast/forms/select-innerHTML-many-options.html fast/forms/select/menulist-disabled-option.html fast/forms/select/option-selecting.html imported/w3c/web-platform-tests/html/select/options-length-too-large.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/selected-index.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143945 "Found 2 new test failures: imported/w3c/web-platform-tests/html/select/options-length-too-large.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/selected-index.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47283 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/41397 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143804 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47962 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/41397 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113151 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38727 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119840 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46468 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/41397 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45870 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->