### PR TITLE
Text fragment directives beginning with apostrophe can incorrectly match in middle of words.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/start-word-bounded-katakana-expected.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/start-word-bounded-katakana-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8" />
+<title>Scroll to text fragment - target inside a katakana word must be word-bounded</title>
+<style>
+  span {
+    background-color: pink;
+  }
+</style>
+
+<p>Pass condition: only the katakana for bread on the last line is highlighted; the first line is not highlighted.</p>
+<!-- champagne -->
+<p>シャンパン</p>
+<!-- bread -->
+<p><span>パン</span></p>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/start-word-bounded-katakana.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/start-word-bounded-katakana.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to text fragment - target inside a katakana word must be word-bounded</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<meta name="assert" content="This test checks that a fragment directive target which appears as a substring inside a katakana word is rejected.">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-1500" />
+<style>
+  ::target-text { background-color: pink; }
+</style>
+
+<p>Pass condition: only the katakana for bread on the last line is highlighted; the first line is not highlighted.</p>
+<!-- champagne -->
+<p>シャンパン</p>
+<!-- bread -->
+<p>パン</p>
+
+<script>
+  location.href = "#:~:text=%E3%83%91%E3%83%B3";
+</script>
+</html>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/start-word-bounded-leading-apostrophe-expected.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/start-word-bounded-leading-apostrophe-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - target starting with apostrophe must be word-bounded on the left</title>
+<style>
+  span {
+    background-color: pink;
+  }
+</style>
+<p>Pass condition: only the target in the final sentence below is highlighted; nothing in the earlier sentence is highlighted.</p>
+<p>Anyway, it's our only chance.</p>
+<p>And this <span>'s</span> our last time together.</p>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/start-word-bounded-leading-apostrophe.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/start-word-bounded-leading-apostrophe.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to text fragment - target starting with apostrophe must be word-bounded on the left</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<meta name="assert" content="A text directive target beginning with an apostrophe must only match when its start is at a word boundary. The directive should resolve to the standalone apostrophe-s in the final sentence, not the apostrophe-s inside the word it's earlier in the document.">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-1500" />
+<style>
+  ::target-text { background-color: pink; }
+</style>
+<p>Pass condition: only the target in the final sentence below is highlighted; nothing in the earlier sentence is highlighted.</p>
+<p>Anyway, it's our only chance.</p>
+<p>And this 's our last time together.</p>
+<script>
+  location.href = "#:~:text=%27s,-our";
+</script>
+</html>

--- a/LayoutTests/platform/ios/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive-expected.txt
@@ -1,1 +1,0 @@
-:~:text=it.-,This%20is%20the%20text%20without%20a%20space%20fakecode.h%20and%20the%20end%20of%20the%20selecton.,-Additional

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -157,6 +157,7 @@ static std::optional<SimpleRange> findRangeFromNodeList(const String& query, con
         options.add(FindOption::AtWordStarts);
     if (wordEndBounded == WordBounded::Yes)
         options.add(FindOption::AtWordEnds);
+    options.add(FindOption::IcuOnlyWordBoundaries);
 
     auto foundText = findPlainText(searchRange, foldedQuery, options);
 

--- a/Source/WebCore/editing/CachedMatchFinder.cpp
+++ b/Source/WebCore/editing/CachedMatchFinder.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 
 static inline FindOptions matchAffectingOptions(FindOptions options)
 {
-    static constexpr OptionSet matchAffectingFlags { FindOption::CaseInsensitive, FindOption::AtWordStarts, FindOption::TreatMedialCapitalAsWordStart, FindOption::AtWordEnds, FindOption::DoNotTraverseFlatTree };
+    static constexpr OptionSet matchAffectingFlags { FindOption::CaseInsensitive, FindOption::AtWordStarts, FindOption::TreatMedialCapitalAsWordStart, FindOption::AtWordEnds, FindOption::DoNotTraverseFlatTree, FindOption::IcuOnlyWordBoundaries };
     return options & matchAffectingFlags;
 }
 
@@ -66,6 +66,9 @@ CachedMatchFinder::CachedMatchFinder(Document& document)
 
 void CachedMatchFinder::performSearch(StringView buffer, unsigned startOffset, const String& target, FindOptions options, NOESCAPE const Function<SearchShouldContinue(size_t, size_t)>& callback)
 {
+    // IcuOnlyWordBoundaries is intended for use with TextIterator/SearchBuffer. It's untested with CachedMatchFinder.
+    ASSERT(!options.contains(FindOption::IcuOnlyWordBoundaries));
+
     if (buffer.isEmpty() || target.isEmpty())
         return;
 

--- a/Source/WebCore/editing/FindOptions.h
+++ b/Source/WebCore/editing/FindOptions.h
@@ -42,6 +42,7 @@ enum class FindOption : uint16_t {
     AtWordEnds = 1 << 7,
     DoNotTraverseFlatTree = 1 << 8,
     DoNotSetSelection = 1 << 9,
+    IcuOnlyWordBoundaries = 1 << 10
 };
 
 using FindOptions = OptionSet<FindOption>;

--- a/Source/WebCore/editing/ICUSearcher.cpp
+++ b/Source/WebCore/editing/ICUSearcher.cpp
@@ -64,11 +64,13 @@ ICUSearcher::ICUSearcher(const String& foldedTarget, FindOptions& options)
     lock();
     // Characters in the separator category never really occur at the beginning of a word,
     // so if the target begins with such a character, we just ignore the AtWordStart option.
-    if (options.contains(FindOption::AtWordStarts) && foldedTarget.length()) {
-        char32_t targetFirstCharacter;
-        U16_GET(foldedTarget, 0, 0u, foldedTarget.length(), targetFirstCharacter);
-        if (isSeparator(targetFirstCharacter))
-            options.remove(FindOption::AtWordStarts);
+    if (options.contains(FindOption::AtWordStarts) && !options.contains(FindOption::IcuOnlyWordBoundaries)) {
+        if (foldedTarget.length()) {
+            char32_t targetFirstCharacter;
+            U16_GET(foldedTarget, 0, 0u, foldedTarget.length(), targetFirstCharacter);
+            if (isSeparator(targetFirstCharacter))
+                options.remove(FindOption::AtWordStarts);
+        }
     }
 
     UCollationStrength strength = options.contains(FindOption::CaseInsensitive) ? UCOL_SECONDARY : UCOL_TERTIARY;
@@ -326,6 +328,13 @@ bool isWordStartMatch(std::span<const char16_t> buffer, size_t start, size_t len
     if (!start)
         return true;
 
+    if (options.contains(FindOption::IcuOnlyWordBoundaries)) {
+        // buffer is capped by SearchBuffer's sliding window or StringImpl::MaxLength
+        RELEASE_ASSERT(buffer.size() <= static_cast<size_t>(std::numeric_limits<int32_t>::max()));
+        auto* iterator = WTF::wordBreakIterator(buffer);
+        return iterator && ubrk_isBoundary(iterator, static_cast<int32_t>(start));
+    }
+
     int size = buffer.size();
     int offset = start;
     char32_t firstCharacter;
@@ -381,7 +390,16 @@ bool isWordEndMatch(std::span<const char16_t> buffer, size_t start, size_t lengt
 {
     ASSERT(length);
     ASSERT(options.contains(FindOption::AtWordEnds));
-    UNUSED_PARAM(options);
+
+    if (options.contains(FindOption::IcuOnlyWordBoundaries)) {
+        size_t end = start + length;
+
+        // buffer is capped by SearchBuffer's sliding window or StringImpl::MaxLength
+        // end == buffer.size is valid offset to ubrk_isBoundary
+        RELEASE_ASSERT(end <= buffer.size() && buffer.size() <= static_cast<size_t>(std::numeric_limits<int32_t>::max()));
+        auto* iterator = WTF::wordBreakIterator(buffer);
+        return iterator && ubrk_isBoundary(iterator, static_cast<int32_t>(end));
+    }
 
     int size = buffer.size();
     int offset = static_cast<int>(start);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3325,6 +3325,7 @@ static ExceptionOr<FindOptions> parseFindOptions(const Vector<String>& optionLis
         { "DoNotRevealSelection"_s, FindOption::DoNotRevealSelection },
         { "AtWordEnds"_s, FindOption::AtWordEnds },
         { "DoNotTraverseFlatTree"_s, FindOption::DoNotTraverseFlatTree },
+        { "IcuOnlyWordBoundaries"_s, FindOption::IcuOnlyWordBoundaries },
     });
     FindOptions result;
     for (auto& option : optionList) {


### PR DESCRIPTION
#### b6bdbd59138434ab6a0263011111ed9e04b8c3ea
<pre>
Text fragment directives beginning with apostrophe can incorrectly match in middle of words.
<a href="https://bugs.webkit.org/show_bug.cgi?id=315937">https://bugs.webkit.org/show_bug.cgi?id=315937</a>

Reviewed by NOBODY (OOPS!).

The current code drops the AtWordStarts find option when creating ICUSearcher if the search target begins with a separator character. The separator check uses a fixed character set that isn&apos;t context aware. This can cause fragment directives beginning with those separators to match substrings within words. The change adds FindOption::IcuOnlyWordBoundaries that is set when resolving fragment directives. When set, the ICUSearcher constructor won&apos;t remove the AtWordStarts constraint. Additionally, isWordStartMatch and isWordEndMatch use ICU&apos;s ubrk_isBoundary directly to check for boundaries.

This change is broader than what is minimally necessary to fix the issue. For text directives, boundary detection always uses the UAX #29 compliant ubrk_isBoundary rather than findNextWordFromIndex, which has differing per-platform implementations. This consolidation of boundary detection has a side effect of removing unnecessary context in generated fragments on iOS.

Lastly, while I believe the ICUSearcher constructor isn&apos;t the correct place to remove AtWordStarts, removing that code altogether would have effects beyond just fragment directives. Specifically, it would change user-facing behavior where &quot;.org&quot; in &quot;webkit.org&quot; is considered to be AtWordStarts (LayoutTests/editing/text-iterator/findString.html). That behavior seems intentional.

Test: http/tests/scroll-to-text-fragment/start-word-bounded-leading-apostrophe.html
Test: http/tests/scroll-to-text-fragment/start-word-bounded-katakana.html

* LayoutTests/http/tests/scroll-to-text-fragment/start-word-bounded-leading-apostrophe-expected.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/start-word-bounded-leading-apostrophe.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/start-word-bounded-katakana-expected.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/start-word-bounded-katakana.html: Added.
* LayoutTests/platform/ios/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive-expected.txt: Removed.
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::findRangeFromNodeList): Set FindOption::IcuOnlyWordBoundaries when matching directives.
* Source/WebCore/editing/CachedMatchFinder.cpp:
(WebCore::matchAffectingOptions): Add FindOption::IcuOnlyWordBoundaries.
(WebCore::CachedMatchFinder::performSearch): Assert IcuOnlyWordBoundaries isn&apos;t used here.
* Source/WebCore/editing/ICUSearcher.cpp:
(WebCore::ICUSearcher::ICUSearcher): Don&apos;t remove AtWordStarts if FindOption::IcuOnlyWordBoundaries is set.
(WebCore::isWordStartMatch): Use ubrk_isBoundary directly for boundary checking when FindOption::IcuOnlyWordBoundaries is set.
(WebCore::isWordEndMatch): Use ubrk_isBoundary directly for boundary checking when FindOption::IcuOnlyWordBoundaries is set.
* Source/WebCore/testing/Internals.cpp:
(WebCore::parseFindOptions): Add FindOption::IcuOnlyWordBoundaries.
* Source/WebCore/editing/FindOptions.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6bdbd59138434ab6a0263011111ed9e04b8c3ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187501 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141138 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51538 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138664 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96367 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119127 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40856 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39213 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151261 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38899 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35962 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43449 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189930 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147786 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52178 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147568 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42278 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124430 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/118861 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50686 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13879 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50082 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50322 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->