### PR TITLE
REGRESSION (314371@main): (macOS) fast/scrolling/Mac tests are flaky failures

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2435,7 +2435,3 @@ webkit.org/b/316036 [ Debug ] inspector/timeline/timeline-event-TimerFire.html [
 webkit.org/b/315982 [ Sequoia Release x86_64 ] webgl/pending/conformance/glsl/misc/swizzle-as-lvalue.html [ Pass Timeout ]
 
 webkit.org/b/316089 [ Sequoia Release ] inspector/css/setLayoutContextTypeChangedMode.html [ Pass Failure ]
-
-# webkit.org/b/316455 REGRESSION(314371@main): (macOS) fast/scrolling/Mac tests are flaky failures
-fast/scrolling/mac/slow-scrolling-overflow.html [ Pass Failure ]
-fast/scrolling/mac/overflow-scrolled-document.html [ Pass Failure ]

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -79,15 +79,21 @@ bool ScrollingTreeScrollingNode::commitStateBeforeChildren(const ScrollingStateN
         if (m_isFirstCommit) {
             // If the first commit contains a scroll delta, prime m_currentScrollPosition so we apply
             // the delta relative to it later (otherwise we'll apply the delta relative to (0,0) and
-            // end up with the wrong scroll position).
-            FloatSize deltaForFirstCommit;
+            // end up with the wrong scroll position). For an absolute position request, leave
+            // m_currentScrollPosition untouched so that handleScrollPositionRequests() actually scrolls;
+            // scrollTo() early-returns when the destination equals m_currentScrollPosition, which would
+            // skip the layer/viewport update for the initial programmatic scroll.
+            std::optional<FloatSize> deltaForFirstCommit;
             for (auto& request : state->requestedScrollData()) {
                 if (auto* delta = std::get_if<FloatSize>(&request.scrollPositionOrDelta)) {
                     deltaForFirstCommit = *delta;
                     break;
                 }
             }
-            m_currentScrollPosition = m_lastCommittedScrollPosition - deltaForFirstCommit;
+            if (deltaForFirstCommit)
+                m_currentScrollPosition = m_lastCommittedScrollPosition - *deltaForFirstCommit;
+            else if (!state->hasScrollPositionRequest())
+                m_currentScrollPosition = m_lastCommittedScrollPosition;
         }
     }
 


### PR DESCRIPTION
#### 007473a35847ed155a15f5497ef1de88204f6aa9
<pre>
REGRESSION (314371@main): (macOS) fast/scrolling/Mac tests are flaky failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=316455">https://bugs.webkit.org/show_bug.cgi?id=316455</a>
<a href="https://rdar.apple.com/178849808">rdar://178849808</a>

Reviewed by Abrar Rahman Protyasha.

314371@main removed the `state-&gt;hasScrollPositionRequest()` check before initializing `m_currentScrollPosition`
when the UI process receives a programmatic scroll; this caused an update with an absolute scroll request to set
`m_currentScrollPosition`, resulting in code under `handleScrollPositionRequests()` short-circuiting and
failing to reposition layers.

Fix by restoring the check for `hasScrollPositionRequest()` so that when the UI process receives absolute
scroll requests, it does not set `m_currentScrollPosition`.

Tested by `fast/scrolling/mac/slow-scrolling-overflow.html` and `fast/scrolling/mac/overflow-scrolled-document.html`.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::commitStateBeforeChildren):

Canonical link: <a href="https://commits.webkit.org/314710@main">https://commits.webkit.org/314710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3f94ab9872d127704ee9ae85c750d84cabe3435

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124127 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67336745-ecc7-4159-a3ff-6c07819f85ed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40367 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129760 "Found 1 new test failure: scrollbars/scrollbar-drag-thumb-with-large-content.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/58fdf0ee-2ce4-4e2f-8dca-8a61cd2e6d74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110286 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05ca8fb6-a250-409f-9234-98b152ce301a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31137 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29837 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24653 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178455 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31352 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138128 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138040 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37189 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149432 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103927 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33318 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26297 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39628 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112702 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39024 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4391 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39269 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39168 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->