### PR TITLE
WebPageProxy::viewScaleFactorDidChange does not update m_viewScaleFactor

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6874,6 +6874,7 @@ void WebPageProxy::viewScaleFactorDidChange(IPC::Connection& connection, double 
     MESSAGE_CHECK_BASE(scaleFactorIsValid(scaleFactor), connection);
     if (!legacyMainFrameProcess().hasConnection(connection))
         return;
+    m_viewScaleFactor = scaleFactor;
 
     forEachWebContentProcess([&] (auto& process, auto pageID) {
         if (&process == &legacyMainFrameProcess())

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShrinkToFit.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShrinkToFit.mm
@@ -76,4 +76,29 @@ TEST(WebKit, ShrinkToFit)
     TestWebKitAPI::Util::run(&shrinkToFitDisabledDone);
 }
 
+TEST(WebKit, ViewScaleFactorAfterShrinkToFit)
+{
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
+
+    EXPECT_EQ(1.0, [webView _viewScale]);
+
+    [webView _setLayoutMode:_WKLayoutModeDynamicSizeComputedFromMinimumDocumentSize];
+
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
+    [webView loadRequest:request];
+    [webView _test_waitForDidFinishNavigation];
+
+    __block bool done = false;
+    [webView evaluateJavaScript:@"document.body.clientWidth" completionHandler:^(id, NSError *) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    // The WebProcess scaled the view down to fit the wide document and sent
+    // ViewScaleFactorDidChange back to the UIProcess. The cached value must
+    // reflect that scale, not the default of 1.
+    EXPECT_LT([webView _viewScale], 1.0);
+    EXPECT_GT([webView _viewScale], 0.0);
+}
+
 #endif


### PR DESCRIPTION
#### 7c78f81680caa9f34617537bdcfaa1e6a017ea72
<pre>
WebPageProxy::viewScaleFactorDidChange does not update m_viewScaleFactor
<a href="https://bugs.webkit.org/show_bug.cgi?id=316513">https://bugs.webkit.org/show_bug.cgi?id=316513</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

WebPageProxy::viewScaleFactorDidChange() is the IPC handler that the
WebProcess uses to notify the UIProcess after auto-scaling the view to
fit the document (the path enabled by setShouldScaleViewToFitDocument(),
exposed via WKView&apos;s _WKLayoutModeDynamicSizeComputedFromMinimumDocumentSize
layout strategy). Unlike its sibling pageScaleFactorDidChange(), it
forgot to update the cached m_viewScaleFactor member. As a result,
[WKWebView _viewScale] returned a stale value after the auto-scale, and
the stale value was also propagated to newly launched WebContent
processes via WebPageCreationParameters::viewScaleFactor on process swap.

Test: WebKit.ViewScaleFactorAfterShrinkToFit

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::viewScaleFactorDidChange):
Cache the new scale factor, mirroring pageScaleFactorDidChange().

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShrinkToFit.mm:
(TEST(WebKit, ViewScaleFactorAfterShrinkToFit)):
Add a regression test that uses the dynamic-size layout mode to drive
WebProcess-side auto-scale and verifies [WKWebView _viewScale] reflects
the new value.

Canonical link: <a href="https://commits.webkit.org/314774@main">https://commits.webkit.org/314774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaf58fed86b4a5896903a45dda5d475843ba923e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176216 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef61b074-b101-459b-ba54-6b41f79f8eea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130025 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ace3c87a-1115-46f6-9d7b-b719f4249033) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110542 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12c325d5-3e28-45d6-9423-97acab3984ca) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24954 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178756 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31656 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138407 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40736 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138301 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37235 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41424 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104386 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33558 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39928 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113007 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39325 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4659 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39575 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39506 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->