### PR TITLE
[JSC][Wasm] IPInt memory.atomic.notify/wait and memory.grow mishandle dirty upper bits of i32 operands

### DIFF
--- a/JSTests/wasm/stress/memory32-atomics-pointer-upper-bits.js
+++ b/JSTests/wasm/stress/memory32-atomics-pointer-upper-bits.js
@@ -1,0 +1,48 @@
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ runDefaultWasm("-m")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// In IPInt, i32.wrap_i64 is a no-op: the 64-bit stack slot keeps the upper
+// 32 bits of the original i64. memory.atomic.notify/wait32/wait64 must
+// normalize the i32 pointer operand to its low 32 bits before the bounds
+// check; otherwise an in-bounds address with dirty upper bits is wrongly
+// rejected as out-of-bounds.
+
+const wat = `
+(module
+    (memory (export "memory") 1 1 shared)
+    (func (export "notify") (param $dirty i64) (result i32)
+        (memory.atomic.notify (i32.wrap_i64 (local.get $dirty)) (i32.const 0))
+    )
+    (func (export "wait32") (param $dirty i64) (result i32)
+        (memory.atomic.wait32 (i32.wrap_i64 (local.get $dirty)) (i32.const 1) (i64.const 0))
+    )
+    (func (export "wait64") (param $dirty i64) (result i32)
+        (memory.atomic.wait64 (i32.wrap_i64 (local.get $dirty)) (i64.const 1) (i64.const 0))
+    )
+)
+`;
+
+const { exports } = await instantiate(wat, {}, { threads: true });
+
+for (let i = 0; i < wasmTestLoopCount; i++) {
+    // Address 16 is in bounds; the upper 32 bits must be ignored.
+    assert.eq(exports.notify(0x1_0000_0010n), 0);
+    assert.eq(exports.notify(0xffff_ffff_0000_0010n), 0);
+    // Memory contains 0, expected value is 1, so wait returns "not-equal" (1).
+    assert.eq(exports.wait32(0x1_0000_0010n), 1);
+    assert.eq(exports.wait32(0xdead_beef_0000_0010n), 1);
+    assert.eq(exports.wait64(0x1_0000_0010n), 1);
+    assert.eq(exports.wait64(0xdead_beef_0000_0010n), 1);
+
+    // Last in-bounds aligned addresses.
+    assert.eq(exports.notify(0x1_0000_fffcn), 0);
+    assert.eq(exports.wait32(0x1_0000_fffcn), 1);
+    assert.eq(exports.wait64(0x1_0000_fff8n), 1);
+
+    // Out-of-bounds after wrapping must still trap.
+    assert.throws(() => exports.notify(0x1_0001_0000n), WebAssembly.RuntimeError, "Out of bounds memory access");
+    assert.throws(() => exports.wait32(0x1_0001_0000n), WebAssembly.RuntimeError, "Out of bounds memory access");
+    assert.throws(() => exports.wait64(0x1_0001_0000n), WebAssembly.RuntimeError, "Out of bounds memory access");
+}

--- a/JSTests/wasm/stress/memory32-grow-upper-bits.js
+++ b/JSTests/wasm/stress/memory32-grow-upper-bits.js
@@ -1,0 +1,38 @@
+//@ runDefaultWasm("-m")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// In IPInt, i32.wrap_i64 is a no-op: the 64-bit stack slot keeps the upper
+// 32 bits of the original i64. memory.grow must normalize the i32 delta to
+// its low 32 bits; otherwise a valid grow request with dirty upper bits is
+// wrongly rejected with -1.
+
+const wat = `
+(module
+    (memory (export "memory") 1 8)
+    (func (export "grow") (param $dirty i64) (result i32)
+        (memory.grow (i32.wrap_i64 (local.get $dirty)))
+    )
+    (func (export "size") (result i32)
+        (memory.size)
+    )
+)
+`;
+
+const { exports } = await instantiate(wat, {});
+
+// Delta 1 with dirty upper bits: must grow by exactly 1 page.
+assert.eq(exports.grow(0x1_0000_0001n), 1);
+assert.eq(exports.size(), 2);
+assert.eq(exports.grow(0xdead_beef_0000_0001n), 2);
+assert.eq(exports.size(), 3);
+
+for (let i = 0; i < wasmTestLoopCount; i++) {
+    // Delta 0 with dirty upper bits: no-op grow returning the current size.
+    assert.eq(exports.grow(0x1_0000_0000n), 3);
+    assert.eq(exports.grow(0xffff_ffff_0000_0000n), 3);
+    assert.eq(exports.size(), 3);
+
+    // A genuinely huge u32 delta must still fail.
+    assert.eq(exports.grow(0xffff_ffffn), -1);
+}

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -10106,6 +10106,9 @@ ipintAtomicOp(_memory_atomic_wait32, macro()
     loadb IPInt::AtomicMemoryAccessMetadata::memoryIndex[MC], t0
     pushInt32(t0)
     loadq (StackValueSize * 3)[sp], t0
+    btbnz JSWebAssemblyInstance::m_cachedIsMemory64[wasmInstance], .pointerIsMemory64
+    zxi2q t0, t0
+.pointerIsMemory64:
     loadq IPInt::AtomicMemoryAccessMetadata::offset[MC], t1
     baddpc(t1, t0, _ipint_throw_OutOfBoundsMemoryAccess)
     storeq t0, (StackValueSize * 3)[sp] # replace pointer with pointer + offset
@@ -10136,6 +10139,9 @@ ipintAtomicOp(_memory_atomic_wait64, macro()
     loadb IPInt::AtomicMemoryAccessMetadata::memoryIndex[MC], t0
     pushInt32(t0)
     loadq (StackValueSize * 3)[sp], t0
+    btbnz JSWebAssemblyInstance::m_cachedIsMemory64[wasmInstance], .pointerIsMemory64
+    zxi2q t0, t0
+.pointerIsMemory64:
     loadq IPInt::AtomicMemoryAccessMetadata::offset[MC], t1
     baddpc(t1, t0, _ipint_throw_OutOfBoundsMemoryAccess)
     storeq t0, (StackValueSize * 3)[sp] # replace pointer with pointer + offset

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -601,6 +601,8 @@ WASM_IPINT_EXTERN_CPP_DECL(table_grow, IPIntStackEntry* sp, TableGrowMetadata* m
 WASM_IPINT_EXTERN_CPP_DECL(memory_grow, int64_t delta, uint8_t memoryIndex)
 {
     WasmSlowPathWithoutCallFrameTracer tracer(instance->vm());
+    if (!instance->module().moduleInformation().memory(memoryIndex).isMemory64())
+        delta = static_cast<uint32_t>(delta);
     WASM_RETURN_TWO(reinterpret_cast<void*>(Wasm::growMemory(instance, delta, memoryIndex)), 0);
 }
 
@@ -1337,7 +1339,7 @@ WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_notify, IPIntStackEntry* args)
     uint64_t offset = args[0].i64;
     uint8_t memoryIndex = args[1].i32;
     int32_t count = args[2].i32;
-    uint64_t base = args[3].i64;
+    uint64_t base = instance->module().moduleInformation().memory(memoryIndex).isMemory64() ? args[3].i64 : static_cast<uint32_t>(args[3].i32);
     int32_t result = Wasm::memoryAtomicNotify(instance, base, offset, count, memoryIndex);
     WASM_RETURN_TWO(std::bit_cast<void*>(static_cast<intptr_t>(result)), nullptr);
 #else


### PR DESCRIPTION
#### a0d2eebf9e1306df75e2adedb700d32e4c5a0ca2
<pre>
[JSC][Wasm] IPInt memory.atomic.notify/wait and memory.grow mishandle dirty upper bits of i32 operands
<a href="https://bugs.webkit.org/show_bug.cgi?id=316507">https://bugs.webkit.org/show_bug.cgi?id=316507</a>

Reviewed by Yusuke Suzuki.

In IPInt, an i32 value&apos;s stack slot is not guaranteed to have zeroed
upper bits because i32.wrap_i64 is a no-op, so consumers reading a
slot as 64 bits must normalize it to the low 32 bits, the way
popMemoryIndex does with zxi2q.

Four sites read the full 64-bit slot for a memory32 operand without
normalizing: the memory.atomic.notify and memory.grow C++ slow paths,
and the memory.atomic.wait32/wait64 assembly fast paths. As a result,
an in-bounds address (or a valid grow delta) with dirty upper bits is
wrongly rejected. The notify case is a regression from 312831@main,
which fixed the opposite Memory64 truncation bug; the others are
pre-existing.

Fix notify and grow in C++ with the same isMemory64() check as
memory.init/copy/fill. Fix wait32/wait64 in assembly because the slow
path receives the pointer with the offset already added, which is too
late to normalize.

Tests: JSTests/wasm/stress/memory32-atomics-pointer-upper-bits.js
       JSTests/wasm/stress/memory32-grow-upper-bits.js

* JSTests/wasm/stress/memory32-atomics-pointer-upper-bits.js: Added.
* JSTests/wasm/stress/memory32-grow-upper-bits.js: Added.
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):

Canonical link: <a href="https://commits.webkit.org/314871@main">https://commits.webkit.org/314871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f6b2944712946e5a6a6d36e81bcc38c1a91c482

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124275 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129885 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91489 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110410 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31261 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29966 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24802 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159174 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141236 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178603 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27911 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31501 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138253 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138164 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37306 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149561 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104170 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33436 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26426 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199696 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112850 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53701 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39172 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4527 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39417 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39316 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->