### PR TITLE
[Skia] Move upload conditions handling from SkiaRecordingResult to SkiaGPUAtlas

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -28,6 +28,7 @@
 
 #if USE(SKIA)
 #include "BitmapTexture.h"
+#include "PlatformDisplay.h"
 #include "SkiaImageAtlasLayout.h"
 #if USE(GBM)
 #include "MemoryMappedGPUBuffer.h"
@@ -37,15 +38,18 @@
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/core/SkPixmap.h>
+#include <skia/gpu/ganesh/GrDirectContext.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaGPUAtlas);
 
-SkiaGPUAtlas::SkiaGPUAtlas(Ref<BitmapTexture>&& atlasTexture, GrBackendTexture&& backendTexture, const SkiaImageAtlasLayout& layout, const IntSize& size)
+SkiaGPUAtlas::SkiaGPUAtlas(Ref<BitmapTexture>&& atlasTexture, GrBackendTexture&& backendTexture, Ref<AtlasUploadCondition>&& uploadCondition, const SkiaImageAtlasLayout& layout, const IntSize& size)
     : m_atlasTexture(WTF::move(atlasTexture))
     , m_backendTexture(WTF::move(backendTexture))
+    , m_uploadCondition(WTF::move(uploadCondition))
     , m_layout(layout)
     , m_size(size)
 {
@@ -58,7 +62,7 @@ SkiaGPUAtlas::SkiaGPUAtlas(Ref<BitmapTexture>&& atlasTexture, GrBackendTexture&&
 
 SkiaGPUAtlas::~SkiaGPUAtlas() = default;
 
-RefPtr<SkiaGPUAtlas> SkiaGPUAtlas::create(const SkiaImageAtlasLayout& layout, Ref<BitmapTexture>&& atlasTexture)
+RefPtr<SkiaGPUAtlas> SkiaGPUAtlas::create(const SkiaImageAtlasLayout& layout, Ref<BitmapTexture>&& atlasTexture, Ref<AtlasUploadCondition>&& uploadCondition)
 {
     const auto& atlasSize = layout.atlasSize();
     if (atlasSize.isEmpty())
@@ -70,7 +74,7 @@ RefPtr<SkiaGPUAtlas> SkiaGPUAtlas::create(const SkiaImageAtlasLayout& layout, Re
     if (!backendTexture.isValid())
         return nullptr;
 
-    return adoptRef(*new SkiaGPUAtlas(WTF::move(atlasTexture), WTF::move(backendTexture), layout, atlasSize));
+    return adoptRef(*new SkiaGPUAtlas(WTF::move(atlasTexture), WTF::move(backendTexture), WTF::move(uploadCondition), layout, atlasSize));
 }
 
 void SkiaGPUAtlas::uploadImages()
@@ -100,17 +104,17 @@ void SkiaGPUAtlas::uploadImages()
 
 #if USE(GBM)
     if (auto* gpuBuffer = m_atlasTexture->memoryMappedGPUBuffer()) {
-        if (gpuBuffer->isLinear() || gpuBuffer->isVivanteSuperTiled()) {
-            auto writeScope = makeGPUBufferWriteScope(*gpuBuffer);
-            RELEASE_ASSERT_WITH_MESSAGE(writeScope, "Failed to map GPU buffer for atlas upload");
+        RELEASE_ASSERT(gpuBuffer->isLinear() || gpuBuffer->isVivanteSuperTiled());
+        auto writeScope = makeGPUBufferWriteScope(*gpuBuffer);
+        RELEASE_ASSERT_WITH_MESSAGE(writeScope, "Failed to map GPU buffer for atlas upload");
 
-            for (const auto& entry : m_layout->entries()) {
-                if (auto pixels = pixelDataInSRGB(entry.rasterImage))
-                    gpuBuffer->updateContents(*writeScope, pixels->first, entry.atlasRect, pixels->second);
-            }
-
-            return;
+        for (const auto& entry : m_layout->entries()) {
+            if (auto pixels = pixelDataInSRGB(entry.rasterImage))
+                gpuBuffer->updateContents(*writeScope, pixels->first, entry.atlasRect, pixels->second);
         }
+
+        m_uploadCondition->signal();
+        return;
     }
 #endif
 
@@ -119,6 +123,30 @@ void SkiaGPUAtlas::uploadImages()
         if (auto pixels = pixelDataInSRGB(entry.rasterImage))
             m_atlasTexture->updateContents(pixels->first, entry.atlasRect, IntPoint::zero(), pixels->second, PixelFormat::BGRA8);
     }
+
+    m_uploadFence = GLFence::create(PlatformDisplay::sharedDisplay().glDisplay());
+}
+
+void SkiaGPUAtlas::waitForUpload() const
+{
+    if (m_uploadFence) {
+        m_uploadFence->serverWait();
+        return;
+    }
+
+    m_uploadCondition->wait();
+}
+
+sk_sp<SkImage> SkiaGPUAtlas::atlasImageForCurrentThread() const
+{
+    if (!m_backendTexture.isValid())
+        return nullptr;
+
+    waitForUpload();
+
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    RELEASE_ASSERT(grContext);
+    return SkImages::BorrowTextureFrom(grContext, m_backendTexture, kTopLeft_GrSurfaceOrigin, kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
@@ -27,6 +27,7 @@
 
 #if USE(SKIA)
 #include "BitmapTexture.h"
+#include "GLFence.h"
 #include "IntSize.h"
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -35,7 +36,9 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/GrBackendSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
+#include <wtf/Condition.h>
 #include <wtf/HashMap.h>
+#include <wtf/Lock.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -46,6 +49,40 @@ class SkiaImageAtlasLayout;
 
 using ImageToRectMap = HashMap<const SkImage*, SkRect>;
 
+class AtlasUploadCondition : public ThreadSafeRefCounted<AtlasUploadCondition> {
+public:
+    static Ref<AtlasUploadCondition> create() { return adoptRef(*new AtlasUploadCondition); }
+
+    void addPending()
+    {
+        Locker locker { m_lock };
+        ++m_pendingCount;
+    }
+
+    void signal()
+    {
+        Locker locker { m_lock };
+        ASSERT(m_pendingCount);
+        if (!--m_pendingCount)
+            m_condition.notifyAll();
+    }
+
+    void wait()
+    {
+        Locker locker { m_lock };
+        m_condition.wait(m_lock, [this]() WTF_REQUIRES_LOCK(m_lock) {
+            return !m_pendingCount;
+        });
+    }
+
+private:
+    AtlasUploadCondition() = default;
+
+    Lock m_lock;
+    Condition m_condition;
+    unsigned m_pendingCount WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+};
+
 // GPU atlas that uploads raster images into a BitmapTexture.
 // Uses MemoryMappedGPUBuffer directly for dma-buf (GBM) path and
 // BitmapTexture::updateContents() for GL fallback.
@@ -53,23 +90,27 @@ class SkiaGPUAtlas : public ThreadSafeRefCounted<SkiaGPUAtlas, WTF::DestructionT
     WTF_MAKE_TZONE_ALLOCATED(SkiaGPUAtlas);
     WTF_MAKE_NONCOPYABLE(SkiaGPUAtlas);
 public:
-    static RefPtr<SkiaGPUAtlas> create(const SkiaImageAtlasLayout&, Ref<BitmapTexture>&&);
+    static RefPtr<SkiaGPUAtlas> create(const SkiaImageAtlasLayout&, Ref<BitmapTexture>&&, Ref<AtlasUploadCondition>&&);
 
     // Upload images into the atlas texture. Can run from any thread for dma-buf backed textures.
     void uploadImages();
 
     virtual ~SkiaGPUAtlas();
 
-    const GrBackendTexture& backendTexture() const LIFETIME_BOUND { return m_backendTexture; }
     const ImageToRectMap& imageToRect() const LIFETIME_BOUND { return m_imageToRect; }
     const IntSize& size() const LIFETIME_BOUND { return m_size; }
     BitmapTexture& atlasTexture() const { return m_atlasTexture.get(); }
+    sk_sp<SkImage> atlasImageForCurrentThread() const;
 
 private:
-    SkiaGPUAtlas(Ref<BitmapTexture>&&, GrBackendTexture&&, const SkiaImageAtlasLayout&, const IntSize&);
+    SkiaGPUAtlas(Ref<BitmapTexture>&&, GrBackendTexture&&, Ref<AtlasUploadCondition>&&, const SkiaImageAtlasLayout&, const IntSize&);
+
+    void waitForUpload() const;
 
     Ref<BitmapTexture> m_atlasTexture;
     GrBackendTexture m_backendTexture;
+    Ref<AtlasUploadCondition> m_uploadCondition;
+    std::unique_ptr<GLFence> m_uploadFence;
     ImageToRectMap m_imageToRect;
     Ref<const SkiaImageAtlasLayout> m_layout;
     IntSize m_size;

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -129,17 +129,15 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::createBuffer(RenderingMode render
     return CoordinatedUnacceleratedTileBuffer::create(size, contentsOpaque ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha);
 }
 
-RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout& layout, AtlasUploadCondition& uploadCondition, bool& needsUploadFence)
+RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout& layout, AtlasUploadCondition& uploadCondition)
 {
     const auto& atlasSize = layout.atlasSize();
 
     OptionSet<BitmapTexture::Flags> textureFlags { BitmapTexture::Flags::UseBGRALayout, BitmapTexture::Flags::NearestFiltering, BitmapTexture::Flags::SupportsAlpha };
     bool isDMABufBackedTexture = false;
 #if USE(GBM)
-    if (shouldUseDMABufAtlasTextures()) {
-        isDMABufBackedTexture = true;
+    if (shouldUseDMABufAtlasTextures())
         textureFlags.add({ BitmapTexture::Flags::BackedByDMABuf, BitmapTexture::Flags::ForceLinearBuffer });
-    }
 #endif
 
     // Verify the texture actually has DMA-buf backing. BitmapTexture silently
@@ -147,18 +145,17 @@ RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout&
     // GL operations to the upload worker thread (which has no GL context).
     auto texture = BitmapTexturePool::singleton().acquireTexture(atlasSize, textureFlags);
 #if USE(GBM)
-    if (!texture->memoryMappedGPUBuffer())
-        isDMABufBackedTexture = false;
+    if (texture->memoryMappedGPUBuffer())
+        isDMABufBackedTexture = true;
 #endif
 
-    auto atlas = SkiaGPUAtlas::create(layout, WTF::move(texture));
+    auto atlas = SkiaGPUAtlas::create(layout, WTF::move(texture), Ref { uploadCondition });
     if (!atlas)
         return nullptr;
 
     // GL path: upload synchronously.
     if (!isDMABufBackedTexture) [[unlikely]] {
         atlas->uploadImages();
-        needsUploadFence = true;
         return atlas;
     }
 
@@ -166,9 +163,8 @@ RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout&
     if (!m_uploadWorkQueue)
         m_uploadWorkQueue = WorkQueue::create("AtlasUpload"_s);
     uploadCondition.addPending();
-    m_uploadWorkQueue->dispatch([atlas = Ref { *atlas }, condition = Ref { uploadCondition }]() mutable {
+    m_uploadWorkQueue->dispatch([atlas = Ref { *atlas }]() mutable {
         atlas->uploadImages();
-        condition->signal();
     });
     return atlas;
 }
@@ -249,9 +245,8 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
             auto uploadCondition = AtlasUploadCondition::create();
             gpuAtlases.reserveInitialCapacity(result->atlasLayouts().size());
 
-            bool needsUploadFence = false;
             for (const auto& layout : result->atlasLayouts()) {
-                if (auto atlas = createAtlas(layout.get(), uploadCondition.get(), needsUploadFence))
+                if (auto atlas = createAtlas(layout.get(), uploadCondition.get()))
                     gpuAtlases.append(atlas.releaseNonNull());
             }
 
@@ -260,17 +255,12 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
                 // This avoids holding the BitmapTextures by an extra frame, if not needed.
                 if (fingerprint == m_cachedImageFingerprint) {
                     m_cachedGPUAtlases = WTF::move(gpuAtlases);
-                    result->setGPUAtlases(copyToVectorOf<Ref<SkiaGPUAtlas>>(m_cachedGPUAtlases), WTF::move(uploadCondition));
+                    result->setGPUAtlases(copyToVectorOf<Ref<SkiaGPUAtlas>>(m_cachedGPUAtlases));
                 } else {
                     m_cachedImageFingerprint = fingerprint;
                     m_cachedGPUAtlases.clear();
-                    result->setGPUAtlases(WTF::move(gpuAtlases), WTF::move(uploadCondition));
+                    result->setGPUAtlases(WTF::move(gpuAtlases));
                 }
-
-                // Flush and fence only for the GL upload path, where
-                // BitmapTexture::updateContents() issues GL upload commands.
-                if (needsUploadFence)
-                    result->setUploadFence(SkiaUtilities::flushAndSubmitWithFence(grContext));
             }
         }
     } else {

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -69,7 +69,7 @@ public:
 private:
     Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque) const;
     void paintIntoGraphicsContext(const GraphicsLayer&, GraphicsContext&, const IntRect&, bool contentsOpaque, float contentsScale) const;
-    RefPtr<SkiaGPUAtlas> createAtlas(const SkiaImageAtlasLayout&, AtlasUploadCondition&, bool& needsUploadFence);
+    RefPtr<SkiaGPUAtlas> createAtlas(const SkiaImageAtlasLayout&, AtlasUploadCondition&);
     bool tryReuseCachedAtlases(SkiaRecordingResult&, unsigned fingerprint);
 
     RefPtr<WorkerPool> m_paintingWorkerPool;

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp
@@ -62,19 +62,6 @@ void SkiaRecordingResult::waitForFenceIfNeeded(const SkImage& image)
         fence->serverWait();
 }
 
-void SkiaRecordingResult::waitForUploadFence()
-{
-    if (m_uploadFence)
-        m_uploadFence->serverWait();
-}
-
-
-void SkiaRecordingResult::waitForUploadCondition()
-{
-    if (m_uploadCondition)
-        m_uploadCondition->wait();
-}
-
 } // namespace WebCore
 
 #endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
@@ -37,7 +37,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkPicture.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
-#include <wtf/Condition.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -45,40 +44,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 namespace WebCore {
 
 using SkiaImageToFenceMap = HashMap<const SkImage*, std::unique_ptr<GLFence>>;
-
-class AtlasUploadCondition : public ThreadSafeRefCounted<AtlasUploadCondition> {
-public:
-    static Ref<AtlasUploadCondition> create() { return adoptRef(*new AtlasUploadCondition); }
-
-    void addPending()
-    {
-        Locker locker { m_lock };
-        ++m_pendingCount;
-    }
-
-    void signal()
-    {
-        Locker locker { m_lock };
-        ASSERT(m_pendingCount);
-        if (!--m_pendingCount)
-            m_condition.notifyAll();
-    }
-
-    void wait()
-    {
-        Locker locker { m_lock };
-        m_condition.wait(m_lock, [this]() WTF_REQUIRES_LOCK(m_lock) {
-            return !m_pendingCount;
-        });
-    }
-
-private:
-    AtlasUploadCondition() = default;
-
-    Lock m_lock;
-    Condition m_condition;
-    unsigned m_pendingCount WTF_GUARDED_BY_LOCK(m_lock) { 0 };
-};
 
 struct SkiaRecordingData {
     SkiaImageToFenceMap imageToFenceMap;
@@ -106,26 +71,13 @@ public:
     unsigned imageSetFingerprint() const { return m_imageSetFingerprint; }
 
     // GPU atlases prepared on main thread for worker threads to rewrap.
-    void setGPUAtlases(Vector<Ref<SkiaGPUAtlas>>&& atlases, RefPtr<AtlasUploadCondition>&& condition = nullptr)
-    {
-        m_gpuAtlases = WTF::move(atlases);
-        m_uploadCondition = WTF::move(condition);
-    }
-
-    // Set the upload fence for async GPU operations (created by SkiaPaintingEngine).
-    void setUploadFence(std::unique_ptr<GLFence>&& fence) { m_uploadFence = WTF::move(fence); }
+    void setGPUAtlases(Vector<Ref<SkiaGPUAtlas>>&& atlases) { m_gpuAtlases = WTF::move(atlases); }
 
     // Check if GPU atlases are ready.
     bool hasGPUAtlases() const { return !m_gpuAtlases.isEmpty(); }
 
     // Get prepared GPU atlases (for worker threads to rewrap).
     const Vector<Ref<SkiaGPUAtlas>>& gpuAtlases() const LIFETIME_BOUND { return m_gpuAtlases; }
-
-    // Wait for GPU upload fence (call from worker threads before using atlases).
-    void waitForUploadFence();
-
-    // Wait for async DMA-buf atlas upload to complete.
-    void waitForUploadCondition();
 
 private:
     SkiaRecordingResult(sk_sp<SkPicture>&&, SkiaRecordingData&&, const IntRect& recordRect, RenderingMode, bool contentsOpaque, float contentsScale);
@@ -136,8 +88,6 @@ private:
     Vector<Ref<SkiaImageAtlasLayout>> m_atlasLayouts;
     unsigned m_imageSetFingerprint { 0 };
     Vector<Ref<SkiaGPUAtlas>> m_gpuAtlases;
-    std::unique_ptr<GLFence> m_uploadFence; // Fence for async GPU upload
-    RefPtr<AtlasUploadCondition> m_uploadCondition;
     IntRect m_recordRect;
     RenderingMode m_renderingMode { RenderingMode::Unaccelerated };
     bool m_contentsOpaque : 1 { true };

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp
@@ -33,18 +33,13 @@
 #include "SkiaGPUAtlas.h"
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/gpu/ganesh/GrDirectContext.h>
-#include <skia/gpu/ganesh/SkImageGanesh.h>
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaReplayAtlas);
 
-SkiaReplayAtlas::SkiaReplayAtlas(Ref<const SkiaGPUAtlas>&& gpuAtlas, sk_sp<SkImage>&& rewrappedTexture)
+SkiaReplayAtlas::SkiaReplayAtlas(Ref<const SkiaGPUAtlas>&& gpuAtlas, sk_sp<SkImage>&& atlasImage)
     : m_gpuAtlas(WTF::move(gpuAtlas))
-    , m_rewrappedTexture(WTF::move(rewrappedTexture))
+    , m_atlasImage(WTF::move(atlasImage))
 {
 }
 
@@ -52,21 +47,15 @@ SkiaReplayAtlas::~SkiaReplayAtlas() = default;
 
 std::unique_ptr<SkiaReplayAtlas> SkiaReplayAtlas::create(const SkiaGPUAtlas& gpuAtlas)
 {
-    if (!gpuAtlas.backendTexture().isValid())
-        return nullptr;
-
-    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-    RELEASE_ASSERT(grContext);
-
     // Always rewrap the texture for this worker context.
     // The underlying GL texture was created on the main thread context but is
     // shareable via GL context sharing. However, the Skia SkImage wrapper is
     // context-specific and must be rewrapped for each worker's GrDirectContext.
-    auto rewrapped = SkImages::BorrowTextureFrom(grContext, gpuAtlas.backendTexture(), kTopLeft_GrSurfaceOrigin, kBGRA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
-    if (!rewrapped)
+    auto atlasImage = gpuAtlas.atlasImageForCurrentThread();
+    if (!atlasImage)
         return nullptr;
 
-    return std::unique_ptr<SkiaReplayAtlas>(new SkiaReplayAtlas(gpuAtlas, WTF::move(rewrapped)));
+    return makeUnique<SkiaReplayAtlas>(gpuAtlas, WTF::move(atlasImage));
 }
 
 std::optional<SkRect> SkiaReplayAtlas::rectForImage(const SkImage& image) const

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.h
@@ -51,19 +51,18 @@ public:
     // Create atlas wrapper from pre-prepared GPU atlas, rewraps the texture for the current context.
     static std::unique_ptr<SkiaReplayAtlas> create(const SkiaGPUAtlas&);
 
+    SkiaReplayAtlas(Ref<const SkiaGPUAtlas>&&, sk_sp<SkImage>&&);
     ~SkiaReplayAtlas();
 
-    const sk_sp<SkImage>& atlasTexture() const LIFETIME_BOUND { return m_rewrappedTexture; }
+    const sk_sp<SkImage>& atlasImage() const LIFETIME_BOUND { return m_atlasImage; }
 
     // Lookup: original raster image -> rect within atlas texture.
     // Returns nullopt if image is not in this atlas.
     std::optional<SkRect> rectForImage(const SkImage&) const;
 
 private:
-    SkiaReplayAtlas(Ref<const SkiaGPUAtlas>&&, sk_sp<SkImage>&&);
-
     Ref<const SkiaGPUAtlas> m_gpuAtlas;
-    sk_sp<SkImage> m_rewrappedTexture;
+    sk_sp<SkImage> m_atlasImage;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
@@ -45,9 +45,6 @@ SkiaReplayCanvas::SkiaReplayCanvas(const IntSize& size, const RefPtr<SkiaRecordi
         if (!glContext || !glContext->makeContextCurrent())
             return;
 
-        m_recording->waitForUploadCondition();
-        m_recording->waitForUploadFence();
-
         const auto& gpuAtlases = m_recording->gpuAtlases();
         m_atlases.reserveInitialCapacity(gpuAtlases.size());
 
@@ -189,10 +186,10 @@ void SkiaReplayCanvas::onDrawImage2(const SkImage* image, SkScalar x, SkScalar y
         for (auto& atlas : m_atlases) {
             if (auto atlasRect = atlas->rectForImage(*image)) {
                 // Draw from atlas instead of original image.
-                const auto& atlasTexture = atlas->atlasTexture();
-                ASSERT(atlasTexture);
+                const auto& atlasImage = atlas->atlasImage();
+                ASSERT(atlasImage);
                 auto dst = SkRect::MakeXYWH(x, y, atlasRect->width(), atlasRect->height());
-                SkNWayCanvas::onDrawImageRect2(atlasTexture.get(), *atlasRect, dst, sampling, paint, SkCanvas::kStrict_SrcRectConstraint);
+                SkNWayCanvas::onDrawImageRect2(atlasImage.get(), *atlasRect, dst, sampling, paint, SkCanvas::kStrict_SrcRectConstraint);
                 return;
             }
         }
@@ -217,8 +214,8 @@ void SkiaReplayCanvas::onDrawImageRect2(const SkImage* image, const SkRect& src,
         for (auto& atlas : m_atlases) {
             if (auto atlasRect = atlas->rectForImage(*image)) {
                 // Draw from atlas instead of original image.
-                const auto& atlasTexture = atlas->atlasTexture();
-                ASSERT(atlasTexture);
+                const auto& atlasImage = atlas->atlasImage();
+                ASSERT(atlasImage);
 
                 // Map src rect from image coordinates to atlas coordinates.
                 SkScalar atlasX = atlasRect->x() + src.x();
@@ -238,11 +235,11 @@ void SkiaReplayCanvas::onDrawImageRect2(const SkImage* image, const SkRect& src,
                     SkScalar scaleY = dst.height() / src.height();
 
                     auto adjustedDst = SkRect::MakeXYWH(dst.x() + leftClip * scaleX, dst.y() + topClip * scaleY, atlasSrc.width() * scaleX, atlasSrc.height() * scaleY);
-                    SkNWayCanvas::onDrawImageRect2(atlasTexture.get(), atlasSrc, adjustedDst, sampling, paint, SkCanvas::kStrict_SrcRectConstraint);
+                    SkNWayCanvas::onDrawImageRect2(atlasImage.get(), atlasSrc, adjustedDst, sampling, paint, SkCanvas::kStrict_SrcRectConstraint);
                     return;
                 }
 
-                SkNWayCanvas::onDrawImageRect2(atlasTexture.get(), atlasSrc, dst, sampling, paint, SkCanvas::kStrict_SrcRectConstraint);
+                SkNWayCanvas::onDrawImageRect2(atlasImage.get(), atlasSrc, dst, sampling, paint, SkCanvas::kStrict_SrcRectConstraint);
                 return;
             }
         }


### PR DESCRIPTION
#### c18ec1ad8a1dc3ed001583de6e44874967bc0540
<pre>
[Skia] Move upload conditions handling from SkiaRecordingResult to SkiaGPUAtlas
<a href="https://bugs.webkit.org/show_bug.cgi?id=316530">https://bugs.webkit.org/show_bug.cgi?id=316530</a>

Reviewed by Nikolas Zimmermann.

The atlas now contains the AtlasUploadCondition and GLFence that are
signaled/created when upload is done. Then a new method
atlasImageForCurrentThread() waits for the upload and creates a SkImage
valid for the current thread. When deferred display list is implemented,
this method will return a promise image insetad of a rewrapped image.
This patch also renames SkiaReplayAtlas::atlasTexture() as atlasImage()
since it returns a SkImage and it was easy to confused with
SkiaGPUAtlas::atlasTexture() that returns a BitmapTexture.

* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp:
(WebCore::SkiaGPUAtlas::SkiaGPUAtlas):
(WebCore::SkiaGPUAtlas::create):
(WebCore::SkiaGPUAtlas::uploadImages):
(WebCore::SkiaGPUAtlas::waitForUpload const):
(WebCore::SkiaGPUAtlas::atlasImageForCurrentThread const):
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h:
(WebCore::AtlasUploadCondition::create):
(WebCore::AtlasUploadCondition::addPending):
(WebCore::AtlasUploadCondition::signal):
(WebCore::AtlasUploadCondition::wait):
(WebCore::AtlasUploadCondition::WTF_GUARDED_BY_LOCK):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::createAtlas):
(WebCore::SkiaPaintingEngine::record):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp:
(WebCore::SkiaRecordingResult::waitForUploadFence): Deleted.
(WebCore::SkiaRecordingResult::waitForUploadCondition): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h:
(WebCore::AtlasUploadCondition::create): Deleted.
(WebCore::AtlasUploadCondition::addPending): Deleted.
(WebCore::AtlasUploadCondition::signal): Deleted.
(WebCore::AtlasUploadCondition::wait): Deleted.
(WebCore::AtlasUploadCondition::WTF_GUARDED_BY_LOCK): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp:
(WebCore::SkiaReplayAtlas::SkiaReplayAtlas):
(WebCore::SkiaReplayAtlas::create):
* Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.h:
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp:
(WebCore::SkiaReplayCanvas::SkiaReplayCanvas):
(WebCore::SkiaReplayCanvas::onDrawImage2):
(WebCore::SkiaReplayCanvas::onDrawImageRect2):

Canonical link: <a href="https://commits.webkit.org/314797@main">https://commits.webkit.org/314797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9393fe9a592a94797425c53213fb2e9b44c25784

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40761 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/34353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176315 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40774 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130113 "Failed to checkout and rebase branch from PR 66671") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170225 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/110630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25053 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/27978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178856 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/29696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40835 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/138390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41523 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/149773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104528 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25456 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33637 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40027 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39424 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/4746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->