### PR TITLE
[Wasm] Function parser's expression stack should be a single buffer

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3475,16 +3475,16 @@ MacroAssembler::Label BBQJIT::addLoopOSREntrypoint()
     return label;
 }
 
-[[nodiscard]] PartialResult BBQJIT::addBlock(BlockSignature&& signature, Stack& enclosingStack, ControlType& result, Stack& newStack)
+[[nodiscard]] PartialResult BBQJIT::addBlock(BlockSignature&& signature, std::span<TypedExpression> args, ControlType& result)
 {
-    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.argumentCount();
+    auto enclosingStack = m_parser->expressionStack();
+    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + (enclosingStack.size() - args.size());
     result = ControlData(*this, BlockType::Block, WTF::move(signature), height);
     currentControlData().flushAndSingleExit(*this, result, enclosingStack, true, false);
 
     LOG_INSTRUCTION("Block", result.signature());
     LOG_INDENT();
-    splitStack(result.signature(), enclosingStack, newStack);
-    result.startBlock(*this, newStack);
+    result.startBlock(*this, args);
     return { };
 }
 
@@ -3543,7 +3543,7 @@ B3::ValueRep BBQJIT::toB3Rep(Location location)
 }
 
 // This needs to be kept in sync with WasmIPIntSlowPaths.cpp buildEntryBufferForLoopOSR and OMGIRGenerator::addLoop.
-StackMap BBQJIT::makeStackMap(const ControlData& data, Stack& enclosingStack)
+StackMap BBQJIT::makeStackMap(const ControlData& data, std::span<const TypedExpression> enclosingStack)
 {
     unsigned numElements = m_locals.size() + data.enclosedHeight() + data.argumentLocations().size();
     for (const ControlEntry& entry : m_parser->controlStack()) {
@@ -3572,8 +3572,8 @@ StackMap BBQJIT::makeStackMap(const ControlData& data, Stack& enclosingStack)
             ASSERT(!entry.controlData.implicitSlots());
     }
 
-    for (const ControlEntry& entry : m_parser->controlStack()) {
-        for (const TypedExpression& expr : entry.enclosedExpressionStack)
+    for (size_t i = 0; i < m_parser->controlStack().size(); ++i) {
+        for (const TypedExpression& expr : m_parser->enclosedSliceOf(i))
             stackMap[stackMapIndex++] = OSREntryValue(toB3Rep(locationOf(expr.value())), toB3Type(expr.type().kind));
     }
 
@@ -3587,7 +3587,7 @@ StackMap BBQJIT::makeStackMap(const ControlData& data, Stack& enclosingStack)
     return stackMap;
 }
 
-void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& enclosingStack, unsigned loopIndex)
+void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, std::span<const TypedExpression> enclosingStack, unsigned loopIndex)
 {
     auto& tierUpCounter = m_callee.tierUpCounter();
     ASSERT(tierUpCounter.osrEntryTriggers().size() == loopIndex);
@@ -3632,27 +3632,31 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
 #endif
 }
 
-[[nodiscard]] PartialResult BBQJIT::addLoop(BlockSignature&& signature, Stack& enclosingStack, ControlType& result, Stack& newStack, uint32_t loopIndex)
+[[nodiscard]] PartialResult BBQJIT::addLoop(BlockSignature&& signature, std::span<TypedExpression> args, ControlType& result, uint32_t loopIndex)
 {
-    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.argumentCount();
+    auto enclosingStack = m_parser->expressionStack();
+    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + (enclosingStack.size() - args.size());
     result = ControlData(*this, BlockType::Loop, WTF::move(signature), height);
     currentControlData().flushAndSingleExit(*this, result, enclosingStack, true, false);
 
     LOG_INSTRUCTION("Loop", result.signature());
     LOG_INDENT();
-    splitStack(result.signature(), enclosingStack, newStack);
-    result.startBlock(*this, newStack);
+    result.startBlock(*this, args);
     result.setLoopLabel(m_jit.label());
 
     RELEASE_ASSERT(m_compilation->bbqLoopEntrypoints.size() == loopIndex);
     m_compilation->bbqLoopEntrypoints.append(result.loopLabel());
 
-    emitLoopTierUpCheckAndOSREntryData(result, enclosingStack, loopIndex);
+    // makeStackMap iterates argumentLocations separately, so trim args off enclosingStack here.
+    ASSERT(enclosingStack.size() >= args.size());
+    auto enclosingWithoutArgs = enclosingStack.first(enclosingStack.size() - args.size());
+    emitLoopTierUpCheckAndOSREntryData(result, enclosingWithoutArgs, loopIndex);
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addIf(Value condition, BlockSignature&& signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
+[[nodiscard]] PartialResult BBQJIT::addIf(Value condition, BlockSignature&& signature, std::span<TypedExpression> args, ControlData& result)
 {
+    auto enclosingStack = m_parser->expressionStack();
     RegisterSet liveScratchGPRs;
     Location conditionLocation;
     if (!condition.isConst()) {
@@ -3661,7 +3665,7 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
     }
     consume(condition);
 
-    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.argumentCount();
+    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + (enclosingStack.size() - args.size());
     result = ControlData(*this, BlockType::If, WTF::move(signature), height, liveScratchGPRs);
 
     // Despite being conditional, if doesn't need to worry about diverging expression stacks at block boundaries, so it doesn't need multiple exits.
@@ -3669,9 +3673,8 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
 
     LOG_INSTRUCTION("If", result.signature(), condition, conditionLocation);
     LOG_INDENT();
-    splitStack(result.signature(), enclosingStack, newStack);
 
-    result.startBlock(*this, newStack);
+    result.startBlock(*this, args);
     if (condition.isConst() && !condition.asI32())
         result.setIfBranch(m_jit.jump()); // Emit direct branch if we know the condition is false.
     else if (!condition.isConst()) // Otherwise, we only emit a branch at all if we don't know the condition statically.
@@ -3679,9 +3682,9 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addElse(ControlData& data, Stack& expressionStack)
+[[nodiscard]] PartialResult BBQJIT::addElse(ControlData& data, std::span<TypedExpression> ifBranchResults)
 {
-    data.flushAndSingleExit(*this, data, expressionStack, false, true);
+    data.flushAndSingleExit(*this, data, ifBranchResults, false, true);
     ControlData dataElse(ControlData::UseBlockCallingConventionOfOtherBranch, BlockType::Else, data);
     data.linkJumps(&m_jit);
     dataElse.addBranch(m_jit.jump());
@@ -3690,9 +3693,9 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
     LOG_INSTRUCTION("Else");
     LOG_INDENT();
 
-    // We don't care at this point about the values live at the end of the previous control block,
-    // we just need the right number of temps for our arguments on the top of the stack.
-    expressionStack.clear();
+    // Set up temp bindings for the else branch's args (kept separately because the parser
+    // overwrites its own m_expressionStack with the saved if-args right after we return).
+    Stack expressionStack;
     const auto& blockSignature = data.signature();
     while (expressionStack.size() < blockSignature.argumentCount()) {
         Type type = blockSignature.argumentType(expressionStack.size());
@@ -3708,7 +3711,8 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
 {
     // We want to flush or consume all values on the stack to reset the allocator
     // state entering the else block.
-    data.flushAtBlockBoundary(*this, 0, m_parser->expressionStack(), true);
+    auto enclosingStack = m_parser->expressionStack();
+    data.flushAtBlockBoundary(*this, 0, enclosingStack, true);
 
     ControlData dataElse(ControlData::UseBlockCallingConventionOfOtherBranch, BlockType::Else, data);
     data.linkJumps(&m_jit);
@@ -3729,25 +3733,26 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addTry(BlockSignature&& signature, Stack& enclosingStack, ControlType& result, Stack& newStack)
+[[nodiscard]] PartialResult BBQJIT::addTry(BlockSignature&& signature, std::span<TypedExpression> args, ControlType& result)
 {
+    auto enclosingStack = m_parser->expressionStack();
     m_usesExceptions = true;
     ++m_tryCatchDepth;
     ++m_callSiteIndex;
-    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.argumentCount();
+    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + (enclosingStack.size() - args.size());
     result = ControlData(*this, BlockType::Try, WTF::move(signature), height);
     result.setTryInfo(m_callSiteIndex, m_callSiteIndex, m_tryCatchDepth);
     currentControlData().flushAndSingleExit(*this, result, enclosingStack, true, false);
 
     LOG_INSTRUCTION("Try", result.signature());
     LOG_INDENT();
-    splitStack(result.signature(), enclosingStack, newStack);
-    result.startBlock(*this, newStack);
+    result.startBlock(*this, args);
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addTryTable(BlockSignature&& signature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack)
+[[nodiscard]] PartialResult BBQJIT::addTryTable(BlockSignature&& signature, std::span<TypedExpression> args, const Vector<CatchHandler>& targets, ControlType& result)
 {
+    auto enclosingStack = m_parser->expressionStack();
     m_usesExceptions = true;
     ++m_tryCatchDepth;
     ++m_callSiteIndex;
@@ -3763,7 +3768,7 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
         }
     );
 
-    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.argumentCount();
+    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + (enclosingStack.size() - args.size());
     result = ControlData(*this, BlockType::TryTable, WTF::move(signature), height);
     result.setTryInfo(m_callSiteIndex, m_callSiteIndex, m_tryCatchDepth);
     result.setTryTableTargets(WTF::move(targetList));
@@ -3771,12 +3776,11 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
 
     LOG_INSTRUCTION("TryTable", result.signature());
     LOG_INDENT();
-    splitStack(result.signature(), enclosingStack, newStack);
-    result.startBlock(*this, newStack);
+    result.startBlock(*this, args);
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addCatch(unsigned exceptionIndex, const RTT& exceptionSignature, Stack& expressionStack, ControlType& data, ResultList& results)
+[[nodiscard]] PartialResult BBQJIT::addCatch(unsigned exceptionIndex, const RTT& exceptionSignature, std::span<TypedExpression> expressionStack, ControlType& data, ResultList& results)
 {
     m_usesExceptions = true;
     data.flushAndSingleExit(*this, data, expressionStack, false, true);
@@ -3822,7 +3826,7 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addCatchAll(Stack& expressionStack, ControlType& data)
+[[nodiscard]] PartialResult BBQJIT::addCatchAll(std::span<TypedExpression> expressionStack, ControlType& data)
 {
     m_usesExceptions = true;
     data.flushAndSingleExit(*this, data, expressionStack, false, true);
@@ -3887,7 +3891,7 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addThrow(unsigned exceptionIndex, ArgumentList& arguments, Stack&)
+[[nodiscard]] PartialResult BBQJIT::addThrow(unsigned exceptionIndex, ArgumentList& arguments, std::span<TypedExpression>)
 {
 
     LOG_INSTRUCTION("Throw", arguments);
@@ -3923,7 +3927,7 @@ void BBQJIT::prepareForExceptions()
     }
 }
 
-[[nodiscard]] PartialResult BBQJIT::addReturn(const ControlData& data, const Stack& returnValues)
+[[nodiscard]] PartialResult BBQJIT::addReturn(const ControlData& data, std::span<const TypedExpression> returnValues)
 {
     // Use the function signature from the parser
     ASSERT(m_parser);
@@ -3964,7 +3968,7 @@ void BBQJIT::prepareForExceptions()
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addBranch(ControlData& target, Value condition, Stack& results)
+[[nodiscard]] PartialResult BBQJIT::addBranch(ControlData& target, Value condition, std::span<TypedExpression> results)
 {
     if (condition.isConst() && !condition.asI32()) // If condition is known to be false, this is a no-op.
         return { };
@@ -4001,7 +4005,7 @@ void BBQJIT::prepareForExceptions()
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addSwitch(Value condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, Stack& results)
+[[nodiscard]] PartialResult BBQJIT::addSwitch(Value condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, std::span<TypedExpression> results)
 {
     ASSERT(condition.type() == TypeKind::I32);
 
@@ -4089,37 +4093,40 @@ void BBQJIT::prepareForExceptions()
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::endBlock(ControlEntry& entry, Stack& stack)
+[[nodiscard]] PartialResult BBQJIT::endBlock(ControlEntry& entry, std::span<TypedExpression> enclosedStack)
 {
-    return addEndToUnreachable(entry, stack, false);
+    return addEndToUnreachableImpl(entry, enclosedStack, false);
 }
 
-[[nodiscard]] PartialResult BBQJIT::addEndToUnreachable(ControlEntry& entry, Stack& stack, bool unreachable)
+[[nodiscard]] PartialResult BBQJIT::addEndToUnreachable(ControlEntry& entry, std::span<TypedExpression> enclosedStack)
+{
+    return addEndToUnreachableImpl(entry, enclosedStack, true);
+}
+
+[[nodiscard]] PartialResult BBQJIT::addEndToUnreachableImpl(ControlEntry& entry, std::span<TypedExpression> enclosedStack, bool unreachable)
 {
     ControlData& entryData = entry.controlData;
 
     const auto& blockSignature = entryData.signature();
     unsigned returnCount = blockSignature.returnCount();
     if (unreachable) {
+        // Parser pre-allocated empty result slots at the top of enclosedStack.
+        unsigned offset = enclosedStack.size() - returnCount;
         for (unsigned i = 0; i < returnCount; ++i) {
             Type type = blockSignature.returnType(i);
-            entry.enclosedExpressionStack.constructAndAppend(type, Value::fromTemp(type.kind, entryData.enclosedHeight() + entryData.implicitSlots() + i));
+            enclosedStack[offset + i] = TypedExpression(type, Value::fromTemp(type.kind, entryData.enclosedHeight() + entryData.implicitSlots() + i));
         }
         unbindAllRegisters();
-    } else {
-        unsigned offset = stack.size() - returnCount;
-        for (unsigned i = 0; i < returnCount; ++i)
-            entry.enclosedExpressionStack.append(stack[i + offset]);
     }
 
     switch (entryData.blockType()) {
     case BlockType::TopLevel:
-        entryData.flushAndSingleExit(*this, entryData, entry.enclosedExpressionStack, false, true, unreachable);
+        entryData.flushAndSingleExit(*this, entryData, enclosedStack, false, true, unreachable);
         entryData.linkJumps(&m_jit);
         for (unsigned i = 0; i < returnCount; ++i) {
             // Make sure we expect the stack values in the correct locations.
-            if (!entry.enclosedExpressionStack[i].value().isConst()) {
-                Value& value = entry.enclosedExpressionStack[i].value();
+            if (!enclosedStack[i].value().isConst()) {
+                Value& value = enclosedStack[i].value();
                 value = Value::fromTemp(value.type(), i);
                 Location valueLocation = locationOf(value);
                 if (valueLocation.isRegister())
@@ -4128,39 +4135,37 @@ void BBQJIT::prepareForExceptions()
                     bind(value, entryData.resultLocations()[i]);
             }
         }
-        return addReturn(entryData, entry.enclosedExpressionStack);
+        return addReturn(entryData, enclosedStack);
     case BlockType::Loop:
         entryData.convertLoopToBlock();
-        entryData.flushAndSingleExit(*this, entryData, entry.enclosedExpressionStack, false, true, unreachable);
+        entryData.flushAndSingleExit(*this, entryData, enclosedStack, false, true, unreachable);
         entryData.linkJumpsTo(entryData.loopLabel(), &m_jit);
         m_outerLoops.takeLast();
         break;
     case BlockType::Try:
     case BlockType::Catch:
         --m_tryCatchDepth;
-        entryData.flushAndSingleExit(*this, entryData, entry.enclosedExpressionStack, false, true, unreachable);
+        entryData.flushAndSingleExit(*this, entryData, enclosedStack, false, true, unreachable);
         entryData.linkJumps(&m_jit);
         break;
     case BlockType::TryTable: {
         // normal execution: jump past the handlers
-        entryData.flushAndSingleExit(*this, entryData, entry.enclosedExpressionStack, false, true, unreachable);
+        entryData.flushAndSingleExit(*this, entryData, enclosedStack, false, true, unreachable);
         entryData.addBranch(m_jit.jump());
         // similar to IPInt, we make a handler section to avoid jumping into random parts of code and not having
         // a real landing pad
         // FIXME: should we generate this all at the end of the code? this might help icache performance since
         // exceptions are rare
         ++m_callSiteIndex;
-
         for (auto& target : entryData.m_tryTableTargets)
             emitCatchTableImpl(entryData, target);
-
         // we're done!
         --m_tryCatchDepth;
         entryData.linkJumps(&m_jit);
         break;
     }
     default:
-        entryData.flushAndSingleExit(*this, entryData, entry.enclosedExpressionStack, false, true, unreachable);
+        entryData.flushAndSingleExit(*this, entryData, enclosedStack, false, true, unreachable);
         entryData.linkJumps(&m_jit);
         break;
     }
@@ -4168,12 +4173,12 @@ void BBQJIT::prepareForExceptions()
     LOG_DEDENT();
     LOG_INSTRUCTION("End");
 
-    currentControlData().resumeBlock(*this, entryData, entry.enclosedExpressionStack);
+    currentControlData().resumeBlock(*this, entryData, enclosedStack);
 
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::endTopLevel(const Stack&)
+[[nodiscard]] PartialResult BBQJIT::endTopLevel(std::span<const TypedExpression>)
 {
     RELEASE_ASSERT(static_cast<uint32_t>(alignedFrameSize(m_maxCalleeStackSizeForValidation + m_frameSizeForValidation)) <= m_frameSize);
 
@@ -5054,7 +5059,7 @@ BBQJIT::Jump BBQJIT::emitFusedBranchCompareBranch(OpType opType, ExpressionType,
     }
 }
 
-PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, ExpressionType operand, Stack& results)
+PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, ExpressionType operand, std::span<TypedExpression> results)
 {
     ASSERT(!operand.isNone());
 
@@ -5088,8 +5093,9 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addFusedIfCompare(OpType op, ExpressionType operand, BlockSignature&& signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
+[[nodiscard]] PartialResult BBQJIT::addFusedIfCompare(OpType op, ExpressionType operand, BlockSignature&& signature, std::span<TypedExpression> args, ControlType& result)
 {
+    auto enclosingStack = m_parser->expressionStack();
     BranchFoldResult foldResult = tryFoldFusedBranchCompare(op, operand);
 
     ScratchScope<0, 1> scratches(*this);
@@ -5116,7 +5122,7 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
 
     consume(operand);
 
-    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.argumentCount();
+    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + (enclosingStack.size() - args.size());
     result = ControlData(*this, BlockType::If, WTF::move(signature), height, liveScratchGPRs, liveScratchFPRs);
 
     // Despite being conditional, if doesn't need to worry about diverging expression stacks at block boundaries, so it doesn't need multiple exits.
@@ -5124,9 +5130,8 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
 
     LOG_INSTRUCTION("IfCompare", makeString(op).characters(), result.signature(), operand, operandLocation);
     LOG_INDENT();
-    splitStack(result.signature(), enclosingStack, newStack);
 
-    result.startBlock(*this, newStack);
+    result.startBlock(*this, args);
     if (foldResult == BranchNeverTaken)
         result.setIfBranch(m_jit.jump()); // Emit direct branch if we know the condition is false.
     else if (foldResult == BranchNotFolded) // Otherwise, we only emit a branch at all if we don't know the condition statically.
@@ -5317,7 +5322,7 @@ BBQJIT::Jump BBQJIT::emitFusedBranchCompareBranch(OpType opType, ExpressionType 
     }
 }
 
-PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, ExpressionType left, ExpressionType right, Stack& results)
+PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, ExpressionType left, ExpressionType right, std::span<TypedExpression> results)
 {
     switch (tryFoldFusedBranchCompare(opType, left, right)) {
     case BranchNeverTaken:
@@ -5358,8 +5363,9 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addFusedIfCompare(OpType op, ExpressionType left, ExpressionType right, BlockSignature&& signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
+[[nodiscard]] PartialResult BBQJIT::addFusedIfCompare(OpType op, ExpressionType left, ExpressionType right, BlockSignature&& signature, std::span<TypedExpression> args, ControlType& result)
 {
+    auto enclosingStack = m_parser->expressionStack();
     BranchFoldResult foldResult = tryFoldFusedBranchCompare(op, left, right);
 
     Location leftLocation, rightLocation;
@@ -5394,7 +5400,7 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
     consume(left);
     consume(right);
 
-    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.argumentCount();
+    auto height = currentControlData().enclosedHeight() + currentControlData().implicitSlots() + (enclosingStack.size() - args.size());
     result = ControlData(*this, BlockType::If, WTF::move(signature), height, liveScratchGPRs, liveScratchFPRs);
 
     // Despite being conditional, if doesn't need to worry about diverging expression stacks at block boundaries, so it doesn't need multiple exits.
@@ -5402,9 +5408,8 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
 
     LOG_INSTRUCTION("IfCompare", makeString(op).characters(), result.signature(), left, leftLocation, right, rightLocation);
     LOG_INDENT();
-    splitStack(result.signature(), enclosingStack, newStack);
 
-    result.startBlock(*this, newStack);
+    result.startBlock(*this, args);
     if (foldResult == BranchNeverTaken)
         result.setIfBranch(m_jit.jump()); // Emit direct branch if we know the condition is false.
     else if (foldResult == BranchNotFolded) // Otherwise, we only emit a branch at all if we don't know the condition statically.

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1985,7 +1985,7 @@ public:
 
     MacroAssembler::Label addLoopOSREntrypoint();
 
-    [[nodiscard]] PartialResult addBlock(BlockSignature&&, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    [[nodiscard]] PartialResult addBlock(BlockSignature&&, std::span<TypedExpression> args, ControlType& result);
 
     B3::Type NODELETE toB3Type(Type);
 
@@ -1993,20 +1993,20 @@ public:
 
     B3::ValueRep toB3Rep(Location);
 
-    StackMap makeStackMap(const ControlData& data, Stack& enclosingStack);
+    StackMap makeStackMap(const ControlData&, std::span<const TypedExpression> enclosingStack);
 
-    void emitLoopTierUpCheckAndOSREntryData(const ControlData&, Stack& enclosingStack, unsigned loopIndex);
+    void emitLoopTierUpCheckAndOSREntryData(const ControlData&, std::span<const TypedExpression> enclosingStack, unsigned loopIndex);
 
-    [[nodiscard]] PartialResult addLoop(BlockSignature&&, Stack& enclosingStack, ControlType& result, Stack& newStack, uint32_t loopIndex);
+    [[nodiscard]] PartialResult addLoop(BlockSignature&&, std::span<TypedExpression> args, ControlType& result, uint32_t loopIndex);
 
-    [[nodiscard]] PartialResult addIf(Value condition, BlockSignature&&, Stack& enclosingStack, ControlData& result, Stack& newStack);
+    [[nodiscard]] PartialResult addIf(Value condition, BlockSignature&&, std::span<TypedExpression> args, ControlData& result);
 
-    [[nodiscard]] PartialResult addElse(ControlData& data, Stack& expressionStack);
+    [[nodiscard]] PartialResult addElse(ControlData& data, std::span<TypedExpression> ifBranchResults);
 
     [[nodiscard]] PartialResult addElseToUnreachable(ControlData& data);
 
-    [[nodiscard]] PartialResult addTry(BlockSignature&&, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    [[nodiscard]] PartialResult addTryTable(BlockSignature&&, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
+    [[nodiscard]] PartialResult addTry(BlockSignature&&, std::span<TypedExpression> args, ControlType& result);
+    [[nodiscard]] PartialResult addTryTable(BlockSignature&&, std::span<TypedExpression> args, const Vector<CatchHandler>& targets, ControlType& result);
 
     void emitCatchPrologue();
 
@@ -2015,11 +2015,11 @@ public:
     void emitCatchImpl(ControlData& dataCatch, const RTT& exceptionSignature, ResultList& results);
     void emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTarget&);
 
-    [[nodiscard]] PartialResult addCatch(unsigned exceptionIndex, const RTT& exceptionSignature, Stack& expressionStack, ControlType& data, ResultList& results);
+    [[nodiscard]] PartialResult addCatch(unsigned exceptionIndex, const RTT& exceptionSignature, std::span<TypedExpression> expressionStack, ControlType& data, ResultList& results);
 
     [[nodiscard]] PartialResult addCatchToUnreachable(unsigned exceptionIndex, const RTT& exceptionSignature, ControlType& data, ResultList& results);
 
-    [[nodiscard]] PartialResult addCatchAll(Stack& expressionStack, ControlType& data);
+    [[nodiscard]] PartialResult addCatchAll(std::span<TypedExpression> expressionStack, ControlType& data);
 
     [[nodiscard]] PartialResult addCatchAllToUnreachable(ControlType& data);
 
@@ -2027,31 +2027,33 @@ public:
 
     [[nodiscard]] PartialResult addDelegateToUnreachable(ControlType& target, ControlType& data);
 
-    [[nodiscard]] PartialResult addThrow(unsigned exceptionIndex, ArgumentList& arguments, Stack&);
+    [[nodiscard]] PartialResult addThrow(unsigned exceptionIndex, ArgumentList& arguments, std::span<TypedExpression>);
 
     [[nodiscard]] PartialResult addRethrow(unsigned, ControlType& data);
 
-    [[nodiscard]] PartialResult addThrowRef(ExpressionType exception, Stack&);
+    [[nodiscard]] PartialResult addThrowRef(ExpressionType exception, std::span<TypedExpression>);
 
     void prepareForExceptions();
 
-    [[nodiscard]] PartialResult addReturn(const ControlData& data, const Stack& returnValues);
+    [[nodiscard]] PartialResult addReturn(const ControlData& data, std::span<const TypedExpression> returnValues);
 
-    [[nodiscard]] PartialResult addBranch(ControlData& target, Value condition, Stack& results);
+    [[nodiscard]] PartialResult addBranch(ControlData& target, Value condition, std::span<TypedExpression> results);
 
-    [[nodiscard]] PartialResult addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result);
+    [[nodiscard]] PartialResult addBranchNull(ControlData& data, ExpressionType reference, std::span<TypedExpression> returnValues, bool shouldNegate, ExpressionType& result);
 
-    [[nodiscard]] PartialResult addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate);
+    [[nodiscard]] PartialResult addBranchCast(ControlData& data, ExpressionType reference, std::span<TypedExpression> returnValues, bool allowNull, int32_t heapType, bool shouldNegate);
 
-    [[nodiscard]] PartialResult addSwitch(Value condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, Stack& results);
+    [[nodiscard]] PartialResult addSwitch(Value condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, std::span<TypedExpression> results);
 
-    [[nodiscard]] PartialResult endBlock(ControlEntry& entry, Stack& stack);
+    [[nodiscard]] PartialResult endBlock(ControlEntry& entry, std::span<TypedExpression> enclosedStack);
 
-    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry& entry, Stack& stack, bool unreachable = true);
+    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry& entry, std::span<TypedExpression> enclosedStack);
+
+    [[nodiscard]] PartialResult addEndToUnreachableImpl(ControlEntry& entry, std::span<TypedExpression> enclosedStack, bool unreachable);
 
     int alignedFrameSize(int frameSize) const;
 
-    [[nodiscard]] PartialResult endTopLevel(const Stack&);
+    [[nodiscard]] PartialResult endTopLevel(std::span<const TypedExpression>);
 
     enum BranchFoldResult {
         BranchAlwaysTaken,
@@ -2064,10 +2066,10 @@ public:
     [[nodiscard]] BranchFoldResult tryFoldFusedBranchCompare(OpType, ExpressionType, ExpressionType);
     [[nodiscard]] Jump emitFusedBranchCompareBranch(OpType, ExpressionType, Location, ExpressionType, Location);
 
-    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType& target, ExpressionType, Stack&);
-    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType& target, ExpressionType, ExpressionType, Stack&);
-    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature&&, Stack&, ControlType&, Stack&);
-    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature&&, Stack&, ControlType&, Stack&);
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType& target, ExpressionType, std::span<TypedExpression>);
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType& target, ExpressionType, ExpressionType, std::span<TypedExpression>);
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature&&, std::span<TypedExpression> args, ControlType&);
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature&&, std::span<TypedExpression> args, ControlType&);
 
     // Flush a value to its canonical slot.
     void flushValue(Value value);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -3365,7 +3365,7 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
     targetControl.addBranch(m_jit.jump());
 }
 
-[[nodiscard]] PartialResult BBQJIT::addThrowRef(Value exception, Stack&)
+[[nodiscard]] PartialResult BBQJIT::addThrowRef(Value exception, std::span<TypedExpression>)
 {
     LOG_INSTRUCTION("ThrowRef", exception);
 
@@ -3407,7 +3407,7 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addBranchNull(ControlData& data, ExpressionType reference, std::span<TypedExpression> returnValues, bool shouldNegate, ExpressionType& result)
 {
     if (reference.isConst() && (reference.asRef() == JSValue::encode(jsNull())) == shouldNegate) {
         // If branch is known to be not-taken, exit early.
@@ -3472,7 +3472,7 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate)
+[[nodiscard]] PartialResult BBQJIT::addBranchCast(ControlData& data, ExpressionType reference, std::span<TypedExpression> returnValues, bool allowNull, int32_t heapType, bool shouldNegate)
 {
     Value condition;
     if (reference.isConst()) {

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -639,43 +639,43 @@ public:
         return ControlData(WTF::move(signature));
     }
 
-    [[nodiscard]] PartialResult addBlock(BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addLoop(BlockSignature, Stack&, ControlType&, Stack&, uint32_t) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addIf(ExpressionType, BlockSignature, Stack&, ControlData&, Stack&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addElse(ControlData&, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addBlock(BlockSignature, std::span<TypedExpression>, ControlType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addLoop(BlockSignature, std::span<TypedExpression>, ControlType&, uint32_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addIf(ExpressionType, BlockSignature, std::span<TypedExpression>, ControlData&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addElse(ControlData&, std::span<const TypedExpression>) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addElseToUnreachable(ControlData&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addTry(BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addTryTable(BlockSignature, Stack&, const Vector<CatchHandler>&, ControlType&, Stack&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addCatch(unsigned, const RTT&, Stack&, ControlType&, ResultList&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addTry(BlockSignature, std::span<TypedExpression>, ControlType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addTryTable(BlockSignature, std::span<TypedExpression>, const Vector<CatchHandler>&, ControlType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addCatch(unsigned, const RTT&, std::span<const TypedExpression>, ControlType&, ResultList&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addCatchToUnreachable(unsigned, const RTT&, ControlType&, ResultList&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addCatchAll(Stack&, ControlType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addCatchAll(std::span<const TypedExpression>, ControlType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addCatchAllToUnreachable(ControlType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addDelegate(ControlType&, ControlType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addDelegateToUnreachable(ControlType&, ControlType&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addThrow(unsigned, ArgumentList&, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addThrow(unsigned, ArgumentList&, std::span<const TypedExpression>) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addRethrow(unsigned, ControlType&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addThrowRef(ExpressionType, Stack&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addReturn(const ControlData&, const Stack&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addBranch(ControlData&, ExpressionType, Stack&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addBranchNull(ControlType&, ExpressionType, Stack&, bool, ExpressionType&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addBranchCast(ControlType&, ExpressionType, Stack&, bool, int32_t, bool) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addSwitch(ExpressionType, const Vector<ControlData*>&, ControlData&, Stack&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addThrowRef(ExpressionType, std::span<const TypedExpression>) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addReturn(const ControlData&, std::span<const TypedExpression>) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addBranch(ControlData&, ExpressionType, std::span<const TypedExpression>) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addBranchNull(ControlType&, ExpressionType, std::span<const TypedExpression>, bool, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addBranchCast(ControlType&, ExpressionType, std::span<const TypedExpression>, bool, int32_t, bool) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSwitch(ExpressionType, const Vector<ControlData*>&, ControlData&, std::span<const TypedExpression>) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, std::span<const TypedExpression>) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, std::span<const TypedExpression>) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, std::span<TypedExpression>, ControlType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, std::span<TypedExpression>, ControlType&) CONST_EXPR_STUB
 
-    [[nodiscard]] PartialResult NODELETE endBlock(ControlEntry& entry, Stack& expressionStack)
+    [[nodiscard]] PartialResult NODELETE endBlock(ControlEntry& entry, std::span<TypedExpression> enclosedStack)
     {
-        ASSERT(expressionStack.size() == 1);
+        ASSERT(enclosedStack.size() == 1);
         ASSERT_UNUSED(entry, ControlType::isTopLevel(entry.controlData));
-        m_result = expressionStack.first().value();
+        m_result = enclosedStack.front().value();
         return { };
     }
 
-    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry&, Stack&, bool = true) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry&, std::span<TypedExpression>) CONST_EXPR_STUB
 
-    [[nodiscard]] PartialResult endTopLevel(const Stack&)
+    [[nodiscard]] PartialResult endTopLevel(std::span<const TypedExpression>)
     {
         // Some opcodes like "nop" are not detectable by an error stub because the context
         // doesn't get called by the parser. This flag is set by didParseOpcode() to signal

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -63,18 +63,6 @@ enum class CatchKind {
 };
 OVERLOAD_RELATIONAL_OPERATORS_FOR_ENUM_CLASS_WITH_INTEGRALS(CatchKind);
 
-template<typename EnclosingStack, typename NewStack>
-void splitStack(const BlockSignature& signature, EnclosingStack& enclosingStack, NewStack& newStack)
-{
-    ASSERT(enclosingStack.size() >= signature.argumentCount());
-
-    unsigned offset = enclosingStack.size() - signature.argumentCount();
-    newStack = NewStack(signature.argumentCount(), [&](size_t i) {
-        return enclosingStack.at(i + offset);
-    });
-    enclosingStack.shrink(offset);
-}
-
 struct ControlRef {
     size_t m_index { 0 };
 };
@@ -119,8 +107,18 @@ struct FunctionParserTypes {
     using Stack = Vector<TypedExpression, 16, UnsafeVectorOverflow>;
 
     struct ControlEntry {
-        Stack enclosedExpressionStack;
-        Stack elseBlockStack;
+        // FIXME: This field is dead on every ControlEntry that isn't an `if` with
+        // args. On JetStream3, 100% of `if` blocks had argumentCount==0 and 86%
+        // never reached an `else`, so 100% of these slots store an empty
+        // FixedVector. Consider moving this to a sparse side data structure keyed
+        // by the few `if`s that actually have args. Alternatively, since control
+        // is structured there could be another parser-wide expression stack for
+        // else blocks.
+        FixedVector<TypedExpression> elseBlockStack;
+        // Offset in the parser's single contiguous expression-stack Vector where
+        // this entry's own slice begins (its args followed by values pushed by
+        // its body). While this entry is the innermost, equals m_currentStackBegin.
+        uint32_t enclosedStackBegin;
         uint32_t localInitStackHeight;
         ControlType controlData;
     };
@@ -170,7 +168,35 @@ public:
     bool unreachableBlocks() const { return m_unreachableBlocks; }
 
     ControlStack& controlStack() LIFETIME_BOUND { return m_controlStack; }
-    Stack& expressionStack() LIFETIME_BOUND { return m_expressionStack; }
+
+    // Returns the slice of the single backing Vector belonging to the
+    // currently-active control block.
+    std::span<TypedExpression> expressionStack() LIFETIME_BOUND
+    {
+        return m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
+    }
+    std::span<const TypedExpression> expressionStack() const LIFETIME_BOUND
+    {
+        return m_expressionStack.span().subspan(m_currentStackBegin);
+    }
+
+    // Slice of m_expressionStack belonging to the parent of the entry at controlIndex:
+    // the values live in that parent at the moment this entry was opened, after its
+    // args were taken out. For the outermost (TopLevel) entry, this slice is empty.
+    std::span<const TypedExpression> enclosedSliceOf(size_t controlIndex) const LIFETIME_BOUND
+    {
+        ASSERT(controlIndex < m_controlStack.size());
+        uint32_t begin = controlIndex ? m_controlStack[controlIndex - 1].enclosedStackBegin : 0;
+        uint32_t end = m_controlStack[controlIndex].enclosedStackBegin;
+        return m_expressionStack.span().subspan(begin, end - begin);
+    }
+    std::span<TypedExpression> enclosedSliceOf(size_t controlIndex) LIFETIME_BOUND
+    {
+        ASSERT(controlIndex < m_controlStack.size());
+        uint32_t begin = controlIndex ? m_controlStack[controlIndex - 1].enclosedStackBegin : 0;
+        uint32_t end = m_controlStack[controlIndex].enclosedStackBegin;
+        return m_expressionStack.mutableSpan().subspan(begin, end - begin);
+    }
 
     ControlEntry& resolveControlRef(ControlRef ref) { return m_controlStack[ref.m_index]; }
 
@@ -195,21 +221,25 @@ public:
 
     uint32_t getStackHeightInValues() const
     {
-        return m_expressionStack.size() + getControlEntryStackHeightInValues();
+        return m_expressionStack.size();
     }
 
     uint32_t getControlEntryStackHeightInValues() const
     {
-        uint32_t result = 0;
-        for (const ControlEntry& entry : m_controlStack)
-            result += entry.enclosedExpressionStack.size();
-        return result;
+        return m_currentStackBegin;
     }
 
     uint32_t numCallProfiles() const { return m_callProfileIndex; }
 
 private:
     static constexpr bool verbose = false;
+
+    // After takeLast() on m_controlStack, the new parent's enclosedStackBegin
+    // is where the just-ended block's enclosed slice ends (or 0 at TopLevel).
+    uint32_t parentEntryBegin() const
+    {
+        return m_controlStack.isEmpty() ? 0 : m_controlStack.last().enclosedStackBegin;
+    }
 
     [[nodiscard]] PartialResult parseBody();
     [[nodiscard]] PartialResult parseExpression();
@@ -230,10 +260,10 @@ private:
     [[nodiscard]] PartialResult parseReftypeSignature(const ModuleInformation&, BlockSignature&);
 
     [[nodiscard]] PartialResult parseNestedBlocksEagerly(bool&);
-    void switchToBlock(ControlType&&, Stack&&);
+    void switchToBlock(ControlType&&, uint32_t argumentCount);
 
 #define WASM_TRY_POP_EXPRESSION_STACK_INTO(result, what) do { \
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in "_s, what); \
+        WASM_PARSER_FAIL_IF(m_expressionStack.size() == m_currentStackBegin, "can't pop empty stack in "_s, what); \
         result = m_expressionStack.takeLast(); \
         m_context.didPopValueFromStack(result, "WasmFunctionParser.h " STRINGIZE_VALUE_OF(__LINE__) ""_s); \
     } while (0)
@@ -391,6 +421,10 @@ private:
 
     Context& m_context;
     Stack m_expressionStack;
+    // Backing offset where the currently-active control block's slice begins
+    // in m_expressionStack. Every active block's live values share that one
+    // Vector; m_expressionStack[m_currentStackBegin..end] is the live block.
+    uint32_t m_currentStackBegin { 0 };
     ControlStack m_controlStack;
     Vector<Type, 16> m_locals;
     const BlockSignature m_signature;
@@ -508,7 +542,8 @@ auto FunctionParser<Context>::parseConstantExpression() -> Result
 template<typename Context>
 auto FunctionParser<Context>::parseBody() -> PartialResult
 {
-    m_controlStack.append({ { }, { }, 0, m_context.addTopLevel(BlockSignature { m_signature }) });
+    const uint32_t enclosedStackBegin = 0;
+    m_controlStack.constructAndAppend(FixedVector<TypedExpression> { }, enclosedStackBegin, 0, m_context.addTopLevel(BlockSignature { m_signature }));
     uint8_t op = 0;
     while (m_controlStack.size()) {
         m_currentOpcodeStartingOffset = m_offset;
@@ -548,7 +583,7 @@ auto FunctionParser<Context>::parseBody() -> PartialResult
             WASM_FAIL_IF_HELPER_FAILS(parseExpression());
         m_context.didParseOpcode();
     }
-    WASM_FAIL_IF_HELPER_FAILS(m_context.endTopLevel(m_expressionStack));
+    WASM_FAIL_IF_HELPER_FAILS(m_context.endTopLevel(m_expressionStack.span()));
     if (Context::validateFunctionBodySize)
         WASM_PARSER_FAIL_IF(m_offset != source().size(), "function body size doesn't match the expected size");
 
@@ -600,7 +635,7 @@ auto FunctionParser<Context>::binaryCompareCase(OpType op, BinaryOperationHandle
 
             ControlType& data = m_controlStack[m_controlStack.size() - 1 - target].controlData;
             WASM_FAIL_IF_HELPER_FAILS(checkBranchTarget(data, Conditional));
-            WASM_TRY_ADD_TO_CONTEXT(addFusedBranchCompare(op, data, left, right, m_expressionStack));
+            WASM_TRY_ADD_TO_CONTEXT(addFusedBranchCompare(op, data, left, right, expressionStack()));
             m_context.didParseOpcode();
             return { };
         }
@@ -614,20 +649,22 @@ auto FunctionParser<Context>::binaryCompareCase(OpType op, BinaryOperationHandle
             BlockSignature inlineSignature;
             WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get if's signature"_s);
 
-            WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature.argumentCount(), "Too few arguments on stack for if block. If expects ", inlineSignature.argumentCount(), ", but only ", m_expressionStack.size(), " were present. If block has signature: ", inlineSignature);
-            unsigned offset = m_expressionStack.size() - inlineSignature.argumentCount();
-            for (unsigned i = 0; i < inlineSignature.argumentCount(); ++i)
-                WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[offset + i].type(), inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[i].type());
+            const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
+            const uint32_t argumentCount = inlineSignature.argumentCount();
+            WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few arguments on stack for if block. If expects ", argumentCount, ", but only ", sliceSize, " were present. If block has signature: ", inlineSignature);
+            const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
+            for (unsigned i = 0; i < argumentCount; ++i)
+                WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[parentStackHeight + i].type(), inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[parentStackHeight + i].type());
 
-            int64_t oldSize = m_expressionStack.size();
-            Stack newStack;
+            auto args = m_expressionStack.mutableSpan().last(argumentCount);
             ControlType control;
-            WASM_TRY_ADD_TO_CONTEXT(addFusedIfCompare(op, left, right, WTF::move(inlineSignature), m_expressionStack, control, newStack));
-            ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == control.signature().argumentCount());
-            ASSERT(newStack.size() == control.signature().argumentCount());
-
-            m_controlStack.append({ WTF::move(m_expressionStack), newStack, getLocalInitStackHeight(), WTF::move(control) });
-            m_expressionStack = WTF::move(newStack);
+            WASM_TRY_ADD_TO_CONTEXT(addFusedIfCompare(op, left, right, WTF::move(inlineSignature), args, control));
+            FixedVector<TypedExpression> elseSave;
+            if (argumentCount)
+                elseSave = FixedVector<TypedExpression>::createWithSizeFromGenerator(argumentCount, [&](size_t i) { return m_expressionStack[parentStackHeight + i]; });
+            ASSERT(m_currentStackBegin == parentEntryBegin());
+            m_controlStack.constructAndAppend(WTF::move(elseSave), parentStackHeight, getLocalInitStackHeight(), WTF::move(control));
+            m_currentStackBegin = parentStackHeight;
             m_context.didParseOpcode();
             return { };
         }
@@ -672,7 +709,7 @@ auto FunctionParser<Context>::unaryCompareCase(OpType op, UnaryOperationHandler 
 
             ControlType& data = m_controlStack[m_controlStack.size() - 1 - target].controlData;
             WASM_FAIL_IF_HELPER_FAILS(checkBranchTarget(data, Conditional));
-            WASM_TRY_ADD_TO_CONTEXT(addFusedBranchCompare(op, data, value, m_expressionStack));
+            WASM_TRY_ADD_TO_CONTEXT(addFusedBranchCompare(op, data, value, expressionStack()));
             return { };
         }
         if (nextOpcode == OpType::If) {
@@ -682,20 +719,22 @@ auto FunctionParser<Context>::unaryCompareCase(OpType op, UnaryOperationHandler 
             BlockSignature inlineSignature;
             WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get if's signature"_s);
 
-            WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature.argumentCount(), "Too few arguments on stack for if block. If expects ", inlineSignature.argumentCount(), ", but only ", m_expressionStack.size(), " were present. If block has signature: ", inlineSignature);
-            unsigned offset = m_expressionStack.size() - inlineSignature.argumentCount();
-            for (unsigned i = 0; i < inlineSignature.argumentCount(); ++i)
-                WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[offset + i].type(), inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[i].type());
+            const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
+            const uint32_t argumentCount = inlineSignature.argumentCount();
+            WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few arguments on stack for if block. If expects ", argumentCount, ", but only ", sliceSize, " were present. If block has signature: ", inlineSignature);
+            const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
+            for (unsigned i = 0; i < argumentCount; ++i)
+                WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[parentStackHeight + i].type(), inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[parentStackHeight + i].type());
 
-            int64_t oldSize = m_expressionStack.size();
-            Stack newStack;
+            auto args = m_expressionStack.mutableSpan().last(argumentCount);
             ControlType control;
-            WASM_TRY_ADD_TO_CONTEXT(addFusedIfCompare(op, value, WTF::move(inlineSignature), m_expressionStack, control, newStack));
-            ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == control.signature().argumentCount());
-            ASSERT(newStack.size() == control.signature().argumentCount());
-
-            m_controlStack.append({ WTF::move(m_expressionStack), newStack, getLocalInitStackHeight(), WTF::move(control) });
-            m_expressionStack = WTF::move(newStack);
+            WASM_TRY_ADD_TO_CONTEXT(addFusedIfCompare(op, value, WTF::move(inlineSignature), args, control));
+            FixedVector<TypedExpression> elseSave;
+            if (argumentCount)
+                elseSave = FixedVector<TypedExpression>::createWithSizeFromGenerator(argumentCount, [&](size_t i) { return m_expressionStack[parentStackHeight + i]; });
+            ASSERT(m_currentStackBegin == parentEntryBegin());
+            m_controlStack.constructAndAppend(WTF::move(elseSave), parentStackHeight, getLocalInitStackHeight(), WTF::move(control));
+            m_currentStackBegin = parentStackHeight;
             return { };
         }
     }
@@ -1861,9 +1900,10 @@ auto FunctionParser<Context>::checkBranchTarget(const ControlType& target, Branc
     if (!target.branchTargetArity())
         return { };
 
-    WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < target.branchTargetArity(), ControlType::isTopLevel(target) ? "branch out of function"_s : "branch to block"_s, " on expression stack of size "_s, m_expressionStack.size(), ", but block, "_s, target.signature() , " expects "_s, target.branchTargetArity(), " values"_s);
+    const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
+    WASM_VALIDATOR_FAIL_IF(sliceSize < target.branchTargetArity(), ControlType::isTopLevel(target) ? "branch out of function"_s : "branch to block"_s, " on expression stack of size "_s, sliceSize, ", but block, "_s, target.signature() , " expects "_s, target.branchTargetArity(), " values"_s);
 
-    unsigned offset = m_expressionStack.size() - target.branchTargetArity();
+    const unsigned offset = m_expressionStack.size() - target.branchTargetArity();
     for (unsigned i = 0; i < target.branchTargetArity(); ++i) {
         WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[offset + i].type(), target.branchTargetType(i)), "branch's stack type is not a subtype of block's type branch target type. Stack value has type "_s, m_expressionStack[offset + i].type(), " but branch target expects a value of "_s, target.branchTargetType(i), " at index "_s, i);
 
@@ -1894,13 +1934,14 @@ template<typename Context>
 auto FunctionParser<Context>::checkExpressionStack(const ControlType& controlData, bool forceSignature) -> PartialResult
 {
     const auto& blockSignature = controlData.signature();
-    WASM_VALIDATOR_FAIL_IF(blockSignature.returnCount() != m_expressionStack.size(), " block with type: "_s, blockSignature, " returns: "_s, blockSignature.returnCount(), " but stack has: "_s, m_expressionStack.size(), " values"_s);
+    const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
+    WASM_VALIDATOR_FAIL_IF(blockSignature.returnCount() != sliceSize, " block with type: "_s, blockSignature, " returns: "_s, blockSignature.returnCount(), " but stack has: "_s, sliceSize, " values"_s);
     for (unsigned i = 0; i < blockSignature.returnCount(); ++i) {
-        const auto actualType = m_expressionStack[i].type();
+        const auto actualType = m_expressionStack[m_currentStackBegin + i].type();
         const auto expectedType = blockSignature.returnType(i);
         WASM_VALIDATOR_FAIL_IF(!isSubtype(actualType, expectedType), "control flow returns with unexpected type. "_s, actualType, " is not a "_s, expectedType);
         if (forceSignature)
-            m_expressionStack[i].setType(expectedType);
+            m_expressionStack[m_currentStackBegin + i].setType(expectedType);
     }
 
     return { };
@@ -1954,14 +1995,9 @@ ALWAYS_INLINE auto FunctionParser<Context>::parseNestedBlocksEagerly(bool& shoul
 
         ASSERT(!inlineSignature.argumentCount());
 
-        int64_t oldSize = m_expressionStack.size();
-        Stack newStack;
         ControlType block;
-        WASM_TRY_ADD_TO_CONTEXT(addBlock(WTF::move(inlineSignature), m_expressionStack, block, newStack));
-        ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == block.signature().argumentCount());
-        ASSERT(newStack.size() == block.signature().argumentCount());
-
-        switchToBlock(WTF::move(block), WTF::move(newStack));
+        WASM_TRY_ADD_TO_CONTEXT(addBlock(WTF::move(inlineSignature), std::span<TypedExpression>(), block));
+        switchToBlock(WTF::move(block), 0);
 
         if (m_offset >= source().size()) {
             shouldContinue = false;
@@ -2032,10 +2068,12 @@ inline auto FunctionParser<Context>::parseReftypeSignature(const ModuleInformati
 }
 
 template <typename Context>
-ALWAYS_INLINE void FunctionParser<Context>::switchToBlock(ControlType&& block, Stack&& newStack)
+ALWAYS_INLINE void FunctionParser<Context>::switchToBlock(ControlType&& block, uint32_t argumentCount)
 {
-    m_controlStack.append({ WTF::move(m_expressionStack), { }, getLocalInitStackHeight(), WTF::move(block) });
-    m_expressionStack = WTF::move(newStack);
+    ASSERT(m_currentStackBegin == parentEntryBegin());
+    const uint32_t newBegin = m_expressionStack.size() - argumentCount;
+    m_controlStack.constructAndAppend(FixedVector<TypedExpression> { }, newBegin, getLocalInitStackHeight(), WTF::move(block));
+    m_currentStackBegin = newBegin;
 }
 
 template<typename Context>
@@ -2514,7 +2552,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_VALIDATOR_FAIL_IF(argc > maxArrayNewFixedArgs, "array_new_fixed can take at most "_s, maxArrayNewFixedArgs, " operands. Got "_s, argc);
 
             // If more arguments are expected than the current stack size, that's an error
-            WASM_VALIDATOR_FAIL_IF(argc > m_expressionStack.size(), "array_new_fixed: found ", m_expressionStack.size(), " operands on stack; expected ", argc, " operands");
+            WASM_VALIDATOR_FAIL_IF(argc > m_expressionStack.size() - m_currentStackBegin, "array_new_fixed: found ", m_expressionStack.size() - m_currentStackBegin, " operands on stack; expected ", argc, " operands");
 
             // Allocate stack space for arguments
             ArgumentList args;
@@ -2795,7 +2833,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndex(typeIndex, "struct.new"_s));
 
             const auto& structType = m_info.rtt(typeIndex);
-            WASM_PARSER_FAIL_IF(structType.fieldCount() > m_expressionStack.size(), "struct.new "_s, typeIndex, " requires "_s, structType.fieldCount(), " values, but the expression stack currently holds "_s, m_expressionStack.size(), " values"_s);
+            WASM_PARSER_FAIL_IF(structType.fieldCount() > m_expressionStack.size() - m_currentStackBegin, "struct.new "_s, typeIndex, " requires "_s, structType.fieldCount(), " values, but the expression stack currently holds "_s, m_expressionStack.size() - m_currentStackBegin, " values"_s);
 
             ArgumentList args;
             size_t firstArgumentIndex = m_expressionStack.size() - structType.fieldCount();
@@ -2967,7 +3005,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             // Manually pop the stack in order to avoid decreasing the stack size, as we will immediately put it back.
             TypedExpression ref;
-            WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in "_s, opName);
+            WASM_PARSER_FAIL_IF(m_expressionStack.size() == m_currentStackBegin, "can't pop empty stack in "_s, opName);
             ref = m_expressionStack.takeLast();
 
             WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), Type { hasNull1 ? TypeKind::RefNull : TypeKind::Ref, typeIndex1 }), opName, " to type "_s, ref.type(), " expected a reference type with source heaptype"_s);
@@ -2992,7 +3030,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             m_expressionStack.takeLast();
             m_expressionStack.constructAndAppend(nonTakenType, ref.value());
 
-            WASM_TRY_ADD_TO_CONTEXT(addBranchCast(data, ref, m_expressionStack, hasNull2, heapType2, op == ExtGCOpType::BrOnCastFail));
+            WASM_TRY_ADD_TO_CONTEXT(addBranchCast(data, ref, expressionStack(), hasNull2, heapType2, op == ExtGCOpType::BrOnCastFail));
 
             break;
         }
@@ -3131,7 +3169,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_FAIL_IF_HELPER_FAILS(checkBranchTarget(data, Conditional));
 
         ExpressionType result;
-        WASM_TRY_ADD_TO_CONTEXT(addBranchNull(data, ref, m_expressionStack, false, result));
+        WASM_TRY_ADD_TO_CONTEXT(addBranchNull(data, ref, expressionStack(), false, result));
         m_expressionStack.constructAndAppend(Type { TypeKind::Ref, ref.type().index }, result);
 
         return { };
@@ -3143,7 +3181,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         TypedExpression ref;
         // Pop the stack manually to avoid changing the stack size, because the branch needs the value with a different type.
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in br_on_non_null"_s);
+        WASM_PARSER_FAIL_IF(m_expressionStack.size() == m_currentStackBegin, "can't pop empty stack in br_on_non_null"_s);
         ref = m_expressionStack.takeLast();
         m_expressionStack.constructAndAppend(Type { TypeKind::Ref, ref.type().index }, ref.value());
         WASM_VALIDATOR_FAIL_IF(!isRefType(ref.type()), "br_on_non_null ref to type "_s, ref.type(), " expected a reference type"_s);
@@ -3152,7 +3190,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_FAIL_IF_HELPER_FAILS(checkBranchTarget(data, Conditional));
 
         ExpressionType unused;
-        WASM_TRY_ADD_TO_CONTEXT(addBranchNull(data, ref, m_expressionStack, true, unused));
+        WASM_TRY_ADD_TO_CONTEXT(addBranchNull(data, ref, expressionStack(), true, unused));
 
         // On a non-taken branch, the value is null so it's not needed on the stack.
         // We add a drop to ensure the context knows we are discarding this ref value,
@@ -3207,7 +3245,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_FAIL_IF_HELPER_FAILS(parseIndexForLocal(index));
         pushLocalInitialized(index);
 
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't tee_local on empty expression stack"_s);
+        WASM_PARSER_FAIL_IF(m_expressionStack.size() == m_currentStackBegin, "can't tee_local on empty expression stack"_s);
         TypedExpression value;
         WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "tee_local"_s);
         WASM_VALIDATOR_FAIL_IF(index >= m_locals.size(), "attempt to tee unknown local "_s, index, "_s, the number of locals is "_s, m_locals.size());
@@ -3262,7 +3300,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_FAIL_IF_HELPER_FAILS(parseFunctionIndex(functionIndex));
 
         const auto& calleeSignature = m_info.rtt(m_info.typeSignatureIndexFromFunctionIndexSpace(functionIndex));
-        WASM_PARSER_FAIL_IF(calleeSignature.argumentCount() > m_expressionStack.size(), "call function index "_s, functionIndex, " has "_s, calleeSignature.argumentCount(), " arguments, but the expression stack currently holds "_s, m_expressionStack.size(), " values"_s);
+        WASM_PARSER_FAIL_IF(calleeSignature.argumentCount() > m_expressionStack.size() - m_currentStackBegin, "call function index "_s, functionIndex, " has "_s, calleeSignature.argumentCount(), " arguments, but the expression stack currently holds "_s, m_expressionStack.size() - m_currentStackBegin, " values"_s);
 
         size_t firstArgumentIndex = m_expressionStack.size() - calleeSignature.argumentCount();
         ArgumentList args;
@@ -3326,7 +3364,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         const auto& calleeSignature = m_info.rtt(index);
         WASM_VALIDATOR_FAIL_IF(calleeSignature.kind() != RTTKind::Function, "invalid type index (not a function signature) for call_indirect, got ", signatureIndex);
         size_t argumentCount = calleeSignature.argumentCount() + 1; // Add the callee's index.
-        WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size(), "call_indirect expects "_s, argumentCount, " arguments, but the expression stack currently holds "_s, m_expressionStack.size(), " values"_s);
+        WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size() - m_currentStackBegin, "call_indirect expects "_s, argumentCount, " arguments, but the expression stack currently holds "_s, m_expressionStack.size() - m_currentStackBegin, " values"_s);
 
         WASM_VALIDATOR_FAIL_IF(!m_expressionStack.last().type().isI32(), "non-i32 call_indirect index "_s, m_expressionStack.last().type());
 
@@ -3381,7 +3419,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_PARSER_FAIL_IF(!parseVarUInt32(rawTypeIndex), "can't get call_ref's signature index"_s);
         WASM_VALIDATOR_FAIL_IF(rawTypeIndex >= m_info.typeCount(), "call_ref index ", rawTypeIndex, " is out of bounds");
 
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't call_ref on empty expression stack"_s);
+        WASM_PARSER_FAIL_IF(m_expressionStack.size() == m_currentStackBegin, "can't call_ref on empty expression stack"_s);
 
         TypeSignatureIndex typeIndex(rawTypeIndex);
         const auto& calleeSignature = m_info.rtt(typeIndex);
@@ -3390,7 +3428,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack.last().type(), calleeType), "invalid type for call_ref value, expected ", calleeType, " got ", m_expressionStack.last().type());
 
         size_t argumentCount = calleeSignature.argumentCount() + 1; // Add the callee's value.
-        WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size(), "call_ref expects ", argumentCount, " arguments, but the expression stack currently holds ", m_expressionStack.size(), " values");
+        WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size() - m_currentStackBegin, "call_ref expects ", argumentCount, " arguments, but the expression stack currently holds ", m_expressionStack.size() - m_currentStackBegin, " values");
 
         ArgumentList args;
         WASM_ALLOCATOR_FAIL_IF(!args.tryReserveInitialCapacity(argumentCount), "can't allocate enough memory for ", argumentCount, " call_indirect arguments");
@@ -3445,21 +3483,20 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignature;
         WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get block's signature"_s);
 
-        WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature.argumentCount(), "Too few values on stack for block. Block expects ", inlineSignature.argumentCount(), ", but only ", m_expressionStack.size(), " were present. Block has inlineSignature: ", inlineSignature);
-        unsigned offset = m_expressionStack.size() - inlineSignature.argumentCount();
-        for (unsigned i = 0; i < inlineSignature.argumentCount(); ++i) {
-            Type type = m_expressionStack.at(offset + i).type();
+        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
+        const uint32_t argumentCount = inlineSignature.argumentCount();
+
+        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few values on stack for block. Block expects ", argumentCount, ", but only ", sliceSize, " were present. Block has inlineSignature: ", inlineSignature);
+        const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
+        for (unsigned i = 0; i < argumentCount; ++i) {
+            Type type = m_expressionStack[parentStackHeight + i].type();
             WASM_VALIDATOR_FAIL_IF(!isSubtype(type, inlineSignature.argumentType(i)), "Block expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", type);
         }
 
-        int64_t oldSize = m_expressionStack.size();
-        Stack newStack;
+        auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType block;
-        WASM_TRY_ADD_TO_CONTEXT(addBlock(WTF::move(inlineSignature), m_expressionStack, block, newStack));
-        ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == block.signature().argumentCount());
-        ASSERT(newStack.size() == block.signature().argumentCount());
-
-        switchToBlock(WTF::move(block), WTF::move(newStack));
+        WASM_TRY_ADD_TO_CONTEXT(addBlock(WTF::move(inlineSignature), args, block));
+        switchToBlock(WTF::move(block), argumentCount);
         return { };
     }
 
@@ -3467,22 +3504,23 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignature;
         WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get loop's signature"_s);
 
-        WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature.argumentCount(), "Too few values on stack for loop block. Loop expects ", inlineSignature.argumentCount(), ", but only ", m_expressionStack.size(), " were present. Loop has inlineSignature: ", inlineSignature);
-        unsigned offset = m_expressionStack.size() - inlineSignature.argumentCount();
-        for (unsigned i = 0; i < inlineSignature.argumentCount(); ++i) {
-            Type type = m_expressionStack.at(offset + i).type();
+        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
+        const uint32_t argumentCount = inlineSignature.argumentCount();
+
+        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few values on stack for loop block. Loop expects ", argumentCount, ", but only ", sliceSize, " were present. Loop has inlineSignature: ", inlineSignature);
+        const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
+        for (unsigned i = 0; i < argumentCount; ++i) {
+            Type type = m_expressionStack[parentStackHeight + i].type();
             WASM_VALIDATOR_FAIL_IF(!isSubtype(type, inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", type);
         }
 
-        int64_t oldSize = m_expressionStack.size();
-        Stack newStack;
+        auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType loop;
-        WASM_TRY_ADD_TO_CONTEXT(addLoop(WTF::move(inlineSignature), m_expressionStack, loop, newStack, m_loopIndex++));
-        ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == loop.signature().argumentCount());
-        ASSERT(newStack.size() == loop.signature().argumentCount());
+        WASM_TRY_ADD_TO_CONTEXT(addLoop(WTF::move(inlineSignature), args, loop, m_loopIndex++));
 
-        m_controlStack.append({ WTF::move(m_expressionStack), { }, getLocalInitStackHeight(), WTF::move(loop) });
-        m_expressionStack = WTF::move(newStack);
+        ASSERT(m_currentStackBegin == parentEntryBegin());
+        m_controlStack.constructAndAppend(FixedVector<TypedExpression> { }, parentStackHeight, getLocalInitStackHeight(), WTF::move(loop));
+        m_currentStackBegin = parentStackHeight;
         return { };
     }
 
@@ -3493,20 +3531,24 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "if condition"_s);
 
         WASM_VALIDATOR_FAIL_IF(!condition.type().isI32(), "if condition must be i32, got ", condition.type());
-        WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature.argumentCount(), "Too few arguments on stack for if block. If expects ", inlineSignature.argumentCount(), ", but only ", m_expressionStack.size(), " were present. If block has signature: ", inlineSignature);
-        unsigned offset = m_expressionStack.size() - inlineSignature.argumentCount();
-        for (unsigned i = 0; i < inlineSignature.argumentCount(); ++i)
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[offset + i].type(), inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[i].type());
+        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
+        const uint32_t argumentCount = inlineSignature.argumentCount();
 
-        int64_t oldSize = m_expressionStack.size();
-        Stack newStack;
+        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few arguments on stack for if block. If expects ", argumentCount, ", but only ", sliceSize, " were present. If block has signature: ", inlineSignature);
+        const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
+        for (unsigned i = 0; i < argumentCount; ++i)
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[parentStackHeight + i].type(), inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[parentStackHeight + i].type());
+
+        auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType control;
-        WASM_TRY_ADD_TO_CONTEXT(addIf(condition, WTF::move(inlineSignature), m_expressionStack, control, newStack));
-        ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == control.signature().argumentCount());
-        ASSERT(newStack.size() == control.signature().argumentCount());
+        WASM_TRY_ADD_TO_CONTEXT(addIf(condition, WTF::move(inlineSignature), args, control));
 
-        m_controlStack.append({ WTF::move(m_expressionStack), newStack, getLocalInitStackHeight(), WTF::move(control) });
-        m_expressionStack = WTF::move(newStack);
+        FixedVector<TypedExpression> elseSave;
+        if (argumentCount)
+            elseSave = FixedVector<TypedExpression>::createWithSizeFromGenerator(argumentCount, [&](size_t i) { return m_expressionStack[parentStackHeight + i]; });
+        ASSERT(m_currentStackBegin == parentEntryBegin());
+        m_controlStack.constructAndAppend(WTF::move(elseSave), parentStackHeight, getLocalInitStackHeight(), WTF::move(control));
+        m_currentStackBegin = parentStackHeight;
         return { };
     }
 
@@ -3517,8 +3559,10 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         WASM_VALIDATOR_FAIL_IF(!ControlType::isIf(controlEntry.controlData), "else block isn't associated to an if");
         WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
-        WASM_TRY_ADD_TO_CONTEXT(addElse(controlEntry.controlData, m_expressionStack));
-        m_expressionStack = WTF::move(controlEntry.elseBlockStack);
+        auto ifBranchResults = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
+        WASM_TRY_ADD_TO_CONTEXT(addElse(controlEntry.controlData, ifBranchResults));
+        m_expressionStack.shrink(m_currentStackBegin);
+        m_expressionStack.append(controlEntry.elseBlockStack.span());
         resetLocalInitStackToHeight(controlEntry.localInitStackHeight);
         return { };
     }
@@ -3528,20 +3572,21 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignature;
         WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get try's signature"_s);
 
-        WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature.argumentCount(), "Too few arguments on stack for try block. Try expects ", inlineSignature.argumentCount(), ", but only ", m_expressionStack.size(), " were present. Try block has signature: ", inlineSignature);
-        unsigned offset = m_expressionStack.size() - inlineSignature.argumentCount();
-        for (unsigned i = 0; i < inlineSignature.argumentCount(); ++i)
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[offset + i].type(), inlineSignature.argumentType(i)), "Try expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[i].type());
+        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
+        const uint32_t argumentCount = inlineSignature.argumentCount();
 
-        int64_t oldSize = m_expressionStack.size();
-        Stack newStack;
+        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few arguments on stack for try block. Try expects ", argumentCount, ", but only ", sliceSize, " were present. Try block has signature: ", inlineSignature);
+        const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
+        for (unsigned i = 0; i < argumentCount; ++i)
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[parentStackHeight + i].type(), inlineSignature.argumentType(i)), "Try expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[parentStackHeight + i].type());
+
+        auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType control;
-        WASM_TRY_ADD_TO_CONTEXT(addTry(WTF::move(inlineSignature), m_expressionStack, control, newStack));
-        ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == control.signature().argumentCount());
-        ASSERT(newStack.size() == control.signature().argumentCount());
+        WASM_TRY_ADD_TO_CONTEXT(addTry(WTF::move(inlineSignature), args, control));
 
-        m_controlStack.append({ WTF::move(m_expressionStack), { }, getLocalInitStackHeight(), WTF::move(control) });
-        m_expressionStack = WTF::move(newStack);
+        ASSERT(m_currentStackBegin == parentEntryBegin());
+        m_controlStack.constructAndAppend(FixedVector<TypedExpression> { }, parentStackHeight, getLocalInitStackHeight(), WTF::move(control));
+        m_currentStackBegin = parentStackHeight;
         return { };
     }
 
@@ -3557,10 +3602,10 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
 
         ResultList results;
-        Stack preCatchStack;
-        m_expressionStack.swap(preCatchStack);
+        auto preCatchStack = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
         WASM_TRY_ADD_TO_CONTEXT(addCatch(exceptionIndex, exceptionSignature, preCatchStack, controlEntry.controlData, results));
 
+        m_expressionStack.shrink(m_currentStackBegin);
         RELEASE_ASSERT(exceptionSignature.argumentCount() == results.size());
         for (unsigned i = 0; i < exceptionSignature.argumentCount(); ++i) {
             Type argumentType = exceptionSignature.argumentType(i);
@@ -3582,10 +3627,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
         WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
 
-        ResultList results;
-        Stack preCatchStack;
-        m_expressionStack.swap(preCatchStack);
+        auto preCatchStack = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
         WASM_TRY_ADD_TO_CONTEXT(addCatchAll(preCatchStack, controlEntry.controlData));
+        m_expressionStack.shrink(m_currentStackBegin);
         resetLocalInitStackToHeight(controlEntry.localInitStackHeight);
 
         ASSERT(m_info.m_usesLegacyExceptions.loadRelaxed());
@@ -3597,10 +3641,12 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignature;
         WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get try_table's signature"_s);
 
-        WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature.argumentCount(), "Too few values on stack for block. Block expects ", inlineSignature.argumentCount(), ", but only ", m_expressionStack.size(), " were present. Block has inlineSignature: ", inlineSignature);
-        unsigned offset = m_expressionStack.size() - inlineSignature.argumentCount();
-        for (unsigned i = 0; i < inlineSignature.argumentCount(); ++i) {
-            Type type = m_expressionStack.at(offset + i).type();
+        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
+        const uint32_t argumentCount = inlineSignature.argumentCount();
+        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few values on stack for block. Block expects ", argumentCount, ", but only ", sliceSize, " were present. Block has inlineSignature: ", inlineSignature);
+        const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
+        for (unsigned i = 0; i < argumentCount; ++i) {
+            Type type = m_expressionStack[parentStackHeight + i].type();
             WASM_VALIDATOR_FAIL_IF(!isSubtype(type, inlineSignature.argumentType(i)), "Block expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", type);
         }
 
@@ -3666,14 +3712,11 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
                 WASM_VALIDATOR_FAIL_IF(!isSubtype(results[i].type(), target.branchTargetType(i)), "try_table target type mismatch");
         }
 
-        int64_t oldSize = m_expressionStack.size();
-        Stack newStack;
+        auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType block;
-        WASM_TRY_ADD_TO_CONTEXT(addTryTable(WTF::move(inlineSignature), m_expressionStack, targets, block, newStack));
-        ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == block.signature().argumentCount());
-        ASSERT(newStack.size() == block.signature().argumentCount());
+        WASM_TRY_ADD_TO_CONTEXT(addTryTable(WTF::move(inlineSignature), args, targets, block));
 
-        switchToBlock(WTF::move(block), WTF::move(newStack));
+        switchToBlock(WTF::move(block), argumentCount);
         return { };
     }
 
@@ -3691,8 +3734,12 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         WASM_TRY_ADD_TO_CONTEXT(addDelegate(targetData, controlEntry.controlData));
         WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
-        WASM_TRY_ADD_TO_CONTEXT(endBlock(controlEntry, m_expressionStack));
-        m_expressionStack.swap(controlEntry.enclosedExpressionStack);
+
+        const uint32_t parentBegin = parentEntryBegin();
+        auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
+        WASM_TRY_ADD_TO_CONTEXT(endBlock(controlEntry, enclosedStack));
+
+        m_currentStackBegin = parentBegin;
         resetLocalInitStackToHeight(controlEntry.localInitStackHeight);
         return { };
     }
@@ -3702,20 +3749,21 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_FAIL_IF_HELPER_FAILS(parseExceptionIndex(exceptionIndex));
         const auto& exceptionSignature = m_info.rtt(m_info.typeSignatureIndexFromExceptionIndexSpace(exceptionIndex));
 
-        WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < exceptionSignature.argumentCount(), "Too few arguments on stack for the exception being thrown. The exception expects ", exceptionSignature.argumentCount(), ", but only ", m_expressionStack.size(), " were present. Exception has signature: ", exceptionSignature);
+        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
+        WASM_VALIDATOR_FAIL_IF(sliceSize < exceptionSignature.argumentCount(), "Too few arguments on stack for the exception being thrown. The exception expects ", exceptionSignature.argumentCount(), ", but only ", sliceSize, " were present. Exception has signature: ", exceptionSignature);
         unsigned offset = m_expressionStack.size() - exceptionSignature.argumentCount();
         ArgumentList args;
         WASM_ALLOCATOR_FAIL_IF(!args.tryReserveInitialCapacity(exceptionSignature.argumentCount()), "can't allocate enough memory for throw's "_s, exceptionSignature.argumentCount(), " arguments"_s);
         args.grow(exceptionSignature.argumentCount());
         for (unsigned i = 0; i < exceptionSignature.argumentCount(); ++i) {
-            TypedExpression arg = m_expressionStack.at(m_expressionStack.size() - i - 1);
+            TypedExpression arg = m_expressionStack[m_expressionStack.size() - i - 1];
             WASM_VALIDATOR_FAIL_IF(!isSubtype(arg.type(), exceptionSignature.argumentType(exceptionSignature.argumentCount() - i - 1)), "The exception being thrown expects the argument at index ", i, " to be ", exceptionSignature.argumentType(exceptionSignature.argumentCount() - i - 1), " but argument has type ", arg.type());
             args[args.size() - i - 1] = arg;
             m_context.didPopValueFromStack(arg, "Throw"_s);
         }
         m_expressionStack.shrink(offset);
 
-        WASM_TRY_ADD_TO_CONTEXT(addThrow(exceptionIndex, args, m_expressionStack));
+        WASM_TRY_ADD_TO_CONTEXT(addThrow(exceptionIndex, args, expressionStack()));
         m_unreachableBlocks = 1;
         return { };
     }
@@ -3725,7 +3773,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_TRY_POP_EXPRESSION_STACK_INTO(exnref, "exception reference"_s);
         WASM_VALIDATOR_FAIL_IF(!isSubtype(exnref.type(), exnrefType()), "throw_ref expected an exception reference"_s);
 
-        WASM_TRY_ADD_TO_CONTEXT(addThrowRef(exnref, m_expressionStack));
+        WASM_TRY_ADD_TO_CONTEXT(addThrowRef(exnref, expressionStack()));
         m_unreachableBlocks = 1;
         return { };
     }
@@ -3758,7 +3806,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         ControlType& data = m_controlStack[m_controlStack.size() - 1 - target].controlData;
         WASM_FAIL_IF_HELPER_FAILS(checkBranchTarget(data, m_currentOpcode == BrIf ? Conditional : Unconditional));
-        WASM_TRY_ADD_TO_CONTEXT(addBranch(data, condition, m_expressionStack));
+        WASM_TRY_ADD_TO_CONTEXT(addBranch(data, condition, expressionStack()));
         return { };
     }
 
@@ -3804,7 +3852,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         }
 
         WASM_FAIL_IF_HELPER_FAILS(checkBranchTarget(defaultTarget, Unconditional));
-        WASM_TRY_ADD_TO_CONTEXT(addSwitch(condition, targets, defaultTarget, m_expressionStack));
+        WASM_TRY_ADD_TO_CONTEXT(addSwitch(condition, targets, defaultTarget, expressionStack()));
 
         m_unreachableBlocks = 1;
         return { };
@@ -3812,7 +3860,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
     case Return: {
         WASM_FAIL_IF_HELPER_FAILS(checkBranchTarget(m_controlStack[0].controlData, Unconditional));
-        WASM_TRY_ADD_TO_CONTEXT(addReturn(m_controlStack[0].controlData, m_expressionStack));
+        WASM_TRY_ADD_TO_CONTEXT(addReturn(m_controlStack[0].controlData, expressionStack()));
         m_unreachableBlocks = 1;
         return { };
     }
@@ -3821,18 +3869,24 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         ControlEntry data = m_controlStack.takeLast();
         if (ControlType::isIf(data.controlData)) {
             WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(data.controlData));
-            WASM_TRY_ADD_TO_CONTEXT(addElse(data.controlData, m_expressionStack));
-            m_expressionStack = WTF::move(data.elseBlockStack);
+            auto ifBranchResults = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
+            WASM_TRY_ADD_TO_CONTEXT(addElse(data.controlData, ifBranchResults));
+            m_expressionStack.shrink(m_currentStackBegin);
+            m_expressionStack.append(data.elseBlockStack.span());
         }
         // When ending an 'if'/'else', including a synthetic 'else' added right above,
         // the spec requires the output type of 'if' to be the type from the signature.
         const bool shouldForceSignature = ControlType::isElse(data.controlData);
-        // FIXME: This is a little weird in that it will modify the expressionStack for the result of the block.
-        // That's a little too effectful for me but I don't have a better API right now.
+        // FIXME: endBlock may modify the expressionStack slice for the result of the block.
+        // That's a little too effectful but we don't have a better API right now.
         // see: https://bugs.webkit.org/show_bug.cgi?id=164353
         WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(data.controlData, shouldForceSignature));
-        WASM_TRY_ADD_TO_CONTEXT(endBlock(data, m_expressionStack));
-        m_expressionStack.swap(data.enclosedExpressionStack);
+
+        const uint32_t parentBegin = parentEntryBegin();
+        auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
+        WASM_TRY_ADD_TO_CONTEXT(endBlock(data, enclosedStack));
+
+        m_currentStackBegin = parentBegin;
         if (!ControlType::isTopLevel(data.controlData))
             resetLocalInitStackToHeight(data.localInitStackHeight);
         return { };
@@ -3942,7 +3996,8 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         m_unreachableBlocks = 0;
         WASM_VALIDATOR_FAIL_IF(!ControlType::isIf(data.controlData), "else block isn't associated to an if");
         WASM_TRY_ADD_TO_CONTEXT(addElseToUnreachable(data.controlData));
-        m_expressionStack = WTF::move(data.elseBlockStack);
+        m_expressionStack.shrink(m_currentStackBegin);
+        m_expressionStack.append(data.elseBlockStack.span());
         resetLocalInitStackToHeight(data.localInitStackHeight);
         return { };
     }
@@ -3959,7 +4014,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(data.controlData), "catch block isn't associated to a try");
 
         m_unreachableBlocks = 0;
-        m_expressionStack = { };
+        m_expressionStack.shrink(m_currentStackBegin);
         ResultList results;
         WASM_TRY_ADD_TO_CONTEXT(addCatchToUnreachable(exceptionIndex, exceptionSignature, data.controlData, results));
 
@@ -3980,7 +4035,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
 
         ControlEntry& data = m_controlStack.last();
         m_unreachableBlocks = 0;
-        m_expressionStack = { };
+        m_expressionStack.shrink(m_currentStackBegin);
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(data.controlData), "catch block isn't associated to a try");
         WASM_TRY_ADD_TO_CONTEXT(addCatchAllToUnreachable(data.controlData));
         resetLocalInitStackToHeight(data.localInitStackHeight);
@@ -4001,9 +4056,18 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             WASM_VALIDATOR_FAIL_IF(!ControlType::isTry(data) && !ControlType::isTopLevel(data), "delegate target isn't a try block");
 
             WASM_TRY_ADD_TO_CONTEXT(addDelegateToUnreachable(data, controlEntry.controlData));
-            Stack emptyStack;
-            WASM_TRY_ADD_TO_CONTEXT(addEndToUnreachable(controlEntry, emptyStack));
-            m_expressionStack.swap(controlEntry.enclosedExpressionStack);
+
+            // Drop child's slice and pre-allocate result placeholder slots that the generator
+            // will fill in.
+            m_expressionStack.shrink(m_currentStackBegin);
+            const auto& sig = controlEntry.controlData.signature();
+            for (unsigned i = 0; i < sig.returnCount(); ++i)
+                m_expressionStack.constructAndAppend(sig.returnType(i), Context::emptyExpression());
+            const uint32_t parentBegin = parentEntryBegin();
+            auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
+            WASM_TRY_ADD_TO_CONTEXT(addEndToUnreachable(controlEntry, enclosedStack));
+
+            m_currentStackBegin = parentBegin;
             resetLocalInitStackToHeight(controlEntry.localInitStackHeight);
         }
         m_unreachableBlocks--;
@@ -4013,17 +4077,27 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     case End: {
         if (m_unreachableBlocks == 1) {
             ControlEntry data = m_controlStack.takeLast();
+            const uint32_t parentBegin = parentEntryBegin();
             if (ControlType::isIf(data.controlData)) {
                 WASM_TRY_ADD_TO_CONTEXT(addElseToUnreachable(data.controlData));
-                m_expressionStack = WTF::move(data.elseBlockStack);
+                m_expressionStack.shrink(m_currentStackBegin);
+                m_expressionStack.append(data.elseBlockStack.span());
                 WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(data.controlData));
-                WASM_TRY_ADD_TO_CONTEXT(endBlock(data, m_expressionStack));
+
+                // Reachable End handling: the combined enclosedStack now lives in
+                // m_expressionStack[parentBegin..end].
+                auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
+                WASM_TRY_ADD_TO_CONTEXT(endBlock(data, enclosedStack));
             } else {
-                Stack emptyStack;
-                WASM_TRY_ADD_TO_CONTEXT(addEndToUnreachable(data, emptyStack));
+                m_expressionStack.shrink(m_currentStackBegin);
+                const auto& sig = data.controlData.signature();
+                for (unsigned i = 0; i < sig.returnCount(); ++i)
+                    m_expressionStack.constructAndAppend(sig.returnType(i), Context::emptyExpression());
+                auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
+                WASM_TRY_ADD_TO_CONTEXT(addEndToUnreachable(data, enclosedStack));
             }
 
-            m_expressionStack.swap(data.enclosedExpressionStack);
+            m_currentStackBegin = parentBegin;
             if (!ControlType::isTopLevel(data.controlData))
                 resetLocalInitStackToHeight(data.localInitStackHeight);
         }

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -494,40 +494,40 @@ public:
     // Control flow
 
     [[nodiscard]] ControlType addTopLevel(BlockSignature&&);
-    [[nodiscard]] PartialResult addBlock(BlockSignature&&, Stack&, ControlType&, Stack&);
-    [[nodiscard]] PartialResult addLoop(BlockSignature&&, Stack&, ControlType&, Stack&, uint32_t);
-    [[nodiscard]] PartialResult addIf(ExpressionType, BlockSignature&&, Stack&, ControlType&, Stack&);
-    [[nodiscard]] PartialResult addElse(ControlType&, Stack&);
+    [[nodiscard]] PartialResult addBlock(BlockSignature&&, std::span<TypedExpression>, ControlType&);
+    [[nodiscard]] PartialResult addLoop(BlockSignature&&, std::span<TypedExpression>, ControlType&, uint32_t);
+    [[nodiscard]] PartialResult addIf(ExpressionType, BlockSignature&&, std::span<TypedExpression>, ControlType&);
+    [[nodiscard]] PartialResult addElse(ControlType&, std::span<const TypedExpression>);
     [[nodiscard]] PartialResult addElseToUnreachable(ControlType&);
 
-    [[nodiscard]] PartialResult addTry(BlockSignature&&, Stack&, ControlType&, Stack&);
-    [[nodiscard]] PartialResult addTryTable(BlockSignature&&, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
-    [[nodiscard]] PartialResult addCatch(unsigned, const RTT&, Stack&, ControlType&, ResultList&);
+    [[nodiscard]] PartialResult addTry(BlockSignature&&, std::span<TypedExpression>, ControlType&);
+    [[nodiscard]] PartialResult addTryTable(BlockSignature&&, std::span<TypedExpression> args, const Vector<CatchHandler>& targets, ControlType& result);
+    [[nodiscard]] PartialResult addCatch(unsigned, const RTT&, std::span<const TypedExpression>, ControlType&, ResultList&);
     [[nodiscard]] PartialResult addCatchToUnreachable(unsigned, const RTT&, ControlType&, ResultList&);
-    [[nodiscard]] PartialResult addCatchAll(Stack&, ControlType&);
+    [[nodiscard]] PartialResult addCatchAll(std::span<const TypedExpression>, ControlType&);
     [[nodiscard]] PartialResult addCatchAllToUnreachable(ControlType&);
     [[nodiscard]] PartialResult addDelegate(ControlType&, ControlType&);
     [[nodiscard]] PartialResult addDelegateToUnreachable(ControlType&, ControlType&);
-    [[nodiscard]] PartialResult addThrow(unsigned, ArgumentList&, Stack&);
+    [[nodiscard]] PartialResult addThrow(unsigned, ArgumentList&, std::span<const TypedExpression>);
     [[nodiscard]] PartialResult addRethrow(unsigned, ControlType&);
-    [[nodiscard]] PartialResult addThrowRef(ExpressionType, Stack&);
+    [[nodiscard]] PartialResult addThrowRef(ExpressionType, std::span<const TypedExpression>);
 
-    [[nodiscard]] PartialResult addReturn(const ControlType&, const Stack&);
-    [[nodiscard]] PartialResult addBranch(ControlType&, ExpressionType, const Stack&);
-    [[nodiscard]] PartialResult addBranchNull(ControlType&, ExpressionType, Stack&, bool, ExpressionType&);
-    [[nodiscard]] PartialResult addBranchCast(ControlType&, ExpressionType, Stack&, bool, int32_t, bool);
-    [[nodiscard]] PartialResult addSwitch(ExpressionType, const Vector<ControlType*>&, ControlType&, const Stack&);
-    [[nodiscard]] PartialResult endBlock(ControlEntry&, Stack&);
+    [[nodiscard]] PartialResult addReturn(const ControlType&, std::span<const TypedExpression>);
+    [[nodiscard]] PartialResult addBranch(ControlType&, ExpressionType, std::span<const TypedExpression>);
+    [[nodiscard]] PartialResult addBranchNull(ControlType&, ExpressionType, std::span<const TypedExpression>, bool, ExpressionType&);
+    [[nodiscard]] PartialResult addBranchCast(ControlType&, ExpressionType, std::span<const TypedExpression>, bool, int32_t, bool);
+    [[nodiscard]] PartialResult addSwitch(ExpressionType, const Vector<ControlType*>&, ControlType&, std::span<const TypedExpression>);
+    [[nodiscard]] PartialResult endBlock(ControlEntry&, std::span<TypedExpression>);
     void endTryTable(const ControlType& data);
-    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry&, Stack&);
+    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry&, std::span<TypedExpression>);
 
-    [[nodiscard]] PartialResult endTopLevel(const Stack&);
+    [[nodiscard]] PartialResult endTopLevel(std::span<const TypedExpression>);
 
     // Fused comparison stubs (TODO: make use of these for better codegen)
-    [[nodiscard]] PartialResult NODELETE addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    [[nodiscard]] PartialResult NODELETE addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    [[nodiscard]] PartialResult NODELETE addFusedIfCompare(OpType, ExpressionType, BlockSignature&&, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    [[nodiscard]] PartialResult NODELETE addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature&&, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult NODELETE addFusedBranchCompare(OpType, ControlType&, ExpressionType, std::span<const TypedExpression>) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult NODELETE addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, std::span<const TypedExpression>) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult NODELETE addFusedIfCompare(OpType, ExpressionType, BlockSignature&&, std::span<TypedExpression>, ControlType&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult NODELETE addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature&&, std::span<TypedExpression>, ControlType&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     // Calls
 
@@ -2183,10 +2183,9 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addBlock(BlockSignature&& signature, Stack& oldStack, ControlType& block, Stack& newStack)
+[[nodiscard]] PartialResult IPIntGenerator::addBlock(BlockSignature&& signature, std::span<TypedExpression> args, ControlType& block)
 {
-    splitStack(signature, oldStack, newStack);
-    block = ControlType(WTF::move(signature), m_stackSize.value() - newStack.size(), BlockType::Block);
+    block = ControlType(WTF::move(signature), m_stackSize.value() - args.size(), BlockType::Block);
     block.m_index = m_controlStructuresAwaitingCoalescing.size();
     block.m_pc = curPC();
     block.m_mc = curMC();
@@ -2210,10 +2209,9 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addLoop(BlockSignature&& signature, Stack& oldStack, ControlType& block, Stack& newStack, uint32_t loopIndex)
+[[nodiscard]] PartialResult IPIntGenerator::addLoop(BlockSignature&& signature, std::span<TypedExpression> args, ControlType& block, uint32_t loopIndex)
 {
-    splitStack(signature, oldStack, newStack);
-    block = ControlType(WTF::move(signature), m_stackSize.value() - newStack.size(), BlockType::Loop);
+    block = ControlType(WTF::move(signature), m_stackSize.value() - args.size(), BlockType::Loop);
     block.m_index = m_controlStructuresAwaitingCoalescing.size();
     block.m_pendingOffset = -1; // no need to update!
     block.m_pc = curPC();
@@ -2232,7 +2230,7 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     m_metadata->appendMetadata(md);
 
     // Loop OSR
-    ASSERT(m_parser->getStackHeightInValues() + newStack.size() == m_stackSize.value());
+    ASSERT(m_parser->getStackHeightInValues() == m_stackSize.value());
     unsigned numOSREntryDataValues = m_stackSize.value();
 
     // Note the +1: we do this to avoid having 0 as a key in the map, since the current map can't handle 0 as a key
@@ -2241,11 +2239,10 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addIf(ExpressionType, BlockSignature&& signature, Stack& oldStack, ControlType& block, Stack& newStack)
+[[nodiscard]] PartialResult IPIntGenerator::addIf(ExpressionType, BlockSignature&& signature, std::span<TypedExpression> args, ControlType& block)
 {
-    splitStack(signature, oldStack, newStack);
     changeStackSize(-1);
-    block = ControlType(WTF::move(signature), m_stackSize.value() - newStack.size(), BlockType::If);
+    block = ControlType(WTF::move(signature), m_stackSize.value() - args.size(), BlockType::If);
     block.m_index = m_controlStructuresAwaitingCoalescing.size();
     block.m_pc = curPC();
     block.m_mc = curMC();
@@ -2268,7 +2265,7 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addElse(ControlType& block, Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addElse(ControlType& block, std::span<const TypedExpression>)
 {
     return addElseToUnreachable(block);
 }
@@ -2310,13 +2307,12 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
 
 // Exception Handling
 
-[[nodiscard]] PartialResult IPIntGenerator::addTry(BlockSignature&& signature, Stack& oldStack, ControlType& block, Stack& newStack)
+[[nodiscard]] PartialResult IPIntGenerator::addTry(BlockSignature&& signature, std::span<TypedExpression> args, ControlType& block)
 {
     m_tryDepth++;
     m_maxTryDepth = std::max(m_maxTryDepth, m_tryDepth.value());
 
-    splitStack(signature, oldStack, newStack);
-    block = ControlType(WTF::move(signature), m_stackSize.value() - newStack.size(), BlockType::Try);
+    block = ControlType(WTF::move(signature), m_stackSize.value() - args.size(), BlockType::Try);
     block.m_index = m_controlStructuresAwaitingCoalescing.size();
     block.m_tryDepth = m_tryDepth;
     block.m_pc = curPC();
@@ -2341,10 +2337,9 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addTryTable(BlockSignature&& signature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack)
+[[nodiscard]] PartialResult IPIntGenerator::addTryTable(BlockSignature&& signature, std::span<TypedExpression> args, const Vector<CatchHandler>& targets, ControlType& result)
 {
-    splitStack(signature, enclosingStack, newStack);
-    result = ControlType(WTF::move(signature), m_stackSize.value() - newStack.size(), BlockType::TryTable);
+    result = ControlType(WTF::move(signature), m_stackSize.value() - args.size(), BlockType::TryTable);
     result.m_tryTableTargets.reserveInitialCapacity(targets.size());
     result.m_index = m_controlStructuresAwaitingCoalescing.size();
     result.m_pc = curPC();
@@ -2409,7 +2404,7 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
     tryBlock = WTF::move(catchBlock);
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addCatch(unsigned exceptionIndex, const RTT& exceptionSignature, Stack&, ControlType& block, ResultList& results)
+[[nodiscard]] PartialResult IPIntGenerator::addCatch(unsigned exceptionIndex, const RTT& exceptionSignature, std::span<const TypedExpression>, ControlType& block, ResultList& results)
 {
 
     return addCatchToUnreachable(exceptionIndex, exceptionSignature, block, results);
@@ -2450,7 +2445,7 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addCatchAll(Stack&, ControlType& block)
+[[nodiscard]] PartialResult IPIntGenerator::addCatchAll(std::span<const TypedExpression>, ControlType& block)
 {
     return addCatchAllToUnreachable(block);
 }
@@ -2521,7 +2516,7 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addThrow(unsigned exceptionIndex, ArgumentList&, Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addThrow(unsigned exceptionIndex, ArgumentList&, std::span<const TypedExpression>)
 {
     // IPInt reads throw arguments directly from the operand stack, but BBQ copies
     // them to a separate callee stack area. Track the size BBQ will need.
@@ -2554,7 +2549,7 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addThrowRef(ExpressionType, Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addThrowRef(ExpressionType, std::span<const TypedExpression>)
 {
     changeStackSize(-1);
     return { };
@@ -2562,12 +2557,12 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
 
 // Control Flow Branches
 
-[[nodiscard]] PartialResult IPIntGenerator::addReturn(const ControlType&, const Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addReturn(const ControlType&, std::span<const TypedExpression>)
 {
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addBranch(ControlType& block, ExpressionType, const Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addBranch(ControlType& block, ExpressionType, std::span<const TypedExpression>)
 {
     bool isBrIf = (m_parser->currentOpcode() == OpType::BrIf);
     if (isBrIf)
@@ -2591,7 +2586,7 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
 
     return { };
 }
-[[nodiscard]] PartialResult IPIntGenerator::addBranchNull(ControlType& block, ExpressionType, Stack&, bool shouldNegate, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addBranchNull(ControlType& block, ExpressionType, std::span<const TypedExpression>, bool shouldNegate, ExpressionType&)
 {
     // We don't need shouldNegate in the metadata since it's in the opcode
 
@@ -2619,7 +2614,7 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addBranchCast(ControlType& block, ExpressionType, Stack&, bool, int32_t heapType, bool)
+[[nodiscard]] PartialResult IPIntGenerator::addBranchCast(ControlType& block, ExpressionType, std::span<const TypedExpression>, bool, int32_t heapType, bool)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
@@ -2642,7 +2637,7 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSwitch(ExpressionType, const Vector<ControlType*>& jumps, ControlType& defaultJump, const Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addSwitch(ExpressionType, const Vector<ControlType*>& jumps, ControlType& defaultJump, std::span<const TypedExpression>)
 {
     changeStackSize(-1);
     IPInt::SwitchMetadata mdSwitch {
@@ -2673,9 +2668,9 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::endBlock(ControlEntry& entry, Stack& stack)
+[[nodiscard]] PartialResult IPIntGenerator::endBlock(ControlEntry& entry, std::span<TypedExpression> enclosedStack)
 {
-    return addEndToUnreachable(entry, stack);
+    return addEndToUnreachable(entry, enclosedStack);
 }
 
 void IPIntGenerator::endTryTable(const ControlType& data)
@@ -2717,13 +2712,16 @@ void IPIntGenerator::endTryTable(const ControlType& data)
     }
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addEndToUnreachable(ControlEntry& entry, Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addEndToUnreachable(ControlEntry& entry, std::span<TypedExpression> enclosedStack)
 {
     const auto& block = entry.controlData;
-    for (unsigned i = 0; i < block.signature().returnCount(); i ++)
-        entry.enclosedExpressionStack.constructAndAppend(block.signature().returnType(i), IPIntValue { });
+    unsigned returnCount = block.signature().returnCount();
+    ASSERT(enclosedStack.size() >= returnCount);
+    auto resultSlots = enclosedStack.last(returnCount);
+    for (unsigned i = 0; i < returnCount; ++i)
+        resultSlots[i] = TypedExpression(block.signature().returnType(i), IPIntValue { });
     m_stackSize = block.stackSize();
-    changeStackSize(block.signature().returnCount());
+    changeStackSize(returnCount);
 
     if (ControlType::isTry(block) || ControlType::isAnyCatch(block)) {
         --m_tryDepth;
@@ -2773,7 +2771,7 @@ void IPIntGenerator::endTryTable(const ControlType& data)
     return { };
 }
 
-auto IPIntGenerator::endTopLevel(const Stack&) -> PartialResult
+auto IPIntGenerator::endTopLevel(std::span<const TypedExpression>) -> PartialResult
 {
     bool isNotDebugMode = !m_debugInfo;
     if (m_usesSIMD && isNotDebugMode)

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -809,41 +809,41 @@ public:
 
     // Control flow
     [[nodiscard]] ControlData addTopLevel(BlockSignature&&);
-    [[nodiscard]] PartialResult addBlock(BlockSignature&&, Stack& enclosingStack, ControlType& newBlock, Stack& newStack);
-    [[nodiscard]] PartialResult addLoop(BlockSignature&&, Stack& enclosingStack, ControlType& block, Stack& newStack, uint32_t loopIndex);
-    [[nodiscard]] PartialResult addIf(ExpressionType condition, BlockSignature&&, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    [[nodiscard]] PartialResult addElse(ControlData&, const Stack&);
+    [[nodiscard]] PartialResult addBlock(BlockSignature&&, std::span<TypedExpression> args, ControlType& newBlock);
+    [[nodiscard]] PartialResult addLoop(BlockSignature&&, std::span<TypedExpression> args, ControlType& block, uint32_t loopIndex);
+    [[nodiscard]] PartialResult addIf(ExpressionType condition, BlockSignature&&, std::span<TypedExpression> args, ControlType& result);
+    [[nodiscard]] PartialResult addElse(ControlData&, std::span<const TypedExpression>);
     [[nodiscard]] PartialResult addElseToUnreachable(ControlData&);
 
-    [[nodiscard]] PartialResult addTry(BlockSignature&&, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    [[nodiscard]] PartialResult addTryTable(BlockSignature&&, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
-    [[nodiscard]] PartialResult addCatch(unsigned exceptionIndex, const RTT&, Stack&, ControlType&, ResultList&);
+    [[nodiscard]] PartialResult addTry(BlockSignature&&, std::span<TypedExpression> args, ControlType& result);
+    [[nodiscard]] PartialResult addTryTable(BlockSignature&&, std::span<TypedExpression> args, const Vector<CatchHandler>& targets, ControlType& result);
+    [[nodiscard]] PartialResult addCatch(unsigned exceptionIndex, const RTT&, std::span<const TypedExpression>, ControlType&, ResultList&);
     [[nodiscard]] PartialResult addCatchToUnreachable(unsigned exceptionIndex, const RTT&, ControlType&, ResultList&);
-    [[nodiscard]] PartialResult addCatchAll(Stack&, ControlType&);
+    [[nodiscard]] PartialResult addCatchAll(std::span<const TypedExpression>, ControlType&);
     [[nodiscard]] PartialResult addCatchAllToUnreachable(ControlType&);
     [[nodiscard]] PartialResult addDelegate(ControlType&, ControlType&);
     [[nodiscard]] PartialResult addDelegateToUnreachable(ControlType&, ControlType&);
-    [[nodiscard]] PartialResult addThrow(unsigned exceptionIndex, ArgumentList& args, Stack&);
+    [[nodiscard]] PartialResult addThrow(unsigned exceptionIndex, ArgumentList& args, std::span<const TypedExpression>);
     [[nodiscard]] PartialResult addRethrow(unsigned, ControlType&);
-    [[nodiscard]] PartialResult addThrowRef(TypedExpression exception, Stack&);
+    [[nodiscard]] PartialResult addThrowRef(TypedExpression exception, std::span<const TypedExpression>);
 
     [[nodiscard]] PartialResult addInlinedReturn(const auto& returnValues);
 
-    [[nodiscard]] PartialResult addReturn(const ControlData&, const Stack& returnValues);
-    [[nodiscard]] PartialResult addBranch(ControlData&, ExpressionType condition, const Stack& returnValues);
-    [[nodiscard]] PartialResult addBranchNull(ControlType&, ExpressionType, const Stack&, bool, ExpressionType&);
-    [[nodiscard]] PartialResult addBranchCast(ControlType&, TypedExpression, const Stack&, bool, int32_t, bool);
-    [[nodiscard]] PartialResult addSwitch(ExpressionType condition, const Vector<ControlData*>& targets, ControlData& defaultTargets, const Stack& expressionStack);
-    [[nodiscard]] PartialResult endBlock(ControlEntry&, Stack& expressionStack);
-    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry&, const Stack& = { });
+    [[nodiscard]] PartialResult addReturn(const ControlData&, std::span<const TypedExpression> returnValues);
+    [[nodiscard]] PartialResult addBranch(ControlData&, ExpressionType condition, std::span<const TypedExpression> returnValues);
+    [[nodiscard]] PartialResult addBranchNull(ControlType&, ExpressionType, std::span<const TypedExpression>, bool, ExpressionType&);
+    [[nodiscard]] PartialResult addBranchCast(ControlType&, TypedExpression, std::span<const TypedExpression>, bool, int32_t, bool);
+    [[nodiscard]] PartialResult addSwitch(ExpressionType condition, const Vector<ControlData*>& targets, ControlData& defaultTargets, std::span<const TypedExpression> expressionStack);
+    [[nodiscard]] PartialResult endBlock(ControlEntry&, std::span<TypedExpression> enclosedStack);
+    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry&, std::span<TypedExpression> enclosedStack);
 
-    [[nodiscard]] PartialResult NODELETE endTopLevel(const Stack&) { return { }; }
+    [[nodiscard]] PartialResult NODELETE endTopLevel(std::span<const TypedExpression>) { return { }; }
 
     // Fused comparison stubs (B3 will do this for us later).
-    [[nodiscard]] PartialResult NODELETE addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    [[nodiscard]] PartialResult NODELETE addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    [[nodiscard]] PartialResult NODELETE addFusedIfCompare(OpType, ExpressionType, BlockSignature&&, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    [[nodiscard]] PartialResult NODELETE addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature&&, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult NODELETE addFusedBranchCompare(OpType, ControlType&, ExpressionType, std::span<const TypedExpression>) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult NODELETE addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, std::span<const TypedExpression>) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult NODELETE addFusedIfCompare(OpType, ExpressionType, BlockSignature&&, std::span<TypedExpression>, ControlType&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult NODELETE addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature&&, std::span<TypedExpression>, ControlType&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     // Calls
     [[nodiscard]] PartialResult addCall(unsigned, FunctionSpaceIndex functionIndexSpace, const RTT&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
@@ -1015,7 +1015,7 @@ private:
     }
 
     void unify(Value* phi, const ExpressionType& source);
-    void unifyValuesWithBlock(const Stack& resultStack, const ControlData& block);
+    void unifyValuesWithBlock(std::span<const TypedExpression> resultStack, const ControlData& block);
 
     void emitChecksForModOrDiv(B3::Opcode, Value* left, Value* right);
 
@@ -1028,7 +1028,7 @@ private:
 
     void materializeExpressionStackIntoVariables();
     Value* loadFromScratchBuffer(unsigned& indexInBuffer, Value* pointer, B3::Type);
-    void connectValuesAtEntrypoint(unsigned& indexInBuffer, Value* pointer, Stack& expressionStack);
+    void connectValuesAtEntrypoint(unsigned& indexInBuffer, Value* pointer, std::span<const TypedExpression> expressionStack);
     Value* emitCatchImpl(CatchKind, ControlType&, unsigned exceptionIndex = 0);
     void emitCatchTableImpl(ControlData& entryData, const ControlData::TryTableTarget&);
     RefPtr<PatchpointExceptionHandle> preparePatchpointForExceptions(BasicBlock*, PatchpointValue*);
@@ -4535,10 +4535,10 @@ Value* OMGIRGenerator::loadFromScratchBuffer(unsigned& indexInBuffer, Value* poi
     return m_currentBlock->appendNew<MemoryValue>(m_proc, Load, type, origin(), pointer, offset);
 }
 
-void OMGIRGenerator::connectValuesAtEntrypoint(unsigned& indexInBuffer, Value* pointer, Stack& expressionStack)
+void OMGIRGenerator::connectValuesAtEntrypoint(unsigned& indexInBuffer, Value* pointer, std::span<const TypedExpression> expressionStack)
 {
     TRACE_CF("Connect values at entrypoint");
-    for (TypedExpression& expr : expressionStack) {
+    for (const TypedExpression& expr : expressionStack) {
         if (!expr.value().isMaterialized()) {
             RELEASE_ASSERT(expr.value().b3Value()->isConstant());
             indexInBuffer++;
@@ -4550,23 +4550,23 @@ void OMGIRGenerator::connectValuesAtEntrypoint(unsigned& indexInBuffer, Value* p
     }
 };
 
-auto OMGIRGenerator::addLoop(BlockSignature&& signature, Stack& enclosingStack, ControlType& block, Stack& newStack, uint32_t loopIndex) -> PartialResult
+auto OMGIRGenerator::addLoop(BlockSignature&& signature, std::span<TypedExpression> args, ControlType& block, uint32_t loopIndex) -> PartialResult
 {
+    auto enclosingStack = m_parser->expressionStack();
     TRACE_CF("LOOP: entering loop index: ", loopIndex, " signature: ", signature);
     BasicBlock* body = m_proc.addBlock();
     BasicBlock* continuation = m_proc.addBlock();
 
     block = ControlData(m_proc, origin(), WTF::move(signature), BlockType::Loop, continuation, body);
 
-    unsigned offset = enclosingStack.size() - block.signature().argumentCount();
     for (unsigned i = 0; i < block.signature().argumentCount(); ++i) {
-        TypedExpression value = enclosingStack.at(offset + i);
+        TypedExpression value = args[i];
         Value* phi = block.phis[i];
         m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), get(value), phi);
         body->append(phi);
-        newStack.constructAndAppend(block.signature().argumentType(i), phi);
+        // Replace args in place: the parser keeps them as the new block's stack.
+        args[i] = TypedExpression(block.signature().argumentType(i), phi);
     }
-    enclosingStack.shrink(offset);
 
     m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), body);
     if (loopIndex == m_loopIndexForOSREntry) {
@@ -4593,14 +4593,16 @@ auto OMGIRGenerator::addLoop(BlockSignature&& signature, Stack& enclosingStack, 
                 ++indexInBuffer;
         }
 
-        for (auto& control : m_parser->controlStack()) {
-            ASSERT(&control.controlData != &block);
-            connectValuesAtEntrypoint(indexInBuffer, pointer, control.enclosedExpressionStack);
+        for (size_t controlIndex = 0; controlIndex < m_parser->controlStack().size(); ++controlIndex) {
+            ASSERT(&m_parser->controlStack()[controlIndex].controlData != &block);
+            connectValuesAtEntrypoint(indexInBuffer, pointer, m_parser->enclosedSliceOf(controlIndex));
         }
-        connectValuesAtEntrypoint(indexInBuffer, pointer, enclosingStack);
+        // Args are loaded separately into the loop's phis below; trim them off here.
+        ASSERT(enclosingStack.size() >= args.size());
+        connectValuesAtEntrypoint(indexInBuffer, pointer, enclosingStack.first(enclosingStack.size() - args.size()));
         // The loop's stack can be read by the loop body, so the restored values should join using the loop-back phi nodes.
-        for (unsigned i = 0; i < newStack.size(); i++) {
-            auto* load = loadFromScratchBuffer(indexInBuffer, pointer, newStack[i].value().type());
+        for (unsigned i = 0; i < args.size(); i++) {
+            auto* load = loadFromScratchBuffer(indexInBuffer, pointer, args[i].value().type());
             m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), load, block.phis[i]);
         }
 
@@ -4621,18 +4623,19 @@ OMGIRGenerator::ControlData OMGIRGenerator::addTopLevel(BlockSignature&& signatu
     return topLevel;
 }
 
-auto OMGIRGenerator::addBlock(BlockSignature&& signature, Stack& enclosingStack, ControlType& newBlock, Stack& newStack) -> PartialResult
+auto OMGIRGenerator::addBlock(BlockSignature&& signature, std::span<TypedExpression> args, ControlType& newBlock) -> PartialResult
 {
+    UNUSED_PARAM(args);
     TRACE_CF("Block: ", signature);
     BasicBlock* continuation = m_proc.addBlock();
 
-    splitStack(signature, enclosingStack, newStack);
     newBlock = ControlData(m_proc, origin(), WTF::move(signature), BlockType::Block, continuation);
     return { };
 }
 
-auto OMGIRGenerator::addIf(ExpressionType condition, BlockSignature&& signature, Stack& enclosingStack, ControlType& result, Stack& newStack) -> PartialResult
+auto OMGIRGenerator::addIf(ExpressionType condition, BlockSignature&& signature, std::span<TypedExpression> args, ControlType& result) -> PartialResult
 {
+    UNUSED_PARAM(args);
     // FIXME: This needs to do some kind of stack passing.
 
     BasicBlock* taken = m_proc.addBlock();
@@ -4660,12 +4663,11 @@ auto OMGIRGenerator::addIf(ExpressionType condition, BlockSignature&& signature,
 
     m_currentBlock = taken;
     TRACE_CF("IF");
-    splitStack(signature, enclosingStack, newStack);
     result = ControlData(m_proc, origin(), WTF::move(signature), BlockType::If, continuation, notTaken);
     return { };
 }
 
-auto OMGIRGenerator::addElse(ControlData& data, const Stack& currentStack) -> PartialResult
+auto OMGIRGenerator::addElse(ControlData& data, std::span<const TypedExpression> currentStack) -> PartialResult
 {
     unifyValuesWithBlock(currentStack, data);
     m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), data.continuation);
@@ -4681,20 +4683,21 @@ auto OMGIRGenerator::addElseToUnreachable(ControlData& data) -> PartialResult
     return { };
 }
 
-auto OMGIRGenerator::addTry(BlockSignature&& signature, Stack& enclosingStack, ControlType& result, Stack& newStack) -> PartialResult
+auto OMGIRGenerator::addTry(BlockSignature&& signature, std::span<TypedExpression> args, ControlType& result) -> PartialResult
 {
+    UNUSED_PARAM(args);
     ++m_tryCatchDepth;
     TRACE_CF("TRY");
 
     BasicBlock* continuation = m_proc.addBlock();
-    splitStack(signature, enclosingStack, newStack);
     materializeExpressionStackIntoVariables();
     result = ControlData(m_proc, origin(), WTF::move(signature), BlockType::Try, continuation, advanceCallSiteIndex(), m_tryCatchDepth);
     return { };
 }
 
-auto OMGIRGenerator::addTryTable(BlockSignature&& signature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack) -> PartialResult
+auto OMGIRGenerator::addTryTable(BlockSignature&& signature, std::span<TypedExpression> args, const Vector<CatchHandler>& targets, ControlType& result) -> PartialResult
 {
+    UNUSED_PARAM(args);
     ++m_tryCatchDepth;
     TRACE_CF("TRY");
 
@@ -4710,7 +4713,6 @@ auto OMGIRGenerator::addTryTable(BlockSignature&& signature, Stack& enclosingSta
     );
 
     BasicBlock* continuation = m_proc.addBlock();
-    splitStack(signature, enclosingStack, newStack);
     materializeExpressionStackIntoVariables();
     result = ControlData(m_proc, origin(), WTF::move(signature), BlockType::TryTable, continuation, advanceCallSiteIndex(), m_tryCatchDepth);
     result.setTryTableTargets(WTF::move(targetList));
@@ -4718,7 +4720,7 @@ auto OMGIRGenerator::addTryTable(BlockSignature&& signature, Stack& enclosingSta
     return { };
 }
 
-auto OMGIRGenerator::addCatch(unsigned exceptionIndex, const RTT& signature, Stack& currentStack, ControlType& data, ResultList& results) -> PartialResult
+auto OMGIRGenerator::addCatch(unsigned exceptionIndex, const RTT& signature, std::span<const TypedExpression> currentStack, ControlType& data, ResultList& results) -> PartialResult
 {
     TRACE_CF("CATCH: ", signature);
     unifyValuesWithBlock(currentStack, data);
@@ -4772,8 +4774,7 @@ RefPtr<PatchpointExceptionHandle> OMGIRGenerator::preparePatchpointForExceptions
         unsigned end = currentFrame == innerTryFrame ? innerTryControlStackIndex + 1 : currentFrame->m_parser->controlStack().size();
         for (unsigned controlIndex = 0; controlIndex < end; ++controlIndex) {
             ControlData& data = currentFrame->m_parser->controlStack()[controlIndex].controlData;
-            Stack& expressionStack = currentFrame->m_parser->controlStack()[controlIndex].enclosedExpressionStack;
-            for (ExpressionType expr : expressionStack)
+            for (ExpressionType expr : currentFrame->m_parser->enclosedSliceOf(controlIndex))
                 liveValues.append(get(block, expr));
             if (ControlType::isAnyCatch(data))
                 liveValues.append(get(block, data.exception()));
@@ -4852,13 +4853,12 @@ void OMGIRGenerator::materializeExpressionStackIntoVariables()
     for (auto* currentFrame : frames) {
         auto* parser = currentFrame->m_parser;
 
-        for (auto& control : parser->controlStack()) {
-            for (auto& expr : control.enclosedExpressionStack)
+        for (size_t controlIndex = 0; controlIndex < parser->controlStack().size(); ++controlIndex) {
+            for (auto& expr : parser->enclosedSliceOf(controlIndex))
                 materializer.convertToVariable(expr.value(), m_proc.addVariable(expr.value().type()));
         }
-        // Note that this is the not yet (but soon to be) enclosedExpressionStack for the Try/TryTable/Loop.
-        auto& topExpressionStack = parser->expressionStack();
-        for (auto& expr : topExpressionStack)
+        // Note that this is the not yet (but soon to be) enclosed slice for the Try/TryTable/Loop.
+        for (auto& expr : parser->expressionStack())
             materializer.convertToVariable(expr.value(), m_proc.addVariable(expr.value().type()));
     }
 }
@@ -4877,10 +4877,9 @@ void OMGIRGenerator::connectValuesForCatchEntrypoint(ControlData& catchData, Val
         for (auto& local : currentFrame->m_locals)
             m_currentBlock->appendNew<VariableValue>(m_proc, Set, Origin(), local, loadFromScratchBuffer(indexInBuffer, pointer, local->type()));
 
-        for (auto& control : currentFrame->m_parser->controlStack()) {
-            auto& controlData = control.controlData;
-            auto& expressionStack = control.enclosedExpressionStack;
-            connectValuesAtEntrypoint(indexInBuffer, pointer, expressionStack);
+        for (size_t controlIndex = 0; controlIndex < currentFrame->m_parser->controlStack().size(); ++controlIndex) {
+            auto& controlData = currentFrame->m_parser->controlStack()[controlIndex].controlData;
+            connectValuesAtEntrypoint(indexInBuffer, pointer, currentFrame->m_parser->enclosedSliceOf(controlIndex));
             if (ControlType::isAnyCatch(controlData) && &controlData != &catchData) {
                 auto* load = loadFromScratchBuffer(indexInBuffer, pointer, pointerType());
                 m_currentBlock->appendNew<VariableValue>(m_proc, Set, origin(), controlData.exception(), load);
@@ -4888,8 +4887,7 @@ void OMGIRGenerator::connectValuesForCatchEntrypoint(ControlData& catchData, Val
         }
         // inlineParent frames only
         if (currentFrame != this) {
-            auto& topExpressionStack = currentFrame->m_parser->expressionStack();
-            connectValuesAtEntrypoint(indexInBuffer, pointer, topExpressionStack);
+            connectValuesAtEntrypoint(indexInBuffer, pointer, currentFrame->m_parser->expressionStack());
         }
     }
 }
@@ -4908,7 +4906,7 @@ auto OMGIRGenerator::addCatchToUnreachable(unsigned exceptionIndex, const RTT& s
     return { };
 }
 
-auto OMGIRGenerator::addCatchAll(Stack& currentStack, ControlType& data) -> PartialResult
+auto OMGIRGenerator::addCatchAll(std::span<const TypedExpression> currentStack, ControlType& data) -> PartialResult
 {
     unifyValuesWithBlock(currentStack, data);
     TRACE_CF("CATCH_ALL");
@@ -5029,7 +5027,7 @@ auto OMGIRGenerator::addDelegateToUnreachable(ControlType& target, ControlType& 
     return { };
 }
 
-auto OMGIRGenerator::addThrow(unsigned exceptionIndex, ArgumentList& args, Stack&) -> PartialResult
+auto OMGIRGenerator::addThrow(unsigned exceptionIndex, ArgumentList& args, std::span<const TypedExpression>) -> PartialResult
 {
     TRACE_CF("THROW");
 
@@ -5057,7 +5055,7 @@ auto OMGIRGenerator::addThrow(unsigned exceptionIndex, ArgumentList& args, Stack
     return { };
 }
 
-[[nodiscard]] auto OMGIRGenerator::addThrowRef(TypedExpression exnref, Stack&) -> PartialResult
+[[nodiscard]] auto OMGIRGenerator::addThrowRef(TypedExpression exnref, std::span<const TypedExpression>) -> PartialResult
 {
     TRACE_CF("THROW_REF");
 
@@ -5124,7 +5122,7 @@ auto OMGIRGenerator::addInlinedReturn(const auto& returnValues) -> PartialResult
     return { };
 }
 
-auto OMGIRGenerator::addReturn(const ControlData&, const Stack& returnValues) -> PartialResult
+auto OMGIRGenerator::addReturn(const ControlData&, std::span<const TypedExpression> returnValues) -> PartialResult
 {
     TRACE_CF("RETURN");
     if (m_returnContinuation)
@@ -5160,7 +5158,7 @@ auto OMGIRGenerator::addReturn(const ControlData&, const Stack& returnValues) ->
     return { };
 }
 
-auto OMGIRGenerator::addBranch(ControlData& data, ExpressionType condition, const Stack& returnValues) -> PartialResult
+auto OMGIRGenerator::addBranch(ControlData& data, ExpressionType condition, std::span<const TypedExpression> returnValues) -> PartialResult
 {
     unifyValuesWithBlock(returnValues, data);
 
@@ -5197,7 +5195,7 @@ auto OMGIRGenerator::addBranch(ControlData& data, ExpressionType condition, cons
     return { };
 }
 
-auto OMGIRGenerator::addBranchNull(ControlData& data, ExpressionType reference, const Stack& returnValues, bool shouldNegate, ExpressionType& result) -> PartialResult
+auto OMGIRGenerator::addBranchNull(ControlData& data, ExpressionType reference, std::span<const TypedExpression> returnValues, bool shouldNegate, ExpressionType& result) -> PartialResult
 {
     auto condition = push(m_currentBlock->appendNew<Value>(m_proc, shouldNegate ? B3::NotEqual : B3::Equal, origin(), get(reference), m_currentBlock->appendNew<WasmConstRefValue>(m_proc, origin(), JSValue::encode(jsNull()))));
 
@@ -5209,7 +5207,7 @@ auto OMGIRGenerator::addBranchNull(ControlData& data, ExpressionType reference, 
     return { };
 }
 
-auto OMGIRGenerator::addBranchCast(ControlData& data, TypedExpression reference, const Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate) -> PartialResult
+auto OMGIRGenerator::addBranchCast(ControlData& data, TypedExpression reference, std::span<const TypedExpression> returnValues, bool allowNull, int32_t heapType, bool shouldNegate) -> PartialResult
 {
     ExpressionType condition;
     emitRefTestOrCast(CastKind::Test, reference, allowNull, heapType, shouldNegate, condition);
@@ -5219,7 +5217,7 @@ auto OMGIRGenerator::addBranchCast(ControlData& data, TypedExpression reference,
     return { };
 }
 
-auto OMGIRGenerator::addSwitch(ExpressionType condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, const Stack& expressionStack) -> PartialResult
+auto OMGIRGenerator::addSwitch(ExpressionType condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, std::span<const TypedExpression> expressionStack) -> PartialResult
 {
     TRACE_CF("SWITCH");
     UNUSED_PARAM(expressionStack);
@@ -5235,23 +5233,61 @@ auto OMGIRGenerator::addSwitch(ExpressionType condition, const Vector<ControlDat
     return { };
 }
 
-auto OMGIRGenerator::endBlock(ControlEntry& entry, Stack& expressionStack) -> PartialResult
+auto OMGIRGenerator::endBlock(ControlEntry& entry, std::span<TypedExpression> enclosedStack) -> PartialResult
 {
     ControlData& data = entry.controlData;
+    const auto& blockSignature = data.signature();
+    unsigned returnCount = blockSignature.returnCount();
 
-    ASSERT(expressionStack.size() == data.signature().returnCount());
+    ASSERT(enclosedStack.size() >= returnCount);
+    auto blockResults = enclosedStack.last(returnCount);
+
     if (data.blockType() != BlockType::Loop)
-        unifyValuesWithBlock(expressionStack, data);
+        unifyValuesWithBlock(blockResults, data);
 
     m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), data.continuation);
     data.continuation->addPredecessor(m_currentBlock);
 
-    return addEndToUnreachable(entry, expressionStack);
+    m_currentBlock = data.continuation;
+
+    if (data.blockType() == BlockType::If) {
+        data.special->appendNewControlValue(m_proc, Jump, origin(), m_currentBlock);
+        m_currentBlock->addPredecessor(data.special);
+    } else if (data.blockType() == BlockType::Try || data.blockType() == BlockType::Catch)
+        --m_tryCatchDepth;
+    else if (data.blockType() == BlockType::TryTable) {
+        data.endTryTable(advanceCallSiteIndex());
+        auto targets = data.m_tryTableTargets;
+        for (auto& target : targets)
+            emitCatchTableImpl(data, target);
+        --m_tryCatchDepth;
+    }
+
+    if (data.blockType() != BlockType::Loop) {
+        // Replace block result entries with phi-derived values; the parser keeps these
+        // as the resumed parent's stack top.
+        for (unsigned i = 0; i < returnCount; ++i) {
+            Value* result = data.phis[i];
+            m_currentBlock->append(result);
+            blockResults[i] = TypedExpression(blockSignature.returnType(i), push(result));
+        }
+    }
+    // For Loop, blockResults already holds the loop's exit values; no replacement needed.
+
+    if (data.blockType() == BlockType::TopLevel)
+        return addReturn(entry.controlData, std::span<const TypedExpression>(blockResults));
+
+    return { };
 }
 
-auto OMGIRGenerator::addEndToUnreachable(ControlEntry& entry, const Stack& expressionStack) -> PartialResult
+auto OMGIRGenerator::addEndToUnreachable(ControlEntry& entry, std::span<TypedExpression> enclosedStack) -> PartialResult
 {
     ControlData& data = entry.controlData;
+    const auto& blockSignature = data.signature();
+    unsigned returnCount = blockSignature.returnCount();
+    ASSERT(enclosedStack.size() >= returnCount);
+    auto resultSlots = enclosedStack.last(returnCount);
+
     m_currentBlock = data.continuation;
 
     if (data.blockType() == BlockType::If) {
@@ -5268,33 +5304,23 @@ auto OMGIRGenerator::addEndToUnreachable(ControlEntry& entry, const Stack& expre
         --m_tryCatchDepth;
     }
 
-    const auto& blockSignature = data.signature();
     if (data.blockType() != BlockType::Loop) {
-        for (unsigned i = 0; i < blockSignature.returnCount(); ++i) {
+        for (unsigned i = 0; i < returnCount; ++i) {
             Value* result = data.phis[i];
             m_currentBlock->append(result);
-            entry.enclosedExpressionStack.constructAndAppend(blockSignature.returnType(i), push(result));
+            resultSlots[i] = TypedExpression(blockSignature.returnType(i), push(result));
         }
     } else {
-        for (unsigned i = 0; i < blockSignature.returnCount(); ++i) {
-            if (i < expressionStack.size()) {
-                entry.enclosedExpressionStack.append(expressionStack[i]);
-            } else {
-                Type returnType = blockSignature.returnType(i);
-                entry.enclosedExpressionStack.constructAndAppend(returnType, push(constant(toB3Type(returnType), 0xbbadbeef)));
-            }
+        // Loop: any incoming values would have come from the now-unreachable body.
+        for (unsigned i = 0; i < returnCount; ++i) {
+            Type returnType = blockSignature.returnType(i);
+            resultSlots[i] = TypedExpression(returnType, push(constant(toB3Type(returnType), 0xbbadbeef)));
         }
-    }
-
-    if constexpr (WasmOMGIRGeneratorInternal::traceStackValues) {
-        m_parser->expressionStack().swap(entry.enclosedExpressionStack);
-        TRACE_CF("END: ", blockSignature, " block type ", (int) data.blockType());
-        m_parser->expressionStack().swap(entry.enclosedExpressionStack);
     }
 
     // TopLevel does not have any code after this so we need to make sure we emit a return here.
     if (data.blockType() == BlockType::TopLevel)
-        return addReturn(entry.controlData, entry.enclosedExpressionStack);
+        return addReturn(entry.controlData, std::span<const TypedExpression>(resultSlots));
 
     return { };
 }
@@ -6574,7 +6600,7 @@ void OMGIRGenerator::unify(Value* phi, const ExpressionType& source)
     m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), get(source), phi);
 }
 
-void OMGIRGenerator::unifyValuesWithBlock(const Stack& resultStack, const ControlData& block)
+void OMGIRGenerator::unifyValuesWithBlock(std::span<const TypedExpression> resultStack, const ControlData& block)
 {
     const Vector<Value*>& phis = block.phis;
     size_t resultSize = phis.size();
@@ -6582,10 +6608,10 @@ void OMGIRGenerator::unifyValuesWithBlock(const Stack& resultStack, const Contro
     ASSERT(resultSize <= resultStack.size());
 
     for (size_t i = 0; i < resultSize; ++i)
-        unify(phis[resultSize - 1 - i], resultStack.at(resultStack.size() - 1 - i));
+        unify(phis[resultSize - 1 - i], resultStack[resultStack.size() - 1 - i]);
 }
 
-static void dumpExpressionStack(const CommaPrinter& comma, const OMGIRGenerator::Stack& expressionStack)
+static void dumpExpressionStack(const CommaPrinter& comma, std::span<const OMGIRGenerator::TypedExpression> expressionStack)
 {
     dataLog(comma, "ExpressionStack:");
     for (const auto& expression : expressionStack)
@@ -6594,6 +6620,7 @@ static void dumpExpressionStack(const CommaPrinter& comma, const OMGIRGenerator:
 
 void OMGIRGenerator::dump(const ControlStack& controlStack, const Stack* expressionStack)
 {
+    UNUSED_PARAM(expressionStack);
     dataLogLn("Constants:");
     for (const auto& constant : m_constantPool)
         dataLogLn(deepDump(m_proc, constant.value));
@@ -6603,11 +6630,12 @@ void OMGIRGenerator::dump(const ControlStack& controlStack, const Stack* express
     dataLogLn("With current block:", *m_currentBlock);
     dataLogLn("Control stack:");
     ASSERT(controlStack.size());
+    std::span<const TypedExpression> currentSlice = m_parser->expressionStack();
     for (size_t i = controlStack.size(); i--;) {
         dataLog("  ", controlStack[i].controlData, ": ");
         CommaPrinter comma(", "_s, ""_s);
-        dumpExpressionStack(comma, *expressionStack);
-        expressionStack = &controlStack[i].enclosedExpressionStack;
+        dumpExpressionStack(comma, currentSlice);
+        currentSlice = m_parser->enclosedSliceOf(i);
         dataLogLn();
     }
     dataLogLn();


### PR DESCRIPTION
#### 16828c4bb03fe7c335c5fbbd883c8516f4018821
<pre>
[Wasm] Function parser&apos;s expression stack should be a single buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=316500">https://bugs.webkit.org/show_bug.cgi?id=316500</a>
<a href="https://rdar.apple.com/178951229">rdar://178951229</a>

Reviewed by Yusuke Suzuki.

The wasm function parser previously tracked the operand stack as one
Vector&lt;TypedExpression&gt; per active control block. On every Block/Loop/If/Try
the parent&apos;s live values were moved into the new ControlEntry&apos;s
enclosedExpressionStack, m_expressionStack was rewritten to hold just the new
block&apos;s arguments, and End swapped the parent&apos;s slice back. With deeply nested
control flow this meant N live Vectors for N active entries, plus a copy on
each push and a swap-and-destroy on each pop.

Replace the per-block storage with a single contiguous m_expressionStack shared
by every active control block, plus an m_currentStackBegin offset marking
where the innermost block&apos;s slice starts. ControlEntry now stores just one
uint32_t enclosedStackBegin recording the parent&apos;s begin offset. Any of the
generator functions that took a stack before now take a `std::span` into the
relevant stack segment.

The only place still using a Vector to hold stack data is when there&apos;s an
if-else block. In JetStream 3 no function ever passes stack arguments into
the else block. The else block is also itself rare 87% of ifs don&apos;t have one.
I also looked at the max stack depth of functions in JS3 and the P99 depth
is 15 so the current inline capacity of 15 should cover nearly all functions.

No new tests, no behavior change. Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/315376@main">https://commits.webkit.org/315376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57a510f245720266d5cc41afc48b57b23dbe908d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167591 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125272 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4e842ea-f7fd-4fae-8d1f-c83c950ec966) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130396 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91665 "3 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41527568-e908-44d0-ae37-2434647f4393) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110913 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99f7df8f-5187-4d7d-9c44-7f15306113b9) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/166912 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31790 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30487 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25381 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160348 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141777 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179188 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/28837 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138803 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41160 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138679 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41848 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26947 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105006 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25720 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33934 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113608 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200268 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40352 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5048 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53812 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39749 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40000 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39894 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->