### PR TITLE
Fix scroll overcompensation of fixed anchor-positioned elements when nested

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-nested-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-nested-001-expected.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  width: 1000px;
+  height: 1000px;
+}
+
+div {
+  width: 50px;
+  height: 50px;
+}
+
+#anchor1 {
+  position: absolute;
+  left: 150px;
+  top: 150px;
+  background: orange;
+}
+
+#anchor2 {
+  position: absolute;
+  left: 250px;
+  top: 250px;
+  background: teal;
+}
+
+#f1 {
+  position: fixed;
+  left: 100px;
+  top: 100px;
+  background: yellow;
+}
+
+#f2 {
+  position: fixed;
+  left: 200px;
+  top: 200px;
+  background: aqua;
+}
+
+#f3 {
+  position: fixed;
+  left: 100px;
+  top: 200px;
+  background: aqua;
+}
+</style>
+
+<div id="anchor1"></div>
+<div id="anchor2"></div>
+<div id="f1"></div>
+<div id="f2"></div>
+<div id="f3"></div>
+
+<script>
+document.documentElement.scrollLeft = 100;
+document.documentElement.scrollTop = 100;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-nested-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-nested-001.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<title>Fixed-positioned element nested in anchor-scroll-adjusted container doesn't double-compensate for viewport scroll</title>
+<link rel="author" href="mailto:fantasai@inkedblade.net">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#default-scroll-shift">
+<link rel="match" href="reference/anchor-scroll-fixedpos-nested-001-ref.html">
+<style>
+body {
+  margin: 0;
+  width: 1000px;
+  height: 1000px;
+}
+
+div {
+  width: 50px;
+  height: 50px;
+}
+
+#anchor1 {
+  position: absolute;
+  left: 150px;
+  top: 150px;
+  anchor-name: --a1;
+  background: orange;
+}
+
+#anchor2 {
+  position: absolute;
+  left: 250px;
+  top: 250px;
+  anchor-name: --a2;
+  background: teal;
+}
+
+#f1 {
+  position: fixed;
+  position-anchor: --a1;
+  position-area: bottom right;
+  background: yellow;
+}
+
+#f2 {
+  position: fixed;
+  position-anchor: --a2;
+  position-area: bottom right;
+  background: aqua;
+}
+
+#f3 {
+  position: fixed;
+  position-anchor: --a1;
+  position-area: bottom right;
+  margin-top: 100px;
+  background: aqua;
+}
+</style>
+
+<div id="anchor1"></div>
+<div id="anchor2"></div>
+<div id="f1">
+  <div id="wrapper">
+    <div id="f2"></div>
+    <div id="f3"></div>
+  </div>
+</div>
+
+<script>
+document.documentElement.scrollLeft = 100;
+document.documentElement.scrollTop = 100;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-nested-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-nested-002-expected.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  width: 1000px;
+  height: 1000px;
+}
+
+div {
+  width: 50px;
+  height: 50px;
+}
+
+#scroller {
+  position: absolute;
+  left: 150px;
+  top: 150px;
+  width: 200px;
+  height: 200px;
+  overflow: scroll;
+  outline: 1px solid black;
+}
+
+#scroller-content {
+  position: relative;
+  width: 400px;
+  height: 400px;
+}
+
+#anchor1 {
+  position: absolute;
+  left: 75px;
+  top: 100px;
+  background: orange;
+}
+
+#anchor2 {
+  position: absolute;
+  left: 175px;
+  top: 100px;
+  background: teal;
+}
+
+#f1 {
+  position: fixed;
+  left: 150px;
+  top: 150px;
+  background: yellow;
+}
+
+#f2 {
+  position: fixed;
+  left: 250px;
+  top: 150px;
+  background: aqua;
+}
+</style>
+
+<div id="scroller">
+  <div id="scroller-content">
+    <div id="anchor1"></div>
+    <div id="anchor2"></div>
+  </div>
+</div>
+<div id="f1"></div>
+<div id="f2"></div>
+
+<script>
+document.documentElement.scrollLeft = 100;
+document.documentElement.scrollTop = 100;
+let scroller = document.getElementById('scroller');
+scroller.scrollLeft = 25;
+scroller.scrollTop = 50;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-nested-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-nested-002.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<title>Fixed-positioned element nested in anchor-scroll-adjusted container doesn't double-compensate for scroll container scroll</title>
+<link rel="author" href="mailto:fantasai@inkedblade.net">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#default-scroll-shift">
+<link rel="match" href="reference/anchor-scroll-fixedpos-nested-002-ref.html">
+<style>
+body {
+  margin: 0;
+  width: 1000px;
+  height: 1000px;
+}
+
+div {
+  width: 50px;
+  height: 50px;
+}
+
+#scroller {
+  position: absolute;
+  left: 150px;
+  top: 150px;
+  width: 200px;
+  height: 200px;
+  overflow: scroll;
+  outline: 1px solid black;
+}
+
+#scroller-content {
+  position: relative;
+  width: 400px;
+  height: 400px;
+}
+
+#anchor1 {
+  position: absolute;
+  left: 75px;
+  top: 100px;
+  anchor-name: --a1;
+  background: orange;
+}
+
+#anchor2 {
+  position: absolute;
+  left: 175px;
+  top: 100px;
+  anchor-name: --a2;
+  background: teal;
+}
+
+#f1 {
+  position: fixed;
+  position-anchor: --a1;
+  position-area: bottom right;
+  background: yellow;
+}
+
+#f2 {
+  position: fixed;
+  position-anchor: --a2;
+  position-area: bottom right;
+  background: aqua;
+}
+</style>
+
+<div id="scroller">
+  <div id="scroller-content">
+    <div id="anchor1"></div>
+    <div id="anchor2"></div>
+  </div>
+</div>
+<div id="f1">
+  <div id="wrapper">
+    <div id="f2"></div>
+  </div>
+</div>
+
+<script>
+document.documentElement.scrollLeft = 100;
+document.documentElement.scrollTop = 100;
+let scroller = document.getElementById('scroller');
+scroller.scrollLeft = 25;
+scroller.scrollTop = 50;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-scroll-fixedpos-nested-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-scroll-fixedpos-nested-001-ref.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  width: 1000px;
+  height: 1000px;
+}
+
+div {
+  width: 50px;
+  height: 50px;
+}
+
+#anchor1 {
+  position: absolute;
+  left: 150px;
+  top: 150px;
+  background: orange;
+}
+
+#anchor2 {
+  position: absolute;
+  left: 250px;
+  top: 250px;
+  background: teal;
+}
+
+#f1 {
+  position: fixed;
+  left: 100px;
+  top: 100px;
+  background: yellow;
+}
+
+#f2 {
+  position: fixed;
+  left: 200px;
+  top: 200px;
+  background: aqua;
+}
+
+#f3 {
+  position: fixed;
+  left: 100px;
+  top: 200px;
+  background: aqua;
+}
+</style>
+
+<div id="anchor1"></div>
+<div id="anchor2"></div>
+<div id="f1"></div>
+<div id="f2"></div>
+<div id="f3"></div>
+
+<script>
+document.documentElement.scrollLeft = 100;
+document.documentElement.scrollTop = 100;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-scroll-fixedpos-nested-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-scroll-fixedpos-nested-002-ref.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  width: 1000px;
+  height: 1000px;
+}
+
+div {
+  width: 50px;
+  height: 50px;
+}
+
+#scroller {
+  position: absolute;
+  left: 150px;
+  top: 150px;
+  width: 200px;
+  height: 200px;
+  overflow: scroll;
+  outline: 1px solid black;
+}
+
+#scroller-content {
+  position: relative;
+  width: 400px;
+  height: 400px;
+}
+
+#anchor1 {
+  position: absolute;
+  left: 75px;
+  top: 100px;
+  background: orange;
+}
+
+#anchor2 {
+  position: absolute;
+  left: 175px;
+  top: 100px;
+  background: teal;
+}
+
+#f1 {
+  position: fixed;
+  left: 150px;
+  top: 150px;
+  background: yellow;
+}
+
+#f2 {
+  position: fixed;
+  left: 250px;
+  top: 150px;
+  background: aqua;
+}
+</style>
+
+<div id="scroller">
+  <div id="scroller-content">
+    <div id="anchor1"></div>
+    <div id="anchor2"></div>
+  </div>
+</div>
+<div id="f1"></div>
+<div id="f2"></div>
+
+<script>
+document.documentElement.scrollLeft = 100;
+document.documentElement.scrollTop = 100;
+let scroller = document.getElementById('scroller');
+scroller.scrollLeft = 25;
+scroller.scrollTop = 50;
+</script>

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -1047,7 +1047,7 @@ AnchorScrollAdjuster::Diff LocalFrameViewLayoutContext::registerAnchorScrollAdju
     return recaptureDiffers ? AnchorScrollAdjuster::SnapshotsDiffer : AnchorScrollAdjuster::SnapshotsMatch;
 }
 
-void LocalFrameViewLayoutContext::unregisterAnchorScrollAdjusterFor(const RenderBox& anchored)
+void LocalFrameViewLayoutContext::unregisterAnchorScrollAdjusterFor(const RenderBox& anchored, bool clearAnchorScrollAdjustment)
 {
     m_anchorScrollAdjusters.removeFirstMatching([&](auto& item) {
         return item.anchored() == &anchored;
@@ -1056,8 +1056,12 @@ void LocalFrameViewLayoutContext::unregisterAnchorScrollAdjusterFor(const Render
         return item.anchored() == &anchored;
     }));
 
-    if (anchored.layer())
-        anchored.layer()->clearAnchorScrollAdjustment();
+    if (anchored.layer()) {
+        if (clearAnchorScrollAdjustment)
+            anchored.layer()->clearAnchorScrollAdjustment();
+        else
+            anchored.layer()->setAnchorScrollAdjustment(LayoutSize { });
+    }
 }
 
 void LocalFrameViewLayoutContext::invalidateAnchorDependenciesForScroller(const RenderBox& scroller)

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -190,7 +190,7 @@ public:
     Vector<AnchorScrollAdjuster>& anchorScrollAdjusters() LIFETIME_BOUND { return m_anchorScrollAdjusters; }
     const AnchorScrollAdjuster* anchorScrollAdjusterFor(const RenderBox& anchored) const LIFETIME_BOUND;
     AnchorScrollAdjuster::Diff registerAnchorScrollAdjuster(AnchorScrollAdjuster&&);
-    void unregisterAnchorScrollAdjusterFor(const RenderBox& anchored);
+    void unregisterAnchorScrollAdjusterFor(const RenderBox& anchored, bool clearAnchorScrollAdjustment = true); // If clearAnchorScrollAdjustment is true, removes the layer's anchorScrollAdjustment; otherwise sets it to zero.
     void invalidateAnchorDependenciesForScroller(const RenderBox& scroller);
     void removeScrollerFromAnchorScrollAdjusters(const RenderBox& scroller);
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -848,7 +848,7 @@ public:
     bool hasTransformedAncestor() const { return m_hasTransformedAncestor; }
     bool participatesInPreserve3D() const;
 
-    std::optional<LayoutSize> anchorScrollAdjustment() const { return m_anchorScrollAdjustment; };
+    std::optional<LayoutSize> anchorScrollAdjustment() const { return m_anchorScrollAdjustment; }; // This is zero (rather than missing) on certain fixed boxes that don't have an AnchorScrollAdjuster.
     bool setAnchorScrollAdjustment(LayoutSize); // Returns true if changed.
     void clearAnchorScrollAdjustment();
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4121,8 +4121,8 @@ bool RenderLayerCompositor::requiresCompositingForPosition(RenderLayerModelObjec
         return false;
     }
 
-    bool intersectsViewport = fixedLayerIntersectsViewport(layer);
-    if (!intersectsViewport) {
+    // Scroll-adjusted boxes can be scrolled into view, so don't check viewport intersection on them.
+    if (!layer.anchorScrollAdjustment() && !fixedLayerIntersectsViewport(layer)) {
         queryData.nonCompositedForPositionReason = RenderLayer::NotCompositedForBoundsOutOfView;
         LOG_WITH_STREAM(Compositing, stream << "Layer " << &layer << " is outside the viewport");
         return false;

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -256,15 +256,26 @@ bool AnchorScrollAdjuster::invalidateForScroller(const RenderBox& scroller)
     return anchoredNeedsInvalidation;
 }
 
+void AnchorScrollAdjuster::removeMatchingSnapshots(const AnchorScrollAdjuster& containerAdjuster)
+{
+    if (m_adjustmentForViewport != containerAdjuster.m_adjustmentForViewport)
+        return;
+    for (auto containerSnapshot : containerAdjuster.m_scrollSnapshots) {
+        m_scrollSnapshots.removeFirstMatching([containerSnapshot](const auto& selfSnapshot) {
+            return selfSnapshot.m_scroller.get() == containerSnapshot.m_scroller.get();
+        });
+    }
+}
+
 namespace Style {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AnchorPositionedState);
 
-static inline void clearAnchorScrollSnapshots(RenderBox& anchored)
+static inline void clearAnchorScrollSnapshots(RenderBox& anchored, bool clearAnchorScrollAdjustment = true)
 {
     if (!anchored.layer()->anchorScrollAdjustment())
         return;
-    anchored.layoutContext().unregisterAnchorScrollAdjusterFor(anchored);
+    anchored.layoutContext().unregisterAnchorScrollAdjusterFor(anchored, clearAnchorScrollAdjustment);
 }
 
 static inline bool isFixed(const RenderBoxModelObject& box)
@@ -291,8 +302,8 @@ void AnchorPositionEvaluator::captureScrollSnapshots(RenderBox& anchored, bool i
     bool isFixedAnchor = isFixed(*defaultAnchor);
     if (defaultAnchor->isStickilyPositioned())
         adjuster.addStickySnapshot(*defaultAnchor);
-    for (auto* ancestor = defaultAnchor->container(); ancestor && ancestor != containingBlock; ancestor = ancestor->container()) {
-        if (auto* box = dynamicDowncast<RenderBox>(ancestor)) {
+    for (CheckedPtr ancestor = defaultAnchor->container(); ancestor && ancestor != containingBlock; ancestor = ancestor->container()) {
+        if (auto* box = dynamicDowncast<RenderBox>(ancestor.get())) {
             if (box->hasPotentiallyScrollableOverflow())
                 adjuster.addScrollSnapshot(*box);
             if (isFixed(*box))
@@ -302,14 +313,27 @@ void AnchorPositionEvaluator::captureScrollSnapshots(RenderBox& anchored, bool i
         }
     }
 
+    bool clearAdjustmentIfEmpty = true;
     bool isFixedAnchored = isFixed(anchored);
     if (isFixedAnchored != isFixedAnchor && !isFixed(*containingBlock)) {
         auto direction = isFixedAnchored ? AnchorScrollAdjuster::Direction::Normal : AnchorScrollAdjuster::Direction::Reverse;
         adjuster.addViewportSnapshot(anchored.view(), direction);
+        // Check if we're already nested in a scroll-adjusted container, and if so unwind any shared scroll adjustments.
+        for (CheckedPtr ancestor = anchored.parent(); ancestor && ancestor != containingBlock; ancestor = ancestor->parent()) {
+            auto* box = dynamicDowncast<RenderBox>(ancestor.get());
+            if (!box || !box->layer() || !box->layer()->anchorScrollAdjustment())
+                continue;
+            if (auto* ancestorAdjuster = box->layoutContext().anchorScrollAdjusterFor(*box)) {
+                adjuster.removeMatchingSnapshots(*ancestorAdjuster);
+                // We use the presence of the adjustment on fixedpos as a compositing signal.
+                anchored.layer()->setAnchorScrollAdjustment({ });
+                clearAdjustmentIfEmpty = false;
+            }
+        }
     }
 
     if (adjuster.isEmpty())
-        return clearAnchorScrollSnapshots(anchored);
+        return clearAnchorScrollSnapshots(anchored, clearAdjustmentIfEmpty);
 
     if (!anchored.style().positionTryFallbacks().isNone()
         || anchored.style().positionVisibility().contains(PositionVisibilityValue::NoOverflow))

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -102,6 +102,7 @@ public:
 
     enum Diff : uint8_t { New, SnapshotsDiffer, SnapshotsMatch };
     bool NODELETE recaptureDiffers(const AnchorScrollAdjuster&) const; // Snapshot differences can require invalidation.
+    void removeMatchingSnapshots(const AnchorScrollAdjuster&);
 
     void setFallbackLimits(const RenderBox& anchored);
     bool hasFallbackLimits() const { return m_hasFallback; }


### PR DESCRIPTION
#### ce2cb07293043620ed0e8b851f50a10c4e11342d
<pre>
Fix scroll overcompensation of fixed anchor-positioned elements when nested
<a href="https://bugs.webkit.org/show_bug.cgi?id=310888">https://bugs.webkit.org/show_bug.cgi?id=310888</a>
<a href="https://rdar.apple.com/174010503">rdar://174010503</a>

Reviewed by Simon Fraser.

Because the transform we use to compensate for scrolling affects descendants
(including out-of-flow descendants), a fixedpos anchored box inside another
fixedpos box currently double-compensates for scrolling.

This patch introduces an unwind() method to the AnchorScrollAdjuster so that
it can avoid duplicating the scroll compensation of its parent.
It also tags such boxes by setting a zeroed anchorScrollAdjustment on them even
if their AnchorScrollAdjuster is fully empty, so that the compositing code knows
that (unlike regular fixedpos elements) they can be scrolled into view.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-nested-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-nested-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-nested-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos-nested-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-scroll-fixedpos-nested-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/anchor-scroll-fixedpos-nested-002-ref.html: Added.
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::unregisterAnchorScrollAdjusterFor):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/rendering/RenderLayer.h:

Allow maintaining an anchorScrollAdjustment even if there is no anchorScrollAdjuster
(to identify cases where the scroll adjustment is managed by an ancestor).

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::requiresCompositingForPosition const):

Maintain compositing of scroll-adjusted fixedpos boxes, even if they&apos;re offscreen.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::AnchorScrollAdjuster::removeMatchingSnapshots):
(WebCore::Style::clearAnchorScrollSnapshots):
(WebCore::Style::AnchorPositionEvaluator::captureScrollSnapshots):
* Source/WebCore/style/AnchorPositionEvaluator.h:

Unwind scroll adjustments already performed by our ancestor.

Canonical link: <a href="https://commits.webkit.org/314757@main">https://commits.webkit.org/314757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b91cc85fec5cfdf4e4d04cce03ee9fa0ed8dc25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176190 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a469c2e-eb6c-4f8f-a2a9-15c04eecbd1b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40648 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130001 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a66efb6-dfda-446f-b4dc-8827b6c2c2a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170101 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110518 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0770b4f6-c56f-4e18-8fbc-9a6295ec7a36) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24929 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178731 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/29593 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40711 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138278 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37217 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149673 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104357 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33541 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39903 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39300 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/4646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/39550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39444 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->