### PR TITLE
clampToInteger<T> does not clamp values below INT_MIN

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -302,11 +302,6 @@ constexpr TargetType clampTo(SourceType value, TargetType min = defaultMinimumFo
     return static_cast<TargetType>(value);
 }
 
-constexpr int clampToInteger(double value)
-{
-    return clampTo<int>(value);
-}
-
 constexpr unsigned clampToUnsigned(double value)
 {
     return clampTo<unsigned>(value);
@@ -320,21 +315,6 @@ constexpr float clampToFloat(double value)
 constexpr int clampToPositiveInteger(double value)
 {
     return clampTo<int>(value, 0);
-}
-
-constexpr int clampToInteger(float value)
-{
-    return clampTo<int>(value);
-}
-
-template<std::integral T>
-constexpr int clampToInteger(T x)
-{
-    constexpr T intMax = static_cast<unsigned>(std::numeric_limits<int>::max());
-
-    if (x >= intMax)
-        return std::numeric_limits<int>::max();
-    return static_cast<int>(x);
 }
 
 // Explicitly accept 64bit result when clamping double value.

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1427,8 +1427,8 @@ void Element::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, 
         Style::adjustForAbsoluteZoom(renderer->scrollTop(), *renderer)
     );
     IntPoint scrollPosition(
-        clampToInteger(scrollToOptions.left.value() * renderer->style().usedZoom()),
-        clampToInteger(scrollToOptions.top.value() * renderer->style().usedZoom())
+        clampTo<int>(scrollToOptions.left.value() * renderer->style().usedZoom()),
+        clampTo<int>(scrollToOptions.top.value() * renderer->style().usedZoom())
     );
 
     auto animated = useSmoothScrolling(scrollToOptions.behavior, this) ? ScrollIsAnimated::Yes : ScrollIsAnimated::No;
@@ -1767,14 +1767,14 @@ void Element::setScrollLeft(int newLeft)
 
     if (document->scrollingElement() == this) {
         if (RefPtr frame = documentFrameWithNonNullView()) {
-            IntPoint position(clampToInteger(newLeft * frame->pageZoomFactor() * frame->frameScaleFactor()), frame->view()->scrollY());
+            IntPoint position(clampTo<int>(newLeft * frame->pageZoomFactor() * frame->frameScaleFactor()), frame->view()->scrollY());
             protect(frame->view())->setScrollPosition(position, options);
         }
         return;
     }
 
     if (CheckedPtr renderer = renderBox()) {
-        int clampedLeft = clampToInteger(newLeft * renderer->style().usedZoom());
+        int clampedLeft = clampTo<int>(newLeft * renderer->style().usedZoom());
         renderer->setScrollLeft(clampedLeft, options);
         if (auto* scrollableArea = renderer && renderer->layer() ? renderer->layer()->scrollableArea() : nullptr)
             scrollableArea->setScrollShouldClearLatchedState(true);
@@ -1795,14 +1795,14 @@ void Element::setScrollTop(int newTop)
 
     if (document->scrollingElement() == this) {
         if (RefPtr frame = documentFrameWithNonNullView()) {
-            IntPoint position(frame->view()->scrollX(), clampToInteger(newTop * frame->pageZoomFactor() * frame->frameScaleFactor()));
+            IntPoint position(frame->view()->scrollX(), clampTo<int>(newTop * frame->pageZoomFactor() * frame->frameScaleFactor()));
             protect(frame->view())->setScrollPosition(position, options);
         }
         return;
     }
 
     if (CheckedPtr renderer = renderBox()) {
-        int clampedTop = clampToInteger(newTop * renderer->style().usedZoom());
+        int clampedTop = clampTo<int>(newTop * renderer->style().usedZoom());
         renderer->setScrollTop(clampedTop, options);
         if (auto* scrollableArea = renderer && renderer->layer() ? renderer->layer()->scrollableArea() : nullptr)
             scrollableArea->setScrollShouldClearLatchedState(true);

--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -82,7 +82,7 @@ public:
     }
     explicit LayoutUnit(double value)
     {
-        m_value = clampToInteger(value * kFixedPointDenominator);
+        m_value = clampTo<int>(value * kFixedPointDenominator);
     }
 
     LayoutUnit& operator=(const LayoutUnit&) = default;
@@ -92,12 +92,12 @@ public:
 
     static LayoutUnit fromFloatCeil(float value)
     {
-        return fromRawValue(clampToInteger(ceilf(value * kFixedPointDenominator)));
+        return fromRawValue(clampTo<int>(ceilf(value * kFixedPointDenominator)));
     }
 
     static LayoutUnit fromFloatFloor(float value)
     {
-        return fromRawValue(clampToInteger(floorf(value * kFixedPointDenominator)));
+        return fromRawValue(clampTo<int>(floorf(value * kFixedPointDenominator)));
     }
 
     static LayoutUnit fromFloatRound(float value)

--- a/Source/WebCore/platform/graphics/DoublePoint.h
+++ b/Source/WebCore/platform/graphics/DoublePoint.h
@@ -137,12 +137,12 @@ constexpr DoublePoint operator-(const DoublePoint& a, const DoubleSize& b)
 
 inline IntPoint flooredIntPoint(const DoublePoint& p)
 {
-    return IntPoint(clampToInteger(floor(p.x())), clampToInteger(floor(p.y())));
+    return IntPoint(clampTo<int>(floor(p.x())), clampTo<int>(floor(p.y())));
 }
 
 inline IntPoint roundedIntPoint(const DoublePoint& p)
 {
-    return IntPoint(clampToInteger(round(p.x())), clampToInteger(round(p.y())));
+    return IntPoint(clampTo<int>(round(p.x())), clampTo<int>(round(p.y())));
 }
 
 inline DoubleSize toDoubleSize(const DoublePoint& a)

--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -265,29 +265,29 @@ inline void FloatPoint::rotate(double angleInRadians, const FloatPoint& aboutPoi
 
 inline IntSize flooredIntSize(const FloatPoint& p)
 {
-    return IntSize(clampToInteger(floorf(p.x())), clampToInteger(floorf(p.y())));
+    return IntSize(clampTo<int>(floorf(p.x())), clampTo<int>(floorf(p.y())));
 }
 
 #if USE(CG)
 inline IntPoint roundedIntPoint(const CGPoint& p)
 {
-    return IntPoint(clampToInteger(roundf(p.x)), clampToInteger(roundf(p.y)));
+    return IntPoint(clampTo<int>(roundf(p.x)), clampTo<int>(roundf(p.y)));
 }
 #endif
 
 inline IntPoint roundedIntPoint(const FloatPoint& p)
 {
-    return IntPoint(clampToInteger(roundf(p.x())), clampToInteger(roundf(p.y())));
+    return IntPoint(clampTo<int>(roundf(p.x())), clampTo<int>(roundf(p.y())));
 }
 
 inline IntPoint flooredIntPoint(const FloatPoint& p)
 {
-    return IntPoint(clampToInteger(floorf(p.x())), clampToInteger(floorf(p.y())));
+    return IntPoint(clampTo<int>(floorf(p.x())), clampTo<int>(floorf(p.y())));
 }
 
 inline IntPoint ceiledIntPoint(const FloatPoint& p)
 {
-    return IntPoint(clampToInteger(ceilf(p.x())), clampToInteger(ceilf(p.y())));
+    return IntPoint(clampTo<int>(ceilf(p.x())), clampTo<int>(ceilf(p.y())));
 }
 
 inline FloatPoint floorPointToDevicePixels(const FloatPoint& p, float deviceScaleFactor)

--- a/Source/WebCore/platform/graphics/FloatSize.h
+++ b/Source/WebCore/platform/graphics/FloatSize.h
@@ -240,22 +240,22 @@ inline bool areEssentiallyEqual(const FloatSize& a, const FloatSize& b)
 
 inline IntSize roundedIntSize(const FloatSize& p)
 {
-    return IntSize(clampToInteger(roundf(p.width())), clampToInteger(roundf(p.height())));
+    return IntSize(clampTo<int>(roundf(p.width())), clampTo<int>(roundf(p.height())));
 }
 
 inline IntSize flooredIntSize(const FloatSize& p)
 {
-    return IntSize(clampToInteger(floorf(p.width())), clampToInteger(floorf(p.height())));
+    return IntSize(clampTo<int>(floorf(p.width())), clampTo<int>(floorf(p.height())));
 }
 
 inline IntSize expandedIntSize(const FloatSize& p)
 {
-    return IntSize(clampToInteger(ceilf(p.width())), clampToInteger(ceilf(p.height())));
+    return IntSize(clampTo<int>(ceilf(p.width())), clampTo<int>(ceilf(p.height())));
 }
 
 inline IntPoint flooredIntPoint(const FloatSize& p)
 {
-    return IntPoint(clampToInteger(floorf(p.width())), clampToInteger(floorf(p.height())));
+    return IntPoint(clampTo<int>(floorf(p.width())), clampTo<int>(floorf(p.height())));
 }
 
 constexpr FloatSize FloatSize::nanSize()

--- a/Source/WebCore/platform/graphics/IntPoint.cpp
+++ b/Source/WebCore/platform/graphics/IntPoint.cpp
@@ -33,8 +33,8 @@
 namespace WebCore {
 
 IntPoint::IntPoint(const FloatPoint& p)
-    : m_x(clampToInteger(p.x()))
-    , m_y(clampToInteger(p.y()))
+    : m_x(clampTo<int>(p.x()))
+    , m_y(clampTo<int>(p.y()))
 {
 }
 

--- a/Source/WebCore/platform/graphics/IntRect.cpp
+++ b/Source/WebCore/platform/graphics/IntRect.cpp
@@ -39,8 +39,8 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IntRect);
 
 IntRect::IntRect(const FloatRect& r)
-    : m_location(clampToInteger(r.x()), clampToInteger(r.y()))
-    , m_size(clampToInteger(r.width()), clampToInteger(r.height()))
+    : m_location(clampTo<int>(r.x()), clampTo<int>(r.y()))
+    , m_size(clampTo<int>(r.width()), clampTo<int>(r.height()))
 {
 }
 

--- a/Source/WebCore/platform/graphics/IntSize.cpp
+++ b/Source/WebCore/platform/graphics/IntSize.cpp
@@ -33,8 +33,8 @@
 namespace WebCore {
 
 IntSize::IntSize(const FloatSize& s)
-    : m_width(clampToInteger(s.width()))
-    , m_height(clampToInteger(s.height()))
+    : m_width(clampTo<int>(s.width()))
+    , m_height(clampTo<int>(s.height()))
 {
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -447,7 +447,7 @@ static constexpr IntSize NODELETE fallbackMaxSurfaceDimension()
 
 static IntSize computeMaximumSurfaceSize()
 {
-    auto maxSize = IntSize { clampToInteger(IOSurfaceGetPropertyMaximum(kIOSurfaceWidth)), clampToInteger(IOSurfaceGetPropertyMaximum(kIOSurfaceHeight)) };
+    auto maxSize = IntSize { clampTo<int>(IOSurfaceGetPropertyMaximum(kIOSurfaceWidth)), clampTo<int>(IOSurfaceGetPropertyMaximum(kIOSurfaceHeight)) };
 
     // On iOS, there's an additional 8K clamp in CA (rdar://101936907).
     // On some macOS VMs, IOSurfaceGetPropertyMaximum() returns INT_MAX (rdar://113661708).

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -141,7 +141,7 @@ AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, Attachmen
         attachmentRect.unite(line.backgroundRect);
     if (!subtitleTextRect.isEmpty()) {
         FloatRect roundedSubtitleTextRect = subtitleTextRect;
-        roundedSubtitleTextRect.inflateX(attachmentSubtitleWidthIncrement - clampToInteger(ceilf(subtitleTextRect.width())) % attachmentSubtitleWidthIncrement);
+        roundedSubtitleTextRect.inflateX(attachmentSubtitleWidthIncrement - clampTo<int>(ceilf(subtitleTextRect.width())) % attachmentSubtitleWidthIncrement);
         attachmentRect.unite(roundedSubtitleTextRect);
     }
     attachmentRect.inflate(attachmentMargin);

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -113,7 +113,7 @@ Adjuster::Adjuster(const Document& document, const Style::ComputedStyle& parentS
 static void addIntrinsicMargins(Style::ComputedStyle& style)
 {
     // Intrinsic margin value.
-    const auto intrinsicMargin = MarginEdge::Fixed { static_cast<float>(clampToInteger(2 * style.usedZoom())) };
+    const auto intrinsicMargin = MarginEdge::Fixed { static_cast<float>(clampTo<int>(2 * style.usedZoom())) };
 
     // FIXME: Using width/height alone and not also dealing with min-width/max-width is flawed.
     // FIXME: Using "hasQuirk" to decide the margin wasn't set is kind of lame.

--- a/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
+++ b/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
@@ -121,7 +121,7 @@ static IntPoint positionFromEvent(WPEEvent* event)
 {
     double x, y;
     if (wpe_event_get_position(event, &x, &y))
-        return { clampToInteger(x), clampToInteger(y) };
+        return { clampTo<int>(x), clampTo<int>(y) };
     return { };
 }
 

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
@@ -67,7 +67,7 @@ DropTarget::DropTarget(GtkWidget* webView)
         if (drop.m_drop != gdkDrop)
             return static_cast<GdkDragAction>(0);
 
-        drop.enter({ clampToInteger(x), clampToInteger(y) });
+        drop.enter({ clampTo<int>(x), clampTo<int>(y) });
         return dragOperationToSingleGdkDragAction(drop.m_operation);
     }), this);
 
@@ -76,7 +76,7 @@ DropTarget::DropTarget(GtkWidget* webView)
         if (drop.m_drop != gdkDrop)
             return static_cast<GdkDragAction>(0);
 
-        drop.update({ clampToInteger(x), clampToInteger(y) });
+        drop.update({ clampTo<int>(x), clampTo<int>(y) });
         return dragOperationToSingleGdkDragAction(drop.m_operation);
     }), this);
 
@@ -93,7 +93,7 @@ DropTarget::DropTarget(GtkWidget* webView)
         if (drop.m_drop != gdkDrop)
             return FALSE;
 
-        drop.drop({ clampToInteger(x), clampToInteger(y) });
+        drop.drop({ clampTo<int>(x), clampTo<int>(y) });
         return TRUE;
     }), this);
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -1472,10 +1472,10 @@ static gboolean webkitWebViewBaseScrollEvent(GtkWidget* widget, GdkEventScroll* 
     auto phase = gdk_event_is_scroll_stop_event(event) ? WebWheelEvent::Phase::Ended : WebWheelEvent::Phase::Changed;
     double x, y;
     gdk_event_get_coords(event, &x, &y);
-    IntPoint position(clampToInteger(x), clampToInteger(y));
+    IntPoint position(clampTo<int>(x), clampTo<int>(y));
     double xRoot, yRoot;
     gdk_event_get_root_coords(event, &xRoot, &yRoot);
-    IntPoint globalPosition(clampToInteger(xRoot), clampToInteger(yRoot));
+    IntPoint globalPosition(clampTo<int>(xRoot), clampTo<int>(yRoot));
 
     bool hasPreciseScrollingDeltas = false;
     FloatSize wheelTicks;

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
@@ -94,7 +94,7 @@ static WebCore::VideoFrameRotation computeVideoFrameRotation(int rotation)
 
     AVCaptureDeviceRotationCoordinator* coordinator = (AVCaptureDeviceRotationCoordinator*)object;
     String persistentId = [coordinator device].uniqueID;
-    auto rotation = computeVideoFrameRotation(clampToInteger([coordinator videoRotationAngleForHorizonLevelPreview]));
+    auto rotation = computeVideoFrameRotation(clampTo<int>([coordinator videoRotationAngleForHorizonLevelPreview]));
 
     RunLoop::mainSingleton().dispatch([protectedSelf = retainPtr(self), self, persistentId = WTF::move(persistentId).isolatedCopy(), rotation] {
         if (_managerProxy)
@@ -122,7 +122,7 @@ static WebCore::VideoFrameRotation computeVideoFrameRotation(int rotation)
         iterator->value = WTF::move(coordinator);
     }
 
-    return computeVideoFrameRotation((clampToInteger([iterator->value videoRotationAngleForHorizonLevelPreview])));
+    return computeVideoFrameRotation((clampTo<int>([iterator->value videoRotationAngleForHorizonLevelPreview])));
 }
 
 -(void)stop:(const String&)persistentId {

--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -89,7 +89,7 @@ TEST(WTF, clampToIntLongLong)
     EXPECT_EQ(clampTo<int>(underflowInt), minInt);
 }
 
-TEST(WTF, clampToIntegerFloat)
+TEST(WTF, clampToIntFloat)
 {
     // This test is inaccurate as floats will round the min / max integer
     // due to the narrow mantissa. However it will properly checks within
@@ -107,14 +107,14 @@ TEST(WTF, clampToIntegerFloat)
     EXPECT_GT(overflowInt, maxInt);
     EXPECT_LT(underflowInt, minInt);
 
-    EXPECT_EQ(clampToInteger(maxInt), static_cast<int>(maxInt));
-    EXPECT_EQ(clampToInteger(minInt), std::numeric_limits<int>::min());
+    EXPECT_EQ(clampTo<int>(maxInt), static_cast<int>(maxInt));
+    EXPECT_EQ(clampTo<int>(minInt), std::numeric_limits<int>::min());
 
-    EXPECT_EQ(clampToInteger(overflowInt), std::numeric_limits<int>::max());
-    EXPECT_EQ(clampToInteger(underflowInt), std::numeric_limits<int>::min());
+    EXPECT_EQ(clampTo<int>(overflowInt), std::numeric_limits<int>::max());
+    EXPECT_EQ(clampTo<int>(underflowInt), std::numeric_limits<int>::min());
 }
 
-TEST(WTF, clampToIntegerDouble)
+TEST(WTF, clampToIntDouble)
 {
     double maxInt = std::numeric_limits<int>::max();
     double minInt = std::numeric_limits<int>::min();
@@ -124,11 +124,35 @@ TEST(WTF, clampToIntegerDouble)
     EXPECT_GT(overflowInt, maxInt);
     EXPECT_LT(underflowInt, minInt);
 
-    EXPECT_EQ(clampToInteger(maxInt), maxInt);
-    EXPECT_EQ(clampToInteger(minInt), minInt);
+    EXPECT_EQ(clampTo<int>(maxInt), maxInt);
+    EXPECT_EQ(clampTo<int>(minInt), minInt);
 
-    EXPECT_EQ(clampToInteger(overflowInt), maxInt);
-    EXPECT_EQ(clampToInteger(underflowInt), minInt);
+    EXPECT_EQ(clampTo<int>(overflowInt), maxInt);
+    EXPECT_EQ(clampTo<int>(underflowInt), minInt);
+}
+
+TEST(WTF, clampToIntIntegral)
+{
+    constexpr int intMax = std::numeric_limits<int>::max();
+    constexpr int intMin = std::numeric_limits<int>::min();
+
+    // int64_t: values in range pass through, out-of-range clamps both ends.
+    EXPECT_EQ(clampTo<int>(int64_t { 0 }), 0);
+    EXPECT_EQ(clampTo<int>(int64_t { 42 }), 42);
+    EXPECT_EQ(clampTo<int>(int64_t { -42 }), -42);
+    EXPECT_EQ(clampTo<int>(int64_t { intMax }), intMax);
+    EXPECT_EQ(clampTo<int>(int64_t { intMin }), intMin);
+    EXPECT_EQ(clampTo<int>(static_cast<int64_t>(intMax) + 1), intMax);
+    EXPECT_EQ(clampTo<int>(static_cast<int64_t>(intMin) - 1), intMin);
+    EXPECT_EQ(clampTo<int>(std::numeric_limits<int64_t>::max()), intMax);
+    EXPECT_EQ(clampTo<int>(std::numeric_limits<int64_t>::min()), intMin);
+
+    // uint64_t: in-range values pass through, large values clamp to intMax.
+    EXPECT_EQ(clampTo<int>(uint64_t { 0 }), 0);
+    EXPECT_EQ(clampTo<int>(uint64_t { 42 }), 42);
+    EXPECT_EQ(clampTo<int>(static_cast<uint64_t>(intMax)), intMax);
+    EXPECT_EQ(clampTo<int>(static_cast<uint64_t>(intMax) + 1), intMax);
+    EXPECT_EQ(clampTo<int>(std::numeric_limits<uint64_t>::max()), intMax);
 }
 
 TEST(WTF, clampToFloat)


### PR DESCRIPTION
#### 59604007e4c6efaa4a40868de016f7afcb5fb2a7
<pre>
clampToInteger&lt;T&gt; does not clamp values below INT_MIN
<a href="https://bugs.webkit.org/show_bug.cgi?id=316511">https://bugs.webkit.org/show_bug.cgi?id=316511</a>

Reviewed by Darin Adler.

clampToInteger had three overloads. The float and double versions were thin
wrappers that delegated to clampTo&lt;int&gt;. The integral version was its own
implementation that only clamped the upper bound — for values below INT_MIN it
fell through to a bare static_cast&lt;int&gt;(x), which is implementation-defined for
out-of-range conversions. In practice, clampToInteger&lt;int64_t&gt;(INT64_MIN)
returned 0 and clampToInteger&lt;int64_t&gt;(INT_MIN - 1) returned INT_MAX instead of
clamping to INT_MIN.

The integral version was also miscompiled for narrow signed/unsigned T (int8_t,
int16_t, uint8_t, uint16_t) because `static_cast&lt;unsigned&gt;(INT_MAX)` truncates
when assigned to `T intMax` — caught by -Werror=constant-conversion, so those
instantiations were unreachable from production code.

Rather than fix the integral overload in place, remove the API entirely and
migrate callers to clampTo&lt;int&gt;(value), whose existing overload set already
handles every integral and floating-point source type with correct two-sided
clamping.

Test: Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp

* Source/WTF/wtf/MathExtras.h:
(clampToInteger): Deleted.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::scrollTo):
(WebCore::Element::setScrollLeft):
(WebCore::Element::setScrollTop):
* Source/WebCore/platform/LayoutUnit.h:
(WebCore::LayoutUnit::LayoutUnit):
(WebCore::LayoutUnit::fromFloatCeil):
(WebCore::LayoutUnit::fromFloatFloor):
* Source/WebCore/platform/graphics/DoublePoint.h:
(WebCore::flooredIntPoint):
(WebCore::roundedIntPoint):
* Source/WebCore/platform/graphics/FloatPoint.h:
(WebCore::flooredIntSize):
(WebCore::roundedIntPoint):
(WebCore::flooredIntPoint):
(WebCore::ceiledIntPoint):
* Source/WebCore/platform/graphics/FloatSize.h:
(WebCore::roundedIntSize):
(WebCore::flooredIntSize):
(WebCore::expandedIntSize):
(WebCore::flooredIntPoint):
* Source/WebCore/platform/graphics/IntPoint.cpp:
(WebCore::IntPoint::IntPoint):
* Source/WebCore/platform/graphics/IntRect.cpp:
(WebCore::IntRect::IntRect):
* Source/WebCore/platform/graphics/IntSize.cpp:
(WebCore::IntSize::IntSize):
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::computeMaximumSurfaceSize):
* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::AttachmentLayout::AttachmentLayout):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::addIntrinsicMargins):
* Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp:
(WebKit::positionFromEvent):
* Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp:
(WebKit::DropTarget::DropTarget):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseScrollEvent):
* Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm:
(-[WKRotationCoordinatorObserver observeValueForKeyPath:ofObject:change:context:]):
(-[WKRotationCoordinatorObserver start:layer:]):
* Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp:
(TestWebKitAPI::TEST(WTF, clampToIntFloat)):
(TestWebKitAPI::TEST(WTF, clampToIntDouble)):
(TestWebKitAPI::TEST(WTF, clampToIntIntegral)):
(TestWebKitAPI::TEST(WTF, clampToIntegerFloat)): Deleted.
(TestWebKitAPI::TEST(WTF, clampToIntegerDouble)): Deleted.

Canonical link: <a href="https://commits.webkit.org/314768@main">https://commits.webkit.org/314768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a014b58ed9f73210e709e0c52bd8a17345fb19aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124283 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/efae6317-000b-480e-a1eb-e301027198d0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129894 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91499 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16b440c8-e162-413b-ad37-d91f95dc8204) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110419 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5caaf48c-aa17-4435-9381-41aa48ba4cc9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31270 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29975 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24810 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159182 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178611 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27919 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31509 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138262 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40585 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34124 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 11 flakes 3 failures; Uploaded test results; 11 flakes 3 failures; Compiled WebKit (warnings); 2 failures; Passed layout tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138173 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37226 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149570 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104192 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33445 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26435 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199704 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39784 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112858 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53706 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39180 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4536 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39425 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39324 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->