### PR TITLE
[JSC] Date and DateSpecYearMonth both require a DateYear

### DIFF
--- a/JSTests/stress/temporal-string-parsing-edge.js
+++ b/JSTests/stress/temporal-string-parsing-edge.js
@@ -82,3 +82,40 @@ function shouldThrow(fn, msg) {
     shouldBe(t3.hour, 23, "max time hour");
     shouldBe(t3.nanosecond, 999, "max time ns");
 }
+
+// Regression: short DateMonth/DateDay-prefixed inputs used to dereference
+// past the end of the parsing buffer in ISO8601::parseDate, producing SIGTRAP
+// on hardened builds and OOB reads on unhardened builds. They must throw cleanly.
+{
+    const oobInputs = [
+        "0", "1",                                  // 1-char crashers
+        "01", "02", "03", "04", "05", "06", "07",  // 2-char crashers
+        "08", "09", "10", "11", "12",
+        "010", "011", "012", "013",                // 3-char crashers
+        "120", "121", "122", "123",
+    ];
+    const parsers = [
+        ["PlainDate", s => Temporal.PlainDate.from(s)],
+        ["PlainDateTime", s => Temporal.PlainDateTime.from(s)],
+        ["PlainMonthDay", s => Temporal.PlainMonthDay.from(s)],
+        ["PlainYearMonth", s => Temporal.PlainYearMonth.from(s)],
+        ["Instant", s => Temporal.Instant.from(s)],
+    ];
+    for (const [name, fn] of parsers) {
+        for (const s of oobInputs)
+            shouldThrow(() => fn(s), `${name}.from("${s}") OOB regression`);
+    }
+}
+
+// Per Temporal grammar, Date and DateSpecYearMonth both require a DateYear.
+// Only DateSpecMonthDay permits the no-year (MMDD / MM-DD) form. These inputs
+// previously parsed as year=0000.
+{
+    shouldThrow(() => Temporal.PlainYearMonth.from("0115"), "YM 0115 needs year");
+    shouldThrow(() => Temporal.PlainDate.from("01-15"), "Date 01-15 needs year");
+    // MonthDay accepts the no-year form.
+    const md = Temporal.PlainMonthDay.from("0115");
+    shouldBe(md.toString(), "01-15", "MonthDay 0115");
+    const md2 = Temporal.PlainMonthDay.from("01-15");
+    shouldBe(md2.toString(), "01-15", "MonthDay 01-15");
+}

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -1115,6 +1115,11 @@ static std::optional<PlainDate> NODELETE parseDate(StringParsingBuffer<Character
             splitByHyphen = true;
             buffer.advance();
         }
+    } else {
+        // Per the Temporal grammar, Date and DateSpecYearMonth both require DateYear.
+        // Only DateSpecMonthDay permits the no-year form.
+        if (format != TemporalDateFormat::MonthDay)
+            return std::nullopt;
     }
 
     unsigned month = 0;


### PR DESCRIPTION
#### 544a3bff9b31c9ba947710eac79486e43d053c11
<pre>
[JSC] Date and DateSpecYearMonth both require a DateYear
<a href="https://bugs.webkit.org/show_bug.cgi?id=316440">https://bugs.webkit.org/show_bug.cgi?id=316440</a>
<a href="https://rdar.apple.com/178843098">rdar://178843098</a>

Reviewed by Yijia Huang.

If parse format is not DateSpecMonthDay, DateYear is mandatory.

* JSTests/stress/temporal-string-parsing-edge.js:
(shouldBe):
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::parseDate):

Canonical link: <a href="https://commits.webkit.org/314669@main">https://commits.webkit.org/314669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8e6009b8f51ca3659af99cf6717c6e8c51dc622

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124031 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e3fddbe-8081-45d4-86cd-473baa407677) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129674 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae6c78d4-5bdd-457b-8ad2-f38505369512) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110200 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/759d72ca-4c49-4bfb-bdfb-a9d0c4f084a6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31048 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29749 "Passed tests") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158930 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178356 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27667 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31256 "Found 2 new failures in css/SelectorChecker.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138038 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137951 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103818 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25389 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33234 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26205 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199452 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39532 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112606 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53615 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38928 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4296 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39173 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39071 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->