### PR TITLE
[CMake] Shrink the single-core long pole at the end of the build

### DIFF
--- a/Tools/MiniBrowser/mac/CMakeLists.txt
+++ b/Tools/MiniBrowser/mac/CMakeLists.txt
@@ -68,10 +68,14 @@ add_executable(MiniBrowser MACOSX_BUNDLE ${MiniBrowser_SOURCES})
 WEBKIT_ADD_TARGET_CXX_FLAGS(MiniBrowser -Wno-unused-parameter)
 set_target_properties(MiniBrowser PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${MINIBROWSER_DIR}/Info.plist)
 target_link_libraries(MiniBrowser ${MiniBrowser_LIBRARIES})
-add_dependencies(MiniBrowser MiniBrowserNibs WebProcess NetworkProcess GPUProcess)
+add_dependencies(MiniBrowser MiniBrowserNibs)
+set(MiniBrowser_XPC_SERVICES WebProcess NetworkProcess GPUProcess)
 if (TARGET WebProcessEnhancedSecurity)
-    add_dependencies(MiniBrowser WebProcessEnhancedSecurity WebProcessCaptivePortal)
+    list(APPEND MiniBrowser_XPC_SERVICES WebProcessEnhancedSecurity WebProcessCaptivePortal)
 endif ()
+foreach (_service IN LISTS MiniBrowser_XPC_SERVICES)
+    set_property(TARGET MiniBrowser APPEND PROPERTY LINK_DEPENDS $<TARGET_FILE:${_service}>)
+endforeach ()
 
 # SIP strips DYLD_* for XPC children, so they load system WebKit -> version mismatch crash.
 # Set __XPC_DYLD_FRAMEWORK_PATH so XPC services find this build's frameworks.

--- a/Tools/WebKitTestRunner/CMakeLists.txt
+++ b/Tools/WebKitTestRunner/CMakeLists.txt
@@ -59,11 +59,11 @@ add_custom_command(
     COMMAND_EXPAND_LISTS
     VERBATIM)
 
-list(APPEND WebKitTestRunner_SOURCES
-    ${WebKitTestRunner_DERIVED_SOURCES_DIR}/TestOptionsGeneratedKeys.h
+add_custom_target(WebKitTestRunnerGeneratedPreferences
+    DEPENDS ${WebKitTestRunner_DERIVED_SOURCES_DIR}/TestOptionsGeneratedKeys.h
 )
 
-set(WebKitTestRunner_DEPENDENCIES TestRunnerInjectedBundle)
+set(WebKitTestRunner_DEPENDENCIES TestRunnerInjectedBundle WebKitTestRunnerGeneratedPreferences)
 
 set(TestRunnerInjectedBundle_SOURCES
     InjectedBundle/AccessibilityController.cpp


### PR DESCRIPTION
#### 2b512794648301eed5163145f052956d8ece7e91
<pre>
[CMake] Shrink the single-core long pole at the end of the build
<a href="https://bugs.webkit.org/show_bug.cgi?id=316469">https://bugs.webkit.org/show_bug.cgi?id=316469</a>
<a href="https://rdar.apple.com/178872143">rdar://178872143</a>

Reviewed by Brandon Stewart.

* Tools/MiniBrowser/mac/CMakeLists.txt: Change target dependency to
link dependency so that compilation can overlap with the end of
WebKit compilation.

* Tools/WebKitTestRunner/CMakeLists.txt: Put TestOptionsGeneratedKeys.h
in its own custom target so that it does not inherit link dependencies.
This allows TestOptionsGeneratedKeys.h to generate right away and
start compilation before previous frameworks are done linking.

Canonical link: <a href="https://commits.webkit.org/314697@main">https://commits.webkit.org/314697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35de3cc359e75a44eade66bad1f55600e18df12d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175933 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124143 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129769 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110295 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31148 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29852 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24669 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141121 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178471 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138138 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138050 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149445 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103950 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25403 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33326 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26310 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39644 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39040 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4404 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39285 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39184 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->