### PR TITLE
webkitscmpy.program.command shouldn't hardcode "Canonical link"

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py
@@ -76,7 +76,7 @@ class FilteredCommand(Command):
     REVISION_RES = (re.compile(r'^(?P<revision>\d+)\s'), re.compile(r'(?P<revision>[rR]\d+)'))
     HASH_RES = (re.compile(r'^(?P<hash>[a-f0-9A-F]{8}[a-f0-9A-F]+)\s'), re.compile(r'(?P<hash>[a-f0-9A-F]{8}[a-f0-9A-F]+)'))
     IDENTIFIER_RES = (re.compile(r'^(?P<identifier>(?:\d+\.)?\d+@\S*)'), re.compile(r'(?P<identifier>(?:\d+\.)?\d+@\S*)'))
-    NO_FILTER_RES = [re.compile(r'    Canonical link:'), re.compile(r'    git-svn-id:')]
+    NO_FILTER_RES = [re.compile(r'    Canonical(?:-| )link:'), re.compile(r'    git-svn-id:')]
     DIFF_RE = re.compile(r'^diff --git ')
 
     REPLACE_MODE = 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/command_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/command_unittest.py
@@ -155,6 +155,21 @@ class TestFilteredCommandHash(TestFilteredCommandBase):
             self._run_log(git, ref=root.hash),
         )
 
+    def test_canonical_link_hyphen_not_transformed(self):
+        git = mocks.local.Git(self.path)
+        root = git.commits['main'][0]
+        root.message = 'Patch Series\n\nCanonical-link: https://commits.webkit.org/5@main\n'
+        self.assertEqual(
+            'commit 9b8311f25a77 (1@main)\n'
+            'Author: Jonathan Bedard <jbedard@apple.com>\n'
+            'Date:   Fri Oct 02 17:33:20 2020 +0000\n'
+            '\n'
+            '    Patch Series\n'
+            '\n'
+            '    Canonical-link: https://commits.webkit.org/5@main\n',
+            self._run_log(git, ref=root.hash),
+        )
+
     def test_canonical_link_space_not_transformed(self):
         git = mocks.local.Git(self.path)
         root = git.commits['main'][0]


### PR DESCRIPTION
#### 2ad20f50e2435a0fa7ad5e0c667a77f3667d6901
<pre>
webkitscmpy.program.command shouldn&apos;t hardcode &quot;Canonical link&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=301469">https://bugs.webkit.org/show_bug.cgi?id=301469</a>
<a href="https://rdar.apple.com/163410599">rdar://163410599</a>

Reviewed by Elliott Williams.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py:
(FilteredCommand): Allow a hyphen in &quot;Canonical-link&quot;.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/command_unittest.py:
(TestFilteredCommandHash.test_canonical_link_hyphen_not_transformed):

Canonical link: <a href="https://commits.webkit.org/314679@main">https://commits.webkit.org/314679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/601394a9ab7c9f6734e0b87fba6018d474e6bd44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40347 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/33928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175905 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42d37d55-5fb8-4d75-9595-c1d4b8b68e86) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40355 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/129749 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/201547c9-ad5d-4165-9ead-4e38ff8a3087) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169816 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110275 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6be00217-0985-439f-b527-889e32888fb8) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/166180 "Found 1 webkitpy test failure: webkitscmpy.test.land_unittest.TestLandBitBucket.test_insert_review") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/24641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/27623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178443 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/29330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/166259 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40417 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138029 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41105 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/149421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103907 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25397 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/33308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39616 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39012 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/4379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39257 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39156 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->