### PR TITLE
REGRESSION(305413.674@safari-7624-branch): Crash in StreamPipeToState::globalObject

### DIFF
--- a/LayoutTests/streams/pipeTo-removed-iframe-crash-expected.txt
+++ b/LayoutTests/streams/pipeTo-removed-iframe-crash-expected.txt
@@ -1,0 +1,4 @@
+Tests that pipeTo does not crash when the document frame is detached during error propagation.
+WebKit should not crash, and you should see PASS below.
+
+PASS

--- a/LayoutTests/streams/pipeTo-removed-iframe-crash.html
+++ b/LayoutTests/streams/pipeTo-removed-iframe-crash.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Tests that pipeTo does not crash when the document frame is detached during error propagation.<br>
+WebKit should not crash, and you should see PASS below.</p>
+<div id="result"></div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// The crash: StreamPipeToState::globalObject() calls
+// jsDynamicCast<JSDOMGlobalObject*>(context->globalObject()), but
+// ScriptExecutionContext::globalObject() can return null when the document
+// has no frame (e.g. after its iframe is removed). jsDynamicCast does not
+// null-check its argument, so passing null crashes with a read from 0x0.
+//
+// To reproduce, pipeTo must be called in the iframe's JS context so that
+// StreamPipeToState is associated with the iframe's ScriptExecutionContext.
+// Erroring the source stream queues a microtask. If the iframe is removed
+// before that microtask runs, context->globalObject() returns null when the
+// error-propagation callback fires.
+
+const iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+
+// Run pipeTo inside the iframe's context (CallWith=CurrentGlobalObject means
+// the StreamPipeToState gets the iframe's ScriptExecutionContext).
+iframe.contentWindow.eval(`
+    var readable = new ReadableStream({ start(c) { window._controller = c; } });
+    var writable = new WritableStream();
+    readable.pipeTo(writable).catch(() => {});
+    window._controller.error("test error");
+`);
+
+// Detach the iframe's document from its frame before the error-propagation
+// microtask runs. After this, ScriptExecutionContext::globalObject() returns
+// null for the iframe's context (document->frame() is null).
+iframe.remove();
+
+// Let microtasks and the event loop run. Without the fix, the error-propagation
+// microtask crashes in StreamPipeToState::globalObject().
+setTimeout(() => {
+    document.getElementById('result').textContent = 'PASS';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, 0);
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -276,8 +276,12 @@ StreamPipeToState::~StreamPipeToState() = default;
 JSDOMGlobalObject* StreamPipeToState::globalObject()
 {
     RefPtr context = scriptExecutionContext();
-
-    return context ? dynamicDowncast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
+    if (!context)
+        return nullptr;
+    auto* jsGlobalObject = context->globalObject();
+    if (!jsGlobalObject)
+        return nullptr;
+    return dynamicDowncast<JSDOMGlobalObject>(jsGlobalObject);
 }
 
 void StreamPipeToState::handleSignal()

--- a/Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp
@@ -166,6 +166,9 @@ void InternalReadableStreamDefaultReader::onClosedPromiseRejection(Function<void
     domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto result) {
         if (isFulfilled || !globalObject)
             return;
+        auto* scriptExecutionContext = globalObject->scriptExecutionContext();
+        if (!scriptExecutionContext || scriptExecutionContext->activeDOMObjectsAreStopped())
+            return;
         callback(*globalObject, result);
     });
 }
@@ -193,7 +196,12 @@ void InternalReadableStreamDefaultReader::onClosedPromiseResolution(Function<voi
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto*, bool isFulfilled, auto) {
+    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto) {
+        if (!globalObject)
+            return;
+        auto* scriptExecutionContext = globalObject->scriptExecutionContext();
+        if (!scriptExecutionContext || scriptExecutionContext->activeDOMObjectsAreStopped())
+            return;
         if (isFulfilled)
             callback();
     });

--- a/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
@@ -158,6 +158,9 @@ void InternalWritableStreamWriter::onClosedPromiseRejection(Function<void(JSDOMG
     domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto result) mutable {
         if (isFulfilled || !globalObject)
             return;
+        auto* scriptExecutionContext = globalObject->scriptExecutionContext();
+        if (!scriptExecutionContext || scriptExecutionContext->activeDOMObjectsAreStopped())
+            return;
         callback(*globalObject, result);
     });
 }
@@ -183,8 +186,11 @@ void InternalWritableStreamWriter::onClosedPromiseResolution(Function<void()>&& 
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto*, bool isFulfilled, auto) mutable {
-        if (!isFulfilled)
+    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto) mutable {
+        if (!isFulfilled || !globalObject)
+            return;
+        auto* scriptExecutionContext = globalObject->scriptExecutionContext();
+        if (!scriptExecutionContext || scriptExecutionContext->activeDOMObjectsAreStopped())
             return;
         callback();
     });
@@ -238,7 +244,12 @@ void InternalWritableStreamWriter::whenReady(Function<void (bool)>&& callback)
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto*, bool isFulfilled, auto) mutable {
+    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto) mutable {
+        if (!globalObject)
+            return;
+        auto* scriptExecutionContext = globalObject->scriptExecutionContext();
+        if (!scriptExecutionContext || scriptExecutionContext->activeDOMObjectsAreStopped())
+            return;
         callback(isFulfilled);
     });
 }


### PR DESCRIPTION
#### 64ad3f36af0d8f25efc49f0390c7a3732e99c825
<pre>
REGRESSION(305413.674@safari-7624-branch): Crash in StreamPipeToState::globalObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=312938">https://bugs.webkit.org/show_bug.cgi?id=312938</a>
<a href="https://rdar.apple.com/175084445">rdar://175084445</a>

Reviewed by Chris Dumez.

The crash was caused by StreamPipeToState::globalObject calling jsDynamicCast&lt;JSDOMGlobalObject*&gt;
on context-&gt;globalObject() without a nullptr check. Fixed the crash by adding a nullptr check.

The newly written test revealed a related bug that we were calling DOMPromise::status even when
active DOM objects had been stopped. Added a bunch of early returns to functions in
InternalReadableStreamDefaultReader and InternalWritableStreamWriter to avoid debug assertions
in these cases, one of which is hit by the new test.

Test: streams/pipeTo-removed-iframe-crash.html

* LayoutTests/streams/pipeTo-removed-iframe-crash-expected.txt: Added.
* LayoutTests/streams/pipeTo-removed-iframe-crash.html: Added.
* Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp:
(WebCore::StreamPipeToState::globalObject):
* Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp:
(WebCore::InternalReadableStreamDefaultReader::onClosedPromiseRejection):
(WebCore::InternalReadableStreamDefaultReader::onClosedPromiseResolution):
* Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp:
(WebCore::InternalWritableStreamWriter::onClosedPromiseRejection):
(WebCore::InternalWritableStreamWriter::onClosedPromiseResolution):
(WebCore::InternalWritableStreamWriter::whenReady):

Originally-landed-as: 305413.711@safari-7624-branch (90e48031ed4d). <a href="https://rdar.apple.com/176059102">rdar://176059102</a>
Canonical link: <a href="https://commits.webkit.org/314699@main">https://commits.webkit.org/314699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17f7a547ffddadc5a815f950630676ee821d8ee0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124172 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb74b6bd-5036-4571-a912-ca7857d8c246) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129798 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55bb787f-8cb7-4901-9fd9-0cc0a67c18cc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110323 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a05d9bed-8db4-456f-a141-c89275b638ea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31175 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29877 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24698 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178500 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31398 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29379 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138167 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138078 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149470 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103993 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25405 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33351 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26335 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112747 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39069 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4432 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39314 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39213 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->