### PR TITLE
WIP

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -127,6 +127,26 @@ FontCascadeFonts::FontCascadeFonts(const FontPlatformData& platformData)
 
 FontCascadeFonts::~FontCascadeFonts() = default;
 
+#if FONTCASCADEFONTS_THREAD_AFFINITY_CHECK
+void FontCascadeFonts::ref() const
+{
+    if (currentThreadID() != m_refDerefThreadID) {
+        WTFReportBacktrace();
+        RELEASE_ASSERT_WITH_MESSAGE(false, "FontCascadeFonts %p ref() on thread %u, created on thread %u, refCount %u", static_cast<const void*>(this), currentThreadID(), m_refDerefThreadID, refCount());
+    }
+    RefCounted::ref();
+}
+
+void FontCascadeFonts::deref() const
+{
+    if (currentThreadID() != m_refDerefThreadID) {
+        WTFReportBacktrace();
+        RELEASE_ASSERT_WITH_MESSAGE(false, "FontCascadeFonts %p deref() on thread %u, created on thread %u, refCount %u", static_cast<const void*>(this), currentThreadID(), m_refDerefThreadID, refCount());
+    }
+    RefCounted::deref();
+}
+#endif
+
 void FontCascadeFonts::determinePitch(const FontCascadeDescription& description, FontSelector* fontSelector)
 {
     auto& primaryRanges = realizeFallbackRangesAt(description, fontSelector, 0);

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -104,6 +104,13 @@ struct MarkableTraits<WebCore::GlyphOverflow> {
 
 namespace WebCore {
 
+// FIXME: Remove. Temporary instrumentation to diagnose bug 316XXX: a flaky
+// "ASSERTION FAILED: refCount" over-deref of FontCascadeFonts during render-tree
+// teardown. Asserts every ref/deref happens on the instance's creation thread
+// (no refCount==1 ownership-transfer exemption), so a cross-thread ref/deref is
+// caught in the act with a backtrace. Set to 0 to compile out.
+#define FONTCASCADEFONTS_THREAD_AFFINITY_CHECK 1
+
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FontCascadeFonts);
 class FontCascadeFonts : public RefCounted<FontCascadeFonts> {
     WTF_MAKE_NONCOPYABLE(FontCascadeFonts);
@@ -113,6 +120,11 @@ public:
     static Ref<FontCascadeFonts> createForPlatformFont(const FontPlatformData& platformData) { return adoptRef(*new FontCascadeFonts(platformData)); }
 
     WEBCORE_EXPORT ~FontCascadeFonts();
+
+#if FONTCASCADEFONTS_THREAD_AFFINITY_CHECK
+    WEBCORE_EXPORT void ref() const;
+    WEBCORE_EXPORT void deref() const;
+#endif
 
     bool isForPlatformFont() const { return m_isForPlatformFont; }
 
@@ -205,6 +217,9 @@ private:
     TriState m_canTakeFixedPitchFastContentMeasuring : 2 { TriState::Indeterminate };
 #if ASSERT_ENABLED
     std::optional<uint32_t> m_creationThreadID;
+#endif
+#if FONTCASCADEFONTS_THREAD_AFFINITY_CHECK
+    uint32_t m_refDerefThreadID { currentThreadID() };
 #endif
 };
 


### PR DESCRIPTION
#### 8f31b51bc887da1e7e8bf101e6f858737296e439
<pre>
WIP

No new tests (OOPS!).

* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::ref const):
(WebCore::FontCascadeFonts::deref const):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f31b51bc887da1e7e8bf101e6f858737296e439

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124190 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129813 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91415 "3 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110338 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31186 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29891 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24716 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141160 "Found 12 new API test failures: TestWebKitAPI.WebKitLegacy.WebGLNoCrashOnOtherThreadAccess, TestWebKitAPI.WebKitLegacy.WebGLPrepareDisplayOnWebThread, TestWebKitAPI.WebKitLegacy.SetTimeoutFunction, TestWebKitAPI.WebKitLegacy.ScrollToRevealSelection, TestWebKitAPI.IndexedDB.IndexedDBPersistence, TestWebKitAPI.WebKitLegacy.DateInputAccessoryViewTest, TestWebKitAPI.WebKitLegacy.DateTimeLocalInputAccessoryViewTest, TestWebKitAPI.QuickLook.LegacyQuickLookContent, TestWebKitAPI.WebKitLegacy.TimeInputAccessoryViewTest, TestWebKitAPI.WebKitLegacy.RenderInContextSnapshot ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178518 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31416 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138182 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138093 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149485 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104022 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26350 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39691 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112765 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39087 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4448 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39332 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->