### PR TITLE
[JSC] Update async generator code aligned to the spec

### DIFF
--- a/JSTests/stress/async-generator-next-on-completed-reentrant.js
+++ b/JSTests/stress/async-generator-next-on-completed-reentrant.js
@@ -1,0 +1,34 @@
+// https://bugs.webkit.org/show_bug.cgi?id=316447
+// %AsyncGeneratorPrototype%.next step 5: completed -> resolve { undefined, true } directly. Resolving reads
+// `then`, so a reentrant next() must still see the completed state and resolve inline (h2 before m1).
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+let log = [];
+
+async function* gen() { }
+let it = gen();
+
+it.next().then(function () {
+    let phase = 1;
+    Object.defineProperty(Object.prototype, "then", {
+        configurable: true,
+        get() {
+            if (phase === 1) {
+                phase = 2;
+                it.next().then(() => { log.push("h2"); });
+                Promise.resolve().then(() => { log.push("m1"); });
+            }
+            return undefined;
+        },
+    });
+
+    it.next();
+});
+
+drainMicrotasks();
+
+shouldBe(log.join("|"), "h2|m1");

--- a/JSTests/stress/async-generator-reentrant-resume-during-resolve.js
+++ b/JSTests/stress/async-generator-reentrant-resume-during-resolve.js
@@ -1,0 +1,58 @@
+// Regression test for https://bugs.webkit.org/show_bug.cgi?id=316132
+//
+// Resolving an async generator request reads `.then` on the iterator result object. A user-defined
+// `then` getter on Object.prototype can reentrantly call `iter.next()` while the generator is
+// suspended at a yield. The old driver resumed the generator nested inside that resolve and could
+// leave it awaiting, then resumed it again from the outer drain — asserting/crashing.
+//
+// After aligning the driver to the current spec (AsyncGeneratorDrainQueue / AsyncGeneratorResume /
+// AsyncGeneratorCompleteStep with a draining-queue state), the resolve in AsyncGeneratorYield runs
+// while the generator is in an execution state, so the reentrant next() only enqueues; the request
+// is then resumed inline. The observed order matches SpiderMonkey (the spec sequences CompleteStep,
+// which fulfils the first next()'s promise, before the inline resume re-suspends on the awaited
+// return value). It intentionally differs from V8's order; engines do not agree here.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+let log = [];
+let iter;
+let thenGets = 0;
+
+Object.defineProperty(Object.prototype, "then", {
+    get() {
+        log.push("then:" + thenGets);
+        if (thenGets++ === 0)
+            iter.next();
+        return undefined;
+    },
+    configurable: true,
+});
+
+async function* gen() {
+    log.push("start");
+    yield 1;
+    log.push("resume");
+    return 2;
+}
+
+let error = null;
+let resolvedWith = null;
+
+(async function main() {
+    iter = gen();
+    await iter.next();
+    log.push("await-first");
+    await 0;
+    await 0;
+    return 10;
+})().then(result => { resolvedWith = result; }, e => { error = e; });
+
+drainMicrotasks();
+
+if (error)
+    throw error;
+shouldBe(log.join("|"), "start|then:0|resume|await-first|then:1");
+shouldBe(resolvedWith, 10);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -150,12 +150,6 @@ test/language/import/import-attributes/text-string.js:
   module: 'TypeError: Import attribute type "text" is not valid'
 test/language/import/import-attributes/text-via-namespace.js:
   module: 'TypeError: Import attribute type "text" is not valid'
-test/language/statements/async-generator/yield-star-promise-not-unwrapped.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: yield* should not unwrap promises from manually-implemented async iterators Expected SameValue(«"unwrapped value"», «[object Promise]») to be true'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: yield* should not unwrap promises from manually-implemented async iterators Expected SameValue(«"unwrapped value"», «[object Promise]») to be true'
-test/language/statements/async-generator/yield-star-return-then-getter-ticks.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Actual [start, tick 1, tick 2, get then, tick 3, get return, get then] and expected [start, tick 1, get then, tick 2, get return, get then, tick 3] should have the same contents. Ticks for return with thenable getter'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Actual [start, tick 1, tick 2, get then, tick 3, get return, get then] and expected [start, tick 1, get then, tick 2, get return, get then, tick 3] should have the same contents. Ticks for return with thenable getter'
 test/language/statements/class/elements/private-class-field-on-nonextensible-objects.js:
   strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
 test/language/statements/class/subclass/private-class-field-on-nonextensible-return-override.js:

--- a/Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js
@@ -24,122 +24,71 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@linkTimeConstant
-function asyncGeneratorResumeNext(generator, resumeMode)
-{
-    "use strict";
-
-    @assert(@isAsyncGenerator(generator), "Generator is not an AsyncGenerator instance.");
-
-    while (true) {
-        var state = @getAsyncGeneratorInternalField(generator, @generatorFieldState);
-
-        @assert(state !== @AsyncGeneratorStateExecuting, "Async generator should not be in executing state");
-
-        if (state === @AsyncGeneratorStateAwaitingReturn)
-            return;
-
-        if (resumeMode === @AsyncGeneratorResumeModeEmpty)
-            return;
-
-        var resumeValue = @getAsyncGeneratorInternalField(generator, @asyncGeneratorFieldResumeValue);
-
-        if (resumeMode !== @GeneratorResumeModeNormal) {
-            if (state === @AsyncGeneratorStateInit) {
-                @putAsyncGeneratorInternalField(generator, @generatorFieldState, @AsyncGeneratorStateCompleted);
-                state = @AsyncGeneratorStateCompleted;
-            }
-
-            if (resumeMode === @GeneratorResumeModeReturn) {
-                if (state === @AsyncGeneratorStateCompleted) {
-                    @putAsyncGeneratorInternalField(generator, @generatorFieldState, @AsyncGeneratorStateAwaitingReturn);
-                    return @resolveWithInternalMicrotaskForAsyncAwait(resumeValue, @InternalMicrotaskAsyncGeneratorResumeNext, generator);
-                }
-
-                if (state > 0 && (state & @AsyncGeneratorSuspendReasonMask) === @AsyncGeneratorSuspendReasonYield) {
-                    state = (state & ~@AsyncGeneratorSuspendReasonMask) | @AsyncGeneratorSuspendReasonAwait;
-                    @putAsyncGeneratorInternalField(generator, @generatorFieldState, state);
-                    return @resolveWithInternalMicrotaskForAsyncAwait(resumeValue, @InternalMicrotaskAsyncGeneratorBodyCallReturn, generator);
-                }
-            } else {
-                @assert(resumeMode === @GeneratorResumeModeThrow, "Async generator has wrong mode");
-                if (state === @AsyncGeneratorStateCompleted) {
-                    resumeMode = @asyncGeneratorQueueDequeueReject(generator, resumeValue);
-                    continue;
-                }
-            }
-        } else if (state === @AsyncGeneratorStateCompleted) {
-            resumeMode = @asyncGeneratorQueueDequeueResolve(generator, { value: @undefined, done: true });
-            continue;
-        }
-
-        var value = @undefined;
-
-        @putAsyncGeneratorInternalField(generator, @generatorFieldState, @AsyncGeneratorStateExecuting);
-
-        try {
-            value = @getAsyncGeneratorInternalField(generator, @generatorFieldNext).@call(@getAsyncGeneratorInternalField(generator, @generatorFieldThis), generator, state >> @AsyncGeneratorSuspendReasonShift, resumeValue, resumeMode, @getAsyncGeneratorInternalField(generator, @generatorFieldFrame));
-            state = @getAsyncGeneratorInternalField(generator, @generatorFieldState);
-            if (state === @AsyncGeneratorStateExecuting) {
-                @putAsyncGeneratorInternalField(generator, @generatorFieldState, @AsyncGeneratorStateCompleted);
-                state = @AsyncGeneratorStateCompleted;
-            }
-        } catch (error) {
-            @putAsyncGeneratorInternalField(generator, @generatorFieldState, @AsyncGeneratorStateCompleted);
-            resumeMode = @asyncGeneratorQueueDequeueReject(generator, error);
-            continue;
-        }
-
-        if (state > 0) {
-            if ((state & @AsyncGeneratorSuspendReasonMask) === @AsyncGeneratorSuspendReasonAwait)
-                return @resolveWithInternalMicrotaskForAsyncAwait(value, @InternalMicrotaskAsyncGeneratorBodyCallNormal, generator);
-
-            state = (state & ~@AsyncGeneratorSuspendReasonMask) | @AsyncGeneratorSuspendReasonAwait;
-            @putAsyncGeneratorInternalField(generator, @generatorFieldState, state);
-            return @resolveWithInternalMicrotaskForAsyncAwait(value, @InternalMicrotaskAsyncGeneratorYieldAwaited, generator);
-        }
-
-        if (state === @AsyncGeneratorStateCompleted) {
-            @assert(@getAsyncGeneratorInternalField(generator, @generatorFieldState) == @AsyncGeneratorStateCompleted);
-            resumeMode = @asyncGeneratorQueueDequeueResolve(generator, { value, done: true });
-            continue;
-        }
-        return;
-    }
-}
-
+// https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next
 function next(value)
 {
     "use strict";
 
     var promise = @newPromise();
-    var resumeMode = @asyncGeneratorQueueEnqueue(this, value, @GeneratorResumeModeNormal, promise);
-    if (resumeMode !== @AsyncGeneratorResumeModeEmpty)
-        @asyncGeneratorResumeNext(this, resumeMode);
+    // 3. Let result be Completion(AsyncGeneratorValidate(gen, empty)).
+    // 4. IfAbruptRejectPromise(result, promiseCapability).
+    // 5. Let state be gen.[[AsyncGeneratorState]].
+    // 6. If state is completed, then
+    // 6.a. Let iteratorResult be CreateIteratorResultObject(undefined, true).
+    // 6.b. Perform ! Call(promiseCapability.[[Resolve]], undefined, « iteratorResult »).
+    // 6.c. Return promiseCapability.[[Promise]].
+    // 7. Let completion be NormalCompletion(value).
+    // 8. Perform AsyncGeneratorEnqueue(gen, completion, promiseCapability).
+    // 9. If state is either suspended-start or suspended-yield, then
+    // 9.a. Perform AsyncGeneratorResume(gen, completion).
+    // 10. Else,
+    // 10.a. Assert: state is either executing or draining-queue.
+    var resumeMode = @asyncGeneratorNextQueueEnqueue(this, value, @GeneratorResumeModeNormal, promise);
+    if (resumeMode === @AsyncGeneratorResumeModeEmpty)
+        return promise;
+    @assert(@isAsyncGenerator(this), "Generator is not an AsyncGenerator instance.");
 
-    return promise;
-}
+    // https://tc39.es/ecma262/#sec-asyncgeneratorresume
+    //
+    // 3. Set gen.[[AsyncGeneratorState]] to executing.
+    // 4. Perform ! RunSuspendedContext(genContext, completion).
+    var state = @getAsyncGeneratorInternalField(this, @generatorFieldState);
+    @putAsyncGeneratorInternalField(this, @generatorFieldState, @AsyncGeneratorStateExecuting);
 
-function return(value)
-{
-    "use strict";
+    var result;
+    try {
+        result = @getAsyncGeneratorInternalField(this, @generatorFieldNext).@call(
+            @getAsyncGeneratorInternalField(this, @generatorFieldThis),
+            this,
+            state >> @AsyncGeneratorSuspendReasonShift,
+            @getAsyncGeneratorInternalField(this, @asyncGeneratorFieldResumeValue),
+            @GeneratorResumeModeNormal,
+            @getAsyncGeneratorInternalField(this, @generatorFieldFrame));
+    } catch (error) {
+        // https://tc39.es/ecma262/#sec-asyncgeneratorstart
+        // 4.g. Set acGen.[[AsyncGeneratorState]] to draining-queue.
+        // 4.h. If result is a normal completion, set result to NormalCompletion(undefined).
+        // 4.i. If result is a return completion, set result to NormalCompletion(result.[[Value]]).
+        // 4.j. Perform AsyncGeneratorCompleteStep(acGen, result, true).
+        // 4.k. Perform AsyncGeneratorDrainQueue(acGen).
+        @asyncGeneratorCompleteAndDrain(this, error, true);
+        return promise;
+    }
 
-    var promise = @newPromise();
-    var resumeMode = @asyncGeneratorQueueEnqueue(this, value, @GeneratorResumeModeReturn, promise);
-    if (resumeMode !== @AsyncGeneratorResumeModeEmpty)
-        @asyncGeneratorResumeNext(this, resumeMode);
+    state = @getAsyncGeneratorInternalField(this, @generatorFieldState);
 
-    return promise;
-}
+    // Body suspended at `await` / `yield` / `yield*`.
+    if (state > 0) {
+        @asyncGeneratorSuspend(this, result);
+        return promise;
+    }
 
-function throw(value)
-{
-    "use strict";
-
-    var promise = @newPromise();
-    var resumeMode = @asyncGeneratorQueueEnqueue(this, value, @GeneratorResumeModeThrow, promise);
-    if (resumeMode !== @AsyncGeneratorResumeModeEmpty)
-        @asyncGeneratorResumeNext(this, resumeMode);
-
+    // https://tc39.es/ecma262/#sec-asyncgeneratorstart
+    // 4.g. Set acGen.[[AsyncGeneratorState]] to draining-queue.
+    // 4.h. If result is a normal completion, set result to NormalCompletion(undefined).
+    // 4.i. If result is a return completion, set result to NormalCompletion(result.[[Value]]).
+    // 4.j. Perform AsyncGeneratorCompleteStep(acGen, result, true).
+    // 4.k. Perform AsyncGeneratorDrainQueue(acGen).
+    @asyncGeneratorCompleteAndDrain(this, result, false);
     return promise;
 }

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -86,9 +86,9 @@ namespace JSC {
     macro(newResolvedPromise) \
     macro(newRejectedPromise) \
     macro(resolveWithInternalMicrotaskForAsyncAwait) \
-    macro(asyncGeneratorQueueEnqueue) \
-    macro(asyncGeneratorQueueDequeueResolve) \
-    macro(asyncGeneratorQueueDequeueReject) \
+    macro(asyncGeneratorNextQueueEnqueue) \
+    macro(asyncGeneratorCompleteAndDrain) \
+    macro(asyncGeneratorSuspend) \
     macro(driveAsyncFunction) \
     macro(newHandledRejectedPromise) \
     macro(promiseReturnUndefinedOnFulfilled) \

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
@@ -114,11 +114,8 @@ BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry(VM& vm)
     m_AsyncGeneratorStateCompleted.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed)));
     m_AsyncGeneratorStateExecuting.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Executing)));
     m_AsyncGeneratorStateInit.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Init)));
-    m_AsyncGeneratorStateAwaitingReturn.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::AwaitingReturn)));
-    m_AsyncGeneratorSuspendReasonYield.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Yield)));
-    m_AsyncGeneratorSuspendReasonAwait.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Await)));
+    m_AsyncGeneratorStateDrainingQueue.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::DrainingQueue)));
     m_AsyncGeneratorSuspendReasonShift.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncGenerator::reasonShift)));
-    m_AsyncGeneratorSuspendReasonMask.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncGenerator::reasonMask)));
     m_asyncFromSyncIteratorFieldSyncIterator.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncFromSyncIterator::Field::SyncIterator)));
     m_asyncFromSyncIteratorFieldNextMethod.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncFromSyncIterator::Field::NextMethod)));
     m_abstractModuleRecordFieldState.set(m_vm, jsNumber(static_cast<int32_t>(AbstractModuleRecord::Field::State)));
@@ -142,10 +139,6 @@ BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry(VM& vm)
     m_AsyncDisposableStackStateDisposed.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncDisposableStack::State::Disposed)));
     m_InternalMicrotaskAsyncFromSyncIteratorContinue.set(m_vm, jsNumber(static_cast<int32_t>(InternalMicrotask::AsyncFromSyncIteratorContinue)));
     m_InternalMicrotaskAsyncFromSyncIteratorDone.set(m_vm, jsNumber(static_cast<int32_t>(InternalMicrotask::AsyncFromSyncIteratorDone)));
-    m_InternalMicrotaskAsyncGeneratorYieldAwaited.set(m_vm, jsNumber(static_cast<int32_t>(InternalMicrotask::AsyncGeneratorYieldAwaited)));
-    m_InternalMicrotaskAsyncGeneratorBodyCallNormal.set(m_vm, jsNumber(static_cast<int32_t>(InternalMicrotask::AsyncGeneratorBodyCallNormal)));
-    m_InternalMicrotaskAsyncGeneratorBodyCallReturn.set(m_vm, jsNumber(static_cast<int32_t>(InternalMicrotask::AsyncGeneratorBodyCallReturn)));
-    m_InternalMicrotaskAsyncGeneratorResumeNext.set(m_vm, jsNumber(static_cast<int32_t>(InternalMicrotask::AsyncGeneratorResumeNext)));
 }
 
 std::optional<BytecodeIntrinsicRegistry::Entry> BytecodeIntrinsicRegistry::lookup(const Identifier& ident) const

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -176,12 +176,9 @@ enum class LinkTimeConstant : int32_t;
     macro(AsyncGeneratorResumeModeEmpty) \
     macro(AsyncGeneratorStateCompleted) \
     macro(AsyncGeneratorStateExecuting) \
-    macro(AsyncGeneratorStateAwaitingReturn) \
+    macro(AsyncGeneratorStateDrainingQueue) \
     macro(AsyncGeneratorStateInit) \
-    macro(AsyncGeneratorSuspendReasonYield) \
-    macro(AsyncGeneratorSuspendReasonAwait) \
     macro(AsyncGeneratorSuspendReasonShift) \
-    macro(AsyncGeneratorSuspendReasonMask) \
     macro(asyncFromSyncIteratorFieldSyncIterator) \
     macro(asyncFromSyncIteratorFieldNextMethod) \
     macro(abstractModuleRecordFieldState) \
@@ -203,10 +200,6 @@ enum class LinkTimeConstant : int32_t;
     macro(AsyncDisposableStackStateDisposed) \
     macro(InternalMicrotaskAsyncFromSyncIteratorContinue) \
     macro(InternalMicrotaskAsyncFromSyncIteratorDone) \
-    macro(InternalMicrotaskAsyncGeneratorYieldAwaited) \
-    macro(InternalMicrotaskAsyncGeneratorBodyCallNormal) \
-    macro(InternalMicrotaskAsyncGeneratorBodyCallReturn) \
-    macro(InternalMicrotaskAsyncGeneratorResumeNext) \
 
 
 #define JSC_COMMON_BYTECODE_INTRINSIC_CONSTANTS_CUSTOM_EACH_NAME(macro) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -66,9 +66,9 @@ class JSGlobalObject;
     v(newResolvedPromise, nullptr) \
     v(newRejectedPromise, nullptr) \
     v(resolveWithInternalMicrotaskForAsyncAwait, nullptr) \
-    v(asyncGeneratorQueueEnqueue, nullptr) \
-    v(asyncGeneratorQueueDequeueResolve, nullptr) \
-    v(asyncGeneratorQueueDequeueReject, nullptr) \
+    v(asyncGeneratorNextQueueEnqueue, nullptr) \
+    v(asyncGeneratorCompleteAndDrain, nullptr) \
+    v(asyncGeneratorSuspend, nullptr) \
     v(driveAsyncFunction, nullptr) \
     v(newHandledRejectedPromise, nullptr) \
     v(promiseReturnUndefinedOnFulfilled, nullptr) \

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -5313,6 +5313,9 @@ void BytecodeGenerator::emitYieldPoint(RegisterID* argument, JSAsyncGenerator::A
 
 RegisterID* BytecodeGenerator::emitYield(RegisterID* argument)
 {
+    // For async generators the operand is Awaited by the driver (reason Yield), not here, so there is no
+    // extra yield point. `yield*` instead suspends with YieldNoAwait (see emitDelegateYield) so the driver
+    // skips that await.
     emitYieldPoint(argument, JSAsyncGenerator::AsyncGeneratorSuspendReason::Yield);
 
     Ref<Label> normalLabel = newLabel();
@@ -5509,7 +5512,10 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
 
             Ref<Label> branchOnResult = newLabel();
             {
-                emitYieldPoint(value.get(), JSAsyncGenerator::AsyncGeneratorSuspendReason::Yield);
+                // `yield*` delegates the inner iterator's value without an enclosing Await (the iterator
+                // result was already Awaited above). YieldNoAwait tells the async driver not to await it.
+                // (Sync generators ignore the suspend reason.)
+                emitYieldPoint(value.get(), JSAsyncGenerator::AsyncGeneratorSuspendReason::YieldNoAwait);
                 move(value.get(), generatorValueRegister());
 
                 Ref<Label> normalLabel = newLabel();

--- a/Source/JavaScriptCore/runtime/AsyncGeneratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/AsyncGeneratorPrototype.cpp
@@ -28,6 +28,17 @@
 #include "AsyncGeneratorPrototype.h"
 
 #include "JSCInlines.h"
+#include "JSAsyncGenerator.h"
+#include "JSGenerator.h"
+#include "JSMicrotask.h"
+#include "JSPromise.h"
+
+namespace JSC {
+
+static JSC_DECLARE_HOST_FUNCTION(asyncGeneratorPrototypeReturn);
+static JSC_DECLARE_HOST_FUNCTION(asyncGeneratorPrototypeThrow);
+
+} // namespace JSC
 
 #include "AsyncGeneratorPrototype.lut.h"
 
@@ -37,11 +48,102 @@ const ClassInfo AsyncGeneratorPrototype::s_info = { "AsyncGenerator"_s, &Base::s
 
 /* Source for AsyncGeneratorPrototype.lut.h
 @begin asyncGeneratorPrototypeTable
-  next      JSBuiltin    DontEnum|Function 1
-  return    JSBuiltin    DontEnum|Function 1
-  throw     JSBuiltin    DontEnum|Function 1
+  next      JSBuiltin                       DontEnum|Function 1
+  return    asyncGeneratorPrototypeReturn   DontEnum|Function 1
+  throw     asyncGeneratorPrototypeThrow    DontEnum|Function 1
 @end
 */
+
+// https://tc39.es/ecma262/#sec-asyncgenerator-prototype-return
+JSC_DEFINE_HOST_FUNCTION(asyncGeneratorPrototypeReturn, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+
+    // 3. Let result be Completion(AsyncGeneratorValidate(gen, empty)).
+    // 4. IfAbruptRejectPromise(result, promiseCapability).
+    auto* generator = dynamicDowncast<JSAsyncGenerator>(callFrame->thisValue());
+    if (!generator) [[unlikely]] {
+        promise->reject(vm, createTypeError(globalObject, "|this| should be an async generator"_s));
+        return JSValue::encode(promise);
+    }
+
+    // 5. Let completion be ReturnCompletion(value).
+    // 6. Perform AsyncGeneratorEnqueue(gen, completion, promiseCapability).
+    generator->enqueue(vm, callFrame->argument(0), static_cast<int32_t>(JSGenerator::ResumeMode::ReturnMode), promise);
+
+    // 7. Let state be gen.[[AsyncGeneratorState]].
+    int32_t state = generator->state();
+    // 8. If state is either suspended-start or completed, then
+    if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Init) || state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed)) {
+        // 8.a. Set gen.[[AsyncGeneratorState]] to draining-queue.
+        // 8.b. Perform AsyncGeneratorAwaitReturn(gen).
+        generator->setState(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::DrainingQueue));
+        asyncGeneratorAwaitReturn(globalObject, generator);
+    } else if (JSAsyncGenerator::isSuspendedYieldState(state)) {
+        // 9. Else if state is suspended-yield, then
+        // 9.a. Perform AsyncGeneratorResume(gen, completion).
+        asyncGeneratorResume(globalObject, generator);
+    } else {
+        // 10. Else,
+        // 10.a. Assert: state is either executing or draining-queue.
+        ASSERT(JSAsyncGenerator::isExecutingState(state) || state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::DrainingQueue));
+    }
+
+    // 11. Return promiseCapability.[[Promise]].
+    return JSValue::encode(promise);
+}
+
+// https://tc39.es/ecma262/#sec-asyncgenerator-prototype-throw
+JSC_DEFINE_HOST_FUNCTION(asyncGeneratorPrototypeThrow, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+
+    // 3. Let result be Completion(AsyncGeneratorValidate(gen, empty)).
+    // 4. IfAbruptRejectPromise(result, promiseCapability).
+    auto* generator = dynamicDowncast<JSAsyncGenerator>(callFrame->thisValue());
+    if (!generator) [[unlikely]] {
+        promise->reject(vm, createTypeError(globalObject, "|this| should be an async generator"_s));
+        return JSValue::encode(promise);
+    }
+
+    JSValue exception = callFrame->argument(0);
+    int32_t state = generator->state();
+    // 5. Let state be gen.[[AsyncGeneratorState]].
+    // 6. If state is suspended-start, then
+    if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Init)) {
+        // 6.a. Set gen.[[AsyncGeneratorState]] to completed.
+        // 6.b. Set state to completed.
+        generator->setState(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed));
+        state = static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed);
+    }
+
+    // 7. If state is completed, then
+    if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed)) {
+        // 7.a. Perform ! Call(promiseCapability.[[Reject]], undefined, « exception »).
+        // 7.b. Return promiseCapability.[[Promise]].
+        promise->reject(vm, exception);
+        return JSValue::encode(promise);
+    }
+
+    // 8. Let completion be ThrowCompletion(exception).
+    // 9. Perform AsyncGeneratorEnqueue(gen, completion, promiseCapability).
+    generator->enqueue(vm, exception, static_cast<int32_t>(JSGenerator::ResumeMode::ThrowMode), promise);
+
+    // 10. If state is suspended-yield, then
+    // 10.a. Perform AsyncGeneratorResume(gen, completion).
+    if (JSAsyncGenerator::isSuspendedYieldState(state))
+        asyncGeneratorResume(globalObject, generator);
+    else {
+        // 11. Else,
+        // 11.a. Assert: state is either executing or draining-queue.
+        ASSERT(JSAsyncGenerator::isExecutingState(state) || state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::DrainingQueue));
+    }
+
+    // 12. Return promiseCapability.[[Promise]].
+    return JSValue::encode(promise);
+}
 
 void AsyncGeneratorPrototype::finishCreation(VM& vm)
 {

--- a/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
@@ -43,11 +43,14 @@ public:
         return vm.asyncGeneratorSpace<mode>();
     }
 
+    // JSC encoding of spec [[AsyncGeneratorState]]: suspended-start = Init; suspended-yield = positive
+    // state with reason Yield; executing = Executing or positive+Await (suspended mid-await); draining-queue
+    // = DrainingQueue; completed = Completed. https://tc39.es/ecma262/#sec-properties-of-asyncgenerator-instances
     enum class AsyncGeneratorState : int32_t {
         Completed = -1,
         Executing = -2,
         Init = 0,
-        AwaitingReturn = -3,
+        DrainingQueue = -3,
     };
     static_assert(static_cast<int32_t>(AsyncGeneratorState::Completed) == static_cast<int32_t>(JSGenerator::State::Completed));
     static_assert(static_cast<int32_t>(AsyncGeneratorState::Executing) == static_cast<int32_t>(JSGenerator::State::Executing));
@@ -56,9 +59,13 @@ public:
     enum class AsyncGeneratorSuspendReason : int32_t {
         Await = 0,
         Yield = 1,
+        // `yield*` delegation: the spec yields IteratorValue(innerResult) via AsyncGeneratorYield without an
+        // enclosing Await (unlike plain `yield`, which is AsyncGeneratorYield(? Await(value))). This reason
+        // tells the driver to deliver the value without awaiting it.
+        YieldNoAwait = 2,
     };
-    static constexpr int32_t reasonMask = 0x1;
-    static constexpr int32_t reasonShift = 1;
+    static constexpr int32_t reasonMask = 0x3;
+    static constexpr int32_t reasonShift = 2;
 
     enum class AsyncGeneratorResumeMode : int32_t {
         Empty = -1,
@@ -173,9 +180,14 @@ public:
         return resumeMode() == static_cast<int32_t>(AsyncGeneratorResumeMode::Empty);
     }
 
-    bool isExecutionState() const
+    // ~suspended-yield~: a positive state whose reason bits are Yield.
+    static bool isSuspendedYieldState(int32_t state)
     {
-        int32_t state = this->state();
+        return state > 0 && (state & reasonMask) == static_cast<int32_t>(AsyncGeneratorSuspendReason::Yield);
+    }
+
+    static bool isExecutingState(int32_t state)
+    {
         if (state == static_cast<int32_t>(AsyncGeneratorState::Executing))
             return true;
         if (state > 0 && (state & reasonMask) == static_cast<int32_t>(AsyncGeneratorSuspendReason::Await))

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -117,6 +117,7 @@
 #include "IntlSegmenterPrototype.h"
 #include "IntlSegments.h"
 #include "IntlSegmentsPrototype.h"
+#include "IteratorOperations.h"
 #include "JSAPIWrapperObject.h"
 #include "JSArrayBuffer.h"
 #include "JSArrayBufferConstructor.h"
@@ -372,9 +373,7 @@ static JSC_DECLARE_HOST_FUNCTION(promiseReturnUndefinedOnFulfilled);
 static JSC_DECLARE_HOST_FUNCTION(promiseResolve);
 static JSC_DECLARE_HOST_FUNCTION(promiseReject);
 static JSC_DECLARE_HOST_FUNCTION(performPromiseThen);
-static JSC_DECLARE_HOST_FUNCTION(asyncGeneratorQueueEnqueue);
-static JSC_DECLARE_HOST_FUNCTION(asyncGeneratorQueueDequeueResolve);
-static JSC_DECLARE_HOST_FUNCTION(asyncGeneratorQueueDequeueReject);
+static JSC_DECLARE_HOST_FUNCTION(asyncGeneratorNextQueueEnqueue);
 #if ASSERT_ENABLED
 static JSC_DECLARE_HOST_FUNCTION(assertCall);
 #endif
@@ -878,7 +877,8 @@ JSC_DEFINE_HOST_FUNCTION(performPromiseThen, (JSGlobalObject* globalObject, Call
     return encodedJSUndefined();
 }
 
-JSC_DEFINE_HOST_FUNCTION(asyncGeneratorQueueEnqueue, (JSGlobalObject* globalObject, CallFrame* callFrame))
+// https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next
+JSC_DEFINE_HOST_FUNCTION(asyncGeneratorNextQueueEnqueue, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
 
@@ -887,44 +887,43 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorQueueEnqueue, (JSGlobalObject* globalObje
     int32_t resumeMode = callFrame->uncheckedArgument(2).asInt32();
     JSPromise* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(3));
 
+    // 3. Let result be Completion(AsyncGeneratorValidate(gen, empty)).
+    // 4. IfAbruptRejectPromise(result, promiseCapability).
+    // https://tc39.es/ecma262/#sec-asyncgeneratorvalidate
     if (!generator) [[unlikely]] {
         promise->reject(vm, createTypeError(globalObject, "|this| should be an async generator"_s));
         return JSValue::encode(jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorResumeMode::Empty)));
     }
 
+    // 5. Let state be gen.[[AsyncGeneratorState]].
+    auto state = generator->state();
+    // 6. If state is completed, then
+    if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed)) {
+        // 6.a. Let iteratorResult be CreateIteratorResultObject(undefined, true).
+        // 6.b. Perform ! Call(promiseCapability.[[Resolve]], undefined, « iteratorResult »).
+        // 6.c. Return promiseCapability.[[Promise]].
+        ASSERT(resumeMode == static_cast<int32_t>(JSGenerator::ResumeMode::NormalMode));
+        auto* iteratorResult = createIteratorResultObject(globalObject, jsUndefined(), /* done */ true);
+        promise->resolve(globalObject, vm, iteratorResult);
+        return JSValue::encode(jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorResumeMode::Empty)));
+    }
+
+    // 7. Let completion be NormalCompletion(value).
+    // 8. Perform AsyncGeneratorEnqueue(gen, completion, promiseCapability).
     generator->enqueue(vm, value, resumeMode, promise);
 
-    if (generator->isExecutionState())
-        return JSValue::encode(jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorResumeMode::Empty)));
-    return JSValue::encode(jsNumber(generator->resumeMode()));
-}
+    // 9. If state is either suspended-start or suspended-yield, then
+    if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Init) || JSAsyncGenerator::isSuspendedYieldState(state)) {
+        // 9.a. Perform AsyncGeneratorResume(gen, completion).
+        return JSValue::encode(jsNumber(generator->resumeMode()));
+    }
 
-JSC_DEFINE_HOST_FUNCTION(asyncGeneratorQueueDequeueResolve, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    VM& vm = globalObject->vm();
+    // 10. Else,
+    // 10.a. Assert: state is either executing or draining-queue.
+    ASSERT(JSAsyncGenerator::isExecutingState(state) || state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::DrainingQueue));
 
-    JSAsyncGenerator* generator = uncheckedDowncast<JSAsyncGenerator>(callFrame->uncheckedArgument(0));
-    JSValue resolution = callFrame->uncheckedArgument(1);
-
-    auto [value, resumeMode, promise] = generator->dequeue(vm);
-
-    promise->resolve(globalObject, vm, resolution);
-
-    return JSValue::encode(jsNumber(generator->resumeMode()));
-}
-
-JSC_DEFINE_HOST_FUNCTION(asyncGeneratorQueueDequeueReject, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    VM& vm = globalObject->vm();
-
-    JSAsyncGenerator* generator = uncheckedDowncast<JSAsyncGenerator>(callFrame->uncheckedArgument(0));
-    JSValue error = callFrame->uncheckedArgument(1);
-
-    auto [value, resumeMode, promise] = generator->dequeue(vm);
-
-    promise->reject(vm, error);
-
-    return JSValue::encode(jsNumber(generator->resumeMode()));
+    // 11. Return promiseCapability.[[Promise]].
+    return JSValue::encode(jsNumber(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorResumeMode::Empty)));
 }
 
 JS_GLOBAL_OBJECT_ADDITIONS_2;
@@ -2014,14 +2013,14 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::resolveWithInternalMicrotaskForAsyncAwait)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, init.owner, 3, "resolveWithInternalMicrotaskForAsyncAwait"_s, resolveWithInternalMicrotaskForAsyncAwait, ImplementationVisibility::Private));
         });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncGeneratorQueueEnqueue)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, init.owner, 4, "asyncGeneratorQueueEnqueue"_s, asyncGeneratorQueueEnqueue, ImplementationVisibility::Private));
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncGeneratorNextQueueEnqueue)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, init.owner, 4, "asyncGeneratorNextQueueEnqueue"_s, asyncGeneratorNextQueueEnqueue, ImplementationVisibility::Private));
         });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncGeneratorQueueDequeueResolve)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, init.owner, 2, "asyncGeneratorQueueDequeueResolve"_s, asyncGeneratorQueueDequeueResolve, ImplementationVisibility::Private));
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncGeneratorCompleteAndDrain)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, init.owner, 3, "asyncGeneratorCompleteAndDrain"_s, asyncGeneratorCompleteAndDrain, ImplementationVisibility::Private));
         });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncGeneratorQueueDequeueReject)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, init.owner, 2, "asyncGeneratorQueueDequeueReject"_s, asyncGeneratorQueueDequeueReject, ImplementationVisibility::Private));
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncGeneratorSuspend)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, init.owner, 2, "asyncGeneratorSuspend"_s, asyncGeneratorSuspend, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::driveAsyncFunction)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, init.owner, 2, "driveAsyncFunction"_s, driveAsyncFunction, ImplementationVisibility::Private));

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -467,58 +467,75 @@ static void promiseAnyResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
     }
 }
 
-static bool NODELETE isSuspendYieldState(int32_t state)
-{
-    return state > 0 && (state & JSAsyncGenerator::reasonMask) == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Yield);
-}
+static void asyncGeneratorBodyCall(JSGlobalObject*, JSAsyncGenerator*, JSValue resumeValue, int32_t resumeMode);
+static void asyncGeneratorCompleteStep(JSGlobalObject*, JSAsyncGenerator*, JSValue, bool isThrow, bool done);
+static void asyncGeneratorDrainQueue(JSGlobalObject*, JSAsyncGenerator*);
+static void asyncGeneratorDispatchSuspend(JSGlobalObject*, JSAsyncGenerator*, JSValue value);
 
-static void asyncGeneratorResumeNext(JSGlobalObject*, JSAsyncGenerator*);
-
-template<IterationStatus status>
-static void asyncGeneratorReject(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue error)
+// https://tc39.es/ecma262/#sec-asyncgeneratorcompletestep
+static void asyncGeneratorCompleteStep(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue value, bool isThrow, bool done)
 {
     VM& vm = globalObject->vm();
 
-    auto [value, resumeMode, promise] = generator->dequeue(vm);
+    // 1-4. Remove the first request from the queue.
+    auto [reqValue, reqMode, promise] = generator->dequeue(vm);
     ASSERT(promise);
 
-    promise->reject(vm, error);
+    // 6. throw completion -> reject.
+    if (isThrow) {
+        promise->reject(vm, value);
+        return;
+    }
 
-    if constexpr (status == IterationStatus::Continue)
-        asyncGeneratorResumeNext(globalObject, generator);
+    // 7. normal completion -> resolve with CreateIteratorResultObject(value, done).
+    auto* iteratorResult = createIteratorResultObject(globalObject, value, done);
+    promise->resolve(globalObject, vm, iteratorResult);
 }
 
-template<IterationStatus status>
-static void asyncGeneratorResolve(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue value, bool done)
+// https://tc39.es/ecma262/#sec-asyncgeneratorawaitreturn
+void asyncGeneratorAwaitReturn(JSGlobalObject* globalObject, JSAsyncGenerator* generator)
+{
+    VM& vm = globalObject->vm();
+    ASSERT(generator->state() == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::DrainingQueue));
+    JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, generator->resumeValue(), InternalMicrotask::AsyncGeneratorAwaitReturn, generator);
+}
+
+// https://tc39.es/ecma262/#sec-asyncgeneratordrainqueue
+static void asyncGeneratorDrainQueue(JSGlobalObject* globalObject, JSAsyncGenerator* generator)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto [itemValue, itemResumeMode, promise] = generator->dequeue(vm);
-    ASSERT(promise);
+    ASSERT(generator->state() == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::DrainingQueue));
 
-    auto* iteratorResult = createIteratorResultObject(globalObject, value, done);
+    // 3. Repeat, while the queue is not empty.
+    while (!generator->isQueueEmpty()) {
+        int32_t resumeMode = generator->resumeMode();
 
-    promise->resolve(globalObject, vm, iteratorResult);
-    RETURN_IF_EXCEPTION(scope, void());
+        // 5c. return completion -> AsyncGeneratorAwaitReturn and stop.
+        if (resumeMode == static_cast<int32_t>(JSGenerator::ResumeMode::ReturnMode)) {
+            scope.release();
+            asyncGeneratorAwaitReturn(globalObject, generator);
+            return;
+        }
 
-    if constexpr (status == IterationStatus::Continue)
-        RELEASE_AND_RETURN(scope, asyncGeneratorResumeNext(globalObject, generator));
-}
-
-template<IterationStatus status>
-static bool asyncGeneratorBodyCall(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue resumeValue, int32_t resumeMode)
-{
-    VM& vm = globalObject->vm();
-
-    int32_t state = generator->state();
-    if (resumeMode == static_cast<int32_t>(JSGenerator::ResumeMode::ReturnMode) && isSuspendYieldState(state)) {
-        state = (state & ~JSAsyncGenerator::reasonMask) | static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Await);
-        generator->setState(state);
-        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, resumeValue, InternalMicrotask::AsyncGeneratorBodyCallReturn, generator);
-        return false;
+        // 5d. throw -> reject; normal -> resolve { undefined, true }.
+        bool isThrow = resumeMode == static_cast<int32_t>(JSGenerator::ResumeMode::ThrowMode);
+        asyncGeneratorCompleteStep(globalObject, generator, isThrow ? generator->resumeValue() : jsUndefined(), isThrow, /* done */ true);
+        RETURN_IF_EXCEPTION(scope, void());
     }
 
+    // 3a. queue empty -> completed.
+    generator->setState(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed));
+}
+
+// https://tc39.es/ecma262/#sec-asyncgeneratorresume (then AsyncGeneratorStart's completion handling).
+static void asyncGeneratorBodyCall(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue resumeValue, int32_t resumeMode)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    int32_t state = generator->state();
     generator->setState(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Executing));
 
     JSValue generatorFunction = generator->next();
@@ -528,114 +545,144 @@ static bool asyncGeneratorBodyCall(JSGlobalObject* globalObject, JSAsyncGenerato
     JSValue value;
     JSValue error;
     {
-        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         value = callMicrotask(globalObject, generatorFunction, generatorThis, generator, "handler is not a function"_s, nullptr,
             generator, jsNumber(state >> JSAsyncGenerator::reasonShift), resumeValue, jsNumber(resumeMode), generatorFrame);
-        if (scope.exception()) [[unlikely]] {
-            error = scope.exception()->value();
-            if (!scope.clearExceptionExceptTermination()) [[unlikely]]
-                return false;
+        if (catchScope.exception()) [[unlikely]] {
+            error = catchScope.exception()->value();
+            if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
+                return;
         }
-    }
-
-    if (error) [[unlikely]] {
-        generator->setState(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed));
-        asyncGeneratorReject<status>(globalObject, generator, error);
-        return true;
     }
 
     state = generator->state();
-    if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Executing)) {
-        generator->setState(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed));
-        state = static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed);
-    }
 
+    // The body suspended at an `await` or a `yield`/`yield*`.
     if (state > 0) {
-        if ((state & JSAsyncGenerator::reasonMask) == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Await)) {
-            JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, value, InternalMicrotask::AsyncGeneratorBodyCallNormal, generator);
-            return false;
-        }
-
-        state = (state & ~JSAsyncGenerator::reasonMask) | static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Await);
-        generator->setState(state);
-        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, value, InternalMicrotask::AsyncGeneratorYieldAwaited, generator);
-        return false;
+        scope.release();
+        asyncGeneratorDispatchSuspend(globalObject, generator, value);
+        return;
     }
 
-    if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed)) {
-        asyncGeneratorResolve<status>(globalObject, generator, value, true);
-        return true;
-    }
-
-    return false;
+    // https://tc39.es/ecma262/#sec-asyncgeneratorstart
+    ASSERT(state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Executing));
+    // 4.g. Set acGen.[[AsyncGeneratorState]] to draining-queue.
+    generator->setState(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::DrainingQueue));
+    // 4.h. If result is a normal completion, set result to NormalCompletion(undefined).
+    // 4.i. If result is a return completion, set result to NormalCompletion(result.[[Value]]).
+    // 4.j. Perform AsyncGeneratorCompleteStep(acGen, result, true).
+    asyncGeneratorCompleteStep(globalObject, generator, error ? error : value, /* isThrow */ !!error, /* done */ true);
+    RETURN_IF_EXCEPTION(scope, void());
+    // 4.k. Perform AsyncGeneratorDrainQueue(acGen).
+    RELEASE_AND_RETURN(scope, asyncGeneratorDrainQueue(globalObject, generator));
 }
 
-static void asyncGeneratorResumeNext(JSGlobalObject* globalObject, JSAsyncGenerator* generator)
+// https://tc39.es/ecma262/#sec-asyncgeneratorunwrapyieldresumption
+static void asyncGeneratorUnwrapYieldResumption(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue resumeValue, int32_t resumeMode)
+{
+    VM& vm = globalObject->vm();
+    int32_t state = generator->state();
+    ASSERT(state > 0);
+    // 1. If resumptionValue is not a return completion, return ? resumptionValue.
+    if (resumeMode != static_cast<int32_t>(JSGenerator::ResumeMode::ReturnMode)) {
+        asyncGeneratorBodyCall(globalObject, generator, resumeValue, resumeMode);
+        return;
+    }
+
+    // 2. Let awaited be Completion(Await(resumptionValue.[[Value]])).
+    // 3. If awaited is a throw completion, return ? awaited.
+    // 4. Assert: awaited is a normal completion.
+    // 5. Return ReturnCompletion(awaited.[[Value]]).
+    generator->setState((state & ~JSAsyncGenerator::reasonMask) | static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Await));
+    JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, resumeValue, InternalMicrotask::AsyncGeneratorBodyCallReturn, generator);
+}
+
+// https://tc39.es/ecma262/#sec-asyncgeneratorresume
+void asyncGeneratorResume(JSGlobalObject* globalObject, JSAsyncGenerator* generator)
+{
+    // 1. Assert: gen.[[AsyncGeneratorState]] is either suspended-start or suspended-yield.
+    ASSERT(generator->state() == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Init) || JSAsyncGenerator::isSuspendedYieldState(generator->state()));
+    asyncGeneratorUnwrapYieldResumption(globalObject, generator, generator->resumeValue(), generator->resumeMode());
+}
+
+// https://tc39.es/ecma262/#sec-asyncgeneratoryield
+static void asyncGeneratorYield(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue value)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    while (true) {
-        int32_t state = generator->state();
+    // Stay executing across CompleteStep so reentrant requests only enqueue.
+    int32_t state = generator->state();
+    generator->setState((state & ~JSAsyncGenerator::reasonMask) | static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Await));
 
-        ASSERT(state != static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Executing));
+    // 9. Perform AsyncGeneratorCompleteStep(gen, completion, false, previousRealm).
+    asyncGeneratorCompleteStep(globalObject, generator, value, /* isThrow */ false, /* done */ false);
+    RETURN_IF_EXCEPTION(scope, void());
 
-        if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::AwaitingReturn))
-            return;
-
-        if (generator->isQueueEmpty())
-            return;
-
-        JSValue nextValue = generator->resumeValue();
-        int32_t resumeMode = generator->resumeMode();
-
-        if (resumeMode != static_cast<int32_t>(JSGenerator::ResumeMode::NormalMode)) {
-            if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Init)) {
-                generator->setState(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed));
-                state = static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed);
-            }
-
-            if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed)) {
-                if (resumeMode == static_cast<int32_t>(JSGenerator::ResumeMode::ReturnMode)) {
-                    generator->setState(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::AwaitingReturn));
-                    RELEASE_AND_RETURN(scope, JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, nextValue, InternalMicrotask::AsyncGeneratorResumeNext, generator));
-                }
-
-                ASSERT(resumeMode == static_cast<int32_t>(JSGenerator::ResumeMode::ThrowMode));
-                asyncGeneratorReject<IterationStatus::Done>(globalObject, generator, nextValue);
-                continue;
-            }
-        } else if (state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed)) {
-            asyncGeneratorResolve<IterationStatus::Done>(globalObject, generator, jsUndefined(), true);
-            RETURN_IF_EXCEPTION(scope, void());
-            continue;
-        }
-
-        ASSERT(state == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Init) || isSuspendYieldState(state));
-        bool next = asyncGeneratorBodyCall<IterationStatus::Done>(globalObject, generator, nextValue, resumeMode);
-        RETURN_IF_EXCEPTION(scope, void());
-        if (!next)
-            return;
+    // 10. Let queue be gen.[[AsyncGeneratorQueue]].
+    // 11. If queue is not empty, then
+    if (!generator->isQueueEmpty()) {
+        // 11.a. NOTE: Execution continues without suspending the generator.
+        // 11.b. Let toYield be the first element of queue.
+        // 11.c. Let resumptionValue be Completion(toYield.[[Completion]]).
+        // 11.d. Return ? AsyncGeneratorUnwrapYieldResumption(resumptionValue).
+        scope.release();
+        asyncGeneratorUnwrapYieldResumption(globalObject, generator, generator->resumeValue(), generator->resumeMode());
+        return;
     }
+    // 12. Set gen.[[AsyncGeneratorState]] to suspended-yield.
+    state = generator->state();
+    generator->setState((state & ~JSAsyncGenerator::reasonMask) | static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Yield));
 }
 
+// Plain `yield`'s operand Await (AsyncGeneratorYield(? Await(value))) has settled.
 static void asyncGeneratorYieldAwaited(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue result, JSPromise::Status status)
 {
     switch (status) {
     case JSPromise::Status::Pending:
         RELEASE_ASSERT_NOT_REACHED();
-        break;
+        return;
     case JSPromise::Status::Rejected:
-        asyncGeneratorBodyCall<IterationStatus::Continue>(globalObject, generator, result, static_cast<int32_t>(JSGenerator::ResumeMode::ThrowMode));
+        // `? Await(value)` threw -> resume the body with a throw at the yield.
+        asyncGeneratorBodyCall(globalObject, generator, result, static_cast<int32_t>(JSGenerator::ResumeMode::ThrowMode));
         return;
-    case JSPromise::Status::Fulfilled: {
-        int32_t state = generator->state();
-        state = (state & ~JSAsyncGenerator::reasonMask) | static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Yield);
-        generator->setState(state);
-        asyncGeneratorResolve<IterationStatus::Continue>(globalObject, generator, result, false);
+    case JSPromise::Status::Fulfilled:
+        asyncGeneratorYield(globalObject, generator, result);
+        return;
+    }
+}
+
+// The body suspended (state > 0); dispatch on the suspend reason:
+//   Await        `await x`   -> resume the body once x settles (AsyncGeneratorBodyCallNormal).
+//   Yield        `yield x`   -> AsyncGeneratorYield(? Await(value)): Await first (AsyncGeneratorYieldAwaited).
+//   YieldNoAwait `yield* x`  -> AsyncGeneratorYield(value): deliver directly.
+static void asyncGeneratorDispatchSuspend(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue value)
+{
+    VM& vm = globalObject->vm();
+    int32_t state = generator->state();
+    switch (static_cast<JSAsyncGenerator::AsyncGeneratorSuspendReason>(state & JSAsyncGenerator::reasonMask)) {
+    case JSAsyncGenerator::AsyncGeneratorSuspendReason::Await: {
+        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, value, InternalMicrotask::AsyncGeneratorBodyCallNormal, generator);
+        return;
+    }
+    case JSAsyncGenerator::AsyncGeneratorSuspendReason::Yield: {
+        generator->setState((state & ~JSAsyncGenerator::reasonMask) | static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorSuspendReason::Await));
+        JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, vm, value, InternalMicrotask::AsyncGeneratorYieldAwaited, generator);
+        return;
+    }
+    case JSAsyncGenerator::AsyncGeneratorSuspendReason::YieldNoAwait: {
+        asyncGeneratorYield(globalObject, generator, value);
         return;
     }
     }
+}
+
+// Entry for the next() builtin once the body suspends (await / yield / yield*).
+JSC_DEFINE_HOST_FUNCTION(asyncGeneratorSuspend, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    auto* generator = uncheckedDowncast<JSAsyncGenerator>(callFrame->uncheckedArgument(0));
+    asyncGeneratorDispatchSuspend(globalObject, generator, callFrame->uncheckedArgument(1));
+    return JSValue::encode(jsUndefined());
 }
 
 static void asyncGeneratorBodyCallNormal(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue result, JSPromise::Status status)
@@ -645,10 +692,10 @@ static void asyncGeneratorBodyCallNormal(JSGlobalObject* globalObject, JSAsyncGe
         RELEASE_ASSERT_NOT_REACHED();
         break;
     case JSPromise::Status::Rejected:
-        asyncGeneratorBodyCall<IterationStatus::Continue>(globalObject, generator, result, static_cast<int32_t>(JSGenerator::ResumeMode::ThrowMode));
+        asyncGeneratorBodyCall(globalObject, generator, result, static_cast<int32_t>(JSGenerator::ResumeMode::ThrowMode));
         return;
     case JSPromise::Status::Fulfilled:
-        asyncGeneratorBodyCall<IterationStatus::Continue>(globalObject, generator, result, static_cast<int32_t>(JSGenerator::ResumeMode::NormalMode));
+        asyncGeneratorBodyCall(globalObject, generator, result, static_cast<int32_t>(JSGenerator::ResumeMode::NormalMode));
         return;
     }
 }
@@ -660,29 +707,57 @@ static void asyncGeneratorBodyCallReturn(JSGlobalObject* globalObject, JSAsyncGe
         RELEASE_ASSERT_NOT_REACHED();
         break;
     case JSPromise::Status::Rejected:
-        asyncGeneratorBodyCall<IterationStatus::Continue>(globalObject, generator, result, static_cast<int32_t>(JSGenerator::ResumeMode::ThrowMode));
+        asyncGeneratorBodyCall(globalObject, generator, result, static_cast<int32_t>(JSGenerator::ResumeMode::ThrowMode));
         return;
     case JSPromise::Status::Fulfilled:
-        asyncGeneratorBodyCall<IterationStatus::Continue>(globalObject, generator, result, static_cast<int32_t>(JSGenerator::ResumeMode::ReturnMode));
+        asyncGeneratorBodyCall(globalObject, generator, result, static_cast<int32_t>(JSGenerator::ResumeMode::ReturnMode));
         return;
     }
 }
 
-static void asyncGeneratorResumeNextReturn(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue result, JSPromise::Status status)
+// https://tc39.es/ecma262/#sec-asyncgeneratorawaitreturn
+static void asyncGeneratorAwaitReturnContinuation(JSGlobalObject* globalObject, JSAsyncGenerator* generator, JSValue result, JSPromise::Status status)
 {
-    generator->setState(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::Completed));
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(generator->state() == static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::DrainingQueue));
 
     switch (status) {
     case JSPromise::Status::Pending:
         RELEASE_ASSERT_NOT_REACHED();
-        break;
-    case JSPromise::Status::Rejected:
-        asyncGeneratorReject<IterationStatus::Continue>(globalObject, generator, result);
         return;
     case JSPromise::Status::Fulfilled:
-        asyncGeneratorResolve<IterationStatus::Continue>(globalObject, generator, result, true);
-        return;
+        asyncGeneratorCompleteStep(globalObject, generator, result, /* isThrow */ false, /* done */ true);
+        RETURN_IF_EXCEPTION(scope, void());
+        break;
+    case JSPromise::Status::Rejected:
+        asyncGeneratorCompleteStep(globalObject, generator, result, /* isThrow */ true, /* done */ true);
+        RETURN_IF_EXCEPTION(scope, void());
+        break;
     }
+
+    RELEASE_AND_RETURN(scope, asyncGeneratorDrainQueue(globalObject, generator));
+}
+
+// AsyncGeneratorStart completion (https://tc39.es/ecma262/#sec-asyncgeneratorstart : 4.g-4.k):
+// CompleteStep with done=true, then drain. Called by the next() builtin once the body finishes.
+JSC_DEFINE_HOST_FUNCTION(asyncGeneratorCompleteAndDrain, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* generator = uncheckedDowncast<JSAsyncGenerator>(callFrame->uncheckedArgument(0));
+    JSValue value = callFrame->uncheckedArgument(1);
+    bool isThrow = callFrame->uncheckedArgument(2).asBoolean();
+
+    generator->setState(static_cast<int32_t>(JSAsyncGenerator::AsyncGeneratorState::DrainingQueue));
+    asyncGeneratorCompleteStep(globalObject, generator, value, isThrow, /* done */ true);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    scope.release();
+    asyncGeneratorDrainQueue(globalObject, generator);
+    return JSValue::encode(jsUndefined());
 }
 
 static void promiseFinallyAwaitJob(JSGlobalObject* globalObject, VM& vm, JSValue settledValue, JSPromiseCombinatorsGlobalContext* context, JSPromise::Status status)
@@ -1734,9 +1809,9 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         RELEASE_AND_RETURN(scope, asyncGeneratorBodyCallReturn(generator->realm(), generator, arguments[1], static_cast<JSPromise::Status>(payload)));
     }
 
-    case InternalMicrotask::AsyncGeneratorResumeNext: {
+    case InternalMicrotask::AsyncGeneratorAwaitReturn: {
         auto* generator = uncheckedDowncast<JSAsyncGenerator>(arguments[2]);
-        RELEASE_AND_RETURN(scope, asyncGeneratorResumeNextReturn(generator->realm(), generator, arguments[1], static_cast<JSPromise::Status>(payload)));
+        RELEASE_AND_RETURN(scope, asyncGeneratorAwaitReturnContinuation(generator->realm(), generator, arguments[1], static_cast<JSPromise::Status>(payload)));
     }
 
     case InternalMicrotask::PromiseFinallyReactionJob: {

--- a/Source/JavaScriptCore/runtime/JSMicrotask.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.h
@@ -32,7 +32,20 @@
 namespace JSC {
 
 class MicrotaskCall;
+class JSAsyncGenerator;
 
 void runInternalMicrotask(JSGlobalObject*, VM&, InternalMicrotask, uint8_t, std::span<const JSValue, maxMicrotaskArguments>, MicrotaskCall* = nullptr);
+
+// https://tc39.es/ecma262/#sec-asyncgeneratorresume and #sec-asyncgeneratorawaitreturn — used by the C++
+// %AsyncGeneratorPrototype%.return / .throw host functions to drive a non-busy generator.
+void asyncGeneratorResume(JSGlobalObject*, JSAsyncGenerator*);
+void asyncGeneratorAwaitReturn(JSGlobalObject*, JSAsyncGenerator*);
+
+// AsyncGeneratorCompleteStep(done) + AsyncGeneratorDrainQueue, for the builtin next() driver's completion path.
+JSC_DECLARE_HOST_FUNCTION(asyncGeneratorCompleteAndDrain);
+
+// Dispatches the next() builtin's body-suspension: `await` resumes the body, `yield` Awaits then delivers,
+// `yield*` delivers directly. https://tc39.es/ecma262/#sec-asyncgeneratoryield
+JSC_DECLARE_HOST_FUNCTION(asyncGeneratorSuspend);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/Microtask.h
+++ b/Source/JavaScriptCore/runtime/Microtask.h
@@ -59,7 +59,7 @@ enum class InternalMicrotask : uint8_t {
     AsyncGeneratorYieldAwaited,
     AsyncGeneratorBodyCallNormal,
     AsyncGeneratorBodyCallReturn,
-    AsyncGeneratorResumeNext,
+    AsyncGeneratorAwaitReturn,
 
     InvokeFunctionJob,
     AsyncModuleExecutionResume,


### PR DESCRIPTION
#### d096ff9cfae1885b50963d346ef89b3e4729e37d
<pre>
[JSC] Update async generator code aligned to the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=316447">https://bugs.webkit.org/show_bug.cgi?id=316447</a>
<a href="https://rdar.apple.com/178560512">rdar://178560512</a>

Reviewed by Yijia Huang.

When Object.prototype.then is set, when resolving iterator result
object, it can have a side effect since it can look up &quot;then&quot; field.
And this can cause recursive generator reentrance which confuses the
state machine of the async generator, which exists in the old spec&apos;s
behavior.

Instead we update our implementation to the latest spec&apos;s behavior more
closely. Introducing DrainingQueue state instead of AwaitingReturn as it
is updated in the spec.

We also move return / throw implementations to C++ to make next function
simplified. These two functions are called only when abruption happens.
Then we also move the code to next() function as a helper is only used
by one function now.

Test: JSTests/stress/async-generator-reentrant-resume-during-resolve.js

* JSTests/stress/async-generator-next-on-completed-reentrant.js: Added.
(shouldBe):
(async gen):
* JSTests/stress/async-generator-reentrant-resume-during-resolve.js: Added.
(shouldBe):
(async gen):
(async main):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js:
(next):
(linkTimeConstant.asyncGeneratorResumeNext):
(return): Deleted.
(throw): Deleted.
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp:
(JSC::BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitYield):
(JSC::BytecodeGenerator::emitDelegateYield):
* Source/JavaScriptCore/runtime/AsyncGeneratorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSAsyncGenerator.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::asyncGeneratorCompleteStep):
(JSC::asyncGeneratorAwaitReturn):
(JSC::asyncGeneratorDrainQueue):
(JSC::asyncGeneratorBodyCall):
(JSC::asyncGeneratorUnwrapYieldResumption):
(JSC::asyncGeneratorResume):
(JSC::asyncGeneratorYield):
(JSC::asyncGeneratorYieldAwaited):
(JSC::asyncGeneratorDispatchSuspend):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::asyncGeneratorBodyCallNormal):
(JSC::asyncGeneratorBodyCallReturn):
(JSC::asyncGeneratorAwaitReturnContinuation):
(JSC::runInternalMicrotask):
(JSC::isSuspendYieldState): Deleted.
(JSC::asyncGeneratorReject): Deleted.
(JSC::asyncGeneratorResolve): Deleted.
(JSC::asyncGeneratorResumeNext): Deleted.
(JSC::asyncGeneratorResumeNextReturn): Deleted.
* Source/JavaScriptCore/runtime/JSMicrotask.h:
* Source/JavaScriptCore/runtime/Microtask.h:

Canonical link: <a href="https://commits.webkit.org/314732@main">https://commits.webkit.org/314732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19bb0aabf49b6f6422b899cc31bf35663a2b8ac0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167011 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124269 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32d96432-846b-45f3-8ab9-5730b4a5548b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129880 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91485 "7 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5bf2579-115c-4d45-bf2d-0fde1061be63) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110405 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/458ece7c-26bf-4733-a534-457c7c364220) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31255 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29961 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24796 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159168 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141230 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178597 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27905 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31495 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138248 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138159 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149556 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104161 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25421 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33431 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26421 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199690 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39770 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112844 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53695 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39166 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4522 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39411 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39310 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->