### PR TITLE
git-webkit log --hash rewrites too much

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -412,6 +412,22 @@ nothing to commit, working tree clean
                     ][:int(args[2].split('=')[-1])])
                 )
             ), mocks.Subprocess.Route(
+                self.executable, 'log', '--oneline', re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs: mocks.ProcessCompletion(
+                    returncode=0,
+                    stdout=''.join([
+                        '{hash} {subject}\n'.format(
+                            hash=commit.hash[:7],
+                            subject=commit.message.splitlines()[0],
+                        ) for commit in self.rev_list(args[3])
+                    ])
+                )
+            ), mocks.Subprocess.Route(
+                self.executable, 'log', '--abbrev-commit', re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs: self.log(args[3], args, path, git_svn)
+            ), mocks.Subprocess.Route(
                 self.executable, '--no-replace-objects', 'log', re.compile(r'.+'),
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self.log(args[3], args, path, git_svn)
@@ -894,16 +910,27 @@ nothing to commit, working tree clean
             stdout='{}\n'.format(self.count(ref))
         ) if self.find(ref) else mocks.ProcessCompletion(returncode=128)
 
+    def decoration(self, commit):
+        branches = []
+        for branch, commits in self.commits.items():
+            if commits[-1] == commit:
+                branches.append(branch)
+        if branches:
+            return ' ({})'.format(', '.join(sorted(branches)))
+        return ''
+
     def log(self, ref, args, path, git_svn):
         """Helper for git log"""
+        decorate = '--decorate' in args
         return mocks.ProcessCompletion(
             returncode=0,
             stdout='\n'.join([
-                'commit {hash}\n'
+                'commit {hash}{decoration}\n'
                 'Author: {author} <{email}>\n'
                 'Date:   {date}\n'
                 '\n{log}\n'.format(
-                    hash=commit.hash,
+                    hash=commit.hash[:7] if '--abbrev-commit' in args else commit.hash,
+                    decoration=self.decoration(commit) if decorate else '',
                     author=commit.author.name,
                     email=commit.author.email,
                     date=commit.timestamp if '--date=unix' in args else datetime.fromtimestamp(commit.timestamp + time.timezone, timezone.utc).strftime('%a %b %d %H:%M:%S %Y +0000'),

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py
@@ -70,12 +70,12 @@ class FilteredCommand(Command):
     HASH = 'hash'
     REVISION = 'revision'
 
-    GIT_HEADER_RE = re.compile(r'^(commit )?(?P<hash>[a-f0-9A-F]+)')
+    GIT_HEADER_RE = re.compile(r'^(commit )?(?P<hash>[a-f0-9A-F]{4,})(?=[ \n])')
     SVN_HEADER_RE = re.compile(r'^(?P<revision>r/d+) | ')
 
     REVISION_RES = (re.compile(r'^(?P<revision>\d+)\s'), re.compile(r'(?P<revision>[rR]\d+)'))
     HASH_RES = (re.compile(r'^(?P<hash>[a-f0-9A-F]{8}[a-f0-9A-F]+)\s'), re.compile(r'(?P<hash>[a-f0-9A-F]{8}[a-f0-9A-F]+)'))
-    IDENTIFIER_RES = (re.compile(r'^(?P<identifier>(\d+\.)?\d+@\S*)'), re.compile(r'(?P<identifier>(\d+\.)?\d+@\S*)'))
+    IDENTIFIER_RES = (re.compile(r'^(?P<identifier>(?:\d+\.)?\d+@\S*)'), re.compile(r'(?P<identifier>(?:\d+\.)?\d+@\S*)'))
     NO_FILTER_RES = [re.compile(r'    Canonical link:'), re.compile(r'    git-svn-id:')]
     DIFF_RE = re.compile(r'^diff --git ')
 
@@ -241,7 +241,7 @@ class FilteredCommand(Command):
                     reference = '{} ({})'.format(match.groups()[-1], reference)
                 if mode == cls.HEADER_MODE:
                     alternates = [] if match.groups()[-1].startswith(reference) else [match.groups()[-1]]
-                    for repr in {'revision', 'hash', 'identifier'} - {'hash' if repository.is_git else 'revision', representation}:
+                    for repr in sorted({'revision', 'hash', 'identifier'} - {'hash' if repository.is_git else 'revision', representation}):
                         if repr in kwargs:
                             continue
                         other = getattr(cache, 'to_{}'.format(repr), lambda **kwargs: None)(**kwargs)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/command_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/command_unittest.py
@@ -1,0 +1,311 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import abc
+import os
+import sys
+
+from unittest.mock import patch
+
+from webkitcorepy import OutputCapture, Terminal, testing
+from webkitcorepy.mocks import Time as MockTime
+from webkitscmpy import program, mocks
+
+
+class TestFilteredCommandBase(testing.PathTestCase, abc.ABC):
+    basepath = 'mock/repository'
+
+    @property
+    @abc.abstractmethod
+    def representation(self) -> str:
+        ...
+
+    def setUp(self):
+        super().setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    def _run_log(self, git, ref, args=()):
+        with OutputCapture() as captured, git, mocks.local.Svn(), MockTime, patch('time.timezone', 0), Terminal.override_atty(sys.stdin, isatty=False):
+            program.main(args=('log', ref, self.representation) + args, path=self.path)
+        return captured.stdout.getvalue()
+
+
+class TestFilteredCommandHash(TestFilteredCommandBase):
+    representation = '--hash'
+
+    def test_output(self):
+        git = mocks.local.Git(self.path)
+        root = git.commits['main'][0]
+        self.assertEqual(
+            'commit 9b8311f25a77 (1@main)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    1st commit\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+    def test_abbrev_commit(self):
+        git = mocks.local.Git(self.path)
+        root = git.commits['main'][0]
+        self.assertEqual(
+            'commit 9b8311f (1@main)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    1st commit\n',
+            self._run_log(git, ref=root.hash, args=('--abbrev-commit',)),
+        )
+
+    def test_oneline(self):
+        git = mocks.local.Git(self.path)
+        root = git.commits['main'][0]
+        self.assertEqual(
+            '9b8311f (1@main) 1st commit\n',
+            self._run_log(git, ref=root.hash, args=('--oneline',)),
+        )
+
+    def test_decorate(self):
+        git = mocks.local.Git(self.path)
+        tip = git.commits['main'][-1]
+        output = self._run_log(git, ref=tip.hash, args=('--decorate',))
+        lines = output.splitlines(keepends=True)
+        self.assertEqual(lines[0], 'commit d8bce26fa65c (5@main) (main)\n')
+        self.assertEqual(lines[1], 'Author: Jonathan Bedard <jbedard@apple.com>\n')
+        self.assertEqual(lines[2], 'Date:   Fri Oct 02 19:46:40 2020 +0000\n')
+
+    def test_decorate_multiple_branches(self):
+        git = mocks.local.Git(self.path)
+        git.commits['test-branch'] = git.commits['main'][:]
+        tip = git.commits['main'][-1]
+        output = self._run_log(git, ref=tip.hash, args=('--decorate',))
+        lines = output.splitlines(keepends=True)
+        self.assertEqual(lines[0], 'commit d8bce26fa65c (5@main) (main, test-branch)\n')
+
+    def test_decorate_non_tip_commit(self):
+        git = mocks.local.Git(self.path)
+        non_tip = git.commits['main'][0]
+        output = self._run_log(git, ref=non_tip.hash, args=('--decorate',))
+        lines = output.splitlines(keepends=True)
+        self.assertEqual(lines[0], 'commit 9b8311f25a77 (1@main)\n')
+
+    def test_identifier_in_body_transformed(self):
+        git = mocks.local.Git(self.path)
+        root = git.commits['main'][0]
+        root.message = 'Patch Series\n\nSee also 5@main for context.\n'
+        self.assertEqual(
+            'commit 9b8311f25a77 (1@main)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    Patch Series\n'
+            '\n'
+            '    See also 5@main (d8bce26fa65c) for context.\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+    def test_hash_in_body_not_transformed(self):
+        git = mocks.local.Git(self.path)
+        root = git.commits['main'][0]
+        root.message = 'Patch Series\n\nSee also 9b8311f25a77ba14923d9d5a6532103f54abefcb for context.\n'
+        self.assertEqual(
+            'commit 9b8311f25a77 (1@main)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    Patch Series\n'
+            '\n'
+            '    See also 9b8311f25a77ba14923d9d5a6532103f54abefcb for context.\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+    def test_revision_in_body_transformed(self):
+        git = mocks.local.Git(self.path, git_svn=True)
+        root = git.commits['main'][0]
+        root.message = 'Patch Series\n\nSee also r1 for context.\n'
+        self.assertEqual(
+            'commit 9b8311f25a77 (1@main, r1)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    Patch Series\n'
+            '\n'
+            '    See also r1 (9b8311f25a77) for context.\n'
+            '    git-svn-id: https://svn.example.org/repository/repository/trunk@1 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+    def test_canonical_link_space_not_transformed(self):
+        git = mocks.local.Git(self.path)
+        root = git.commits['main'][0]
+        root.message = 'Patch Series\n\nCanonical link: https://commits.webkit.org/5@main\n'
+        self.assertEqual(
+            'commit 9b8311f25a77 (1@main)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    Patch Series\n'
+            '\n'
+            '    Canonical link: https://commits.webkit.org/5@main\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+    def test_git_svn_id_not_transformed(self):
+        git = mocks.local.Git(self.path, git_svn=True)
+        root = git.commits['main'][0]
+        self.assertEqual(
+            'commit 9b8311f25a77 (1@main, r1)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    1st commit\n'
+            '    git-svn-id: https://svn.example.org/repository/repository/trunk@1 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+
+class TestFilteredCommandIdentifier(TestFilteredCommandBase):
+    representation = '--identifier'
+
+    def test_output(self):
+        git = mocks.local.Git(self.path)
+        root = git.commits['main'][0]
+        self.assertEqual(
+            'commit 1@main (9b8311f25a77ba14923d9d5a6532103f54abefcb)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    1st commit\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+    def test_hash_in_body_transformed(self):
+        git = mocks.local.Git(self.path)
+        root = git.commits['main'][0]
+        root.message = 'Patch Series\n\nSee also d8bce26fa65c6fc8f39c17927abb77f69fab82fc for context.\n'
+        self.assertEqual(
+            'commit 1@main (9b8311f25a77ba14923d9d5a6532103f54abefcb)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    Patch Series\n'
+            '\n'
+            '    See also d8bce26fa65c6fc8f39c17927abb77f69fab82fc (5@main) for context.\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+    def test_identifier_in_body_not_transformed(self):
+        git = mocks.local.Git(self.path)
+        root = git.commits['main'][0]
+        root.message = 'Patch Series\n\nSee also 1@main for context.\n'
+        self.assertEqual(
+            'commit 1@main (9b8311f25a77ba14923d9d5a6532103f54abefcb)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    Patch Series\n'
+            '\n'
+            '    See also 1@main for context.\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+    def test_revision_in_body_transformed(self):
+        git = mocks.local.Git(self.path, git_svn=True)
+        root = git.commits['main'][0]
+        root.message = 'Patch Series\n\nSee also r1 for context.\n'
+        self.assertEqual(
+            'commit 1@main (9b8311f25a77ba14923d9d5a6532103f54abefcb, r1)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    Patch Series\n'
+            '\n'
+            '    See also r1 (1@main) for context.\n'
+            '    git-svn-id: https://svn.example.org/repository/repository/trunk@1 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+
+class TestFilteredCommandRevision(TestFilteredCommandBase):
+    representation = '--revision'
+
+    def test_output(self):
+        git = mocks.local.Git(self.path, git_svn=True)
+        root = git.commits['main'][0]
+        self.assertEqual(
+            'commit r1 (9b8311f25a77ba14923d9d5a6532103f54abefcb, 1@main)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    1st commit\n'
+            '    git-svn-id: https://svn.example.org/repository/repository/trunk@1 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+    def test_identifier_in_body_transformed(self):
+        git = mocks.local.Git(self.path, git_svn=True)
+        root = git.commits['main'][0]
+        root.message = 'Patch Series\n\nSee also 5@main for context.\n'
+        self.assertEqual(
+            'commit r1 (9b8311f25a77ba14923d9d5a6532103f54abefcb, 1@main)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    Patch Series\n'
+            '\n'
+            '    See also 5@main (r9) for context.\n'
+            '    git-svn-id: https://svn.example.org/repository/repository/trunk@1 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+    def test_hash_in_body_transformed(self):
+        git = mocks.local.Git(self.path, git_svn=True)
+        root = git.commits['main'][0]
+        root.message = 'Patch Series\n\nSee also d8bce26fa65c6fc8f39c17927abb77f69fab82fc for context.\n'
+        self.assertEqual(
+            'commit r1 (9b8311f25a77ba14923d9d5a6532103f54abefcb, 1@main)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    Patch Series\n'
+            '\n'
+            '    See also d8bce26fa65c6fc8f39c17927abb77f69fab82fc (r9) for context.\n'
+            '    git-svn-id: https://svn.example.org/repository/repository/trunk@1 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n',
+            self._run_log(git, ref=root.hash),
+        )
+
+    def test_revision_in_body_not_transformed(self):
+        git = mocks.local.Git(self.path, git_svn=True)
+        root = git.commits['main'][0]
+        root.message = 'Patch Series\n\nSee also r1 for context.\n'
+        self.assertEqual(
+            'commit r1 (9b8311f25a77ba14923d9d5a6532103f54abefcb, 1@main)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    Patch Series\n'
+            '\n'
+            '    See also r1 for context.\n'
+            '    git-svn-id: https://svn.example.org/repository/repository/trunk@1 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n',
+            self._run_log(git, ref=root.hash),
+        )


### PR DESCRIPTION
#### bc35cc462465e305e36faed733769a295f162d2a
<pre>
git-webkit log --hash rewrites too much
<a href="https://bugs.webkit.org/show_bug.cgi?id=301470">https://bugs.webkit.org/show_bug.cgi?id=301470</a>
<a href="https://rdar.apple.com/163410883">rdar://163410883</a>

Reviewed by Elliott Williams.

This fixes some regexes and adds a load of tests.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py: Add more mocks for git log.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py:
(FilteredCommand.GIT_HEADER_RE): Avoid matching all lines which start with hex characters (e.g. &quot;Date&quot;).
(FilteredCommand.IDENTIFIER_RES): The first subpattern needs to be non-capturing, as otherwise it is used as the replacement.
(FilteredCommand.main.replace_line): Handle the various types of replacement in deterministic order.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/command_unittest.py: Added.
(TestFilteredCommandBase):
(TestFilteredCommandBase.representation):
(TestFilteredCommandBase.setUp):
(TestFilteredCommandBase._run_log):
(TestFilteredCommandHash):
(TestFilteredCommandHash.test_output):
(TestFilteredCommandHash.test_abbrev_commit):
(TestFilteredCommandHash.test_oneline):
(TestFilteredCommandHash.test_decorate):
(TestFilteredCommandHash.test_decorate_multiple_branches):
(TestFilteredCommandHash.test_decorate_non_tip_commit):
(TestFilteredCommandHash.test_identifier_in_body_transformed):
(TestFilteredCommandHash.test_hash_in_body_not_transformed):
(TestFilteredCommandHash.test_revision_in_body_transformed):
(TestFilteredCommandHash.test_canonical_link_space_not_transformed):
(TestFilteredCommandHash.test_git_svn_id_not_transformed):
(TestFilteredCommandIdentifier):
(TestFilteredCommandIdentifier.test_output):
(TestFilteredCommandIdentifier.test_hash_in_body_transformed):
(TestFilteredCommandIdentifier.test_identifier_in_body_not_transformed):
(TestFilteredCommandIdentifier.test_revision_in_body_transformed):
(TestFilteredCommandRevision):
(TestFilteredCommandRevision.test_output):
(TestFilteredCommandRevision.test_identifier_in_body_transformed):
(TestFilteredCommandRevision.test_hash_in_body_transformed):
(TestFilteredCommandRevision.test_revision_in_body_not_transformed):

Canonical link: <a href="https://commits.webkit.org/314676@main">https://commits.webkit.org/314676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/577f2b3f5b6a67358b7b0cc2d5c507f75a53abfa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166855 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/40345 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/33926 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175903 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/168721 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/40778 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/40353 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/175903 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/169814 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/40778 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/33926 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175903 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/166178 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/40778 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/40353 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/40778 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/33926 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/178441 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/33926 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/178441 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/166257 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/40415 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/40353 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/178441 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/41103 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/33926 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/103905 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25395 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/41103 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/33926 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/39614 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/39010 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/33926 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/39255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/39153 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->