### PR TITLE
Add feature flag for making scrollable overflow containers keyboard-focusable

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3158,6 +3158,20 @@ FlexFormattingContextIntegrationEnabled:
     WebCore:
       default: true
 
+FocusableScrollableOverflowContainersEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "Focusable Scrollable Overflow Containers"
+  humanReadableDescription: "Enable focusable scrollable overflow containers"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 FontFaceSetConstructorEnabled:
   type: bool
   status: developer

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3160,7 +3160,7 @@ FlexFormattingContextIntegrationEnabled:
 
 FocusableScrollableOverflowContainersEnabled:
   type: bool
-  status: testable
+  status: unstable
   category: css
   humanReadableName: "Focusable Scrollable Overflow Containers"
   humanReadableDescription: "Enable focusable scrollable overflow containers"

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1017,6 +1017,13 @@ bool AccessibilityRenderObject::computeIsIgnored() const
         return false;
     }
 
+    // Scrollable containers with overflow that are implicitly keyboard-focusable,
+    // and do not contain keyboard-focusable descendants, should not be ignored.
+    if (RefPtr element = dynamicDowncast<Element>(node())) {
+        if (element->isScrollFocusableContainer(ScrollFocusLayoutBehavior::DoNotForceLayout) && !element->hasKeyboardFocusableDescendants())
+            return false;
+    }
+
     if (!m_renderer)
         return AccessibilityNodeObject::computeIsIgnored();
 
@@ -2477,6 +2484,13 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
 
     if (m_renderer->isRenderTableSection())
         return AccessibilityRole::Ignored;
+
+    // Scrollable containers with overflow that are implicitly keyboard-focusable,
+    // and do not contain keyboard-focusable descendants, should become a ScrollArea.
+    if (RefPtr element = dynamicDowncast<Element>(node)) {
+        if (element->isScrollFocusableContainer(ScrollFocusLayoutBehavior::DoNotForceLayout) && !element->hasKeyboardFocusableDescendants())
+            return AccessibilityRole::ScrollArea;
+    }
 
     auto treatStyleFormatGroupAsInline = is<RenderInline>(*m_renderer) ? TreatStyleFormatGroupAsInline::Yes : TreatStyleFormatGroupAsInline::No;
     auto roleFromNode = determineAccessibilityRoleFromNode(treatStyleFormatGroupAsInline);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -435,6 +435,11 @@ void Element::hideNonceSlow()
 
 bool Element::supportsFocus() const
 {
+    // Scroll containers with overflow are implicitly keyboard-focusable.
+    if (isScrollFocusableContainer(ScrollFocusLayoutBehavior::DoNotForceLayout)
+        && !hasKeyboardFocusableDescendants())
+        return true;
+
     return !!tabIndexSetExplicitly();
 }
 
@@ -450,6 +455,12 @@ void Element::setTabIndexForBindings(int value)
 
 bool Element::isKeyboardFocusable(const FocusEventData&) const
 {
+    // Check whether this element qualifies as implicitly keyboard-focusable because
+    // it is a scroll container with no keyboard-focusable descendants.
+    if (isScrollFocusableContainer(ScrollFocusLayoutBehavior::DoNotForceLayout)) {
+        if (!hasKeyboardFocusableDescendants())
+            return true;
+    }
     if (!isFocusable() || shouldBeIgnoredInSequentialFocusNavigation() || tabIndexSetExplicitly().value_or(0) < 0)
         return false;
     if (auto* root = shadowRoot()) {
@@ -1477,6 +1488,44 @@ static int adjustContentsScrollPositionOrSizeForZoom(int value, const LocalFrame
     if (zoomFactor > 1)
         value++;
     return static_cast<int>(value / zoomFactor);
+}
+
+bool Element::isScrollFocusableContainer(ScrollFocusLayoutBehavior layoutBehavior) const
+{
+    if (!document().settings().focusableScrollableOverflowContainersEnabled())
+        return false;
+
+    RefPtr page = document().page();
+    if (!page || !page->tabKeyCyclesThroughElements())
+        return false;
+
+    CheckedPtr renderer = renderBox();
+    if (!renderer)
+        return false;
+
+    if (layoutBehavior == ScrollFocusLayoutBehavior::AllowLayoutUpdate) {
+        if (RefPtr view = document().view())
+            view->updateLayoutAndStyleIfNeededRecursive();
+
+        renderer = renderBox();
+        if (!renderer)
+            return false;
+    }
+
+    return renderer->canBeScrolledAndHasScrollableArea();
+}
+
+bool Element::hasKeyboardFocusableDescendants() const
+{
+    // Walk all descendant elements and check if any would be a tab stop.
+    for (auto& descendant : descendantsOfType<Element>(*this)) {
+        auto explicitTabIndex = descendant.tabIndexSetExplicitly();
+        if (!descendant.renderer() || !descendant.isFocusable() || descendant.shouldBeIgnoredInSequentialFocusNavigation() || (explicitTabIndex && *explicitTabIndex < 0))
+            continue;
+
+        return true;
+    }
+    return false;
 }
 
 enum LegacyCSSOMElementMetricsRoundingStrategy { Round, Floor };

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -108,6 +108,7 @@ enum class ParserContentPolicy : uint8_t;
 enum class PopoverState : uint8_t { None, Auto, Manual };
 enum class ResolveURLs : uint8_t { No, NoExcludingURLsForPrivacy, Yes, YesExcludingURLsForPrivacy };
 enum class SelectionRestorationMode : uint8_t;
+enum class ScrollFocusLayoutBehavior: bool { AllowLayoutUpdate, DoNotForceLayout };
 enum class ShadowRootDelegatesFocus : bool { No, Yes };
 enum class ShadowRootMode : uint8_t;
 enum class ShadowRootClonable : bool { No, Yes };
@@ -312,6 +313,9 @@ public:
     void scrollBy(double x, double y);
     virtual void scrollTo(const ScrollToOptions&, ScrollClamping = ScrollClamping::Clamped, ScrollSnapPointSelectionMethod = ScrollSnapPointSelectionMethod::Closest, std::optional<FloatSize> originalScrollDelta = std::nullopt);
     void scrollTo(double x, double y);
+
+    bool isScrollFocusableContainer(ScrollFocusLayoutBehavior) const;
+    bool hasKeyboardFocusableDescendants() const;
 
     WEBCORE_EXPORT int offsetLeftForBindings();
     WEBCORE_EXPORT int offsetLeft();


### PR DESCRIPTION
#### dd99ceba7151b6c0a791b0c5278f47f51b2206dd
<pre>
Add feature flag for making scrollable overflow containers keyboard-focusable
<a href="https://bugs.webkit.org/show_bug.cgi?id=277290">https://bugs.webkit.org/show_bug.cgi?id=277290</a>
<a href="https://rdar.apple.com/132760015">rdar://132760015</a>

Reviewed by NOBODY (OOPS!).

Scrollable overflow containers with no keyboard-focusable descendants are now included in the
keyboard tab order when Safari&apos;s &quot;Press Tab to highlight each item on a webpage&quot; preference
is enabled. This matches the current behaviour in Chrome and addresses a long-standing gap
where keyboard-only users had no way to scroll containers whose content is entirely non-interactive. At present,
Firefox behaves similarly albeit is more permissive (all containers with overflow are keyboard-focusable whether or not they
have focusable descendants).

The main DOM change in this patch is the new isScrollFocusableContainer() method on the Element class that gates
on the feature flag and Safari&apos;s browser-level &quot;Press Tab...&quot; feature (controlled by tabKeyCyclesThroughElements()).
This includes a call to RenderBox::canBeScrolledAndHasScrollableArea() to confirm the container both has a
scrollable overflow style and actually overflows its box. Overflow containers that should be focusable, and also have
keyboard-focusable descendants, are excluded.

The LayoutUpdateBehavior enum is to avoid forcing layout recalculation during keyboard
navigation (i.e., Tab key) while still allowing layout recalculation for programmatic focus changes.

Such containers should also be exposed to assistive technology users, so they are no longer
ignored (and should have a WebKit-computed role, i.e., ScrollArea).

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::supportsFocus const):
(WebCore::Element::isKeyboardFocusable const):
(WebCore::Element::isScrollFocusableContainer const):
(WebCore::Element::hasKeyboardFocusableDescendants const):
* Source/WebCore/dom/Element.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85b567207fd2bf93b092679eec50d9019bfb78b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126012 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130985 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92082 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111497 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32440 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31143 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26335 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160930 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142426 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180239 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29558 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32963 "Found 2 new failures in dom/Element.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30666 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139423 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41880 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35302 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139286 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42568 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106052 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34578 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27637 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200989 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41072 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114328 "Found 2 new failures in dom/Element.cpp") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53988 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40469 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5721 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->