### PR TITLE
[JSC] `isDefinitelyNonThenable` Structure cache can go stale when the prototype belongs to another realm

### DIFF
--- a/JSTests/stress/promise-resolve-non-thenable-structure-cache-cross-realm-proto.js
+++ b/JSTests/stress/promise-resolve-non-thenable-structure-cache-cross-realm-proto.js
@@ -1,0 +1,84 @@
+// The isDefinitelyNonThenable Structure cache may only cache NonThenable when the
+// prototype is the Object.prototype of the *structure's* realm: a cached `true` is
+// guarded by structure->realm()'s promiseThenWatchpointSet, which only watches that
+// realm's Object.prototype. This test mixes a structure from one realm with the
+// Object.prototype of another realm and verifies that adding `then` to the foreign
+// prototype is always observed.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`bad value (${msg ?? ""}): got ${String(actual)}, expected ${String(expected)}`);
+}
+
+function asyncTest(fn) {
+    let done = false;
+    let error;
+    fn().then(() => { done = true; }, (e) => { error = e; done = true; });
+    drainMicrotasks();
+    if (!done)
+        throw new Error("async test did not settle: " + fn.name);
+    if (error)
+        throw error;
+}
+
+const other = createGlobalObject();
+
+// --- 1. Structure from this realm, prototype from the other realm. The other
+//        realm warms the cache; poisoning the other realm's Object.prototype
+//        must still be observed when resolving from this realm. ---
+asyncTest(async function localStructureForeignProto() {
+    const otherProto = other.Object.prototype;
+    function make() {
+        const o = { a: 1 };
+        Object.setPrototypeOf(o, otherProto);
+        return o;
+    }
+
+    // Warm up from the other realm: must not cache NonThenable on this realm's
+    // structure, since this realm's watchpoint set does not watch otherProto.
+    for (let i = 0; i < 100; i++)
+        other.Promise.resolve(make());
+    other.drainMicrotasks();
+
+    // Fires only the other realm's watchpoint.
+    other.Function(`
+        Object.prototype.then = function(resolve) { resolve("foreign-proto-poisoned"); };
+    `)();
+    try {
+        const v = await Promise.resolve(make());
+        shouldBe(v, "foreign-proto-poisoned", "localStructureForeignProto");
+    } finally {
+        other.Function("delete Object.prototype.then;")();
+    }
+});
+
+// --- 2. Mirror: structure from the other realm, prototype from this realm.
+//        This realm warms the cache; poisoning this realm's Object.prototype
+//        must still be observed when resolving from the other realm. ---
+asyncTest(async function foreignStructureLocalProto() {
+    const make = other.Function("proto", `
+        const o = { b: 2 };
+        Object.setPrototypeOf(o, proto);
+        return o;
+    `);
+
+    for (let i = 0; i < 100; i++)
+        Promise.resolve(make(Object.prototype));
+    drainMicrotasks();
+
+    const resolveInOther = other.Function("value", "onSettled", `
+        Promise.resolve(value).then(onSettled);
+    `);
+
+    // Fires only this realm's watchpoint.
+    Object.prototype.then = function(resolve) { resolve("local-proto-poisoned"); };
+    try {
+        let settled;
+        resolveInOther(make(Object.prototype), (v) => { settled = v; });
+        other.drainMicrotasks();
+        drainMicrotasks();
+        shouldBe(settled, "local-proto-poisoned", "foreignStructureLocalProto");
+    } finally {
+        delete Object.prototype.then;
+    }
+});

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -449,7 +449,7 @@ bool isDefinitelyNonThenable(JSObject* object, JSGlobalObject* globalObject)
             // (null proto) or [self, Object.prototype]. Mark anything else Uncacheable
             // so subsequent calls skip this check and go straight to the walk.
             JSValue proto = structure->storedPrototype();
-            if (!proto.isObject() || asObject(proto) == globalObject->objectPrototype())
+            if (!proto.isObject() || asObject(proto) == structure->realm()->objectPrototype())
                 structure->setDefinitelyNonThenableState(Structure::DefinitelyNonThenableState::NonThenable);
             else
                 structure->setDefinitelyNonThenableState(Structure::DefinitelyNonThenableState::Uncacheable);


### PR DESCRIPTION
#### 8d6b11214830b69bad2f02f552a64d9f972ef698
<pre>
[JSC] `isDefinitelyNonThenable` Structure cache can go stale when the prototype belongs to another realm
<a href="https://bugs.webkit.org/show_bug.cgi?id=316506">https://bugs.webkit.org/show_bug.cgi?id=316506</a>

Reviewed by Yusuke Suzuki.

A cached NonThenable is guarded by structure-&gt;realm()&apos;s
promiseThenWatchpointSet, but the cacheability check compared the prototype
against the caller&apos;s objectPrototype(). Once a realm-A structure holds realm
B&apos;s Object.prototype and the first resolution happens in realm B, the cache
survives `then` being added to realm B&apos;s Object.prototype. That fires only
realm B&apos;s watchpoint set. So realm A treats a genuine thenable as a plain value:

    const other = createGlobalObject();
    function make() {
        const o = { a: 1 };
        Object.setPrototypeOf(o, other.Object.prototype);
        return o;
    }
    other.Promise.resolve(make()); // caches NonThenable on the realm-A structure
    drainMicrotasks();
    other.Object.prototype.then = function (resolve) { resolve(42); };
    const v = await Promise.resolve(make()); // v is the object, should be 42

Compare against structure-&gt;realm()-&gt;objectPrototype() instead; mixed-realm
chains become Uncacheable and take the per-call walk.

Test: JSTests/stress/promise-resolve-non-thenable-structure-cache-cross-realm-proto.js

* JSTests/stress/promise-resolve-non-thenable-structure-cache-cross-realm-proto.js: Added.
(shouldBe):
(asyncTest.async localStructureForeignProto.make):
(asyncTest.async localStructureForeignProto.other.Function):
(asyncTest.async localStructureForeignProto):
(asyncTest.async foreignStructureLocalProto.Object.prototype.then):
(asyncTest.async foreignStructureLocalProto):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::isDefinitelyNonThenable):

Canonical link: <a href="https://commits.webkit.org/314775@main">https://commits.webkit.org/314775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9eedf901e77b9d88ba432aaa22347162a09f9ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124273 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129883 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91488 "2 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110408 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31259 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29963 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; 1 api test failed or timed out; re-run-api-tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24800 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159172 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178601 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27909 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31499 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29468 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138251 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138162 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37231 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149559 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104168 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33432 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26424 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199694 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39774 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112848 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53699 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39170 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4525 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->