### PR TITLE
pathFromEllipseElement reads style.rx() and style.ry() without checking isAuto()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-clip-path-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-clip-path-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<svg width="320" height="160">
+  <defs>
+    <clipPath id="explicit-1"><ellipse cx="80" cy="80" rx="50" ry="50"/></clipPath>
+    <clipPath id="explicit-2"><ellipse cx="240" cy="80" rx="50" ry="50"/></clipPath>
+  </defs>
+  <rect x="0" y="0" width="160" height="160" fill="green" clip-path="url(#explicit-1)"/>
+  <rect x="160" y="0" width="160" height="160" fill="green" clip-path="url(#explicit-2)"/>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-clip-path-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-clip-path-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<svg width="320" height="160">
+  <defs>
+    <clipPath id="explicit-1"><ellipse cx="80" cy="80" rx="50" ry="50"/></clipPath>
+    <clipPath id="explicit-2"><ellipse cx="240" cy="80" rx="50" ry="50"/></clipPath>
+  </defs>
+  <rect x="0" y="0" width="160" height="160" fill="green" clip-path="url(#explicit-1)"/>
+  <rect x="160" y="0" width="160" height="160" fill="green" clip-path="url(#explicit-2)"/>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-clip-path.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-clip-path.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<title>SVG ellipse with auto rx/ry inside &lt;clipPath&gt; resolves per SVG 2</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#EllipseElement">
+<link rel="match" href="ellipse-auto-rx-clip-path-ref.html">
+<meta name="assert" content="An ellipse with auto rx (or auto ry) used as the geometry of a <clipPath> must clip identically to an ellipse with the resolved explicit value, per SVG 2 §10.4.">
+<svg width="320" height="160">
+  <defs>
+    <clipPath id="auto-rx"><ellipse cx="80" cy="80" rx="auto" ry="50"/></clipPath>
+    <clipPath id="auto-ry"><ellipse cx="240" cy="80" rx="50" ry="auto"/></clipPath>
+  </defs>
+  <rect x="0" y="0" width="160" height="160" fill="green" clip-path="url(#auto-rx)"/>
+  <rect x="160" y="0" width="160" height="160" fill="green" clip-path="url(#auto-ry)"/>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-css-clip-path-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-css-clip-path-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<svg width="320" height="160">
+  <defs>
+    <clipPath id="explicit-1" clipPathUnits="userSpaceOnUse">
+      <ellipse cx="80" cy="80" rx="50" ry="50"/>
+    </clipPath>
+    <clipPath id="explicit-2" clipPathUnits="userSpaceOnUse">
+      <ellipse cx="240" cy="80" rx="50" ry="50"/>
+    </clipPath>
+  </defs>
+  <rect x="0" y="0" width="160" height="160" fill="green" style="clip-path: url(#explicit-1)"/>
+  <rect x="160" y="0" width="160" height="160" fill="green" style="clip-path: url(#explicit-2)"/>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-css-clip-path-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-css-clip-path-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<svg width="320" height="160">
+  <defs>
+    <clipPath id="explicit-1" clipPathUnits="userSpaceOnUse">
+      <ellipse cx="80" cy="80" rx="50" ry="50"/>
+    </clipPath>
+    <clipPath id="explicit-2" clipPathUnits="userSpaceOnUse">
+      <ellipse cx="240" cy="80" rx="50" ry="50"/>
+    </clipPath>
+  </defs>
+  <rect x="0" y="0" width="160" height="160" fill="green" style="clip-path: url(#explicit-1)"/>
+  <rect x="160" y="0" width="160" height="160" fill="green" style="clip-path: url(#explicit-2)"/>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-css-clip-path.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-css-clip-path.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<title>SVG ellipse with auto rx/ry as CSS clip-path: url() reference resolves per SVG 2</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#EllipseElement">
+<link rel="help" href="https://drafts.fxtf.org/css-masking/#the-clip-path">
+<link rel="match" href="ellipse-auto-rx-css-clip-path-ref.html">
+<meta name="assert" content="An ellipse with auto rx (or auto ry) referenced via CSS clip-path: url(...) must clip identically to an ellipse with the resolved explicit value, per SVG 2 §10.4.">
+<svg width="320" height="160">
+  <defs>
+    <clipPath id="auto-rx" clipPathUnits="userSpaceOnUse">
+      <ellipse cx="80" cy="80" rx="auto" ry="50"/>
+    </clipPath>
+    <clipPath id="auto-ry" clipPathUnits="userSpaceOnUse">
+      <ellipse cx="240" cy="80" rx="50" ry="auto"/>
+    </clipPath>
+  </defs>
+  <rect x="0" y="0" width="160" height="160" fill="green" style="clip-path: url(#auto-rx)"/>
+  <rect x="160" y="0" width="160" height="160" fill="green" style="clip-path: url(#auto-ry)"/>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-percent-clip-path-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-percent-clip-path-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<svg width="400" height="100">
+  <defs>
+    <clipPath id="explicit-1"><ellipse cx="100" cy="50" rx="40" ry="40"/></clipPath>
+    <clipPath id="explicit-2"><ellipse cx="300" cy="50" rx="40" ry="40"/></clipPath>
+  </defs>
+  <rect x="0"   y="0" width="200" height="100" fill="green" clip-path="url(#explicit-1)"/>
+  <rect x="200" y="0" width="200" height="100" fill="green" clip-path="url(#explicit-2)"/>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-percent-clip-path-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-percent-clip-path-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<svg width="400" height="100">
+  <defs>
+    <clipPath id="explicit-1"><ellipse cx="100" cy="50" rx="40" ry="40"/></clipPath>
+    <clipPath id="explicit-2"><ellipse cx="300" cy="50" rx="40" ry="40"/></clipPath>
+  </defs>
+  <rect x="0"   y="0" width="200" height="100" fill="green" clip-path="url(#explicit-1)"/>
+  <rect x="200" y="0" width="200" height="100" fill="green" clip-path="url(#explicit-2)"/>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-percent-clip-path.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-percent-clip-path.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<title>SVG ellipse with auto rx/ry and percentage on the other axis inside &lt;clipPath&gt; resolves per SVG 2</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#EllipseElement">
+<link rel="match" href="ellipse-auto-rx-percent-clip-path-ref.html">
+<meta name="assert" content="An ellipse with auto on one of rx/ry and a percentage on the other must resolve the auto axis to the percentage's pixel value computed against the percentage's own axis (Width for rx, Height for ry), per SVG 2 §10.4. The result must clip identically to the explicit pixel value.">
+<svg width="400" height="100">
+  <defs>
+    <!-- 40% of height (100) = 40, then auto rx = 40. -->
+    <clipPath id="auto-rx-pct"><ellipse cx="100" cy="50" rx="auto" ry="40%"/></clipPath>
+    <!-- 10% of width (400) = 40, then auto ry = 40. -->
+    <clipPath id="auto-ry-pct"><ellipse cx="300" cy="50" rx="10%"  ry="auto"/></clipPath>
+  </defs>
+  <rect x="0"   y="0" width="200" height="100" fill="green" clip-path="url(#auto-rx-pct)"/>
+  <rect x="200" y="0" width="200" height="100" fill="green" clip-path="url(#auto-ry-pct)"/>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-textpath-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-textpath-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+text { font-family: Ahem; font-size: 20px; fill: black; }
+</style>
+<svg width="320" height="200">
+  <defs>
+    <ellipse id="explicit-1" cx="80" cy="100" rx="60" ry="60"/>
+    <ellipse id="explicit-2" cx="240" cy="100" rx="60" ry="60"/>
+  </defs>
+  <text><textPath href="#explicit-1">XXXXXXXX</textPath></text>
+  <text><textPath href="#explicit-2">XXXXXXXX</textPath></text>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-textpath-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-textpath-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+text { font-family: Ahem; font-size: 20px; fill: black; }
+</style>
+<svg width="320" height="200">
+  <defs>
+    <ellipse id="explicit-1" cx="80" cy="100" rx="60" ry="60"/>
+    <ellipse id="explicit-2" cx="240" cy="100" rx="60" ry="60"/>
+  </defs>
+  <text><textPath href="#explicit-1">XXXXXXXX</textPath></text>
+  <text><textPath href="#explicit-2">XXXXXXXX</textPath></text>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-textpath.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-textpath.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<title>SVG ellipse with auto rx/ry referenced from &lt;textPath&gt; resolves per SVG 2</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#EllipseElement">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElement">
+<link rel="match" href="ellipse-auto-rx-textpath-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="An ellipse with auto rx (or auto ry) referenced as the path geometry of a <textPath> must lay glyphs out identically to an ellipse with the resolved explicit value, per SVG 2 §10.4.">
+<style>
+text { font-family: Ahem; font-size: 20px; fill: black; }
+</style>
+<svg width="320" height="200">
+  <defs>
+    <ellipse id="auto-rx" cx="80" cy="100" rx="auto" ry="60"/>
+    <ellipse id="auto-ry" cx="240" cy="100" rx="60" ry="auto"/>
+  </defs>
+  <text><textPath href="#auto-rx">XXXXXXXX</textPath></text>
+  <text><textPath href="#auto-ry">XXXXXXXX</textPath></text>
+</svg>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/scripted/ellipse-auto-radii-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/scripted/ellipse-auto-radii-expected.txt
@@ -1,0 +1,9 @@
+
+PASS SVG ellipse rx/ry auto resolution affects SVGGeometryElement methods, getTotalLength resolves auto rx/ry.
+PASS SVG ellipse rx/ry auto resolution affects SVGGeometryElement methods, getTotalLength returns 0 when both rx and ry are auto.
+PASS SVG ellipse rx/ry auto resolution affects SVGGeometryElement methods, getPointAtLength(0) at the 3 o'clock starting point.
+PASS SVG ellipse rx/ry auto resolution affects SVGGeometryElement methods, isPointInFill resolves auto rx/ry.
+PASS SVG ellipse rx/ry auto resolution affects SVGGeometryElement methods, isPointInStroke with dasharray resolves auto rx/ry.
+PASS SVG ellipse rx/ry auto resolution affects SVGGeometryElement methods, getTotalLength resolves auto rx/ry against percentage values on the correct axis.
+PASS SVG ellipse rx/ry auto resolution affects SVGGeometryElement methods, getPointAtLength(0) with percentage ry uses height-axis resolution.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/scripted/ellipse-auto-radii.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/scripted/ellipse-auto-radii.svg
@@ -1,0 +1,122 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:html="http://www.w3.org/1999/xhtml"
+     viewBox="0 0 200 200">
+  <title>SVG ellipse rx/ry auto resolution affects SVGGeometryElement methods</title>
+  <metadata>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#EllipseElement"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGeometryElement"/>
+    <html:meta name="assert" content="Per SVG 2 §10.4, an 'auto' value for either rx or ry on an ellipse resolves to the used value of the other property; if both are auto, both used values are 0. This resolution must apply uniformly to every SVGGeometryElement method (getTotalLength, getPointAtLength, isPointInFill, isPointInStroke)."/>
+  </metadata>
+  <html:script src="/resources/testharness.js"/>
+  <html:script src="/resources/testharnessreport.js"/>
+
+  <ellipse id="auto-rx" cx="50" cy="50" rx="auto" ry="50"/>
+  <ellipse id="auto-ry" cx="50" cy="50" rx="50" ry="auto"/>
+  <ellipse id="auto-both" cx="50" cy="50"/>
+  <ellipse id="explicit" cx="50" cy="50" rx="50" ry="50"/>
+
+  <ellipse id="stroke-auto-rx" cx="100" cy="100" rx="auto" ry="50"
+           stroke="black" stroke-width="4" stroke-dasharray="4 2" fill="none"/>
+  <ellipse id="stroke-auto-ry" cx="100" cy="100" rx="50" ry="auto"
+           stroke="black" stroke-width="4" stroke-dasharray="4 2" fill="none"/>
+  <ellipse id="stroke-explicit" cx="100" cy="100" rx="50" ry="50"
+           stroke="black" stroke-width="4" stroke-dasharray="4 2" fill="none"/>
+
+  <!--
+    Percentage cases. Inner <svg> establishes its own 200x100 viewport so
+    that a percentage on rx resolves against width=200 and a percentage on
+    ry resolves against height=100. With auto on the other axis, the used
+    value of the auto axis equals the resolved (axis-correct) pixel value
+    of the non-auto axis.
+  -->
+  <svg id="pct-viewport" x="0" y="200" width="200" height="100">
+    <ellipse id="pct-auto-rx-50ry" cx="100" cy="50" rx="auto" ry="50%"/>
+    <ellipse id="pct-50rx-auto-ry" cx="100" cy="50" rx="50%"  ry="auto"/>
+    <ellipse id="pct-auto-rx-25ry" cx="100" cy="50" rx="auto" ry="25%"/>
+  </svg>
+
+  <script><![CDATA[
+    'use strict';
+
+    test(function() {
+      const expected = document.getElementById('explicit').getTotalLength();
+      assert_approx_equals(document.getElementById('auto-rx').getTotalLength(),
+                           expected, 0.5,
+                           'auto rx should resolve to ry');
+      assert_approx_equals(document.getElementById('auto-ry').getTotalLength(),
+                           expected, 0.5,
+                           'auto ry should resolve to rx');
+    }, document.title + ', getTotalLength resolves auto rx/ry.');
+
+    test(function() {
+      assert_equals(document.getElementById('auto-both').getTotalLength(), 0,
+                    'both auto means rendering disabled');
+    }, document.title + ', getTotalLength returns 0 when both rx and ry are auto.');
+
+    test(function() {
+      const expectedPoint = { x: 100, y: 50 };
+      const explicitPt = document.getElementById('explicit').getPointAtLength(0);
+      assert_approx_equals(explicitPt.x, expectedPoint.x, 0.5, 'explicit x');
+      assert_approx_equals(explicitPt.y, expectedPoint.y, 0.5, 'explicit y');
+
+      const autoRxPt = document.getElementById('auto-rx').getPointAtLength(0);
+      assert_approx_equals(autoRxPt.x, expectedPoint.x, 0.5, 'auto-rx x');
+      assert_approx_equals(autoRxPt.y, expectedPoint.y, 0.5, 'auto-rx y');
+
+      const autoRyPt = document.getElementById('auto-ry').getPointAtLength(0);
+      assert_approx_equals(autoRyPt.x, expectedPoint.x, 0.5, 'auto-ry x');
+      assert_approx_equals(autoRyPt.y, expectedPoint.y, 0.5, 'auto-ry y');
+    }, document.title + ', getPointAtLength(0) at the 3 o\'clock starting point.');
+
+    test(function() {
+      const center = { x: 50, y: 50 };
+      const outside = { x: 200, y: 50 };
+      ['auto-rx', 'auto-ry', 'explicit'].forEach(function(id) {
+        const el = document.getElementById(id);
+        assert_true(el.isPointInFill(center),
+                    id + ': center is in fill');
+        assert_false(el.isPointInFill(outside),
+                     id + ': point outside the resolved ellipse is not in fill');
+      });
+    }, document.title + ', isPointInFill resolves auto rx/ry.');
+
+    test(function() {
+      const onBoundary = { x: 150, y: 100 };
+      assert_true(document.getElementById('stroke-explicit')
+                  .isPointInStroke(onBoundary),
+                  'explicit: point on boundary is in stroke');
+      assert_true(document.getElementById('stroke-auto-rx')
+                  .isPointInStroke(onBoundary),
+                  'auto-rx: point on boundary is in stroke (auto rx resolves to ry=50)');
+      assert_true(document.getElementById('stroke-auto-ry')
+                  .isPointInStroke(onBoundary),
+                  'auto-ry: point on boundary is in stroke (auto ry resolves to rx=50)');
+    }, document.title + ', isPointInStroke with dasharray resolves auto rx/ry.');
+
+    // Inner <svg> viewport is 200x100. Percentages must resolve against the
+    // non-auto axis (a 50% on ry resolves against height=100, not width=200);
+    // the auto axis then takes that resolved pixel value.
+    test(function() {
+      // rx=auto, ry=50% in 200x100 -> ry = 50, rx = 50, perimeter = 2*pi*50.
+      assert_approx_equals(document.getElementById('pct-auto-rx-50ry').getTotalLength(),
+                           2 * Math.PI * 50, 1.0,
+                           'auto rx with ry=50% must resolve via height axis (50), not width axis (100)');
+      // rx=50%, ry=auto in 200x100 -> rx = 100, ry = 100, perimeter = 2*pi*100.
+      assert_approx_equals(document.getElementById('pct-50rx-auto-ry').getTotalLength(),
+                           2 * Math.PI * 100, 1.0,
+                           'auto ry with rx=50% must resolve via width axis (100), not height axis (50)');
+      // rx=auto, ry=25% in 200x100 -> ry = 25, rx = 25, perimeter = 2*pi*25.
+      assert_approx_equals(document.getElementById('pct-auto-rx-25ry').getTotalLength(),
+                           2 * Math.PI * 25, 0.5,
+                           'auto rx with ry=25% must resolve via height axis (25)');
+    }, document.title + ', getTotalLength resolves auto rx/ry against percentage values on the correct axis.');
+
+    test(function() {
+      // Path begins at the 3 o'clock point: (cx + rx, cy).
+      // For rx=auto, ry=50% in 200x100: (100 + 50, 50) = (150, 50).
+      const p = document.getElementById('pct-auto-rx-50ry').getPointAtLength(0);
+      assert_approx_equals(p.x, 150, 0.5, 'auto-rx + ry=50% starting point x');
+      assert_approx_equals(p.y, 50,  0.5, 'auto-rx + ry=50% starting point y');
+    }, document.title + ', getPointAtLength(0) with percentage ry uses height-axis resolution.');
+  ]]></script>
+</svg>

--- a/Source/WebCore/rendering/svg/SVGPathData.cpp
+++ b/Source/WebCore/rendering/svg/SVGPathData.cpp
@@ -69,12 +69,25 @@ static Path pathFromEllipseElement(const SVGEllipseElement& element)
 
     auto& style = renderer->style();
     SVGLengthContext lengthContext(&element);
-    float rx = lengthContext.valueForLength(style.rx(), Style::ZoomNeeded { }, SVGLengthMode::Width);
-    if (rx <= 0)
+
+    // Per SVG 2 §10.4: an `auto` value for either rx or ry is converted to the
+    // used value of the other property. If both are auto, both used values are 0.
+    auto& rxStyle = style.rx();
+    auto& ryStyle = style.ry();
+    if (rxStyle.isAuto() && ryStyle.isAuto())
         return { };
 
-    float ry = lengthContext.valueForLength(style.ry(), Style::ZoomNeeded { }, SVGLengthMode::Height);
-    if (ry <= 0)
+    float rx, ry;
+    if (rxStyle.isAuto())
+        rx = ry = lengthContext.valueForLength(ryStyle, Style::ZoomNeeded { }, SVGLengthMode::Height);
+    else if (ryStyle.isAuto())
+        ry = rx = lengthContext.valueForLength(rxStyle, Style::ZoomNeeded { }, SVGLengthMode::Width);
+    else {
+        rx = lengthContext.valueForLength(rxStyle, Style::ZoomNeeded { }, SVGLengthMode::Width);
+        ry = lengthContext.valueForLength(ryStyle, Style::ZoomNeeded { }, SVGLengthMode::Height);
+    }
+
+    if (rx <= 0 || ry <= 0)
         return { };
 
     Path path;


### PR DESCRIPTION
#### bdffad83ec6dff81c58fb20356f55210b68bcd45
<pre>
pathFromEllipseElement reads style.rx() and style.ry() without checking isAuto()
<a href="https://bugs.webkit.org/show_bug.cgi?id=316505">https://bugs.webkit.org/show_bug.cgi?id=316505</a>
<a href="https://rdar.apple.com/178959205">rdar://178959205</a>

Reviewed by Simon Fraser.

Per SVG 2 [1], an `auto` value for either `rx` or `ry` on an &lt;ellipse&gt;
resolves to the used value of the other property; if both are auto, both
used values are 0. RenderSVGEllipse honors this rule
(RenderSVGEllipse.cpp:99-107), but pathFromEllipseElement reads
style.rx() / style.ry() raw, and SVGLengthContext::valueForLength returns
0 for the Auto variant. The result is that every consumer of
pathFromGraphicsElement() — getTotalLength, getPointAtLength,
isPointInStroke (with stroke-dasharray, which forces the ensure-path
slow path), &lt;clipPath&gt;, CSS clip-path: url(), and &lt;textPath&gt; — sees an
empty path even though the element renders correctly.

Fix by mirroring the resolution from RenderSVGEllipse::calculateRadiiAndCenter:
substitute the auto operand before valueForLength, then re-overwrite
post-resolution to handle the borrowed-percentage axis mismatch.

This brings WebKit to interop parity with Firefox 152 on SVG 2 ellipse
auto resolution.

[1] <a href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#EllipseElement">https://w3c.github.io/svgwg/svg2-draft/shapes.html#EllipseElement</a>

Tests: imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-clip-path-ref.html
       imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-clip-path.html
       imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-css-clip-path-ref.html
       imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-css-clip-path.html
       imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-percent-clip-path-ref.html
       imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-percent-clip-path.html
       imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-textpath-ref.html
       imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-textpath.html
       imported/w3c/web-platform-tests/svg/shapes/scripted/ellipse-auto-radii.svg

* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-clip-path-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-clip-path-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-clip-path.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-css-clip-path-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-css-clip-path-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-css-clip-path.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-percent-clip-path-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-percent-clip-path-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-percent-clip-path.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-textpath-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-textpath-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/ellipse-auto-rx-textpath.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/scripted/ellipse-auto-radii-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/scripted/ellipse-auto-radii.svg: Added.
* Source/WebCore/rendering/svg/SVGPathData.cpp:
(WebCore::pathFromEllipseElement):

Canonical link: <a href="https://commits.webkit.org/314846@main">https://commits.webkit.org/314846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba84b49daa1b661861d48b4be8905c91c3d2baa6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176265 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7bac0456-25cb-45f6-a333-e2f479cdd62f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130065 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0948307f-5adb-487a-ae0f-ad6aa5b5c18b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110582 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23cb61d8-9bb7-4919-9b0f-f1e629fa28e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31449 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30148 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25003 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178806 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31705 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29649 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138450 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138342 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37284 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149726 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104456 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33590 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26601 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39977 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113056 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39374 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4699 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39624 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->