### PR TITLE
iOS selection and editable content interaction should match UIKit behavior

### DIFF
--- a/LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element-expected.txt
@@ -1,0 +1,14 @@
+Verifies that long-pressing non-editable text while a separate editable element is focused starts a selection and dismisses the keyboard (mirrors UIKit TextField behavior: focus and non-editable selection are mutually exclusive). Requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS keyboardWasShowing is true
+PASS focusedElementWasInput is true
+PASS getSelection().toString() became 'Hello'
+PASS keyboardDismissed is true
+PASS focusedElementBlurred is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello

--- a/LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element.html
+++ b/LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+.target {
+    font-size: 40px;
+    width: 300px;
+}
+
+input {
+    display: block;
+    margin-top: 40px;
+    width: 300px;
+    height: 80px;
+    font-size: 40px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+description("Verifies that long-pressing non-editable text while a separate editable element is focused starts a selection and dismisses the keyboard (mirrors UIKit TextField behavior: focus and non-editable selection are mutually exclusive). Requires WebKitTestRunner.");
+
+addEventListener("load", async () => {
+    const input = document.querySelector("input");
+    const inputRect = input.getBoundingClientRect();
+    await UIHelper.activateAndWaitForInputSessionAt(inputRect.left + inputRect.width / 2, inputRect.top + inputRect.height / 2);
+
+    window.keyboardWasShowing = await UIHelper.isShowingKeyboard();
+    shouldBeTrue("keyboardWasShowing");
+    window.focusedElementWasInput = document.activeElement === input;
+    shouldBeTrue("focusedElementWasInput");
+
+    await UIHelper.longPressElement(document.querySelector(".target"));
+    await shouldBecomeEqual("getSelection().toString()", "'Hello'");
+
+    await UIHelper.waitForKeyboardToHide();
+    window.keyboardDismissed = !(await UIHelper.isShowingKeyboard());
+    shouldBeTrue("keyboardDismissed");
+    window.focusedElementBlurred = document.activeElement !== input;
+    shouldBeTrue("focusedElementBlurred");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <span class="target">Hello</span>
+    <input>
+</body>
+</html>

--- a/LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard-expected.txt
@@ -1,0 +1,13 @@
+Verifies that long-pressing non-editable text while a separate editable element is focused with a hardware (Magic) keyboard attached starts a selection and blurs the focused element (mirrors UIKit TextField behavior: focus and non-editable selection are mutually exclusive).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS focusedElementWasInput is true
+PASS getSelection().toString() became 'Hello'
+PASS document.activeElement === document.querySelector('input') became false
+PASS focusedElementBlurred is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello

--- a/LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard.html
+++ b/LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+.target {
+    font-size: 40px;
+    width: 300px;
+}
+
+input {
+    display: block;
+    margin-top: 40px;
+    width: 300px;
+    height: 80px;
+    font-size: 40px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+description("Verifies that long-pressing non-editable text while a separate editable element is focused with a hardware (Magic) keyboard attached starts a selection and blurs the focused element (mirrors UIKit TextField behavior: focus and non-editable selection are mutually exclusive).");
+
+addEventListener("load", async () => {
+    const input = document.querySelector("input");
+    await UIHelper.activateElementAndWaitForInputSession(input);
+
+    window.focusedElementWasInput = document.activeElement === input;
+    shouldBeTrue("focusedElementWasInput");
+
+    await UIHelper.longPressElement(document.querySelector(".target"));
+    await shouldBecomeEqual("getSelection().toString()", "'Hello'");
+
+    await shouldBecomeEqual("document.activeElement === document.querySelector('input')", "false");
+    window.focusedElementBlurred = document.activeElement !== input;
+    shouldBeTrue("focusedElementBlurred");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <span class="target">Hello</span>
+    <input>
+</body>
+</html>

--- a/LayoutTests/editing/selection/ios/tap-focused-input-clears-outside-selection-expected.txt
+++ b/LayoutTests/editing/selection/ios/tap-focused-input-clears-outside-selection-expected.txt
@@ -1,0 +1,13 @@
+Verifies that tapping a previously-focused input while a non-editable selection is active refocuses the input and clears the outside selection (mirrors UIKit TextField behavior: tapping the field reclaims first-responder and discards any standalone selection). Requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getSelection().toString() became 'Hello'
+PASS focusedElementIsInput is true
+PASS outsideSelectionGone is true
+PASS inputCaretCollapsed is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello

--- a/LayoutTests/editing/selection/ios/tap-focused-input-clears-outside-selection.html
+++ b/LayoutTests/editing/selection/ios/tap-focused-input-clears-outside-selection.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+.target {
+    font-size: 40px;
+    width: 300px;
+}
+
+input {
+    display: block;
+    margin-top: 40px;
+    width: 300px;
+    height: 80px;
+    font-size: 40px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+description("Verifies that tapping a previously-focused input while a non-editable selection is active refocuses the input and clears the outside selection (mirrors UIKit TextField behavior: tapping the field reclaims first-responder and discards any standalone selection). Requires WebKitTestRunner.");
+
+addEventListener("load", async () => {
+    const input = document.querySelector("input");
+
+    // Set up: focus the input (keyboard up), then long-press outside to pull focus away
+    // and create a non-editable selection. After this, the input is blurred and 'Hello' is selected.
+    const inputRect = input.getBoundingClientRect();
+    await UIHelper.activateAndWaitForInputSessionAt(inputRect.left + inputRect.width / 2, inputRect.top + inputRect.height / 2);
+    await UIHelper.longPressElement(document.querySelector(".target"));
+    await shouldBecomeEqual("getSelection().toString()", "'Hello'");
+
+    // Now tap the (currently blurred) input. UIKit's behavior: the field becomes first responder again,
+    // and the standalone selection is discarded.
+    await UIHelper.activateElementAndWaitForInputSession(input);
+
+    window.focusedElementIsInput = document.activeElement === input;
+    shouldBeTrue("focusedElementIsInput");
+
+    // The standalone 'Hello' selection must have been discarded; the document-level selection
+    // should no longer reflect any outside text.
+    window.outsideSelectionGone = getSelection().toString() === "";
+    shouldBeTrue("outsideSelectionGone");
+
+    // And the caret should now live inside the input as a collapsed selection on its internal
+    // text control. (The input owns its selection internally, not via document.getSelection().)
+    window.inputCaretCollapsed = input.selectionStart === input.selectionEnd;
+    shouldBeTrue("inputCaretCollapsed");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <span class="target">Hello</span>
+    <input>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -582,6 +582,7 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _isChangingFocusUsingAccessoryTab;
     BOOL _didAccessoryTabInitiateFocus;
     BOOL _isExpectingFastSingleTapCommit;
+    BOOL _blurringFocusedElementForLoupeSelection;
     BOOL _showDebugTapHighlightsForFastClicking;
     BOOL _textInteractionDidChangeFocusedElement;
     BOOL _treatAsContentEditableUntilNextEditorStateUpdate;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1549,6 +1549,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _didAccessoryTabInitiateFocus = NO;
     _isChangingFocusUsingAccessoryTab = NO;
     _isExpectingFastSingleTapCommit = NO;
+    _blurringFocusedElementForLoupeSelection = NO;
     _needsDeferredEndScrollingSelectionUpdate = NO;
     [_formInputSession invalidate];
     _formInputSession = nil;
@@ -3789,8 +3790,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return YES;
 #endif
 
-    // If we're currently focusing an editable element, only allow the selection to move within that focused element.
-    if (self.isFocusingElement)
+    // If we're currently focusing an editable element, only allow the selection to move within that focused
+    // element. The loupe is exempt: it may begin a new selection on non-editable content outside the field.
+    if (self.isFocusingElement && gesture != WKBEGestureTypeLoupe)
         return _positionInformation.elementContext && _positionInformation.elementContext->isSameElement(_focusedElementInformation.elementContext);
 
     if (_positionInformation.prefersDraggingOverTextSelection)
@@ -5848,7 +5850,8 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 - (void)selectPositionAtPoint:(CGPoint)point completionHandler:(void (^)(void))completionHandler
 {
     _autocorrectionContextNeedsUpdate = YES;
-    [self _selectPositionAtPoint:point stayingWithinFocusedElement:self._hasFocusedElement completionHandler:completionHandler];
+    BOOL stayingWithinFocusedElement = self._hasFocusedElement && _focusedElementInformation.interactionRect.contains(WebCore::roundedIntPoint(point));
+    [self _selectPositionAtPoint:point stayingWithinFocusedElement:stayingWithinFocusedElement completionHandler:completionHandler];
 }
 
 - (void)_selectPositionAtPoint:(CGPoint)point stayingWithinFocusedElement:(BOOL)stayingWithinFocusedElement completionHandler:(void (^)(void))completionHandler
@@ -5857,6 +5860,20 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
     _autocorrectionContextNeedsUpdate = YES;
     _usingGestureForSelection = YES;
+
+    if (!stayingWithinFocusedElement && self._hasFocusedElement) {
+        _blurringFocusedElementForLoupeSelection = YES;
+        cancelPotentialTapIfNecessary(self);
+        protect(_page)->blurFocusedElement();
+        BOOL isInteractingWithFocusedElement = false;
+        [self.textInteractionLoupeGestureRecognizer _wk_cancel];
+        protect(_page)->selectWithGesture(WebCore::IntPoint(point), WebKit::GestureType::Loupe, WebKit::GestureRecognizerState::Began, isInteractingWithFocusedElement,
+        [view = retainPtr(self), completionHandler = makeBlockPtr(completionHandler)](const WebCore::IntPoint&, WebKit::GestureType, WebKit::GestureRecognizerState, OptionSet<WebKit::SelectionFlags>) {
+            completionHandler();
+            view->_usingGestureForSelection = NO;
+        });
+        return;
+    }
 
     protect(_page)->selectPositionAtPoint(WebCore::IntPoint(point), stayingWithinFocusedElement, [view = retainPtr(self), completionHandler = makeBlockPtr(completionHandler)]() {
         completionHandler();
@@ -8297,8 +8314,9 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 
     self.inputDelegate = nil;
     [self setUpTextSelectionAssistant];
-    
-    [_textInteractionWrapper deactivateSelection];
+
+    if (!_blurringFocusedElementForLoupeSelection)
+        [_textInteractionWrapper deactivateSelection];
     [protect(_formAccessoryView) hideAutoFillButton];
 
     // FIXME: Does it make sense to call -reloadInputViews on watchOS?
@@ -8805,6 +8823,8 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
         _didAccessoryTabInitiateFocus = NO;
 
     _lastInsertedCharacterToOverrideCharacterBeforeSelection = std::nullopt;
+
+    _blurringFocusedElementForLoupeSelection = NO;
 }
 
 - (void)_updateInputContextAfterBlurringAndRefocusingElement
@@ -9424,7 +9444,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
         if (postLayoutData.selectionIsTransparentOrFullyClipped)
             selectionIsTransparentOrFullyClipped = YES;
 
-        if (self._hasFocusedElement) {
+        if (self._hasFocusedElement && editorState.isContentEditable) {
             auto elementArea = visualData.editableRootBounds.area<RecordOverflow>();
             if (!elementArea.hasOverflowed() && elementArea < minimumFocusedElementAreaForSuppressingSelectionAssistant)
                 focusedElementIsTooSmall = YES;


### PR DESCRIPTION
#### a107e5c0a7606a6d5fef43b7d5611b730294577c
<pre>
iOS selection and editable content interaction should match UIKit behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=316445">https://bugs.webkit.org/show_bug.cgi?id=316445</a>
<a href="https://rdar.apple.com/178846185">rdar://178846185</a>

Reviewed by Wenson Hsieh.

We do not match UIKit&apos;s behavior for selection and editable content interaction.
Currently, it is not possible to create a selection when focus is on editable content.

I addressed this by matching UIKit&apos;s behavior:
When the selection is created, focus leaves the editable content. If focus is returned
to the editable content, then the selection is removed.

Tests: editing/selection/ios/select-text-by-long-press-with-focused-element.html
       editing/selection/ios/select-text-by-long-press-with-hardware-keyboard.html
       editing/selection/ios/tap-focused-input-clears-outside-selection.html

* LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element.html: Added.
* LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-text-by-long-press-with-hardware-keyboard.html: Added.
* LayoutTests/editing/selection/ios/tap-focused-input-clears-outside-selection-expected.txt: Added.
* LayoutTests/editing/selection/ios/tap-focused-input-clears-outside-selection.html: Added.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):
(-[WKContentView textInteractionGesture:shouldBeginAtPoint:]):
(-[WKContentView selectPositionAtPoint:completionHandler:]):
(-[WKContentView _selectPositionAtPoint:stayingWithinFocusedElement:completionHandler:]):
(-[WKContentView _hideKeyboard:]):
(-[WKContentView _elementDidBlur]):
(-[WKContentView _updateSelectionAssistantSuppressionState]):

Canonical link: <a href="https://commits.webkit.org/314741@main">https://commits.webkit.org/314741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f9bff123cdad50748ab6a9e83295e15949029d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175900 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124110 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14320e36-f0c7-4e00-a31d-0fc38df1ab8e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129745 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91368 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef3e91f8-ddc3-4c3b-9408-4bea79808a92) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110271 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31124 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29822 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24636 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178438 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138113 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33970 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138026 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37208 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149417 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103898 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33303 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26282 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39611 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112685 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39007 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4375 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39252 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39150 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->