### PR TITLE
[GStreamer][WebAudio] Disallow RialtoMSEAudio in WebAudio

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
@@ -66,6 +66,7 @@ GStreamerQuirkRialto::GStreamerQuirkRialto()
                 m_sinkCaps = WTF::move(templateCaps);
         }
     }
+    m_disallowedWebAudioDecoders = { "rialtomseaudiosink"_s };
 }
 
 bool GStreamerQuirkRialto::isPlatformSupported() const

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
@@ -41,6 +41,7 @@ public:
     GstElement* createAudioSink() final;
     GstElement* createWebAudioSink() final;
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
+    Vector<String> disallowedWebAudioDecoders() const final { return m_disallowedWebAudioDecoders; }
     bool shouldParseIncomingLibWebRTCBitStream() const final { return false; }
     unsigned getAdditionalPlaybinFlags() const { return getGstPlayFlag("text") | getGstPlayFlag("native-audio") | getGstPlayFlag("native-video"); }
     bool needsCustomInstantRateChange() const final { return true; }
@@ -48,6 +49,7 @@ public:
 
 private:
     GRefPtr<GstCaps> m_sinkCaps;
+    Vector<String> m_disallowedWebAudioDecoders;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### c5970460b5775dd2316062396dc15e9c84214f83
<pre>
[GStreamer][WebAudio] Disallow RialtoMSEAudio in WebAudio
<a href="https://bugs.webkit.org/show_bug.cgi?id=316404">https://bugs.webkit.org/show_bug.cgi?id=316404</a>

Reviewed by Xabier Rodriguez-Calvar.

When WebAudio tries to find a decoder in Rialto, the platform-specific
RialtoMSEAudioSink matches caps and is auto-plugged, but it&apos;s not
actually suitable for the task. That sink can only play (render) encoded
audio, and isn&apos;t able to just do decoding (so that the decoded samples
are taken back by WebAudio). It can&apos;t play raw audio either. For those
reasons, it should be disabled for WebAudio usage.

This problem affects AudioContext.decodeAudioData usage when there is a
discrepancy between rialtomseaudiosink and software decoding plugins
available on the platform. Such a situation causes
HTMLMediaElement::canPlayType() declare support for content type but it
should be understood as playback and not decoding to PCM. In turn, it
makes `autoplug-select` as used in AudioFileReaderGStreamer.cpp [1] to
pick `rialtomseaudiosink` which is invalid as per case when:

- Non-PCM content is used - get stuck in sample passing loop, it will be
  waiting to play which doesn&apos;t really happen in this scenario as samples
  were to be pulled and passed to another pipeline.
- PCM content is used - crash as the samples pulled won&apos;t be available
  to be taken.

Adding rialtomseaudiosink to disallowed plugins list in quirks corrects
the situation and in case of missing browser side decoding plugin makes
it simply fail. when they are present, however, they will be the only and
right choice for decoding making it work as expected.

[1] <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/blob/wpe-2.38/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp#L413C42-L413C57">https://github.com/WebPlatformForEmbedded/WPEWebKit/blob/wpe-2.38/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp#L413C42-L413C57</a>

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1680">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1680</a>

Original author: BunioFH &lt;buniofh@gmail.com&gt;

* Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp:
(WebCore::GStreamerQuirkRialto::GStreamerQuirkRialto): Add rialtomseaudiosink to the list of disallowed WebAudio decoders.
* Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h: Added Vector of disallowed decoders. Override disallowedWebAudioDecoders() to return the Vector.

Canonical link: <a href="https://commits.webkit.org/314726@main">https://commits.webkit.org/314726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a2a97f93eb70eaa4debf3edce106a35b02200a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124306 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168914 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129912 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110437 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31286 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29991 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24835 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178634 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31532 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138278 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/166450 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138189 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37201 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104232 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33460 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26449 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39807 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112881 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39203 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4550 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39448 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->