### PR TITLE
[JSC] `String#split` RegExp fast path misses side effects from `ToString(this)` and `ToUint32(limit)`

### DIFF
--- a/JSTests/stress/string-split-regexp-fast-path-limit-side-effects.js
+++ b/JSTests/stress/string-split-regexp-fast-path-limit-side-effects.js
@@ -1,0 +1,26 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function doSplit(string, separator, limit) {
+    return string.split(separator, limit);
+}
+noInline(doSplit);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(JSON.stringify(doSplit("a,b,c", /,/, 4)), '["a","b","c"]');
+
+let execCalled = false;
+let evil = {
+    valueOf() {
+        RegExp.prototype.exec = function() {
+            execCalled = true;
+            return null;
+        };
+        return 4;
+    }
+};
+let result = doSplit("a,b,c", /,/, evil);
+shouldBe(execCalled, true);
+shouldBe(JSON.stringify(result), '["a,b,c"]');

--- a/JSTests/stress/string-split-regexp-fast-path-tostring-side-effects.js
+++ b/JSTests/stress/string-split-regexp-fast-path-tostring-side-effects.js
@@ -1,0 +1,43 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+{
+    let constructed = false;
+    class MyRegExp extends RegExp {
+        constructor(...args) {
+            constructed = true;
+            super(...args);
+        }
+    }
+    let re = /,/;
+    let obj = {
+        toString() {
+            re.constructor = MyRegExp;
+            return "a,b,c";
+        }
+    };
+    let result = String.prototype.split.call(obj, re);
+    shouldBe(constructed, true);
+    shouldBe(JSON.stringify(result), '["a","b","c"]');
+}
+
+// Overriding RegExp.prototype.exec fires the primordial RegExp watchpoint, so
+// this must stay the last case in this file.
+{
+    let execCalled = false;
+    let re = /,/;
+    let obj = {
+        toString() {
+            RegExp.prototype.exec = function() {
+                execCalled = true;
+                return null;
+            };
+            return "a,b,c";
+        }
+    };
+    let result = String.prototype.split.call(obj, re);
+    shouldBe(execCalled, true);
+    shouldBe(JSON.stringify(result), '["a,b,c"]');
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4077,7 +4077,7 @@ JSC_DEFINE_JIT_OPERATION(operationStringSplitRegExp, EncodedJSValue, (JSGlobalOb
 
     JSValue limitValue = JSValue::decode(encodedLimit);
 
-    if (separator->isSymbolSplitFastAndNonObservable()) [[likely]] {
+    if (separator->isSymbolSplitFastAndNonObservable() && (limitValue.isUndefined() || limitValue.isNumber())) [[likely]] {
         unsigned limit = 0xFFFFFFFFu;
         if (!limitValue.isUndefined()) {
             limit = limitValue.toUInt32(globalObject);

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1250,15 +1250,13 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplit, (JSGlobalObject* globalObject, Ca
     //    directly — this beats the JS-builtin path on the steady state.
     if (separatorValue.isObject()) {
         JSObject* separatorObject = asObject(separatorValue);
-        if (auto* regExpObject = dynamicDowncast<RegExpObject>(separatorObject); regExpObject && regExpObject->isSymbolSplitFastAndNonObservable()) {
-            JSString* thisString = thisValue.toString(globalObject);
-            RETURN_IF_EXCEPTION(scope, { });
+        if (auto* regExpObject = dynamicDowncast<RegExpObject>(separatorObject); regExpObject && regExpObject->isSymbolSplitFastAndNonObservable() && thisValue.isString() && (limitValue.isUndefined() || limitValue.isNumber())) {
             unsigned limit = 0xFFFFFFFFu;
             if (!limitValue.isUndefined()) {
                 limit = limitValue.toUInt32(globalObject);
                 RETURN_IF_EXCEPTION(scope, { });
             }
-            RELEASE_AND_RETURN(scope, JSValue::encode(regExpSplitFast(globalObject, regExpObject, thisString, limit)));
+            RELEASE_AND_RETURN(scope, JSValue::encode(regExpSplitFast(globalObject, regExpObject, asString(thisValue), limit)));
         }
 
         JSValue splitter = separatorObject->get(globalObject, vm.propertyNames->splitSymbol);


### PR DESCRIPTION
#### b4b15818d650a5949ea4da79172341b163636f41
<pre>
[JSC] `String#split` RegExp fast path misses side effects from `ToString(this)` and `ToUint32(limit)`
<a href="https://bugs.webkit.org/show_bug.cgi?id=316508">https://bugs.webkit.org/show_bug.cgi?id=316508</a>

Reviewed by Yusuke Suzuki.

stringProtoFuncSplit ran ToString(this) and ToUint32(limit) after checking
isSymbolSplitFastAndNonObservable(). Both conversions can run arbitrary JS that
invalidates the checked conditions (e.g. overriding RegExp.prototype.exec or
installing an own .constructor on the separator), which RegExpSplit observes
after those conversions. operationStringSplitRegExp had the same problem for
ToUint32(limit).

Only take the fast path when both conversions are non-observable: `this` is a
string primitive and limit is a number or undefined. Otherwise fall through to
the generic @@split call, as the old JS-builtin implementation did
(isLimitNumberOrUndefined, bmo#1287525).

    let execCalled = false;
    let evil = { valueOf() { RegExp.prototype.exec = () =&gt; { execCalled = true; return null; }; return 4; } };
    &quot;a,b,c&quot;.split(/,/, evil);
    // Before: [&quot;a&quot;,&quot;b&quot;,&quot;c&quot;], execCalled === false
    // After (spec, V8): [&quot;a,b,c&quot;], execCalled === true

Tests: JSTests/stress/string-split-regexp-fast-path-limit-side-effects.js
       JSTests/stress/string-split-regexp-fast-path-tostring-side-effects.js

* JSTests/stress/string-split-regexp-fast-path-limit-side-effects.js: Added.
(shouldBe):
(let.evil.valueOf.RegExp.prototype.exec):
(let.evil.valueOf):
* JSTests/stress/string-split-regexp-fast-path-tostring-side-effects.js: Added.
(shouldBe):
(throw.new.Error.MyRegExp):
(throw.new.Error):
(shouldBe.let.obj.toString.RegExp.prototype.exec):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/314772@main">https://commits.webkit.org/314772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05427aa5c6910a9e2b3702c37ef789e72afca38d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176066 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124276 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129886 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91491 "3 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110411 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31263 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29967 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24803 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159175 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141238 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178604 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27912 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31502 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29471 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138254 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138165 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37230 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104171 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33438 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26427 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199697 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39777 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112851 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53702 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39173 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4528 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->