### PR TITLE
AX: LocalFrame is used off the main-thread in accessibility isolated tree mode tests, causing lots of assertions when running tests

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp
@@ -132,9 +132,10 @@ Ref<AccessibilityUIElement> AccessibilityController::rootElement(JSContextRef co
         return AccessibilityUIElementClientMac::createForUIProcess();
 #endif
 
+    WKRetainPtr<WKBundleFrameRef> frame = WKBundleFrameForJavaScriptContext(context);
     PlatformUIElement root;
     executeOnAXThreadAndWait([&] () {
-        root = static_cast<PlatformUIElement>(_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)));
+        root = static_cast<PlatformUIElement>(_WKAccessibilityRootObjectForTesting(frame.get()));
     });
     return AccessibilityUIElement::create(root);
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
@@ -179,11 +179,12 @@ RefPtr<AccessibilityUIElement> AccessibilityController::accessibleElementById(JS
         return findElementByIdRecursive(root.ptr(), toWTFString(idAttribute));
     }
 
-    PlatformUIElement root = static_cast<PlatformUIElement>(_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)));
+    WKRetainPtr<WKBundleFrameRef> frame = WKBundleFrameForJavaScriptContext(context);
 
     NSString *attributeName = [NSString stringWithJSStringRef:idAttribute];
     RetainPtr<id> result;
-    executeOnAXThreadAndWait([&root, &attributeName, &result] {
+    executeOnAXThreadAndWait([&frame, &attributeName, &result] {
+        PlatformUIElement root = static_cast<PlatformUIElement>(_WKAccessibilityRootObjectForTesting(frame.get()));
         result = findAccessibleObjectById(root, attributeName);
     });
 


### PR DESCRIPTION
#### d222ffc9fecaaacd5859962448b3c4c88d9996ec
<pre>
AX: LocalFrame is used off the main-thread in accessibility isolated tree mode tests, causing lots of assertions when running tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=316436">https://bugs.webkit.org/show_bug.cgi?id=316436</a>
<a href="https://rdar.apple.com/178839190">rdar://178839190</a>

Reviewed by Andres Gonzalez.

We cannot call WKBundleFrameForJavaScriptContext, as it requires
touching Documents and LocalFrames, which cannot be used off the
main-thread.

Fix this by hosting the WKBundleFrameForJavaScriptContext call out of the lambda so the
WeakPtr&lt;LocalFrame&gt; walk happens on the main thread (where the JS callback runs),
and store the result in a WKRetainPtr&lt;WKBundleFrameRef&gt;. We don&apos;t actually use this
frame ref off the main-thread _WKAccessibilityRootObjectForTesting, so the issue is avoided.

* Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp:
(WTR::AccessibilityController::rootElement):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm:
(WTR::AccessibilityController::accessibleElementById):

Canonical link: <a href="https://commits.webkit.org/314824@main">https://commits.webkit.org/314824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5bf88cf879bd58be3fbf37a474173cb97a94c84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175822 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124032 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Compiled WebKit") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4a49ee3-ef91-4384-9b29-4b59a2a00a50) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129675 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91334 "2 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ec80dcf-0b27-40ae-be0b-06aab1146141) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110201 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f077a17f-b9c7-4aa8-b8d8-c32ee4b95571) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31049 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29750 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24558 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178358 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29251 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138039 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137952 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37272 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149342 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103819 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26207 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39533 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38929 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4298 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39174 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39072 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->