### PR TITLE
SVGGeometryElement path query APIs should compute geometry for display:none basic shapes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt
@@ -3,13 +3,13 @@ PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with 
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none and inline style
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: none The object is in an invalid state.
+PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: none
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, circle with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, circle with display: none The object is in an invalid state.
+PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, circle with display: none
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, polygon with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, polygon with display: none The object is in an invalid state.
+PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, polygon with display: none
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, polyline with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, polyline with display: none The object is in an invalid state.
+PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, polyline with display: none
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, ellipse with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, ellipse with display: none The object is in an invalid state.
+PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, ellipse with display: none
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-05-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-05-expected.txt
@@ -1,14 +1,14 @@
 
 PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, path with display: default and an empty path
 PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, path with display: none and an empty path
-FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, rect with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
+PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, rect with display: default and an empty path
 PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, rect with display: none and an empty path
-FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, circle with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
+PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, circle with display: default and an empty path
 PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, circle with display: none and an empty path
-FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, polygon with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
+PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, polygon with display: default and an empty path
 PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, polygon with display: none and an empty path
-FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, polyline with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
+PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, polyline with display: default and an empty path
 PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, polyline with display: none and an empty path
-FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, ellipse with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
+PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, ellipse with display: default and an empty path
 PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, ellipse with display: none and an empty path
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getTotalLength-02-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getTotalLength-02-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL SVGGeometryElement.getTotalLength: 'display:none' assert_equals: expected 40 but got 0
+PASS SVGGeometryElement.getTotalLength: 'display:none'
 

--- a/Source/WebCore/rendering/svg/SVGPathData.cpp
+++ b/Source/WebCore/rendering/svg/SVGPathData.cpp
@@ -43,19 +43,28 @@
 
 namespace WebCore {
 
+// For a non-rendered element (e.g. display:none) there is no renderer to read the used style from,
+// but the geometry can still be computed from the element's computed style. getTotalLength() and
+// getPointAtLength() are required to work in that case. https://svgwg.org/svg2-draft/types.html
+static const Style::ComputedStyle* styleForGraphicsElement(const SVGElement& element)
+{
+    if (auto* renderer = element.renderer())
+        return &renderer->style();
+    return const_cast<SVGElement&>(element).computedStyle();
+}
+
 static Path pathFromCircleElement(const SVGCircleElement& element)
 {
-    RenderElement* renderer = element.renderer();
-    if (!renderer)
+    auto* style = styleForGraphicsElement(element);
+    if (!style)
         return { };
 
     Path path;
-    auto& style = renderer->style();
     SVGLengthContext lengthContext(&element);
-    float r = lengthContext.valueForLength(style.r(), Style::ZoomNeeded { });
+    float r = lengthContext.valueForLength(style->r(), Style::ZoomNeeded { });
     if (r > 0) {
-        float cx = lengthContext.valueForLength(style.cx(), Style::ZoomNeeded { }, SVGLengthMode::Width);
-        float cy = lengthContext.valueForLength(style.cy(), Style::ZoomNeeded { }, SVGLengthMode::Height);
+        float cx = lengthContext.valueForLength(style->cx(), Style::ZoomNeeded { }, SVGLengthMode::Width);
+        float cy = lengthContext.valueForLength(style->cy(), Style::ZoomNeeded { }, SVGLengthMode::Height);
         path.addEllipseInRect(FloatRect(cx - r, cy - r, r * 2, r * 2));
     }
     return path;
@@ -63,17 +72,16 @@ static Path pathFromCircleElement(const SVGCircleElement& element)
 
 static Path pathFromEllipseElement(const SVGEllipseElement& element)
 {
-    RenderElement* renderer = element.renderer();
-    if (!renderer)
+    auto* style = styleForGraphicsElement(element);
+    if (!style)
         return { };
 
-    auto& style = renderer->style();
     SVGLengthContext lengthContext(&element);
 
     // Per SVG 2 §10.4: an `auto` value for either rx or ry is converted to the
     // used value of the other property. If both are auto, both used values are 0.
-    auto& rxStyle = style.rx();
-    auto& ryStyle = style.ry();
+    auto& rxStyle = style->rx();
+    auto& ryStyle = style->ry();
     if (rxStyle.isAuto() && ryStyle.isAuto())
         return { };
 
@@ -91,8 +99,8 @@ static Path pathFromEllipseElement(const SVGEllipseElement& element)
         return { };
 
     Path path;
-    float cx = lengthContext.valueForLength(style.cx(), Style::ZoomNeeded { }, SVGLengthMode::Width);
-    float cy = lengthContext.valueForLength(style.cy(), Style::ZoomNeeded { }, SVGLengthMode::Height);
+    float cx = lengthContext.valueForLength(style->cx(), Style::ZoomNeeded { }, SVGLengthMode::Width);
+    float cy = lengthContext.valueForLength(style->cy(), Style::ZoomNeeded { }, SVGLengthMode::Height);
     path.addEllipseInRect(FloatRect(cx - rx, cy - ry, rx * 2, ry * 2));
     return path;
 }
@@ -145,36 +153,35 @@ static Path pathFromPolylineElement(const SVGPolylineElement& element)
 
 static Path pathFromRectElement(const SVGRectElement& element)
 {
-    RenderElement* renderer = element.renderer();
-    if (!renderer)
+    auto* style = styleForGraphicsElement(element);
+    if (!style)
         return { };
 
-    auto& style = renderer->style();
-    auto usedZoom = style.usedZoomForLength();
+    auto usedZoom = style->usedZoomForLength();
     SVGLengthContext lengthContext(&element);
     auto size = FloatSize {
-        lengthContext.valueForLength(style.width(), usedZoom, SVGLengthMode::Width),
-        lengthContext.valueForLength(style.height(), usedZoom, SVGLengthMode::Height)
+        lengthContext.valueForLength(style->width(), usedZoom, SVGLengthMode::Width),
+        lengthContext.valueForLength(style->height(), usedZoom, SVGLengthMode::Height)
     };
 
     if (size.isEmpty())
         return { };
 
     auto location = FloatPoint {
-        lengthContext.valueForLength(style.x(), Style::ZoomNeeded { }, SVGLengthMode::Width),
-        lengthContext.valueForLength(style.y(), Style::ZoomNeeded { }, SVGLengthMode::Height)
+        lengthContext.valueForLength(style->x(), Style::ZoomNeeded { }, SVGLengthMode::Width),
+        lengthContext.valueForLength(style->y(), Style::ZoomNeeded { }, SVGLengthMode::Height)
     };
 
     auto radii = FloatSize {
-        lengthContext.valueForLength(style.rx(), Style::ZoomNeeded { }, SVGLengthMode::Width),
-        lengthContext.valueForLength(style.ry(), Style::ZoomNeeded { }, SVGLengthMode::Height)
+        lengthContext.valueForLength(style->rx(), Style::ZoomNeeded { }, SVGLengthMode::Width),
+        lengthContext.valueForLength(style->ry(), Style::ZoomNeeded { }, SVGLengthMode::Height)
     };
 
     // Per SVG spec: if one of radii.x() and radii.y() is auto or negative, then the other corner
     // radius value is used. If both are auto or negative, then they are both set to 0.
-    if (style.rx().isAuto() || radii.width() < 0)
+    if (style->rx().isAuto() || radii.width() < 0)
         radii.setWidth(std::max(0.f, radii.height()));
-    if (style.ry().isAuto() || radii.height() < 0)
+    if (style->ry().isAuto() || radii.height() < 0)
         radii.setHeight(std::max(0.f, radii.width()));
 
     Path path;

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -28,8 +28,10 @@
 #include "LegacyRenderSVGResource.h"
 #include "LegacyRenderSVGShape.h"
 #include "NodeDocument.h"
+#include "Path.h"
 #include "RenderSVGShape.h"
 #include "SVGDocumentExtensions.h"
+#include "SVGPathData.h"
 #include "SVGPathUtilities.h"
 #include "SVGPoint.h"
 #include "SVGPropertyOwnerRegistry.h"
@@ -53,41 +55,47 @@ float SVGGeometryElement::getTotalLength() const
 {
     protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
-    auto* renderer = this->renderer();
-    if (!renderer)
-        return 0;
-
-    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
-        return renderSVGShape->getTotalLength();
-
-    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
-        return renderSVGShape->getTotalLength();
-
-    ASSERT_NOT_REACHED();
-    return 0;
+    // The length is computed from the element's path geometry. This works for both rendered and
+    // non-rendered (e.g. display:none) elements; the renderer-based path is derived from the same
+    // geometry, so the result is equivalent. For a <path>, SVGPathElement overrides this method.
+    if (const Path* path = cachedRendererPath())
+        return path->length();
+    return pathFromGraphicsElement(*this).length();
 }
 
 ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) const
 {
     protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
-    auto* renderer = this->renderer();
-    // Spec: If current element is a non-rendered element, throw an InvalidStateError.
-    if (!renderer)
+    // Reuse the renderer's cached path when it has one; only compute the geometry directly for
+    // non-rendered (e.g. display:none) elements and uncached shape fast paths.
+    Path computedPath;
+    const Path* path = cachedRendererPath();
+    if (!path) {
+        computedPath = pathFromGraphicsElement(*this);
+        path = &computedPath;
+    }
+
+    // Spec: If the user agent is not able to compute the total length of the path (i.e. the element
+    // has no path geometry), throw an InvalidStateError. This covers empty rendered shapes as well
+    // as non-rendered (e.g. display:none) elements, independent of the 'display' value.
+    if (path->isEmpty())
         return Exception { ExceptionCode::InvalidStateError };
 
-    // Spec: Clamp distance to [0, length].
-    distance = clampTo<float>(distance, 0, getTotalLength());
+    // Spec: Clamp distance to [0, length], then return a newly created, detached SVGPoint.
+    distance = clampTo<float>(distance, 0, path->length());
+    return SVGPoint::create(path->pointAtLength(distance));
+}
 
-    // Spec: Return a newly created, detached SVGPoint object.
-    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
-        return SVGPoint::create(renderSVGShape->getPointAtLength(distance));
+const Path* SVGGeometryElement::cachedRendererPath() const
+{
+    if (auto* renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer()); renderSVGShape && renderSVGShape->hasPath())
+        return &renderSVGShape->path();
 
-    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
-        return SVGPoint::create(renderSVGShape->getPointAtLength(distance));
+    if (auto* renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer()); renderSVGShape && renderSVGShape->hasPath())
+        return &renderSVGShape->path();
 
-    ASSERT_NOT_REACHED();
-    return Exception { ExceptionCode::InvalidStateError };
+    return nullptr;
 }
 
 bool SVGGeometryElement::isPointInFill(DOMPointInit&& pointInit)

--- a/Source/WebCore/svg/SVGGeometryElement.h
+++ b/Source/WebCore/svg/SVGGeometryElement.h
@@ -56,6 +56,11 @@ protected:
 private:
     bool isSVGGeometryElement() const override { return true; }
 
+    // Returns the path cached by the renderer, if it has one. Returns nullptr for non-rendered
+    // elements (e.g. display:none) and for shapes whose renderer draws without caching a path
+    // (rect/ellipse fast paths); callers then compute the geometry via pathFromGraphicsElement().
+    const Path* cachedRendererPath() const;
+
     const Ref<SVGAnimatedNumber> m_pathLength { SVGAnimatedNumber::create(this) };
 };
 


### PR DESCRIPTION
#### 1a7b628204d9e3bd062e9291af5d72f7213a0b29
<pre>
SVGGeometryElement path query APIs should compute geometry for display:none basic shapes
<a href="https://bugs.webkit.org/show_bug.cgi?id=316475">https://bugs.webkit.org/show_bug.cgi?id=316475</a>
<a href="https://rdar.apple.com/178874694">rdar://178874694</a>

Reviewed by NOBODY (OOPS!).

Per the SVG specification [1], getTotalLength() and getPointAtLength() compute an
element&apos;s path geometry and only throw an InvalidStateError when that geometry
cannot be computed; they are not gated on the element being rendered. WebKit got
this wrong for the basic shapes (rect, circle, ellipse, polygon, polyline): both
APIs bailed out when there was no renderer (e.g. display:none), and
getPointAtLength() returned (0, 0) instead of throwing for empty rendered shapes.

Reuse the path the renderer already caches in m_path (via hasPath()/path()) for
both the legacy (LegacyRenderSVGShape) and LBSE (RenderSVGShape) engines, and only
compute the geometry directly via pathFromGraphicsElement() for the cases that
lack a cached path: non-rendered (e.g. display:none) elements and the rect/ellipse
fast-path renderers that draw without caching a path. This avoids constructing a
fresh Path on every call in the common rendered case while still resolving the
geometry when there is no renderer. getPointAtLength() now throws an
InvalidStateError only when the resulting path is empty, which also covers empty
rendered shapes. SVGPathData falls back to computedStyle() when there is no
renderer so circle/ellipse/rect can still resolve their geometry, mirroring
<a href="https://commits.webkit.org/314654@main">314654@main</a>.

[1] <a href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGeometryElement">https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGeometryElement</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-05-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getTotalLength-02-expected.txt: Ditto
* Source/WebCore/rendering/svg/SVGPathData.cpp:
(WebCore::styleForGraphicsElement):
(WebCore::pathFromCircleElement):
(WebCore::pathFromEllipseElement):
(WebCore::pathFromRectElement):
* Source/WebCore/svg/SVGGeometryElement.h:
* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::getTotalLength const):
(WebCore::SVGGeometryElement::getPointAtLength const):
(WebCore::SVGGeometryElement::cachedRendererPath const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a7b628204d9e3bd062e9291af5d72f7213a0b29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125378 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130481 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91702 "3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110998 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31884 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30582 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25487 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179294 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32344 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138878 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138763 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41954 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105130 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34029 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27053 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113709 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39855 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5156 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40106 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40000 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->