### PR TITLE
Remove many unused member variables

### DIFF
--- a/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
+++ b/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
@@ -163,7 +163,6 @@ private:
     UncheckedKeyHashSet<Hash::Key, Hash, Hash::KeyTraits> m_stubs;
     UncheckedKeyHashMap<StatelessCacheKey, Ref<PolymorphicAccessJITStubRoutine>> m_statelessStubs;
     UncheckedKeyHashMap<DOMJITCacheKey, MacroAssemblerCodeRef<JITStubRoutinePtrTag>> m_domJITCodes;
-    std::array<RefPtr<InlineCacheHandler>, numberOfAccessTypes> m_fallbackHandlers { };
     std::array<RefPtr<InlineCacheHandler>, numberOfAccessTypes> m_slowPathHandlers { };
 };
 

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -7354,7 +7354,6 @@ private:
     RegisterAtOffsetList m_calleeSaves;
     MacroAssembler::JumpList m_abortExecution;
     MacroAssembler::JumpList m_hitMatchLimit;
-    MacroAssembler::Label m_tryReadUnicodeCharacterEntry;
     MacroAssembler::JumpList m_inlinedMatched;
     MacroAssembler::JumpList m_inlinedFailedMatch;
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransformBackend.h
@@ -46,7 +46,6 @@ private:
     Lock m_inputCallbackLock;
     Callback m_inputCallback;
 
-    Lock m_outputCallbackLock;
 };
 
 inline GStreamerRtpTransformBackend::GStreamerRtpTransformBackend(MediaType mediaType, Side side)

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -97,7 +97,6 @@ private:
 
     Timer m_cachedCurrentTimeClearanceTimer;
     Vector<Ref<ScrollTimeline>> m_updatedScrollTimelines;
-    HashMap<FramesPerSecond, ReducedResolutionSeconds> m_animationFrameRateToLastTickTimeMap;
     WeakHashSet<AnimationTimeline> m_timelines;
     WeakHashSet<WebAnimation, WeakPtrImplWithEventTargetData> m_pendingAnimations;
     TaskCancellationGroup m_pendingAnimationsProcessingTaskCancellationGroup;

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -621,7 +621,6 @@ private:
     void popMacroAssemblerRegisters(StackAllocator&);
     bool generatePrologue();
     void generateEpilogue(StackAllocator&);
-    StackAllocator::StackReferenceVector m_macroAssemblerRegistersStackReferences;
     StackAllocator::StackReferenceVector m_prologueStackReferences;
 
     Assembler m_assembler;

--- a/Source/WebCore/editing/DeleteSelectionCommand.h
+++ b/Source/WebCore/editing/DeleteSelectionCommand.h
@@ -103,7 +103,6 @@ private:
     RefPtr<Node> m_endRoot;
     RefPtr<Node> m_startTableRow;
     RefPtr<Node> m_endTableRow;
-    RefPtr<Node> m_temporaryPlaceholder;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/SurroundingText.h
+++ b/Source/WebCore/editing/SurroundingText.h
@@ -47,7 +47,6 @@ public:
 
 private:
     RefPtr<Range> m_contentRange;
-    size_t m_positionOffsetInContent;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/fileapi/FileReaderLoader.h
+++ b/Source/WebCore/fileapi/FileReaderLoader.h
@@ -122,7 +122,6 @@ private:
     bool m_isRawDataConverted;
 
     String m_stringResult;
-    RefPtr<Blob> m_blobResult;
 
     // The decoder used to decode the text data.
     RefPtr<TextResourceDecoder> m_decoder;

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
@@ -87,7 +87,6 @@ private:
 
 #if PLATFORM(COCOA)
     std::unique_ptr<WebCore::RunLoopObserver> m_frameStartObserver;
-    std::unique_ptr<WebCore::RunLoopObserver> m_frameStopObserver;
     int m_runLoopNestingLevel { 0 };
 #elif USE(GLIB_EVENT_LOOP)
     RefPtr<RunLoop::EventObserver> m_runLoopObserver;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1532,7 +1532,6 @@ private:
     PlatformDisplayID m_displayID { 0 };
     std::optional<FramesPerSecond> m_displayNominalFramesPerSecond;
 
-    String m_groupName;
     bool m_openedByDOM { false };
     bool m_openedByDOMWithOpener { false };
 

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -109,7 +109,6 @@ private:
     RefPtr<DataDetectorHighlight> m_activeHighlight;
     RefPtr<DataDetectorHighlight> m_nextActiveHighlight;
     HashSet<Ref<DataDetectorHighlight>> m_potentialHighlights;
-    HashSet<Ref<DataDetectorHighlight>> m_animatingHighlights;
     WeakHashSet<DataDetectorHighlight> m_highlights;
 
     Vector<LayoutRect> m_currentSelectionRects;

--- a/Source/WebCore/platform/audio/AudioBus.h
+++ b/Source/WebCore/platform/audio/AudioBus.h
@@ -161,7 +161,6 @@ private:
     Vector<std::unique_ptr<AudioChannel>> m_channels;
     int m_layout;
     float m_busGain { 1 };
-    std::unique_ptr<AudioFloatArray> m_dezipperGainValues;
     bool m_isFirstTime { 0 };
     float m_sampleRate { 0 }; // 0.0 if unknown or N/A
 };

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h
@@ -85,7 +85,6 @@ protected:
     size_t m_sampleCount { 0 };
     size_t m_sampleCapacity { 0 };
     size_t m_maxBufferSizePerChannel { 0 };
-    size_t m_bufferListBaseSize { 0 };
     const UniqueRef<WebAudioBufferList> m_bufferList;
 };
 

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.h
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.h
@@ -101,7 +101,6 @@ private:
     bool m_setupArbitrationOngoing { false };
     bool m_inRoutingArbitration { false };
     std::optional<bool> m_playingToBluetooth;
-    std::optional<bool> m_playingToBluetoothOverride;
 #endif
     mutable std::optional<double> m_sampleRate;
     mutable std::optional<size_t> m_bufferSize;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -340,8 +340,6 @@ protected:
     Function<void()> m_pendingSeek;
     MediaTime m_lastSeekTime;
 
-    mutable Lock m_queuedNotificationsLock;
-    Deque<Notification> m_queuedNotifications WTF_GUARDED_BY_LOCK(m_queuedNotificationsLock);
 
     MediaPlayer::NetworkState m_networkState;
     MediaPlayer::ReadyState m_readyState;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -204,7 +204,6 @@ enum MediaPlayerAVFoundationObservationContext {
 @interface WebCoreAVFMovieObserver : NSObject <AVPlayerItemLegibleOutputPushDelegate, AVPlayerItemMetadataOutputPushDelegate, AVPlayerItemMetadataCollectorPushDelegate>
 {
     ThreadSafeWeakPtr<MediaPlayerPrivateAVFoundationObjC> m_player;
-    int m_delayCallbacks;
     RefPtr<WorkQueue> m_backgroundQueue;
 }
 -(id)initWithPlayer:(ThreadSafeWeakPtr<MediaPlayerPrivateAVFoundationObjC>&&)callback;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -376,7 +376,6 @@ private:
     bool m_allRenderersHaveAvailableSamples WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
     bool m_pageIsVisible WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
     ViewportVisibility m_viewportVisibility WTF_GUARDED_BY_CAPABILITY(mainThread) { ViewportVisibility::NotVisible };
-    RetainPtr<CVOpenGLTextureRef> m_lastTexture WTF_GUARDED_BY_CAPABILITY(mainThread);
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     RefPtr<MediaPlaybackTarget> m_playbackTarget WTF_GUARDED_BY_CAPABILITY(mainThread);
     bool m_shouldPlayToTarget WTF_GUARDED_BY_CAPABILITY(mainThread) { false };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -195,7 +195,6 @@ private:
     const MediaSourceConfiguration m_configuration;
 
     std::optional<FloatSize> m_cachedSize WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());
-    FloatSize m_currentSize WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());
     std::atomic<bool> m_waitingForKey { true };
     std::optional<TrackID> m_enabledVideoTrackID WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());
     std::optional<TrackID> m_protectedTrackID WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());

--- a/Source/WebCore/platform/mediastream/DisplayCaptureManager.h
+++ b/Source/WebCore/platform/mediastream/DisplayCaptureManager.h
@@ -36,7 +36,6 @@ public:
 
     struct WindowCaptureDevice {
         CaptureDevice m_device;
-        String m_application;
     };
 
     virtual bool requiresCaptureDevicesEnumeration() const { return false; }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -145,7 +145,6 @@ private:
     VideoCaptureFactory* m_videoCaptureFactoryOverride { nullptr };
     DisplayCaptureFactory* m_displayCaptureFactoryOverride { nullptr };
 
-    bool m_shouldInterruptAudioOnPageVisibilityChange { false };
 
 #if ENABLE(APP_PRIVACY_REPORT)
     OSObjectPtr<tcc_identity_t> m_identity;

--- a/Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureUnit.h
@@ -213,7 +213,6 @@ private:
 #if !LOG_DISABLED
     void checkTimestamps(const AudioTimeStamp&, double);
 
-    String m_ioUnitName;
 #endif
 
     LongCapabilityRange m_sampleRateCapabilities;
@@ -238,7 +237,6 @@ private:
 
     bool m_shouldUseVPIO { true };
     bool m_canRenderAudio { true };
-    bool m_shouldSetVoiceActivityListener { false };
     bool m_voiceActivityDetectionEnabled { false };
 #if PLATFORM(MAC)
     StoredAudioUnit m_storedVPIOUnit { nullptr };

--- a/Source/WebCore/platform/mediastream/cocoa/MockRealtimeVideoSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/MockRealtimeVideoSourceCocoa.h
@@ -60,7 +60,6 @@ private:
     bool canResizeVideoFrames() const final { return true; }
 
     std::unique_ptr<ImageTransferSessionVT> m_imageTransferSession;
-    IntSize m_presetSize;
     size_t m_pixelGenerationFailureCount { 0 };
 };
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -107,7 +107,6 @@ protected:
     bool m_muted { false };
     bool m_isStopped { true };
     RefPtr<MediaStreamTrackPrivate> m_track;
-    std::optional<RealtimeMediaSourceSettings> m_initialSettings;
     GRefPtr<GstElement> m_bin;
     GRefPtr<GstElement> m_inputSelector;
     GRefPtr<GstElement> m_fallbackSource;

--- a/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h
@@ -88,7 +88,6 @@ private:
     String m_preferredMicrophoneID;
     String m_preferredSpeakerID;
     bool m_isReceiverPreferredSpeaker { false };
-    bool m_recomputeDevices { true };
     mutable RetainPtr<AVAudioSessionPortDescription> m_lastDefaultMicrophone;
 };
 

--- a/Source/WebCore/rendering/RenderEmbeddedObject.h
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.h
@@ -96,7 +96,6 @@ private:
     String m_unavailablePluginReplacementText;
     bool m_unavailablePluginIndicatorIsPressed;
     bool m_mouseDownWasInUnavailablePluginIndicator;
-    String m_unavailabilityDescription;
     bool m_hasShadowContent { false };
 };
 

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -291,7 +291,6 @@ private:
     bool m_hasQuotesNeedingUpdate { false };
 
     SingleThreadWeakHashSet<RenderCounter> m_countersNeedingUpdate;
-    unsigned m_renderCounterCount { 0 };
     unsigned m_renderersWithOutlineCount { 0 };
 
     bool m_hasSoftwareFilters { false };

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -162,7 +162,6 @@ private:
     std::span<const IntSize, 4> NODELETE resultsButtonSizes() const;
     void setSearchFieldSize(Style::ComputedStyle&) const;
 
-    mutable RetainPtr<NSPopUpButtonCell> m_popupButton;
 
     RetainPtr<WebCoreRenderThemeNotificationObserver> m_notificationObserver;
 };

--- a/Source/WebDriver/WebSocketServer.h
+++ b/Source/WebDriver/WebSocketServer.h
@@ -145,7 +145,6 @@ private:
     void sendMessage(WebSocketMessageHandler::Connection, const String& message);
     void sendErrorResponse(WebSocketMessageHandler::Connection, std::optional<unsigned> commandId, CommandResult::ErrorCode, const String& errorMessage, std::optional<String> stacktrace = std::nullopt);
     WebSocketMessageHandler& m_messageHandler;
-    String m_listenerURL;
     RefPtr<WebSocketListener> m_listener;
     HashMap<WebSocketMessageHandler::Connection, String> m_connectionToSession;
 

--- a/Source/WebGPU/WebGPU/ShaderModule.h
+++ b/Source/WebGPU/WebGPU/ShaderModule.h
@@ -124,8 +124,6 @@ private:
     ShaderModule::FragmentOutputs parseFragmentReturnType(const WGSL::Type&, const WGSL::CallGraph::EntryPoint&);
 
     const Ref<Device> m_device;
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250441 - this needs to be populated from the compiler
-    HashMap<String, String> m_constantIdentifiersToNames;
     HashMap<String, FragmentOutputs> m_fragmentReturnTypeForEntryPoint;
     HashMap<String, FragmentInputs> m_fragmentInputsForEntryPoint;
     HashMap<String, VertexOutputs> m_vertexReturnTypeForEntryPoint;

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -218,7 +218,6 @@ private:
     simd_float3 m_originalBoundingBoxExtents { simd_make_float3(0, 0, 0) };
     simd_float3 m_originalEntityScale { simd_make_float3(1, 1, 1) };
     float m_pitch { 0 };
-    float m_yaw { 0 };
 
     RESRT m_transformSRT; // SRT=Scaling/Rotation/Translation. This is stricter than a WebCore::TransformationMatrix.
     bool m_transformNeedsUpdateAfterNextLayout { false };

--- a/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h
+++ b/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h
@@ -122,7 +122,6 @@ private:
     Vector<GRefPtr<RiceTcpListener>> m_tcpListeners;
 
     HashMap<String, GUniquePtr<RiceAddress>> m_addressCache;
-    HashMap<unsigned, Vector<String>, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_udpSocketAddressesCache;
 
     const RiceAddress* ensureRiceAddressFromCache(const String&);
 };

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
@@ -131,7 +131,6 @@ private:
     HashMap<RealmIdentifier, RealmInfo> m_activeRealms;
 
     // Track realm counters for navigation detection: frame ID -> counter
-    HashMap<WebCore::FrameIdentifier, uint64_t> m_frameRealmCounters;
 
     Vector<std::pair<PreloadScriptIdentifier, PreloadScriptInfo>> m_preloadScripts;
 };

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -257,9 +257,6 @@ private:
     bool m_isMetalShaderValidationEnabledForTesting { false };
 #endif
 
-#if HAVE(SCREEN_CAPTURE_KIT)
-    bool m_hasEnabledScreenCaptureKit { false };
-#endif
     static std::optional<GPUProcessMediaCodecCapabilities> s_gpuProcessMediaCodecCapabilities;
 #if PLATFORM(COCOA)
     static bool s_enableMetalDebugDeviceInNewGPUProcessesForTesting;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -124,9 +124,6 @@ private:
 #if HAVE(AVKIT)
     HashMap<WebCore::PlatformLayerIdentifier, PlaybackSessionContextIdentifier> m_videoLayers;
 #endif
-#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    HashSet<WebCore::PlatformLayerIdentifier> m_overlayRegionIDs;
-#endif
 #if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
     HashSet<WebCore::PlatformLayerIdentifier> m_modelLayers;
 #endif

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.h
@@ -102,7 +102,6 @@ private:
     SpeechRecognitionPermissionChecker m_permissionChecker;
     std::unique_ptr<WebCore::SpeechRecognizer> m_recognizer;
     SpeechRecognitionCheckIfMockSpeechRecognitionEnabled m_checkIfMockSpeechRecognitionEnabled;
-    bool m_isResetting { false };
 
 #if ENABLE(MEDIA_STREAM)
     RealtimeMediaSourceCreateFunction m_realtimeMediaSourceCreateFunction;

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -231,7 +231,6 @@ private:
     HashSet<WebCore::FrameIdentifier> m_grantedAudioFrames;
     HashSet<WebCore::FrameIdentifier> m_grantedVideoFrames;
 #if PLATFORM(COCOA)
-    HashCountedSet<String> m_monitoredDeviceIds;
     RetainPtr<WKRotationCoordinatorObserver> m_objcObserver;
 #endif
     std::optional<MonotonicTime> m_lastCaptureTime;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -4081,10 +4081,6 @@ private:
     bool m_isNeverRichlyEditableForTouchBar { false };
 #endif
 
-#if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
-    bool m_requiresTargetMonitoring { false };
-#endif
-
 #if ENABLE(META_VIEWPORT)
     bool m_forceAlwaysUserScalable { false };
     double m_viewportConfigurationLayoutSizeScaleFactorFromClient { 1 };

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -900,10 +900,6 @@ private:
     RetainPtr<NSMutableDictionary> m_bundleParameters;
 #endif
 
-#if ENABLE(CONTENT_EXTENSIONS)
-    HashMap<String, String> m_encodedContentExtensions;
-#endif
-
 #if ENABLE(GAMEPAD)
     WeakHashSet<WebProcessProxy> m_processesUsingGamepads;
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -613,13 +613,11 @@ private:
     std::optional<WebsiteDataStoreConfiguration::Directories> m_resolvedDirectories WTF_GUARDED_BY_LOCK(m_resolveDirectoriesLock);
     FileSystem::Salt m_mediaKeysStorageSalt WTF_GUARDED_BY_LOCK(m_resolveDirectoriesLock);
     const Ref<const WebsiteDataStoreConfiguration> m_configuration;
-    bool m_hasResolvedDirectories { false };
     const RefPtr<DeviceIdHashSaltStorage> m_deviceIdHashSaltStorage;
 #if ENABLE(ENCRYPTED_MEDIA)
     const RefPtr<DeviceIdHashSaltStorage> m_mediaKeysHashSaltStorage;
 #endif
 #if PLATFORM(IOS_FAMILY)
-    String m_resolvedContainerCachesWebContentDirectory;
     String m_resolvedContainerCachesNetworkingDirectory;
     String m_resolvedContainerTemporaryDirectory;
     String m_resolvedCookieStorageDirectory;
@@ -683,7 +681,6 @@ private:
     CompletionHandler<void(String&&)> m_completionHandlerForRemovalFromNetworkProcess;
 
     bool m_inspectionForServiceWorkersAllowed { true };
-    bool m_isBlobRegistryPartitioningEnabled { false };
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
     std::optional<bool> m_cachedIsOptInCookiePartitioningEnabled;
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -377,7 +377,6 @@ private:
     String m_webContentRestrictionsConfigurationFile;
 #endif
     String m_additionalDomainsWithUserInteractionForTesting;
-    std::optional<unsigned> m_overridePersistentNotificationMinimumLifetimeForTesting;
 };
 
 }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -83,7 +83,6 @@ OBJC_CLASS NSView;
 OBJC_CLASS QLPreviewPanel;
 OBJC_CLASS WebTextIndicatorLayer;
 OBJC_CLASS WKAccessibilitySettingsObserver;
-OBJC_CLASS WKBrowsingContextController;
 OBJC_CLASS WKDOMPasteMenuDelegate;
 OBJC_CLASS WKEditorUndoTarget;
 OBJC_CLASS WKFullScreenWindowController;
@@ -1099,10 +1098,6 @@ private:
 
     RetainPtr<_WKRemoteObjectRegistry> m_remoteObjectRegistry;
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    RetainPtr<WKBrowsingContextController> m_browsingContextController;
-ALLOW_DEPRECATED_DECLARATIONS_END
-
     RefPtr<ViewGestureController> m_gestureController;
     bool m_allowsBackForwardNavigationGestures { false };
     bool m_allowsMagnification { false };
@@ -1110,7 +1105,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr<NSAccessibilityRemoteUIElement> m_remoteAccessibilityChild;
     RetainPtr<NSData> m_remoteAccessibilityChildToken;
     RetainPtr<NSData> m_remoteAccessibilityTokenGeneratedByUIProcess;
-    RetainPtr<NSMutableDictionary> m_remoteAccessibilityFrameCache;
     HashSet<pid_t> m_registeredRemoteAccessibilityPids;
 
     struct PromisedImageDragData {

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -197,7 +197,6 @@ private:
     
     RefPtr<PDFPluginPasswordField> m_passwordField;
 
-    String m_temporaryPDFUUID;
 
     RetainPtr<WKPDFLayerControllerDelegate> m_pdfLayerControllerDelegate;
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -240,7 +240,6 @@ private:
     const Ref<PDFPluginBase> m_plugin;
     WeakPtr<WebPage> m_webPage;
     URL m_mainResourceURL;
-    String m_mainResourceContentType;
     bool m_shouldUseManualLoader { false };
 
     bool m_isInitialized { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -3229,12 +3229,10 @@ private:
     HashMap<String, Ref<WebURLSchemeHandlerProxy>> m_schemeToURLSchemeHandlerProxyMap;
     HashMap<WebURLSchemeHandlerIdentifier, WeakRef<WebURLSchemeHandlerProxy>> m_identifierToURLSchemeHandlerProxyMap;
 
-    HashMap<uint64_t, Function<void(bool granted)>> m_storageAccessResponseCallbackMap;
 
     OptionSet<LayerTreeFreezeReason> m_layerTreeFreezeReasons;
     bool m_isSuspended { false };
     bool m_needsFontAttributes { false };
-    bool m_firstFlushAfterCommit { false };
     bool m_needsFixedContainerEdgesUpdate { true };
 #if PLATFORM(COCOA)
     WeakPtr<WebRemoteObjectRegistry> m_remoteObjectRegistry;
@@ -3307,7 +3305,6 @@ private:
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
     RefPtr<WebCore::MediaSessionCoordinator> m_mediaSessionCoordinator;
-    RefPtr<RemoteMediaSessionCoordinator> m_remoteMediaSessionCoordinator;
 #endif
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -253,7 +253,6 @@ private:
     HashCountedSet<WebCore::MediaPlayerClientIdentifier> m_clientCounts;
 #if HAVE(PIP_SKIP_PREROLL)
     WeakPtr<WebCore::MediaSession> m_mediaSession;
-    bool m_canSkipAd { false };
 #endif
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.h
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.h
@@ -97,7 +97,6 @@ private:
     RetainPtr<CFStringRef> m_proxyHost;
     RetainPtr<CFNumberRef> m_proxyPort;
 
-    RetainPtr<CFHTTPMessageRef> m_proxyResponseMessage;
     bool m_sentStoredCredentials;
     bool m_shouldAcceptInsecureCertificates;
     RetainPtr<CFReadStreamRef> m_readStream;


### PR DESCRIPTION
#### 5101cdc679ab68b47516eb1eed86b24e89e0db03
<pre>
Remove many unused member variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=316502">https://bugs.webkit.org/show_bug.cgi?id=316502</a>
<a href="https://rdar.apple.com/178952050">rdar://178952050</a>

Reviewed by Richard Robinson.

* Source/JavaScriptCore/bytecode/SharedJITStubSet.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransformBackend.h:
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
* Source/WebCore/editing/DeleteSelectionCommand.h:
* Source/WebCore/editing/SurroundingText.h:
* Source/WebCore/fileapi/FileReaderLoader.h:
* Source/WebCore/inspector/agents/page/PageTimelineAgent.h:
* Source/WebCore/page/Page.h:
* Source/WebCore/page/mac/ServicesOverlayController.h:
* Source/WebCore/platform/audio/AudioBus.h:
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h:
* Source/WebCore/platform/audio/mac/AudioSessionMac.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::WTF_GUARDED_BY_CAPABILITY):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/mediastream/DisplayCaptureManager.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:
* Source/WebCore/platform/mediastream/cocoa/CoreAudioCaptureUnit.h:
* Source/WebCore/platform/mediastream/cocoa/MockRealtimeVideoSourceCocoa.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:
* Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h:
* Source/WebCore/rendering/RenderEmbeddedObject.h:
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/rendering/mac/RenderThemeMac.h:
* Source/WebDriver/WebSocketServer.h:
* Source/WebGPU/WebGPU/ShaderModule.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h:
* Source/WebKit/UIProcess/Automation/BidiScriptAgent.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/SpeechRecognitionServer.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.h:

Canonical link: <a href="https://commits.webkit.org/314733@main">https://commits.webkit.org/314733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a560ac8c06a240f786cb20ef9e8d5c00ecadd2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176062 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124272 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72b0dd35-be34-49e1-8145-679839c0704d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129882 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91487 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ed692a1-e403-4a16-853e-bdb35a59b888) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110407 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba78f463-e7a5-4bd3-89b1-12e3e860f49b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31257 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29964 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24799 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159171 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178600 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27908 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31498 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138250 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40574 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138161 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149558 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104167 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25422 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33434 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26423 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199693 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39773 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112847 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53698 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39169 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4524 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39414 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39313 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->