### PR TITLE
[JSC] Map/Set iteration fast paths should perform `IteratorClose` when the callback throws

### DIFF
--- a/JSTests/stress/iterator-close-map-set-fast-path-mid-iteration-return.js
+++ b/JSTests/stress/iterator-close-map-set-fast-path-mid-iteration-return.js
@@ -1,0 +1,184 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected: ${String(expected)}`);
+}
+
+const error = new Error("boom");
+const mapIteratorPrototype = Object.getPrototypeOf(new Map()[Symbol.iterator]());
+const setIteratorPrototype = Object.getPrototypeOf(new Set()[Symbol.iterator]());
+
+// Iterator.prototype.forEach over a Map iterator: "return" installed on the iterator
+// mid-iteration must be invoked by IteratorClose when the callback throws.
+{
+    let returnCalled = 0;
+    let resumeValue = null;
+    const map = new Map([[1, 1], [2, 2], [3, 3]]);
+    const iterator = map.keys();
+    let caught = null;
+    try {
+        iterator.forEach(function (value) {
+            if (value === 2) {
+                iterator.return = function () {
+                    returnCalled++;
+                    resumeValue = this.next().value;
+                    return { done: true };
+                };
+                throw error;
+            }
+        });
+    } catch (e) {
+        caught = e;
+    }
+    shouldBe(caught, error);
+    shouldBe(returnCalled, 1);
+    shouldBe(resumeValue, 3);
+}
+
+// Same for a Set iterator.
+{
+    let returnCalled = 0;
+    let resumeValue = null;
+    const set = new Set([1, 2, 3]);
+    const iterator = set.values();
+    let caught = null;
+    try {
+        iterator.forEach(function (value) {
+            if (value === 2) {
+                iterator.return = function () {
+                    returnCalled++;
+                    resumeValue = this.next().value;
+                    return { done: true };
+                };
+                throw error;
+            }
+        });
+    } catch (e) {
+        caught = e;
+    }
+    shouldBe(caught, error);
+    shouldBe(returnCalled, 1);
+    shouldBe(resumeValue, 3);
+}
+
+// "return" installed on %MapIteratorPrototype% mid-iteration.
+{
+    let returnCalled = 0;
+    const map = new Map([[1, 10], [2, 20], [3, 30]]);
+    const iterator = map.entries();
+    let caught = null;
+    try {
+        iterator.forEach(function (entry) {
+            if (entry[0] === 2) {
+                mapIteratorPrototype.return = function () {
+                    returnCalled++;
+                    return { done: true };
+                };
+                throw error;
+            }
+        });
+    } catch (e) {
+        caught = e;
+    }
+    delete mapIteratorPrototype.return;
+    shouldBe(caught, error);
+    shouldBe(returnCalled, 1);
+}
+
+// "return" installed on %SetIteratorPrototype% mid-iteration.
+{
+    let returnCalled = 0;
+    const set = new Set([1, 2, 3]);
+    const iterator = set.keys();
+    let caught = null;
+    try {
+        iterator.forEach(function (value) {
+            if (value === 2) {
+                setIteratorPrototype.return = function () {
+                    returnCalled++;
+                    return { done: true };
+                };
+                throw error;
+            }
+        });
+    } catch (e) {
+        caught = e;
+    }
+    delete setIteratorPrototype.return;
+    shouldBe(caught, error);
+    shouldBe(returnCalled, 1);
+}
+
+// new Map(map) storage fast path: Map.prototype.set throwing mid-iteration must
+// trigger IteratorClose, invoking a "return" installed on %MapIteratorPrototype%,
+// with the iterator positioned where iteration stopped.
+{
+    let returnCalled = 0;
+    let resumeKey = null;
+    const map = new Map([[1, 10], [2, 20], [3, 30]]);
+    const originalSet = Map.prototype.set;
+    Map.prototype.set = function (key, value) {
+        if (key === 2) {
+            mapIteratorPrototype.return = function () {
+                returnCalled++;
+                resumeKey = this.next().value[0];
+                return { done: true };
+            };
+            throw error;
+        }
+        return originalSet.call(this, key, value);
+    };
+    let caught = null;
+    try {
+        new Map(map);
+    } catch (e) {
+        caught = e;
+    }
+    Map.prototype.set = originalSet;
+    delete mapIteratorPrototype.return;
+    shouldBe(caught, error);
+    shouldBe(returnCalled, 1);
+    shouldBe(resumeKey, 3);
+}
+
+// new Set(set) storage fast path: same via Set.prototype.add.
+{
+    let returnCalled = 0;
+    let resumeValue = null;
+    const set = new Set([1, 2, 3]);
+    const originalAdd = Set.prototype.add;
+    Set.prototype.add = function (value) {
+        if (value === 2) {
+            setIteratorPrototype.return = function () {
+                returnCalled++;
+                resumeValue = this.next().value;
+                return { done: true };
+            };
+            throw error;
+        }
+        return originalAdd.call(this, value);
+    };
+    let caught = null;
+    try {
+        new Set(set);
+    } catch (e) {
+        caught = e;
+    }
+    Set.prototype.add = originalAdd;
+    delete setIteratorPrototype.return;
+    shouldBe(caught, error);
+    shouldBe(returnCalled, 1);
+    shouldBe(resumeValue, 3);
+}
+
+// Normal exhaustion must not invoke "return".
+{
+    let returnCalled = 0;
+    const map = new Map([[1, 1], [2, 2]]);
+    const iterator = map.keys();
+    iterator.return = function () {
+        returnCalled++;
+        return { done: true };
+    };
+    iterator.forEach(function () { });
+    shouldBe(returnCalled, 0);
+}

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -88,7 +88,7 @@ JS_EXPORT_PRIVATE IterationMode NODELETE getIterationMode(VM&, JSGlobalObject*, 
 JS_EXPORT_PRIVATE IterationMode getIterationMode(VM&, JSGlobalObject*, JSValue iterable, JSValue symbolIterator);
 
 
-static ALWAYS_INLINE void forEachInMapStorage(VM& vm, JSGlobalObject* globalObject, JSCell* storageCell, JSMap::Helper::Entry startEntry, IterationKind iterationKind, NOESCAPE const auto& callback)
+static ALWAYS_INLINE void forEachInMapStorage(VM& vm, JSGlobalObject* globalObject, JSCell* storageCell, JSMap::Helper::Entry startEntry, IterationKind iterationKind, NOESCAPE const auto& callback, NOESCAPE const auto& callbackExceptionHandler)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -123,17 +123,30 @@ static ALWAYS_INLINE void forEachInMapStorage(VM& vm, JSGlobalObject* globalObje
 
         if constexpr (std::same_as<IterationStatus, std::invoke_result_t<decltype(callback), VM&, JSGlobalObject*, JSValue>>) {
             auto result = callback(vm, globalObject, value);
-            RETURN_IF_EXCEPTION(scope, void());
+            if (scope.exception()) [[unlikely]] {
+                scope.release();
+                callbackExceptionHandler(storageCell, entry);
+                return;
+            }
             if (result == IterationStatus::Done)
                 break;
         } else {
             callback(vm, globalObject, value);
-            RETURN_IF_EXCEPTION(scope, void());
+            if (scope.exception()) [[unlikely]] {
+                scope.release();
+                callbackExceptionHandler(storageCell, entry);
+                return;
+            }
         }
     }
 }
 
-static ALWAYS_INLINE void forEachInSetStorage(VM& vm, JSGlobalObject* globalObject, JSCell* storageCell, JSSet::Helper::Entry startEntry, NOESCAPE const auto& callback)
+static ALWAYS_INLINE void forEachInMapStorage(VM& vm, JSGlobalObject* globalObject, JSCell* storageCell, JSMap::Helper::Entry startEntry, IterationKind iterationKind, NOESCAPE const auto& callback)
+{
+    forEachInMapStorage(vm, globalObject, storageCell, startEntry, iterationKind, callback, [](JSCell*, JSMap::Helper::Entry) { });
+}
+
+static ALWAYS_INLINE void forEachInSetStorage(VM& vm, JSGlobalObject* globalObject, JSCell* storageCell, JSSet::Helper::Entry startEntry, NOESCAPE const auto& callback, NOESCAPE const auto& callbackExceptionHandler)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -151,14 +164,27 @@ static ALWAYS_INLINE void forEachInSetStorage(VM& vm, JSGlobalObject* globalObje
 
         if constexpr (std::same_as<IterationStatus, std::invoke_result_t<decltype(callback), VM&, JSGlobalObject*, JSValue>>) {
             auto result = callback(vm, globalObject, entryKey);
-            RETURN_IF_EXCEPTION(scope, void());
+            if (scope.exception()) [[unlikely]] {
+                scope.release();
+                callbackExceptionHandler(storageCell, entry);
+                return;
+            }
             if (result == IterationStatus::Done)
                 break;
         } else {
             callback(vm, globalObject, entryKey);
-            RETURN_IF_EXCEPTION(scope, void());
+            if (scope.exception()) [[unlikely]] {
+                scope.release();
+                callbackExceptionHandler(storageCell, entry);
+                return;
+            }
         }
     }
+}
+
+static ALWAYS_INLINE void forEachInSetStorage(VM& vm, JSGlobalObject* globalObject, JSCell* storageCell, JSSet::Helper::Entry startEntry, NOESCAPE const auto& callback)
+{
+    forEachInSetStorage(vm, globalObject, storageCell, startEntry, callback, [](JSCell*, JSSet::Helper::Entry) { });
 }
 
 static ALWAYS_INLINE void forEachInFastArray(JSGlobalObject* globalObject, JSValue iterable, JSArray* array, NOESCAPE const Invocable<void(VM&, JSGlobalObject*, JSValue)> auto& callback)
@@ -241,7 +267,12 @@ void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, NOESCAPE 
         if (jsMap->isIteratorProtocolFastAndNonObservable()) {
             JSCell* storageCell = jsMap->storageOrSentinel(vm);
             if (storageCell != vm.orderedHashTableSentinel()) {
-                forEachInMapStorage(vm, globalObject, storageCell, 0, IterationKind::Entries, callback);
+                forEachInMapStorage(vm, globalObject, storageCell, 0, IterationKind::Entries, callback, [&](JSCell* currentStorageCell, JSMap::Helper::Entry entry) {
+                    JSMapIterator* iterator = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), jsMap, IterationKind::Entries);
+                    iterator->setStorage(vm, currentStorageCell);
+                    iterator->setEntry(vm, entry);
+                    iteratorClose(globalObject, iterator);
+                });
                 RETURN_IF_EXCEPTION(scope, void());
             }
             return;
@@ -250,7 +281,12 @@ void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, NOESCAPE 
         if (jsSet->isIteratorProtocolFastAndNonObservable()) {
             JSCell* storageCell = jsSet->storageOrSentinel(vm);
             if (storageCell != vm.orderedHashTableSentinel()) {
-                forEachInSetStorage(vm, globalObject, storageCell, 0, callback);
+                forEachInSetStorage(vm, globalObject, storageCell, 0, callback, [&](JSCell* currentStorageCell, JSSet::Helper::Entry entry) {
+                    JSSetIterator* iterator = JSSetIterator::create(vm, globalObject->setIteratorStructure(), jsSet, IterationKind::Values);
+                    iterator->setStorage(vm, currentStorageCell);
+                    iterator->setEntry(vm, entry);
+                    iteratorClose(globalObject, iterator);
+                });
                 RETURN_IF_EXCEPTION(scope, void());
             }
             return;
@@ -343,7 +379,11 @@ void forEachInIteratorProtocol(JSGlobalObject* globalObject, JSValue iterable, N
                 while (mapIterator->next(globalObject, value)) {
                     RETURN_IF_EXCEPTION(scope, void());
                     callback(vm, globalObject, value);
-                    RETURN_IF_EXCEPTION(scope, void());
+                    if (scope.exception()) [[unlikely]] {
+                        scope.release();
+                        iteratorClose(globalObject, mapIterator);
+                        return;
+                    }
                 }
                 RETURN_IF_EXCEPTION(scope, void());
                 return;
@@ -356,7 +396,11 @@ void forEachInIteratorProtocol(JSGlobalObject* globalObject, JSValue iterable, N
                 while (setIterator->next(globalObject, value)) {
                     RETURN_IF_EXCEPTION(scope, void());
                     callback(vm, globalObject, value);
-                    RETURN_IF_EXCEPTION(scope, void());
+                    if (scope.exception()) [[unlikely]] {
+                        scope.release();
+                        iteratorClose(globalObject, setIterator);
+                        return;
+                    }
                 }
                 RETURN_IF_EXCEPTION(scope, void());
                 return;


### PR DESCRIPTION
#### 84a71a9868ed742fd639b35b926f10f5d2decf81
<pre>
[JSC] Map/Set iteration fast paths should perform `IteratorClose` when the callback throws
<a href="https://bugs.webkit.org/show_bug.cgi?id=316495">https://bugs.webkit.org/show_bug.cgi?id=316495</a>

Reviewed by Yusuke Suzuki.

The Map/Set iterator fast paths in forEachInIteratorProtocol and the Map/Set
storage fast paths in forEachInIterable returned immediately when the callback
threw, without performing IteratorClose. A &quot;return&quot; method installed during
iteration was therefore never invoked. This was observable e.g. via
Iterator.prototype.forEach over a Map/Set iterator, or via new Map(map) /
new Set(set) with an overridden adder that throws.

Fix it the same way forEachInFastArray already handles this for arrays: on a
callback exception, close the iterator, lazily materializing one positioned
where the iteration stopped in the forEachInIterable case. Set.prototype
methods iterating internal set data keep the old behavior (no IteratorClose),
and the happy path performs no extra allocation.

Test: JSTests/stress/iterator-close-map-set-fast-path-mid-iteration-return.js

* JSTests/stress/iterator-close-map-set-fast-path-mid-iteration-return.js: Added.
(shouldBe):
(const.setIteratorPrototype.Object.getPrototypeOf.new.Set.Symbol.iterator.try.):
(const.setIteratorPrototype.Object.getPrototypeOf.new.Set.Symbol.iterator):
(shouldBe.try.):
(shouldBe.const.iterator.set values):
(shouldBe.const.set new):
(shouldBe.const.iterator.set keys):
(shouldBe.mapIteratorPrototype.return):
(shouldBe.Map.prototype):
(shouldBe.setIteratorPrototype.return):
(shouldBe.Set.prototype.add):
(shouldBe.set catch):
(shouldBe.iterator.return):
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInMapStorage):
(JSC::forEachInSetStorage):
(JSC::forEachInIterable):
(JSC::forEachInIteratorProtocol):

Canonical link: <a href="https://commits.webkit.org/314776@main">https://commits.webkit.org/314776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb4e92fa8e8171d4a4964e82f1353b65eb4f80a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176026 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124236 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129850 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91458 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110375 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31226 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29931 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24762 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159135 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141200 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178564 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27872 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31462 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29434 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138218 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138129 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37232 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149525 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104108 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33403 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26390 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199657 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112811 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53683 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39133 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4489 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39378 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->