### PR TITLE
[JSC] DFG `RegExpSearch` constant folding drops `TypeError` for non-writable lastIndex

### DIFF
--- a/JSTests/stress/regexp-search-strength-reduction-lastIndex-frozen-mid-execution.js
+++ b/JSTests/stress/regexp-search-strength-reduction-lastIndex-frozen-mid-execution.js
@@ -1,0 +1,48 @@
+//@ requireOptions("--useConcurrentJIT=0")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+function shouldThrow(run, errorType) {
+    let actual;
+    let hadError = false;
+    try {
+        actual = run();
+    } catch (e) {
+        hadError = true;
+        actual = e;
+    }
+    if (!hadError)
+        throw new Error(`Expected ${run}() to throw ${errorType.name}, but did not throw.`);
+    if (!(actual instanceof errorType))
+        throw new Error(`Expected ${run}() to throw ${errorType.name}, but threw '${actual}'`);
+}
+
+// The regexp gets frozen between its creation and the constant-folded search,
+// inside the same function execution. The "RegExp lastIndex is writable"
+// watchpoint fires mid-execution, so the code must deoptimize at the
+// invalidation point after the call and the search must throw a TypeError.
+function search(callback) {
+    const re = /b/;
+    callback(re);
+    return "abc".search(re);
+}
+noInline(search);
+
+function benign(re) {
+}
+
+for (var i = 0; i < testLoopCount; i++)
+    shouldBe(search(benign), 1);
+
+shouldThrow(() => search((re) => {
+    re.lastIndex = 3;
+    Object.freeze(re);
+}), TypeError);
+
+// A fresh regexp in later calls is unaffected, even though the realm's
+// watchpoint has fired by now.
+for (var i = 0; i < 10; i++)
+    shouldBe(search(benign), 1);

--- a/JSTests/stress/regexp-search-strength-reduction-lastIndex-not-writable.js
+++ b/JSTests/stress/regexp-search-strength-reduction-lastIndex-not-writable.js
@@ -1,0 +1,83 @@
+//@ requireOptions("--useConcurrentJIT=0")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+function shouldThrow(run, errorType) {
+    let actual;
+    let hadError = false;
+    try {
+        actual = run();
+    } catch (e) {
+        hadError = true;
+        actual = e;
+    }
+    if (!hadError)
+        throw new Error(`Expected ${run}() to throw ${errorType.name}, but did not throw.`);
+    if (!(actual instanceof errorType))
+        throw new Error(`Expected ${run}() to throw ${errorType.name}, but threw '${actual}'`);
+}
+
+// Warm up both String.prototype.search and RegExp.prototype[Symbol.search]
+// before making any lastIndex non-writable, so both get constant-folded while
+// the realm's "RegExp lastIndex is writable" watchpoint is still intact.
+const re1 = /b/;
+re1.lastIndex = 3;
+function stringSearch() {
+    return "abc".search(re1);
+}
+noInline(stringSearch);
+
+const re2 = /b/;
+re2.lastIndex = 3;
+function symbolSearch() {
+    return re2[Symbol.search]("abc");
+}
+noInline(symbolSearch);
+
+for (var i = 0; i < testLoopCount; i++) {
+    shouldBe(stringSearch(), 1);
+    shouldBe(symbolSearch(), 1);
+}
+
+// Making lastIndex non-writable after tier-up must throw a TypeError because
+// RegExp.prototype[@@search] sets lastIndex to 0 when it is not already 0.
+Object.defineProperty(re1, "lastIndex", { writable: false });
+for (var i = 0; i < 10; i++) {
+    shouldThrow(() => stringSearch(), TypeError);
+    shouldBe(symbolSearch(), 1); // re2's lastIndex is still writable.
+}
+
+Object.defineProperty(re2, "lastIndex", { writable: false });
+for (var i = 0; i < 10; i++)
+    shouldThrow(() => symbolSearch(), TypeError);
+
+// A search becoming hot after the watchpoint already fired: the fold has to
+// use a runtime guard instead, and flipping writability must still throw.
+const re4 = /b/;
+re4.lastIndex = 3;
+function lateSearch() {
+    return "abc".search(re4);
+}
+noInline(lateSearch);
+
+for (var i = 0; i < testLoopCount; i++)
+    shouldBe(lateSearch(), 1);
+
+Object.defineProperty(re4, "lastIndex", { writable: false });
+for (var i = 0; i < 10; i++)
+    shouldThrow(() => lateSearch(), TypeError);
+
+// When lastIndex is already 0, @@search never needs to write lastIndex for a
+// non-global RegExp, so a non-writable lastIndex must not throw.
+const re3 = /b/;
+Object.defineProperty(re3, "lastIndex", { value: 0, writable: false });
+function nonThrowingSearch() {
+    return "abc".search(re3);
+}
+noInline(nonThrowingSearch);
+
+for (var i = 0; i < testLoopCount; i++)
+    shouldBe(nonThrowingSearch(), 1);

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -760,6 +760,7 @@ private:
 
             Node* regExpObjectNode = nullptr;
             RegExp* regExp = nullptr;
+            JSGlobalObject* regExpRealm = nullptr;
             bool regExpObjectNodeIsConstant = false;
             if (m_node->op() == RegExpExec || m_node->op() == RegExpTest || m_node->op() == RegExpMatchFast || m_node->op() == RegExpSearch) {
                 regExpObjectNode = m_node->child2().node();
@@ -771,6 +772,7 @@ private:
                     }
                     m_graph.watchpoints().addLazily(globalObject->regExpRecompiledWatchpointSet());
                     regExp = regExpObject->regExp();
+                    regExpRealm = globalObject;
                     regExpObjectNodeIsConstant = true;
                 } else if (regExpObjectNode->op() == NewRegExp) {
                     JSGlobalObject* globalObject = m_graph.globalObjectFor(regExpObjectNode->origin.semantic);
@@ -780,6 +782,7 @@ private:
                     }
                     m_graph.watchpoints().addLazily(globalObject->regExpRecompiledWatchpointSet());
                     regExp = regExpObjectNode->castOperand<RegExp*>();
+                    regExpRealm = globalObject;
                 } else {
                     dataLogLnIf(verbose, "Giving up because the regexp is unknown.");
                     break;
@@ -1070,7 +1073,28 @@ private:
                 // Because SetRegExpObjectLastIndex may exit and it clobbers exit state, we do that
                 // first.
 
-                if (regExp->globalOrSticky() && !wasSearch) {
+                if (wasSearch) {
+                    ASSERT(regExpObjectNode);
+                    ASSERT(regExpRealm);
+                    WatchpointSet& lastIndexWritableWatchpointSet = regExpRealm->regExpLastIndexWritableWatchpointSet();
+                    if (lastIndexWritableWatchpointSet.isStillValid())
+                        m_graph.watchpoints().addLazily(lastIndexWritableWatchpointSet);
+                    else {
+                        // The watchpoint has already fired, so guard at runtime instead: storing
+                        // lastIndex back to itself is a no-op when it is writable, and exits when
+                        // it is not, so that @@search throws the TypeError the spec requires.
+                        Node* lastIndexNode = m_insertionSet.insertNode(
+                            m_nodeIndex, SpecNone, GetRegExpObjectLastIndex, origin,
+                            Edge(regExpObjectNode, RegExpObjectUse));
+                        m_insertionSet.insertNode(
+                            m_nodeIndex, SpecNone, SetRegExpObjectLastIndex, origin,
+                            OpInfo(false),
+                            Edge(regExpObjectNode, RegExpObjectUse),
+                            Edge(lastIndexNode, UntypedUse));
+
+                        origin = origin.withInvalidExit();
+                    }
+                } else if (regExp->globalOrSticky()) {
                     ASSERT(regExpObjectNode);
                     m_insertionSet.insertNode(
                         m_nodeIndex, SpecNone, SetRegExpObjectLastIndex, origin,

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -940,6 +940,7 @@ JSGlobalObject::JSGlobalObject(VM& vm, Structure* structure, const GlobalObjectM
     , m_varInjectionWatchpointSet(WatchpointSet::create(IsWatched))
     , m_varReadOnlyWatchpointSet(WatchpointSet::create(IsWatched))
     , m_regExpRecompiledWatchpointSet(WatchpointSet::create(IsWatched))
+    , m_regExpLastIndexWritableWatchpointSet(WatchpointSet::create(IsWatched))
     , m_arrayBufferDetachWatchpointSet(WatchpointSet::create(IsWatched))
     , m_weakRandom(Options::forceWeakRandomSeed() ? Options::forcedWeakRandomSeed() : cryptographicallyRandomNumber<uint32_t>())
     , m_runtimeFlags()

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -506,6 +506,7 @@ public:
     const Ref<WatchpointSet> m_varInjectionWatchpointSet;
     const Ref<WatchpointSet> m_varReadOnlyWatchpointSet;
     const Ref<WatchpointSet> m_regExpRecompiledWatchpointSet;
+    const Ref<WatchpointSet> m_regExpLastIndexWritableWatchpointSet;
     const Ref<WatchpointSet> m_arrayBufferDetachWatchpointSet;
 
     struct RareData;
@@ -1147,6 +1148,7 @@ public:
     WatchpointSet& varInjectionWatchpointSet() { return m_varInjectionWatchpointSet.get(); }
     WatchpointSet& varReadOnlyWatchpointSet() { return m_varReadOnlyWatchpointSet.get(); }
     WatchpointSet& regExpRecompiledWatchpointSet() { return m_regExpRecompiledWatchpointSet.get(); }
+    WatchpointSet& regExpLastIndexWritableWatchpointSet() { return m_regExpLastIndexWritableWatchpointSet.get(); }
     WatchpointSet& arrayBufferDetachWatchpointSet() { return m_arrayBufferDetachWatchpointSet.get(); }
 
     bool isHavingABadTime() const

--- a/Source/JavaScriptCore/runtime/RegExpObject.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpObject.cpp
@@ -115,8 +115,10 @@ bool RegExpObject::defineOwnProperty(JSObject* object, JSGlobalObject* globalObj
             regExp->setLastIndex(globalObject, descriptor.value(), false);
             RETURN_IF_EXCEPTION(scope, false);
         }
-        if (descriptor.writablePresent() && !descriptor.writable())
+        if (descriptor.writablePresent() && !descriptor.writable()) {
             regExp->setLastIndexIsNotWritable();
+            regExp->realm()->regExpLastIndexWritableWatchpointSet().fireAll(vm, "RegExp lastIndex was made non-writable");
+        }
         return true;
     }
 


### PR DESCRIPTION
#### 21b46f50939e307338b866ac8548e02d98f6a73f
<pre>
[JSC] DFG `RegExpSearch` constant folding drops `TypeError` for non-writable lastIndex
<a href="https://bugs.webkit.org/show_bug.cgi?id=316496">https://bugs.webkit.org/show_bug.cgi?id=316496</a>

Reviewed by Yusuke Suzuki.

RegExp.prototype[@@search] writes lastIndex (it sets it to 0 and restores it
afterwards), so it throws a TypeError when lastIndex is not writable. The
RegExpSearch DFG node speculates on this, but constant folding in
DFGStrengthReductionPhase dropped that speculation: after tier-up, making
lastIndex non-writable returned a result instead of throwing. Reachable via
both String.prototype.search and RegExp.prototype[Symbol.search].

Fix this with a new watchpoint set on JSGlobalObject, fired by
RegExpObject::defineOwnProperty when a lastIndex is made non-writable. The
fold just registers the watchpoint, so the generated code is exactly the
same as before this change. If the watchpoint has already been invalidated,
the fold instead emits a runtime guard that stores lastIndex back to itself,
which exits when lastIndex is not writable.

Tests: JSTests/stress/regexp-search-strength-reduction-lastIndex-frozen-mid-execution.js
       JSTests/stress/regexp-search-strength-reduction-lastIndex-not-writable.js

* JSTests/stress/regexp-search-strength-reduction-lastIndex-frozen-mid-execution.js: Added.
(shouldBe):
(shouldThrow):
(search):
(benign):
(shouldThrow.search):
* JSTests/stress/regexp-search-strength-reduction-lastIndex-not-writable.js: Added.
(shouldBe):
(shouldThrow):
(stringSearch):
(symbolSearch):
(lateSearch):
(nonThrowingSearch):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::JSGlobalObject):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::regExpLastIndexWritableWatchpointSet):
* Source/JavaScriptCore/runtime/RegExpObject.cpp:
(JSC::RegExpObject::defineOwnProperty):

Canonical link: <a href="https://commits.webkit.org/315170@main">https://commits.webkit.org/315170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50976543186add50337f998d72bde4d30c85de20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124237 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129851 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91459 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110376 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31227 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29932 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24763 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159136 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178565 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27873 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31463 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138219 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138130 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37499 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149527 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104112 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33404 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26392 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199658 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39738 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112812 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53684 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39134 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4491 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39379 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39278 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->