### PR TITLE
NetworkStateNotifier on Mac reports IPv6-only networks as offline

### DIFF
--- a/Source/WebCore/platform/network/mac/NetworkStateNotifierMac.cpp
+++ b/Source/WebCore/platform/network/mac/NetworkStateNotifierMac.cpp
@@ -64,8 +64,14 @@ void NetworkStateNotifier::updateStateWithoutNotifying()
         if (CFStringHasPrefix(interfaceName.get(), CFSTR("vmnet")))
             continue;
 
-        auto key = adoptCF(SCDynamicStoreKeyCreateNetworkInterfaceEntity(0, kSCDynamicStoreDomainState, interfaceName.get(), kSCEntNetIPv4));
-        if (auto value = adoptCF(SCDynamicStoreCopyValue(m_store.get(), key.get()))) {
+        RetainPtr ipv4Key = adoptCF(SCDynamicStoreKeyCreateNetworkInterfaceEntity(0, kSCDynamicStoreDomainState, interfaceName.get(), kSCEntNetIPv4));
+        if (RetainPtr value = adoptCF(SCDynamicStoreCopyValue(m_store.get(), ipv4Key.get()))) {
+            m_isOnLine = true;
+            return;
+        }
+
+        RetainPtr ipv6Key = adoptCF(SCDynamicStoreKeyCreateNetworkInterfaceEntity(0, kSCDynamicStoreDomainState, interfaceName.get(), kSCEntNetIPv6));
+        if (RetainPtr value = adoptCF(SCDynamicStoreCopyValue(m_store.get(), ipv6Key.get()))) {
             m_isOnLine = true;
             return;
         }
@@ -92,10 +98,12 @@ void NetworkStateNotifier::startObserving()
 
     auto keys = adoptCF(CFArrayCreateMutable(0, 0, &kCFTypeArrayCallBacks));
     CFArrayAppendValue(keys.get(), adoptCF(SCDynamicStoreKeyCreateNetworkGlobalEntity(0, kSCDynamicStoreDomainState, kSCEntNetIPv4)).get());
+    CFArrayAppendValue(keys.get(), adoptCF(SCDynamicStoreKeyCreateNetworkGlobalEntity(0, kSCDynamicStoreDomainState, kSCEntNetIPv6)).get());
     CFArrayAppendValue(keys.get(), adoptCF(SCDynamicStoreKeyCreateNetworkGlobalEntity(0, kSCDynamicStoreDomainState, kSCEntNetDNS)).get());
 
     auto patterns = adoptCF(CFArrayCreateMutable(0, 0, &kCFTypeArrayCallBacks));
     CFArrayAppendValue(patterns.get(), adoptCF(SCDynamicStoreKeyCreateNetworkInterfaceEntity(0, kSCDynamicStoreDomainState, kSCCompAnyRegex, kSCEntNetIPv4)).get());
+    CFArrayAppendValue(patterns.get(), adoptCF(SCDynamicStoreKeyCreateNetworkInterfaceEntity(0, kSCDynamicStoreDomainState, kSCCompAnyRegex, kSCEntNetIPv6)).get());
 
     SCDynamicStoreSetNotificationKeys(m_store.get(), keys.get(), patterns.get());
 }


### PR DESCRIPTION
#### 66bd4cd17ad414f641e59933eeb0e9ae8e473cae
<pre>
NetworkStateNotifier on Mac reports IPv6-only networks as offline
<a href="https://bugs.webkit.org/show_bug.cgi?id=316409">https://bugs.webkit.org/show_bug.cgi?id=316409</a>

Reviewed by Basuke Suzuki.

NetworkStateNotifierMac only consulted the IPv4 SCDynamicStore entity
when probing each network interface, so machines on IPv6-only links
(e.g. NAT64 / cellular IPv6 PD / IPv6-only Wi-Fi) walked every
interface, never found an IPv4 entity, and reported the system as
offline. As a result, navigator.onLine was false even though the
network was fully reachable.

The notification key list had the same asymmetry: only the IPv4
global entity and an IPv4 per-interface pattern were watched, so
IPv6-only state changes did not wake the notifier.

Also probe kSCEntNetIPv6 per interface, and add the IPv6 global
entity plus an IPv6 per-interface pattern to the watched keys.

* Source/WebCore/platform/network/mac/NetworkStateNotifierMac.cpp:
(WebCore::NetworkStateNotifier::updateStateWithoutNotifying):
(WebCore::NetworkStateNotifier::startObserving):

Canonical link: <a href="https://commits.webkit.org/314721@main">https://commits.webkit.org/314721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7d27904ba8aea9337b50b41e424c8e35574c711

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175752 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123961 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40316c4c-98bd-4c7e-bb42-ff195d711b82) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129618 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91292 "2 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a690e14b-3784-409e-a305-cc60bdf46dca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110143 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f3514ea-c88c-4be0-a10e-ac51be41705e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30989 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29687 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23893 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178286 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31186 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137978 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137895 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37198 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149281 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103737 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33182 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26146 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39463 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112537 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38859 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4236 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39002 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->