### PR TITLE
font shorthand fails to serialize when font-width is a constant calc() percentage

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-shorthand-serialization-font-stretch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-shorthand-serialization-font-stretch-expected.txt
@@ -2,5 +2,5 @@
 PASS Keywords should appear in serialization of font and fontStretch
 PASS Percentages which can be transformed into keywords should be for serialization of font, but not of fontStretch
 PASS Percentages which cannot be transformed into keywords should prevent the font shorthand from serializing, but not fontStretch
-FAIL calc() transformation into keywords assert_equals: expected "ultra-condensed medium serif" but got ""
+PASS calc() transformation into keywords
 

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -1049,8 +1049,12 @@ String ShorthandSerializer::serializeFont() const
     if (widthKeyword == CSSValueInvalid) {
         Ref widthValue = downcast<CSSPrimitiveValue>(longhandValue(widthIndex));
         auto keyword = WTF::switchOn(widthValue.get(),
-            [](const CSSPrimitiveValue::Calc&) -> std::optional<CSSValueID> {
-                return std::nullopt;
+            [](const CSSPrimitiveValue::Calc& calc) -> std::optional<CSSValueID> {
+                // A calc() that resolves to a constant percentage (no length/font units) can be
+                // expressed as a font width keyword; anything requiring conversion data cannot.
+                if (calc.requiresConversionData())
+                    return std::nullopt;
+                return fontWidthKeyword(calc.evaluate(NoConversionDataRequiredToken { }));
             },
             [](const CSSPrimitiveValue::Raw& raw) -> std::optional<CSSValueID> {
                 if (raw.unit != CSSUnitType::CSS_PERCENTAGE)


### PR DESCRIPTION
#### 0b421dc3e66812597e347492bb872c78873bcd4e
<pre>
font shorthand fails to serialize when font-width is a constant calc() percentage
<a href="https://bugs.webkit.org/show_bug.cgi?id=316481">https://bugs.webkit.org/show_bug.cgi?id=316481</a>
<a href="https://rdar.apple.com/178882968">rdar://178882968</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The `font` shorthand can only represent font-width as a keyword, since a
percentage there would be ambiguous with font-size. When the font-width
longhand was a calc() value, ShorthandSerializer::serializeFont() bailed
out unconditionally and serialized the whole shorthand as the empty
string, even when the calc() resolved to a constant percentage that maps
cleanly onto a font-width keyword.

A calc() with no length/font-relative units (i.e. one that does not
require conversion data) can be evaluated up front and mapped to a
keyword just like a raw percentage. Only calc() expressions that depend
on conversion data must continue to serialize as the empty string.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-shorthand-serialization-font-stretch-expected.txt: Progression
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeFont const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b421dc3e66812597e347492bb872c78873bcd4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124165 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ee56ede-40df-4545-8bdf-ceb8c8911934) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129792 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91398 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e515390-bb00-403b-ab9a-1ebb8f35ea80) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110317 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87258c16-7017-4d3f-a676-b5f829b66e29) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31169 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29871 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24691 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141143 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178493 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31391 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138161 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138072 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149465 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103981 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26330 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39666 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112740 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39062 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4426 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39307 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39206 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->