### PR TITLE
[iOS] CNN.com subtitles don't work in native fullscreen

### DIFF
--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -768,6 +768,7 @@ $(PROJECT_DIR)/Modules/modern-media-controls/gesture-recognizers/gesture-recogni
 $(PROJECT_DIR)/Modules/modern-media-controls/gesture-recognizers/pinch.js
 $(PROJECT_DIR)/Modules/modern-media-controls/gesture-recognizers/tap.js
 $(PROJECT_DIR)/Modules/modern-media-controls/main.js
+$(PROJECT_DIR)/Modules/modern-media-controls/media/CNNCaptionQuirk.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/airplay-support.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/audio-support.js

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -2342,6 +2342,7 @@ ModernMediaControls.js : $(MODERN_MEDIA_CONTROLS_SCRIPTS)
 USER_AGENT_SCRIPTS = \
     ModernMediaControls.js \
 	$(WebCore)/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js \
+	$(WebCore)/Modules/modern-media-controls/media/CNNCaptionQuirk.js \
 #
 
 USER_AGENT_SCRIPTS_FILES = \

--- a/Source/WebCore/Modules/modern-media-controls/media/CNNCaptionQuirk.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/CNNCaptionQuirk.js
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+(function() {
+    "use strict";
+
+    // CNN's "Bolt" player renders captions into a React-managed overlay subtree
+    // rather than via TextTracks on the <video>. As a result, when WebKit enters
+    // its native fullscreen UI the captions disappear because they were never
+    // exposed to the media element.
+    //
+    // The Bolt overlay is rooted at [data-testid="overlay-root"], and each
+    // visible caption line is a descendant tagged [data-testid="cueBoxRowTextCue"].
+    // We watch that subtree and mirror whatever text is currently rendered into a
+    // hidden 'forced' TextTrack on the <video>. When the element enters fullscreen
+    // (where Bolt's React overlay is no longer visible) we flip the track to
+    // 'showing' so WebKit renders the captions itself.
+    class CaptionMirror {
+        static _instances = new WeakMap();
+
+        // Public methods:
+        constructor(video) {
+            // If there was a previous instance of CaptionMirror associated with the same video
+            // invalidate the previous instance, which removes all event listeners and mutation
+            // observers:
+            let oldMirror = CaptionMirror._instances.get(video);
+            if (oldMirror) {
+                oldMirror.invalidate();
+                CaptionMirror._instances.delete(video);
+            }
+            CaptionMirror._instances.set(video, this);
+
+            this._video = video;
+            this._playerSelector = '[data-component-name="video-player"]';
+            this._overlayRootSelector = '[data-testid="overlay-root"]';
+            this._captionRowSelector = '[data-testid="cueBoxRowTextCue"]';
+            this._player = this._findPlayerRoot(video);
+            this._mirrorTrack = video.addTextTrack('forced', 'CNN Captions');
+            this._mirrorTrack.mode = 'hidden';
+            this._captionObserver = null;
+            this._waitObserver = null;
+
+            this._onPresentationModeChanged = () => this._handlePresentationModeChanged();
+            this._video.addEventListener('webkitpresentationmodechanged', this._onPresentationModeChanged);
+
+            if (this._player)
+                this._attachOverlayObserver();
+        }
+
+        invalidate() {
+            if (this._captionObserver) {
+                this._captionObserver.disconnect();
+                this._captionObserver = null;
+            }
+            if (this._waitObserver) {
+                this._waitObserver.disconnect();
+                this._waitObserver = null;
+            }
+            this._mirrorTrack.mode = 'disabled';
+            this._video.removeEventListener('webkitpresentationmodechanged', this._onPresentationModeChanged);
+        }
+
+        // Private methods:
+        _findPlayerRoot(video) {
+            return video.closest(this._playerSelector);
+        }
+
+        _syncCues(overlayRoot) {
+            while (this._mirrorTrack.cues?.length)
+                this._mirrorTrack.removeCue(this._mirrorTrack.cues[0]);
+
+            var rows = Array.from(overlayRoot.querySelectorAll(this._captionRowSelector));
+            if (!rows.length)
+                return;
+
+            var text = rows.map(row => row.textContent).join('\n');
+            if (!text)
+                return;
+
+            var cue = new VTTCue(0, 10e7, text);
+
+            // Set some reasonable defaults for the cue display:
+            cue.snapToLines = true;
+            cue.line = -4;
+            cue.position = 'auto';
+            cue.positionAlign = 'center';
+
+            this._mirrorTrack.addCue(cue);
+        }
+
+        // The overlay-root may not exist at the moment the <video> is connected — Bolt
+        // mounts it asynchronously. If it isn't there yet, watch the player subtree until
+        // it appears, then switch to the targeted caption observer.
+        _attachOverlayObserver() {
+            var overlayRoot = this._player.querySelector(this._overlayRootSelector);
+            if (overlayRoot) {
+                this._attachCaptionObserver(overlayRoot);
+                return;
+            }
+            this._waitObserver = new MutationObserver(() => {
+                var overlayRoot = this._player.querySelector(this._overlayRootSelector);
+                if (overlayRoot) {
+                    this._attachCaptionObserver(overlayRoot);
+                    this._waitObserver.disconnect();
+                    this._waitObserver = null;
+                }
+            });
+            this._waitObserver.observe(this._player, { childList: true, subtree: true });
+        }
+
+        _attachCaptionObserver(overlayRoot) {
+            if (this._captionObserver)
+                this._captionObserver.disconnect();
+            this._captionObserver = new MutationObserver(() => {
+                // The overlay-root element itself may have been replaced by a React
+                // remount; re-query rather than caching the original reference.
+                var current = this._player.querySelector(this._overlayRootSelector);
+                if (current)
+                    this._syncCues(current);
+            });
+            this._captionObserver.observe(overlayRoot, {
+                childList: true,
+                subtree: true,
+                characterData: true,
+            });
+            this._syncCues(overlayRoot);
+        }
+
+        _handlePresentationModeChanged() {
+            if (this._video.webkitPresentationMode == 'inline') {
+                this._mirrorTrack.mode = 'hidden';
+                return;
+            }
+            this._mirrorTrack.mode = 'showing';
+        }
+    }
+
+    window.setupCaptionMirroring = function(video) {
+        new CaptionMirror(video);
+    }
+}());

--- a/Source/WebCore/PlatformCocoa.cmake
+++ b/Source/WebCore/PlatformCocoa.cmake
@@ -1411,6 +1411,7 @@ set(ADDITIONAL_BINDINGS_DEPENDENCIES
 set(WebCore_USER_AGENT_SCRIPTS
     ${WebCore_DERIVED_SOURCES_DIR}/ModernMediaControls.js
     ${WEBCORE_DIR}/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
+    ${WEBCORE_DIR}/Modules/modern-media-controls/media/CNNCaptionQuirk.js
 )
 
 list(APPEND WebCoreTestSupport_LIBRARIES PRIVATE WebCore)

--- a/Source/WebCore/dom/DocumentMediaElement.cpp
+++ b/Source/WebCore/dom/DocumentMediaElement.cpp
@@ -89,6 +89,15 @@ bool DocumentMediaElement::setupAndCallYouTubeQuirkJS(NOESCAPE const JSSetupFunc
     return setupAndCallJS(task, world);
 }
 
+bool DocumentMediaElement::setupAndCallCNNQuirkJS(NOESCAPE const JSSetupFunction& task)
+{
+    if (!ensureCNNQuirkScript())
+        return false;
+
+    Ref world = mainThreadNormalWorldSingleton();
+    return setupAndCallJS(task, world);
+}
+
 DOMWrapperWorld& DocumentMediaElement::ensureIsolatedWorld()
 {
     if (!m_isolatedWorld) {
@@ -146,6 +155,29 @@ bool DocumentMediaElement::ensureYouTubeQuirkScript()
         return true;
     }, world);
     return m_haveParsedYouTubeQuirkScript;
+}
+
+bool DocumentMediaElement::ensureCNNQuirkScript()
+{
+    if (m_haveParsedCNNQuirkScript)
+        return true;
+
+    Ref document = this->document();
+    auto cnnQuirkScript = RenderTheme::singleton().cnnQuirkScript();
+    if (cnnQuirkScript.isEmpty() || document->activeDOMObjectsAreSuspended() || document->activeDOMObjectsAreStopped())
+        return false;
+
+    Ref world = mainThreadNormalWorldSingleton();
+    m_haveParsedCNNQuirkScript = setupAndCallJS([cnnQuirkScript = WTF::move(cnnQuirkScript)](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject&, ScriptController& scriptController, DOMWrapperWorld& world) {
+        auto& vm = globalObject.vm();
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
+        scriptController.evaluateInWorldIgnoringException(ScriptSourceCode(cnnQuirkScript, JSC::SourceTaintedOrigin::Untainted), world);
+        RETURN_IF_EXCEPTION(scope, false);
+
+        return true;
+    }, world);
+    return m_haveParsedCNNQuirkScript;
 }
 
 bool DocumentMediaElement::setupAndCallJS(NOESCAPE const JSSetupFunction& task, DOMWrapperWorld& world)

--- a/Source/WebCore/dom/DocumentMediaElement.h
+++ b/Source/WebCore/dom/DocumentMediaElement.h
@@ -53,6 +53,7 @@ public:
     using JSSetupFunction = Function<bool(JSDOMGlobalObject&, JSC::JSGlobalObject&, ScriptController&, DOMWrapperWorld&)>;
     bool setupAndCallMediaControlsJS(NOESCAPE const JSSetupFunction&);
     bool setupAndCallYouTubeQuirkJS(NOESCAPE const JSSetupFunction&);
+    bool setupAndCallCNNQuirkJS(NOESCAPE const JSSetupFunction&);
 
 private:
     bool isDocumentMediaElement() const final { return true; }
@@ -65,11 +66,13 @@ private:
     bool setupAndCallJS(NOESCAPE const JSSetupFunction&, DOMWrapperWorld&);
 
     bool ensureYouTubeQuirkScript();
+    bool ensureCNNQuirkScript();
 
     CheckedRef<Document> m_document;
     RefPtr<DOMWrapperWorld> m_isolatedWorld;
     bool m_haveParsedMediaControlsScript { false };
     bool m_haveParsedYouTubeQuirkScript { false };
+    bool m_haveParsedCNNQuirkScript { false };
 };
 
 }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1190,6 +1190,36 @@ void HTMLMediaElement::postConnectionSteps()
             return true;
         });
     }
+
+    if (protect(document())->quirks().needsCNNCaptionQuirk()) {
+        DocumentMediaElement::from(protect(document())).setupAndCallCNNQuirkJS([this](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject& lexicalGlobalObject, ScriptController&, DOMWrapperWorld&) {
+            auto& vm = globalObject.vm();
+            auto scope = DECLARE_THROW_SCOPE(vm);
+
+            auto functionValue = globalObject.get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, "setupCaptionMirroring"_s));
+            if (scope.exception()) [[unlikely]]
+                return false;
+            if (functionValue.isUndefinedOrNull())
+                return false;
+
+            auto mediaJSWrapper = toJS(&lexicalGlobalObject, &globalObject, *this);
+
+            JSC::MarkedArgumentBuffer argList;
+            argList.append(mediaJSWrapper);
+            ASSERT(!argList.hasOverflowed());
+
+            auto* function = functionValue.toObject(&lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+            auto callData = JSC::getCallData(function);
+            if (callData.type == JSC::CallData::Type::None)
+                return false;
+
+            JSC::call(&lexicalGlobalObject, function, callData, &globalObject, argList);
+
+            RETURN_IF_EXCEPTION(scope, false);
+            return true;
+        });
+    }
 }
 
 void HTMLMediaElement::pauseAfterDetachedTask()

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -414,6 +414,17 @@ bool Quirks::needsYouTubeCaptionsQuirk() const
 #endif
 }
 
+bool Quirks::needsCNNCaptionQuirk() const
+{
+#if PLATFORM(COCOA)
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsCNNCaptionQuirk);
+#else
+    return false;
+#endif
+}
+
 // theguardian.com rdar://166727225
 bool Quirks::needsYouTubeEmbedAutoplayQuirk() const
 {
@@ -2939,6 +2950,9 @@ static void handleCNNQuirks(QuirksData& quirksData, const URL& /* quirksURL */, 
     // cnn.com rdar://176539646
 #if ENABLE(THREADED_ANIMATIONS)
     quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldDisableThreadedAnimationsQuirk);
+#endif
+#if PLATFORM(COCOA)
+    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsCNNCaptionQuirk);
 #endif
 }
 

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -124,6 +124,8 @@ public:
     bool needsYouTubeEmbedAutoplayQuirk() const;
     WEBCORE_EXPORT bool NODELETE needsYouTubeMouseOutQuirk() const;
 
+    WEBCORE_EXPORT bool needsCNNCaptionQuirk() const;
+
     WEBCORE_EXPORT bool shouldDisableWritingSuggestionsByDefault() const;
 
     WEBCORE_EXPORT static void updateStorageAccessUserAgentStringQuirks(HashMap<RegistrableDomain, String>&&);

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -85,6 +85,9 @@ struct QuirksData {
         NeedsBodyScrollbarWidthNoneDisabledQuirk,
         NeedsCanPlayAfterSeekedQuirk,
         NeedsChromeMediaControlsPseudoElementQuirk,
+#if PLATFORM(COCOA)
+        NeedsCNNCaptionQuirk,
+#endif
         NeedsLogoutCookieCleanupQuirk,
 #if PLATFORM(IOS_FAMILY)
         NeedsAmazonDesignMenuViewportUnitQuirk,

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -130,6 +130,7 @@ public:
     virtual String mediaControlsBase64StringForIconNameAndType(const String&, const String&) { return String(); }
     virtual String mediaControlsFormattedStringForDuration(double) { return String(); }
     virtual String youTubeQuirkScript() { return { }; }
+    virtual String cnnQuirkScript() { return { }; }
 #endif // ENABLE(VIDEO)
 #if ENABLE(ATTACHMENT_ELEMENT)
     virtual String attachmentStyleSheet() const;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -89,6 +89,7 @@ public:
     RefPtr<FragmentedSharedBuffer> mediaControlsImageDataForIconNameAndType(const String&, const String&) final;
     String mediaControlsFormattedStringForDuration(double) final;
     String youTubeQuirkScript() final;
+    String cnnQuirkScript() final;
 #endif
 
 #if ENABLE(FORM_CONTROL_REFRESH)
@@ -305,6 +306,7 @@ private:
     String m_mediaControlsStyleSheet;
     RetainPtr<NSDateComponentsFormatter> m_durationFormatter;
     String m_youTubeCaptionQuirkScript;
+    String m_cnnCaptionQuirkScript;
 #endif // ENABLE(VIDEO)
 };
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -1348,6 +1348,14 @@ String RenderThemeCocoa::youTubeQuirkScript()
     return m_youTubeCaptionQuirkScript;
 }
 
+String RenderThemeCocoa::cnnQuirkScript()
+{
+    if (!m_cnnCaptionQuirkScript)
+        m_cnnCaptionQuirkScript = StringImpl::createWithoutCopying(CNNCaptionQuirkJavaScript);
+
+    return m_cnnCaptionQuirkScript;
+}
+
 #endif // ENABLE(VIDEO)
 
 #if ENABLE(ATTACHMENT_ELEMENT)


### PR DESCRIPTION
#### e923dba3a033f32e09809aa64920df2f86bbdaf4
<pre>
[iOS] CNN.com subtitles don&apos;t work in native fullscreen
<a href="https://rdar.apple.com/175298523">rdar://175298523</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316460">https://bugs.webkit.org/show_bug.cgi?id=316460</a>

Reviewed by Jean-Yves Avenard.

Add a Quirk to CNN.com which &quot;mirrors&quot; the captions provided in the DOM
into VTTCues and a synthetic text track.

* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/modern-media-controls/media/CNNCaptionQuirk.js: Added.
(CaptionMirror):
(CaptionMirror.prototype.invalidate):
(CaptionMirror.prototype._findPlayerRoot):
(CaptionMirror.prototype._syncCues):
(CaptionMirror.prototype._attachOverlayObserver):
(CaptionMirror.prototype._attachCaptionObserver):
(CaptionMirror.prototype._handlePresentationModeChanged):
(window.setupCaptionMirroring):
* Source/WebCore/PlatformCocoa.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/DocumentMediaElement.cpp:
(WebCore::DocumentMediaElement::setupAndCallCNNQuirkJS):
(WebCore::DocumentMediaElement::ensureCNNQuirkScript):
* Source/WebCore/dom/DocumentMediaElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::postConnectionSteps):
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::cnnQuirkScript):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::cnnQuirkScript):

Canonical link: <a href="https://commits.webkit.org/315789@main">https://commits.webkit.org/315789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/250700e4658438acf659ee81e19a699786cac494

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175891 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124101 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129738 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91367 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110264 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31116 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29814 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24627 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141089 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178429 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33962 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138106 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138019 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37919 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41091 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26274 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103889 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33297 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112676 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39602 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4367 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38998 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39243 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39141 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->