### PR TITLE
[GStreamer][MSE] Reduce TrackQueue buffer size

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.h
@@ -67,14 +67,14 @@ private:
     // If we had no queue, the main thread would have to be awaken for every frame. On the other hand, if the
     // queue had unlimited size WebKit would end up requesting flushes more often than necessary when frames
     // in the future are re-appended. As a sweet spot between these extremes we choose to allow enqueueing a
-    // few seconds worth of samples.
+    // couple hundred milliseconds worth of samples.
 
     // `isReadyForMoreSamples` follows the classical two water levels strategy: initially it's true until the
     // high water level is reached, then it becomes false until the queue drains down to the low water level
     // and the cycle repeats. This way we avoid stalls and minimize context switches.
 
-    static const GstClockTime s_durationEnqueuedHighWaterLevel = 5 * GST_SECOND;
-    static const GstClockTime s_durationEnqueuedLowWaterLevel = 2 * GST_SECOND;
+    static const GstClockTime s_durationEnqueuedHighWaterLevel = 200 * GST_MSECOND;
+    static const GstClockTime s_durationEnqueuedLowWaterLevel = 100 * GST_MSECOND;
 
     GstClockTime durationEnqueued() const;
     void checkLowLevel();


### PR DESCRIPTION
#### 82f3a3ac140f31863f53438cd94131ae7fc641d1
<pre>
[GStreamer][MSE] Reduce TrackQueue buffer size
<a href="https://bugs.webkit.org/show_bug.cgi?id=316412">https://bugs.webkit.org/show_bug.cgi?id=316412</a>

Reviewed by Xabier Rodriguez-Calvar.

Currently, the TrackQueue used in MSE for GStreamer is rather large, up
to 5 seconds, much larger than the ones used in the rest of the playback
pipeline.

By reducing the queue size more quality changes can be completed without
a flush -- or in a flushless implementation, with lower latency.

* Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.h:

Canonical link: <a href="https://commits.webkit.org/315219@main">https://commits.webkit.org/315219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/624beb735305b18c9af2e2dc2c41108370d397a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177738 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126111 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131069 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92162 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111580 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32519 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31222 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26434 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142505 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180338 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33062 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139504 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139368 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37528 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42667 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106270 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34658 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27717 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41171 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114427 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40568 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5802 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40819 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->