### PR TITLE
[YARR] Add auto-possession optimization

### DIFF
--- a/JSTests/stress/yarr-auto-possessification.js
+++ b/JSTests/stress/yarr-auto-possessification.js
@@ -1,0 +1,109 @@
+// Regression coverage for YarrJIT auto-possessification: a Greedy single-character term
+// (PatternCharacter / CharacterClass) immediately followed by a mandatory term whose first
+// character is disjoint from the greedy term's set is matched possessively (the JIT skips the
+// futile give-back/retry backtracking). Results must be identical to a fully-backtracking
+// engine, so every case below is also validated against the Yarr interpreter and V8.
+// Throws on mismatch; no output on success.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: got ${actual}, expected ${expected}`);
+}
+
+function match(re, str) {
+    let m = re.exec(str);
+    return m === null ? "null" : JSON.stringify(Array.from(m).map(x => x === undefined ? null : x)) + "@" + m.index;
+}
+
+function test(reSource, flags, str, expected) {
+    // Compile once and run hot so the JIT tiers up and the possessive backtrack path runs.
+    let re = new RegExp(reSource, flags);
+    for (let i = 0; i < 200; ++i)
+        shouldBe(match(re, str), expected);
+}
+
+// --- Greedy followed by a disjoint mandatory single character (the possessified case) ---
+// Successful matches must still produce the correct longest match.
+test("[0-9a-f]{1,4}:", "", "abcd:", '["abcd:"]@0');
+test("[0-9a-f]{1,4}:", "", "a:", '["a:"]@0');
+test("^([0-9a-f]{1,4}:)+x$", "", "abcd:1:ef01:x", '["abcd:1:ef01:x","ef01:"]@0');
+test("^[0-9]+\\.[0-9]+$", "", "123.456", '["123.456"]@0');
+test("^[a-z]+-end$", "", "hello-end", '["hello-end"]@0');
+test("a+b", "", "aaab", '["aaab"]@0');
+
+// --- Failing inputs: possessification must not change the (non-)match ---
+test("^([0-9a-f]{1,8}-)+x$", "", "abcdef12-abcdef12-y", "null");
+test("[0-9a-f]{1,4}:", "", "abcd", "null");
+test("^[0-9]+\\.[0-9]+$", "", "123.", "null");
+test("a+b", "", "aaac", "null");
+test("^([0-9a-f]{1,4}:){7}(?:[0-9a-f]{1,4}|:)$", "", "2001:db8:0:1:1:1:1::1", "null");
+
+// --- Overlapping follower: MUST NOT be possessified (give-back is required) ---
+test("a+a$", "", "aaaa", '["aaaa"]@0');         // 'a+' followed by 'a' (same char): must give back one.
+test("a+ab", "", "aaab", '["aaab"]@0');         // 'a+' must yield the 'a' that 'ab' needs.
+test("[0-9]+[0-9a-f]+g$", "", "12ffg", '["12ffg"]@0');   // overlapping classes.
+test("[0-9]+[5-9]z$", "", "1239z", '["1239z"]@0');       // overlapping ranges: give-back needed.
+
+// --- ignoreCase: class folds in case; follower case-insensitive ---
+test("[a-z]+;", "i", "ABCdef;", '["ABCdef;"]@0');
+test("[a-z]+X", "i", "abcx", '["abcx"]@0');     // follower 'X' under /i matches 'x' which IS in [a-z]: must not possessify.
+
+// --- Disjoint follower under /i where follower has no case (digit/punct) ---
+test("[a-z]+9", "i", "ABc9", '["ABc9"]@0');
+
+// --- Greedy CharacterClass followed by disjoint class-shaped literal, with captures intact ---
+test("^(\\d{1,3})\\.(\\d{1,3})$", "", "12.250", '["12.250","12","250"]@0');
+
+// --- Quantified parentheses wrapping a possessive inner term (IPv6-like) ---
+test("^(?:[0-9a-f]{1,4}:){2}[0-9a-f]{1,4}$", "", "ab:cd:ef", '["ab:cd:ef"]@0');
+test("^(?:[0-9a-f]{1,4}:){2}[0-9a-f]{1,4}$", "", "ab:cd:", "null");
+
+// === Unicode (/u) and unicodeSets (/v): surrogate-pair decode and case-fold soundness ===
+// All expected values below were cross-checked against V8 (a fully-backtracking engine).
+
+// --- Non-BMP greedy PatternCharacter + disjoint BMP follower: give-back must be doubled
+//     (2 code units per matched code point). ---
+test("\\u{1F600}+x", "u", "\u{1F600}\u{1F600}\u{1F600}x", '["\u{1F600}\u{1F600}\u{1F600}x"]@0');
+test("\\u{1F600}+x", "u", "\u{1F600}\u{1F600}\u{1F600}y", "null"); // possessive give-back is futile.
+
+// --- Non-BMP, fixed-width CharacterClass greedy + disjoint follower (count << 1 give-back). ---
+test("[\\u{1F600}-\\u{1F610}]+!", "u", "\u{1F600}\u{1F601}\u{1F602}!", '["\u{1F600}\u{1F601}\u{1F602}!"]@0');
+test("[\\u{1F600}-\\u{1F610}]+!", "u", "\u{1F600}\u{1F601}\u{1F602}?", "null");
+// Bounded greedy: possessive at index 0 fails, engine still finds the later non-anchored match.
+test("[\\u{1F600}-\\u{1F610}]{1,3}!", "u", "\u{1F600}\u{1F601}\u{1F602}\u{1F603}!", '["\u{1F601}\u{1F602}\u{1F603}!"]@2');
+
+// --- Variable-width class (mixes BMP + non-BMP): NOT fixed width, so the JIT must fall back to
+//     the normal per-step backtrack under surrogate decoding. Result must still be correct. ---
+test("[a\\u{1F600}]+!", "u", "a\u{1F600}a!", '["a\u{1F600}a!"]@0');
+test("[a\\u{1F600}]+!", "u", "a\u{1F600}a?", "null");
+
+// --- Inverted class under /u is variable width too (JIT falls back); must stay correct. ---
+test("[^0-9]+5", "u", "abc5", '["abc5"]@0');
+test("[^0-9]+5", "u", "ab\u{1F600}c5", '["ab\u{1F600}c5"]@0');
+test("[^0-9]+5", "u", "abc6", "null");
+
+// --- Case-fold soundness under /iu: a disjoint follower whose Unicode fold reaches a non-ASCII
+//     char (Kelvin U+212A folds to 'k', long-s U+017F folds to 's'). The greedy [0-9]/[a-z] class
+//     genuinely rejects those, so possessification is valid and the follower still matches them. ---
+test("[0-9]+k", "iu", "123K", '["123K"]@0'); // follower /k/iu matches Kelvin.
+test("[0-9]+s", "iu", "12ſ", '["12ſ"]@0');   // follower /s/iu matches long-s.
+test("[0-9]+k", "iu", "123k", '["123k"]@0');
+
+// --- The dangerous case that must NOT be possessified: under /iu, [K] folds to {k,K,Kelvin},
+//     so it DOES overlap the ASCII follower 'k' and give-back is required. (A naive analysis that
+//     only saw the literal Kelvin code point would wrongly possessify and return null.) ---
+test("[\\u212A]+k", "iu", "KKKk", '["KKKk"]@0');
+test("[\\u212A]+k", "iu", "KKk", '["KKk"]@0');
+
+// --- /v string-disjunction class: [\q{..}] is decomposed into a group, so the inner single-char
+//     class is FixedCount (never the greedy term) and the strings are never possessified away. ---
+test("[\\q{ab}c]+d", "v", "ababccd", '["ababccd"]@0');
+test("[\\q{xy}a]+b", "v", "xyaab", '["xyaab"]@0');
+test("[\\q{ab}]+a", "v", "ababa", '["ababa"]@0');
+
+// --- Dot (non-dotAll) is the newline class inverted: '.' rejects '\n', so '.+\n' is possessifiable.
+//     This is the BMP path (one code unit per match). ---
+test(".+\\n", "", "abc\ndef", '["abc\\n"]@0');
+test(".+\\n", "", "abcdef", "null");
+test("[^0-9]+5", "", "abc5", '["abc5"]@0');
+test("[^0-9]+5", "", "abc6", "null");

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2952,6 +2952,17 @@ class YarrGenerator final : public YarrJITInfo {
 
         m_backtrackingState.link(*this, op);
 
+        if (term->possessive()) {
+            // When term is possessive, we do not need to do backtracking.
+            // Just rewind index completely and falling through to the next backtracking.
+            loadFromFrame(term->frameLocation + BackTrackInfoPatternCharacter::matchAmountIndex(), countRegister);
+            if (m_decodeSurrogatePairs && !U_IS_BMP(term->patternCharacter))
+                m_jit.lshift32(MacroAssembler::TrustedImm32(1), countRegister);
+            m_jit.sub32(countRegister, m_regs.index);
+            m_backtrackingState.fallthrough();
+            return;
+        }
+
         loadFromFrame(term->frameLocation + BackTrackInfoPatternCharacter::matchAmountIndex(), countRegister);
         m_backtrackingState.append(m_jit.branchTest32(MacroAssembler::Zero, countRegister));
         m_jit.sub32(MacroAssembler::TrustedImm32(1), countRegister);
@@ -3265,6 +3276,18 @@ class YarrGenerator final : public YarrJITInfo {
         const MacroAssembler::RegisterID countRegister = m_regs.regT1;
 
         m_backtrackingState.link(*this, op);
+
+        // Leveraging possessive flag to optimize this backtracking by rewinding entire matching so far.
+        // Important thing is possessive in YarrJIT is optional optimization flag: we can leverage this only when we can use it easily.
+        // We can completely ignore this flag and still this is OK.
+        if (term->possessive() && (!m_decodeSurrogatePairs || term->isFixedWidthCharacterClass())) {
+            loadFromFrame(term->frameLocation + BackTrackInfoCharacterClass::matchAmountIndex(), countRegister);
+            if (m_decodeSurrogatePairs && term->characterClass->hasNonBMPCharacters())
+                m_jit.lshift32(MacroAssembler::TrustedImm32(1), countRegister); // 2 code units per match.
+            m_jit.sub32(countRegister, m_regs.index);
+            m_backtrackingState.fallthrough();
+            return;
+        }
 
         loadFromFrame(term->frameLocation + BackTrackInfoCharacterClass::matchAmountIndex(), countRegister);
         m_backtrackingState.append(m_jit.branchTest32(MacroAssembler::Zero, countRegister));

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -36,6 +36,7 @@
 #include <wtf/BitSet.h>
 #include <wtf/DataLog.h>
 #include <wtf/StackCheck.h>
+#include <wtf/TriState.h>
 #include <wtf/Vector.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -2090,6 +2091,125 @@ public:
         }
     }
 
+    // Auto-possessification optimization
+    //
+    // "Possessive Quantifier" is yet another quantifier type supported in non-JS RegExp engines (e.g. PCRE2).
+    // https://www.pcre.org/current/doc/html/pcre2syntax.html
+    // It is like /a++/, /a*+/. This is different from Greedy quantifier (/a+/, /a*/) in particular it never does backtracking.
+    // Once it greedily matches, even if the subsequent pattern fails, we do not do backtracking. For example,
+    //
+    // /.*+b/ and "textb". In /.*b/ case, .* will do backtrack to spare "b" for the subsequent pattern. But possessive quantifier
+    // drains all text input in this case and never doing backtracking, thus match fails.
+    //
+    // The benefit of possessive quantifier is it can eliminate the cost of backtracking, so failure becomes quick due to removal
+    // of backtracking.
+    //
+    // While JS RegExp does not support possessive quantifiers, we can internally support and convert patterns to possessive quantifier
+    // if we can find this term's backtracking never produces the potentially matching cases for the subsequent patterns.
+    //
+    // Let's show an example. A greedy single-character term `T` immediately followed by a mandatory term `U` whose first character
+    // can never be a character that `T` matches is effectively possessive. Once `T` has matched greedily, giving characters back
+    // can never let `U` match (a given-back position still holds a `T` character, which `U` rejects), so all of the backtracking the
+    // engine would do into `T` is futile. We mark such a `T` so the JIT can skip generating (and running) that dead backtracking.
+
+    void optimizePossessiveQuantifiers()
+    {
+        auto rawClassContains = [](const CharacterClass* characterClass, char32_t ch) -> TriState {
+            if (characterClass->m_anyCharacter)
+                return TriState::True;
+
+            if (!characterClass->hasSingleCharacters())
+                return characterClass->m_table ? TriState::Indeterminate : TriState::False;
+
+            bool isLatin1Char = isLatin1(ch);
+            const auto& matches = isLatin1Char ? characterClass->m_matches8 : characterClass->m_matches32;
+            for (auto match : matches) {
+                if (match == ch)
+                    return TriState::True;
+            }
+            const auto& ranges = isLatin1Char ? characterClass->m_ranges8 : characterClass->m_ranges32;
+            for (auto range : ranges) {
+                if (ch >= range.begin && ch <= range.end)
+                    return TriState::True;
+            }
+            return TriState::False;
+        };
+
+        auto termMatchesCharacter = [&](const PatternTerm& term, char32_t ch) -> TriState {
+            if (term.type == PatternTerm::Type::PatternCharacter) {
+                char32_t pc = term.patternCharacter;
+                if (pc == ch)
+                    return TriState::True;
+                if (term.ignoreCase()) {
+                    if (!isASCII(pc) || !isASCII(ch))
+                        return TriState::Indeterminate;
+                    if (toASCIIUpper(pc) == toASCIIUpper(ch))
+                        return TriState::True;
+                }
+                return TriState::False;
+            }
+
+            ASSERT(term.type == PatternTerm::Type::CharacterClass);
+            TriState raw = rawClassContains(term.characterClass, ch);
+            if (raw == TriState::Indeterminate)
+                return TriState::Indeterminate;
+            if (term.invert())
+                return raw == TriState::True ? TriState::False : TriState::True;
+            return raw;
+        };
+
+        // Returns true if and only if `next` (the term right after the greedy term) is mandatory and its
+        // first character is provably disjoint from `greedy`'s set.
+        auto followerForcesPossessive = [&](const PatternTerm& greedy, const PatternTerm& next) -> bool {
+            if (next.type != PatternTerm::Type::PatternCharacter)
+                return false;
+
+            if (next.quantityType != QuantifierType::FixedCount || next.quantityMinCount < 1)
+                return false;
+
+            // Every character `next` would accept must be rejected by `greedy`.
+            char32_t fc = next.patternCharacter;
+            if (termMatchesCharacter(greedy, fc) != TriState::False)
+                return false;
+
+            if (next.ignoreCase()) {
+                if (!isASCII(fc))
+                    return false; // Don't reason about non-ASCII case folds.
+
+                if (termMatchesCharacter(greedy, toASCIIUpper(fc)) != TriState::False)
+                    return false;
+
+                if (termMatchesCharacter(greedy, toASCIILower(fc)) != TriState::False)
+                    return false;
+            }
+            return true;
+        };
+
+        auto isPossessifiableGreedyTerm = [](const PatternTerm& term) -> bool {
+            return term.quantityType == QuantifierType::Greedy && (term.type == PatternTerm::Type::PatternCharacter || term.type == PatternTerm::Type::CharacterClass);
+        };
+
+        for (auto& disjunction : m_pattern.m_disjunctions) {
+            for (auto& alternative : disjunction->m_alternatives) {
+                if (alternative->matchDirection() != Forward)
+                    continue;
+
+                auto& terms = alternative->m_terms;
+                for (unsigned i = 1; i < terms.size(); ++i) {
+                    PatternTerm& current = terms[i - 1];
+                    PatternTerm& next = terms[i];
+                    if (!isPossessifiableGreedyTerm(current))
+                        continue;
+
+                    if (!followerForcesPossessive(current, next))
+                        continue;
+
+                    current.m_possessive = true;
+                }
+            }
+        }
+    }
+
     void optimizeBOL()
     {
         // Look for expressions containing beginning of line (^) anchoring and unroll them.
@@ -2706,6 +2826,7 @@ ErrorCode YarrPattern::compile(StringView patternString)
     constructor.checkForTerminalParentheses();
     constructor.optimizeDotStarWrappedExpressions();
     constructor.optimizeBOL();
+    constructor.optimizePossessiveQuantifiers();
 
     if (hasError(constructor.error()))
         return constructor.error();
@@ -2885,6 +3006,8 @@ void PatternTerm::dumpQuantifier(PrintStream& out)
         out.print(" greedy");
     else if (quantityType == QuantifierType::NonGreedy)
         out.print(" non-greedy");
+    if (m_possessive)
+        out.print(" possessive");
 }
 
 void PatternTerm::dump(PrintStream& out, YarrPattern* thisPattern, unsigned nestingDepth)

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -248,6 +248,12 @@ struct PatternTerm {
     unsigned inputPosition;
     unsigned frameLocation;
 
+    // Set by YarrPattern's auto-possessification pass for a Greedy single-character
+    // (PatternCharacter / CharacterClass) term whose following mandatory term can never
+    // match a character this term matches. Backtracking into such a term is always futile,
+    // so the JIT generates a possessive (no-give-back) backtrack instead of the retry loop.
+    bool m_possessive { false };
+
     PatternTerm(char32_t ch, OptionSet<Flags> currFlags, MatchDirection matchDirection = Forward)
         : type(PatternTerm::Type::PatternCharacter)
         , m_currentFlags(currFlags)
@@ -389,22 +395,27 @@ struct PatternTerm {
         return m_matchDirection;
     }
 
-    bool capture()
+    bool capture() const
     {
         return m_capture;
     }
 
-    bool NODELETE ignoreCase()
+    bool possessive() const
+    {
+        return m_possessive;
+    }
+
+    bool NODELETE ignoreCase() const
     {
         return m_currentFlags.contains(Flags::IgnoreCase);
     }
 
-    bool NODELETE multiline()
+    bool NODELETE multiline() const
     {
         return m_currentFlags.contains(Flags::Multiline);
     }
 
-    bool NODELETE dotAll()
+    bool NODELETE dotAll() const
     {
         return m_currentFlags.contains(Flags::DotAll);
     }
@@ -414,7 +425,7 @@ struct PatternTerm {
         return type == Type::CharacterClass && characterClass->hasOneCharacterSize() && !invert();
     }
 
-    bool containsAnyCaptures()
+    bool containsAnyCaptures() const
     {
         ASSERT(this->type == Type::ParenthesesSubpattern
             || this->type == Type::ParentheticalAssertion);


### PR DESCRIPTION
#### 2a8223d802c84d515fdb50d7e2a65fe5f05505a1
<pre>
[YARR] Add auto-possession optimization
<a href="https://bugs.webkit.org/show_bug.cgi?id=316491">https://bugs.webkit.org/show_bug.cgi?id=316491</a>
<a href="https://rdar.apple.com/178912776">rdar://178912776</a>

Reviewed by Yijia Huang.

This is an initial patch adding auto-possession optimization to YarrJIT.
This optimization adds possessive flag to Terms. This is completely
optional and implementation can leverage this additional information
just if they want, but it is totally fine to ignore this flag too.

When you have a code like, /a*b/, and `a` and `b` are exclusive each other,
then you can find that backtracking `a` part is meaningless since
once-`a`-matched character never matches against `b`.

We detect this pattern and annotate Term with possessive flag. Then
YarrJIT can skip backtracking when this flag is set.

Test: JSTests/stress/yarr-auto-possessification.js

* JSTests/stress/yarr-auto-possessification.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::optimizePossessiveQuantifiers):
(JSC::Yarr::YarrPattern::compile):
(JSC::Yarr::PatternTerm::dumpQuantifier):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::PatternTerm::capture const):
(JSC::Yarr::PatternTerm::possessive const):
(JSC::Yarr::PatternTerm::ignoreCase const):
(JSC::Yarr::PatternTerm::multiline const):
(JSC::Yarr::PatternTerm::dotAll const):
(JSC::Yarr::PatternTerm::containsAnyCaptures const):
(JSC::Yarr::PatternTerm::capture): Deleted.
(JSC::Yarr::PatternTerm::ignoreCase): Deleted.
(JSC::Yarr::PatternTerm::multiline): Deleted.
(JSC::Yarr::PatternTerm::dotAll): Deleted.
(JSC::Yarr::PatternTerm::containsAnyCaptures): Deleted.

Canonical link: <a href="https://commits.webkit.org/314736@main">https://commits.webkit.org/314736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9354e0534552d74d86f487e23b847b33aacdfcd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176010 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124220 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e3c4ee7-8770-4539-9b9e-250b789042d6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129837 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91445 "2 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/030135c3-db6a-4d72-b070-59dee1c75f8f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150017 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110362 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86623764-e69a-4ef7-9c06-0cc4aa8fe092) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29917 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24746 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159119 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178548 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27856 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31446 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138205 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138116 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149512 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104075 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25424 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26377 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199641 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39721 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112795 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53680 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39117 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4476 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39362 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39261 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->