### PR TITLE
[Site Isolation] Make key events attribute user interaction to the top frame's origin

### DIFF
--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/iframe-with-input.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/iframe-with-input.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<body style="margin:0">
+<input id="iframeInput" style="position:absolute; top:0; left:0; width:100%; height:100%; box-sizing:border-box;">
+<script>
+const input = document.getElementById("iframeInput");
+input.addEventListener("focus", () => {
+    parent.postMessage("input-focused", "*");
+});
+input.addEventListener("keydown", () => {
+    parent.postMessage("keydown-received", "*");
+    setTimeout(() => {
+        parent.postMessage(input.value === "a" ? "key-typed" : "key-not-typed", "*");
+    }, 0);
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/resourceLoadStatistics/user-interaction-keyboard-in-cross-origin-sub-frame-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/user-interaction-keyboard-in-cross-origin-sub-frame-expected.txt
@@ -1,0 +1,18 @@
+Tests that keystroke user interaction in a cross-origin sub-frame is logged for the top document/frame, not the sub-frame.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.location.origin is topFrameOrigin
+PASS testRunner.isStatisticsHasHadUserInteraction(topFrameOrigin) is false
+PASS testRunner.isStatisticsHasHadUserInteraction(subFrameOrigin) is false
+PASS inputFocused is true
+PASS testRunner.isStatisticsHasHadUserInteraction(topFrameOrigin) is false
+PASS iframeReceivedKeyDown is true
+PASS keyTyped is true
+PASS testRunner.isStatisticsHasHadUserInteraction(topFrameOrigin) is true
+PASS testRunner.isStatisticsHasHadUserInteraction(subFrameOrigin) is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/resourceLoadStatistics/user-interaction-keyboard-in-cross-origin-sub-frame.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/user-interaction-keyboard-in-cross-origin-sub-frame.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="resources/util.js"></script>
+<script>
+description("Tests that keystroke user interaction in a cross-origin sub-frame is logged for the top document/frame, not the sub-frame.");
+jsTestIsAsync = true;
+
+const topFrameOrigin = "http://127.0.0.1:8000";
+const subFrameOrigin = "http://localhost:8000";
+
+let inputFocused = false;
+let iframeReceivedKeyDown = false;
+let keyTyped = false;
+let resolveInputFocused;
+let resolveKeyTypedOrNot;
+
+const inputFocusedPromise = new Promise(r => { resolveInputFocused = r; });
+const keyTypedOrNotPromise = new Promise(r => { resolveKeyTypedOrNot = r; });
+
+window.addEventListener("message", (event) => {
+    if (event.data === "input-focused") {
+        inputFocused = true;
+        resolveInputFocused();
+    } else if (event.data === "keydown-received") {
+        iframeReceivedKeyDown = true;
+    } else if (event.data === "key-typed") {
+        keyTyped = true;
+        resolveKeyTypedOrNot();
+    } else if (event.data === "key-not-typed") {
+        keyTyped = false;
+        resolveKeyTypedOrNot();
+    }
+});
+
+async function activateElement(elementId) {
+    const element = document.getElementById(elementId);
+    const centerX = element.offsetLeft + element.offsetWidth / 2;
+    const centerY = element.offsetTop + element.offsetHeight / 2;
+    await UIHelper.activateAt(centerX, centerY);
+}
+
+onload = function() {
+    setEnableFeature(true, async function() {
+        shouldBe("document.location.origin", "topFrameOrigin");
+        shouldBeFalse("testRunner.isStatisticsHasHadUserInteraction(topFrameOrigin)");
+        shouldBeFalse("testRunner.isStatisticsHasHadUserInteraction(subFrameOrigin)");
+
+        // Click into the iframe to we can fire a key event in it.
+        // The click is a mouse event and this attributes the user
+        // interaction to the top frame via the mouse path.
+        await activateElement("testFrame");
+        await inputFocusedPromise;
+        shouldBeTrue("inputFocused");
+
+        // Wait long enough for the 5 second window enforced by
+        // ResourceLoadStatistics::reduceTimeResolution() to pass
+        // so the key event's user interaction isn't ignored.
+        await new Promise(r => setTimeout(r, 6000));
+
+        // Reset the NetworkProcess-side storage so that the top
+        // frame origin no longer contains a user interaction
+        // (the one introduced by the click).
+        await new Promise(r => testRunner.setStatisticsHasHadUserInteraction(topFrameOrigin, false, r));
+        shouldBeFalse("testRunner.isStatisticsHasHadUserInteraction(topFrameOrigin)");
+
+        eventSender.keyDown("a");
+        await keyTypedOrNotPromise;
+        shouldBeTrue("iframeReceivedKeyDown");
+        shouldBeTrue("keyTyped");
+
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
+        shouldBeTrue("testRunner.isStatisticsHasHadUserInteraction(topFrameOrigin)");
+        shouldBeFalse("testRunner.isStatisticsHasHadUserInteraction(subFrameOrigin)");
+
+        setEnableFeature(false, finishJSTest);
+    });
+};
+</script>
+<iframe id="testFrame" src="http://localhost:8000/resourceLoadStatistics/resources/iframe-with-input.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2912,6 +2912,8 @@ webkit.org/b/247166 fast/canvas/webgl/match-page-color-space-p3.html [ ImageOnly
 webkit.org/b/174120 http/tests/resourceLoadStatistics/user-interaction-in-cross-origin-sub-frame.html [ Skip ]
 http/tests/resourceLoadStatistics/user-interaction-only-reported-once-within-short-period-of-time.html [ Skip ]
 http/tests/resourceLoadStatistics/user-interaction-reported-after-website-data-removal.html [ Skip ]
+http/tests/resourceLoadStatistics/user-interaction-keyboard-in-cross-origin-sub-frame.html [ Skip ]
+
 # Skipped in WK2 expectations because cookie partitioning is only available in macOS High Sierra and iOS 11.
 http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store.html [ Pass ]
 http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store-one-hour.html [ Pass ]

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4161,26 +4161,24 @@ bool EventHandler::keyEvent(const PlatformKeyboardEvent& keyEvent)
 {
     Ref frame = m_frame.get();
     RefPtr page = frame->page();
-    RefPtr mainFrameDocument = frame->document() ? frame->document()->mainFrameDocument() : nullptr;
+    RefPtr document = frame->document();
     MonotonicTime savedLastHandledUserGestureTimestamp;
     bool savedUserDidInteractWithPage = page && page->userDidInteractWithPage();
 
-    if (auto* document = frame->document())
+    if (document)
         savedLastHandledUserGestureTimestamp = document->lastHandledUserGestureTimestamp();
 
     bool wasHandled = internalKeyEvent(keyEvent);
 
     // If the key event was not handled, do not treat it as user interaction with the page.
-    if (mainFrameDocument) {
+    if (document) {
         if (!wasHandled) {
             if (page)
                 page->setUserDidInteractWithPage(savedUserDidInteractWithPage);
+            document->updateLastHandledUserGestureTimestamp(savedLastHandledUserGestureTimestamp);
         } else
-            ResourceLoadObserver::singleton().logUserInteractionWithReducedTimeResolution(*mainFrameDocument);
+            ResourceLoadObserver::singleton().logUserInteractionWithReducedTimeResolution(*document);
     }
-
-    if (!wasHandled && frame->document())
-        protect(frame->document())->updateLastHandledUserGestureTimestamp(savedLastHandledUserGestureTimestamp);
 
     return wasHandled;
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
@@ -369,7 +369,11 @@ void WebResourceLoadObserver::logWebSocketLoading(const URL& targetURL, const UR
 
 void WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution(const Document& document)
 {
-    auto& url = document.url();
+    RefPtr page = document.page();
+    if (!page)
+        return;
+
+    auto& url = page->mainFrameURL();
     if (url.protocolIsAbout() || url.protocolIsFile() || url.isEmpty())
         return;
 
@@ -388,13 +392,15 @@ void WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution(const 
         statistics.mostRecentUserInteractionTime = newTime;
     }
 
-    if (RefPtr frame = document.frame()) {
-        if (RefPtr opener = dynamicDowncast<LocalFrame>(frame->opener())) {
-            if (RefPtr openerDocument = opener->document()) {
-                if (RefPtr openerPage = openerDocument->page())
-                    requestStorageAccessUnderOpener(topFrameDomain, Ref { *WebPage::fromCorePage(*openerPage) }, *openerDocument);
-            }
+    if (RefPtr mainFrameDocument = document.mainFrameDocument()) {
+        RefPtr frame = mainFrameDocument->frame();
+        if (RefPtr opener = frame ? dynamicDowncast<LocalFrame>(frame->opener()) : nullptr) {
+            RefPtr openerDocument = opener->document();
+            if (RefPtr openerPage = openerDocument ? openerDocument->page() : nullptr)
+                requestStorageAccessUnderOpener(topFrameDomain, Ref { *WebPage::fromCorePage(*openerPage) }, *openerDocument);
         }
+    } else {
+        LOG_ONCE(SiteIsolation, "Unable to request storage access under opener when logging user interation without access to the main frame document ");
     }
 
     // We notify right away in case of a user interaction instead of waiting the usual 5 seconds because we want


### PR DESCRIPTION
#### 9fd79b30a635bfa5c6cfebcf0eed889ed9bbdc90
<pre>
[Site Isolation] Make key events attribute user interaction to the top frame&apos;s origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=316465">https://bugs.webkit.org/show_bug.cgi?id=316465</a>
<a href="https://rdar.apple.com/178865421">rdar://178865421</a>

Reviewed by Alex Christensen.

When a key event happens in a cross-site iframe, we record that a user interation
happened, but not on the iframe&apos;s origin, but rather the top frame&apos;s origin. This
works with site isolation off (the test this patch adds shows that). But it doesn&apos;t
work with site isolation on.

EventHandler::keyEvent() only calls logUserInteractionWithReducedTimeResolution()
if it finds the main frame&apos;s document, which it can&apos;t if called from a cross-site
iframe. The reason logUserInteractionWithReducedTimeResolution() expects to be
given the main frame&apos;s document is so it can extract the top frame&apos;s origin.

We fix this by having EventHandler::keyEvent() send in the current document (which
could be the cross-site iframe&apos;s document) and having
logUserInteractionWithReducedTimeResolution() extract the top frame&apos;s origin from
it via the documentSyncData stored on the page.

This makes the test pass with site isolation enabled as well.

It looks like logUserInteractionWithReducedTimeResolution() also uses the main
frame&apos;s document to call requestStorageAccessUnderOpener(). Since this already
doesn&apos;t work with site isolation on, and we aren&apos;t fixing it here, we just log
the site isolation error (similiar to other places that check mainFrameDocument).

Notes about the test:

Making a keyEvent work in the cross-site iframe meant selecting the iframe. This is
a mouse event, which already attributes user interaction to the top frame&apos;s origin.
So to test this properly, we need to clear this attribution. Two nuances:

1. logUserInteractionWithReducedTimeResolution() reduces the wall-clock time to a
   5-second bucket (ResourceLoadStatistics::reduceTimeResolution()). If two
   interactions happen within 5 seconds of each other the second is discarded. So
   to test this properly, our key event has to happen at least 5 seconds after the
   click (we use a 6 second timeout).

2. We need to clear the attribution stored in the network process (done by calling
   TestController::setStatisticsHasHadUserInteraction()).

* LayoutTests/http/tests/resourceLoadStatistics/resources/iframe-with-input.html: Added.
* LayoutTests/http/tests/resourceLoadStatistics/user-interaction-keyboard-in-cross-origin-sub-frame-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/user-interaction-keyboard-in-cross-origin-sub-frame.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::keyEvent):
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp:
(WebKit::WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution):

Canonical link: <a href="https://commits.webkit.org/314903@main">https://commits.webkit.org/314903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c87bbd6803396319d7af1b004e4638f7a0c9482c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176463 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f41808e-518e-48bd-8331-e8546239282f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130233 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/790b441f-b1b4-4e50-863f-83e79c38b5dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110750 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67fa45a8-b377-45ba-9c28-71c15557474c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31626 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30323 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25202 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179007 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31903 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138631 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40983 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138519 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149905 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104746 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25498 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33770 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26783 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40175 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113256 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39572 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4881 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39822 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39717 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->