### PR TITLE
Cherry-pick 314374@main (e1d8d5471e3f). https://bugs.webkit.org/show_bug.cgi?id=316004

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -783,8 +783,11 @@ static constexpr bool unreachableForValue = false;
 #define SENSITIVE_LOG_STRING "s"
 #define LOGF(channel, priority, fmt, ...) do { \
     auto& logChannel = LOG_CHANNEL(channel); \
-    if (logChannel.state != WTFLogChannelState::Off) \
-        fprintf(stderr, "[" LOG_CHANNEL_WEBKIT_SUBSYSTEM ":%s:%i] " fmt "\n", logChannel.name, priority, ##__VA_ARGS__); \
+    if (logChannel.state != WTFLogChannelState::Off) { \
+        IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call") \
+        fprintf(stderr, "[" LOG_CHANNEL_WEBKIT_SUBSYSTEM ":%s:%u] " fmt "\n", logChannel.name, static_cast<unsigned>(priority), ##__VA_ARGS__); \
+        IGNORE_WARNINGS_END \
+    } \
 } while (0)
 
 #define RELEASE_LOG(channel, ...) LOGF(channel, 4, __VA_ARGS__)

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -378,7 +378,9 @@ private:
 #elif ENABLE(JOURNALD_LOG)
         sd_journal_send("WEBKIT_SUBSYSTEM=" LOG_CHANNEL_WEBKIT_SUBSYSTEM, "WEBKIT_CHANNEL=%s", channel.name, "MESSAGE=%s", logMessage.utf8().data(), nullptr);
 #else
+        IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
         fprintf(stderr, "[" LOG_CHANNEL_WEBKIT_SUBSYSTEM ":%s:-] %s\n", channel.name, logMessage.utf8().data());
+        IGNORE_WARNINGS_END
 #endif
 
         sendMessageToObservers(channel, level, arguments...);

--- a/Source/WebCore/platform/glib/UserAgentGLib.cpp
+++ b/Source/WebCore/platform/glib/UserAgentGLib.cpp
@@ -83,6 +83,8 @@ static String buildUserAgentString(const UserAgentQuirks& quirks)
 
     if (quirks.contains(UserAgentQuirks::NeedsMacintoshPlatform))
         uaString.append(UserAgentQuirks::stringForQuirk(UserAgentQuirks::NeedsMacintoshPlatform));
+    else if (quirks.contains(UserAgentQuirks::NeedsAndroidPlatform))
+        uaString.append(UserAgentQuirks::stringForQuirk(UserAgentQuirks::NeedsAndroidPlatform));
     else {
         uaString.append(platformForUAString(), "; "_s);
 #if defined(USER_AGENT_BRANDING)

--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -157,6 +157,17 @@ static bool urlRequiresMacintoshPlatform(const String& domain, const String& bas
     return false;
 }
 
+static bool urlRequiresAndroidPlatform([[maybe_unused]] const String& baseDomain)
+{
+#if ENABLE(WEBXR) && PLATFORM(WPE)
+    // When WebXR is available the model viewer support provides a better UX.
+    if (baseDomain == "ikea.com"_s)
+        return true;
+#endif
+
+    return false;
+}
+
 static bool urlRequiresUnbrandedUserAgent(const String& domain)
 {
     // Google uses an ugly fallback login page if application branding is
@@ -192,6 +203,8 @@ UserAgentQuirks UserAgentQuirks::quirksForURL(const URL& url)
 
     if (urlRequiresMacintoshPlatform(domain, baseDomain))
         quirks.add(UserAgentQuirks::NeedsMacintoshPlatform);
+    else if (urlRequiresAndroidPlatform(baseDomain))
+        quirks.add(UserAgentQuirks::NeedsAndroidPlatform);
 
     if (urlRequiresUnbrandedUserAgent(domain))
         quirks.add(UserAgentQuirks::NeedsUnbrandedUserAgent);
@@ -208,6 +221,8 @@ String UserAgentQuirks::stringForQuirk(UserAgentQuirk quirk)
         return "; rv:300.0) Gecko/20100101 Firefox/300.0"_s;
     case NeedsMacintoshPlatform:
         return "Macintosh; Intel Mac OS X 10_15"_s;
+    case NeedsAndroidPlatform:
+        return "Linux; Android 12.0.0"_s;
     case NeedsUnbrandedUserAgent:
     case NumUserAgentQuirks:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/glib/UserAgentQuirks.h
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.h
@@ -36,6 +36,7 @@ public:
         NeedsChromeBrowser,
         NeedsFirefoxBrowser,
         NeedsMacintoshPlatform,
+        NeedsAndroidPlatform,
         NeedsUnbrandedUserAgent,
 
         NumUserAgentQuirks

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp
@@ -438,7 +438,19 @@ static const struct zwp_text_input_v3_listener textInputListenerV3 = {
 
         if (updateIm && global->serial == serial)
             textInputV3UpdateState(context, ZWP_TEXT_INPUT_V3_CHANGE_CAUSE_INPUT_METHOD);
-    }
+    },
+#ifdef ZWP_TEXT_INPUT_V3_ACTION_SINCE_VERSION
+    // action
+    nullptr,
+#endif
+#ifdef ZWP_TEXT_INPUT_V3_LANGUAGE_SINCE_VERSION
+    // language
+    nullptr,
+#endif
+#ifdef ZWP_TEXT_INPUT_V3_PREEDIT_HINT_SINCE_VERSION
+    // preedit_hint
+    nullptr
+#endif
 };
 
 static void wpeIMContextWaylandV3GlobalFree(gpointer data)

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
@@ -61,9 +61,24 @@ static void assertUserAgentForURLHasMacPlatformQuirk(const char* url)
     EXPECT_TRUE(uaString.contains("Macintosh"_s));
     EXPECT_TRUE(uaString.contains("Mac OS X"_s));
     EXPECT_FALSE(uaString.contains("Linux"_s));
+    EXPECT_FALSE(uaString.contains("Android"_s));
     EXPECT_FALSE(uaString.contains("Chrome"_s));
     EXPECT_FALSE(uaString.contains("FreeBSD"_s));
 }
+
+#if ENABLE(WEBXR) && PLATFORM(WPE)
+static void assertUserAgentForURLHasAndroidQuirk(const char* url)
+{
+    String uaString = standardUserAgentForURL(URL(String::fromLatin1(url)));
+
+    EXPECT_FALSE(uaString.contains("Macintosh"_s));
+    EXPECT_FALSE(uaString.contains("Mac OS X"_s));
+    EXPECT_TRUE(uaString.contains("Linux"_s));
+    EXPECT_TRUE(uaString.contains("Android"_s));
+    EXPECT_FALSE(uaString.contains("Chrome"_s));
+    EXPECT_FALSE(uaString.contains("FreeBSD"_s));
+}
+#endif
 
 // Some Google domains require an unbranded user agent, which is a little
 // awkward to test for. We want to check that standardUserAgentForURL is
@@ -104,6 +119,10 @@ TEST(UserAgentTest, Quirks)
 #if ENABLE(THUNDER)
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.netflix.com/");
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.disneyplus.com/");
+#endif
+
+#if ENABLE(WEBXR) && PLATFORM(WPE)
+    assertUserAgentForURLHasAndroidQuirk("https://www.ikea.com/");
 #endif
 
     assertUserAgentForURLHasMacPlatformQuirk("http://www.yahoo.com/");


### PR DESCRIPTION
#### 31deefad901ebf80960ddce6b2fb1c2062362369
<pre>
Cherry-pick 314374@main (e1d8d5471e3f). <a href="https://bugs.webkit.org/show_bug.cgi?id=316004">https://bugs.webkit.org/show_bug.cgi?id=316004</a>

    [WTF][glib] Fix build with -DENABLE_JOURNALD_LOG=FALSE
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316004">https://bugs.webkit.org/show_bug.cgi?id=316004</a>

    Reviewed by Adrian Perez de Castro.

    This patch fixes builds that use fprintf-based logging with clang 22.
    This is the case for glib builds when configuring with
    -DENABLE_JOURNALD_LOG=FALSE.

    This patch is the counterpart to
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312457">https://bugs.webkit.org/show_bug.cgi?id=312457</a> where similar compiler
    flag guards had to be added for the journald-backed logging code.

    * Source/WTF/wtf/Assertions.h:
    * Source/WTF/wtf/Logger.h:
    (WTF::Logger::log):

    Canonical link: <a href="https://commits.webkit.org/314374@main">https://commits.webkit.org/314374@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.710@webkitglib/2.52">https://commits.webkit.org/305877.710@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 13d21c60d6788a42c7f6a09b2954ea0616b354c9
<pre>
Cherry-pick 314304@main (b0f3b044233d). <a href="https://bugs.webkit.org/show_bug.cgi?id=315991">https://bugs.webkit.org/show_bug.cgi?id=315991</a>

    [WPE] missing-field-initializers warnings in WPEInputMethodContextWaylandV3.cpp
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315991">https://bugs.webkit.org/show_bug.cgi?id=315991</a>

    Reviewed by Adrian Perez de Castro.

    Silence missing-field-initializers clang warnings by providing explicit initializers for the action,
    language and preedit_hint callbacks.

    * Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp:

    Canonical link: <a href="https://commits.webkit.org/314304@main">https://commits.webkit.org/314304@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.709@webkitglib/2.52">https://commits.webkit.org/305877.709@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### ba2e3dfc8180a191d23f75ac3b2f67ab823a28f4
<pre>
Cherry-pick 314216@main (843b726247e0). <a href="https://bugs.webkit.org/show_bug.cgi?id=315839">https://bugs.webkit.org/show_bug.cgi?id=315839</a>

    [WPE][WebXR] Use an Android User-Agent when visiting ikea.com
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315839">https://bugs.webkit.org/show_bug.cgi?id=315839</a>

    Reviewed by Adrian Perez de Castro.

    When WebXR is available the model viewer support provides a better UX.

    * Source/WebCore/platform/glib/UserAgentGLib.cpp:
    (WebCore::buildUserAgentString):
    * Source/WebCore/platform/glib/UserAgentQuirks.cpp:
    (WebCore::urlRequiresAndroidPlatform):
    (WebCore::UserAgentQuirks::quirksForURL):
    (WebCore::UserAgentQuirks::stringForQuirk):
    * Source/WebCore/platform/glib/UserAgentQuirks.h:

    Canonical link: <a href="https://commits.webkit.org/314216@main">https://commits.webkit.org/314216@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.708@webkitglib/2.52">https://commits.webkit.org/305877.708@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/901956c7de503ecf1f7ad20d3d4faf21b54a16f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166945 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/40435 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/34016 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175993 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124203 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168811 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/40868 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/40443 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129824 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124203 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169904 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/40868 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/34016 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110349 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/40868 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/40443 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24729 "Built successfully") | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/159102 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/40868 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/34016 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178531 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/27839 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31429 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/34016 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138192 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/40505 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/40443 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138103 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/41193 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/34016 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/104044 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25414 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/41193 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/34016 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199624 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/39704 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112778 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53674 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/39100 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/34016 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/39345 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/39244 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->