### PR TITLE
Add missing return statements in LazyRef.h and LazyUniqueRef.h

### DIFF
--- a/Source/WTF/wtf/LazyRef.h
+++ b/Source/WTF/wtf/LazyRef.h
@@ -88,7 +88,7 @@ public:
         return std::bit_cast<T*>(m_pointer);
     }
 
-    T* ptr(OwnerType& owner) LIFETIME_BOUND RETURNS_NONNULL { &get(owner); }
+    T* ptr(OwnerType& owner) LIFETIME_BOUND RETURNS_NONNULL { return &get(owner); }
     T* ptr(const OwnerType& owner) const LIFETIME_BOUND RETURNS_NONNULL { return &get(owner); }
 
     template<typename Func>

--- a/Source/WTF/wtf/LazyUniqueRef.h
+++ b/Source/WTF/wtf/LazyUniqueRef.h
@@ -88,7 +88,7 @@ public:
         return std::bit_cast<T*>(m_pointer);
     }
 
-    T* ptr(OwnerType& owner) LIFETIME_BOUND RETURNS_NONNULL { &get(owner); }
+    T* ptr(OwnerType& owner) LIFETIME_BOUND RETURNS_NONNULL { return &get(owner); }
     T* ptr(const OwnerType& owner) const LIFETIME_BOUND RETURNS_NONNULL { return &get(owner); }
 
     template<typename Func>


### PR DESCRIPTION
#### 6667782c52faa1910f4273dc6429be091848c008
<pre>
Add missing return statements in LazyRef.h and LazyUniqueRef.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=316510">https://bugs.webkit.org/show_bug.cgi?id=316510</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/LazyRef.h:
* Source/WTF/wtf/LazyUniqueRef.h:

Canonical link: <a href="https://commits.webkit.org/314767@main">https://commits.webkit.org/314767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b3aa87c8524f54a269a0aedc9cd3b0361b71919

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124282 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec8154e5-6397-45a9-adae-2f465da25729) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129892 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91497 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7158b690-2591-44f4-91bd-5d01397aeb4c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110417 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a16f5dbf-d3ea-4fe2-9d8f-d57b9c76cf31) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31268 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29973 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24809 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159181 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141243 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27770 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178610 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27918 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31508 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138260 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138171 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37227 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149568 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104182 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26433 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199703 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39783 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112857 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53705 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39179 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4534 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39424 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39323 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->