### PR TITLE
[css-anchor-position-1] REGRESSION(311053@main): crash hiding a popover whose ::after pseudo-element inherits position-anchor and position-area

### DIFF
--- a/LayoutTests/fast/dom/pseudo-element-hidePopover-then-crash-expected.txt
+++ b/LayoutTests/fast/dom/pseudo-element-hidePopover-then-crash-expected.txt
@@ -1,0 +1,9 @@
+Tests that we don't crash when hiding a popover that's has a pseudo-element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/pseudo-element-hidePopover-then-crash.html
+++ b/LayoutTests/fast/dom/pseudo-element-hidePopover-then-crash.html
@@ -1,0 +1,60 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+      .trigger {
+        inline-size: 100px;
+        block-size: 100px;
+        anchor-name: --tooltip;
+      }
+      .tooltip {
+        position: absolute;
+        inline-size: 20px;
+        block-size: 20px;
+        inset: 0;
+        margin: 0;
+        position-anchor: --tooltip;
+        position-area: bottom;
+
+        &::after {
+          content: '';
+          inline-size: 10px;
+          block-size: 10px;
+          background-color: blue;
+          position: fixed;
+          position-anchor: inherit; /* both inherits together */
+          position-area: inherit;   /* are required to crash */
+        }
+      }
+    </style>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+      window.jsTestIsAsync = true;
+
+      window.addEventListener('load', async () => {
+        description("Tests that we don't crash when hiding a popover that's has a pseudo-element.");
+
+        const trigger = document.querySelector('.trigger');
+        const tooltip = document.querySelector('.tooltip');
+        trigger.addEventListener('mouseover', () => tooltip.showPopover());
+        trigger.addEventListener('mouseout', () => tooltip.hidePopover());
+
+        const triggerBounds = trigger.getBoundingClientRect();
+        await UIHelper.moveMouseAndWaitForFrame(triggerBounds.right - 10, triggerBounds.bottom - 10);
+
+        // Moving out of the trigger causes the crash.
+        await UIHelper.moveMouseAndWaitForFrame(triggerBounds.right + 10, triggerBounds.bottom + 10);
+
+        finishJSTest();
+      });
+    </script>
+</head>
+<body>
+    <div class="trigger"></div>
+    <div class="tooltip" popover="manual"></div>
+    <div id="console"></div>
+    <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1399,6 +1399,8 @@ auto AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap(AnchorPositionedT
             RefPtr element = &styleable->element;
             if (styleable->pseudoElementIdentifier)
                 element = element->pseudoElementIfExists(*styleable->pseudoElementIdentifier);
+            if (!element)
+                continue;
 
             map.ensure(*anchor.renderer, [&] {
                 return Vector<Ref<Element>> { };


### PR DESCRIPTION
#### f7a8a5c0476af3f6349707dad1fd026c80eaf763
<pre>
[css-anchor-position-1] REGRESSION(311053@main): crash hiding a popover whose ::after pseudo-element inherits position-anchor and position-area
<a href="https://bugs.webkit.org/show_bug.cgi?id=316441">https://bugs.webkit.org/show_bug.cgi?id=316441</a>

Reviewed by Kiet Ho.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap):
Just because the `Styleable` (i.e. `Element`) exists doesn&apos;t guarantee that a psuedo-element for it exists, so check that before trying to use it.

* LayoutTests/fast/dom/pseudo-element-hidePopover-then-crash.html: Added.
* LayoutTests/fast/dom/pseudo-element-hidePopover-then-crash-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/314698@main">https://commits.webkit.org/314698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7ce04683b5caa618065e707b12c223cbc40100f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129783 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110309 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31163 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29866 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24685 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141136 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178487 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31384 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138152 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40461 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34014 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 15 flakes 3 failures; Uploaded test results; Ignored 2 pre-existing failure based on results-db") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138064 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37181 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103974 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26326 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39660 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112734 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39056 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4422 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->