### PR TITLE
[Swift GTK] Enable Swift back forward list on GTK by default (take two)

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -2101,6 +2101,8 @@ def generate_swift_message_handler(receiver):
     result.append('        self.target = target\n')
     result.append('    }\n')
     result.append('\n')
+    # @used ensures these are retained even with -O -wmo: rdar://179098545
+    result.append('    @used\n')
     result.append('    func getMessageTarget() -> %s? {\n' % (class_name))
     result.append('        target\n')
     result.append('    }\n')

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionallyMessageReceiver.swift
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionallyMessageReceiver.swift
@@ -33,6 +33,7 @@ final class TestWithSwiftConditionallyWeakRef {
         self.target = target
     }
 
+    @used
     func getMessageTarget() -> TestWithSwiftConditionally? {
         target
     }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSwiftMessageReceiver.swift
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSwiftMessageReceiver.swift
@@ -30,6 +30,7 @@ final class TestWithSwiftWeakRef {
         self.target = target
     }
 
+    @used
     func getMessageTarget() -> TestWithSwift? {
         target
     }

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -135,6 +135,8 @@ final class WebBackForwardList {
         #endif
     }()
 
+    // @used ensures these are retained even under -O -wmo: rdar://179098545
+    @used
     init(page: WebKit.WeakPtrWebPageProxy) {
         self.page = page
         self.messageForwarder = WebKit.WebBackForwardListMessageForwarder.create(target: self)
@@ -147,12 +149,14 @@ final class WebBackForwardList {
         assert(page.get().map { !$0.hasRunningProcess() } ?? (currentIndex == nil))
     }
 
+    @used
     func getMessageReceiver() -> RefWebBackForwardListMessageForwarder {
         // Guaranteed to be Some after construction
         // swift-format-ignore: NeverForceUnwrap
         self.messageForwarder!
     }
 
+    @used
     func itemForID(identifier: WebCore.BackForwardItemIdentifier) -> WebKit.WebBackForwardListItem? {
         // FIXME: consider restructuring this a bit. It's a bit odd that it basically refers
         // to a map within WebBackForwardListItem. Maybe WebBackForwardList should
@@ -170,6 +174,7 @@ final class WebBackForwardList {
         return WebKit.WebBackForwardListItem.itemForID(identifier)
     }
 
+    @used
     func pageClosed() {
         backForwardLog("(Back/Forward) WebBackForwardList \(ObjectIdentifier(self)) had its page closed with current size \(entries.count)")
 
@@ -276,6 +281,7 @@ final class WebBackForwardList {
         page.didChangeBackForwardList(newItem, consuming: WebKit.BackForwardListItemVector(array: removedItems))
     }
 
+    @used
     func goToItem(item: WebKit.WebBackForwardListItem) {
         assertValidIndex()
 
@@ -334,6 +340,7 @@ final class WebBackForwardList {
         page.didChangeBackForwardList(Optional.none, consuming: WebKit.BackForwardListItemVector(array: removedItems))
     }
 
+    @used
     func currentItem() -> WebKit.WebBackForwardListItem? {
         assertValidIndex()
 
@@ -348,6 +355,7 @@ final class WebBackForwardList {
         return entries[currentIndex]
     }
 
+    @used
     func backItem() -> WebKit.WebBackForwardListItem? {
         assertValidIndex()
 
@@ -369,6 +377,7 @@ final class WebBackForwardList {
         return entries[currentIndex - 1]
     }
 
+    @used
     func forwardItem() -> WebKit.WebBackForwardListItem? {
         assertValidIndex()
 
@@ -390,6 +399,7 @@ final class WebBackForwardList {
         return entries[currentIndex + 1]
     }
 
+    @used
     func itemAtDeltaFromCurrentIndex(delta: Int, allowSkipping: Bool = true) -> WebKit.WebBackForwardListItem? {
         assertValidIndex()
 
@@ -474,10 +484,12 @@ final class WebBackForwardList {
         case yes
     }
 
+    @used
     func backListCountForAPI() -> Int {
         backListWithLimitInternal(limit: UInt(rawBackListEntryCount()), makeAPIArray: .no).count
     }
 
+    @used
     func forwardListCountForAPI() -> Int {
         forwardListWithLimitInternal(limit: UInt(rawForwardListEntryCount()), makeAPIArray: .no).count
     }
@@ -498,11 +510,13 @@ final class WebBackForwardList {
         return (count: count, array: array)
     }
 
+    @used
     func backListAsAPIArrayWithLimit(limit: UInt) -> API.RefAPIArray {
         // swift-format-ignore: NeverForceUnwrap
         backListWithLimitInternal(limit: limit, makeAPIArray: .yes).array!
     }
 
+    @used
     func forwardListAsAPIArrayWithLimit(limit: UInt) -> API.RefAPIArray {
         // swift-format-ignore: NeverForceUnwrap
         forwardListWithLimitInternal(limit: limit, makeAPIArray: .yes).array!
@@ -609,6 +623,7 @@ final class WebBackForwardList {
         page.get()!.didChangeBackForwardList(Optional.none, consuming: WebKit.BackForwardListItemVector(array: entriesCopy))
     }
 
+    @used
     func clear() {
         assertValidIndex()
 
@@ -650,6 +665,7 @@ final class WebBackForwardList {
         page.didChangeBackForwardList(nil, consuming: WebKit.BackForwardListItemVector(array: removedItems))
     }
 
+    @used
     func backForwardListState(filter: WebBackForwardListItemFilter) -> WebKit.BackForwardListState {
         assertValidIndex()
 
@@ -680,6 +696,7 @@ final class WebBackForwardList {
         return backForwardListState
     }
 
+    @used
     func restoreFromState(backForwardListState: WebKit.BackForwardListState) {
         guard let page = page.get() else {
             return
@@ -696,12 +713,14 @@ final class WebBackForwardList {
         backForwardLog("(Back/Forward) WebBackForwardList \(ObjectIdentifier(self)) restored from state (has \(entries.count) entries)")
     }
 
+    @used
     func setItemsAsRestoredFromSession() {
         for entry in entries {
             entry.setWasRestoredFromSession()
         }
     }
 
+    @used
     func setItemsAsRestoredFromSessionIf(functor: WebBackForwardListItemFilter) {
         for entry in entries where functor.pointee(entry) {
             entry.setWasRestoredFromSession()
@@ -838,6 +857,7 @@ final class WebBackForwardList {
         return item
     }
 
+    @used
     func goBackItemSkippingItemsWithoutUserGesture() -> WebKit.RefPtrWebBackForwardListItem {
         guard let currentIndex = currentIndex else {
             return WebKit.RefPtrWebBackForwardListItem()
@@ -850,6 +870,7 @@ final class WebBackForwardList {
         )
     }
 
+    @used
     func goForwardItemSkippingItemsWithoutUserGesture() -> WebKit.RefPtrWebBackForwardListItem {
         guard let currentIndex = currentIndex else {
             return WebKit.RefPtrWebBackForwardListItem()
@@ -862,6 +883,7 @@ final class WebBackForwardList {
         )
     }
 
+    @used
     func findFrameStateInItem(
         itemID: WebCore.BackForwardItemIdentifier,
         parentFrameID: WebCore.FrameIdentifier,
@@ -882,6 +904,7 @@ final class WebBackForwardList {
         return getFrameState(childFrameItem)
     }
 
+    @used
     func loggingString() -> Swift.String {
         var result =
             "\nWebBackForwardList \(ObjectIdentifier(self)) - \(entries.count) entries, has current index \(currentIndex != nil ? "YES" : "NO") (\(currentIndex ?? 0))\n"
@@ -934,6 +957,7 @@ final class WebBackForwardList {
         return frameState
     }
 
+    @used
     func backForwardAddItemShared(
         connection: IPC.Connection,
         navigatedFrameState: WebKit.RefFrameState,
@@ -1009,6 +1033,7 @@ final class WebBackForwardList {
 
     // IPCs from here on
 
+    @used
     func backForwardAddItem(connection: IPC.Connection, navigatedFrameState: WebKit.RefFrameState) {
         if let page = page.get() {
             backForwardAddItemShared(
@@ -1019,6 +1044,7 @@ final class WebBackForwardList {
         }
     }
 
+    @used
     func backForwardSetChildItem(frameItemID: WebCore.BackForwardFrameItemIdentifier, frameState: WebKit.RefFrameState) {
         guard let item = currentItem() else {
             return
@@ -1029,12 +1055,14 @@ final class WebBackForwardList {
         }
     }
 
+    @used
     func backForwardClearChildren(itemID: WebCore.BackForwardItemIdentifier, frameItemID: WebCore.BackForwardFrameItemIdentifier) {
         if let frameItem = WebKit.WebBackForwardListFrameItem.itemForID(itemID, frameItemID) {
             frameItem.clearChildren()
         }
     }
 
+    @used
     func backForwardUpdateItem(connection: IPC.Connection, frameState: WebKit.RefFrameState) {
         // __convertToBool necessary due to rdar://137879510
         if !frameState.ptr().itemID.__convertToBool() || !frameState.ptr().frameItemID.__convertToBool() {
@@ -1067,12 +1095,14 @@ final class WebBackForwardList {
         webPageProxy.updateCanGoBackAndForward()
     }
 
+    @used
     func updateFrameIdentifier(oldFrameID: WebCore.FrameIdentifier, newFrameID: WebCore.FrameIdentifier) {
         for entry in entries {
             entry.updateFrameID(oldFrameID, newFrameID)
         }
     }
 
+    @used
     func backForwardGoToItem(
         itemID: WebCore.BackForwardItemIdentifier,
         completionHandler: CompletionHandlers.WebBackForwardList.BackForwardGoToItemCompletionHandler
@@ -1088,6 +1118,7 @@ final class WebBackForwardList {
         backForwardGoToItemShared(itemID: itemID, completionHandler: completionHandler)
     }
 
+    @used
     func backForwardListContainsItem(
         itemID: WebCore.BackForwardItemIdentifier,
         completionHandler: CompletionHandlers.WebBackForwardList.BackForwardListContainsItemCompletionHandler
@@ -1095,6 +1126,7 @@ final class WebBackForwardList {
         completionHandler.pointee(itemForID(identifier: itemID) != nil)
     }
 
+    @used
     func backForwardGoToItemShared(
         itemID: WebCore.BackForwardItemIdentifier,
         completionHandler: CompletionHandlers.WebBackForwardList.BackForwardGoToItemCompletionHandler
@@ -1116,6 +1148,7 @@ final class WebBackForwardList {
         completionHandler.pointee(consuming: rawCounts())
     }
 
+    @used
     func backForwardAllItems(
         frameID: WebCore.FrameIdentifier,
         completionHandler: CompletionHandlers.WebBackForwardList.BackForwardAllItemsCompletionHandler
@@ -1129,6 +1162,7 @@ final class WebBackForwardList {
         completionHandler.pointee(consuming: WebKit.VectorRefFrameState(array: frameStates))
     }
 
+    @used
     func backForwardItemAtIndexForWebContent(
         delta: Int32,
         frameID: WebCore.FrameIdentifier,
@@ -1147,6 +1181,7 @@ final class WebBackForwardList {
         completionHandler.pointee(consuming: WebKit.RefPtrFrameState(frameItem.copyFrameStateWithChildren().ptr()))
     }
 
+    @used
     func backForwardListCounts(completionHandler: CompletionHandlers.WebBackForwardList.BackForwardListCountsCompletionHandler) {
         completionHandler.pointee(consuming: rawCounts())
     }

--- a/Source/cmake/WebKitFeatures.cmake
+++ b/Source/cmake/WebKitFeatures.cmake
@@ -145,14 +145,16 @@ macro(WEBKIT_OPTION_BEGIN)
         set(ENABLE_UNIFIED_BUILDS_DEFAULT ON)
     endif ()
 
-    # Default the Swift demo URI scheme on for GTK/WPE, but only when the toolchain
-    # can build it: Clang (not GCC) with a new-enough Swift. Otherwise it stays off;
+    # Default the Swift prototype features on for GTK/WPE, but only when the toolchain
+    # can build it: Clang (not GCC) with a new-enough Swift. Otherwise they stay off;
     # an explicit -D against such a toolchain is rejected in WEBKIT_OPTION_END.
     set(ENABLE_SWIFT_DEMO_URI_SCHEME_DEFAULT OFF)
+    set(ENABLE_BACK_FORWARD_LIST_SWIFT_DEFAULT OFF)
     if ((PORT STREQUAL "GTK" OR PORT STREQUAL "WPE") AND COMPILER_IS_CLANG)
         _WEBKIT_DETECT_SWIFT_CXX_INTEROP_SUPPORT(_swift_interop_ok)
         if (_swift_interop_ok)
             set(ENABLE_SWIFT_DEMO_URI_SCHEME_DEFAULT ON)
+            set(ENABLE_BACK_FORWARD_LIST_SWIFT_DEFAULT ON)
         endif ()
     endif ()
 
@@ -183,7 +185,7 @@ macro(WEBKIT_OPTION_BEGIN)
     WEBKIT_OPTION_DEFINE(ENABLE_AUTOCAPITALIZE "Toggle autocapitalize support" PRIVATE OFF)
     WEBKIT_OPTION_DEFINE(ENABLE_AV1 "Toggle AV1 codec support" PRIVATE OFF)
     WEBKIT_OPTION_DEFINE(ENABLE_AVF_CAPTIONS "Toggle AVFoundation caption support" PRIVATE OFF)
-    WEBKIT_OPTION_DEFINE(ENABLE_BACK_FORWARD_LIST_SWIFT "Toggle Swift back forward list" PRIVATE OFF)
+    WEBKIT_OPTION_DEFINE(ENABLE_BACK_FORWARD_LIST_SWIFT "Toggle Swift back forward list" PRIVATE ${ENABLE_BACK_FORWARD_LIST_SWIFT_DEFAULT})
     WEBKIT_OPTION_DEFINE(ENABLE_BREAKPAD "Toggle breakpad minidump support." PRIVATE OFF)
     WEBKIT_OPTION_DEFINE(ENABLE_BUBBLEWRAP_SANDBOX "Toggle Bubblewrap sandboxing support" PRIVATE OFF)
     WEBKIT_OPTION_DEFINE(ENABLE_CACHE_PARTITIONING "Toggle cache partitioning support" PRIVATE OFF)


### PR DESCRIPTION
#### 278083067fd6e189d4ab83901578e43bcc37c92a
<pre>
[Swift GTK] Enable Swift back forward list on GTK by default (take two)
<a href="https://bugs.webkit.org/show_bug.cgi?id=316286">https://bugs.webkit.org/show_bug.cgi?id=316286</a>

Reviewed by Geoffrey Garen.

Enable the Swift back forward list by default in environments with sufficiently
recent toolchains, so that it&apos;s tested on WebKit GTM CI.

This is a reland because the first land didn&apos;t work reliably in clean builds,
just incremental builds. This reland includes lots of @used annotations to
ensure that functions are not discarded by the Swift optimiser even if they&apos;re
used only from C++, not Swift.

Canonical link: <a href="https://commits.webkit.org/314923@main">https://commits.webkit.org/314923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f73cf7a8e2044bed91891d700bdd63835ca272bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124967 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94ccc48d-d483-4855-8132-18a1b4b9dc9a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40794 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130130 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/612144e7-cb9a-4109-badb-17c05854a7c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110647 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6055755-ffd2-489a-ba89-7684c6a88dca) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/166607 "Found 1 webkitpy test failure: webkitscmpy.test.land_unittest.TestLandBitBucket.test_insert_review") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31515 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30215 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25074 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159452 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141497 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178877 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/28190 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31775 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29715 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138519 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138409 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37342 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41543 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104585 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33657 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26668 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199963 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40047 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113128 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53758 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39444 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4766 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39694 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39589 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->