### PR TITLE
[JSC] NativeExecutable should have name and length in the same way to FunctionExecutable

### DIFF
--- a/JSTests/stress/promise-resolving-functions-name-and-length.js
+++ b/JSTests/stress/promise-resolving-functions-name-and-length.js
@@ -1,0 +1,96 @@
+// Regression test for https://bugs.webkit.org/show_bug.cgi?id=316443
+// NativeExecutable now holds name/length the same way FunctionExecutable does, and the
+// internal promise resolving / combinator / finally functions reify their "name" and "length"
+// from the NativeExecutable instead of receiving them eagerly at creation time. These functions
+// are spec-anonymous built-ins (CreateBuiltinFunction with name ""), so they must expose an
+// *own* "name" property whose value is "" (not undefined, not inherited from Function.prototype),
+// and an *own* "length" property. This locks that observable shape down.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+function checkAnonymousBuiltin(label, f, expectedLength) {
+    shouldBe(typeof f, "function");
+
+    // "name" must be an own property (not merely inherited from Function.prototype.name === "").
+    shouldBe(Object.prototype.hasOwnProperty.call(f, "name"), true);
+    shouldBe(f.name, "");
+
+    let nameDesc = Object.getOwnPropertyDescriptor(f, "name");
+    shouldBe(nameDesc.value, "");
+    shouldBe(nameDesc.writable, false);
+    shouldBe(nameDesc.enumerable, false);
+    shouldBe(nameDesc.configurable, true);
+
+    // "length" must be an own property with the expected value.
+    shouldBe(Object.prototype.hasOwnProperty.call(f, "length"), true);
+    shouldBe(f.length, expectedLength);
+
+    let lengthDesc = Object.getOwnPropertyDescriptor(f, "length");
+    shouldBe(lengthDesc.value, expectedLength);
+    shouldBe(lengthDesc.writable, false);
+    shouldBe(lengthDesc.enumerable, false);
+    shouldBe(lengthDesc.configurable, true);
+
+    if (label) { /* keep label referenced for debugging */ }
+}
+
+// Resolve / reject functions handed to a Promise executor (CreateResolvingFunctions).
+{
+    let resolve, reject;
+    new Promise(function (res, rej) {
+        resolve = res;
+        reject = rej;
+    });
+    checkAnonymousBuiltin("resolve", resolve, 1);
+    checkAnonymousBuiltin("reject", reject, 1);
+}
+
+// Promise.withResolvers exposes the same pair of functions.
+{
+    let { resolve, reject } = Promise.withResolvers();
+    checkAnonymousBuiltin("withResolvers.resolve", resolve, 1);
+    checkAnonymousBuiltin("withResolvers.reject", reject, 1);
+}
+
+// Reading "name" first, then "length" (and vice versa) must both reify correctly and independently.
+{
+    let resolve, reject;
+    new Promise(function (res, rej) { resolve = res; reject = rej; });
+    // Force name reification before touching length.
+    shouldBe(resolve.name, "");
+    shouldBe(Object.prototype.hasOwnProperty.call(resolve, "length"), true);
+    shouldBe(resolve.length, 1);
+
+    // Force length reification before touching name on the other function.
+    shouldBe(reject.length, 1);
+    shouldBe(Object.prototype.hasOwnProperty.call(reject, "name"), true);
+    shouldBe(reject.name, "");
+}
+
+// The "name" property is configurable, so user code may redefine it; doing so must not
+// corrupt the originally-observed value on a freshly created pair.
+{
+    let resolve;
+    new Promise(function (res) { resolve = res; });
+    Object.defineProperty(resolve, "name", { value: "mutated", configurable: true });
+    shouldBe(resolve.name, "mutated");
+
+    let resolve2;
+    new Promise(function (res) { resolve2 = res; });
+    checkAnonymousBuiltin("resolve2", resolve2, 1);
+}
+
+// Run many times so the test covers all JIT tiers / repeated allocation paths.
+for (let i = 0; i < testLoopCount; ++i) {
+    let resolve, reject;
+    new Promise(function (res, rej) { resolve = res; reject = rej; });
+    shouldBe(resolve.name, "");
+    shouldBe(reject.name, "");
+    shouldBe(resolve.length, 1);
+    shouldBe(reject.length, 1);
+    shouldBe(Object.prototype.hasOwnProperty.call(resolve, "name"), true);
+    shouldBe(Object.prototype.hasOwnProperty.call(reject, "name"), true);
+}

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1235,9 +1235,13 @@ private:
                 Edge target = m_graph.child(node, 0);
                 AbstractValue& targetValue = m_state.forNode(target);
                 auto& structureSet = targetValue.m_structure;
-                if (!(targetValue.m_type & ~SpecFunction) && structureSet.isFinite() && structureSet.size() == 1) {
-                    RegisteredStructure structure = structureSet.onlyStructure();
-                    if (JSBoundFunction::canSkipNameAndLengthMaterialization(globalObject, structure.get())) {
+                if (!(targetValue.m_type & ~SpecFunction) && structureSet.isFinite() && structureSet.size() >= 1) {
+                    bool allCanSkip = true;
+                    structureSet.forEach([&](RegisteredStructure structure) {
+                        if (!JSBoundFunction::canSkipNameAndLengthMaterialization(globalObject, structure.get()))
+                            allCanSkip = false;
+                    });
+                    if (allCanSkip) {
                         node->convertToNewBoundFunction(m_graph.freeze(m_graph.m_vm.getBoundFunction(/* isJSFunction */ true, SourceTaintedOrigin::Untainted)));
                         changed = true;
                         break;

--- a/Source/JavaScriptCore/jit/JITThunks.cpp
+++ b/Source/JavaScriptCore/jit/JITThunks.cpp
@@ -74,7 +74,7 @@ static inline NativeExecutable& NODELETE getMayBeDyingNativeExecutable(const Wea
 
 inline unsigned JITThunks::WeakNativeExecutableHash::hash(const NativeExecutable* executable)
 {
-    return hash(executable->function(), executable->constructor(), executable->implementationVisibility(), executable->name());
+    return hash(executable->function(), executable->constructor(), executable->implementationVisibility(), executable->length(), executable->name());
 }
 
 inline unsigned JITThunks::WeakNativeExecutableHash::hash(const Weak<NativeExecutable>& key)
@@ -86,7 +86,7 @@ inline bool JITThunks::WeakNativeExecutableHash::equal(const NativeExecutable& a
 {
     if (&a == &b)
         return true;
-    return a.function() == b.function() && a.constructor() == b.constructor() && a.implementationVisibility() == b.implementationVisibility() && a.name() == b.name();
+    return a.function() == b.function() && a.constructor() == b.constructor() && a.implementationVisibility() == b.implementationVisibility() && a.length() == b.length() && a.name() == b.name();
 }
 
 inline bool JITThunks::WeakNativeExecutableHash::equal(const Weak<NativeExecutable>& a, const Weak<NativeExecutable>& b)
@@ -102,7 +102,7 @@ inline bool JITThunks::WeakNativeExecutableHash::equal(const Weak<NativeExecutab
 inline bool JITThunks::WeakNativeExecutableHash::equal(const Weak<NativeExecutable>& a, const HostFunctionKey& b)
 {
     auto& aExecutable = getMayBeDyingNativeExecutable(a);
-    return aExecutable.function() == std::get<0>(b) && aExecutable.constructor() == std::get<1>(b) && aExecutable.implementationVisibility() == std::get<2>(b) && aExecutable.name() == std::get<3>(b);
+    return aExecutable.function() == std::get<0>(b) && aExecutable.constructor() == std::get<1>(b) && aExecutable.implementationVisibility() == std::get<2>(b) && aExecutable.length() == std::get<3>(b) && aExecutable.name() == std::get<4>(b);
 }
 
 CodePtr<JITThunkPtrTag> JITThunks::ctiNativeCall(VM&)
@@ -227,7 +227,7 @@ struct JITThunks::NativeExecutableTranslator {
 void JITThunks::finalize(Handle<Unknown> handle, void*)
 {
     auto* nativeExecutable = static_cast<NativeExecutable*>(handle.get().asCell());
-    auto hostFunctionKey = std::make_tuple(nativeExecutable->function(), nativeExecutable->constructor(), nativeExecutable->implementationVisibility(), nativeExecutable->name());
+    auto hostFunctionKey = std::make_tuple(nativeExecutable->function(), nativeExecutable->constructor(), nativeExecutable->implementationVisibility(), nativeExecutable->length(), nativeExecutable->name());
     {
         AssertNoGC assertNoGC;
         auto iterator = m_nativeExecutableSet.find<HostKeySearcher>(hostFunctionKey);
@@ -238,17 +238,17 @@ void JITThunks::finalize(Handle<Unknown> handle, void*)
     }
 }
 
-NativeExecutable* JITThunks::hostFunctionStub(VM& vm, TaggedNativeFunction function, TaggedNativeFunction constructor, ImplementationVisibility implementationVisibility, const String& name)
+NativeExecutable* JITThunks::hostFunctionStub(VM& vm, TaggedNativeFunction function, TaggedNativeFunction constructor, ImplementationVisibility implementationVisibility, unsigned length, const String& name)
 {
-    return hostFunctionStub(vm, function, constructor, nullptr, implementationVisibility, NoIntrinsic, nullptr, name);
+    return hostFunctionStub(vm, function, constructor, nullptr, implementationVisibility, NoIntrinsic, nullptr, length, name);
 }
 
-NativeExecutable* JITThunks::hostFunctionStub(VM& vm, TaggedNativeFunction function, TaggedNativeFunction constructor, ThunkGenerator generator, ImplementationVisibility implementationVisibility, Intrinsic intrinsic, const DOMJIT::Signature* signature, const String& name)
+NativeExecutable* JITThunks::hostFunctionStub(VM& vm, TaggedNativeFunction function, TaggedNativeFunction constructor, ThunkGenerator generator, ImplementationVisibility implementationVisibility, Intrinsic intrinsic, const DOMJIT::Signature* signature, unsigned length, const String& name)
 {
-    ASSERT(!isCompilationThread());    
+    ASSERT(!isCompilationThread());
     ASSERT(Options::useJIT());
 
-    auto hostFunctionKey = std::make_tuple(function, constructor, implementationVisibility, name);
+    auto hostFunctionKey = std::make_tuple(function, constructor, implementationVisibility, length, name);
     {
         AssertNoGC assertNoGC;
         auto iterator = m_nativeExecutableSet.find<HostKeySearcher>(hostFunctionKey);
@@ -268,10 +268,10 @@ NativeExecutable* JITThunks::hostFunctionStub(VM& vm, TaggedNativeFunction funct
         forCall = adoptRef(new NativeDOMJITCode(MacroAssemblerCodeRef<JSEntryPtrTag>::createSelfManagedCodeRef(ctiNativeCall(vm).retagged<JSEntryPtrTag>()), JITType::HostCallThunk, intrinsic, signature));
     else
         forCall = adoptRef(new NativeJITCode(MacroAssemblerCodeRef<JSEntryPtrTag>::createSelfManagedCodeRef(ctiNativeCall(vm).retagged<JSEntryPtrTag>()), JITType::HostCallThunk, intrinsic));
-    
+
     Ref<JSC::JITCode> forConstruct = adoptRef(*new NativeJITCode(MacroAssemblerCodeRef<JSEntryPtrTag>::createSelfManagedCodeRef(ctiNativeConstruct(vm).retagged<JSEntryPtrTag>()), JITType::HostCallThunk, NoIntrinsic));
-    
-    NativeExecutable* nativeExecutable = NativeExecutable::create(vm, forCall.releaseNonNull(), function, WTF::move(forConstruct), constructor, implementationVisibility, name);
+
+    NativeExecutable* nativeExecutable = NativeExecutable::create(vm, forCall.releaseNonNull(), function, WTF::move(forConstruct), constructor, implementationVisibility, length, name);
     {
         AssertNoGC assertNoGC;
         auto addResult = m_nativeExecutableSet.add<NativeExecutableTranslator>(nativeExecutable);
@@ -291,9 +291,9 @@ NativeExecutable* JITThunks::hostFunctionStub(VM& vm, TaggedNativeFunction funct
     return nativeExecutable;
 }
 
-NativeExecutable* JITThunks::hostFunctionStub(VM& vm, TaggedNativeFunction function, ThunkGenerator generator, ImplementationVisibility implementationVisibility, Intrinsic intrinsic, const String& name)
+NativeExecutable* JITThunks::hostFunctionStub(VM& vm, TaggedNativeFunction function, ThunkGenerator generator, ImplementationVisibility implementationVisibility, Intrinsic intrinsic, unsigned length, const String& name)
 {
-    return hostFunctionStub(vm, function, callHostFunctionAsConstructor, generator, implementationVisibility, intrinsic, nullptr, name);
+    return hostFunctionStub(vm, function, callHostFunctionAsConstructor, generator, implementationVisibility, intrinsic, nullptr, length, name);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -203,9 +203,9 @@ public:
     MacroAssemblerCodeRef<JITThunkPtrTag> ctiStub(VM&, ThunkGenerator);
     MacroAssemblerCodeRef<JITThunkPtrTag> ctiSlowPathFunctionStub(VM&, SlowPathFunction);
 
-    NativeExecutable* hostFunctionStub(VM&, TaggedNativeFunction, TaggedNativeFunction constructor, ImplementationVisibility, const String& name);
-    NativeExecutable* hostFunctionStub(VM&, TaggedNativeFunction, TaggedNativeFunction constructor, ThunkGenerator, ImplementationVisibility, Intrinsic, const DOMJIT::Signature*, const String& name);
-    NativeExecutable* hostFunctionStub(VM&, TaggedNativeFunction, ThunkGenerator, ImplementationVisibility, Intrinsic, const String& name);
+    NativeExecutable* hostFunctionStub(VM&, TaggedNativeFunction, TaggedNativeFunction constructor, ImplementationVisibility, unsigned length, const String& name);
+    NativeExecutable* hostFunctionStub(VM&, TaggedNativeFunction, TaggedNativeFunction constructor, ThunkGenerator, ImplementationVisibility, Intrinsic, const DOMJIT::Signature*, unsigned length, const String& name);
+    NativeExecutable* hostFunctionStub(VM&, TaggedNativeFunction, ThunkGenerator, ImplementationVisibility, Intrinsic, unsigned length, const String& name);
 
     void initialize(VM&);
 
@@ -221,14 +221,14 @@ private:
     };
     using CTIStubMap = UncheckedKeyHashMap<ThunkGenerator, Entry>;
 
-    using HostFunctionKey = std::tuple<TaggedNativeFunction, TaggedNativeFunction, ImplementationVisibility, String>;
+    using HostFunctionKey = std::tuple<TaggedNativeFunction, TaggedNativeFunction, ImplementationVisibility, unsigned, String>;
 
     struct WeakNativeExecutableHash {
         static inline unsigned NODELETE hash(const Weak<NativeExecutable>&);
         static inline unsigned hash(const NativeExecutable*);
         static unsigned hash(const HostFunctionKey& key)
         {
-            return hash(std::get<0>(key), std::get<1>(key), std::get<2>(key), std::get<3>(key));
+            return hash(std::get<0>(key), std::get<1>(key), std::get<2>(key), std::get<3>(key), std::get<4>(key));
         }
 
         static inline bool NODELETE equal(const Weak<NativeExecutable>&, const Weak<NativeExecutable>&);
@@ -238,12 +238,13 @@ private:
         static constexpr bool safeToCompareToEmptyOrDeleted = false;
 
     private:
-        static unsigned hash(TaggedNativeFunction function, TaggedNativeFunction constructor, ImplementationVisibility implementationVisibility, const String& name)
+        static unsigned hash(TaggedNativeFunction function, TaggedNativeFunction constructor, ImplementationVisibility implementationVisibility, unsigned length, const String& name)
         {
             Hasher hasher;
             WTF::add(hasher, function);
             WTF::add(hasher, constructor);
             WTF::add(hasher, implementationVisibility);
+            WTF::add(hasher, length);
             if (!name.isNull())
                 WTF::add(hasher, name);
             return hasher.hash();

--- a/Source/JavaScriptCore/runtime/BooleanConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/BooleanConstructor.cpp
@@ -64,14 +64,12 @@ void BooleanConstructor::finishCreation(VM& vm, BooleanPrototype* booleanPrototy
 {
     Base::finishCreation(vm);
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, booleanPrototype, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | PropertyAttribute::DontDelete);
-    putDirectWithoutTransition(vm, vm.propertyNames->length, jsNumber(1), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-    putDirectWithoutTransition(vm, vm.propertyNames->name, jsString(vm, vm.propertyNames->Boolean.string()), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
 }
 
 BooleanConstructor* BooleanConstructor::create(VM& vm, Structure* structure, BooleanPrototype* booleanPrototype)
 {
     JSGlobalObject* globalObject = structure->realm();
-    NativeExecutable* executable = vm.getHostFunction(callBooleanConstructor, ImplementationVisibility::Public, BooleanConstructorIntrinsic, constructWithBooleanConstructor, nullptr, vm.propertyNames->Boolean.string());
+    NativeExecutable* executable = vm.getHostFunction(callBooleanConstructor, ImplementationVisibility::Public, BooleanConstructorIntrinsic, constructWithBooleanConstructor, nullptr, 1, vm.propertyNames->Boolean.string());
     BooleanConstructor* constructor = new (NotNull, allocateCell<BooleanConstructor>(vm)) BooleanConstructor(vm, executable, globalObject, structure);
     constructor->finishCreation(vm, booleanPrototype);
     return constructor;

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
@@ -406,6 +406,11 @@ bool JSBoundFunction::canSkipNameAndLengthMaterialization(JSGlobalObject* global
         return true;
     if (structure == globalObject->sloppyFunctionStructure(true) || structure == globalObject->sloppyFunctionStructure(false))
         return true;
+    // Plain host functions now use the lazy reify path for length/name (mirroring JS function and
+    // builtin behavior), so an untransitioned hostFunctionStructure means length/name are still
+    // recoverable from NativeExecutable via originalLength()/originalName().
+    if (structure == globalObject->hostFunctionStructure())
+        return true;
 
     return false;
 }

--- a/Source/JavaScriptCore/runtime/JSCustomGetterFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSCustomGetterFunction.cpp
@@ -63,13 +63,16 @@ JSCustomGetterFunction::JSCustomGetterFunction(VM& vm, NativeExecutable* executa
 JSCustomGetterFunction* JSCustomGetterFunction::create(VM& vm, JSGlobalObject* globalObject, const PropertyName& propertyName, CustomFunctionPointer getter, std::optional<DOMAttributeAnnotation> domAttribute)
 {
     ASSERT(getter);
-    NativeExecutable* executable = vm.getHostFunction(customGetterFunctionCall, ImplementationVisibility::Public, callHostFunctionAsConstructor, String(propertyName.publicName()));
+    NativeExecutable* executable = vm.getHostFunction(customGetterFunctionCall, ImplementationVisibility::Public, callHostFunctionAsConstructor, 0, String(propertyName.publicName()));
     Structure* structure = globalObject->customGetterFunctionStructure();
     JSCustomGetterFunction* function = new (NotNull, allocateCell<JSCustomGetterFunction>(vm)) JSCustomGetterFunction(vm, executable, globalObject, structure, propertyName, getter, domAttribute);
-
-    // Can't do this during initialization because getHostFunction might do a GC allocation.
+    function->finishCreation(vm);
+    // ECMAScript-style "get foo" name is exposed via the JSFunction's `name` property; keep the
+    // raw NativeExecutable name unprefixed so toString() renders as `function foo() { [native code] }`.
     auto name = makeString("get "_s, propertyName.publicName());
-    function->finishCreation(vm, executable, 0, name);
+    FunctionRareData* rareData = function->ensureRareData(vm);
+    rareData->setHasReifiedName();
+    function->putDirect(vm, vm.propertyNames->name, jsString(vm, WTF::move(name)), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
     return function;
 }
 

--- a/Source/JavaScriptCore/runtime/JSCustomSetterFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSCustomSetterFunction.cpp
@@ -53,13 +53,16 @@ JSCustomSetterFunction::JSCustomSetterFunction(VM& vm, NativeExecutable* executa
 JSCustomSetterFunction* JSCustomSetterFunction::create(VM& vm, JSGlobalObject* globalObject, const PropertyName& propertyName, CustomFunctionPointer setter)
 {
     ASSERT(setter);
-    NativeExecutable* executable = vm.getHostFunction(customSetterFunctionCall, ImplementationVisibility::Public, callHostFunctionAsConstructor, String(propertyName.publicName()));
+    NativeExecutable* executable = vm.getHostFunction(customSetterFunctionCall, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, String(propertyName.publicName()));
     Structure* structure = globalObject->customSetterFunctionStructure();
     JSCustomSetterFunction* function = new (NotNull, allocateCell<JSCustomSetterFunction>(vm)) JSCustomSetterFunction(vm, executable, globalObject, structure, propertyName, setter);
-
-    // Can't do this during initialization because getHostFunction might do a GC allocation.
+    function->finishCreation(vm);
+    // ECMAScript-style "set foo" name is exposed via the JSFunction's `name` property; keep the
+    // raw NativeExecutable name unprefixed so toString() renders as `function foo() { [native code] }`.
     auto name = makeString("set "_s, propertyName.publicName());
-    function->finishCreation(vm, executable, 1, name);
+    FunctionRareData* rareData = function->ensureRareData(vm);
+    rareData->setHasReifiedName();
+    function->putDirect(vm, vm.propertyNames->name, jsString(vm, WTF::move(name)), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
     return function;
 }
 

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -97,11 +97,10 @@ JSFunction* JSFunction::create(VM& vm, JSGlobalObject*, FunctionExecutable* exec
 
 JSFunction* JSFunction::create(VM& vm, JSGlobalObject* globalObject, unsigned length, const String& name, NativeFunction nativeFunction, ImplementationVisibility implementationVisibility, Intrinsic intrinsic, NativeFunction nativeConstructor, const DOMJIT::Signature* signature)
 {
-    NativeExecutable* executable = vm.getHostFunction(nativeFunction, implementationVisibility, intrinsic, nativeConstructor, signature, name);
+    NativeExecutable* executable = vm.getHostFunction(nativeFunction, implementationVisibility, intrinsic, nativeConstructor, signature, length, name);
     Structure* structure = globalObject->hostFunctionStructure();
     JSFunction* function = new (NotNull, allocateCell<JSFunction>(vm)) JSFunction(vm, executable, globalObject, structure);
-    // Can't do this during initialization because getHostFunction might do a GC allocation.
-    function->finishCreation(vm, executable, length, name);
+    function->finishCreation(vm);
     return function;
 }
 
@@ -111,35 +110,6 @@ JSFunction::JSFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* glo
 {
     assertTypeInfoFlagInvariants();
     ASSERT(structure->realm() == globalObject);
-}
-
-#if ASSERT_ENABLED
-void JSFunction::finishCreation(VM& vm)
-{
-    Base::finishCreation(vm);
-    ASSERT(is<JSFunction>(this));
-    ASSERT(type() == JSFunctionType);
-    // JSCell::{getCallData,getConstructData} relies on the following conditions.
-    ASSERT(methodTable()->getConstructData == &JSFunction::getConstructData);
-    ASSERT(methodTable()->getCallData == &JSFunction::getCallData);
-}
-#endif
-
-void JSFunction::finishCreation(VM& vm, NativeExecutable*, unsigned length, const String& name)
-{
-    Base::finishCreation(vm);
-    ASSERT(inherits(info()));
-    ASSERT(type() == JSFunctionType);
-    // JSCell::{getCallData,getConstructData} relies on the following conditions.
-    ASSERT(methodTable()->getConstructData == &JSFunction::getConstructData);
-    ASSERT(methodTable()->getCallData == &JSFunction::getCallData);
-
-    // JSBoundFunction/JSRemoteFunction instances use finishCreation(VM&) overload and lazily allocate their name string / length.
-    ASSERT(!this->inherits<JSBoundFunction>() && !this->inherits<JSRemoteFunction>());
-
-    putDirect(vm, vm.propertyNames->length, jsNumber(length), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
-    if (!name.isNull())
-        putDirect(vm, vm.propertyNames->name, jsString(vm, name), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
 }
 
 FunctionRareData* JSFunction::allocateRareData(VM& vm)
@@ -607,7 +577,9 @@ JSFunction::PropertyStatus JSFunction::reifyLazyPropertyIfNeeded(VM& vm, JSGloba
         status = PropertyStatus::Eager;
 
     if constexpr (set == SetHasModifiedLengthOrName::Yes) {
-        if (isNonBoundHostFunction() || !structure()->didTransition())
+        // Skip if length/name haven't been reified yet (no transition = no own length/name slot),
+        // or if this is a JSBoundFunction (which tracks modifications differently).
+        if (!structure()->didTransition() || this->inherits<JSBoundFunction>())
             return status;
         bool isLengthProperty = propertyName == vm.propertyNames->length;
         bool isNameProperty = propertyName == vm.propertyNames->name;
@@ -626,11 +598,10 @@ JSFunction::PropertyStatus JSFunction::reifyLazyPropertyIfNeeded(VM& vm, JSGloba
 JSFunction::PropertyStatus JSFunction::reifyLazyPropertyForHostOrBuiltinIfNeeded(VM& vm, JSGlobalObject* globalObject, PropertyName propertyName)
 {
     ASSERT(isHostOrBuiltinFunction());
-    if (isBuiltinFunction() || this->inherits<JSBoundFunction>() || this->inherits<JSRemoteFunction>()) {
-        PropertyStatus lazyLength = reifyLazyLengthIfNeeded(vm, globalObject, propertyName);
-        if (isLazy(lazyLength))
-            return lazyLength;
-    }
+    // length is lazy for everything in here (host, builtin, bound, remote).
+    PropertyStatus lazyLength = reifyLazyLengthIfNeeded(vm, globalObject, propertyName);
+    if (isLazy(lazyLength))
+        return lazyLength;
     return reifyLazyBoundNameIfNeeded(vm, globalObject, propertyName);
 }
 
@@ -696,6 +667,13 @@ JSFunction::PropertyStatus JSFunction::reifyLazyBoundNameIfNeeded(VM& vm, JSGlob
         JSString* name = uncheckedDowncast<JSRemoteFunction>(this)->nameMayBeNull();
         if (!name)
             name = jsEmptyString(vm);
+        unsigned initialAttributes = PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly;
+        rareData->setHasReifiedName();
+        putDirect(vm, nameIdent, name, initialAttributes);
+    } else {
+        ASSERT(isNonBoundHostFunction());
+        FunctionRareData* rareData = this->ensureRareData(vm);
+        JSString* name = uncheckedDowncast<NativeExecutable>(executable())->nameJSString(vm);
         unsigned initialAttributes = PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly;
         rareData->setHasReifiedName();
         putDirect(vm, nameIdent, name, initialAttributes);

--- a/Source/JavaScriptCore/runtime/JSFunction.h
+++ b/Source/JavaScriptCore/runtime/JSFunction.h
@@ -192,13 +192,7 @@ public:
 protected:
     JS_EXPORT_PRIVATE JSFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*);
     JSFunction(VM&, FunctionExecutable*, JSScope*, Structure*);
-
-    void finishCreation(VM&, NativeExecutable*, unsigned length, const String& name);
-#if ASSERT_ENABLED
-    void finishCreation(VM&);
-#else
-    using Base::finishCreation;
-#endif
+    DECLARE_DEFAULT_FINISH_CREATION;
 
     static bool getOwnPropertySlot(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
     static void getOwnSpecialPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArrayBuilder&, DontEnumPropertiesMode);

--- a/Source/JavaScriptCore/runtime/JSFunctionInlines.h
+++ b/Source/JavaScriptCore/runtime/JSFunctionInlines.h
@@ -158,7 +158,10 @@ inline double JSFunction::originalLength(VM& vm)
         return uncheckedDowncast<JSBoundFunction>(this)->length(vm);
     if (inherits<JSRemoteFunction>())
         return uncheckedDowncast<JSRemoteFunction>(this)->length(vm);
-    ASSERT(!isHostFunction());
+    if (isHostFunction()) {
+        // The original length is captured in NativeExecutable at creation time.
+        return uncheckedDowncast<NativeExecutable>(executable())->length();
+    }
     return jsExecutable()->parameterCount();
 }
 
@@ -192,7 +195,14 @@ inline JSString* JSFunction::originalName(JSGlobalObject* globalObject)
         return jsEmptyString(vm);
     }
 
-    ASSERT(!isHostFunction());
+    if (isHostFunction()) {
+        // Mirror the JS path below: build a fresh JSString from the original name stored on
+        // NativeExecutable. NativeExecutable is shared and uniquely keyed by name, so this
+        // always returns the original (creation-time) value even after the JSFunction's "name"
+        // property has been reified or mutated.
+        return uncheckedDowncast<NativeExecutable>(executable())->nameJSString(vm);
+    }
+
     const Identifier& ecmaName = jsExecutable()->ecmaName();
     String name;
     // https://tc39.github.io/ecma262/#sec-exports-runtime-semantics-evaluation
@@ -215,9 +225,12 @@ inline JSString* JSFunction::originalName(JSGlobalObject* globalObject)
 
 inline bool JSFunction::canAssumeNameAndLengthAreOriginal(VM&)
 {
-    // Bound functions are not eagerly generating name and length.
-    // Thus, we can use FunctionRareData's tracking. This is useful to optimize func.bind().bind() case.
-    if (isNonBoundHostFunction())
+    // Plain host, builtin, and JS functions all reify length/name lazily; the original value is
+    // recoverable via originalLength()/originalName() (from NativeExecutable for hosts, from
+    // FunctionExecutable for JS), so the only thing we have to refuse is bound functions
+    // (which set their length/name at bind time, not via FunctionRareData tracking) and any
+    // function whose length or name has since been user-mutated.
+    if (this->inherits<JSBoundFunction>())
         return false;
     FunctionRareData* rareData = this->rareData();
     if (!rareData)

--- a/Source/JavaScriptCore/runtime/JSFunctionWithFields.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunctionWithFields.cpp
@@ -40,11 +40,11 @@ JSFunctionWithFields::JSFunctionWithFields(VM& vm, NativeExecutable* executable,
 {
 }
 
-JSFunctionWithFields* JSFunctionWithFields::create(VM& vm, JSGlobalObject* globalObject, NativeExecutable* executable, unsigned length, const String& name)
+JSFunctionWithFields* JSFunctionWithFields::create(VM& vm, JSGlobalObject* globalObject, NativeExecutable* executable)
 {
     JSFunctionWithFields* function = new (NotNull, allocateCell<JSFunctionWithFields>(vm)) JSFunctionWithFields(vm, executable, globalObject, globalObject->functionWithFieldsStructure());
     ASSERT(function->realm());
-    function->finishCreation(vm, executable, length, name);
+    function->finishCreation(vm);
     return function;
 }
 

--- a/Source/JavaScriptCore/runtime/JSFunctionWithFields.h
+++ b/Source/JavaScriptCore/runtime/JSFunctionWithFields.h
@@ -71,7 +71,7 @@ public:
 
     DECLARE_VISIT_CHILDREN;
 
-    static JSFunctionWithFields* create(VM&, JSGlobalObject*, NativeExecutable*, unsigned length, const String& name);
+    static JSFunctionWithFields* create(VM&, JSGlobalObject*, NativeExecutable*);
 
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/runtime/JSNativeStdFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSNativeStdFunction.cpp
@@ -46,15 +46,9 @@ void JSNativeStdFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 DEFINE_VISIT_CHILDREN(JSNativeStdFunction);
 
-void JSNativeStdFunction::finishCreation(VM& vm, NativeExecutable* executable, unsigned length, const String& name)
+NativeExecutable* JSNativeStdFunction::getHostFunction(VM& vm, Intrinsic intrinsic, NativeFunction nativeConstructor, unsigned length, const String& name)
 {
-    Base::finishCreation(vm, executable, length, name);
-    ASSERT(inherits(info()));
-}
-
-NativeExecutable* JSNativeStdFunction::getHostFunction(VM& vm, Intrinsic intrinsic, NativeFunction nativeConstructor, const String& name)
-{
-    return vm.getHostFunction(runStdFunction, ImplementationVisibility::Private, intrinsic, nativeConstructor, nullptr, name);
+    return vm.getHostFunction(runStdFunction, ImplementationVisibility::Private, intrinsic, nativeConstructor, nullptr, length, name);
 }
 
 JSC_DEFINE_HOST_FUNCTION(runStdFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -66,10 +60,10 @@ JSC_DEFINE_HOST_FUNCTION(runStdFunction, (JSGlobalObject* globalObject, CallFram
 
 JSNativeStdFunction* JSNativeStdFunction::create(VM& vm, JSGlobalObject* globalObject, unsigned length, const String& name, NativeStdFunction&& nativeStdFunction, Intrinsic intrinsic, NativeFunction nativeConstructor)
 {
-    NativeExecutable* executable = vm.getHostFunction(runStdFunction, ImplementationVisibility::Private, intrinsic, nativeConstructor, nullptr, name);
+    NativeExecutable* executable = vm.getHostFunction(runStdFunction, ImplementationVisibility::Private, intrinsic, nativeConstructor, nullptr, length, name);
     Structure* structure = globalObject->nativeStdFunctionStructure();
     JSNativeStdFunction* function = new (NotNull, allocateCell<JSNativeStdFunction>(vm)) JSNativeStdFunction(vm, executable, globalObject, structure, WTF::move(nativeStdFunction));
-    function->finishCreation(vm, executable, length, name);
+    function->finishCreation(vm);
     return function;
 }
 

--- a/Source/JavaScriptCore/runtime/JSNativeStdFunction.h
+++ b/Source/JavaScriptCore/runtime/JSNativeStdFunction.h
@@ -60,10 +60,10 @@ public:
     static JSNativeStdFunction* create(VM& vm, JSGlobalObject* globalObject, unsigned length, const String& name, NativeStdFunction&& nativeFunction, auto... captures)
         requires (sizeof...(captures) > 0)
     {
-        NativeExecutable* executable = getHostFunction(vm, NoIntrinsic, callHostFunctionAsConstructor, name);
+        NativeExecutable* executable = getHostFunction(vm, NoIntrinsic, callHostFunctionAsConstructor, length, name);
         Structure* structure = globalObject->nativeStdFunctionStructure();
         JSNativeStdFunction* function = new (NotNull, allocateCell<JSNativeStdFunction>(vm)) JSNativeStdFunction(vm, executable, globalObject, structure, WTF::move(nativeFunction), captures...);
-        function->finishCreation(vm, executable, length, name);
+        function->finishCreation(vm);
         return function;
     }
 
@@ -79,8 +79,7 @@ private:
     {
     }
 
-    JS_EXPORT_PRIVATE void finishCreation(VM&, NativeExecutable*, unsigned length, const String& name);
-    JS_EXPORT_PRIVATE static NativeExecutable* getHostFunction(VM&, Intrinsic, NativeFunction, const String& name);
+    JS_EXPORT_PRIVATE static NativeExecutable* getHostFunction(VM&, Intrinsic, NativeFunction, unsigned length, const String& name);
 
     NativeStdFunction m_function;
     FixedVector<WriteBarrier<Unknown>> m_captures;

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -112,7 +112,7 @@ std::tuple<JSObject*, JSObject*, JSObject*> JSPromise::newPromiseCapability(JSGl
         return { promise, resolve, reject };
     }
 
-    auto* executor = JSFunctionWithFields::create(vm, globalObject, vm.promiseCapabilityExecutorExecutable(), 2, emptyString());
+    auto* executor = JSFunctionWithFields::create(vm, globalObject, vm.promiseCapabilityExecutorExecutable());
     executor->setField(vm, JSFunctionWithFields::Field::ExecutorResolve, jsUndefined());
     executor->setField(vm, JSFunctionWithFields::Field::ExecutorReject, jsUndefined());
 
@@ -709,8 +709,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseCapabilityExecutor, (JSGlobalObject* globalObjec
 
 std::tuple<JSFunction*, JSFunction*> JSPromise::createResolvingFunctions(VM& vm, JSGlobalObject* globalObject)
 {
-    auto* resolve = JSFunctionWithFields::create(vm, globalObject, vm.promiseResolvingFunctionResolveExecutable(), 1, nullString());
-    auto* reject = JSFunctionWithFields::create(vm, globalObject, vm.promiseResolvingFunctionRejectExecutable(), 1, nullString());
+    auto* resolve = JSFunctionWithFields::create(vm, globalObject, vm.promiseResolvingFunctionResolveExecutable());
+    auto* reject = JSFunctionWithFields::create(vm, globalObject, vm.promiseResolvingFunctionRejectExecutable());
 
     resolve->setField(vm, JSFunctionWithFields::Field::ResolvingPromise, this);
     resolve->setField(vm, JSFunctionWithFields::Field::ResolvingOther, reject);
@@ -723,14 +723,14 @@ std::tuple<JSFunction*, JSFunction*> JSPromise::createResolvingFunctions(VM& vm,
 
 JSFunction* JSPromise::createFirstResolveFunction(VM& vm, JSGlobalObject* globalObject)
 {
-    auto* resolve = JSFunctionWithFields::create(vm, globalObject, vm.promiseFirstResolvingFunctionResolveExecutable(), 1, nullString());
+    auto* resolve = JSFunctionWithFields::create(vm, globalObject, vm.promiseFirstResolvingFunctionResolveExecutable());
     resolve->setField(vm, JSFunctionWithFields::Field::FirstResolvingPromise, this);
     return resolve;
 }
 
 JSFunction* JSPromise::createFirstRejectFunction(VM& vm, JSGlobalObject* globalObject)
 {
-    auto* reject = JSFunctionWithFields::create(vm, globalObject, vm.promiseFirstResolvingFunctionRejectExecutable(), 1, nullString());
+    auto* reject = JSFunctionWithFields::create(vm, globalObject, vm.promiseFirstResolvingFunctionRejectExecutable());
     reject->setField(vm, JSFunctionWithFields::Field::FirstResolvingPromise, this);
     return reject;
 }
@@ -744,8 +744,8 @@ std::tuple<JSFunction*, JSFunction*> JSPromise::createResolvingFunctionsWithInte
 {
     JSValue encodedTask = jsNumber(static_cast<int32_t>(task));
 
-    auto* resolve = JSFunctionWithFields::create(vm, globalObject, vm.promiseResolvingFunctionResolveWithInternalMicrotaskExecutable(), 1, nullString());
-    auto* reject = JSFunctionWithFields::create(vm, globalObject, vm.promiseResolvingFunctionRejectWithInternalMicrotaskExecutable(), 1, nullString());
+    auto* resolve = JSFunctionWithFields::create(vm, globalObject, vm.promiseResolvingFunctionResolveWithInternalMicrotaskExecutable());
+    auto* reject = JSFunctionWithFields::create(vm, globalObject, vm.promiseResolvingFunctionRejectWithInternalMicrotaskExecutable());
 
     auto* all = JSPromiseCombinatorsGlobalContext::create(vm, encodedTask, encodedTask, context);
 

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -409,7 +409,7 @@ static JSObject* promiseAllSlow(JSGlobalObject* globalObject, CallFrame* callFra
 
         JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, currentIndex);
 
-        auto* onFulfilled = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllSlowFulfillFunctionExecutable(), 1, emptyString());
+        auto* onFulfilled = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllSlowFulfillFunctionExecutable());
         onFulfilled->setField(vm, JSFunctionWithFields::Field::PromiseAllContext, context);
         onFulfilled->setField(vm, JSFunctionWithFields::Field::PromiseAllResolve, resolve);
 
@@ -539,7 +539,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
         }
 
         JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, index);
-        auto* onFulfilled = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllFulfillFunctionExecutable(), 1, emptyString());
+        auto* onFulfilled = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllFulfillFunctionExecutable());
         onFulfilled->setField(vm, JSFunctionWithFields::Field::PromiseAllContext, context);
 
         MarkedArgumentBuffer thenArguments;
@@ -737,10 +737,10 @@ static JSObject* promiseAllSettledSlow(JSGlobalObject* globalObject, CallFrame* 
 
         JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, currentIndex);
 
-        auto* onFulfilled = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllSettledSlowFulfillFunctionExecutable(), 1, emptyString());
+        auto* onFulfilled = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllSettledSlowFulfillFunctionExecutable());
         onFulfilled->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledContext, context);
 
-        auto* onRejected = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllSettledSlowRejectFunctionExecutable(), 1, emptyString());
+        auto* onRejected = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllSettledSlowRejectFunctionExecutable());
         onRejected->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledContext, context);
 
         onFulfilled->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledOther, onRejected);
@@ -861,10 +861,10 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
         }
 
         JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, index);
-        auto* onFulfilled = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllSettledFulfillFunctionExecutable(), 1, emptyString());
+        auto* onFulfilled = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllSettledFulfillFunctionExecutable());
         onFulfilled->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledContext, context);
 
-        auto* onRejected = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllSettledRejectFunctionExecutable(), 1, emptyString());
+        auto* onRejected = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllSettledRejectFunctionExecutable());
         onRejected->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledContext, context);
 
         onFulfilled->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledOther, onRejected);
@@ -1227,7 +1227,7 @@ static JSObject* promiseAnySlow(JSGlobalObject* globalObject, CallFrame* callFra
         JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, index);
 
         // For Promise.any slow path, use resolve directly as onFulfilled
-        auto* onRejected = JSFunctionWithFields::create(vm, globalObject, vm.promiseAnySlowRejectFunctionExecutable(), 1, emptyString());
+        auto* onRejected = JSFunctionWithFields::create(vm, globalObject, vm.promiseAnySlowRejectFunctionExecutable());
         onRejected->setField(vm, JSFunctionWithFields::Field::PromiseAnyContext, context);
         onRejected->setField(vm, JSFunctionWithFields::Field::PromiseAnyReject, reject);
 
@@ -1348,7 +1348,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
             resolve = promise->createFirstResolveFunction(vm, globalObject);
 
         JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, index);
-        auto* onRejected = JSFunctionWithFields::create(vm, globalObject, vm.promiseAnyRejectFunctionExecutable(), 1, emptyString());
+        auto* onRejected = JSFunctionWithFields::create(vm, globalObject, vm.promiseAnyRejectFunctionExecutable());
         onRejected->setField(vm, JSFunctionWithFields::Field::PromiseAnyContext, context);
 
         JSValue then = nextPromise->get(globalObject, vm.propertyNames->then);

--- a/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
@@ -184,8 +184,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseFinallyThenFinallyFunc, (JSGlobalObject* globalO
     auto* resolvedPromise = JSPromise::promiseResolve(globalObject, constructor, result);
     RETURN_IF_EXCEPTION(scope, { });
 
-    NativeExecutable* thunkExecutable = vm.getHostFunction(promiseFinallyValueThunkFunc, ImplementationVisibility::Public, callHostFunctionAsConstructor, nullString());
-    auto* valueThunk = JSFunctionWithFields::create(vm, globalObject, thunkExecutable, 0, nullString());
+    NativeExecutable* thunkExecutable = vm.getHostFunction(promiseFinallyValueThunkFunc, ImplementationVisibility::Public, callHostFunctionAsConstructor, 0, nullString());
+    auto* valueThunk = JSFunctionWithFields::create(vm, globalObject, thunkExecutable);
     valueThunk->setField(vm, JSFunctionWithFields::Field::ResolvingPromise, value);
 
     JSValue then = resolvedPromise->get(globalObject, vm.propertyNames->then);
@@ -216,8 +216,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseFinallyCatchFinallyFunc, (JSGlobalObject* global
     auto* resolvedPromise = JSPromise::promiseResolve(globalObject, constructor, result);
     RETURN_IF_EXCEPTION(scope, { });
 
-    NativeExecutable* throwerExecutable = vm.getHostFunction(promiseFinallyThrowerFunc, ImplementationVisibility::Public, callHostFunctionAsConstructor, nullString());
-    auto* thrower = JSFunctionWithFields::create(vm, globalObject, throwerExecutable, 0, nullString());
+    NativeExecutable* throwerExecutable = vm.getHostFunction(promiseFinallyThrowerFunc, ImplementationVisibility::Public, callHostFunctionAsConstructor, 0, nullString());
+    auto* thrower = JSFunctionWithFields::create(vm, globalObject, throwerExecutable);
     thrower->setField(vm, JSFunctionWithFields::Field::ResolvingPromise, reason);
 
     JSValue then = resolvedPromise->get(globalObject, vm.propertyNames->then);
@@ -255,13 +255,13 @@ static EncodedJSValue promiseProtoFuncFinallySlow(JSGlobalObject* globalObject, 
         RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, then, thenCallData, thisValue, thenArguments)));
     }
 
-    NativeExecutable* thenFinallyExecutable = vm.getHostFunction(promiseFinallyThenFinallyFunc, ImplementationVisibility::Public, callHostFunctionAsConstructor, nullString());
-    auto* thenFinally = JSFunctionWithFields::create(vm, globalObject, thenFinallyExecutable, 1, nullString());
+    NativeExecutable* thenFinallyExecutable = vm.getHostFunction(promiseFinallyThenFinallyFunc, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, nullString());
+    auto* thenFinally = JSFunctionWithFields::create(vm, globalObject, thenFinallyExecutable);
     thenFinally->setField(vm, JSFunctionWithFields::Field::ResolvingPromise, onFinally);
     thenFinally->setField(vm, JSFunctionWithFields::Field::ResolvingOther, constructor);
 
-    NativeExecutable* catchFinallyExecutable = vm.getHostFunction(promiseFinallyCatchFinallyFunc, ImplementationVisibility::Public, callHostFunctionAsConstructor, nullString());
-    auto* catchFinally = JSFunctionWithFields::create(vm, globalObject, catchFinallyExecutable, 1, nullString());
+    NativeExecutable* catchFinallyExecutable = vm.getHostFunction(promiseFinallyCatchFinallyFunc, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, nullString());
+    auto* catchFinally = JSFunctionWithFields::create(vm, globalObject, catchFinallyExecutable);
     catchFinally->setField(vm, JSFunctionWithFields::Field::ResolvingPromise, onFinally);
     catchFinally->setField(vm, JSFunctionWithFields::Field::ResolvingOther, constructor);
 

--- a/Source/JavaScriptCore/runtime/NativeExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/NativeExecutable.cpp
@@ -35,11 +35,11 @@ namespace JSC {
 
 const ClassInfo NativeExecutable::s_info = { "NativeExecutable"_s, &ExecutableBase::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(NativeExecutable) };
 
-NativeExecutable* NativeExecutable::create(VM& vm, Ref<JSC::JITCode>&& callThunk, TaggedNativeFunction function, Ref<JSC::JITCode>&& constructThunk, TaggedNativeFunction constructor, ImplementationVisibility implementationVisibility, const String& name)
+NativeExecutable* NativeExecutable::create(VM& vm, Ref<JSC::JITCode>&& callThunk, TaggedNativeFunction function, Ref<JSC::JITCode>&& constructThunk, TaggedNativeFunction constructor, ImplementationVisibility implementationVisibility, unsigned length, const String& name)
 {
     NativeExecutable* executable;
     executable = new (NotNull, allocateCell<NativeExecutable>(vm)) NativeExecutable(vm, function, constructor, implementationVisibility);
-    executable->finishCreation(vm, WTF::move(callThunk), WTF::move(constructThunk), name);
+    executable->finishCreation(vm, WTF::move(callThunk), WTF::move(constructThunk), length, name);
 
     vm.forEachDebugger([&] (Debugger& debugger) {
         debugger.didCreateNativeExecutable(*executable);
@@ -58,7 +58,7 @@ Structure* NativeExecutable::createStructure(VM& vm, JSGlobalObject* globalObjec
     return Structure::create(vm, globalObject, proto, TypeInfo(NativeExecutableType, StructureFlags), info());
 }
 
-void NativeExecutable::finishCreation(VM& vm, Ref<JSC::JITCode>&& callThunk, Ref<JSC::JITCode>&& constructThunk, const String& name)
+void NativeExecutable::finishCreation(VM& vm, Ref<JSC::JITCode>&& callThunk, Ref<JSC::JITCode>&& constructThunk, unsigned length, const String& name)
 {
     Base::finishCreation(vm);
     m_jitCodeForCall = WTF::move(callThunk);
@@ -66,6 +66,7 @@ void NativeExecutable::finishCreation(VM& vm, Ref<JSC::JITCode>&& callThunk, Ref
     m_jitCodeForCallWithArityCheck = m_jitCodeForCall->addressForCall(ArityCheckMode::MustCheckArity);
     m_jitCodeForConstructWithArityCheck = m_jitCodeForConstruct->addressForCall(ArityCheckMode::MustCheckArity);
     m_name = name;
+    m_length = length;
 
     assertIsTaggedWith<JSEntryPtrTag>(m_jitCodeForCall->addressForCall(ArityCheckMode::ArityCheckNotRequired).taggedPtr());
     assertIsTaggedWith<JSEntryPtrTag>(m_jitCodeForConstruct->addressForCall(ArityCheckMode::ArityCheckNotRequired).taggedPtr());
@@ -115,6 +116,11 @@ JSString* NativeExecutable::toStringSlow(JSGlobalObject *globalObject)
     WTF::storeStoreFence();
     m_asString.set(vm, this, asString);
     return asString;
+}
+
+JSString* NativeExecutable::nameJSString(VM& vm) const
+{
+    return m_name.isNull() ? jsEmptyString(vm) : jsString(vm, m_name);
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/runtime/NativeExecutable.h
+++ b/Source/JavaScriptCore/runtime/NativeExecutable.h
@@ -37,7 +37,7 @@ public:
     typedef ExecutableBase Base;
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
 
-    static NativeExecutable* create(VM&, Ref<JSC::JITCode>&& callThunk, TaggedNativeFunction, Ref<JSC::JITCode>&& constructThunk, TaggedNativeFunction constructor, ImplementationVisibility, const String& name);
+    static NativeExecutable* create(VM&, Ref<JSC::JITCode>&& callThunk, TaggedNativeFunction, Ref<JSC::JITCode>&& constructThunk, TaggedNativeFunction constructor, ImplementationVisibility, unsigned length, const String& name);
 
     static void destroy(JSCell*);
     
@@ -74,6 +74,8 @@ public:
     DECLARE_INFO;
 
     const String& name() const LIFETIME_BOUND { return m_name; }
+    JSString* nameJSString(VM&) const;
+    unsigned length() const { return m_length; }
 
     const DOMJIT::Signature* signatureFor(CodeSpecializationKind) const;
     ImplementationVisibility implementationVisibility() const { return static_cast<ImplementationVisibility>(m_implementationVisibility); }
@@ -88,10 +90,9 @@ public:
 
     JSString* asStringConcurrently() const LIFETIME_BOUND { return m_asString.get(); }
     static constexpr ptrdiff_t offsetOfAsString() { return OBJECT_OFFSETOF(NativeExecutable, m_asString); }
-
 private:
     NativeExecutable(VM&, TaggedNativeFunction, TaggedNativeFunction constructor, ImplementationVisibility);
-    void finishCreation(VM&, Ref<JSC::JITCode>&& callThunk, Ref<JSC::JITCode>&& constructThunk, const String& name);
+    void finishCreation(VM&, Ref<JSC::JITCode>&& callThunk, Ref<JSC::JITCode>&& constructThunk, unsigned length, const String& name);
 
     JSString* toStringSlow(JSGlobalObject*);
 
@@ -99,6 +100,7 @@ private:
     TaggedNativeFunction m_constructor;
 
     unsigned m_implementationVisibility : bitWidthOfImplementationVisibility;
+    unsigned m_length { 0 };
 
     String m_name;
     WriteBarrier<JSString> m_asString;

--- a/Source/JavaScriptCore/runtime/NumberConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/NumberConstructor.cpp
@@ -63,7 +63,7 @@ NumberConstructor::NumberConstructor(VM& vm, NativeExecutable* executable, JSGlo
 NumberConstructor* NumberConstructor::create(VM& vm, Structure* structure, NumberPrototype* numberPrototype)
 {
     JSGlobalObject* globalObject = structure->realm();
-    NativeExecutable* executable = vm.getHostFunction(callNumberConstructor, ImplementationVisibility::Public, NumberConstructorIntrinsic, constructNumberConstructor, nullptr, vm.propertyNames->Number.string());
+    NativeExecutable* executable = vm.getHostFunction(callNumberConstructor, ImplementationVisibility::Public, NumberConstructorIntrinsic, constructNumberConstructor, nullptr, 1, vm.propertyNames->Number.string());
     NumberConstructor* constructor = new (NotNull, allocateCell<NumberConstructor>(vm)) NumberConstructor(vm, executable, globalObject, structure);
     constructor->finishCreation(vm, numberPrototype);
     return constructor;
@@ -77,8 +77,6 @@ void NumberConstructor::finishCreation(VM& vm, NumberPrototype* numberPrototype)
     JSGlobalObject* globalObject = numberPrototype->realm();
 
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, numberPrototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-    putDirectWithoutTransition(vm, vm.propertyNames->length, jsNumber(1), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-    putDirectWithoutTransition(vm, vm.propertyNames->name, jsString(vm, vm.propertyNames->Number.string()), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
 
     putDirectWithoutTransition(vm, Identifier::fromString(vm, "EPSILON"_s), jsDoubleNumber(std::numeric_limits<double>::epsilon()), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
     putDirectWithoutTransition(vm, Identifier::fromString(vm, "MAX_VALUE"_s), jsDoubleNumber(1.7976931348623157E+308), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);

--- a/Source/JavaScriptCore/runtime/PinballCompletion.cpp
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.cpp
@@ -117,9 +117,9 @@ extern "C" {
 
 static JSFunctionWithFields* createHandler(VM& vm, JSGlobalObject* globalObject, PinballCompletion* pinballCompletion, NativeFunction function, const String name)
 {
-    NativeExecutable* executable = vm.getHostFunction(function, ImplementationVisibility::Private, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
     constexpr unsigned length = 1;
-    JSFunctionWithFields* handler = JSFunctionWithFields::create(vm, globalObject, executable, length, name);
+    NativeExecutable* executable = vm.getHostFunction(function, ImplementationVisibility::Private, NoIntrinsic, callHostFunctionAsConstructor, nullptr, length, name);
+    JSFunctionWithFields* handler = JSFunctionWithFields::create(vm, globalObject, executable);
     handler->setField(vm, JSFunctionWithFields::Field::PromiseHandlerPinballCompletion, pinballCompletion);
     return handler;
 }

--- a/Source/JavaScriptCore/runtime/StringConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/StringConstructor.cpp
@@ -61,14 +61,12 @@ void StringConstructor::finishCreation(VM& vm, StringPrototype* stringPrototype)
 {
     Base::finishCreation(vm);
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, stringPrototype, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | PropertyAttribute::DontDelete);
-    putDirectWithoutTransition(vm, vm.propertyNames->length, jsNumber(1), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-    putDirectWithoutTransition(vm, vm.propertyNames->name, jsString(vm, vm.propertyNames->String.string()), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
 }
 
 StringConstructor* StringConstructor::create(VM& vm, Structure* structure, StringPrototype* stringPrototype)
 {
     JSGlobalObject* globalObject = structure->realm();
-    NativeExecutable* executable = vm.getHostFunction(callStringConstructor, ImplementationVisibility::Public, StringConstructorIntrinsic, constructWithStringConstructor, nullptr, vm.propertyNames->String.string());
+    NativeExecutable* executable = vm.getHostFunction(callStringConstructor, ImplementationVisibility::Public, StringConstructorIntrinsic, constructWithStringConstructor, nullptr, 1, vm.propertyNames->String.string());
     StringConstructor* constructor = new (NotNull, allocateCell<StringConstructor>(vm)) StringConstructor(vm, executable, globalObject, structure);
     constructor->finishCreation(vm, stringPrototype);
     return constructor;

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -842,9 +842,9 @@ MacroAssemblerCodeRef<JITThunkPtrTag> VM::getCTIStub(CommonJITThunkID thunkID)
 
 #endif // ENABLE(JIT)
 
-NativeExecutable* VM::getHostFunction(NativeFunction function, ImplementationVisibility implementationVisibility, NativeFunction constructor, const String& name)
+NativeExecutable* VM::getHostFunction(NativeFunction function, ImplementationVisibility implementationVisibility, NativeFunction constructor, unsigned length, const String& name)
 {
-    return getHostFunction(function, implementationVisibility, NoIntrinsic, constructor, nullptr, name);
+    return getHostFunction(function, implementationVisibility, NoIntrinsic, constructor, nullptr, length, name);
 }
 
 static Ref<NativeJITCode> jitCodeForCallTrampoline(Intrinsic intrinsic)
@@ -881,19 +881,19 @@ static Ref<NativeJITCode> jitCodeForConstructTrampoline()
     return result.get();
 }
 
-NativeExecutable* VM::getHostFunction(NativeFunction function, ImplementationVisibility implementationVisibility, Intrinsic intrinsic, NativeFunction constructor, const DOMJIT::Signature* signature, const String& name)
+NativeExecutable* VM::getHostFunction(NativeFunction function, ImplementationVisibility implementationVisibility, Intrinsic intrinsic, NativeFunction constructor, const DOMJIT::Signature* signature, unsigned length, const String& name)
 {
 #if ENABLE(JIT)
     if (Options::useJIT()) {
         return jitStubs->hostFunctionStub(
             *this, toTagged(function), toTagged(constructor),
             intrinsic != NoIntrinsic ? thunkGeneratorForIntrinsic(intrinsic) : nullptr,
-            implementationVisibility, intrinsic, signature, name);
+            implementationVisibility, intrinsic, signature, length, name);
     }
 #endif // ENABLE(JIT)
     UNUSED_PARAM(intrinsic);
     UNUSED_PARAM(signature);
-    return NativeExecutable::create(*this, jitCodeForCallTrampoline(intrinsic), toTagged(function), jitCodeForConstructTrampoline(), toTagged(constructor), implementationVisibility, name);
+    return NativeExecutable::create(*this, jitCodeForCallTrampoline(intrinsic), toTagged(function), jitCodeForConstructTrampoline(), toTagged(constructor), implementationVisibility, length, name);
 }
 
 NativeExecutable* VM::getBoundFunction(bool isJSFunction, SourceTaintedOrigin taintedness)
@@ -909,7 +909,7 @@ NativeExecutable* VM::getBoundFunction(bool isJSFunction, SourceTaintedOrigin ta
             slowCase ? boundFunctionCall : boundThisNoArgsFunctionCall,
             ImplementationVisibility::Private, // Bound function's visibility is private on the stack.
             slowCase ? NoIntrinsic : BoundFunctionCallIntrinsic,
-            boundFunctionConstruct, nullptr, String());
+            boundFunctionConstruct, nullptr, 0, String());
         slot.setWithoutWriteBarrier(result);
         return result;
     };
@@ -933,7 +933,7 @@ NativeExecutable* VM::getRemoteFunction(bool isJSFunction)
         NativeExecutable* result = getHostFunction(
             slowCase ? remoteFunctionCallGeneric : remoteFunctionCallForJSFunction,
             ImplementationVisibility::Public, intrinsic,
-            callHostFunctionAsConstructor, nullptr, String());
+            callHostFunctionAsConstructor, nullptr, 0, String());
         slot = Weak<NativeExecutable>(result);
         return result;
     };
@@ -1633,7 +1633,7 @@ JSPropertyNameEnumerator* VM::emptyPropertyNameEnumeratorSlow()
 NativeExecutable* VM::promiseResolvingFunctionResolveExecutableSlow()
 {
     ASSERT(!m_promiseResolvingFunctionResolveExecutable);
-    auto* executable = getHostFunction(promiseResolvingFunctionResolve, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseResolvingFunctionResolve, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseResolvingFunctionResolveExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1641,7 +1641,7 @@ NativeExecutable* VM::promiseResolvingFunctionResolveExecutableSlow()
 NativeExecutable* VM::promiseResolvingFunctionRejectExecutableSlow()
 {
     ASSERT(!m_promiseResolvingFunctionRejectExecutable);
-    auto* executable = getHostFunction(promiseResolvingFunctionReject, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseResolvingFunctionReject, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseResolvingFunctionRejectExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1649,7 +1649,7 @@ NativeExecutable* VM::promiseResolvingFunctionRejectExecutableSlow()
 NativeExecutable* VM::promiseFirstResolvingFunctionResolveExecutableSlow()
 {
     ASSERT(!m_promiseFirstResolvingFunctionResolveExecutable);
-    auto* executable = getHostFunction(promiseFirstResolvingFunctionResolve, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseFirstResolvingFunctionResolve, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseFirstResolvingFunctionResolveExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1657,7 +1657,7 @@ NativeExecutable* VM::promiseFirstResolvingFunctionResolveExecutableSlow()
 NativeExecutable* VM::promiseFirstResolvingFunctionRejectExecutableSlow()
 {
     ASSERT(!m_promiseFirstResolvingFunctionRejectExecutable);
-    auto* executable = getHostFunction(promiseFirstResolvingFunctionReject, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseFirstResolvingFunctionReject, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseFirstResolvingFunctionRejectExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1665,7 +1665,7 @@ NativeExecutable* VM::promiseFirstResolvingFunctionRejectExecutableSlow()
 NativeExecutable* VM::promiseResolvingFunctionResolveWithInternalMicrotaskExecutableSlow()
 {
     ASSERT(!m_promiseResolvingFunctionResolveWithInternalMicrotaskExecutable);
-    auto* executable = getHostFunction(promiseResolvingFunctionResolveWithInternalMicrotask, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseResolvingFunctionResolveWithInternalMicrotask, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseResolvingFunctionResolveWithInternalMicrotaskExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1673,7 +1673,7 @@ NativeExecutable* VM::promiseResolvingFunctionResolveWithInternalMicrotaskExecut
 NativeExecutable* VM::promiseResolvingFunctionRejectWithInternalMicrotaskExecutableSlow()
 {
     ASSERT(!m_promiseResolvingFunctionRejectWithInternalMicrotaskExecutable);
-    auto* executable = getHostFunction(promiseResolvingFunctionRejectWithInternalMicrotask, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseResolvingFunctionRejectWithInternalMicrotask, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseResolvingFunctionRejectWithInternalMicrotaskExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1681,7 +1681,7 @@ NativeExecutable* VM::promiseResolvingFunctionRejectWithInternalMicrotaskExecuta
 NativeExecutable* VM::promiseCapabilityExecutorExecutableSlow()
 {
     ASSERT(!m_promiseCapabilityExecutorExecutable);
-    auto* executable = getHostFunction(promiseCapabilityExecutor, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseCapabilityExecutor, ImplementationVisibility::Public, callHostFunctionAsConstructor, 2, emptyString());
     m_promiseCapabilityExecutorExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1689,7 +1689,7 @@ NativeExecutable* VM::promiseCapabilityExecutorExecutableSlow()
 NativeExecutable* VM::promiseAllFulfillFunctionExecutableSlow()
 {
     ASSERT(!m_promiseAllFulfillFunctionExecutable);
-    auto* executable = getHostFunction(promiseAllFulfillFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseAllFulfillFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseAllFulfillFunctionExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1697,7 +1697,7 @@ NativeExecutable* VM::promiseAllFulfillFunctionExecutableSlow()
 NativeExecutable* VM::promiseAllSlowFulfillFunctionExecutableSlow()
 {
     ASSERT(!m_promiseAllSlowFulfillFunctionExecutable);
-    auto* executable = getHostFunction(promiseAllSlowFulfillFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseAllSlowFulfillFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseAllSlowFulfillFunctionExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1705,7 +1705,7 @@ NativeExecutable* VM::promiseAllSlowFulfillFunctionExecutableSlow()
 NativeExecutable* VM::promiseAllSettledFulfillFunctionExecutableSlow()
 {
     ASSERT(!m_promiseAllSettledFulfillFunctionExecutable);
-    auto* executable = getHostFunction(promiseAllSettledFulfillFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseAllSettledFulfillFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseAllSettledFulfillFunctionExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1713,7 +1713,7 @@ NativeExecutable* VM::promiseAllSettledFulfillFunctionExecutableSlow()
 NativeExecutable* VM::promiseAllSettledRejectFunctionExecutableSlow()
 {
     ASSERT(!m_promiseAllSettledRejectFunctionExecutable);
-    auto* executable = getHostFunction(promiseAllSettledRejectFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseAllSettledRejectFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseAllSettledRejectFunctionExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1721,7 +1721,7 @@ NativeExecutable* VM::promiseAllSettledRejectFunctionExecutableSlow()
 NativeExecutable* VM::promiseAllSettledSlowFulfillFunctionExecutableSlow()
 {
     ASSERT(!m_promiseAllSettledSlowFulfillFunctionExecutable);
-    auto* executable = getHostFunction(promiseAllSettledSlowFulfillFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseAllSettledSlowFulfillFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseAllSettledSlowFulfillFunctionExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1729,7 +1729,7 @@ NativeExecutable* VM::promiseAllSettledSlowFulfillFunctionExecutableSlow()
 NativeExecutable* VM::promiseAllSettledSlowRejectFunctionExecutableSlow()
 {
     ASSERT(!m_promiseAllSettledSlowRejectFunctionExecutable);
-    auto* executable = getHostFunction(promiseAllSettledSlowRejectFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseAllSettledSlowRejectFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseAllSettledSlowRejectFunctionExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1737,7 +1737,7 @@ NativeExecutable* VM::promiseAllSettledSlowRejectFunctionExecutableSlow()
 NativeExecutable* VM::promiseAnyRejectFunctionExecutableSlow()
 {
     ASSERT(!m_promiseAnyRejectFunctionExecutable);
-    auto* executable = getHostFunction(promiseAnyRejectFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseAnyRejectFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseAnyRejectFunctionExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
@@ -1745,7 +1745,7 @@ NativeExecutable* VM::promiseAnyRejectFunctionExecutableSlow()
 NativeExecutable* VM::promiseAnySlowRejectFunctionExecutableSlow()
 {
     ASSERT(!m_promiseAnySlowRejectFunctionExecutable);
-    auto* executable = getHostFunction(promiseAnySlowRejectFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    auto* executable = getHostFunction(promiseAnySlowRejectFunction, ImplementationVisibility::Public, callHostFunctionAsConstructor, 1, emptyString());
     m_promiseAnySlowRejectFunctionExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -746,8 +746,8 @@ public:
     std::unique_ptr<FTL::Thunks> ftlThunks;
 #endif
 
-    NativeExecutable* getHostFunction(NativeFunction, ImplementationVisibility, NativeFunction constructor, const String& name);
-    NativeExecutable* getHostFunction(NativeFunction, ImplementationVisibility, Intrinsic, NativeFunction constructor, const DOMJIT::Signature*, const String& name);
+    NativeExecutable* getHostFunction(NativeFunction, ImplementationVisibility, NativeFunction constructor, unsigned length, const String& name);
+    NativeExecutable* getHostFunction(NativeFunction, ImplementationVisibility, Intrinsic, NativeFunction constructor, const DOMJIT::Signature*, unsigned length, const String& name);
 
     NativeExecutable* getBoundFunction(bool isJSFunction, SourceTaintedOrigin taintedness);
     NativeExecutable* getRemoteFunction(bool isJSFunction);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -81,11 +81,11 @@ JSC_DEFINE_HOST_FUNCTION(callWebAssemblyFunction, (JSGlobalObject* globalObject,
 
 WebAssemblyFunction* WebAssemblyFunction::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, unsigned length, const String& name, JSWebAssemblyInstance* instance, Wasm::IPIntCallee& wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Ref<const Wasm::RTT>&& rtt)
 {
-    NativeExecutable* base = vm.getHostFunction(callWebAssemblyFunction, ImplementationVisibility::Public, WasmFunctionIntrinsic, callHostFunctionAsConstructor, nullptr, String());
+    NativeExecutable* base = vm.getHostFunction(callWebAssemblyFunction, ImplementationVisibility::Public, WasmFunctionIntrinsic, callHostFunctionAsConstructor, nullptr, 0, String());
     // Since ClosureCall uses this executable as an identity for Wasm CallIC thunk, we need to make it diversified.
-    NativeExecutable* executable = NativeExecutable::create(vm, base->generatedJITCodeForCall(), callWebAssemblyFunction, base->generatedJITCodeForConstruct(), callHostFunctionAsConstructor, ImplementationVisibility::Public, name);
+    NativeExecutable* executable = NativeExecutable::create(vm, base->generatedJITCodeForCall(), callWebAssemblyFunction, base->generatedJITCodeForConstruct(), callHostFunctionAsConstructor, ImplementationVisibility::Public, length, name);
     WebAssemblyFunction* function = new (NotNull, allocateCell<WebAssemblyFunction>(vm)) WebAssemblyFunction(vm, executable, globalObject, structure, instance, wasmCallee, wasmToWasmEntrypointLoadLocation, WTF::move(rtt));
-    function->finishCreation(vm, executable, length, name);
+    function->finishCreation(vm);
     // The LLInt and JIT JS->Wasm entry trampolines read m_boxedJSToWasmCallee and
     // m_frameSize directly from this object, and are entered from many paths that
     // bypass callWebAssemblyFunction. Ensure they are populated before any such entry.

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp
@@ -56,12 +56,6 @@ void WebAssemblyFunctionBase::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 DEFINE_VISIT_CHILDREN(WebAssemblyFunctionBase);
 
-void WebAssemblyFunctionBase::finishCreation(VM& vm, NativeExecutable* executable, unsigned length, const String& name)
-{
-    Base::finishCreation(vm, executable, length, name);
-    ASSERT(inherits(info()));
-}
-
 const Wasm::RTT& WebAssemblyFunctionBase::signature() const
 {
     return *m_importableFunction.rtt;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
@@ -68,7 +68,7 @@ public:
     static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WebAssemblyFunctionBase, m_importableFunction) + WasmToWasmImportableFunction::offsetOfRTT(); }
 
 protected:
-    void finishCreation(VM&, NativeExecutable*, unsigned length, const String& name);
+    DECLARE_DEFAULT_FINISH_CREATION;
     WebAssemblyFunctionBase(VM&, NativeExecutable*, JSGlobalObject*, Structure*, Wasm::WasmOrJSImportableFunction&&, Wasm::WasmOrJSImportableFunctionCallLinkInfo*);
 
     Wasm::WasmOrJSImportableFunction m_importableFunction;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp
@@ -91,9 +91,9 @@ JSC_DEFINE_HOST_FUNCTION(runWebAssemblyPromisingFunction, (JSGlobalObject* globa
 JSFunctionWithFields* createWebAssemblyPromisingFunction(VM& vm, JSGlobalObject* globalObject, JSFunction* wrappedFunction)
 {
     const String name = "WebAssembly.promising"_s;
-    NativeExecutable* executable = vm.getHostFunction(runWebAssemblyPromisingFunction, ImplementationVisibility::Private, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
     constexpr unsigned length = 1;
-    JSFunctionWithFields* function = JSFunctionWithFields::create(vm, globalObject, executable, length, name);
+    NativeExecutable* executable = vm.getHostFunction(runWebAssemblyPromisingFunction, ImplementationVisibility::Private, NoIntrinsic, callHostFunctionAsConstructor, nullptr, length, name);
+    JSFunctionWithFields* function = JSFunctionWithFields::create(vm, globalObject, executable);
     function->setField(vm, JSFunctionWithFields::Field::WebAssemblyPromisingWrappedFunction, wrappedFunction);
     return function;
 }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
@@ -192,9 +192,8 @@ void* runWebAssemblySuspendingFunction(JSGlobalObject* globalObject, CallFrame* 
 JSFunctionWithFields* createWebAssemblySuspendingFunction(VM& vm, JSGlobalObject* globalObject, JSValue callable)
 {
     const String name = "WebAssembly.Suspending"_s;
-    NativeExecutable* executable = vm.getHostFunction(enterWebAssemblySuspendingFunction, ImplementationVisibility::Private, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
-    constexpr unsigned length = 0;
-    JSFunctionWithFields* function = JSFunctionWithFields::create(vm, globalObject, executable, length, name);
+    NativeExecutable* executable = vm.getHostFunction(enterWebAssemblySuspendingFunction, ImplementationVisibility::Private, NoIntrinsic, callHostFunctionAsConstructor, nullptr, 0, name);
+    JSFunctionWithFields* function = JSFunctionWithFields::create(vm, globalObject, executable);
     function->setField(vm, JSFunctionWithFields::Field::WebAssemblySuspendingWrappedCallable, callable);
     return function;
 }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
@@ -50,10 +50,11 @@ WebAssemblyWrapperFunction* WebAssemblyWrapperFunction::create(VM& vm, JSGlobalO
 
     String name = emptyString();
     NativeExecutable* executable = nullptr;
+    unsigned length = signature->argumentCount();
     if (signature->argumentsOrResultsIncludeV128() || signature->argumentsOrResultsIncludeExnref()) [[unlikely]]
-        executable = vm.getHostFunction(callWebAssemblyWrapperFunctionIncludingInvalidValues, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
+        executable = vm.getHostFunction(callWebAssemblyWrapperFunctionIncludingInvalidValues, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, length, name);
     else
-        executable = vm.getHostFunction(callWebAssemblyWrapperFunction, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
+        executable = vm.getHostFunction(callWebAssemblyWrapperFunction, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, length, name);
 
     RELEASE_ASSERT(JSValue(function).isCallable());
     WebAssemblyWrapperFunction* result = new (NotNull, allocateCell<WebAssemblyWrapperFunction>(vm)) WebAssemblyWrapperFunction(vm, executable, globalObject, structure, function,
@@ -71,7 +72,7 @@ WebAssemblyWrapperFunction* WebAssemblyWrapperFunction::create(VM& vm, JSGlobalO
         },
         instance->importFunctionInfo(importIndex));
     result->m_importableFunction.importFunction.set(vm, globalObject, function);
-    result->finishCreation(vm, executable, signature->argumentCount(), name);
+    result->finishCreation(vm);
     return result;
 }
 


### PR DESCRIPTION
#### a633a8abfee7ea63976bbf236a78fb00b866dbf8
<pre>
[JSC] NativeExecutable should have name and length in the same way to FunctionExecutable
<a href="https://bugs.webkit.org/show_bug.cgi?id=316443">https://bugs.webkit.org/show_bug.cgi?id=316443</a>
<a href="https://rdar.apple.com/178844469">rdar://178844469</a>

Reviewed by Justin Michaud and Yijia Huang.

This is slight optimization for case doing `bind` with native functions,
but largely a preparation for introducing optimization for patterns converting
JS builtins to C++ native functions. Previously NativeExecutable was not
holding length / name appropriately while FunctionExecutable was doing
so. As a result, JSBoundFunction related optimization was skipping
NativeExecutable cases. This becomes a problem when we convert JS
builtin functions to Native version as bind starts going to the slow path.
This patch alignes NativeExecutable&apos;s name and length handling much more
to FunctionExecutable.

* JSTests/stress/promise-resolving-functions-name-and-length.js: Added.
(shouldBe):
(new.Promise):
(checkAnonymousBuiltin):
(i.new.Promise):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/jit/JITThunks.cpp:
(JSC::JITThunks::WeakNativeExecutableHash::hash):
(JSC::JITThunks::WeakNativeExecutableHash::equal):
(JSC::JITThunks::finalize):
(JSC::JITThunks::hostFunctionStub):
* Source/JavaScriptCore/jit/JITThunks.h:
* Source/JavaScriptCore/runtime/BooleanConstructor.cpp:
(JSC::BooleanConstructor::finishCreation):
(JSC::BooleanConstructor::create):
* Source/JavaScriptCore/runtime/JSBoundFunction.cpp:
(JSC::JSBoundFunction::canSkipNameAndLengthMaterialization):
* Source/JavaScriptCore/runtime/JSCustomGetterFunction.cpp:
(JSC::JSCustomGetterFunction::create):
* Source/JavaScriptCore/runtime/JSCustomSetterFunction.cpp:
(JSC::JSCustomSetterFunction::create):
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::create):
(JSC::JSFunction::reifyLazyPropertyIfNeeded):
(JSC::JSFunction::reifyLazyPropertyForHostOrBuiltinIfNeeded):
(JSC::JSFunction::reifyLazyBoundNameIfNeeded):
(JSC::JSFunction::finishCreation): Deleted.
* Source/JavaScriptCore/runtime/JSFunction.h:
* Source/JavaScriptCore/runtime/JSFunctionInlines.h:
(JSC::JSFunction::originalLength):
(JSC::JSFunction::originalName):
(JSC::JSFunction::canAssumeNameAndLengthAreOriginal):
* Source/JavaScriptCore/runtime/JSFunctionWithFields.cpp:
(JSC::JSFunctionWithFields::create):
* Source/JavaScriptCore/runtime/JSFunctionWithFields.h:
* Source/JavaScriptCore/runtime/JSNativeStdFunction.cpp:
(JSC::JSNativeStdFunction::getHostFunction):
(JSC::JSNativeStdFunction::create):
(JSC::JSNativeStdFunction::finishCreation): Deleted.
* Source/JavaScriptCore/runtime/JSNativeStdFunction.h:
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::createFirstResolveFunction):
(JSC::JSPromise::createFirstRejectFunction):
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::promiseAllSlow):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::promiseAllSettledSlow):
(JSC::promiseAnySlow):
* Source/JavaScriptCore/runtime/JSPromisePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::promiseProtoFuncFinallySlow):
* Source/JavaScriptCore/runtime/NativeExecutable.cpp:
(JSC::NativeExecutable::create):
(JSC::NativeExecutable::finishCreation):
(JSC::NativeExecutable::nameJSString const):
* Source/JavaScriptCore/runtime/NativeExecutable.h:
* Source/JavaScriptCore/runtime/NumberConstructor.cpp:
(JSC::NumberConstructor::create):
(JSC::NumberConstructor::finishCreation):
* Source/JavaScriptCore/runtime/PinballCompletion.cpp:
(JSC::createHandler):
* Source/JavaScriptCore/runtime/StringConstructor.cpp:
(JSC::StringConstructor::finishCreation):
(JSC::StringConstructor::create):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::getHostFunction):
(JSC::VM::getBoundFunction):
(JSC::VM::getRemoteFunction):
(JSC::VM::promiseResolvingFunctionResolveExecutableSlow):
(JSC::VM::promiseResolvingFunctionRejectExecutableSlow):
(JSC::VM::promiseFirstResolvingFunctionResolveExecutableSlow):
(JSC::VM::promiseFirstResolvingFunctionRejectExecutableSlow):
(JSC::VM::promiseResolvingFunctionResolveWithInternalMicrotaskExecutableSlow):
(JSC::VM::promiseResolvingFunctionRejectWithInternalMicrotaskExecutableSlow):
(JSC::VM::promiseCapabilityExecutorExecutableSlow):
(JSC::VM::promiseAllFulfillFunctionExecutableSlow):
(JSC::VM::promiseAllSlowFulfillFunctionExecutableSlow):
(JSC::VM::promiseAllSettledFulfillFunctionExecutableSlow):
(JSC::VM::promiseAllSettledRejectFunctionExecutableSlow):
(JSC::VM::promiseAllSettledSlowFulfillFunctionExecutableSlow):
(JSC::VM::promiseAllSettledSlowRejectFunctionExecutableSlow):
(JSC::VM::promiseAnyRejectFunctionExecutableSlow):
(JSC::VM::promiseAnySlowRejectFunctionExecutableSlow):
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::WebAssemblyFunction::create):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp:
(JSC::WebAssemblyFunctionBase::finishCreation): Deleted.
* Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp:
(JSC::createWebAssemblyPromisingFunction):
* Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp:
(JSC::createWebAssemblySuspendingFunction):
* Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp:
(JSC::WebAssemblyWrapperFunction::create):

Canonical link: <a href="https://commits.webkit.org/314682@main">https://commits.webkit.org/314682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/612a56806a226dbb12631fd7d34a928b02717e5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40362 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/33943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175920 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40370 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129766 "Build is in progress. Recent messages:") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169831 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/110292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159029 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/27636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178458 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27766 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31355 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/29343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40432 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/138044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41120 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/149434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103930 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25398 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/33320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199551 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39631 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112705 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53648 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39027 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/4393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39272 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39171 "Failed to checkout and rebase branch from PR 66580") | | | | 
<!--EWS-Status-Bubble-End-->