### PR TITLE
[libpas] Build fix after 313922@main

### DIFF
--- a/Source/bmalloc/libpas/build.sh
+++ b/Source/bmalloc/libpas/build.sh
@@ -27,19 +27,19 @@
 build_variant_xcodebuild() {
     variant=$1
     target=$2
-    extra_xcodebuild_options="EXTRA_DEFINES=$3"
-    
+    extra_defines=$3
+
     build_dir=build-$sdk-$variant
     mkdir -p $build_dir
-    
-    xcodebuild_options="-project libpas.xcodeproj -configuration $config -sdk $sdk OBJROOT=$build_dir SYMROOT=$build_dir $extra_xcodebuild_options"
+
+    xcodebuild_options="-project libpas.xcodeproj -configuration $config -sdk $sdk OBJROOT=$build_dir SYMROOT=$build_dir"
 
     if [ "x$archs" != "xblank" ]
     then
         xcodebuild_options="$xcodebuild_options ARCHS=$archs"
     fi
-    
-    xcodebuild $xcodebuild_options -target $target
+
+    xcodebuild $xcodebuild_options "EXTRA_DEFINES=$extra_defines" -target $target
             
     case $target in
         mbmalloc|all)
@@ -93,10 +93,10 @@ build_variant_cmake() {
 build_variant() {
     case $sdk in
         cmake)
-            build_variant_cmake $@
+            build_variant_cmake "$@"
             ;;
         *)
-            build_variant_xcodebuild $@
+            build_variant_xcodebuild "$@"
             ;;
     esac
 }
@@ -106,12 +106,12 @@ build_variants() {
 
     case $variants in
         all|testing)
-            build_variant testing $target "ENABLE_PAS_TESTING"
+            build_variant testing $target "ENABLE_PAS_TESTING PAS_BMALLOC_HIDDEN=0"
             ;;
     esac
     case $variants in
         all|default)
-            build_variant default $target ""
+            build_variant default $target "PAS_BMALLOC_HIDDEN=0"
             ;;
     esac
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.h
@@ -176,19 +176,11 @@ static inline void pas_bitfit_directory_set_unprocessed_max_free(pas_bitfit_dire
     pas_bitfit_directory_set_max_free_not_empty_impl(directory, index, PAS_BITFIT_MAX_FREE_UNPROCESSED);
 }
 
-PAS_API void pas_bitfit_directory_update_biasing_eligibility(pas_bitfit_directory* directory,
-                                                             size_t index);
-
 PAS_API void pas_bitfit_directory_max_free_did_become_unprocessed(pas_bitfit_directory* directory,
                                                                   size_t index,
                                                                   const char* reason);
 
 PAS_API void pas_bitfit_directory_max_free_did_become_unprocessed_unchecked(
-    pas_bitfit_directory* directory,
-    size_t index,
-    const char* reason);
-
-PAS_API void pas_bitfit_directory_max_free_did_become_empty_without_biasing_update(
     pas_bitfit_directory* directory,
     size_t index,
     const char* reason);

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator.h
@@ -166,8 +166,6 @@ PAS_API bool pas_local_allocator_stop(pas_local_allocator* allocator,
                                       pas_lock_lock_mode page_lock_mode,
                                       pas_lock_hold_mode heap_lock_hold_mode);
 
-PAS_API pas_lock_hold_mode pas_local_allocator_heap_lock_hold_mode(pas_local_allocator* allocator);
-
 /* This is appropriate to call for allocators that are used under a lock and you're holding that
    lock. Allocators associated with TLCs use subtly different logic.
 

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
@@ -210,10 +210,6 @@ PAS_API void pas_thread_local_cache_ensure_committed(pas_thread_local_cache* thr
                                                      pas_allocator_index begin_allocator_index,
                                                      pas_allocator_index end_allocator_index);
 
-PAS_API void pas_thread_local_cache_did_recommit_accidentally(pas_thread_local_cache* thread_local_cache,
-                                                              pas_allocator_index begin_allocator_index,
-                                                              pas_allocator_index end_allocator_index);
-
 static PAS_ALWAYS_INLINE void*
 pas_thread_local_cache_get_local_allocator_direct_without_any_checks_whatsoever(
     pas_thread_local_cache* thread_local_cache,
@@ -349,8 +345,6 @@ pas_thread_local_cache_get_local_allocator_if_can_set_cache_for_possibly_uniniti
 
 PAS_API pas_allocator_index pas_thread_local_cache_allocator_index_for_allocator(pas_thread_local_cache* cache,
                                                                                  void* allocator);
-
-PAS_API unsigned pas_thread_local_cache_get_num_allocators(pas_thread_local_cache* cache);
 
 PAS_API void pas_thread_local_cache_stop_local_allocators(
     pas_thread_local_cache* thread_local_cache,

--- a/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h
@@ -56,7 +56,10 @@ __PAS_BEGIN_EXTERN_C;
 #define __PAS_NEVER_INLINE __attribute__((__noinline__))
 #define __PAS_NO_RETURN __attribute((__noreturn__))
 
+// build.sh defines this for freestanding builds
+#if !defined(PAS_BMALLOC_HIDDEN)
 #define PAS_BMALLOC_HIDDEN 1
+#endif
 
 #if defined(PAS_LIBMALLOC) && PAS_LIBMALLOC || defined(PAS_BMALLOC_HIDDEN) && PAS_BMALLOC_HIDDEN
 #define __PAS_API __attribute__((visibility("hidden")))


### PR DESCRIPTION
#### 1a8a72a5bc1a3e224bc01f3a8f56b40eaf19edbf
<pre>
[libpas] Build fix after 313922@main
<a href="https://rdar.apple.com/problem/178853873">rdar://problem/178853873</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316457">https://bugs.webkit.org/show_bug.cgi?id=316457</a>

Reviewed by Geoffrey Garen.

The patch 313922@main i.e.
[Build Speed] Reduce the number of Swift module variants generated
added an unconditional &quot;#define PAS_BMALLOC_HIDDEN 1` to
pas_utils_prefix.h; this broke freestanding builds which depend on
the pas_verifier target.

* Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h:

Canonical link: <a href="https://commits.webkit.org/314680@main">https://commits.webkit.org/314680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca9f8529459af52fa9a08fe50d1c4adae27cc014

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1128a0f-7623-48b9-a6f9-e9d3af0e9678) 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c4158fdd-b95d-4c08-adfb-ada68f9326ca) 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00d13a87-caa1-46d0-9e73-576d77d03b6e) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->