### PR TITLE
[CMake] Optimize configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,8 @@ if (DEVELOPER_MODE)
     endif ()
 endif ()
 
+WEBKIT_GENERATE_HEADER_MAPS()
+
 # -----------------------------------------------------------------------------
 # Print the features list last, for maximum visibility.
 # -----------------------------------------------------------------------------

--- a/Source/ThirdParty/ANGLE/PlatformCocoa.cmake
+++ b/Source/ThirdParty/ANGLE/PlatformCocoa.cmake
@@ -2,7 +2,9 @@ find_library(COREGRAPHICS_LIBRARY CoreGraphics)
 find_library(FOUNDATION_LIBRARY Foundation)
 find_library(IOSURFACE_LIBRARY IOSurface)
 find_library(METAL_LIBRARY Metal)
-find_package(ZLIB REQUIRED)
+if (NOT TARGET ZLIB::ZLIB)
+    find_package(ZLIB REQUIRED)
+endif ()
 
 list(APPEND ANGLE_SOURCES
     ${metal_backend_sources}

--- a/Source/WTF/Scripts/generate-unified-source-bundles.py
+++ b/Source/WTF/Scripts/generate-unified-source-bundles.py
@@ -128,6 +128,13 @@ class SourceFile:
         else:
             return str(self._args.derived_sources_path / self.path)
 
+    def bundled_source_form(self) -> str:
+        # String form for the --print-bundled-sources list: derived sources are
+        # rooted under derived_sources_path, source-tree files stay relative.
+        if self.derived:
+            return str(self._args.derived_sources_path / self.path)
+        return str(self.path)
+
 
 class BundleManager:
     def __init__(self, extension: str, suffix: str, max_count: int, args, generated_sources: list[str], output_sources: list[str]):
@@ -223,8 +230,9 @@ def parse_args():
                         help='Path to the root of the source directory.')
 
     mode_group = parser.add_mutually_exclusive_group()
-    mode_group.add_argument('--print-bundled-sources', action='store_true', default=False,
-                            help='Print bundled sources rather than generating sources.')
+    mode_group.add_argument('--print-bundled-sources', type=Path, metavar='PATH',
+                            help='While generating bundles, also write the bundled member '
+                                 'sources (one per line) to PATH.')
     mode_group.add_argument('--print-all-sources', action='store_true', default=False,
                             help='Print all sources rather than generating sources.')
     mode_group.add_argument('--generate-xcfilelists', action='store_true', default=False,
@@ -262,9 +270,7 @@ def parse_args():
         parser.error("Source tree {} does not exist.".format(args.source_tree_path))
 
     # Determine mode from flags
-    if args.print_bundled_sources:
-        args.mode = 'PrintBundledSources'
-    elif args.print_all_sources:
+    if args.print_all_sources:
         args.mode = 'PrintAllSources'
     elif args.generate_xcfilelists:
         args.mode = 'GenerateXCFilelists'
@@ -293,6 +299,7 @@ def main() -> None:
     generated_sources: list[str] = []
     input_sources: list[str] = []
     output_sources: list[str] = []
+    bundled_members: list[str] = []
 
     bundle_managers = {
         '.cpp': BundleManager('cpp', '.cpp', args.max_cpp_bundle_count, args, generated_sources, output_sources),
@@ -347,11 +354,11 @@ def main() -> None:
     for source_file in sorted(source_files, key=SourceFile.sort_key):
         if args.mode in ('GenerateBundles', 'GenerateXCFilelists'):
             process_file_for_unified_source_generation(source_file, args, bundle_managers, generated_sources, input_sources)
+            if args.mode == 'GenerateBundles' and args.print_bundled_sources \
+                    and bundle_managers.get(source_file.bundle_manager_key) and source_file.unifiable:
+                bundled_members.append(source_file.bundled_source_form())
         elif args.mode == 'PrintAllSources':
             generated_sources.append(str(source_file))
-        elif args.mode == 'PrintBundledSources':
-            if bundle_managers.get(source_file.bundle_manager_key) and source_file.unifiable:
-                generated_sources.append(str(source_file))
 
     if args.mode != 'PrintAllSources':
         for manager in bundle_managers.values():
@@ -378,6 +385,12 @@ def main() -> None:
         if args.output_xcfilelist_path:
             with open(args.output_xcfilelist_path, 'w') as f:
                 f.write("\n".join(sorted(output_sources)) + "\n")
+
+    if args.mode == 'GenerateBundles' and args.print_bundled_sources:
+        with open(args.print_bundled_sources, 'w') as f:
+            f.write("\n".join(bundled_members))
+            if bundled_members:
+                f.write("\n")
 
     # We use stdout to report our unified source list to CMake.
     # Add trailing semicolon and avoid a trailing newline for CMake's sake.

--- a/Source/WTF/wtf/PlatformCocoa.cmake
+++ b/Source/WTF/wtf/PlatformCocoa.cmake
@@ -131,7 +131,7 @@ add_custom_command(
         ${WTF_DERIVED_SOURCES_DIR}/mach_exc.h
         ${WTF_DERIVED_SOURCES_DIR}/mach_excServer.c
         ${WTF_DERIVED_SOURCES_DIR}/mach_excUser.c
-    MAIN_DEPENDENCY mac/MachExceptions.defs
+    MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/mac/MachExceptions.defs
     WORKING_DIRECTORY ${WTF_DERIVED_SOURCES_DIR}
     COMMAND mig -DMACH_EXC_SERVER_TASKIDTOKEN_STATE -sheader MachExceptionsServer.h MachExceptions.defs
     VERBATIM)

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2815,7 +2815,7 @@ list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/ColorData.cpp)
 # Generate DOMJITAbstractHeapRepository.h
 add_custom_command(
     OUTPUT ${WebCore_DERIVED_SOURCES_DIR}/DOMJITAbstractHeapRepository.h
-    MAIN_DEPENDENCY domjit/DOMJITAbstractHeapRepository.yaml
+    MAIN_DEPENDENCY ${WEBCORE_DIR}/domjit/DOMJITAbstractHeapRepository.yaml
     DEPENDS ${WEBCORE_DIR}/domjit/generate-abstract-heap.rb
     COMMAND ${Ruby_EXECUTABLE} ${WEBCORE_DIR}/domjit/generate-abstract-heap.rb ${WEBCORE_DIR}/domjit/DOMJITAbstractHeapRepository.yaml ${WebCore_DERIVED_SOURCES_DIR}/DOMJITAbstractHeapRepository.h
     VERBATIM)
@@ -2824,7 +2824,7 @@ list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/DOMJITAbstractHeapRep
 # Generate XMLViewerCSS.h
 add_custom_command(
     OUTPUT ${WebCore_DERIVED_SOURCES_DIR}/XMLViewerCSS.h ${WebCore_DERIVED_SOURCES_DIR}/XMLViewer.min.css
-    MAIN_DEPENDENCY xml/XMLViewer.css
+    MAIN_DEPENDENCY ${WEBCORE_DIR}/xml/XMLViewer.css
     DEPENDS ${JavaScriptCore_SCRIPTS_DIR}/xxd.pl ${JavaScriptCore_SCRIPTS_DIR}/cssmin.py
     COMMAND ${PYTHON_EXECUTABLE} ${JavaScriptCore_SCRIPTS_DIR}/cssmin.py < ${WEBCORE_DIR}/xml/XMLViewer.css > ${WebCore_DERIVED_SOURCES_DIR}/XMLViewer.min.css
     COMMAND ${PERL_EXECUTABLE} ${JavaScriptCore_SCRIPTS_DIR}/xxd.pl XMLViewer_css ${WebCore_DERIVED_SOURCES_DIR}/XMLViewer.min.css ${WebCore_DERIVED_SOURCES_DIR}/XMLViewerCSS.h
@@ -2834,7 +2834,7 @@ list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/XMLViewerCSS.h)
 # Generate XMLViewerJS.h
 add_custom_command(
     OUTPUT ${WebCore_DERIVED_SOURCES_DIR}/XMLViewerJS.h ${WebCore_DERIVED_SOURCES_DIR}/XMLViewer.min.js
-    MAIN_DEPENDENCY xml/XMLViewer.js
+    MAIN_DEPENDENCY ${WEBCORE_DIR}/xml/XMLViewer.js
     DEPENDS ${JavaScriptCore_SCRIPTS_DIR}/xxd.pl ${JavaScriptCore_SCRIPTS_DIR}/jsmin.py
     COMMAND ${PYTHON_EXECUTABLE} ${JavaScriptCore_SCRIPTS_DIR}/jsmin.py < ${WEBCORE_DIR}/xml/XMLViewer.js > ${WebCore_DERIVED_SOURCES_DIR}/XMLViewer.min.js
     COMMAND ${PERL_EXECUTABLE} ${JavaScriptCore_SCRIPTS_DIR}/xxd.pl XMLViewer_js ${WebCore_DERIVED_SOURCES_DIR}/XMLViewer.min.js ${WebCore_DERIVED_SOURCES_DIR}/XMLViewerJS.h

--- a/Source/WebCore/PlatformCocoa.cmake
+++ b/Source/WebCore/PlatformCocoa.cmake
@@ -82,11 +82,14 @@ find_library(UNIFORMTYPEIDENTIFIERS_LIBRARY UniformTypeIdentifiers)
 find_library(VIDEOTOOLBOX_LIBRARY VideoToolbox)
 find_library(XML2_LIBRARY XML2)
 
-find_package(SQLite3 REQUIRED)
-find_package(ZLIB REQUIRED)
-
-if (NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+# SQLite3::SQLite3 and ZLIB::ZLIB are declared in OptionsCocoa.cmake; only search
+# if missing (e.g. ANGLE/WebCore configured standalone).
+if (NOT TARGET SQLite3::SQLite3)
+    find_package(SQLite3 REQUIRED)
     add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif ()
+if (NOT TARGET ZLIB::ZLIB)
+    find_package(ZLIB REQUIRED)
 endif ()
 
 list(APPEND WebCore_UNIFIED_SOURCE_LIST_FILES

--- a/Source/WebCore/WebCoreMacros.cmake
+++ b/Source/WebCore/WebCoreMacros.cmake
@@ -59,29 +59,53 @@ function(GENERATE_BINDINGS target)
     set(included_idl_files_list ${CMAKE_CURRENT_BINARY_DIR}/included_idl_files_${target}.tmp)
     set(_supplemental_dependency)
 
-    set(content)
-    foreach (f ${arg_INPUT_FILES} ${arg_SUPPLEMENTAL_IDL_FILES})
+    # Absolutize inputs once. These feed both the file lists handed to the
+    # generator and the custom command DEPENDS below: relative DEPENDS force
+    # CMake's O(N^2) linear output-to-source search during generation, and with
+    # ~1000 IDLs that dominates the configure's generate step.
+    set(_abs_input_files)
+    foreach (f ${arg_INPUT_FILES})
         if (NOT IS_ABSOLUTE ${f})
             set(f ${CMAKE_CURRENT_SOURCE_DIR}/${f})
         endif ()
+        list(APPEND _abs_input_files ${f})
+    endforeach ()
+    set(_abs_supplemental_files)
+    foreach (f ${arg_SUPPLEMENTAL_IDL_FILES})
+        if (NOT IS_ABSOLUTE ${f})
+            set(f ${CMAKE_CURRENT_SOURCE_DIR}/${f})
+        endif ()
+        list(APPEND _abs_supplemental_files ${f})
+    endforeach ()
+    set(_abs_pp_input_files)
+    foreach (f ${arg_PP_INPUT_FILES})
+        if (NOT IS_ABSOLUTE ${f})
+            set(f ${CMAKE_CURRENT_SOURCE_DIR}/${f})
+        endif ()
+        list(APPEND _abs_pp_input_files ${f})
+    endforeach ()
+    set(_abs_included_files)
+    foreach (f ${arg_INCLUDED_FILES})
+        if (NOT IS_ABSOLUTE ${f})
+            set(f ${CMAKE_CURRENT_SOURCE_DIR}/${f})
+        endif ()
+        list(APPEND _abs_included_files ${f})
+    endforeach ()
+
+    set(content)
+    foreach (f ${_abs_input_files} ${_abs_supplemental_files})
         set(content "${content}${f}\n")
     endforeach ()
     file(WRITE ${idl_files_list} ${content})
 
     set(pp_content)
-    foreach (f ${arg_PP_INPUT_FILES})
-        if (NOT IS_ABSOLUTE ${f})
-            set(f ${CMAKE_CURRENT_SOURCE_DIR}/${f})
-        endif ()
+    foreach (f ${_abs_pp_input_files})
         set(pp_content "${pp_content}${f}\n")
     endforeach ()
     file(WRITE ${pp_idl_files_list} ${pp_content})
 
     set(include_content)
-    foreach (f ${arg_INPUT_FILES} ${arg_SUPPLEMENTAL_IDL_FILES} ${arg_INCLUDED_FILES})
-        if (NOT IS_ABSOLUTE ${f})
-            set(f ${CMAKE_CURRENT_SOURCE_DIR}/${f})
-        endif ()
+    foreach (f ${_abs_input_files} ${_abs_supplemental_files} ${_abs_included_files})
         set(include_content "${include_content}${f}\n")
     endforeach ()
     file(WRITE ${included_idl_files_list} ${include_content})
@@ -170,9 +194,9 @@ function(GENERATE_BINDINGS target)
         COMMAND ${PERL_EXECUTABLE} ${binding_generator} ${args}
         COMMAND ${CMAKE_COMMAND} -E touch ${_stamp_file}
         DEPENDS
-            ${arg_INPUT_FILES}
-            ${arg_SUPPLEMENTAL_IDL_FILES}
-            ${arg_PP_INPUT_FILES}
+            ${_abs_input_files}
+            ${_abs_supplemental_files}
+            ${_abs_pp_input_files}
             ${common_generator_dependencies}
             ${binding_generator}
             ${idl_attributes_file}

--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -51,24 +51,26 @@ set(CMAKE_LINK_DEPENDS_NO_SHARED ON)
 
 set(USE_ANGLE_EGL ON)
 
-find_package(SQLite3 REQUIRED)
+function(WEBKIT_ADD_SDK_IMPORTED_LIBRARY _target _library)
+    if (NOT TARGET ${_target})
+        add_library(${_target} UNKNOWN IMPORTED)
+        set_target_properties(${_target} PROPERTIES IMPORTED_LOCATION "${CMAKE_OSX_SYSROOT}/usr/lib/${_library}")
+    endif ()
+endfunction()
+
+WEBKIT_ADD_SDK_IMPORTED_LIBRARY(SQLite::SQLite3 libsqlite3.tbd)
+WEBKIT_ADD_SDK_IMPORTED_LIBRARY(LibXml2::LibXml2 libxml2.tbd)
+WEBKIT_ADD_SDK_IMPORTED_LIBRARY(LibXslt::LibXslt libxslt.tbd)
+WEBKIT_ADD_SDK_IMPORTED_LIBRARY(LibXslt::LibExslt libexslt.tbd)
+WEBKIT_ADD_SDK_IMPORTED_LIBRARY(ZLIB::ZLIB libz.tbd)
 if (NOT TARGET SQLite3::SQLite3)
     add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
 endif ()
 
 find_package(ICU 70.1 REQUIRED COMPONENTS data i18n uc)
-find_package(LibXml2 2.8.0 REQUIRED)
-find_package(LibXslt 1.1.13 REQUIRED)
 set(CMAKE_HAVE_PTHREAD_H 1 CACHE INTERNAL "")
 set(CMAKE_HAVE_LIBC_PTHREAD 1 CACHE INTERNAL "")
 find_package(Threads REQUIRED)
-
-# Strip ${SDK}/usr/include from these imported targets; reachable via -isysroot.
-foreach (_t SQLite::SQLite3 LibXml2::LibXml2 LibXslt::LibXslt LibXslt::LibExslt)
-    if (TARGET ${_t})
-        set_target_properties(${_t} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")
-    endif ()
-endforeach ()
 
 string(REGEX MATCH "^[0-9]+" _sdk_major "${_sdk_version}")
 set(_additions_candidates

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -153,12 +153,20 @@ if (EXISTS "${_clang}")
     set(CMAKE_OBJCXX_COMPILER "${_clang}++")
 endif ()
 
-# Deployment target must match SDK version -- PlatformHave.h SPI guards depend on
-# __MAC_OS_X_VERSION_MIN_REQUIRED. Auto-bump if the preset floor is below the SDK.
-string(REGEX MATCH "^[0-9]+\\.[0-9]+" _sdk_major_minor "${_sdk_version}")
-if (_sdk_major_minor AND (NOT CMAKE_OSX_DEPLOYMENT_TARGET OR CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS _sdk_major_minor))
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "${_sdk_major_minor}" CACHE STRING "Minimum macOS version" FORCE)
-    message(WARNING "Deployment target auto-set to SDK version: ${CMAKE_OSX_DEPLOYMENT_TARGET} (SPI header guards require this)")
+# Default the deployment target to the host macOS version.
+if (NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+    execute_process(
+        COMMAND sw_vers -productVersion
+        OUTPUT_VARIABLE _host_os_version
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE _host_os_result)
+    string(REGEX MATCH "^[0-9]+\\.[0-9]+" _host_os_major_minor "${_host_os_version}")
+    if (_host_os_result EQUAL 0 AND _host_os_major_minor)
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "${_host_os_major_minor}" CACHE STRING "Minimum macOS version" FORCE)
+    endif ()
+    unset(_host_os_version)
+    unset(_host_os_result)
+    unset(_host_os_major_minor)
 endif ()
 
 set(_sdk_prefix "macosx")

--- a/Source/cmake/WebKitCommon.cmake
+++ b/Source/cmake/WebKitCommon.cmake
@@ -245,11 +245,27 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
     # Set the variable with uppercase name to keep compatibility with code and users expecting it.
     set(PYTHON_EXECUTABLE ${Python_EXECUTABLE} CACHE FILEPATH "Path to the Python interpreter")
 
-    # We cannot check for Ruby_FOUND because it is set only when the full package is installed and
-    # the only thing we need is the interpreter. Unlike Python, cmake does not provide a macro
-    # for finding only the Ruby interpreter.
+    # We only need the Ruby interpreter (to run .rb generators), not the dev
+    # package, so find the executable and query its version directly instead of
+    # paying find_package(Ruby)'s config probing (a dozen ruby subprocesses).
     message(CHECK_START "Ruby interpreter executable")
-    find_package(Ruby 2.5 QUIET)
+    # Honor a pinned interpreter passed as -DRUBY_EXECUTABLE=... (the legacy name
+    # find_package(Ruby) accepted; some bots use it to avoid a broken PATH ruby).
+    if (RUBY_EXECUTABLE AND NOT Ruby_EXECUTABLE)
+        set(Ruby_EXECUTABLE "${RUBY_EXECUTABLE}" CACHE FILEPATH "Path to the Ruby interpreter")
+    endif ()
+    find_program(Ruby_EXECUTABLE NAMES ruby)
+    if (Ruby_EXECUTABLE)
+        execute_process(
+            COMMAND "${Ruby_EXECUTABLE}" -e "print RUBY_VERSION"
+            OUTPUT_VARIABLE Ruby_VERSION
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            RESULT_VARIABLE _ruby_version_result)
+        if (NOT _ruby_version_result EQUAL 0)
+            set(Ruby_VERSION "")
+        endif ()
+        unset(_ruby_version_result)
+    endif ()
     if (Ruby_EXECUTABLE AND Ruby_VERSION)
         if (Ruby_VERSION VERSION_LESS 2.5)
             message(CHECK_FAIL "${Ruby_EXECUTABLE} (version: ${Ruby_VERSION}, minimum required 2.5)")

--- a/Source/cmake/WebKitHeaderMap.cmake
+++ b/Source/cmake/WebKitHeaderMap.cmake
@@ -6,6 +6,13 @@ else ()
 endif ()
 option(USE_HEADER_MAPS "Collapse per-target include directories into a Clang header map" ${_USE_HEADER_MAPS_DEFAULT})
 
+if (USE_HEADER_MAPS)
+    # One flat directory holds every framework's .hmap and its .hmap.manifest.
+    # Cleared once per configure so entries for removed targets don't linger.
+    file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/HeaderMaps")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/HeaderMaps")
+endif ()
+
 function(WEBKIT_MAKE_HEADER_MAP _target _source_root _dirs_var)
     set(_hmap_dirs)
     set(_result)
@@ -43,21 +50,32 @@ function(WEBKIT_MAKE_HEADER_MAP _target _source_root _dirs_var)
         return()
     endif ()
 
-    set(_dirs_file "${CMAKE_CURRENT_BINARY_DIR}/${_target}HeaderMap.dirs")
-    set(_hmap_file "${CMAKE_CURRENT_BINARY_DIR}/${_target}.hmap")
+    set(_hmap_file "${CMAKE_BINARY_DIR}/HeaderMaps/${_target}.hmap")
     list(JOIN _hmap_dirs "\n" _dirs_content)
-    file(WRITE "${_dirs_file}" "${_dirs_content}\n")
-
-    execute_process(
-        COMMAND "${PYTHON_EXECUTABLE}" "${TOOLS_DIR}/Scripts/generate-header-map"
-                --dirs-file "${_dirs_file}" --framework "${_target}" -o "${_hmap_file}"
-        RESULT_VARIABLE _hmap_result
-    )
-    if (NOT _hmap_result EQUAL 0)
-        message(WARNING "generate-header-map failed for ${_target}; falling back to -I directories")
-        return()
-    endif ()
+    # Write a self-describing manifest (output path, framework, then dirs). The
+    # .hmap files are generated in one batched python pass (WEBKIT_GENERATE_HEADER_MAPS)
+    # after all targets are configured. The .hmap path is deterministic, so wire
+    # it into this target's include directories now.
+    file(WRITE "${CMAKE_BINARY_DIR}/HeaderMaps/${_target}.hmap.manifest"
+        "${_hmap_file}\n${_target}\n${_dirs_content}\n")
 
     list(TRANSFORM _result REPLACE "^${_placeholder}$" "${_hmap_file}")
     set(${_dirs_var} "${_result}" PARENT_SCOPE)
+endfunction()
+
+# Generate every framework's .hmap in a single python invocation, reading the
+# manifests left in ${CMAKE_BINARY_DIR}/HeaderMaps. Call once after all targets
+# are configured. One interpreter launch replaces ~2 per framework.
+function(WEBKIT_GENERATE_HEADER_MAPS)
+    if (NOT USE_HEADER_MAPS)
+        return()
+    endif ()
+    execute_process(
+        COMMAND "${PYTHON_EXECUTABLE}" "${TOOLS_DIR}/Scripts/generate-header-map"
+                --header-maps-dir "${CMAKE_BINARY_DIR}/HeaderMaps"
+        RESULT_VARIABLE _result
+    )
+    if (NOT _result EQUAL 0)
+        message(WARNING "generate-header-map (batch) failed; targets fall back to -I directories")
+    endif ()
 endfunction()

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -48,9 +48,12 @@ macro(WEBKIT_COMPUTE_SOURCES _framework)
     endif ()
 
     if (ENABLE_UNIFIED_BUILDS)
+        # One pass generates the bundles (stdout = files to compile) and writes the
+        # bundled member list to a side file via --print-bundled-sources.
+        set(_bundledSourcesFile "${CMAKE_CURRENT_BINARY_DIR}/${_framework}BundledSources.txt")
         execute_process(COMMAND ${Python_EXECUTABLE} ${WTF_SCRIPTS_DIR}/generate-unified-source-bundles.py
             ${gusb_args}
-            "--print-bundled-sources"
+            --print-bundled-sources "${_bundledSourcesFile}"
             ${_sourceListFileTruePaths}
             RESULT_VARIABLE _resultTmp
             OUTPUT_VARIABLE _outputTmp)
@@ -59,21 +62,13 @@ macro(WEBKIT_COMPUTE_SOURCES _framework)
              message(FATAL_ERROR "generate-unified-source-bundles.py exited with non-zero status, exiting")
         endif ()
 
-        foreach (_sourceFileTmp IN LISTS _outputTmp)
+        # Member sources folded into bundles: compiled via the bundle, so mark header-only.
+        file(STRINGS "${_bundledSourcesFile}" _bundledSources)
+        foreach (_sourceFileTmp IN LISTS _bundledSources)
             set_source_files_properties(${_sourceFileTmp} PROPERTIES HEADER_FILE_ONLY ON)
             list(APPEND ${_framework}_HEADERS ${_sourceFileTmp})
         endforeach ()
         unset(_sourceFileTmp)
-
-        execute_process(COMMAND ${Python_EXECUTABLE} ${WTF_SCRIPTS_DIR}/generate-unified-source-bundles.py
-            ${gusb_args}
-            ${_sourceListFileTruePaths}
-            RESULT_VARIABLE  _resultTmp
-            OUTPUT_VARIABLE _outputTmp)
-
-        if (${_resultTmp})
-            message(FATAL_ERROR "generate-unified-source-bundles.py exited with non-zero status, exiting")
-        endif ()
 
         foreach (_file IN LISTS _outputTmp)
             # rdar://177465799 (Move bare filenames in DerivedSources to logical sub-folders)
@@ -668,13 +663,13 @@ function(WEBKIT_COPY_FILES target_name)
         if (APPLE AND NOT opt_NO_SYMLINK)
             add_custom_command(OUTPUT ${dst_file}
                 COMMAND ${CMAKE_COMMAND} -E create_symlink ${src_file} ${dst_file}
-                MAIN_DEPENDENCY ${file}
+                MAIN_DEPENDENCY ${src_file}
                 VERBATIM
             )
         else ()
             add_custom_command(OUTPUT ${dst_file}
                 COMMAND ${CMAKE_COMMAND} -E copy_if_different ${src_file} ${dst_file}
-                MAIN_DEPENDENCY ${file}
+                MAIN_DEPENDENCY ${src_file}
                 VERBATIM
             )
         endif ()
@@ -725,7 +720,7 @@ function(WEBKIT_SYMLINK_FILES target_name)
         endif ()
         add_custom_command(OUTPUT ${dst_file}
             COMMAND ${CMAKE_COMMAND} -E create_symlink ${src_file} ${dst_file}
-            MAIN_DEPENDENCY ${file}
+            MAIN_DEPENDENCY ${src_file}
             VERBATIM
         )
         list(APPEND dst_files ${dst_file})

--- a/Tools/Scripts/generate-header-map
+++ b/Tools/Scripts/generate-header-map
@@ -29,13 +29,25 @@ On basename collisions the first directory listed wins, matching -I search order
 """
 
 import argparse
-import json
+import importlib.util
 import os
-import subprocess
 import sys
+from importlib.machinery import SourceFileLoader
 
 HEADER_EXTENSIONS = ('.h', '.hh', '.hpp', '.hxx', '.inc', '.def')
 HMAPTOOL = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'hmaptool')
+
+
+def _load_hmaptool():
+    # hmaptool has no .py extension, so load it via an explicit source loader.
+    # Calling its writer in-process avoids a second Python interpreter launch
+    # (and a JSON manifest round-trip through disk) per framework, which
+    # dominated header-map generation time.
+    loader = SourceFileLoader('hmaptool', HMAPTOOL)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
 
 
 def collect_mappings(directories, framework=None):
@@ -85,25 +97,52 @@ def collect_mappings(directories, framework=None):
     return mappings
 
 
+def _generate(directories, framework, output, write_headermap):
+    mappings = collect_mappings([d for d in directories if d], framework)
+    # Sort keys for deterministic output (clang header maps are order-sensitive
+    # in their bucket layout; sorting keeps regenerated maps byte-stable).
+    write_headermap(dict(sorted(mappings.items())), output)
+
+
+def run_header_maps_dir(header_maps_dir):
+    # Batch mode: every *.hmap.manifest in header_maps_dir is self-describing --
+    # line 1 is the output .hmap path, line 2 the framework, lines 3+ the
+    # directories. One interpreter launch and one hmaptool import for all
+    # frameworks, instead of one process (plus one for hmaptool) per framework.
+    write_headermap = _load_hmaptool().write_headermap
+    for name in sorted(os.listdir(header_maps_dir)):
+        if not name.endswith('.hmap.manifest'):
+            continue
+        with open(os.path.join(header_maps_dir, name)) as f:
+            lines = f.read().splitlines()
+        output, framework, directories = lines[0], lines[1] or None, lines[2:]
+        _generate(directories, framework, output, write_headermap)
+    return 0
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('-o', '--output', required=True, help='output .hmap path')
-    parser.add_argument('--dirs-file', required=True,
-                        help='file containing one include directory per line')
+    parser.add_argument('--header-maps-dir',
+                        help='batch mode: generate every .hmap described by the '
+                             '*.hmap.manifest files in this directory, in one process')
+    parser.add_argument('-o', '--output', help='output .hmap path (single-file mode)')
+    parser.add_argument('--dirs-file',
+                        help='file with one include directory per line (single-file mode)')
     parser.add_argument('--framework',
                         help='if set, also emit FRAMEWORK/Header.h entries so '
                              '<FRAMEWORK/Header.h> resolves to the source/derived path '
                              'without requiring a physical PrivateHeaders/ copy')
     args = parser.parse_args()
 
+    if args.header_maps_dir:
+        return run_header_maps_dir(args.header_maps_dir)
+
+    if not args.dirs_file or not args.output:
+        parser.error('--dirs-file and --output are required unless --header-maps-dir is given')
     with open(args.dirs_file) as f:
         directories = [line.strip() for line in f if line.strip()]
-
-    manifest = args.output + '.json'
-    with open(manifest, 'w') as f:
-        json.dump({'mappings': collect_mappings(directories, args.framework)}, f, indent=2, sort_keys=True)
-
-    return subprocess.call([sys.executable, HMAPTOOL, 'write', manifest, args.output])
+    _generate(directories, args.framework, args.output, _load_hmaptool().write_headermap)
+    return 0
 
 
 if __name__ == '__main__':

--- a/Tools/Scripts/hmaptool
+++ b/Tools/Scripts/hmaptool
@@ -175,23 +175,10 @@ def next_power_of_two(value):
         raise ArgumentError
     return 1 if value == 0 else 2**(value - 1).bit_length()
 
-def action_write(name, args):
-    "write a headermap file from a JSON definition"
-
-    parser = optparse.OptionParser("%%prog %s [options] <input path> <output path>" % (
-            name,))
-    (opts, args) = parser.parse_args(args)
-
-    if len(args) != 2:
-        parser.error("invalid number of arguments")
-
-    input_path,output_path = args
-
-    with open(input_path, "r") as f:
-        input_data = json.load(f)
+def write_headermap(mappings, output_path):
+    "write a binary headermap file from a {key: value} mappings dict"
 
     # Compute the headermap contents, we make a table that is 1/3 full.
-    mappings = input_data['mappings']
     num_buckets = next_power_of_two(len(mappings) * 3)
 
     table = [(0, 0, 0)
@@ -241,6 +228,23 @@ def action_write(name, args):
         for bucket in table:
             f.write(struct.pack(bucket_fmt, *bucket))
         f.write(strtable.encode())
+
+def action_write(name, args):
+    "write a headermap file from a JSON definition"
+
+    parser = optparse.OptionParser("%%prog %s [options] <input path> <output path>" % (
+            name,))
+    (opts, args) = parser.parse_args(args)
+
+    if len(args) != 2:
+        parser.error("invalid number of arguments")
+
+    input_path,output_path = args
+
+    with open(input_path, "r") as f:
+        input_data = json.load(f)
+
+    write_headermap(input_data['mappings'], output_path)
 
 def action_tovfs(name, args):
     "convert a headermap to a VFS layout"


### PR DESCRIPTION
#### 1dc64ec88d623774c090964a87ca272169b2600a
<pre>
[CMake] Optimize configuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=316493">https://bugs.webkit.org/show_bug.cgi?id=316493</a>
<a href="https://rdar.apple.com/178919004">rdar://178919004</a>

Reviewed by Mike Wyrzykowski.

Saves about 5s in a clean build. (Worth 120 CPUs on a Mac Studio, since
configuration is single-core and blocks the rest of the build).

* CMakeLists.txt: Moved header map generation to be a single Python invocation
at the end of configuration, instead of one invocation per target, since each
invocation costs like 150ms.

* Source/ThirdParty/ANGLE/PlatformCocoa.cmake: Only search for ZLib if needed.

* Source/WTF/Scripts/generate-unified-source-bundles.py: Run
--print-bundled-sources during --generate-bundles so we can run this script once
instead of twice.

* Source/WTF/wtf/PlatformCocoa.cmake: Use absolute paths when specifying
dependencies because absolute paths get the O(1) hash table treatment in
depdendency resolution while relative paths get the O(N^2) linear scan treatment.

* Source/WebCore/PlatformCocoa.cmake: Only search for SQLite and ZLib if needed.

* Source/WebCore/WebCoreMacros.cmake: Use absolute paths. (See above.)

* Source/cmake/OptionsCocoa.cmake: No need to search for things that we know
are in the SDK. They have no other location.

* Source/cmake/OptionsMac.cmake: Stop erroring when using a newer SDK to target
an older OS. This is a supported configuration (for downlevels), and the warning
was crufting up my output.

* Source/cmake/WebKitCommon.cmake: Stop launching Ruby 16 times to evaluate all
its features; we just need a version number.

* Source/cmake/WebKitHeaderMap.cmake: Put all header map manifests in one place
so they&apos;re easy to find at the end of configuration, for a single pass of header
map generation.

* Source/cmake/WebKitMacros.cmake: generate-unified-source-bundles.py only needs
to run once now.

Use absolutely paths to avoid the O(N^2) behavior. (See above.)

* Tools/Scripts/generate-header-map: Search for all header map manifests in a
single folder and generate them all. (Used to avoid lauching Python once per
target. There are many targets.)

* Tools/Scripts/hmaptool: Factored write_headermap into a helper function so we
can call it more than once for more than one manifest.

Canonical link: <a href="https://commits.webkit.org/314748@main">https://commits.webkit.org/314748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bfe0eac451255fef2e74f0dfbc24c828edc0f83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176018 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124228 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a60a02fa-f89c-4b23-bd23-37938dec5ae1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129844 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91451 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9df2dd0c-1b8b-4b70-9c16-2912ebe52b54) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110369 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/50cd8b70-b762-4ac2-8e9a-08ad2ea13ae8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31220 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29925 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24754 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159127 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141194 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178556 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27864 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31454 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138212 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138123 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149519 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104089 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25435 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33397 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26384 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199649 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39729 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112803 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53681 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39125 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4483 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39269 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->