### PR TITLE
[JSC] Remove redundant eager length definition in `JSPromiseConstructor`

### DIFF
--- a/JSTests/stress/promise-constructor-length.js
+++ b/JSTests/stress/promise-constructor-length.js
@@ -1,0 +1,48 @@
+// The Promise constructor's "length" is no longer defined eagerly at creation time; it is
+// lazily reified from the builtin executable's parameter count. This locks down the
+// observable shape: value 1 with { writable: false, enumerable: false, configurable: true },
+// correct property ordering, and standard delete / redefine behavior.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+shouldBe(Promise.length, 1);
+shouldBe(Object.prototype.hasOwnProperty.call(Promise, "length"), true);
+
+let desc = Object.getOwnPropertyDescriptor(Promise, "length");
+shouldBe(desc.value, 1);
+shouldBe(desc.writable, false);
+shouldBe(desc.enumerable, false);
+shouldBe(desc.configurable, true);
+
+// "length" and "name" must come first in own property order.
+let keys = Object.getOwnPropertyNames(Promise);
+shouldBe(keys[0], "length");
+shouldBe(keys[1], "name");
+shouldBe(Object.keys(Promise).length, 0);
+
+// writable: false. Strict mode write throws; the value is unchanged.
+shouldBe((() => {
+    "use strict";
+    try {
+        Promise.length = 42;
+        return "no throw";
+    } catch (error) {
+        return String(error.constructor === TypeError);
+    }
+})(), "true");
+shouldBe(Promise.length, 1);
+
+// Bound function lengths derive from the original length.
+shouldBe(Promise.bind(null).length, 1);
+shouldBe(Promise.bind(null, function() {}).length, 0);
+
+// configurable: true. delete and redefine work.
+shouldBe(delete Promise.length, true);
+shouldBe(Object.prototype.hasOwnProperty.call(Promise, "length"), false);
+shouldBe(Promise.length, 0); // Inherited from Function.prototype.length.
+
+Object.defineProperty(Promise, "length", { value: 7, writable: false, enumerable: false, configurable: true });
+shouldBe(Promise.length, 7);

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -99,7 +99,6 @@ void JSPromiseConstructor::finishCreation(VM& vm, JSPromisePrototype* promisePro
 {
     Base::finishCreation(vm);
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, promisePrototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-    putDirectWithoutTransition(vm, vm.propertyNames->length, jsNumber(1), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
 
     JSGlobalObject* globalObject = this->realm();
 


### PR DESCRIPTION
#### deb8f86fbe49e78729f8ce772c5168082a82dd84
<pre>
[JSC] Remove redundant eager length definition in `JSPromiseConstructor`
<a href="https://bugs.webkit.org/show_bug.cgi?id=316478">https://bugs.webkit.org/show_bug.cgi?id=316478</a>

Reviewed by Yusuke Suzuki.

JSPromiseConstructor is a builtin function backed by a FunctionExecutable
whose parameter count is 1 (`Promise(executor)`), so JSFunction&apos;s lazy
property reification already provides `length` with the same value and
attributes (DontEnum | ReadOnly). The eager definition in finishCreation
is redundant. This follows the same approach as 314682@main, which
removed eager name / length definitions from Boolean / Number /
StringConstructor.

No behavior change: value, attributes, property enumeration order,
delete / redefine behavior, and bound function lengths are all identical.

Test: JSTests/stress/promise-constructor-length.js

* JSTests/stress/promise-constructor-length.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::JSPromiseConstructor::finishCreation):

Canonical link: <a href="https://commits.webkit.org/314777@main">https://commits.webkit.org/314777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c861e1814310ba492b34913234363326db8a6153

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124160 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129786 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91393 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149967 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110311 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31165 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29868 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24686 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159059 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178488 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27796 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31386 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138155 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138066 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37233 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149462 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103975 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26327 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199581 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39661 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112735 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53661 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39057 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4423 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39302 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39201 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->