### PR TITLE
Make BasicShape evaluation take a FloatRect

### DIFF
--- a/Source/WebCore/style/values/masking/StyleClipPath.cpp
+++ b/Source/WebCore/style/values/masking/StyleClipPath.cpp
@@ -80,7 +80,7 @@ AcceleratedEffectClipPath Evaluation<ClipPath, AcceleratedEffectClipPath>::opera
             return { .value = evaluate<AcceleratedEffectClipPath::ReferencePath>(path, data, zoom) };
         },
         [&](const BasicShapePath& path) -> AcceleratedEffectClipPath {
-            return { .value = evaluate<AcceleratedEffectClipPath::BasicShapePath>(path, data, zoom) };
+            return { .value = evaluate<AcceleratedEffectClipPath::BasicShapePath>(path, data.boundingBox, zoom) };
         },
         [&](const BoxPath& path) -> AcceleratedEffectClipPath {
             return { .value = evaluate<AcceleratedEffectClipPath::BoxPath>(path, data, zoom) };

--- a/Source/WebCore/style/values/motion/StyleOffsetPath.cpp
+++ b/Source/WebCore/style/values/motion/StyleOffsetPath.cpp
@@ -117,7 +117,7 @@ AcceleratedEffectOffsetPath Evaluation<OffsetPath, AcceleratedEffectOffsetPath>:
             return { .value = evaluate<AcceleratedEffectOffsetPath::ReferencePath>(path, data, zoom) };
         },
         [&](const BasicShapePath& path) -> AcceleratedEffectOffsetPath {
-            return { .value = evaluate<AcceleratedEffectOffsetPath::BasicShapePath>(path, data, zoom) };
+            return { .value = evaluate<AcceleratedEffectOffsetPath::BasicShapePath>(path, data.motionPathData->offsetRect().rect(), zoom) };
         },
         [&](const BoxPath& path) -> AcceleratedEffectOffsetPath {
             return { .value = evaluate<AcceleratedEffectOffsetPath::BoxPath>(path, data, zoom) };

--- a/Source/WebCore/style/values/shapes/StyleBasicShape.cpp
+++ b/Source/WebCore/style/values/shapes/StyleBasicShape.cpp
@@ -157,26 +157,26 @@ WindRule WindRuleComputation<BasicShape>::operator()(const BasicShape& shape)
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-AcceleratedEffectBasicShape Evaluation<BasicShape, AcceleratedEffectBasicShape>::operator()(const BasicShape& shape, const TransformOperationData& data, ZoomFactor zoom)
+AcceleratedEffectBasicShape Evaluation<BasicShape, AcceleratedEffectBasicShape>::operator()(const BasicShape& shape, const FloatRect& containingBlock, ZoomFactor zoom)
 {
     return WTF::switchOn(shape,
         [&](const Style::CircleFunction& shape) -> AcceleratedEffectBasicShape {
-            return { .function = evaluate<AcceleratedEffectCircleFunction>(shape, data, zoom) };
+            return { .function = evaluate<AcceleratedEffectCircleFunction>(shape, containingBlock.size(), zoom) };
         },
         [&](const Style::EllipseFunction& shape) -> AcceleratedEffectBasicShape {
-            return { .function = evaluate<AcceleratedEffectEllipseFunction>(shape, data, zoom) };
+            return { .function = evaluate<AcceleratedEffectEllipseFunction>(shape, containingBlock.size(), zoom) };
         },
         [&](const Style::InsetFunction& shape) -> AcceleratedEffectBasicShape {
-            return { .function = evaluate<AcceleratedEffectInsetFunction>(shape, data, zoom) };
+            return { .function = evaluate<AcceleratedEffectInsetFunction>(shape, containingBlock.size(), zoom) };
         },
         [&](const Style::PathFunction& shape) -> AcceleratedEffectBasicShape {
-            return { .function = evaluate<AcceleratedEffectPathFunction>(shape, data, zoom) };
+            return { .function = evaluate<AcceleratedEffectPathFunction>(shape, containingBlock.size(), zoom) };
         },
         [&](const Style::PolygonFunction& shape) -> AcceleratedEffectBasicShape {
-            return { .function = evaluate<AcceleratedEffectPolygonFunction>(shape, data, zoom) };
+            return { .function = evaluate<AcceleratedEffectPolygonFunction>(shape, containingBlock.size(), zoom) };
         },
         [&](const Style::ShapeFunction& shape) -> AcceleratedEffectBasicShape {
-            return { .function = evaluate<AcceleratedEffectShapeFunction>(shape, data, zoom) };
+            return { .function = evaluate<AcceleratedEffectShapeFunction>(shape, containingBlock, zoom) };
         }
     );
 }

--- a/Source/WebCore/style/values/shapes/StyleBasicShape.h
+++ b/Source/WebCore/style/values/shapes/StyleBasicShape.h
@@ -88,7 +88,7 @@ template<> struct WindRuleComputation<BasicShape> { WebCore::WindRule operator()
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-template<> struct Evaluation<BasicShape, AcceleratedEffectBasicShape> { AcceleratedEffectBasicShape operator()(const BasicShape&, const TransformOperationData&, ZoomFactor); };
+template<> struct Evaluation<BasicShape, AcceleratedEffectBasicShape> { AcceleratedEffectBasicShape operator()(const BasicShape&, const FloatRect&, ZoomFactor); };
 
 #endif
 

--- a/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
@@ -32,7 +32,6 @@
 #include "StyleLengthWrapper+Blending.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
-#include "TransformOperationData.h"
 #include <numbers>
 #include <wtf/TinyLRUCache.h>
 
@@ -181,10 +180,8 @@ AcceleratedEffectCircleFunction::RadialSize Evaluation<Circle::RadialSize, Accel
     );
 }
 
-AcceleratedEffectCircleFunction Evaluation<CircleFunction, AcceleratedEffectCircleFunction>::operator()(const CircleFunction& value, const TransformOperationData& data, ZoomFactor zoom)
+AcceleratedEffectCircleFunction Evaluation<CircleFunction, AcceleratedEffectCircleFunction>::operator()(const CircleFunction& value, const FloatSize& containingBlockSize, ZoomFactor zoom)
 {
-    auto containingBlockSize = data.motionPathData->offsetRect().rect().size();
-
     return {
         .radius = evaluate<AcceleratedEffectCircleFunction::RadialSize>(value->radius, containingBlockSize, zoom),
         .position = value->position ? std::optional { evaluate<FloatPoint>(*value->position, containingBlockSize, zoom) } : std::nullopt,

--- a/Source/WebCore/style/values/shapes/StyleCircleFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleCircleFunction.h
@@ -32,7 +32,6 @@
 namespace WebCore {
 
 struct AcceleratedEffectCircleFunction;
-struct TransformOperationData;
 
 namespace Style {
 
@@ -73,7 +72,7 @@ template<> struct Blending<Circle> {
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-template<> struct Evaluation<CircleFunction, AcceleratedEffectCircleFunction> { AcceleratedEffectCircleFunction operator()(const CircleFunction&, const TransformOperationData&, ZoomFactor); };
+template<> struct Evaluation<CircleFunction, AcceleratedEffectCircleFunction> { AcceleratedEffectCircleFunction operator()(const CircleFunction&, const FloatSize&, ZoomFactor); };
 
 #endif
 

--- a/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
@@ -33,7 +33,6 @@
 #include "StyleLengthWrapper+Blending.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
-#include "TransformOperationData.h"
 #include <WebCore/StylePosition.h>
 #include <wtf/TinyLRUCache.h>
 
@@ -193,10 +192,8 @@ AcceleratedEffectEllipseFunction::RadialSize Evaluation<Ellipse::RadialSize, Acc
     );
 }
 
-AcceleratedEffectEllipseFunction Evaluation<EllipseFunction, AcceleratedEffectEllipseFunction>::operator()(const EllipseFunction& value, const TransformOperationData& data, ZoomFactor zoom)
+AcceleratedEffectEllipseFunction Evaluation<EllipseFunction, AcceleratedEffectEllipseFunction>::operator()(const EllipseFunction& value, const FloatSize& containingBlockSize, ZoomFactor zoom)
 {
-    auto containingBlockSize = data.motionPathData->offsetRect().rect().size();
-
     return {
         .radii = {
             evaluate<AcceleratedEffectEllipseFunction::RadialSize>(get<0>(value->radii), containingBlockSize.width(), zoom),

--- a/Source/WebCore/style/values/shapes/StyleEllipseFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleEllipseFunction.h
@@ -32,7 +32,6 @@
 namespace WebCore {
 
 struct AcceleratedEffectEllipseFunction;
-struct TransformOperationData;
 
 namespace Style {
 
@@ -73,7 +72,7 @@ template<> struct Blending<Ellipse> {
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-template<> struct Evaluation<EllipseFunction, AcceleratedEffectEllipseFunction> { AcceleratedEffectEllipseFunction operator()(const EllipseFunction&, const TransformOperationData&, ZoomFactor); };
+template<> struct Evaluation<EllipseFunction, AcceleratedEffectEllipseFunction> { AcceleratedEffectEllipseFunction operator()(const EllipseFunction&, const FloatSize&, ZoomFactor); };
 
 #endif
 

--- a/Source/WebCore/style/values/shapes/StyleInsetFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleInsetFunction.cpp
@@ -30,7 +30,6 @@
 #include "GeometryUtilities.h"
 #include "Path.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
-#include "TransformOperationData.h"
 #include <wtf/TinyLRUCache.h>
 
 namespace WebCore {
@@ -84,10 +83,8 @@ WebCore::Path PathComputation<Inset>::operator()(const Inset& value, const Float
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-AcceleratedEffectInsetFunction Evaluation<InsetFunction, AcceleratedEffectInsetFunction>::operator()(const InsetFunction& value, const TransformOperationData& data, ZoomFactor zoom)
+AcceleratedEffectInsetFunction Evaluation<InsetFunction, AcceleratedEffectInsetFunction>::operator()(const InsetFunction& value, const FloatSize& containingBlockSize, ZoomFactor zoom)
 {
-    auto containingBlockSize = data.motionPathData->offsetRect().rect().size();
-
     return {
         .insets = evaluate<RectEdges<float>>(value->insets, containingBlockSize, zoom),
         .radii = evaluate<CornerRadii>(value->radii, containingBlockSize, zoom),

--- a/Source/WebCore/style/values/shapes/StyleInsetFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleInsetFunction.h
@@ -33,7 +33,6 @@ namespace WebCore {
 
 class Path;
 struct AcceleratedEffectInsetFunction;
-struct TransformOperationData;
 
 namespace Style {
 
@@ -63,7 +62,7 @@ template<> struct PathComputation<Inset> { WebCore::Path operator()(const Inset&
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-template<> struct Evaluation<InsetFunction, AcceleratedEffectInsetFunction> { AcceleratedEffectInsetFunction operator()(const InsetFunction&, const TransformOperationData&, ZoomFactor); };
+template<> struct Evaluation<InsetFunction, AcceleratedEffectInsetFunction> { AcceleratedEffectInsetFunction operator()(const InsetFunction&, const FloatSize&, ZoomFactor); };
 
 #endif
 

--- a/Source/WebCore/style/values/shapes/StylePathFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePathFunction.cpp
@@ -181,7 +181,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const Path::Data& value)
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-AcceleratedEffectPathFunction Evaluation<PathFunction, AcceleratedEffectPathFunction>::operator()(const PathFunction& value, const TransformOperationData&, ZoomFactor)
+AcceleratedEffectPathFunction Evaluation<PathFunction, AcceleratedEffectPathFunction>::operator()(const PathFunction& value, const FloatSize&, ZoomFactor)
 {
     return {
         .fillRule = windRule(value),

--- a/Source/WebCore/style/values/shapes/StylePathFunction.h
+++ b/Source/WebCore/style/values/shapes/StylePathFunction.h
@@ -33,7 +33,6 @@
 namespace WebCore {
 
 struct AcceleratedEffectPathFunction;
-struct TransformOperationData;
 
 namespace Style {
 
@@ -100,7 +99,7 @@ template<> struct Blending<Path> {
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-template<> struct Evaluation<PathFunction, AcceleratedEffectPathFunction> { AcceleratedEffectPathFunction operator()(const PathFunction&, const TransformOperationData&, ZoomFactor); };
+template<> struct Evaluation<PathFunction, AcceleratedEffectPathFunction> { AcceleratedEffectPathFunction operator()(const PathFunction&, const FloatSize&, ZoomFactor); };
 
 #endif
 

--- a/Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp
+++ b/Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp
@@ -190,10 +190,10 @@ AcceleratedEffectReferencePath Evaluation<ReferencePath, AcceleratedEffectRefere
     };
 }
 
-AcceleratedEffectBasicShapePath Evaluation<BasicShapePath, AcceleratedEffectBasicShapePath>::operator()(const BasicShapePath& value, const TransformOperationData& data, ZoomFactor zoom)
+AcceleratedEffectBasicShapePath Evaluation<BasicShapePath, AcceleratedEffectBasicShapePath>::operator()(const BasicShapePath& value, const FloatRect& containingBlock, ZoomFactor zoom)
 {
     return {
-        .basicShape = evaluate<AcceleratedEffectBasicShape>(value.shape(), data, zoom),
+        .basicShape = evaluate<AcceleratedEffectBasicShape>(value.shape(), containingBlock, zoom),
         .box = toAcceleratedEffectCoordBox(value.referenceBox()),
     };
 }

--- a/Source/WebCore/style/values/shapes/StylePathOperationWrappers.h
+++ b/Source/WebCore/style/values/shapes/StylePathOperationWrappers.h
@@ -209,7 +209,7 @@ template<> struct Serialize<BasicShapePath> { void operator()(StringBuilder&, co
 
 template<> struct Evaluation<RayPath, AcceleratedEffectRayPath> { AcceleratedEffectRayPath operator()(const RayPath&, const TransformOperationData& data, ZoomFactor); };
 template<> struct Evaluation<ReferencePath, AcceleratedEffectReferencePath> { AcceleratedEffectReferencePath operator()(const ReferencePath&, const TransformOperationData&, ZoomFactor); };
-template<> struct Evaluation<BasicShapePath, AcceleratedEffectBasicShapePath> { AcceleratedEffectBasicShapePath operator()(const BasicShapePath&, const TransformOperationData&, ZoomFactor); };
+template<> struct Evaluation<BasicShapePath, AcceleratedEffectBasicShapePath> { AcceleratedEffectBasicShapePath operator()(const BasicShapePath&, const FloatRect&, ZoomFactor); };
 template<> struct Evaluation<BoxPath, AcceleratedEffectBoxPath> { AcceleratedEffectBoxPath operator()(const BoxPath&, const TransformOperationData&, ZoomFactor); };
 
 #endif

--- a/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
@@ -31,7 +31,6 @@
 #include "Path.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
-#include "TransformOperationData.h"
 #include <wtf/TinyLRUCache.h>
 
 namespace WebCore {
@@ -97,10 +96,8 @@ auto Blending<Polygon>::blend(const Polygon& a, const Polygon& b, const Blending
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-AcceleratedEffectPolygonFunction Evaluation<PolygonFunction, AcceleratedEffectPolygonFunction>::operator()(const PolygonFunction& value, const TransformOperationData& data, ZoomFactor zoom)
+AcceleratedEffectPolygonFunction Evaluation<PolygonFunction, AcceleratedEffectPolygonFunction>::operator()(const PolygonFunction& value, const FloatSize& containingBlockSize, ZoomFactor zoom)
 {
-    auto containingBlockSize = data.motionPathData->offsetRect().rect().size();
-
     return {
         .fillRule = windRule(value),
         .vertices = WTF::map(value->vertices, [&](auto& vertex) -> FloatPoint {

--- a/Source/WebCore/style/values/shapes/StylePolygonFunction.h
+++ b/Source/WebCore/style/values/shapes/StylePolygonFunction.h
@@ -33,7 +33,6 @@
 namespace WebCore {
 
 struct AcceleratedEffectPolygonFunction;
-struct TransformOperationData;
 
 namespace Style {
 
@@ -74,7 +73,7 @@ template<> struct Blending<Polygon> {
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-template<> struct Evaluation<PolygonFunction, AcceleratedEffectPolygonFunction> { AcceleratedEffectPolygonFunction operator()(const PolygonFunction&, const TransformOperationData&, ZoomFactor); };
+template<> struct Evaluation<PolygonFunction, AcceleratedEffectPolygonFunction> { AcceleratedEffectPolygonFunction operator()(const PolygonFunction&, const FloatSize&, ZoomFactor); };
 
 #endif
 

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -38,7 +38,6 @@
 #include "StylePathFunction.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
-#include "TransformOperationData.h"
 
 namespace WebCore {
 namespace Style {
@@ -918,10 +917,8 @@ AcceleratedEffectShapeFunction::CloseCommand Evaluation<CloseCommand, Accelerate
     return { };
 }
 
-AcceleratedEffectShapeFunction Evaluation<ShapeFunction, AcceleratedEffectShapeFunction>::operator()(const ShapeFunction& value, const TransformOperationData& data, ZoomFactor zoom)
+AcceleratedEffectShapeFunction Evaluation<ShapeFunction, AcceleratedEffectShapeFunction>::operator()(const ShapeFunction& value, const FloatRect& rect, ZoomFactor zoom)
 {
-    auto rect = data.motionPathData->offsetRect().rect();
-
     auto evaluatedCommands = [&] {
         return WTF::map(value->commands, [&](auto& command) -> AcceleratedEffectShapeFunction::Command {
             return WTF::switchOn(command,

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.h
@@ -34,7 +34,6 @@
 namespace WebCore {
 
 struct AcceleratedEffectShapeFunction;
-struct TransformOperationData;
 
 namespace Style {
 
@@ -431,7 +430,7 @@ std::optional<Shape> makeShapeFromPath(const Path&);
 
 #if ENABLE(THREADED_ANIMATIONS)
 
-template<> struct Evaluation<ShapeFunction, AcceleratedEffectShapeFunction> { AcceleratedEffectShapeFunction operator()(const ShapeFunction&, const TransformOperationData&, ZoomFactor); };
+template<> struct Evaluation<ShapeFunction, AcceleratedEffectShapeFunction> { AcceleratedEffectShapeFunction operator()(const ShapeFunction&, const FloatRect&, ZoomFactor); };
 
 #endif
 


### PR DESCRIPTION
#### 1018f0121a72ede441e51313db35128e7bcf9c67
<pre>
Make BasicShape evaluation take a FloatRect
<a href="https://bugs.webkit.org/show_bug.cgi?id=316438">https://bugs.webkit.org/show_bug.cgi?id=316438</a>

Reviewed by Sam Weinig.

Make BasicShape evaluation take a FloatRect instead of
a TransformOperationData parameter to allow specifying the
containing block size, which is different for clip-path and offset-path.

* Source/WebCore/style/values/masking/StyleClipPath.cpp:
(WebCore::Style::AcceleratedEffectClipPath&gt;::operator):
* Source/WebCore/style/values/motion/StyleOffsetPath.cpp:
(WebCore::Style::AcceleratedEffectOffsetPath&gt;::operator):
* Source/WebCore/style/values/shapes/StyleBasicShape.cpp:
(WebCore::Style::AcceleratedEffectBasicShape&gt;::operator):
* Source/WebCore/style/values/shapes/StyleBasicShape.h:
* Source/WebCore/style/values/shapes/StyleCircleFunction.cpp:
(WebCore::Style::AcceleratedEffectCircleFunction&gt;::operator):
* Source/WebCore/style/values/shapes/StyleCircleFunction.h:
* Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp:
(WebCore::Style::AcceleratedEffectEllipseFunction&gt;::operator):
* Source/WebCore/style/values/shapes/StyleEllipseFunction.h:
* Source/WebCore/style/values/shapes/StyleInsetFunction.cpp:
(WebCore::Style::AcceleratedEffectInsetFunction&gt;::operator):
* Source/WebCore/style/values/shapes/StyleInsetFunction.h:
* Source/WebCore/style/values/shapes/StylePathFunction.cpp:
(WebCore::Style::AcceleratedEffectPathFunction&gt;::operator):
* Source/WebCore/style/values/shapes/StylePathFunction.h:
* Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp:
(WebCore::Style::AcceleratedEffectBasicShapePath&gt;::operator):
* Source/WebCore/style/values/shapes/StylePathOperationWrappers.h:
* Source/WebCore/style/values/shapes/StylePolygonFunction.cpp:
(WebCore::Style::AcceleratedEffectPolygonFunction&gt;::operator):
* Source/WebCore/style/values/shapes/StylePolygonFunction.h:
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:
(WebCore::Style::AcceleratedEffectShapeFunction&gt;::operator):
* Source/WebCore/style/values/shapes/StyleShapeFunction.h:

Canonical link: <a href="https://commits.webkit.org/314705@main">https://commits.webkit.org/314705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2708e3e8516f897b46312e52df5592d3d0b1d99e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166764 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175812 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129671 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110196 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31040 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29743 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24548 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141011 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178346 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31246 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138035 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137949 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37187 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149335 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103809 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33232 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26200 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112597 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38919 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4291 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Uploaded test results") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39164 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->