### PR TITLE
SelectFallbackButtonElement should not have styling in base appearance mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<link rel=stylesheet href="/fonts/ahem.css">
+
+<style>
+  .select {
+    display: inline-flex;
+    box-sizing: border-box;
+    width: 40px;
+    gap: 0.5em;
+    font: 20px/1 Ahem;
+    color: black;
+  }
+  .icon {
+    display: block;
+    margin-inline-start: auto;
+    color: red;
+  }
+  .icon::before { content: "X"; }
+</style>
+
+<p><span class=select><span>XXX</span><span class=icon></span></span>
+<p><span class=select><span>XXX</span><span class=icon></span></span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<link rel=stylesheet href="/fonts/ahem.css">
+
+<style>
+  .select {
+    display: inline-flex;
+    box-sizing: border-box;
+    width: 40px;
+    gap: 0.5em;
+    font: 20px/1 Ahem;
+    color: black;
+  }
+  .icon {
+    display: block;
+    margin-inline-start: auto;
+    color: red;
+  }
+  .icon::before { content: "X"; }
+</style>
+
+<p><span class=select><span>XXX</span><span class=icon></span></span>
+<p><span class=select><span>XXX</span><span class=icon></span></span>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>appearance:base-select must not clip its button text or icon</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">
+<link rel=match href="select-button-text-and-icon-clipping-ref.html">
+<link rel=stylesheet href="/fonts/ahem.css">
+<meta name=assert content="An appearance:base-select <select> should not have its button text or icon clipped, regardless of whether a button element is used.">
+
+<style>
+  select {
+    appearance: base-select;
+    box-sizing: border-box;
+    width: 40px;
+    border: 0;
+    padding: 0;
+    font: 20px/1 Ahem;
+    color: black;
+  }
+  select::picker-icon {
+    content: "X";
+    color: red;
+  }
+  /* :focus-visible behavior is UA-defined, do not exercise it. */
+  select:focus-visible { outline: none; }
+</style>
+
+<p><select><option>XXX</option></select>
+<p><select><button><selectedcontent></selectedcontent></button><option>XXX</option></select>

--- a/Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp
@@ -130,10 +130,12 @@ std::optional<Style::UnadjustedStyle> SelectFallbackButtonElement::resolveCustom
     auto elementStyle = resolveStyle(resolutionContext);
     CheckedRef style = *elementStyle.style;
 
-    style->setFlexGrow(1);
-    style->setFlexShrink(1);
-    // min-width: 0; is needed for correct shrinking.
-    style->setLogicalMinWidth(0_css_px);
+    if (hostStyle->usedAppearance() != StyleAppearance::Base) {
+        style->setFlexGrow(1);
+        style->setFlexShrink(1);
+        // min-width: 0; is needed for correct shrinking.
+        style->setLogicalMinWidth(0_css_px);
+    }
 
     auto hostTextAlign = hostStyle->textAlign();
     if (hostTextAlign == Style::TextAlign::Start)


### PR DESCRIPTION
#### 00e82a4b47c74f8eb80f032a740ca2e78c40623f
<pre>
SelectFallbackButtonElement should not have styling in base appearance mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=316407">https://bugs.webkit.org/show_bug.cgi?id=316407</a>

Reviewed by Tim Nguyen.

This code was introduced in 306393@main when base appearance was not
yet added. It&apos;s separate from the code branching on appearance below
as it needs to apply to None as well.

Tests: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-button-text-and-icon-clipping.html

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/60425">https://github.com/web-platform-tests/wpt/pull/60425</a>
Canonical link: <a href="https://commits.webkit.org/314693@main">https://commits.webkit.org/314693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/340407b3617d6d4c75be1ee40ba100d0dc082134

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123966 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21019531-0e7b-4310-a686-8194161a1a25) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129623 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/972f6668-ef11-4738-b2f8-dab89a7ed9f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110148 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2b28f08-46b9-4bed-82b1-175fd73b590f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30994 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29692 "Passed tests") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24449 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140965 "Found 1 new API test failure: TestWebKitAPI.HSTS.Preconnect (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178291 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31191 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137983 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137900 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149286 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103749 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25402 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33187 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26151 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39468 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112542 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38864 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4241 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39109 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39007 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->