### PR TITLE
Cherry-pick 314533@main (82c645da79b5). https://bugs.webkit.org/show_bug.cgi?id=316190

### DIFF
--- a/LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata-expected.txt
+++ b/LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS requestVideoFrameCallback metadata for canvas captureStream (2d context)
+

--- a/LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata.html
+++ b/LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata.html
@@ -1,0 +1,74 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+    <body>
+        <canvas id="canvas" width=100 height=100></canvas>
+        <video id="video" autoplay width=100 height=100></video>
+        <script src="../../../resources/testharness.js"></script>
+        <script src="../../../resources/testharnessreport.js"></script>
+        <script>
+
+const canvas = document.getElementById("canvas");
+const video  = document.getElementById("video");
+
+function drawFrame(color) {
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+function waitForFrame(v) {
+    return new Promise((resolve, reject) => {
+        const id = v.requestVideoFrameCallback((now, metadata) => resolve({ now, metadata }));
+        setTimeout(() => {
+            v.cancelVideoFrameCallback(id);
+            reject("requestVideoFrameCallback timed out after 5s");
+        }, 5000);
+    });
+}
+
+promise_test(async test => {
+    const stream = canvas.captureStream();
+    video.srcObject = stream;
+
+    // Let the pipeline initialize before registering the first callback.
+    await new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve, 0)));
+
+    drawFrame("green");
+    const { metadata: meta1 } = await waitForFrame(video);
+
+    // Dimensions must match the canvas.
+    assert_equals(meta1.width,  canvas.width,  "width matches canvas");
+    assert_equals(meta1.height, canvas.height, "height matches canvas");
+
+    // presentedFrames must be at least 1.
+    assert_greater_than(meta1.presentedFrames, 0, "presentedFrames > 0");
+
+    // presentationTime is a DOMHighResTimeStamp (ms since time origin), must be positive.
+    assert_greater_than(meta1.presentationTime, 0, "presentationTime > 0");
+
+    // expectedDisplayTime must be at or after presentationTime.
+    assert_greater_than_equal(meta1.expectedDisplayTime, meta1.presentationTime,
+        "expectedDisplayTime >= presentationTime");
+
+    // mediaTime is stream-relative (seconds since stream start), must be non-negative
+    // and well below the system uptime, confirming it is not the raw clock value.
+    assert_greater_than_equal(meta1.mediaTime, 0, "mediaTime >= 0");
+    assert_less_than(meta1.mediaTime, 60, "mediaTime is stream-relative, not an absolute clock value");
+
+    // captureTime must be provided for canvas capture frames.
+    assert_not_equals(meta1.captureTime, undefined, "captureTime is set");
+    assert_greater_than(meta1.captureTime, 0, "captureTime > 0");
+
+    // Draw a second frame and verify all monotonically-increasing fields advance.
+    drawFrame("green");
+    const { metadata: meta2 } = await waitForFrame(video);
+
+    assert_greater_than(meta2.presentedFrames, meta1.presentedFrames, "presentedFrames increases");
+    assert_greater_than(meta2.presentationTime, meta1.presentationTime, "presentationTime increases");
+    assert_greater_than(meta2.mediaTime, meta1.mediaTime, "mediaTime increases");
+
+}, "requestVideoFrameCallback metadata for canvas captureStream (2d context)");
+
+        </script>
+    </body>
+</html>

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS: pruning a back/forward-cached MediaKeySession page does not crash.

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash.html
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash.html
@@ -1,0 +1,87 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+// Regression test: pruning a back/forward-cached page that still owns an open MediaKeySession must not crash.
+//
+// When the page enters the BackForwardCache its active DOM objects are suspended and its event-loop task group is
+// suspended. If the cached page is then pruned (rather than restored), Document teardown stops the active DOM
+// objects: markAsReadyToStop() runs first and -- because the group was suspended -- transitions it straight to
+// Stopped, while activeDOMObjectsAreSuspended() stays true. MediaKeySession::stop() then closes the CDM session;
+// the Thunder/Mock backends invoke the close callback synchronously, so before the fix sessionClosed() resolved
+// the "closed" promise synchronously here, tripping DeferredPromise's suspended-context assertion.
+//
+// This page opens a MediaKeySession and navigates to a helper so this document enters the BackForwardCache (the
+// proven page-cache navigation idiom -- a separate document, not a same-URL query change). The helper then prunes
+// the cache, which destroys this still-cached document. The result is reported by the helper, since this page is
+// gone by then.
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const encoder = new TextEncoder();
+
+async function setUpOpenSession() {
+    // Mirror the working mock-EME setup (mock-MediaKeySession-close.html): enable the mock media engine first or
+    // "video/mock" is unsupported and requestMediaKeySystemAccess rejects.
+    internals.initializeMockMediaSource();
+    // Pin the factory on window: CDMFactory's registry holds only a WeakRef, MockCDM holds only a WeakPtr,
+    // so the JS wrapper is the only strong reference. A local would let GC collect it across the awaits below,
+    // unregistering the factory mid-flight -- the failure presents as NotSupportedError or NotAllowedError
+    // depending on which await GC interleaves with.
+    window.__mock = internals.registerMockCDM();
+    window.__mock.supportedDataTypes = ["keyids"];
+
+    const access = await navigator.requestMediaKeySystemAccess("org.webkit.mock", [{
+        initDataTypes: ["keyids"],
+        videoCapabilities: [{ contentType: 'video/mock; codecs="mock"' }],
+    }]);
+    const mediaKeys = await access.createMediaKeys();
+    const session = mediaKeys.createSession("temporary");
+
+    // Keep both alive on the window so the session survives un-closed into the BackForwardCache; that is what makes
+    // MediaKeySession::stop() run against a suspended-then-stopped context when the cached page is pruned.
+    window.__mediaKeys = mediaKeys;
+    window.__session = session;
+
+    await session.generateRequest("keyids", encoder.encode(JSON.stringify({ kids: ["MTIzNDU="] })));
+
+    // Touch the "closed" attribute so a DeferredPromise is registered on its DOMPromiseProxy (real EME apps do
+    // `session.closed.then(...)`). Without an attached deferred promise, resolving the closed promise during
+    // teardown is a no-op that never reaches DeferredPromise::callFunction -- so the assertion would not fire and
+    // the test would pass even on the buggy build.
+    window.__closed = session.closed;
+}
+
+window.addEventListener("load", () => {
+    if (!window.internals || !window.testRunner) {
+        document.body.textContent = "FAIL: this test requires window.internals and window.testRunner.";
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+
+    setUpOpenSession().then(() => {
+        // Navigate outside the load/promise continuation so it produces a history entry.
+        setTimeout(() => { window.location.href = "resources/mock-MediaKeySession-backforwardcache-prune-helper.html"; }, 0);
+    }, e => {
+        document.body.textContent = "FAIL: could not set up MediaKeySession: " + e;
+        testRunner.notifyDone();
+    });
+});
+</script>
+</head>
+<body>
+<!-- Substantial visible content so the main frame is "visually non-empty"; canCachePage refuses a visually-empty
+     main frame, which would stop the page entering the cache at all. -->
+<div style="width: 400px; height: 400px;">
+This page opens an EME MediaKeySession and then navigates to a helper so that this document enters the back/forward
+cache. The helper prunes the cache, destroying this still-cached document while its MediaKeySession is open, which
+is the teardown path the fix is about. This paragraph exists so the page is visually non-empty and therefore
+eligible for the back/forward cache in the first place.
+</div>
+</body>
+</html>

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close-expected.txt
@@ -1,0 +1,19 @@
+RUN(internals.initializeMockMediaSource())
+RUN(mock = internals.registerMockCDM())
+RUN(mock.supportedDataTypes = ["keyids"])
+RUN(capabilities.initDataTypes = ["keyids"])
+RUN(capabilities.videoCapabilities = [{ contentType: 'video/mock; codecs="mock"' }] )
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities]))
+Promise resolved OK
+RUN(promise = mediaKeySystemAccess.createMediaKeys())
+Promise resolved OK
+RUN(kids = JSON.stringify({ kids: [ "MTIzNDU=" ] }))
+RUN(mediaKeySession = mediaKeys.createSession("temporary"))
+RUN(promise = mediaKeySession.generateRequest("keyids", encoder.encode(kids)))
+Promise resolved OK
+Two concurrent close() calls should both resolve without crashing.
+RUN(promise = mediaKeySession.close())
+RUN(promise2 = mediaKeySession.close())
+Survived concurrent close() and the "closed" promise resolved exactly once.
+END OF TEST
+

--- a/LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close.html
+++ b/LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src=../video-test.js></script>
+    <script type="text/javascript">
+    // Regression test: two concurrent close() calls on the same MediaKeySession must not resolve the
+    // "closed" promise twice. Each close() checks m_closed before queuing its work, but m_closed is only
+    // set when the queued task runs, so both calls queue a sessionClosed() task; resolving the "closed"
+    // promise a second time previously tripped an assertion in DOMPromiseProxy::resolve().
+    var mock;
+    var promise;
+    var promise2;
+    var mediaKeySystemAccess;
+    var mediaKeys;
+    var mediaKeySession;
+    var capabilities = {};
+    var kids;
+    var encoder = new TextEncoder();
+
+    function doTest()
+    {
+        if (!window.internals) {
+            failTest("Internals is required for this test.");
+            return;
+        }
+
+        run('internals.initializeMockMediaSource()');
+        run('mock = internals.registerMockCDM()');
+        run('mock.supportedDataTypes = ["keyids"]');
+        run('capabilities.initDataTypes = ["keyids"]');
+        run(`capabilities.videoCapabilities = [{ contentType: 'video/mock; codecs="mock"' }] `);
+        run('promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities])');
+        shouldResolve(promise).then(gotMediaKeySystemAccess, failTest);
+    }
+
+    function gotMediaKeySystemAccess(result) {
+        mediaKeySystemAccess = result;
+        run('promise = mediaKeySystemAccess.createMediaKeys()');
+        shouldResolve(promise).then(gotMediaKeys, failTest);
+    }
+
+    function gotMediaKeys(result) {
+        mediaKeys = result;
+        run('kids = JSON.stringify({ kids: [ "MTIzNDU=" ] })');
+        run('mediaKeySession = mediaKeys.createSession("temporary")');
+        run('promise = mediaKeySession.generateRequest("keyids", encoder.encode(kids))');
+        shouldResolve(promise).then(closeConcurrently, failTest);
+    }
+
+    function closeConcurrently() {
+        consoleWrite('Two concurrent close() calls should both resolve without crashing.');
+        run('promise = mediaKeySession.close()');
+        run('promise2 = mediaKeySession.close()');
+        // Wait on the raw promises (no per-promise logging) so completion order does not affect the output.
+        Promise.all([promise, promise2, mediaKeySession.closed]).then(finish, failTest);
+    }
+
+    function finish() {
+        consoleWrite('Survived concurrent close() and the "closed" promise resolved exactly once.');
+        mock.unregister();
+        endTest();
+    }
+    </script>
+</head>
+<body onload="doTest()">
+</body>
+</html>

--- a/LayoutTests/media/encrypted-media/mock-getSupportedCapabilitiesForAudioVideoType-expected.txt
+++ b/LayoutTests/media/encrypted-media/mock-getSupportedCapabilitiesForAudioVideoType-expected.txt
@@ -1,0 +1,24 @@
+RUN(internals.initializeMockMediaSource())
+RUN(mock = internals.registerMockCDM())
+RUN(mock.supportedDataTypes = ["mock"])
+RUN(mock.unsupportedVideoCodecs = ["bad"])
+
+SET capabilities = '[ { "initDataTypes": [ "mock" ], "videoCapabilities": [ { "contentType": "video/mock; codecs=\"mock\"" }, { "contentType": "video/mock; codecs=\"bad\"" } ] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
+Promise resolved OK
+EXPECTED (access.getConfiguration().videoCapabilities.length == '1') OK
+EXPECTED (access.getConfiguration().videoCapabilities[0].contentType == 'video/mock; codecs="mock"') OK
+
+SET capabilities = '[ { "initDataTypes": [ "mock" ], "videoCapabilities": [ { "contentType": "video/mock; codecs=\"bad\"" } ] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
+Promise rejected correctly OK
+EXPECTED (exceptionCode.name == 'NotSupportedError') OK
+
+RUN(mock.unsupportedVideoCodecs = ["bad", "worse"])
+SET capabilities = '[ { "initDataTypes": [ "mock" ], "videoCapabilities": [ { "contentType": "video/mock; codecs=\"bad\"" }, { "contentType": "video/mock; codecs=\"mock\"" }, { "contentType": "video/mock; codecs=\"worse\"" } ] } ]'
+RUN(promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities))
+Promise resolved OK
+EXPECTED (access.getConfiguration().videoCapabilities.length == '1') OK
+EXPECTED (access.getConfiguration().videoCapabilities[0].contentType == 'video/mock; codecs="mock"') OK
+END OF TEST
+

--- a/LayoutTests/media/encrypted-media/mock-getSupportedCapabilitiesForAudioVideoType.html
+++ b/LayoutTests/media/encrypted-media/mock-getSupportedCapabilitiesForAudioVideoType.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src=../video-test.js></script>
+    <script type="text/javascript">
+    var mock;
+    var promise;
+    var capabilities = {};
+
+    function doTest()
+    {
+        if (!window.internals) {
+            failTest("Internals is required for this test.")
+            return;
+        }
+
+        run('internals.initializeMockMediaSource()');
+        run('mock = internals.registerMockCDM()');
+        run('mock.supportedDataTypes = ["mock"]');
+        run('mock.unsupportedVideoCodecs = ["bad"]');
+
+        next();
+    }
+
+    function next() {
+        if (!tests.length) {
+            mock.unregister();
+            endTest()
+            return;
+        }
+
+        var nextTest = tests.shift();
+        consoleWrite('');
+        nextTest();
+    }
+
+    function passingTestWithCapabilities(capabilities, success) {
+        shouldResolve(testWithCapabilities(capabilities)).then(success).then(next, next);
+    }
+
+    function failingTestWithCapabilities(capabilities, failure) {
+        shouldReject(testWithCapabilities(capabilities)).then(failure).then(next, next);
+    }
+
+    function testWithCapabilities(capabilities) {
+        window.capabilities = capabilities;
+        consoleWrite(`SET capabilities = '${ JSON.stringify(capabilities, null, 1) }'`);
+        run('promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", capabilities)');
+        return promise;
+    }
+
+    tests = [
+        // A "bad" codec that MediaPlayer accepts as a mock mime but the CDM rejects
+        // under supportsConfigurationWithRestrictions must be filtered out, while a
+        // supported sibling capability is retained.
+        function() {
+            passingTestWithCapabilities([{
+                    initDataTypes: ['mock'],
+                    videoCapabilities: [
+                        { contentType: 'video/mock; codecs="mock"' },
+                        { contentType: 'video/mock; codecs="bad"' },
+                    ],
+                }],
+                mediaKeySystemAccess => {
+                    window.access = mediaKeySystemAccess;
+                    testExpected('access.getConfiguration().videoCapabilities.length', '1');
+                    testExpected('access.getConfiguration().videoCapabilities[0].contentType', 'video/mock; codecs="mock"');
+                });
+        },
+
+        // A single "bad" capability must cause the whole request to fail with
+        // NotSupportedError: this is the HBO Max / HEVC-on-unsupported-system case.
+        function() {
+            failingTestWithCapabilities([{
+                    initDataTypes: ['mock'],
+                    videoCapabilities: [{ contentType: 'video/mock; codecs="bad"' }],
+                }],
+                exceptionCode => {
+                    window.exceptionCode = exceptionCode;
+                    testExpected('exceptionCode.name', 'NotSupportedError');
+                });
+        },
+
+        // Multiple "bad" codecs configured: filter all of them, keep the supported one.
+        function() {
+            run('mock.unsupportedVideoCodecs = ["bad", "worse"]');
+            passingTestWithCapabilities([{
+                    initDataTypes: ['mock'],
+                    videoCapabilities: [
+                        { contentType: 'video/mock; codecs="bad"' },
+                        { contentType: 'video/mock; codecs="mock"' },
+                        { contentType: 'video/mock; codecs="worse"' },
+                    ],
+                }],
+                mediaKeySystemAccess => {
+                    window.access = mediaKeySystemAccess;
+                    testExpected('access.getConfiguration().videoCapabilities.length', '1');
+                    testExpected('access.getConfiguration().videoCapabilities[0].contentType', 'video/mock; codecs="mock"');
+                });
+        },
+    ];
+    </script>
+</head>
+<body onload="doTest()">
+</body>
+</html>

--- a/LayoutTests/media/encrypted-media/resources/mock-MediaKeySession-backforwardcache-prune-helper.html
+++ b/LayoutTests/media/encrypted-media/resources/mock-MediaKeySession-backforwardcache-prune-helper.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+// Helper for mock-MediaKeySession-backforwardcache-prune-crash.html. The previous page (with an open
+// MediaKeySession) is now in the BackForwardCache. Prune it -- which synchronously destroys the cached page and
+// tears down its still-open session -- and report the result here, since the pruned page is gone.
+//
+// This is a crash test: the success condition is "tearing down a back/forward-cached MediaKeySession page does not
+// crash". That holds whether the page was actually pruned or never entered the cache at all, so both outcomes
+// report the same PASS. Reporting PASS on non-entry keeps the test from flaking when the environment denies
+// caching: BackForwardCache::canCache() refuses entry while the process is under memory pressure (e.g. the WK2
+// Stress bot). A regression still aborts the process when the prune path is exercised, independent of this text.
+const PASS_MESSAGE = "PASS: pruning a back/forward-cached MediaKeySession page does not crash.";
+
+function finish(message) {
+    document.body.textContent = message;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+function prune(retries = 0) {
+    // The previous page enters the cache as part of this navigation's commit; give it a few ticks if needed so we
+    // exercise the real prune path whenever caching is allowed.
+    if (internals.backForwardCacheSize() < 1) {
+        if (retries < 50) {
+            setTimeout(() => prune(retries + 1), 10);
+            return;
+        }
+        // Page never entered the cache (e.g. denied under memory pressure): nothing to prune, no crash.
+        finish(PASS_MESSAGE);
+        return;
+    }
+
+    // Synchronously destroys the cached page -> Document teardown -> MediaKeySession::stop(). Before the fix this
+    // crashed here; now it must return cleanly.
+    internals.clearBackForwardCache();
+    finish(PASS_MESSAGE);
+}
+
+window.addEventListener("load", () => {
+    if (!window.internals || !window.testRunner) {
+        finish("FAIL: this test requires window.internals and window.testRunner.");
+        return;
+    }
+    prune();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2531,7 +2531,7 @@ webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creat
 
 http/wpt/mediastream/webrtc-vp9-colorspace.html [ Failure ]
 
-webkit.org/b/314659 webrtc/getDisplayMedia-pc-resolution.html [ Failure ]
+webkit.org/b/314659 webrtc/getDisplayMedia-pc-resolution.html [ Failure Timeout ]
 
 # Regressions introduced by https://commits.webkit.org/263750@main
 fast/mediastream/apply-constraints-advanced.html [ Failure ]

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2527,6 +2527,12 @@ webkit.org/b/265860 imported/w3c/web-platform-tests/webrtc-stats/supported-stats
 
 fast/mediastream/video-rotation2.html [ Failure Pass Timeout ]
 
+webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html [ Skip ] # Timeout
+
+http/wpt/mediastream/webrtc-vp9-colorspace.html [ Failure ]
+
+webkit.org/b/314659 webrtc/getDisplayMedia-pc-resolution.html [ Failure ]
+
 # Regressions introduced by https://commits.webkit.org/263750@main
 fast/mediastream/apply-constraints-advanced.html [ Failure ]
 fast/mediastream/apply-constraints-video.html [ Failure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -217,6 +217,7 @@ scrollingcoordinator/non-fast-scrollable-region-scaled-iframe.html [ Skip ]
 scrollingcoordinator/non-fast-scrollable-region-transformed-iframe.html [ Skip ]
 
 imported/w3c/web-platform-tests/video-rvfc [ Pass ]
+fast/mediastream/captureStream/canvas-rvfc-metadata.html [ Failure ]
 fast/mediastream/getUserMedia-rvfc.html [ Pass ]
 webrtc/peerConnection-rvfc.html [ Pass ]
 # Timing out tests until we add XR session.

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -173,6 +173,8 @@ webkit.org/b/61827 fast/events/drag-image-filename.html
 fast/mediastream/microphone-change-while-muted.html [ Pass ]
 
 # Media Stream API is not fully supported.
+fast/mediastream/captureStream/canvas-rvfc-metadata.html [ Failure ]
+
 fast/mediastream/MediaStream-add-ended-tracks.html
 
 fast/mediastream/RTCPeerConnection-ice.html [ Skip ]

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -783,6 +783,12 @@ void MediaKeySession::sessionClosed()
     // W3C Editor's Draft 09 November 2016
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    // close(), stop(), and a CDM-reported close during update() each queue a task that lands here. They guard on
+    // m_closed before enqueuing, but it is only set when the task runs, so more than one task can already be queued.
+    // Update m_closed here to ensure the promise is only resolved once, and avoid an assertion in DOMPromiseProxy.
+    if (std::exchange(m_closed, true))
+        return;
+
     // 1. Let session be the associated MediaKeySession object.
     // 2. If session's session type is "persistent-usage-record", execute the following steps in parallel:
     if (m_sessionType == MediaKeySessionType::PersistentUsageRecord) {
@@ -796,9 +802,6 @@ void MediaKeySession::sessionClosed()
 
     // 4. Run the Update Expiration algorithm on the session, providing NaN.
     updateExpiration(std::numeric_limits<double>::quiet_NaN());
-
-    // Let's consider the session closed before any promise on the 'closed' attribute is resolved.
-    m_closed = true;
 
     // 5. Let promise be the closed attribute of the session.
     // 6. Resolve promise.

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -848,8 +848,14 @@ void MediaKeySession::stop()
         if (!protectedThis)
             return;
 
-        ALWAYS_LOG_WITH_THIS(protectedThis, logIdentifier, "::lambda, closed");
-        protectedThis->sessionClosed();
+        // closeSession() may invoke this callback synchronously (e.g. the Thunder backend), and stop() runs during
+        // document teardown while the event loop has already been marked ready-to-stop. Resolving the closed promise
+        // synchronously here would violate DeferredPromise's suspended-context invariant. Defer to the event loop,
+        // mirroring close(); the task is cleanly dropped if the event loop is already stopped.
+        queueTaskKeepingObjectAlive(*protectedThis, TaskSource::Networking, [logIdentifier](auto& session) {
+            ALWAYS_LOG_WITH_THIS(&session, logIdentifier, "::task, closed");
+            session.sessionClosed();
+        });
     });
 }
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -805,6 +805,14 @@ void MediaKeySession::sessionClosed()
 
     // 5. Let promise be the closed attribute of the session.
     // 6. Resolve promise.
+    // Skip if the context is stopping (e.g. a back/forward-cached page being pruned); otherwise resolving the
+    // promise trips DeferredPromise's suspended-context assertion.
+    RefPtr context = scriptExecutionContext();
+    if (!context || context->activeDOMObjectsAreStopped()) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Context is stopping; not resolving closed promise");
+        return;
+    }
+
     m_closedPromise->resolve();
 }
 
@@ -848,14 +856,10 @@ void MediaKeySession::stop()
         if (!protectedThis)
             return;
 
-        // closeSession() may invoke this callback synchronously (e.g. the Thunder backend), and stop() runs during
-        // document teardown while the event loop has already been marked ready-to-stop. Resolving the closed promise
-        // synchronously here would violate DeferredPromise's suspended-context invariant. Defer to the event loop,
-        // mirroring close(); the task is cleanly dropped if the event loop is already stopped.
-        queueTaskKeepingObjectAlive(*protectedThis, TaskSource::Networking, [logIdentifier](auto& session) {
-            ALWAYS_LOG_WITH_THIS(&session, logIdentifier, "::task, closed");
-            session.sessionClosed();
-        });
+        // Run Session Closed synchronously to avoid the CDM session outliving the page and leaking into the next
+        // navigation.
+        ALWAYS_LOG_WITH_THIS(protectedThis, logIdentifier, "::lambda, closed");
+        protectedThis->sessionClosed();
     });
 }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -656,7 +656,13 @@ void webkitGstWebRTCIceAgentClosed(WebKitGstIceAgent* agent)
     priv->closePromise.clear();
 }
 
-#if GST_CHECK_VERSION(1, 27, 0)
+static bool webkitGstWebRTCIceAgentIsClosed(WebKitGstIceAgent* agent)
+{
+    Locker locker { agent->priv->stateLock };
+    return agent->priv->state == AgentState::Closed;
+}
+
+#if GST_CHECK_VERSION(1, 28, 0)
 static void webkitGstWebRTCIceAgentClose(GstWebRTCICE* ice, GstPromise* promise)
 {
     auto backend = WEBKIT_GST_WEBRTC_ICE_BACKEND(ice);
@@ -693,12 +699,7 @@ static void webkitGstWebRTCIceAgentClose(GstWebRTCICE* ice, GstPromise* promise)
 
     auto timeout = WTF::MonotonicTime::now().secondsSinceEpoch() + 2_s;
     while (WTF::MonotonicTime::now().secondsSinceEpoch() < timeout) {
-        bool isClosed = false;
-        {
-            Locker locker { backend->priv->stateLock };
-            isClosed = backend->priv->state == AgentState::Closed;
-        }
-        if (isClosed)
+        if (webkitGstWebRTCIceAgentIsClosed(backend))
             return;
         g_main_context_iteration(backend->priv->runLoop->mainContext(), FALSE);
     }
@@ -755,6 +756,8 @@ static bool webkitGstWebRTCIceAgentConfigure(WebKitGstIceAgent* backend, RefPtr<
     priv->backendClient->setIncomingDataCallback([weakThis = GThreadSafeWeakPtr(backend)](unsigned streamId, RTCIceProtocol protocol, String&& from, String&& to, SharedMemory::Handle&& data) mutable {
         auto self = weakThis.get();
         if (!self)
+            return;
+        if (webkitGstWebRTCIceAgentIsClosed(self.get()))
             return;
         findStreamAndApply(self.get(), streamId, [protocol, from = WTF::move(from), to = WTF::move(to), data = WTF::move(data)](const auto* stream) mutable {
             webkitGstWebRTCIceStreamHandleIncomingData(stream, protocol, WTF::move(from), WTF::move(to), WTF::move(data));

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -701,13 +701,16 @@ void GStreamerMediaEndpoint::linkOutgoingSources(GstSDPMessage* sdpMessage)
 
         GST_DEBUG_OBJECT(m_pipeline.get(), "Looking-up outgoing source with msid %s in %zu unlinked sources", msid.utf8(), m_unlinkedOutgoingSources.size());
         m_unlinkedOutgoingSources.removeFirstMatching([&, msid = String(msid.span())](auto& source) -> bool {
-            if (source->type() != sourceType)
+            if (source->type() != sourceType) {
+                GST_DEBUG_OBJECT(pipeline(), "Un-matched source type");
                 return false;
-
+            }
             if (const auto& track = source->track()) {
                 auto sourceMsid = makeString(source->mediaStreamID(), ' ', track->id());
-                if (!msid.isEmpty() && sourceMsid != msid)
+                if (!msid.isEmpty() && sourceMsid != msid) {
+                    GST_DEBUG_OBJECT(pipeline(), "Un-matched outgoing source msid: %s", sourceMsid.utf8().data());
                     return false;
+                }
             }
 
             auto allowedCaps = capsFromSDPMedia(media);
@@ -2268,6 +2271,54 @@ void GStreamerMediaEndpoint::onNegotiationNeeded()
 
         GST_DEBUG_OBJECT(m_pipeline.get(), "Negotiation needed!");
         peerConnectionBackend->markAsNeedingNegotiation(m_negotiationNeededEventId);
+    });
+}
+
+void GStreamerMediaEndpoint::trackWasReplaced(const String& previousId, const String& newId)
+{
+    struct TrackIds {
+        String previousId;
+        String newId;
+        bool wasTrackFound;
+    };
+
+    TrackIds ids { previousId, newId, false };
+    forEachTransceiver(m_webrtcBin, [&](auto&& transceiver) -> bool {
+        GRefPtr<GstCaps> caps;
+        g_object_get(transceiver.get(), "codec-preferences", &caps.outPtr(), nullptr);
+
+        auto newCaps = adoptGRef(gst_caps_make_writable(caps.leakRef()));
+        gst_caps_map_in_place(newCaps.get(), [](auto*, auto* structure, gpointer userData) -> gboolean {
+            auto msid = gstStructureGetString(structure, "a-msid"_s);
+            if (msid.isEmpty())
+                return TRUE;
+
+            String msidString = msid.span();
+            auto parts = msidString.split(' ');
+            if (parts.size() != 2)
+                return TRUE;
+
+            auto ids = static_cast<TrackIds*>(userData);
+            if (parts[1] != ids->previousId)
+                return TRUE;
+
+            ids->wasTrackFound = true;
+            if (ids->newId.isEmpty())
+                gst_structure_remove_field(structure, "a-msid");
+            else {
+                auto newMsid = makeString(parts[0], ' ', ids->newId);
+                gst_structure_set(structure, "a-msid", G_TYPE_STRING, newMsid.utf8().data(), nullptr);
+            }
+
+            return TRUE;
+        }, &ids);
+
+        if (ids.wasTrackFound) {
+            g_object_freeze_notify(G_OBJECT(transceiver.get()));
+            g_object_set(transceiver.get(), "codec-preferences", newCaps.get(), nullptr);
+            g_object_thaw_notify(G_OBJECT(transceiver.get()));
+        }
+        return ids.wasTrackFound;
     });
 }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -125,6 +125,8 @@ public:
 
     void onNegotiationNeeded();
 
+    void trackWasReplaced(const String& previousId, const String& newId);
+
 protected:
 #if !RELEASE_LOG_DISABLED
     void onStatsDelivered(const GstStructure*);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -469,6 +469,11 @@ RTCPeerConnection& GStreamerPeerConnectionBackend::connection()
     return m_peerConnection.get();
 }
 
+void GStreamerPeerConnectionBackend::trackWasReplaced(const String& previousId, const String& newId)
+{
+    m_endpoint->trackWasReplaced(previousId, newId);
+}
+
 void GStreamerPeerConnectionBackend::tearDown()
 {
     for (auto& transceiver : connection().currentTransceivers()) {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -115,6 +115,8 @@ private:
     void setReconfiguring(bool isReconfiguring) { m_isReconfiguring = isReconfiguring; }
     bool isReconfiguring() const { return m_isReconfiguring; }
 
+    void trackWasReplaced(const String& previousId, const String& newId);
+
     void tearDown();
 
     Ref<GStreamerMediaEndpoint> m_endpoint;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -149,7 +149,7 @@ void GStreamerRtpSenderBackend::tearDown()
     m_rtcSender = nullptr;
 }
 
-bool GStreamerRtpSenderBackend::replaceTrack(RTCRtpSender&, MediaStreamTrack* track)
+bool GStreamerRtpSenderBackend::replaceTrack(RTCRtpSender& sender, MediaStreamTrack* track)
 {
     GST_DEBUG_OBJECT(m_rtcSender.get(), "Replacing sender track with track %p", track);
 
@@ -161,6 +161,7 @@ bool GStreamerRtpSenderBackend::replaceTrack(RTCRtpSender&, MediaStreamTrack* tr
     // FIXME: We might want to set the reconfiguring flag back to false once the webrtcbin sink pad
     // has renegotiated its caps. Perhaps a pad probe can be used for this.
 
+    auto previousTrackId = sender.trackId();
     RefPtr newTrack = track;
     switchOn(m_source, [&](Ref<RealtimeOutgoingAudioSourceGStreamer>& source) {
         source->replaceTrack(newTrack);
@@ -170,6 +171,7 @@ bool GStreamerRtpSenderBackend::replaceTrack(RTCRtpSender&, MediaStreamTrack* tr
         GST_DEBUG_OBJECT(m_rtcSender.get(), "No outgoing source yet");
     });
 
+    peerConnectionBackend->trackWasReplaced(previousTrackId, newTrack ? newTrack->id() : emptyString());
     return true;
 }
 

--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
@@ -432,7 +432,13 @@ std::optional<Vector<CDMMediaCapability>> CDMPrivate::getSupportedCapabilitiesFo
                 continue;
         }
 
-        if (!supportsConfigurationWithRestrictions(accumulatedConfiguration, restrictions))
+        // NOTE: step 3.13 evaluates the combination including the requested capability.
+        CDMKeySystemConfiguration probeConfiguration = accumulatedConfiguration;
+        if (type == AudioVideoType::Video)
+            probeConfiguration.videoCapabilities.append(requestedCapability);
+        else
+            probeConfiguration.audioCapabilities.append(requestedCapability);
+        if (!supportsConfigurationWithRestrictions(probeConfiguration, restrictions))
             continue;
 
         // 3.13.1. Add requested media capability to supported media capabilities.

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -241,7 +241,7 @@ class CDMProxyDecryptionClient;
 // from background threads (i.e. decryptors).
 class CDMProxy : public ThreadSafeRefCounted<CDMProxy> {
 public:
-    static constexpr Seconds MaxKeyWaitTimeSeconds = 7_s;
+    static constexpr Seconds MaxKeyWaitTimeSeconds = 10_s;
 
     virtual ~CDMProxy() = default;
 

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -174,6 +174,7 @@ public:
     }
 
     unsigned numKeys() const { return m_keys.size(); }
+    bool isEmpty() const { return m_keys.isEmpty(); }
     auto values() const { return m_keys.values(); }
     KeyStoreIDType id() const { return m_id; }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4697,11 +4697,15 @@ std::optional<VideoFrameMetadata> MediaPlayerPrivateGStreamer::videoFrameMetadat
     metadata.presentedFrames = m_sampleCount;
 
     if (GST_BUFFER_PTS_IS_VALID(buffer)) {
-        auto segment = gst_sample_get_segment(m_sample.get());
-        RELEASE_ASSERT(segment);
-        uint64_t streamTime;
-        if (int sign = gst_segment_to_stream_time_full(segment, GST_FORMAT_TIME, GST_BUFFER_PTS(buffer), &streamTime))
-            metadata.mediaTime = sign * fromGstClockTime(streamTime).toDouble();
+        if (isMediaStreamPlayer())
+            metadata.mediaTime = currentTime().toDouble();
+        else {
+            auto segment = gst_sample_get_segment(m_sample.get());
+            RELEASE_ASSERT(segment);
+            uint64_t streamTime;
+            if (int sign = gst_segment_to_stream_time_full(segment, GST_FORMAT_TIME, GST_BUFFER_PTS(buffer), &streamTime))
+                metadata.mediaTime = sign * fromGstClockTime(streamTime).toDouble();
+        }
     }
 
     // FIXME: presentationTime and expectedDisplayTime might not always have the same value, we should try getting more precise values.

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4471,7 +4471,7 @@ bool MediaPlayerPrivateGStreamer::updateVideoSinkStatistics()
 
 std::optional<VideoPlaybackQualityMetrics> MediaPlayerPrivateGStreamer::videoPlaybackQualityMetrics()
 {
-    if (!updateVideoSinkStatistics())
+    if (!m_isEndReached && !updateVideoSinkStatistics())
         return std::nullopt;
 
     uint32_t corruptedVideoFrames = 0;

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
@@ -56,8 +56,15 @@ BoxPtr<OpenCDMSession> CDMProxyThunder::getDecryptionSession(DecryptionContext& 
     auto keyID = mappedKeyID.createVector();
 
     auto keyHandle = getOrWaitForKeyHandle(keyID, WTF::move(in.cdmProxyDecryptionClient));
-    if (!keyHandle.has_value() || !keyHandle.value()->isStatusCurrentlyValid())
+    if (!keyHandle) {
+        GST_ERROR("No key handle");
         return nullptr;
+    }
+
+    if (!keyHandle.value()->isStatusCurrentlyValid()) {
+        GST_ERROR("Key handle has no usable key");
+        return nullptr;
+    }
 
     KeyHandleValueVariant keyData = keyHandle.value()->value();
     ASSERT(std::holds_alternative<BoxPtr<OpenCDMSession>>(keyData));

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -566,10 +566,16 @@ void CDMInstanceSessionThunder::updateLicense(const String& sessionID, LicenseTy
     m_sessionChangedCallbacks.append([this, callback = WTF::move(callback)](bool success, RefPtr<SharedBuffer>&& responseMessage) mutable {
         ASSERT(isMainThread());
         if (success) {
-            if (!responseMessage)
-                callback(false, m_keyStore.convertToJSKeyStatusVector(), std::nullopt, std::nullopt, SuccessValue::Succeeded);
-            else {
-                // FIXME: Using JSON reponse messages is much cleaner than using string prefixes, I believe there
+            if (!responseMessage) {
+                GST_DEBUG("Empty response message");
+                std::optional<KeyStatusVector> keyStatus;
+                // If the keystore is empty, generating an empty status vector would trigger a new
+                // keystatuses event potentially overriding the previous one.
+                if (!m_keyStore.isEmpty())
+                    keyStatus = m_keyStore.convertToJSKeyStatusVector();
+                callback(false, WTF::move(keyStatus), std::nullopt, std::nullopt, SuccessValue::Succeeded);
+            } else {
+                // FIXME: Using JSON response messages is much cleaner than using string prefixes, I believe there
                 // will even be other parts of the spec where not having structured data will be bad.
                 ParsedResponseMessage parsedResponseMessage(responseMessage);
                 ASSERT(parsedResponseMessage);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
@@ -71,7 +71,7 @@ private:
 
     bool m_isDecoding { false };
     IntSize m_videoSize;
-    double m_frameRate;
+    double m_frameRate { 0 };
     uint64_t m_decodedVideoFrames { 0 };
     uint64_t m_framesReceived { 0 };
     uint64_t m_decodedKeyFrames { 0 };

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -797,7 +797,9 @@ private:
             if (timeStamp.isNaN())
                 m_frameRateStats = { now, 1 };
             else if (now - timeStamp >= 1_s) {
-                gst_structure_set(m_stats.get(), "frames-per-second", G_TYPE_UINT, totalFramesSinceLastMeasurement + 1, nullptr);
+                auto delta = now - timeStamp;
+                double frameRate = (totalFramesSinceLastMeasurement + 1) / delta.seconds();
+                gst_structure_set(m_stats.get(), "frames-per-second", G_TYPE_DOUBLE, frameRate, nullptr);
                 m_frameRateStats = { now, 0 };
             } else
                 m_frameRateStats = { timeStamp, totalFramesSinceLastMeasurement + 1 };

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -384,20 +384,52 @@ void RealtimeOutgoingMediaSourceGStreamer::replaceTrack(const RefPtr<MediaStream
     if (newTrack)
         trackPrivate = newTrack->privateTrack();
 
-    if (m_outgoingSource)
+    if (m_outgoingSource) {
         webkitMediaStreamSrcReplaceTrack(WEBKIT_MEDIA_STREAM_SRC_CAST(m_outgoingSource.get()), RefPtr(trackPrivate));
-    else {
-        if (trackPrivate) {
-            m_outgoingSource = webkitMediaStreamSrcNew();
-            gst_bin_add(GST_BIN_CAST(m_bin.get()), m_outgoingSource.get());
-            webkitMediaStreamSrcAddTrack(WEBKIT_MEDIA_STREAM_SRC_CAST(m_outgoingSource.get()), trackPrivate.get());
+        auto srcPad = outgoingSourcePad();
+        if (!gst_pad_is_linked(srcPad.get())) {
             gst_element_link(m_outgoingSource.get(), m_inputSelector.get());
             gst_element_sync_state_with_parent(m_outgoingSource.get());
         }
-        auto srcPad = outgoingSourcePad();
-        auto activePad = adoptGRef(gst_pad_get_peer(srcPad.get()));
-        g_object_set(m_inputSelector.get(), "active-pad", activePad.get(), nullptr);
+    } else if (trackPrivate) {
+        m_outgoingSource = webkitMediaStreamSrcNew();
+        gst_bin_add(GST_BIN_CAST(m_bin.get()), m_outgoingSource.get());
+        webkitMediaStreamSrcAddTrack(WEBKIT_MEDIA_STREAM_SRC_CAST(m_outgoingSource.get()), trackPrivate.get());
+        gst_element_link(m_outgoingSource.get(), m_inputSelector.get());
+        gst_element_sync_state_with_parent(m_outgoingSource.get());
     }
+
+    auto srcPad = outgoingSourcePad();
+    auto activePad = adoptGRef(gst_pad_get_peer(srcPad.get()));
+    RELEASE_ASSERT(activePad);
+    g_object_set(m_inputSelector.get(), "active-pad", activePad.get(), nullptr);
+
+    if (m_transceiver) {
+        GRefPtr<GstCaps> caps;
+        g_object_get(m_transceiver.get(), "codec-preferences", &caps.outPtr(), nullptr);
+
+        m_pendingTrackId = trackPrivate ? trackPrivate->id() : emptyString();
+        auto newCaps = adoptGRef(gst_caps_make_writable(caps.leakRef()));
+        gst_caps_map_in_place(newCaps.get(), [](auto*, auto* structure, gpointer userData) -> gboolean {
+            if (!gst_structure_has_field_typed(structure, "a-msid", G_TYPE_STRING)) [[unlikely]]
+                return TRUE;
+
+            auto self = static_cast<RealtimeOutgoingMediaSourceGStreamer*>(userData);
+            if (self->m_pendingTrackId.isEmpty())
+                gst_structure_remove_field(structure, "a-msid");
+            else {
+                auto newMsid = makeString(self->m_mediaStreamId, ' ', self->m_pendingTrackId);
+                gst_structure_set(structure, "a-msid", G_TYPE_STRING, newMsid.utf8().data(), nullptr);
+            }
+
+            return TRUE;
+        }, this);
+        g_object_freeze_notify(G_OBJECT(m_transceiver.get()));
+        g_object_set(m_transceiver.get(), "codec-preferences", newCaps.get(), nullptr);
+        m_pendingTrackId = emptyString();
+        g_object_thaw_notify(G_OBJECT(m_transceiver.get()));
+    }
+
     if (!newTrack) {
         m_isStopped = true;
         m_track = nullptr;
@@ -405,6 +437,13 @@ void RealtimeOutgoingMediaSourceGStreamer::replaceTrack(const RefPtr<MediaStream
     }
 
     m_track = WTF::move(trackPrivate);
+
+    const auto& webrtcSinkPad = pad();
+    if (!webrtcSinkPad)
+        return;
+    if (!gst_pad_is_linked(webrtcSinkPad.get()))
+        return;
+
     start();
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -155,6 +155,8 @@ private:
     void stopUpdatingStats();
 
     RefPtr<GStreamerRTPPacketizer> getPacketizerForRid(const String&);
+
+    String m_pendingTrackId { emptyString() };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/ParsedContentType.h
+++ b/Source/WebCore/platform/network/ParsedContentType.h
@@ -42,20 +42,20 @@ class ParsedContentType {
 public:
     WEBCORE_EXPORT static std::optional<ParsedContentType> create(const String&);
     ParsedContentType(ParsedContentType&&) = default;
+    ParsedContentType(const ParsedContentType&) = delete;
 
     String mimeType() const { return m_mimeType; }
     String charset() const;
     void setCharset(String&&);
 
     // Note that in the case of multiple values for the same name, the last value is returned.
-    String parameterValueForName(const String&) const;
+    WEBCORE_EXPORT String parameterValueForName(const String&) const;
     size_t parameterCount() const;
 
     WEBCORE_EXPORT String serialize() const;
 
 private:
     ParsedContentType(const String&);
-    ParsedContentType(const ParsedContentType&) = delete;
     ParsedContentType& operator=(const ParsedContentType&) = delete;
     bool parseContentType();
     void setContentType(String&&);

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(ENCRYPTED_MEDIA)
 
 #include "InitDataRegistry.h"
+#include "ParsedContentType.h"
 #include "SharedBuffer.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <algorithm>
@@ -159,9 +160,24 @@ bool MockCDM::supportsConfiguration(const MediaKeySystemConfiguration& configura
 
 }
 
-bool MockCDM::supportsConfigurationWithRestrictions(const MediaKeySystemConfiguration&, const MediaKeysRestrictions&) const
+bool MockCDM::supportsConfigurationWithRestrictions(const MediaKeySystemConfiguration& configuration, const MediaKeysRestrictions&) const
 {
-    // NOTE: Implement;
+    if (!m_factory)
+        return true;
+
+    const auto& unsupportedVideoCodecs = m_factory->unsupportedVideoCodecs();
+    if (unsupportedVideoCodecs.isEmpty())
+        return true;
+
+    for (const auto& capability : configuration.videoCapabilities) {
+        auto contentType = ParsedContentType::create(capability.contentType);
+        if (!contentType)
+            continue;
+        auto codecs = contentType->parameterValueForName("codecs"_s);
+        if (!codecs.isEmpty() && unsupportedVideoCodecs.contains(codecs))
+            return false;
+    }
+
     return true;
 }
 

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -50,13 +50,17 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    const Vector<String>& supportedDataTypes() const { return m_supportedDataTypes; }
+    const Vector<String>& supportedDataTypes() const LIFETIME_BOUND { return m_supportedDataTypes; }
+
+    const Vector<MediaKeySessionType>& supportedSessionTypes() const LIFETIME_BOUND { return m_supportedSessionTypes; }
+
+    const Vector<String>& supportedRobustness() const LIFETIME_BOUND { return m_supportedRobustness; }
+
+    const Vector<MediaKeyEncryptionScheme>& supportedEncryptionSchemes() const LIFETIME_BOUND { return m_supportedEncryptionSchemes; }
+
+    const Vector<String>& unsupportedVideoCodecs() const LIFETIME_BOUND { return m_unsupportedVideoCodecs; }
     void setSupportedDataTypes(Vector<String>&&);
-
-    const Vector<MediaKeySessionType>& supportedSessionTypes() const { return m_supportedSessionTypes; }
     void setSupportedSessionTypes(Vector<MediaKeySessionType>&& types) { m_supportedSessionTypes = WTF::move(types); }
-
-    const Vector<String>& supportedRobustness() const { return m_supportedRobustness; }
     void setSupportedRobustness(Vector<String>&& supportedRobustness) { m_supportedRobustness = WTF::move(supportedRobustness); }
 
     MediaKeysRequirement distinctiveIdentifiersRequirement() const { return m_distinctiveIdentifiersRequirement; }
@@ -73,9 +77,8 @@ public:
 
     bool supportsSessions() const { return m_supportsSessions; }
     void setSupportsSessions(bool flag) { m_supportsSessions = flag; }
-
-    const Vector<MediaKeyEncryptionScheme>& supportedEncryptionSchemes() const { return m_supportedEncryptionSchemes; }
     void setSupportedEncryptionSchemes(Vector<MediaKeyEncryptionScheme>&& schemes) { m_supportedEncryptionSchemes = WTF::move(schemes); }
+    void setUnsupportedVideoCodecs(Vector<String>&& codecs) { m_unsupportedVideoCodecs = WTF::move(codecs); }
 
     void unregister();
 
@@ -96,6 +99,7 @@ private:
     Vector<MediaKeySessionType> m_supportedSessionTypes;
     Vector<String> m_supportedRobustness;
     Vector<MediaKeyEncryptionScheme> m_supportedEncryptionSchemes;
+    Vector<String> m_unsupportedVideoCodecs;
     bool m_registered { true };
     bool m_canCreateInstances { true };
     bool m_supportsServerCertificates { true };

--- a/Source/WebCore/testing/MockCDMFactory.idl
+++ b/Source/WebCore/testing/MockCDMFactory.idl
@@ -37,6 +37,7 @@
     attribute boolean supportsServerCertificates;
     attribute boolean supportsSessions;
     attribute sequence<MediaKeyEncryptionScheme> supportedEncryptionSchemes;
+    attribute sequence<DOMString> unsupportedVideoCodecs;
 
     undefined unregister();
 };


### PR DESCRIPTION
#### aec9d2ad958e716ab4bca4bf03007e6edac7323f
<pre>
Cherry-pick 314533@main (82c645da79b5). <a href="https://bugs.webkit.org/show_bug.cgi?id=316190">https://bugs.webkit.org/show_bug.cgi?id=316190</a>

    [GStreamer] mediaTime from requestVideoFrameCallback is wrong in case of captureCanvas as source
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316190">https://bugs.webkit.org/show_bug.cgi?id=316190</a>

    Reviewed by Philippe Normand.

    Canvas capture frames have their PTS stamped with the absolute GStreamer
    system clock time. Because the default GstSegment has start=0, calling
    gst_segment_to_stream_time on such a buffer returns the raw clock value
    (system uptime in seconds), not a stream-relative position.
    To fix that and set the correct value of mediaTime in VideoFrameMetadata
    provided by requestVideoFrameCallback, this change detects canvas frames
    via their VideoFrameContentHint and uses currentTime() instead.

    A new layout test fast/mediastream/captureStream/canvas-rvfc-metadata.html
    validates the metadata fields returned by requestVideoFrameCallback for a
    canvas captureStream, including that mediaTime is stream-relative and not
    an absolute clock value.

    Test: fast/mediastream/captureStream/canvas-rvfc-metadata.html
    * LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata-expected.txt: Added.
    * LayoutTests/fast/mediastream/captureStream/canvas-rvfc-metadata.html: Added.
    * Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
    (WebCore::MediaPlayerPrivateGStreamer::videoFrameMetadata):

    Canonical link: <a href="https://commits.webkit.org/314533@main">https://commits.webkit.org/314533@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.722@webkitglib/2.52">https://commits.webkit.org/305877.722@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e182502ede3ab5fa25495d5c34157280f4276f8f
<pre>
Cherry-pick 314438@main (25e4e199bf08). <a href="https://bugs.webkit.org/show_bug.cgi?id=316101">https://bugs.webkit.org/show_bug.cgi?id=316101</a>

    REGRESSION(314352@main): [EME] Deferring MediaKeySession teardown leaks the CDM session into the next test
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316101">https://bugs.webkit.org/show_bug.cgi?id=316101</a>

    Reviewed by Xabier Rodriguez-Calvar.

    This makes MediaKeySession teardown synchronous again, instead avoiding
    the promise resolution when we are tearing down.

    Tests clearkey-mp4-playback-destroy-persistent-license.https.html and
    clearkey-mp4-playback-retrieve-persistent-license.https.html cover the
    CDM session leaking scenario, while
    mock-MediaKeySession-backforwardcache-prune-crash.html verifies that
    the promise is not incorrectly resolved.

    * Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
    (WebCore::MediaKeySession::sessionClosed):
    (WebCore::MediaKeySession::stop):

    Canonical link: <a href="https://commits.webkit.org/314438@main">https://commits.webkit.org/314438@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.721@webkitglib/2.52">https://commits.webkit.org/305877.721@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 70aadedb63340708a0a66694a8864a2c22e3601a
<pre>
Cherry-pick 314284@main (30cef1151ab3). <a href="https://bugs.webkit.org/show_bug.cgi?id=315943">https://bugs.webkit.org/show_bug.cgi?id=315943</a>

    REGRESSION(313830@main): [GStreamer] imported/w3c/web-platform-tests/media-source/mediasource-getvideoplaybackquality.html fails
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315943">https://bugs.webkit.org/show_bug.cgi?id=315943</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Since that commit the video sink GRefPtr is cleared along with the pipeline, so at EOS
    updateVideoSinkStatistics() was returning false and no playback quality metrics were reported
    anymore. We now attempt to update the stats only if playback hasn&apos;t ended yet.

    * Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
    (WebCore::MediaPlayerPrivateGStreamer::videoPlaybackQualityMetrics):

    Canonical link: <a href="https://commits.webkit.org/314284@main">https://commits.webkit.org/314284@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.720@webkitglib/2.52">https://commits.webkit.org/305877.720@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6786ce5aaaea54f8844509e02faa0836dc4bf3d5
<pre>
Cherry-pick 314281@main (387b2d3ec9c2). <a href="https://bugs.webkit.org/show_bug.cgi?id=315759">https://bugs.webkit.org/show_bug.cgi?id=315759</a>

    [GStreamer][WebRTC] webrtc/getDisplayMedia-pc-resolution.html is flaky crashing
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315759">https://bugs.webkit.org/show_bug.cgi?id=315759</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Make sure the m_frameRate GStreamerIncomingTrackProcessor member variable is initialized. This is a
    prospective fix for a flaky crash I cannot reproduce, where the stats collector would attempt to
    create a -nan double to an IDLDouble.

    * LayoutTests/platform/glib/TestExpectations:
    * Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h:

    Canonical link: <a href="https://commits.webkit.org/314281@main">https://commits.webkit.org/314281@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.719@webkitglib/2.52">https://commits.webkit.org/305877.719@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 52c54a667a6a59987b905bb976fc136b393c15ee
<pre>
Cherry-pick 314283@main (1961e19bf3e5). <a href="https://bugs.webkit.org/show_bug.cgi?id=315923">https://bugs.webkit.org/show_bug.cgi?id=315923</a>

    [GStreamer][WebRTC] Reported video source stats have incorrect frames-per-second value
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315923">https://bugs.webkit.org/show_bug.cgi?id=315923</a>

    Reviewed by Xabier Rodriguez-Calvar.

    The stats collector expects this caps field to be a double, not unsigned.

    * Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:

    Canonical link: <a href="https://commits.webkit.org/314283@main">https://commits.webkit.org/314283@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.718@webkitglib/2.52">https://commits.webkit.org/305877.718@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### d007e5b4a9d952531f7229e143fb96fa7d2f61e7
<pre>
Cherry-pick 314285@main (cf5066c74642). <a href="https://bugs.webkit.org/show_bug.cgi?id=315917">https://bugs.webkit.org/show_bug.cgi?id=315917</a>

    [GStreamer][WebRTC] webrtc/getDisplayMedia-pc-resolution.html almost consistently times out
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315917">https://bugs.webkit.org/show_bug.cgi?id=315917</a>

    Reviewed by Xabier Rodriguez-Calvar.

    The timeout was happening in the penultimate sub-test that calls replaceTrack before generating an
    offer. In that situation the outgoing media track bin isn&apos;t fully linked and doesn&apos;t have a
    transceiver yet. The transceiver codec-preferences were not updated so the attempt to link outgoing
    sources in the end-point after creating the offer left an unlinked outgoing media track bin, because
    the msid SDP attribute wasn&apos;t matched properly.

    The proposed fix is to iterate over the webrtcbin transceivers after the replaceTrack call and
    update a-msid attributes on their codec-preferences caps when appropriate.

    * LayoutTests/platform/glib/TestExpectations:
    * Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
    (WebCore::GStreamerMediaEndpoint::linkOutgoingSources):
    (WebCore::GStreamerMediaEndpoint::trackWasReplaced):
    * Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
    * Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
    (WebCore::GStreamerPeerConnectionBackend::trackWasReplaced):
    * Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h:
    * Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
    (WebCore::GStreamerRtpSenderBackend::replaceTrack):
    * Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
    (WebCore::RealtimeOutgoingMediaSourceGStreamer::replaceTrack):
    * Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:

    Canonical link: <a href="https://commits.webkit.org/314285@main">https://commits.webkit.org/314285@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.717@webkitglib/2.52">https://commits.webkit.org/305877.717@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### af8b8e7dc7305e8cbf255d338543ffab443d7a38
<pre>
Cherry-pick 314352@main (b09929827ab5). <a href="https://bugs.webkit.org/show_bug.cgi?id=315849">https://bugs.webkit.org/show_bug.cgi?id=315849</a>

    [EME] Crash pruning a back/forward-cached page that owns an open MediaKeySession
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315849">https://bugs.webkit.org/show_bug.cgi?id=315849</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Invoking session.sessionClosed during document teardown can trigger an
    assertion in a deferred promise (JSDOMPromiseDeferred --
    !activeDOMObjectsAreSuspended() ||
    scriptExecutionContext()-&gt;eventLoop().isSuspended()).

    By queueing it, we can ensure the task is dropped if the event loop is
    stopped.

    Test: media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash.html

    * LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash-expected.txt: Added.
    * LayoutTests/media/encrypted-media/mock-MediaKeySession-backforwardcache-prune-crash.html: Added.
    * LayoutTests/media/encrypted-media/resources/mock-MediaKeySession-backforwardcache-prune-helper.html: Added.
    * Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
    (WebCore::MediaKeySession::stop):

    Canonical link: <a href="https://commits.webkit.org/314352@main">https://commits.webkit.org/314352@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.716@webkitglib/2.52">https://commits.webkit.org/305877.716@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 5d7fb54ee9f17f81c3174b91fafc35dc775780f4
<pre>
Cherry-pick 314350@main (eb9354ae86c5). <a href="https://bugs.webkit.org/show_bug.cgi?id=315842">https://bugs.webkit.org/show_bug.cgi?id=315842</a>

    [EME] Protect MediaKeySession::sessionClosed from concurrent calls
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315842">https://bugs.webkit.org/show_bug.cgi?id=315842</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Add an additional m_closed check in MediaKeySession::sessionClosed to
    account from multiple queued counts to close().

    Test: media/encrypted-media/mock-MediaKeySession-concurrent-close.html

    * LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close-expected.txt: Added.
    * LayoutTests/media/encrypted-media/mock-MediaKeySession-concurrent-close.html: Added.
    * Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
    (WebCore::MediaKeySession::sessionClosed):

    Canonical link: <a href="https://commits.webkit.org/314350@main">https://commits.webkit.org/314350@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.715@webkitglib/2.52">https://commits.webkit.org/305877.715@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b20042980bf725104f10070c317b0588f99c6a91
<pre>
Cherry-pick 314032@main (932c6b3792a1). <a href="https://bugs.webkit.org/show_bug.cgi?id=315667">https://bugs.webkit.org/show_bug.cgi?id=315667</a>

    [EME] getSupportedCapabilitiesForAudioVideoType can accidentally include unsupported capabilities
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315667">https://bugs.webkit.org/show_bug.cgi?id=315667</a>

    Reviewed by Philippe Normand.

    A local copy of accumulatedConfiguration is created where we append the
    requestedCapability, then supportsConfigurationWithRestrictions is
    queried. This means that requestedCapabilities cannot be accidentally
    added when they aren&apos;t supported.

    Tested on HBO Max, which was incorrectly serving HEVC content on a system
    that didn&apos;t support it, and added a new test verifying this behaviour
    after extending the MockCDMFactory to support this.

    * LayoutTests/media/encrypted-media/mock-getSupportedCapabilitiesForAudioVideoType-expected.txt: Added.
    * LayoutTests/media/encrypted-media/mock-getSupportedCapabilitiesForAudioVideoType.html: Added.
    * Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp:
    (WebCore::CDMPrivate::getSupportedCapabilitiesForAudioVideoType):
    * Source/WebCore/platform/network/ParsedContentType.h:
    * Source/WebCore/testing/MockCDMFactory.cpp:
    (WebCore::MockCDM::supportsConfigurationWithRestrictions const):
    * Source/WebCore/testing/MockCDMFactory.h:
    (WebCore::MockCDMFactory::setUnsupportedVideoCodecs):
    * Source/WebCore/testing/MockCDMFactory.idl:

    Canonical link: <a href="https://commits.webkit.org/314032@main">https://commits.webkit.org/314032@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.714@webkitglib/2.52">https://commits.webkit.org/305877.714@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 5cfea315b67d8d11fb403818fa441f10ebd6ef8b
<pre>
Cherry-pick 314018@main (8af0c2d1ea00). <a href="https://bugs.webkit.org/show_bug.cgi?id=315571">https://bugs.webkit.org/show_bug.cgi?id=315571</a>

    [GStreamer][WebRTC][Rice] webrtc/datachannel/multiple-connections.html still flaky crashing in Debug
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315571">https://bugs.webkit.org/show_bug.cgi?id=315571</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Don&apos;t attempt to notify incoming data after the ICE agent was closed.

    * Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
    (webkitGstWebRTCIceAgentIsClosed):
    (webkitGstWebRTCIceAgentClose):
    (webkitGstWebRTCIceAgentConfigure):

    Canonical link: <a href="https://commits.webkit.org/314018@main">https://commits.webkit.org/314018@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.713@webkitglib/2.52">https://commits.webkit.org/305877.713@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 159dc1a71fcdfc429916a42c8d405390fdec64c5
<pre>
Cherry-pick 313876@main (4c8616689118). <a href="https://bugs.webkit.org/show_bug.cgi?id=315558">https://bugs.webkit.org/show_bug.cgi?id=315558</a>

    [EME][OCDM] Prevent spurious keystatuses event when all keys expired
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315558">https://bugs.webkit.org/show_bug.cgi?id=315558</a>

    Reviewed by Xabier Rodriguez-Calvar.

    If the keystore is empty, generating an empty status vector would trigger a new keystatuses event
    potentially overriding the previous one. Manually tested with a Widevine L3 CDM. This is sadly not
    testable because there&apos;s no notion of key expiration in ClearKey.

    Driving-by, improve GStreamer logging a bit in CDMProxyThunder.

    * Source/WebCore/platform/encryptedmedia/CDMProxy.h:
    (WebCore::KeyStoreBase::isEmpty const):
    * Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp:
    (WebCore::CDMProxyThunder::getDecryptionSession const):
    * Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
    (WebCore::CDMInstanceSessionThunder::updateLicense):

    Canonical link: <a href="https://commits.webkit.org/313876@main">https://commits.webkit.org/313876@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.712@webkitglib/2.52">https://commits.webkit.org/305877.712@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 7b1f7e96bd5cc0113c463b898338792ad4bc2d0e
<pre>
Cherry-pick 313873@main (6a02a758cba4). <a href="https://bugs.webkit.org/show_bug.cgi?id=315557">https://bugs.webkit.org/show_bug.cgi?id=315557</a>

    [EME] Increase key wait timeout to 10 seconds
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315557">https://bugs.webkit.org/show_bug.cgi?id=315557</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Seven seconds were not sufficient on some embedded device providing a Widevine L3 CDM, so increase
    the timeout to 10 seconds.

    * Source/WebCore/platform/encryptedmedia/CDMProxy.h:

    Canonical link: <a href="https://commits.webkit.org/313873@main">https://commits.webkit.org/313873@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.711@webkitglib/2.52">https://commits.webkit.org/305877.711@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f6fc911213467fc7910ebee5400828fff81ec8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167001 "5 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/40491 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/34072 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176049 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124259 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168867 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/40924 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/40499 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129871 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124259 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169960 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/40924 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/34072 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110396 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/40924 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/40499 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24785 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/40924 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/34072 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178587 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31485 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/34072 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138239 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/40561 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/40499 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138150 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41249 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/34072 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/104144 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25416 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/41249 "Build is in progress. Recent messages:") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/34072 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/39760 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112834 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/39156 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/34072 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/39401 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/39300 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->