### PR TITLE
Use default member initializers for RenderTable data members

### DIFF
--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -76,18 +76,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderTable);
 RenderTable::RenderTable(Type type, Element& element, Style::ComputedStyle&& style)
     : RenderBlock(type, element, WTF::move(style), { })
     , m_columnPos(FillWith { }, 1, 0)
-    , m_currentBorder(nullptr)
-    , m_collapsedBordersValid(false)
-    , m_collapsedEmptyBorderIsPresent(false)
-    , m_hasColElements(false)
-    , m_needsSectionRecalc(false)
-    , m_columnLogicalWidthChanged(false)
-    , m_columnRenderersValid(false)
-    , m_hasCellColspanThatDeterminesTableWidth(false)
-    , m_borderStart(0)
-    , m_borderEnd(0)
-    , m_columnOffsetTop(-1)
-    , m_columnOffsetHeight(-1)
 {
     setChildrenInline(false);
     ASSERT(isRenderTable());
@@ -96,16 +84,6 @@ RenderTable::RenderTable(Type type, Element& element, Style::ComputedStyle&& sty
 RenderTable::RenderTable(Type type, Document& document, Style::ComputedStyle&& style)
     : RenderBlock(type, document, WTF::move(style), { })
     , m_columnPos(FillWith { }, 1, 0)
-    , m_currentBorder(nullptr)
-    , m_collapsedBordersValid(false)
-    , m_collapsedEmptyBorderIsPresent(false)
-    , m_hasColElements(false)
-    , m_needsSectionRecalc(false)
-    , m_columnLogicalWidthChanged(false)
-    , m_columnRenderersValid(false)
-    , m_hasCellColspanThatDeterminesTableWidth(false)
-    , m_borderStart(0)
-    , m_borderEnd(0)
 {
     setChildrenInline(false);
     ASSERT(isRenderTable());

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -279,16 +279,16 @@ protected:
     std::unique_ptr<TableLayout> m_tableLayout;
 
     CollapsedBorderValues m_collapsedBorders;
-    const CollapsedBorderValue* m_currentBorder;
-    bool m_collapsedBordersValid : 1;
-    bool m_collapsedEmptyBorderIsPresent : 1;
+    const CollapsedBorderValue* m_currentBorder { nullptr };
+    bool m_collapsedBordersValid : 1 { false };
+    bool m_collapsedEmptyBorderIsPresent : 1 { false };
 
-    mutable bool m_hasColElements : 1;
-    mutable bool m_needsSectionRecalc : 1;
+    mutable bool m_hasColElements : 1 { false };
+    mutable bool m_needsSectionRecalc : 1 { false };
 
-    bool m_columnLogicalWidthChanged : 1;
-    mutable bool m_columnRenderersValid: 1;
-    mutable bool m_hasCellColspanThatDeterminesTableWidth : 1;
+    bool m_columnLogicalWidthChanged : 1 { false };
+    mutable bool m_columnRenderersValid : 1 { false };
+    mutable bool m_hasCellColspanThatDeterminesTableWidth : 1 { false };
 
     bool hasCellColspanThatDeterminesTableWidth() const
     {
@@ -305,8 +305,8 @@ protected:
     LayoutUnit m_vSpacing;
     LayoutUnit m_borderStart;
     LayoutUnit m_borderEnd;
-    mutable LayoutUnit m_columnOffsetTop;
-    mutable LayoutUnit m_columnOffsetHeight;
+    mutable LayoutUnit m_columnOffsetTop { -1 };
+    mutable LayoutUnit m_columnOffsetHeight { -1 };
     unsigned m_recursiveSectionMovedWithPaginationLevel { 0 };
 };
 


### PR DESCRIPTION
#### d3ba7bd34e048ca3ffb510c681462bc407f4c70f
<pre>
Use default member initializers for RenderTable data members
<a href="https://bugs.webkit.org/show_bug.cgi?id=316504">https://bugs.webkit.org/show_bug.cgi?id=316504</a>
<a href="https://rdar.apple.com/178957380">rdar://178957380</a>

Reviewed by Alan Baradlay.

RenderTable has two constructors (Element&amp; and Document&amp;) that duplicated a
large member init list. The Document&amp; one had drifted out of sync and omitted
m_columnOffsetTop/m_columnOffsetHeight, leaving them at LayoutUnit&apos;s default of
0 instead of the -1 &quot;not yet computed&quot; sentinel used by the &gt;= 0 cache guard in
offsetTopForColumn()/offsetHeightForColumn().

Move the data members to default member initializers in the header so every
constructor stays in sync:

- m_columnOffsetTop/m_columnOffsetHeight default to -1.
- m_currentBorder and the bit-field bools, which are not safely
  default-initialized, get explicit initializers.
- m_borderStart/m_borderEnd are LayoutUnit, which already zero-initializes, so
  the redundant (0) inits are dropped (matching m_hSpacing/m_vSpacing).

Both constructor init lists now collapse to the base RenderBlock call plus
m_columnPos, which needs a non-default Vector construction. No change in
behavior.

* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::m_columnPos):
(WebCore::m_columnOffsetHeight): Deleted.
(WebCore::m_borderEnd): Deleted.
* Source/WebCore/rendering/RenderTable.h:

Canonical link: <a href="https://commits.webkit.org/314742@main">https://commits.webkit.org/314742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d78cfff6936fc6a93876fe1c51d7d126b9a10ff1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176114 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124324 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/397cc374-8053-4767-8451-65c772a8cf91) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129929 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91532 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e1228e3-0552-4099-830a-4bcfa4a7ac15) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170025 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32327 "Found 1 new test failure: fast/forms/datalist/datalist-textinput-suggestions-order.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110454 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3f0a894-262f-4912-8b66-74f81ebec290) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31302 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30009 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24853 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178652 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31550 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138297 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40628 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138208 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37213 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149602 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104265 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33480 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26467 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112899 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39221 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4569 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39467 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39365 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->