### PR TITLE
WPT linter fails with error

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/wpt_linter.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_linter.py
@@ -58,11 +58,21 @@ class WPTLinter(object):
 
     def _run_lint(self, cmd):
         _log.debug('Running WPT linter: %s (cwd=%s)', ' '.join(cmd), self.wpt_path)
-        result = subprocess.run(cmd, cwd=self.wpt_path, capture_output=True)
-        if result.stderr:
-            raise RuntimeError(
-                'WPT linter wrote to stderr:\n' + result.stderr.decode('utf-8', 'replace')
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=self.wpt_path,
+                capture_output=True,
+                check=True,
             )
+        except subprocess.CalledProcessError as e:
+            # lint exits with 1 when there's lint errors; any other exit code is an
+            # actual failure.
+            if e.returncode != 1:
+                raise RuntimeError(
+                    'WPT linter failed:\n' + result.stderr.decode('utf-8', 'replace')
+                ) from e
+            result = e
         for line in result.stdout.splitlines():
             if not line.strip():
                 continue


### PR DESCRIPTION
#### c01c10f363644bad3e3ce88f91e21128d0ef1182
<pre>
WPT linter fails with error
<a href="https://bugs.webkit.org/show_bug.cgi?id=315899">https://bugs.webkit.org/show_bug.cgi?id=315899</a>
<a href="https://rdar.apple.com/177836781">rdar://177836781</a>

Reviewed by Elliott Williams.

After the re-import of web-platform-tests/tools, we can now use the
return code of the linter to distinguish actual failures to linter
errors.

* Tools/Scripts/webkitpy/w3c/wpt_linter.py:
(WPTLinter._run_lint):

Canonical link: <a href="https://commits.webkit.org/314840@main">https://commits.webkit.org/314840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff4e47dbd5c53b1142f0a86d21c89e91b8f4af2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176196 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd87fbe3-0e82-446e-90b3-1e94f91ec429) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130007 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ea4aa2d-a95c-4363-be3e-f56a9802f4e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110524 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab9c8bf7-514f-43d6-8097-aec5a349d6e6) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/166469 "Found 3 webkitpy test failures: webkitscmpy.test.land_unittest.TestLand.test_default, webkitscmpy.test.land_unittest.TestLand.test_svn, webkitscmpy.test.land_unittest.TestLandBitBucket.test_no_reviewer") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31388 "Found 1 new test failure: imported/w3c/web-platform-tests/_venv3/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30092 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24935 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178737 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29590 "Found 1 new test failure: imported/w3c/web-platform-tests/_venv3/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138382 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138281 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41405 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104363 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25470 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33537 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26545 "Found 1 new test failure: imported/w3c/web-platform-tests/_venv3/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39909 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39306 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4643 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39556 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39450 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->