### PR TITLE
[JSC][Temporal] Validate `month` and `eraYear` in Japanese "ce"/"bce" era fast path

### DIFF
--- a/JSTests/stress/temporal-japanese-ce-bce-era-validation.js
+++ b/JSTests/stress/temporal-japanese-ce-bce-era-validation.js
@@ -1,0 +1,123 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = false;
+    try { func(); } catch (e) {
+        threw = true;
+        if (!(e instanceof errorType))
+            throw new Error(`Expected ${errorType.name} but got ${e.constructor.name}: ${e.message}`);
+    }
+    if (!threw)
+        throw new Error(`Expected ${errorType.name} but no exception was thrown`);
+}
+
+// Japanese "ce"/"bce" era fast path: out-of-range month must be constrained
+// (not read out of bounds and produce dates like "2000-255-00").
+{
+    const r = Temporal.PlainDate.from({ calendar: "japanese", era: "ce", eraYear: 2000, month: 255, day: 1 });
+    shouldBe(r.toString(), "2000-12-01[u-ca=japanese]");
+    shouldBe(r.month, 12);
+    shouldBe(r.day, 1);
+}
+{
+    const r = Temporal.PlainDate.from({ calendar: "japanese", era: "ce", eraYear: 2000, month: 13, day: 1 });
+    shouldBe(r.toString(), "2000-12-01[u-ca=japanese]");
+}
+{
+    // ISO year 0 (bce 1); assert via toString since the year getter goes
+    // through ICU and is subject to Julian/Gregorian switch quirks near year 0.
+    const r = Temporal.PlainDate.from({ calendar: "japanese", era: "bce", eraYear: 1, month: 255, day: 40 });
+    shouldBe(r.toString(), "0000-12-31[u-ca=japanese]");
+    shouldBe(r.month, 12);
+    shouldBe(r.day, 31);
+}
+shouldThrow(() => {
+    Temporal.PlainDate.from({ calendar: "japanese", era: "ce", eraYear: 2000, month: 255, day: 1 }, { overflow: "reject" });
+}, RangeError);
+shouldThrow(() => {
+    Temporal.PlainDate.from({ calendar: "japanese", era: "ce", eraYear: 2000, month: 13, day: 1 }, { overflow: "reject" });
+}, RangeError);
+
+// PlainYearMonth.from through the same fast path.
+{
+    const r = Temporal.PlainYearMonth.from({ calendar: "japanese", era: "ce", eraYear: 2000, month: 255 });
+    shouldBe(r.year, 2000);
+    shouldBe(r.month, 12);
+}
+shouldThrow(() => {
+    Temporal.PlainYearMonth.from({ calendar: "japanese", era: "ce", eraYear: 2000, month: 255 }, { overflow: "reject" });
+}, RangeError);
+
+// ZonedDateTime.with / PlainDateTime.with reach the fast path without the
+// fields-layer rough year range check, so the fast path itself must validate.
+{
+    const z = Temporal.ZonedDateTime.from("2000-01-01T00:00[UTC][u-ca=japanese]");
+    shouldBe(z.with({ era: "ce", eraYear: 2000, month: 255 }).toString(), "2000-12-01T00:00:00+00:00[UTC][u-ca=japanese]");
+    // eraYear INT32_MAX silently truncated the 21-bit ISO year field (year became -1).
+    shouldThrow(() => { z.with({ era: "ce", eraYear: 2147483647 }); }, RangeError);
+    // 1 - INT32_MIN overflows int32.
+    shouldThrow(() => { z.with({ era: "bce", eraYear: -2147483648 }); }, RangeError);
+    shouldThrow(() => { z.with({ era: "ce", eraYear: 300000 }); }, RangeError);
+    shouldThrow(() => { z.with({ era: "bce", eraYear: 300000 }); }, RangeError);
+}
+{
+    const pdt = Temporal.PlainDateTime.from("2000-01-01T00:00[u-ca=japanese]");
+    shouldBe(pdt.with({ era: "ce", eraYear: 2000, month: 255 }).toString(), "2000-12-01T00:00:00[u-ca=japanese]");
+    shouldThrow(() => { pdt.with({ era: "ce", eraYear: 2147483647 }); }, RangeError);
+    shouldThrow(() => { pdt.with({ era: "bce", eraYear: -2147483648 }); }, RangeError);
+}
+
+// eraYear out of ISO year limits must throw RangeError (Debug builds asserted
+// in the ISO8601::PlainDate constructor before the fix).
+shouldThrow(() => {
+    Temporal.PlainDate.from({ calendar: "japanese", era: "ce", eraYear: 300000, month: 1, day: 1 });
+}, RangeError);
+shouldThrow(() => {
+    Temporal.PlainDate.from({ calendar: "japanese", era: "bce", eraYear: 300000, month: 1, day: 1 });
+}, RangeError);
+shouldThrow(() => {
+    Temporal.PlainDate.from({ calendar: "japanese", era: "ce", eraYear: 275761, month: 1, day: 1 });
+}, RangeError);
+shouldThrow(() => {
+    Temporal.PlainDate.from({ calendar: "japanese", era: "bce", eraYear: 271823, month: 1, day: 1 });
+}, RangeError);
+
+// Boundary years remain accepted.
+{
+    const r = Temporal.PlainDate.from({ calendar: "japanese", era: "ce", eraYear: 275760, month: 9, day: 13 });
+    shouldBe(r.year, 275760);
+    shouldBe(r.month, 9);
+    shouldBe(r.day, 13);
+}
+{
+    const r = Temporal.PlainDate.from({ calendar: "japanese", era: "bce", eraYear: 271822, month: 4, day: 19 });
+    shouldBe(r.toString(), "-271821-04-19[u-ca=japanese]");
+    shouldBe(r.month, 4);
+    shouldBe(r.day, 19);
+}
+
+// Normal ce/bce dates still resolve correctly.
+{
+    const r = Temporal.PlainDate.from({ calendar: "japanese", era: "ce", eraYear: 2000, month: 2, day: 29 });
+    shouldBe(r.toString(), "2000-02-29[u-ca=japanese]");
+    // The era getters report the canonical era for the date, not the input.
+    shouldBe(r.era, "heisei");
+    shouldBe(r.eraYear, 12);
+}
+{
+    // bce 1 = ISO year 0, which is a leap year.
+    const r = Temporal.PlainDate.from({ calendar: "japanese", era: "bce", eraYear: 1, month: 2, day: 29 });
+    shouldBe(r.year, 0);
+    shouldBe(r.month, 2);
+    shouldBe(r.day, 29);
+}
+
+// year-consistency check with era+eraYear still applies.
+shouldThrow(() => {
+    Temporal.PlainDate.from({ calendar: "japanese", era: "ce", eraYear: 2000, year: 1999, month: 1, day: 1 });
+}, RangeError);

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -30,6 +30,7 @@
 #include "ISOArithmetic.h"
 #include "IntlObject.h"
 #include <unicode/ucal.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/DateMath.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
@@ -1460,19 +1461,31 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
         tookEraPath = true;
         // Japanese "ce"/"bce": eraYear IS the Gregorian year. Use ISO date path.
         if (calendarId == japaneseCalendarID() && (*era == "ce"_s || *era == "bce"_s)) {
-            int32_t isoYear = *era == "bce"_s ? (1 - *eraYear) : *eraYear; // For Japanese "ce"/"bce" eras, the year IS the ISO year — bypass ICU to avoid
+            // For Japanese "ce"/"bce" eras, the year IS the ISO year — bypass ICU to avoid
             // Julian/Gregorian calendar switch issues for pre-1582 dates. Apply overflow.
+            CheckedInt32 checkedISOYear = *eraYear;
+            if (*era == "bce"_s)
+                checkedISOYear = 1 - checkedISOYear;
+            if (checkedISOYear.hasOverflowed() || !ISO8601::isYearWithinLimits(checkedISOYear.value())) [[unlikely]]
+                return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
+            int32_t isoYear = checkedISOYear.value();
             // year.has_value() means user-provided; check for consistency (NonISOResolveFields step).
             if (year && *year != isoYear) [[unlikely]]
                 return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));
+            uint8_t resolvedMonth = month;
+            if (month > 12) {
+                if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                    return makeUnexpected(rangeError("month is out of range for this calendar"_s));
+                resolvedMonth = 12;
+            }
             uint8_t resolvedDay = day;
-            uint8_t daysInMo = static_cast<uint8_t>(ISO8601::daysInMonth(isoYear, month));
+            uint8_t daysInMo = ISO8601::daysInMonth(isoYear, resolvedMonth);
             if (day > daysInMo) {
                 if (overflow == TemporalOverflow::Reject) [[unlikely]]
                     return makeUnexpected(rangeError("Day is out of range for the given month"_s));
                 resolvedDay = daysInMo;
             }
-            return ISO8601::PlainDate(isoYear, month, resolvedDay);
+            return ISO8601::PlainDate(isoYear, resolvedMonth, resolvedDay);
         }
         auto icuEra = mapTemporalEraToICUEra(calendarId, *era);
         if (!icuEra) [[unlikely]]


### PR DESCRIPTION
#### 31e50e893a11dd6a8e8502611d74898dc12dd7fc
<pre>
[JSC][Temporal] Validate `month` and `eraYear` in Japanese &quot;ce&quot;/&quot;bce&quot; era fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=316477">https://bugs.webkit.org/show_bug.cgi?id=316477</a>

Reviewed by Yusuke Suzuki.

The Japanese &quot;ce&quot;/&quot;bce&quot; fast path in calendarDateFromFields passed
user-controlled fields to ISO8601::PlainDate without validation:
month &gt; 12 caused an out-of-bounds read in ISO8601::daysInMonth,
an eraYear outside the ISO year limits was silently truncated by
PlainDate&apos;s 21-bit year bitfield, and 1 - INT32_MIN overflowed int32.

Compute the ISO year with CheckedInt32 and reject it when outside the
ISO year limits, and constrain or reject month &gt; 12 the same way the
regular non-ISO path does.

* JSTests/stress/temporal-japanese-ce-bce-era-validation.js: Added.
* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
(JSC::TemporalCore::calendarDateFromFields):

Canonical link: <a href="https://commits.webkit.org/314786@main">https://commits.webkit.org/314786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7afc48623d214b66f386afb4a3d921fd9559c57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175947 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124157 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129782 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91389 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110308 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31162 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29865 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24683 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159056 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141135 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178485 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27793 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31382 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29368 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138151 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138063 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37245 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149459 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103972 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26324 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199578 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39658 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112732 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53659 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39054 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4420 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->