### PR TITLE
fast/mediastream/enumerateDevices-camera-denied-expose-with-capture.html is (very slightly) flaky

### DIFF
--- a/LayoutTests/fast/mediastream/enumerateDevices-camera-denied-expose-with-capture.html
+++ b/LayoutTests/fast/mediastream/enumerateDevices-camera-denied-expose-with-capture.html
@@ -20,7 +20,8 @@ promise_test(async (test) => {
     if (window.testRunner)
         testRunner.setMicrophonePermission(false);
 
-    await navigator.mediaDevices.getUserMedia({ audio : true });
+    const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const devices = await navigator.mediaDevices.enumerateDevices();
     for (const device of devices)
         assert_true(device.label === "" || device.kind !== "videoinput");
@@ -30,7 +31,8 @@ promise_test(async (test) => {
     if (window.testRunner)
         testRunner.setMicrophonePermission(true);
 
-    await navigator.mediaDevices.getUserMedia({ audio : true });
+    const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const devices = await navigator.mediaDevices.enumerateDevices();
     for (const device of devices)
         assert_true(device.label === "" || device.kind !== "videoinput");

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5550,8 +5550,6 @@ webkit.org/b/316197 imported/w3c/web-platform-tests/media-source/mediasource-add
 
 webkit.org/b/316421 media/track/in-band/track-in-band-srt-mkv-addtrack.html [ Pass Failure ]
 
-webkit.org/b/316424 fast/mediastream/enumerateDevices-camera-denied-expose-with-capture.html [ Pass Failure ]
-
 webkit.org/b/316427 animations/restart-after-scroll.html [ Pass Failure ]
 
 webkit.org/b/316428 imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-inert-invoker.html [ Pass Failure ]


### PR DESCRIPTION
#### 11695f16b3186da0e1b8f9320ec05f575a72d47f
<pre>
fast/mediastream/enumerateDevices-camera-denied-expose-with-capture.html is (very slightly) flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=316424">https://bugs.webkit.org/show_bug.cgi?id=316424</a>

Reviewed by Xabier Rodriguez-Calvar.

* LayoutTests/fast/mediastream/enumerateDevices-camera-denied-expose-with-capture.html: Make sure
each stream&apos;s track is stopped, as in many other mediastream tests.

Canonical link: <a href="https://commits.webkit.org/315007@main">https://commits.webkit.org/315007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4aaa91332b52ba0ac006ae8fc765fcbae802d420

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175973 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124183 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129806 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91410 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31180 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29883 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24709 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178511 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138175 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138086 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37396 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149477 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104014 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33358 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26342 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39684 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39080 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4440 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->