### PR TITLE
[JSC][Temporal] Remove one-line TemporalCore delegate wrappers

### DIFF
--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -603,16 +603,15 @@ ISO8601::Duration differenceTemporalPlainYearMonth(JSGlobalObject* globalObject,
     auto duration = ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration { dateDifference.years(), dateDifference.months(), 0LL, 0LL, 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0) }, 0);
 
     if (smallestUnit != TemporalUnit::Month || increment != 1) {
-        auto originEpochNs = getUTCEpochNanoseconds(TemporalDuration::combineISODateAndTimeRecord(thisDate, ISO8601::PlainTime()));
-        auto isoDateTimeOther = TemporalDuration::combineISODateAndTimeRecord(otherDate, ISO8601::PlainTime());
-        auto destEpochNs = getUTCEpochNanoseconds(isoDateTimeOther);
+        auto originEpochNs = TemporalCore::getUTCEpochNanoseconds(thisDate, ISO8601::PlainTime());
+        auto destEpochNs = TemporalCore::getUTCEpochNanoseconds(otherDate, ISO8601::PlainTime());
         auto roundResult = TemporalCore::roundRelativeDuration(duration, originEpochNs, destEpochNs, thisDate, ISO8601::PlainTime(), largestUnit, increment, smallestUnit, roundingMode, nullptr, calendarId);
         if (!roundResult) [[unlikely]] {
             throwTemporalError(globalObject, scope, roundResult.error());
             return { };
         }
     }
-    auto durResult = TemporalDuration::temporalDurationFromInternal(duration, TemporalUnit::Day);
+    auto durResult = TemporalCore::temporalDurationFromInternal(duration, TemporalUnit::Day);
     if (!durResult) [[unlikely]] {
         throwTemporalError(globalObject, scope, durResult.error());
         return { };

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -662,9 +662,9 @@ JSValue TemporalDuration::compare(JSGlobalObject* globalObject, JSValue valueOne
     // Fast path: no ZDT addZonedDateTime needed — pure 24h-day time comparison.
     bool hasCalendarUnits = one->years() || two->years() || one->months() || two->months() || one->weeks() || two->weeks();
     if (!hasCalendarUnits) {
-        auto timeDuration1 = add24HourDaysToTimeDuration(globalObject, toInternalDuration(one->m_duration).time(), one->days());
+        auto timeDuration1 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(one->m_duration).time(), one->days());
         RETURN_IF_EXCEPTION(scope, { });
-        auto timeDuration2 = add24HourDaysToTimeDuration(globalObject, toInternalDuration(two->m_duration).time(), two->days());
+        auto timeDuration2 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(two->m_duration).time(), two->days());
         RETURN_IF_EXCEPTION(scope, { });
         return jsNumber(timeDuration1 > timeDuration2 ? 1 : timeDuration1 < timeDuration2 ? -1 : 0);
     }
@@ -681,14 +681,14 @@ JSValue TemporalDuration::compare(JSGlobalObject* globalObject, JSValue valueOne
     auto endDate1 = calendarAwareDateAdd(globalObject, relativeTo.calendarId, plainDate, dateDuration1, TemporalOverflow::Constrain);
     RETURN_IF_EXCEPTION(scope, { });
     auto daysDiff1 = TemporalCore::diffISODate(plainDate, endDate1, TemporalUnit::Day);
-    auto timeDuration1 = add24HourDaysToTimeDuration(globalObject, toInternalDuration(one->m_duration).time(), daysDiff1.days());
+    auto timeDuration1 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(one->m_duration).time(), daysDiff1.days());
     RETURN_IF_EXCEPTION(scope, { });
 
     ISO8601::Duration dateDuration2(two->years(), two->months(), two->weeks(), two->days(), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0));
     auto endDate2 = calendarAwareDateAdd(globalObject, relativeTo.calendarId, plainDate, dateDuration2, TemporalOverflow::Constrain);
     RETURN_IF_EXCEPTION(scope, { });
     auto daysDiff2 = TemporalCore::diffISODate(plainDate, endDate2, TemporalUnit::Day);
-    auto timeDuration2 = add24HourDaysToTimeDuration(globalObject, toInternalDuration(two->m_duration).time(), daysDiff2.days());
+    auto timeDuration2 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(two->m_duration).time(), daysDiff2.days());
     RETURN_IF_EXCEPTION(scope, { });
 
     return jsNumber(timeDuration1 > timeDuration2 ? 1 : timeDuration1 < timeDuration2 ? -1 : 0);
@@ -805,24 +805,12 @@ ISO8601::Duration TemporalDuration::add(JSGlobalObject* globalObject, JSValue ot
     }
 
     auto result = ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), timeResult);
-    auto durResult = temporalDurationFromInternal(result, largestUnit);
+    auto durResult = TemporalCore::temporalDurationFromInternal(result, largestUnit);
     if (!durResult) [[unlikely]] {
         throwTemporalError(globalObject, scope, durResult.error());
         return { };
     }
     return *durResult;
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal-tointernaldurationrecord
-ISO8601::InternalDuration TemporalDuration::toInternalDuration(ISO8601::Duration d)
-{
-    return TemporalCore::toInternalDuration(d);
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal-temporaldurationfrominternal
-TemporalResult<ISO8601::Duration> TemporalDuration::temporalDurationFromInternal(ISO8601::InternalDuration internalDuration, TemporalUnit largestUnit)
-{
-    return TemporalCore::temporalDurationFromInternal(internalDuration, largestUnit);
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.subtract
@@ -845,12 +833,6 @@ std::tuple<ISO8601::PlainDate, ISO8601::PlainTime> TemporalDuration::combineISOD
     return { isoDate, isoTime };
 }
 
-// Local wrapper: tuple-form getUTCEpochNanoseconds delegates to TemporalCore two-arg form.
-// https://tc39.es/proposal-temporal/#sec-temporal-getutcepochnanoseconds
-Int128 getUTCEpochNanoseconds(std::tuple<ISO8601::PlainDate, ISO8601::PlainTime> isoDateTime)
-{
-    return TemporalCore::getUTCEpochNanoseconds(std::get<0>(isoDateTime), std::get<1>(isoDateTime));
-}
 
 // RoundDuration ( years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, increment, unit, roundingMode [ , relativeTo ] )
 // https://tc39.es/proposal-temporal/#sec-temporal-roundduration
@@ -1015,7 +997,7 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
             RETURN_IF_EXCEPTION(scope, { });
             zdtInternal = round(globalObject, zdtInternal, roundingIncrement, smallestUnit, roundingMode);
             RETURN_IF_EXCEPTION(scope, { });
-            auto durResult = temporalDurationFromInternal(zdtInternal, largestUnit);
+            auto durResult = TemporalCore::temporalDurationFromInternal(zdtInternal, largestUnit);
             if (!durResult) [[unlikely]] {
                 throwTemporalError(globalObject, scope, durResult.error());
                 return { };
@@ -1030,7 +1012,7 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
         }
         // Step 27 sub-step: If TemporalUnitCategory(largestUnit) is ~date~, set largestUnit to ~hour~.
         TemporalUnit effectiveLargestUnit = (largestUnit <= TemporalUnit::Day) ? TemporalUnit::Hour : largestUnit;
-        auto durResult = temporalDurationFromInternal(*zdtDiffResult, effectiveLargestUnit);
+        auto durResult = TemporalCore::temporalDurationFromInternal(*zdtDiffResult, effectiveLargestUnit);
         if (!durResult) [[unlikely]] {
             throwTemporalError(globalObject, scope, durResult.error());
             return { };
@@ -1066,7 +1048,7 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
         }
 
         // Step 28i: Return ? TemporalDurationFromInternal(internalDuration, largestUnit).
-        auto durResult = temporalDurationFromInternal(*diffResult, largestUnit);
+        auto durResult = TemporalCore::temporalDurationFromInternal(*diffResult, largestUnit);
         if (!durResult) [[unlikely]] {
             throwTemporalError(globalObject, scope, durResult.error());
             return { };
@@ -1090,7 +1072,7 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
     RETURN_IF_EXCEPTION(scope, { });
     auto result = round(globalObject, internalDuration, roundingIncrement, smallestUnit, roundingMode);
     RETURN_IF_EXCEPTION(scope, { });
-    auto durResult2 = temporalDurationFromInternal(result, largestUnit);
+    auto durResult2 = TemporalCore::temporalDurationFromInternal(result, largestUnit);
     if (!durResult2) [[unlikely]] {
         throwTemporalError(globalObject, scope, durResult2.error());
         return { };
@@ -1205,8 +1187,8 @@ double TemporalDuration::total(JSGlobalObject* globalObject, JSValue optionsValu
         RETURN_IF_EXCEPTION(scope, 0);
         ISO8601::PlainTime targetTime = TemporalCore::plainTimeFromSubdayNs(subdayNs);
 
-        Int128 originEpochNs = getUTCEpochNanoseconds(combineISODateAndTimeRecord(plainDate, midnight));
-        Int128 destEpochNs = getUTCEpochNanoseconds(combineISODateAndTimeRecord(targetDate, targetTime));
+        Int128 originEpochNs = TemporalCore::getUTCEpochNanoseconds(plainDate, midnight);
+        Int128 destEpochNs = TemporalCore::getUTCEpochNanoseconds(targetDate, targetTime);
 
         // Spec: DifferencePlainDateTimeWithTotal early-return for zero duration,
         // then ISODateTimeWithinLimits check on both endpoints.
@@ -1298,7 +1280,7 @@ String TemporalDuration::toString(JSGlobalObject* globalObject, JSValue optionsV
     // Step 17: Let roundedDuration be ? TemporalDurationFromInternal(internalDuration, roundedLargestUnit).
     // TemporalDurationFromInternal calls CreateTemporalDuration which calls IsValidDuration.
     // When days+time together exceed 2^53 seconds after decomposition, IsValidDuration fails → RangeError.
-    auto roundedDurationResult = temporalDurationFromInternal(internalDuration, roundedLargestUnit);
+    auto roundedDurationResult = TemporalCore::temporalDurationFromInternal(internalDuration, roundedLargestUnit);
     if (!roundedDurationResult) [[unlikely]] {
         throwTemporalError(globalObject, scope, roundedDurationResult.error());
         return { };

--- a/Source/JavaScriptCore/runtime/TemporalDuration.h
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.h
@@ -72,10 +72,8 @@ public:
     String toString(JSGlobalObject*, JSValue options) const;
     String toString(JSGlobalObject* globalObject, std::tuple<Precision, unsigned> precision = { Precision::Auto, 0 }) const { return toString(globalObject, m_duration, precision); }
 
-    static ISO8601::InternalDuration toInternalDuration(ISO8601::Duration);
     static ISO8601::InternalDuration toInternalDurationRecordWith24HourDays(JSGlobalObject*, ISO8601::Duration);
     ISO8601::Duration addDurations(JSGlobalObject*, AddOrSubtract, ISO8601::Duration, TemporalUnit) const;
-    static TemporalResult<ISO8601::Duration> temporalDurationFromInternal(ISO8601::InternalDuration, TemporalUnit);
 
     static ISO8601::Duration fromDurationLike(JSGlobalObject*, JSObject*);
     static ISO8601::Duration toISO8601Duration(JSGlobalObject*, JSValue);
@@ -95,7 +93,5 @@ private:
 
     ISO8601::Duration m_duration;
 };
-
-Int128 getUTCEpochNanoseconds(std::tuple<ISO8601::PlainDate, ISO8601::PlainTime>);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalInstant.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.cpp
@@ -267,7 +267,7 @@ ISO8601::Duration TemporalInstant::difference(JSGlobalObject* globalObject, Temp
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 5: Return CreateTemporalDuration from the balanced result.
-    auto durResult = TemporalDuration::temporalDurationFromInternal(internalDuration, largestUnit);
+    auto durResult = TemporalCore::temporalDurationFromInternal(internalDuration, largestUnit);
     if (!durResult) [[unlikely]] {
         throwTemporalError(globalObject, scope, durResult.error());
         return { };

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -695,9 +695,7 @@ ISO8601::PlainDate TemporalPlainDate::with(JSGlobalObject* globalObject, JSObjec
 // https://tc39.es/proposal-temporal/#sec-getutcepochnanoseconds
 static Int128 getUTCEpochNanoseconds(ISO8601::PlainDate isoDate)
 {
-    return getUTCEpochNanoseconds(
-        std::tuple<ISO8601::PlainDate, ISO8601::PlainTime>(
-            isoDate, ISO8601::PlainTime()));
+    return TemporalCore::getUTCEpochNanoseconds(isoDate, ISO8601::PlainTime());
 }
 
 ISO8601::Duration TemporalPlainDate::differenceTemporalPlainDate(JSGlobalObject* globalObject, DifferenceOperation op, TemporalPlainDate* other, TemporalUnit smallestUnit, TemporalUnit largestUnit, RoundingMode roundingMode, double increment)
@@ -733,7 +731,7 @@ ISO8601::Duration TemporalPlainDate::differenceTemporalPlainDate(JSGlobalObject*
             return { };
         }
     }
-    auto durResult = TemporalDuration::temporalDurationFromInternal(duration, TemporalUnit::Day);
+    auto durResult = TemporalCore::temporalDurationFromInternal(duration, TemporalUnit::Day);
     if (!durResult) [[unlikely]] {
         throwTemporalError(globalObject, scope, durResult.error());
         return { };
@@ -772,31 +770,6 @@ ISO8601::Duration TemporalPlainDate::since(JSGlobalObject* globalObject, Tempora
     // Steps 5-9: DifferenceTemporalPlainDate.
     RELEASE_AND_RETURN(scope, differenceTemporalPlainDate(globalObject,
         DifferenceOperation::Since, other, smallestUnit, largestUnit, roundingMode, increment));
-}
-
-String TemporalPlainDate::monthCode() const
-{
-    return ISO8601::monthCode(m_plainDate.month());
-}
-
-uint8_t TemporalPlainDate::dayOfWeek() const
-{
-    return ISO8601::dayOfWeek(m_plainDate);
-}
-
-uint16_t TemporalPlainDate::dayOfYear() const
-{
-    return ISO8601::dayOfYear(m_plainDate);
-}
-
-uint8_t TemporalPlainDate::weekOfYear() const
-{
-    return ISO8601::weekOfYear(m_plainDate);
-}
-
-int32_t TemporalPlainDate::yearOfWeek() const
-{
-    return ISO8601::yearOfWeek(m_plainDate);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.h
@@ -73,11 +73,11 @@ public:
 
     ISO8601::PlainDate with(JSGlobalObject*, JSObject* temporalDateLike, JSValue options);
 
-    String monthCode() const;
-    uint8_t dayOfWeek() const;
-    uint16_t dayOfYear() const;
-    uint8_t weekOfYear() const;
-    int32_t yearOfWeek() const;
+    String monthCode() const { return ISO8601::monthCode(m_plainDate.month()); }
+    uint8_t dayOfWeek() const { return ISO8601::dayOfWeek(m_plainDate); }
+    uint16_t dayOfYear() const { return ISO8601::dayOfYear(m_plainDate); }
+    uint8_t weekOfYear() const { return ISO8601::weekOfYear(m_plainDate); }
+    int32_t yearOfWeek() const { return ISO8601::yearOfWeek(m_plainDate); }
 
     String toString(JSGlobalObject*, JSValue options) const;
     String toString() const;

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -574,31 +574,6 @@ String TemporalPlainDateTime::toString(JSGlobalObject* globalObject, JSValue opt
     return base;
 }
 
-String TemporalPlainDateTime::monthCode() const
-{
-    return ISO8601::monthCode(m_plainDate.month());
-}
-
-uint8_t TemporalPlainDateTime::dayOfWeek() const
-{
-    return ISO8601::dayOfWeek(m_plainDate);
-}
-
-uint16_t TemporalPlainDateTime::dayOfYear() const
-{
-    return ISO8601::dayOfYear(m_plainDate);
-}
-
-uint8_t TemporalPlainDateTime::weekOfYear() const
-{
-    return ISO8601::weekOfYear(m_plainDate);
-}
-
-int32_t TemporalPlainDateTime::yearOfWeek() const
-{
-    return ISO8601::yearOfWeek(m_plainDate);
-}
-
 // https://tc39.es/proposal-temporal/#sec-temporal-differencetemporalplaindatetime
 ISO8601::Duration TemporalPlainDateTime::differenceTemporalPlainDateTime(
     JSGlobalObject* globalObject, DifferenceOperation op,

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
@@ -71,11 +71,11 @@ public:
     TemporalPlainDateTime* with(JSGlobalObject*, JSObject* temporalDateLike, JSValue options);
     TemporalPlainDateTime* round(JSGlobalObject*, JSValue options);
 
-    String monthCode() const;
-    uint8_t dayOfWeek() const;
-    uint16_t dayOfYear() const;
-    uint8_t weekOfYear() const;
-    int32_t yearOfWeek() const;
+    String monthCode() const { return ISO8601::monthCode(m_plainDate.month()); }
+    uint8_t dayOfWeek() const { return ISO8601::dayOfWeek(m_plainDate); }
+    uint16_t dayOfYear() const { return ISO8601::dayOfYear(m_plainDate); }
+    uint8_t weekOfYear() const { return ISO8601::weekOfYear(m_plainDate); }
+    int32_t yearOfWeek() const { return ISO8601::yearOfWeek(m_plainDate); }
 
     ISO8601::Duration differenceTemporalPlainDateTime(JSGlobalObject*, DifferenceOperation, TemporalPlainDateTime*, TemporalUnit, TemporalUnit, RoundingMode, double);
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
@@ -359,9 +359,4 @@ ISO8601::PlainDate TemporalPlainMonthDay::with(JSGlobalObject* globalObject, JSO
     return resolved->isoDate;
 }
 
-String TemporalPlainMonthDay::monthCode() const
-{
-    return ISO8601::monthCode(m_plainMonthDay.month());
-}
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
@@ -61,7 +61,7 @@ public:
 
     ISO8601::PlainDate with(JSGlobalObject*, JSObject*, JSValue);
 
-    String monthCode() const;
+    String monthCode() const { return ISO8601::monthCode(m_plainMonthDay.month()); }
 
     String toString(JSGlobalObject*, JSValue options) const;
     String toString() const

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -658,7 +658,7 @@ ISO8601::Duration TemporalPlainTime::differenceTemporalPlainTime(DifferenceOpera
     auto d = ISO8601::roundTimeDuration(globalObject, timeDuration, increment, smallestUnit, roundingMode);
     RETURN_IF_EXCEPTION(scope, { });
     auto duration = ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), d);
-    auto durResult = TemporalDuration::temporalDurationFromInternal(duration, largestUnit);
+    auto durResult = TemporalCore::temporalDurationFromInternal(duration, largestUnit);
     if (!durResult) [[unlikely]] {
         throwTemporalError(globalObject, scope, durResult.error());
         return { };

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
@@ -346,9 +346,4 @@ ISO8601::Duration TemporalPlainYearMonth::since(JSGlobalObject* globalObject, Te
     return sinceOrUntil<DifferenceOperation::Since>(globalObject, other, optionsValue);
 }
 
-String TemporalPlainYearMonth::monthCode() const
-{
-    return ISO8601::monthCode(m_plainYearMonth.month());
-}
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
@@ -67,7 +67,7 @@ public:
 
     ISO8601::PlainDate with(JSGlobalObject*, JSObject*, JSValue);
 
-    String monthCode() const;
+    String monthCode() const { return ISO8601::monthCode(m_plainYearMonth.month()); }
 
     String toString(JSGlobalObject*, JSValue options) const;
     String toString() const;

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
@@ -744,7 +744,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncWith, (JSGlobalObject
     // temporal_rs: ZonedDateTime::with_with_provider — is_exact=true when offset option is 'use'.
     // offset_nanos = Some(givenOffsetNs) always.
     if (offsetOpt == TemporalOffsetDisambiguation::Use) {
-        Int128 naiveNs = getUTCEpochNanoseconds({ newDate, newTime });
+        Int128 naiveNs = TemporalCore::getUTCEpochNanoseconds(newDate, newTime);
         auto resultNs = naiveNs - Int128(givenOffsetNs);
         RELEASE_AND_RETURN(scope, JSValue::encode(zdt->withExactTime(globalObject, ISO8601::ExactTime(resultNs))));
     }


### PR DESCRIPTION
#### 2e83baac62f6ea7db32fae5afa2a2a5ea558c219
<pre>
[JSC][Temporal] Remove one-line TemporalCore delegate wrappers
<a href="https://bugs.webkit.org/show_bug.cgi?id=316456">https://bugs.webkit.org/show_bug.cgi?id=316456</a>
<a href="https://rdar.apple.com/178853392">rdar://178853392</a>

Reviewed by Yusuke Suzuki.

Remove thin wrapper functions that did nothing but forward to
TemporalCore:: or ISO8601:: functions with no added logic:

- TemporalDuration::toInternalDuration and temporalDurationFromInternal
  were static class methods that just called the identically-named
  TemporalCore:: free functions. Remove both and update all callers
  (10 sites across TemporalDuration, TemporalCalendar, TemporalInstant,
  TemporalPlainDate, and TemporalPlainTime) to call TemporalCore::
  directly.

- The file-scope getUTCEpochNanoseconds(tuple&lt;PlainDate, PlainTime&gt;)
  in TemporalDuration.cpp unwrapped the tuple and forwarded to
  TemporalCore::getUTCEpochNanoseconds(PlainDate, PlainTime). Remove
  it and pass the two arguments directly at call sites, eliminating
  the combineISODateAndTimeRecord + tuple-unpack roundtrip.

- monthCode, dayOfWeek, dayOfYear, weekOfYear, and yearOfWeek on
  TemporalPlainDate, TemporalPlainDateTime, TemporalPlainYearMonth,
  and TemporalPlainMonthDay were single-line ISO8601:: delegates
  defined in .cpp files. Move them inline into the class definitions
  in the headers.

No behavioral changes.

Canonical link: <a href="https://commits.webkit.org/314683@main">https://commits.webkit.org/314683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a188a0f0cf7bd7c84e06a201f5983889158243fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175872 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124082 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2f86ccf-23bb-433f-bbc2-aade9507a3a1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129720 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8a86cd8-35f8-4f49-9dd1-f8827686963f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110246 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/697a61d7-3c15-4ac0-90a4-3092ef99ad77) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31097 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29797 "Passed tests") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158981 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141070 "Found 2 new API test failures: TestWebKitAPI.IndexedDB.IndexedDBPersistence, TestWebKitAPI.WritingTools.CompositionWithMultipleChunks (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178410 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27718 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31307 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138086 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137999 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149391 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103870 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25399 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33279 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26256 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199503 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39583 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112657 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53633 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38979 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4349 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39224 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39122 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->