### PR TITLE
[Win] Fix OpenSSLHelper summary() fallback

### DIFF
--- a/Source/WebCore/platform/network/curl/OpenSSLHelper.cpp
+++ b/Source/WebCore/platform/network/curl/OpenSSLHelper.cpp
@@ -196,25 +196,35 @@ static String toString(const ASN1_STRING* name)
     return result;
 }
 
-static String getCommonName(const X509* x509)
+static String getSubjectEntry(const X509* x509, int nid)
 {
     auto subjectName = X509_get_subject_name(x509);
     if (!subjectName)
         return String();
 
-    auto index = X509_NAME_get_index_by_NID(subjectName, NID_commonName, -1);
+    auto index = X509_NAME_get_index_by_NID(subjectName, nid, -1);
     if (index < 0)
         return String();
 
-    auto commonNameEntry = X509_NAME_get_entry(subjectName, index);
-    if (!commonNameEntry)
+    auto entry = X509_NAME_get_entry(subjectName, index);
+    if (!entry)
         return String();
 
-    auto commonNameEntryData = X509_NAME_ENTRY_get_data(commonNameEntry);
-    if (!commonNameEntryData)
+    auto entryData = X509_NAME_ENTRY_get_data(entry);
+    if (!entryData)
         return String();
 
-    return toString(commonNameEntryData);
+    return toString(entryData);
+}
+
+static String getCommonName(const X509* x509)
+{
+    return getSubjectEntry(x509, NID_commonName);
+}
+
+static String getOrganizationName(const X509* x509)
+{
+    return getSubjectEntry(x509, NID_organizationName);
 }
 
 static String getSubjectName(const X509* x509)
@@ -369,7 +379,10 @@ std::optional<WebCore::CertificateSummary> createSummaryInfo(const Vector<uint8_
 
     WebCore::CertificateSummary summaryInfo;
 
+    // Prefer the CN attribute, then O, to match the behavior of SecCertificateCopySubjectSummary on macOS.
     summaryInfo.subject = getCommonName(x509.get());
+    if (summaryInfo.subject.isNull())
+        summaryInfo.subject = getOrganizationName(x509.get());
     if (summaryInfo.subject.isNull())
         summaryInfo.subject = getSubjectName(x509.get());
 


### PR DESCRIPTION
#### 9ff899b9b2f4121ebf7e7f5b376e5ad8dab21574
<pre>
[Win] Fix OpenSSLHelper summary() fallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=316490">https://bugs.webkit.org/show_bug.cgi?id=316490</a>

Reviewed by Yusuke Suzuki.

http/tests/inspector/network/resource-certificate-subject-format.html expects
the certificate subject shown in Web Inspector to be a human-readable summary.
The layout test certificate has no CN attribute (its subject is
&quot;C=AU, ST=Some-State, O=WebKit Layout Tests&quot;), so the curl port fell back to
printing the whole distinguished name (&quot;WebKit Layout Tests, Some-State, AU&quot;).

Fall back to the organization name (O) before the full subject string, matching
the behavior of SecCertificateCopySubjectSummary on macOS and the soup port&apos;s
subjectSummaryFromDN() (314545@main).

* Source/WebCore/platform/network/curl/OpenSSLHelper.cpp:
(WebCore::OpenSSL::getSubjectEntry): Added, generalized from getCommonName.
(WebCore::OpenSSL::getCommonName):
(WebCore::OpenSSL::getOrganizationName): Added.
(WebCore::OpenSSL::createSummaryInfo): Prefer CN, then O, then the full subject.

Canonical link: <a href="https://commits.webkit.org/314770@main">https://commits.webkit.org/314770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/384717b0129ea731d5c2e61a0e21f4765b7c7c36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176012 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124222 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129839 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91446 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110364 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31216 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29919 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24748 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141203 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178550 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31448 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138207 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138118 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37228 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149513 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104079 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33393 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26378 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39723 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112797 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39119 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4494 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39364 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->