### PR TITLE
[Wasm] `intoCharCodeArray` copies 8-bit strings one character at a time

### DIFF
--- a/JSTests/microbenchmarks/wasm-into-char-code-array-8bit-short.js
+++ b/JSTests/microbenchmarks/wasm-into-char-code-array-8bit-short.js
@@ -1,0 +1,23 @@
+//@ $skipModes << :lockdown
+//@ skip if $addressBits <= 32
+// Benchmarks the wasm:js-string intoCharCodeArray builtin with a short 8-bit string.
+// See wasm-into-char-code-array-8bit.js for the module source.
+const moduleBytes = new Uint8Array([0,97,115,109,1,0,0,0,1,146,128,128,128,0,3,94,119,1,96,3,111,99,0,127,1,127,96,1,127,1,100,0,2,164,128,128,128,0,1,14,119,97,115,109,58,106,115,45,115,116,114,105,110,103,17,105,110,116,111,67,104,97,114,67,111,100,101,65,114,114,97,121,0,1,3,131,128,128,128,0,2,2,1,7,147,128,128,128,0,2,9,109,97,107,101,65,114,114,97,121,0,1,3,114,117,110,0,2,10,187,128,128,128,0,2,135,128,128,128,0,0,32,0,251,7,0,11,169,128,128,128,0,1,2,127,2,64,3,64,32,3,32,2,79,13,1,32,4,32,0,32,1,65,0,16,0,106,33,4,32,3,65,1,106,33,3,12,0,11,11,32,4,11]);
+
+const module = new WebAssembly.Module(moduleBytes, { builtins: ['js-string'] });
+const instance = new WebAssembly.Instance(module, {});
+const { makeArray, run } = instance.exports;
+
+const length = 15;
+let string = "";
+for (let i = 0; i < length; ++i)
+    string += String.fromCharCode(0x20 + (i & 0x5f));
+const array = makeArray(length);
+
+const innerIterations = 10000;
+let sum = 0;
+for (let i = 0; i < 250; ++i)
+    sum += run(string, array, innerIterations);
+
+if (sum !== 250 * innerIterations * length)
+    throw new Error("Bad result: " + sum);

--- a/JSTests/microbenchmarks/wasm-into-char-code-array-8bit.js
+++ b/JSTests/microbenchmarks/wasm-into-char-code-array-8bit.js
@@ -1,0 +1,39 @@
+//@ $skipModes << :lockdown
+//@ skip if $addressBits <= 32
+// Benchmarks the wasm:js-string intoCharCodeArray builtin with an 8-bit string.
+/*
+(module
+  (type $a (array (mut i16)))
+  (import "wasm:js-string" "intoCharCodeArray" (func $into (param externref (ref null $a) i32) (result i32)))
+  (func (export "makeArray") (param i32) (result (ref $a))
+    (array.new_default $a (local.get 0)))
+  (func (export "run") (param $s externref) (param $arr (ref null $a)) (param $iters i32) (result i32)
+    (local $i i32) (local $sum i32)
+    (block $done
+      (loop $l
+        (br_if $done (i32.ge_u (local.get $i) (local.get $iters)))
+        (local.set $sum (i32.add (local.get $sum) (call $into (local.get $s) (local.get $arr) (i32.const 0))))
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (br $l)))
+    (local.get $sum))
+)
+*/
+const moduleBytes = new Uint8Array([0,97,115,109,1,0,0,0,1,146,128,128,128,0,3,94,119,1,96,3,111,99,0,127,1,127,96,1,127,1,100,0,2,164,128,128,128,0,1,14,119,97,115,109,58,106,115,45,115,116,114,105,110,103,17,105,110,116,111,67,104,97,114,67,111,100,101,65,114,114,97,121,0,1,3,131,128,128,128,0,2,2,1,7,147,128,128,128,0,2,9,109,97,107,101,65,114,114,97,121,0,1,3,114,117,110,0,2,10,187,128,128,128,0,2,135,128,128,128,0,0,32,0,251,7,0,11,169,128,128,128,0,1,2,127,2,64,3,64,32,3,32,2,79,13,1,32,4,32,0,32,1,65,0,16,0,106,33,4,32,3,65,1,106,33,3,12,0,11,11,32,4,11]);
+
+const module = new WebAssembly.Module(moduleBytes, { builtins: ['js-string'] });
+const instance = new WebAssembly.Instance(module, {});
+const { makeArray, run } = instance.exports;
+
+const length = 1024;
+let string = "";
+for (let i = 0; i < length; ++i)
+    string += String.fromCharCode(0x20 + (i & 0x5f));
+const array = makeArray(length);
+
+const innerIterations = 1000;
+let sum = 0;
+for (let i = 0; i < 100; ++i)
+    sum += run(string, array, innerIterations);
+
+if (sum !== 100 * innerIterations * length)
+    throw new Error("Bad result: " + sum);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
@@ -564,16 +564,10 @@ DEFINE_BUILTIN_IMPLEMENTATION_I32(jsstring, intoCharCodeArray, JSGlobalObject* g
 
     auto data = array->span<char16_t>();
     auto dest = data.subspan(start, stringLength);
-    auto stringValue = string->value(globalObject);
+    auto view = string->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (stringValue.data.is8Bit()) {
-        for (size_t i = 0; i < stringLength; ++i)
-            dest[i] = stringValue.data[i];
-    } else {
-        auto source = stringValue.data.span<char16_t>();
-        memcpySpan(dest, source);
-    }
+    view->getCharacters(dest);
 
     return toUCPUStrictInt32(stringLength);
 }


### PR DESCRIPTION
#### c809392be2a358e2e1532a77029013dfe21ec907
<pre>
[Wasm] `intoCharCodeArray` copies 8-bit strings one character at a time
<a href="https://bugs.webkit.org/show_bug.cgi?id=316494">https://bugs.webkit.org/show_bug.cgi?id=316494</a>

Reviewed by Yusuke Suzuki.

The 8-bit path of the wasm:js-string intoCharCodeArray builtin widens
Latin-1 characters to UTF-16 one character at a time through
String::operator[], which performs an is8Bit() branch per character and
cannot be vectorized. Replace it with JSString::view() and
StringView::getCharacters(), which performs SIMD widening via
StringImpl::copyCharacters(); on ARM64 it widens 64 characters per
iteration with NEON vmovl.

    wasm-into-char-code-array-8bit-short    34.6306+-1.3987  ^  28.1730+-2.0097  ^ definitely 1.2292x faster
    wasm-into-char-code-array-8bit          70.4834+-8.7056  ^   6.4666+-0.1494  ^ definitely 10.8996x faster

Tests: JSTests/microbenchmarks/wasm-into-char-code-array-8bit-short.js
       JSTests/microbenchmarks/wasm-into-char-code-array-8bit.js

* JSTests/microbenchmarks/wasm-into-char-code-array-8bit-short.js: Added.
* JSTests/microbenchmarks/wasm-into-char-code-array-8bit.js: Added.
* Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp:
(JSC::DEFINE_BUILTIN_IMPLEMENTATION_I32):

Canonical link: <a href="https://commits.webkit.org/315565@main">https://commits.webkit.org/315565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e1ec52088bf66705b735558f457a820f4042e46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178677 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127033 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131887 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92825 "10 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112391 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33367 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32029 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27377 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/595 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181277 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30576 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140343 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42899 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140181 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37741 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43588 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28552 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107556 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35449 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115353 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202000 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42098 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6642 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54180 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41746 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->