### PR TITLE
Add AV1 intra support for frame size overriding

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2442,6 +2442,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/generic/ScrollbarsControllerGeneric.h
 
+    platform/graphics/AV1Utilities.h
     platform/graphics/AlphaPremultiplication.h
     platform/graphics/AnimationFrameRate.h
     platform/graphics/AudioTrackPrivate.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1590,7 +1590,7 @@
 		41D015CA0F4B5C71004A662F /* ContentType.h in Headers */ = {isa = PBXBuildFile; fileRef = 41D015C80F4B5C71004A662F /* ContentType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		41D125FE2B6D012E003EB7AA /* WebRTCVideoDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E476512B6CF8A700C30B11 /* WebRTCVideoDecoder.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		41D126022B6D0BD6003EB7AA /* AV1UtilitiesCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1A225B2B075A6D0038923E /* AV1UtilitiesCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		41D126092B6D111D003EB7AA /* AV1Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1A22582B0759AD0038923E /* AV1Utilities.h */; };
+		41D126092B6D111D003EB7AA /* AV1Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1A22582B0759AD0038923E /* AV1Utilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		41D129CE1F3D0EF600D15E47 /* WindowOrWorkerGlobalScopeCaches.h in Headers */ = {isa = PBXBuildFile; fileRef = 41FB278D1F34C28200795487 /* WindowOrWorkerGlobalScopeCaches.h */; };
 		41D129D01F3D0F0500D15E47 /* CacheQueryOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 41FB279B1F34CEF000795487 /* CacheQueryOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		41D129D31F3D0F1600D15E47 /* CacheStorageConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 41D129CC1F3D0EE300D15E47 /* CacheStorageConnection.h */; settings = {ATTRIBUTES = (Private, ); }; };

--- a/Source/WebCore/platform/graphics/AV1Utilities.cpp
+++ b/Source/WebCore/platform/graphics/AV1Utilities.cpp
@@ -648,9 +648,10 @@ std::optional<AV1CodecConfigurationRecord> parseAV1DecoderConfigurationRecord(st
     return record;
 }
 
-std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<const uint8_t> data)
+std::optional<AV1SequenceHeaderInfo> parseSequenceHeaderOBU(std::span<const uint8_t> data)
 {
-    AV1CodecConfigurationRecord record;
+    AV1SequenceHeaderInfo info;
+    auto& record = info.codecRecord;
     record.codecName = "av01"_s;
 
     BitReader bitReader(data);
@@ -680,6 +681,8 @@ std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<cons
     // Per spec: reduced_still_picture_header requires still_picture to be 1
     if (reducedStillPictureHeader && !stillPicture)
         return std::nullopt;
+
+    info.reducedStillPictureHeader = reducedStillPictureHeader;
 
     bool timingInfoPresentFlag = false;
     bool decoderModelInfoPresentFlag = false;
@@ -727,6 +730,7 @@ std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<cons
             if (!value)
                 return std::nullopt;
             bool equalPictureInterval = *value;
+            info.equalPictureInterval = equalPictureInterval;
             if (equalPictureInterval) {
                 // num_ticks_per_picture_minus_1 uvlc()
                 // Parse uvlc: count leading zeros, then read that many bits
@@ -769,6 +773,7 @@ std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<cons
                 value = bitReader.read(5);
                 if (!value)
                     return std::nullopt;
+                info.bufferRemovalTimeLengthMinus1 = static_cast<uint8_t>(*value);
                 // frame_presentation_time_length_minus_1 f(5)
                 value = bitReader.read(5);
                 if (!value)
@@ -776,6 +781,8 @@ std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<cons
             }
         } else
             decoderModelInfoPresentFlag = false;
+
+        info.decoderModelInfoPresentFlag = decoderModelInfoPresentFlag;
 
         // initial_display_delay_present_flag f(1)
         value = bitReader.read(1);
@@ -788,6 +795,7 @@ std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<cons
         if (!value)
             return std::nullopt;
         operatingPointsCntMinus1 = *value;
+        info.operatingPointsCount = static_cast<uint8_t>(operatingPointsCntMinus1 + 1);
 
         // For each operating point
         for (size_t i = 0; i <= operatingPointsCntMinus1; i++) {
@@ -824,6 +832,7 @@ std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<cons
                 if (!value)
                     return std::nullopt;
                 bool decoderModelPresentForThisOp = *value;
+                info.decoderModelPresentForThisOp[i] = decoderModelPresentForThisOp;
                 if (decoderModelPresentForThisOp) {
                     // operating_parameters_info(i)
                     // n = buffer_delay_length_minus_1 + 1
@@ -864,12 +873,14 @@ std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<cons
     if (!value)
         return std::nullopt;
     size_t frameWidthBitsMinus1 = *value;
+    info.frameWidthBitsMinus1 = static_cast<uint8_t>(frameWidthBitsMinus1);
 
     // frame_height_bits_minus_1 f(4)
     value = bitReader.read(4);
     if (!value)
         return std::nullopt;
     size_t frameHeightBitsMinus1 = *value;
+    info.frameHeightBitsMinus1 = static_cast<uint8_t>(frameHeightBitsMinus1);
 
     // max_frame_width_minus_1 f(n) where n = frame_width_bits_minus_1 + 1
     value = bitReader.read(frameWidthBitsMinus1 + 1);
@@ -891,16 +902,20 @@ std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<cons
             return std::nullopt;
         frameIdNumbersPresentFlag = *value;
     }
+    info.frameIdNumbersPresentFlag = frameIdNumbersPresentFlag;
 
     if (frameIdNumbersPresentFlag) {
         // delta_frame_id_length_minus_2 f(4)
         value = bitReader.read(4);
         if (!value)
             return std::nullopt;
+        uint32_t deltaFrameIdLengthMinus2 = static_cast<uint32_t>(*value);
         // additional_frame_id_length_minus_1 f(3)
         value = bitReader.read(3);
         if (!value)
             return std::nullopt;
+        uint32_t additionalFrameIdLengthMinus1 = static_cast<uint32_t>(*value);
+        info.idLen = additionalFrameIdLengthMinus1 + deltaFrameIdLengthMinus2 + 3;
     }
 
     // use_128x128_superblock f(1)
@@ -944,6 +959,7 @@ std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<cons
         if (!value)
             return std::nullopt;
         bool enableOrderHint = *value;
+        info.enableOrderHint = enableOrderHint;
 
         if (enableOrderHint) {
             // enable_jnt_comp f(1)
@@ -971,7 +987,9 @@ std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<cons
                 return std::nullopt;
             seqForceScreenContentTools = *value;
         }
+        info.seqForceScreenContentTools = static_cast<uint8_t>(seqForceScreenContentTools);
 
+        size_t seqForceIntegerMv = 2; // SELECT_INTEGER_MV
         if (seqForceScreenContentTools > 0) {
             // seq_choose_integer_mv f(1)
             value = bitReader.read(1);
@@ -984,14 +1002,18 @@ std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<cons
                 value = bitReader.read(1);
                 if (!value)
                     return std::nullopt;
+                seqForceIntegerMv = *value;
             }
-        }
+        } else
+            seqForceIntegerMv = 0;
+        info.seqForceIntegerMv = static_cast<uint8_t>(seqForceIntegerMv);
 
         if (enableOrderHint) {
             // order_hint_bits_minus_1 f(3)
             value = bitReader.read(3);
             if (!value)
                 return std::nullopt;
+            info.orderHintBits = static_cast<uint8_t>(*value + 1);
         }
     }
 
@@ -1148,7 +1170,7 @@ std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<cons
         chromaSubsamplingValue += chromaSamplePosition;
     record.chromaSubsampling = chromaSubsamplingValue;
 
-    return record;
+    return info;
 }
 
 PlatformVideoColorSpace createPlatformVideoColorSpaceFromAV1CodecConfigurationRecord(const AV1CodecConfigurationRecord& record)
@@ -1322,52 +1344,256 @@ static size_t NODELETE readULEBSize(std::span<const uint8_t> data, size_t& index
     return value;
 }
 
-static std::optional<std::pair<std::span<const uint8_t>, std::span<const uint8_t>>> NODELETE getSequenceHeaderOBU(std::span<const uint8_t> data)
+// AV1 OBU types per AV1 spec section 6.2.1.
+constexpr uint8_t OBU_SEQUENCE_HEADER = 1;
+constexpr uint8_t OBU_FRAME_HEADER = 3;
+constexpr uint8_t OBU_FRAME = 6;
+constexpr uint8_t OBU_REDUNDANT_FRAME_HEADER = 7;
+
+// AV1 frame types per AV1 spec section 6.8.2.
+constexpr uint8_t AV1_FRAME_TYPE_KEY = 0;
+constexpr uint8_t AV1_FRAME_TYPE_INTRA_ONLY = 2;
+constexpr uint8_t AV1_FRAME_TYPE_SWITCH = 3;
+
+struct AV1OBUInfo {
+    uint8_t type;
+    std::span<const uint8_t> fullOBU;
+    std::span<const uint8_t> payload;
+};
+
+static std::optional<AV1OBUInfo> findOBU(std::span<const uint8_t> data, std::initializer_list<uint8_t> wantedTypes)
 {
     size_t index = 0;
-    do {
-        if (index >= data.size())
-            return std::nullopt;
-
+    while (index < data.size()) {
         auto startIndex = index;
         auto value = data[index++];
         if (value >> 7)
             return std::nullopt;
-        auto headerType = value >> 3;
+        auto headerType = (value >> 3) & 0xF;
         bool hasPayloadSize = value & 0x02;
         if (!hasPayloadSize)
             return std::nullopt;
 
         bool hasExtension = value & 0x04;
-        if (hasExtension)
+        if (hasExtension) {
+            if (index >= data.size())
+                return std::nullopt;
             ++index;
+        }
 
         Checked<size_t> payloadSize = readULEBSize(data, index);
-        if (index + payloadSize >= data.size())
+        if (index + payloadSize > data.size())
             return std::nullopt;
 
-        if (headerType == 1) {
-            auto fullObu = data.subspan(startIndex, payloadSize + index - startIndex);
-            auto obuData = data.subspan(index, payloadSize);
-            return std::make_pair(fullObu, obuData);
+        for (auto wantedType : wantedTypes) {
+            if (headerType == wantedType) {
+                return AV1OBUInfo {
+                    static_cast<uint8_t>(headerType),
+                    data.subspan(startIndex, index + payloadSize - startIndex),
+                    data.subspan(index, payloadSize)
+                };
+            }
         }
 
         index += payloadSize;
-    } while (true);
+    }
     return std::nullopt;
+}
+
+// Parses the uncompressed_header() from a Frame Header OBU (or the header portion of a Frame OBU)
+// just far enough to read frame_size() per AV1 spec section 5.9.1. Returns the actual frame
+// dimensions when frame_size_override_flag is set; std::nullopt otherwise (caller should fall back
+// to the max dimensions from the sequence header).
+static std::optional<std::pair<uint32_t, uint32_t>> parseFrameSizeFromFrameHeaderOBU(std::span<const uint8_t> data, const AV1SequenceHeaderInfo& info)
+{
+    BitReader bitReader(data);
+    std::optional<size_t> value;
+
+    if (info.reducedStillPictureHeader) {
+        // Per spec: frame_size_override_flag is forced to 0; no per-frame size override is possible.
+        return std::nullopt;
+    }
+
+    // show_existing_frame f(1)
+    value = bitReader.read(1);
+    if (!value)
+        return std::nullopt;
+    if (*value) {
+        // show_existing_frame returns early; no new frame size is signalled.
+        return std::nullopt;
+    }
+
+    // frame_type f(2)
+    value = bitReader.read(2);
+    if (!value)
+        return std::nullopt;
+    uint8_t frameType = static_cast<uint8_t>(*value);
+    bool frameIsIntra = frameType == AV1_FRAME_TYPE_KEY || frameType == AV1_FRAME_TYPE_INTRA_ONLY;
+
+    // show_frame f(1)
+    value = bitReader.read(1);
+    if (!value)
+        return std::nullopt;
+    bool showFrame = *value;
+
+    if (showFrame && info.decoderModelInfoPresentFlag && !info.equalPictureInterval) {
+        // temporal_point_info() reads frame_presentation_time_length bits, which we don't track.
+        return std::nullopt;
+    }
+
+    if (!showFrame) {
+        // showable_frame f(1)
+        value = bitReader.read(1);
+        if (!value)
+            return std::nullopt;
+    }
+
+    bool errorResilientMode;
+    if (frameType == AV1_FRAME_TYPE_SWITCH || (frameType == AV1_FRAME_TYPE_KEY && showFrame))
+        errorResilientMode = true;
+    else {
+        // error_resilient_mode f(1)
+        value = bitReader.read(1);
+        if (!value)
+            return std::nullopt;
+        errorResilientMode = *value;
+    }
+
+    // disable_cdf_update f(1)
+    value = bitReader.read(1);
+    if (!value)
+        return std::nullopt;
+
+    // allow_screen_content_tools
+    bool allowScreenContentTools = !!info.seqForceScreenContentTools;
+    if (info.seqForceScreenContentTools == 2) {
+        // SELECT_SCREEN_CONTENT_TOOLS
+        value = bitReader.read(1);
+        if (!value)
+            return std::nullopt;
+        allowScreenContentTools = *value;
+    }
+    if (allowScreenContentTools && info.seqForceIntegerMv == 2) {
+        // SELECT_INTEGER_MV: force_integer_mv f(1)
+        value = bitReader.read(1);
+        if (!value)
+            return std::nullopt;
+    }
+
+    if (info.frameIdNumbersPresentFlag) {
+        // current_frame_id f(idLen)
+        value = bitReader.read(info.idLen);
+        if (!value)
+            return std::nullopt;
+    }
+
+    // frame_size_override_flag
+    bool frameSizeOverrideFlag;
+    if (frameType == AV1_FRAME_TYPE_SWITCH)
+        frameSizeOverrideFlag = true;
+    else {
+        value = bitReader.read(1);
+        if (!value)
+            return std::nullopt;
+        frameSizeOverrideFlag = *value;
+    }
+
+    if (!frameSizeOverrideFlag)
+        return std::nullopt;
+
+    // FIXME: for now we can only resolve frame_size() for KEY_FRAME or INTRA_ONLY_FRAME;
+    // Inter frames may use frame_size_with_refs() which depends on reference-frame state.
+    if (frameType != AV1_FRAME_TYPE_KEY && frameType != AV1_FRAME_TYPE_INTRA_ONLY)
+        return std::nullopt;
+
+    // order_hint f(OrderHintBits)
+    if (info.orderHintBits) {
+        value = bitReader.read(info.orderHintBits);
+        if (!value)
+            return std::nullopt;
+    }
+
+    // primary_ref_frame f(3) only when !FrameIsIntra && !error_resilient_mode. Skipped here.
+
+    if (info.decoderModelInfoPresentFlag) {
+        // buffer_removal_time_present_flag f(1)
+        value = bitReader.read(1);
+        if (!value)
+            return std::nullopt;
+        bool bufferRemovalTimePresentFlag = *value;
+        if (bufferRemovalTimePresentFlag) {
+            // For each operating point, buffer_removal_time may be read; the conditional depends on temporal_id and spatial_id matching, which we don't have.
+            // If any op has decoder_model_present, conservatively bail.
+            for (uint8_t i = 0; i < info.operatingPointsCount; ++i) {
+                if (info.decoderModelPresentForThisOp[i])
+                    return std::nullopt;
+            }
+        }
+    }
+
+    // refresh_frame_flags
+    uint32_t refreshFrameFlags = 0xFF;
+    if (frameType != AV1_FRAME_TYPE_KEY || !showFrame) {
+        // KEY_FRAME with !showFrame, or INTRA_ONLY_FRAME (we filtered out other types above).
+        value = bitReader.read(8);
+        if (!value)
+            return std::nullopt;
+        refreshFrameFlags = static_cast<uint32_t>(*value);
+    }
+
+    // ref_order_hint loop: runs when (!FrameIsIntra || refresh_frame_flags != allFrames)
+    // && error_resilient_mode && enable_order_hint. Each iteration reads OrderHintBits.
+    if ((!frameIsIntra || refreshFrameFlags != 0xFF) && errorResilientMode && info.enableOrderHint) {
+        constexpr int NUM_REF_FRAMES = 8;
+        for (int i = 0; i < NUM_REF_FRAMES; ++i) {
+            if (info.orderHintBits) {
+                value = bitReader.read(info.orderHintBits);
+                if (!value)
+                    return std::nullopt;
+            }
+        }
+    }
+
+    // frame_size()
+    size_t bitsCount = static_cast<size_t>(info.frameWidthBitsMinus1) + 1;
+    value = bitReader.read(bitsCount);
+    if (!value)
+        return std::nullopt;
+    uint32_t width = static_cast<uint32_t>(*value + 1);
+
+    bitsCount = static_cast<size_t>(info.frameHeightBitsMinus1) + 1;
+    value = bitReader.read(bitsCount);
+    if (!value)
+        return std::nullopt;
+    uint32_t height = static_cast<uint32_t>(*value + 1);
+
+    if (!width || !height)
+        return std::nullopt;
+    if (width > info.codecRecord.width || height > info.codecRecord.height)
+        return std::nullopt;
+
+    return std::make_pair(width, height);
 }
 
 RefPtr<VideoInfo> createVideoInfoFromAV1Stream(std::span<const uint8_t> data, std::optional<FloatSize> displaySize, const std::optional<PlatformVideoColorSpace>& colorSpaceOverride)
 {
-    auto sequenceHeaderData = getSequenceHeaderOBU(data);
+    auto sequenceHeaderData = findOBU(data, { OBU_SEQUENCE_HEADER });
     if (!sequenceHeaderData)
         return { };
 
-    auto record = parseSequenceHeaderOBU(sequenceHeaderData->second);
-    if (!record)
+    auto info = parseSequenceHeaderOBU(sequenceHeaderData->payload);
+    if (!info)
         return { };
 
-    return createVideoInfoFromAV1CodecConfigurationRecord(*record, sequenceHeaderData->first, displaySize, colorSpaceOverride);
+    AV1CodecConfigurationRecord record = info->codecRecord;
+    if (auto frameOBU = findOBU(data, { OBU_FRAME_HEADER, OBU_FRAME, OBU_REDUNDANT_FRAME_HEADER })) {
+        if (auto frameSize = parseFrameSizeFromFrameHeaderOBU(frameOBU->payload, *info)) {
+            record.width = frameSize->first;
+            record.height = frameSize->second;
+        }
+    }
+
+    return createVideoInfoFromAV1CodecConfigurationRecord(record, sequenceHeaderData->fullOBU, displaySize, colorSpaceOverride);
 }
 
 }

--- a/Source/WebCore/platform/graphics/AV1Utilities.h
+++ b/Source/WebCore/platform/graphics/AV1Utilities.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include "FloatSize.h"
-#include "PlatformExportMacros.h"
-#include "PlatformVideoColorSpace.h"
-#include "SharedBuffer.h"
+#include <WebCore/FloatSize.h>
+#include <WebCore/PlatformExportMacros.h>
+#include <WebCore/PlatformVideoColorSpace.h>
+#include <WebCore/SharedBuffer.h>
 #include <JavaScriptCore/DataView.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/RefPtr.h>
@@ -174,6 +174,28 @@ struct AV1CodecConfigurationRecord {
     uint32_t height { defaultHeight };
 };
 
+// Sequence header state captured during parsing. In addition to the codec configuration record
+// it carries the parser context required by uncompressed_header() to locate the frame size,
+// so a subsequent frame header (or frame) OBU can be parsed to honour frame_size_override_flag.
+struct AV1SequenceHeaderInfo {
+    AV1CodecConfigurationRecord codecRecord;
+
+    bool reducedStillPictureHeader { false };
+    bool frameIdNumbersPresentFlag { false };
+    uint32_t idLen { 0 };
+    bool decoderModelInfoPresentFlag { false };
+    bool equalPictureInterval { true };
+    uint8_t bufferRemovalTimeLengthMinus1 { 0 };
+    bool enableOrderHint { false };
+    uint8_t orderHintBits { 0 };
+    uint8_t seqForceScreenContentTools { 0 };
+    uint8_t seqForceIntegerMv { 0 };
+    uint8_t frameWidthBitsMinus1 { 0 };
+    uint8_t frameHeightBitsMinus1 { 0 };
+    uint8_t operatingPointsCount { 0 };
+    std::array<bool, 32> decoderModelPresentForThisOp { };
+};
+
 struct PlatformMediaCapabilitiesVideoConfiguration;
 class VideoInfo;
 
@@ -184,7 +206,7 @@ WEBCORE_EXPORT bool NODELETE validateAV1ConfigurationRecord(const AV1CodecConfig
 WEBCORE_EXPORT bool validateAV1PerLevelConstraints(const AV1CodecConfigurationRecord&, const PlatformMediaCapabilitiesVideoConfiguration&);
 
 std::optional<AV1CodecConfigurationRecord> parseAV1DecoderConfigurationRecord(std::span<const uint8_t>);
-std::optional<AV1CodecConfigurationRecord> parseSequenceHeaderOBU(std::span<const uint8_t>);
+std::optional<AV1SequenceHeaderInfo> parseSequenceHeaderOBU(std::span<const uint8_t>);
 WEBCORE_EXPORT PlatformVideoColorSpace createPlatformVideoColorSpaceFromAV1CodecConfigurationRecord(const AV1CodecConfigurationRecord&);
 WEBCORE_EXPORT RefPtr<VideoInfo> createVideoInfoFromAV1Stream(std::span<const uint8_t>, std::optional<FloatSize> = std::nullopt, const std::optional<PlatformVideoColorSpace>& colorSpaceOverride = std::nullopt);
 

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -207,6 +207,7 @@ if (ENABLE_WEBCORE)
         Helpers/Utilities.cpp
         Helpers/WebCoreTestUtilities.cpp
 
+        Tests/WebCore/AV1Utilities.cpp
         Tests/WebCore/AffineTransform.cpp
         Tests/WebCore/AudioSampleFormat.cpp
         Tests/WebCore/CSSParser.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -529,6 +529,7 @@
 		07AA27602F83C3A900FE10FC /* Exceptions for "Tests" folder in "TestWebKitAPI" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				WebCore/AV1Utilities.cpp,
 				WebKit/WebPage/AppKitGesturesTests.swift,
 				WebKit/WebPage/EditingFontSizeTests.swift,
 				WebKit/WebPage/JavaScriptExpressionTests.swift,

--- a/Tools/TestWebKitAPI/Tests/WebCore/AV1Utilities.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/AV1Utilities.cpp
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <WebCore/AV1Utilities.h>
+#include <WebCore/TrackInfo.h>
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+// Minimal MSB-first bit writer used to assemble synthetic AV1 OBUs for the parser tests.
+class BitWriter {
+public:
+    void writeBit(bool b)
+    {
+        if (!m_remainingBits) {
+            m_bytes.append(0);
+            m_remainingBits = 8;
+        }
+        if (b)
+            m_bytes.last() |= (1u << (m_remainingBits - 1));
+        --m_remainingBits;
+    }
+
+    void write(uint64_t value, size_t bits)
+    {
+        for (size_t i = 0; i < bits; ++i)
+            writeBit((value >> (bits - 1 - i)) & 1);
+    }
+
+    Vector<uint8_t> takeBytes() { return std::exchange(m_bytes, { }); }
+
+private:
+    Vector<uint8_t> m_bytes;
+    size_t m_remainingBits { 0 };
+};
+
+// Builds the simplest valid AV1 sequence header payload: profile 0, 8-bit 4:2:0, single
+// operating point at level 2.0, no timing info, no decoder-model info, no order hints.
+static Vector<uint8_t> buildSequenceHeaderPayload(uint32_t maxWidth, uint32_t maxHeight, size_t widthBitsMinus1, size_t heightBitsMinus1)
+{
+    BitWriter w;
+    w.write(0, 3);     // seq_profile
+    w.writeBit(false); // still_picture
+    w.writeBit(false); // reduced_still_picture_header
+    w.writeBit(false); // timing_info_present_flag
+    w.writeBit(false); // initial_display_delay_present_flag
+    w.write(0, 5);     // operating_points_cnt_minus_1
+    w.write(0, 12);    // operating_point_idc[0]
+    w.write(0, 5);     // seq_level_idx[0] (level 2.0; no tier byte since <= 7)
+    w.write(widthBitsMinus1, 4);
+    w.write(heightBitsMinus1, 4);
+    w.write(maxWidth - 1, widthBitsMinus1 + 1);
+    w.write(maxHeight - 1, heightBitsMinus1 + 1);
+    w.writeBit(false); // frame_id_numbers_present_flag
+    w.writeBit(false); // use_128x128_superblock
+    w.writeBit(false); // enable_filter_intra
+    w.writeBit(false); // enable_intra_edge_filter
+    w.writeBit(false); // enable_interintra_compound
+    w.writeBit(false); // enable_masked_compound
+    w.writeBit(false); // enable_warped_motion
+    w.writeBit(false); // enable_dual_filter
+    w.writeBit(false); // enable_order_hint
+    w.writeBit(true);  // seq_choose_screen_content_tools (=> seq_force_screen_content_tools = SELECT)
+    w.writeBit(true);  // seq_choose_integer_mv (=> seq_force_integer_mv = SELECT)
+    w.writeBit(false); // enable_superres
+    w.writeBit(false); // enable_cdef
+    w.writeBit(false); // enable_restoration
+    w.writeBit(false); // high_bitdepth
+    w.writeBit(false); // monochrome
+    w.writeBit(false); // color_description_present_flag
+    w.writeBit(false); // color_range
+    w.write(0, 2);     // chroma_sample_position (4:2:0 in profile 0 reads CSP)
+    return w.takeBytes();
+}
+
+// Builds an uncompressed_header() payload for a KEY_FRAME with show_frame=1 sized to use the
+// minimum number of fields we can construct without a full reference-frame model.
+static Vector<uint8_t> buildKeyFrameHeaderPayload(uint32_t width, uint32_t height, size_t widthBitsMinus1, size_t heightBitsMinus1, bool sizeOverride)
+{
+    BitWriter w;
+    w.writeBit(false); // show_existing_frame
+    w.write(0, 2);     // frame_type = KEY_FRAME
+    w.writeBit(true);  // show_frame
+    // showable_frame: not read because show_frame == 1
+    // error_resilient_mode: not read because (frame_type == KEY && show_frame)
+    w.writeBit(false); // disable_cdf_update
+    w.writeBit(false); // allow_screen_content_tools (SELECT path)
+    // force_integer_mv: not read because allow_screen_content_tools == 0
+    // current_frame_id: not read because frame_id_numbers_present_flag == 0
+    w.writeBit(sizeOverride); // frame_size_override_flag
+    // order_hint: skipped because OrderHintBits == 0
+    // primary_ref_frame: skipped because FrameIsIntra && error_resilient_mode
+    // decoder_model_info: skipped (not present)
+    // refresh_frame_flags: not read because (KEY && show_frame) implies allFrames
+    // ref_order_hint loop: not read (allFrames already, FrameIsIntra)
+    if (sizeOverride) {
+        w.write(width - 1, widthBitsMinus1 + 1);
+        w.write(height - 1, heightBitsMinus1 + 1);
+    }
+    return w.takeBytes();
+}
+
+// Wraps `payload` with an OBU header (forbidden=0, ext=0, has_size=1) and a ULEB128 size.
+static Vector<uint8_t> wrapInOBU(uint8_t obuType, std::span<const uint8_t> payload)
+{
+    Vector<uint8_t> out;
+    out.append(static_cast<uint8_t>((obuType << 3) | 0x02));
+    size_t size = payload.size();
+    while (size >= 0x80) {
+        out.append(static_cast<uint8_t>((size & 0x7F) | 0x80));
+        size >>= 7;
+    }
+    out.append(static_cast<uint8_t>(size));
+    out.append(payload);
+    return out;
+}
+
+static Vector<uint8_t> buildBitstream(uint32_t maxWidth, uint32_t maxHeight, std::optional<std::pair<uint32_t, uint32_t>> frameSize, uint8_t frameOBUType, size_t widthBitsMinus1 = 12, size_t heightBitsMinus1 = 12)
+{
+    auto seqPayload = buildSequenceHeaderPayload(maxWidth, maxHeight, widthBitsMinus1, heightBitsMinus1);
+    auto seqOBU = wrapInOBU(/* OBU_SEQUENCE_HEADER */ 1, seqPayload.span());
+
+    Vector<uint8_t> bitstream;
+    bitstream.append(seqOBU.span());
+
+    if (frameOBUType) {
+        auto framePayload = buildKeyFrameHeaderPayload(
+            frameSize ? frameSize->first : maxWidth,
+            frameSize ? frameSize->second : maxHeight,
+            widthBitsMinus1, heightBitsMinus1,
+            frameSize.has_value());
+        auto frameOBU = wrapInOBU(frameOBUType, framePayload.span());
+        bitstream.append(frameOBU.span());
+    }
+    return bitstream;
+}
+
+TEST(AV1Utilities, CreateVideoInfo_FallsBackToMaxWhenNoOverride)
+{
+    auto bitstream = buildBitstream(8192, 8192, std::nullopt, /* OBU_FRAME_HEADER */ 3);
+    auto videoInfo = WebCore::createVideoInfoFromAV1Stream(bitstream.span());
+    ASSERT_TRUE(videoInfo);
+    EXPECT_EQ(static_cast<uint32_t>(videoInfo->size().width()), 8192u);
+    EXPECT_EQ(static_cast<uint32_t>(videoInfo->size().height()), 8192u);
+}
+
+TEST(AV1Utilities, CreateVideoInfo_HonoursFrameSizeOverride)
+{
+    auto bitstream = buildBitstream(8192, 8192, { { 1920, 1080 } }, /* OBU_FRAME_HEADER */ 3);
+    auto videoInfo = WebCore::createVideoInfoFromAV1Stream(bitstream.span());
+    ASSERT_TRUE(videoInfo);
+    EXPECT_EQ(static_cast<uint32_t>(videoInfo->size().width()), 1920u);
+    EXPECT_EQ(static_cast<uint32_t>(videoInfo->size().height()), 1080u);
+}
+
+TEST(AV1Utilities, CreateVideoInfo_FrameSizeOverrideInsideOBU_FRAME)
+{
+    // OBU_FRAME (type 6) carries the same uncompressed_header() bytes; verify the parser
+    // honours the override regardless of whether it was a header-only or combined OBU.
+    auto bitstream = buildBitstream(4096, 4096, { { 640, 360 } }, /* OBU_FRAME */ 6);
+    auto videoInfo = WebCore::createVideoInfoFromAV1Stream(bitstream.span());
+    ASSERT_TRUE(videoInfo);
+    EXPECT_EQ(static_cast<uint32_t>(videoInfo->size().width()), 640u);
+    EXPECT_EQ(static_cast<uint32_t>(videoInfo->size().height()), 360u);
+}
+
+TEST(AV1Utilities, CreateVideoInfo_RedundantFrameHeaderHonoured)
+{
+    auto bitstream = buildBitstream(2048, 2048, { { 800, 600 } }, /* OBU_REDUNDANT_FRAME_HEADER */ 7);
+    auto videoInfo = WebCore::createVideoInfoFromAV1Stream(bitstream.span());
+    ASSERT_TRUE(videoInfo);
+    EXPECT_EQ(static_cast<uint32_t>(videoInfo->size().width()), 800u);
+    EXPECT_EQ(static_cast<uint32_t>(videoInfo->size().height()), 600u);
+}
+
+TEST(AV1Utilities, CreateVideoInfo_RejectsFrameSizeAboveMax)
+{
+    // Per-frame size larger than the sequence-header max should be ignored and the parser
+    // should fall back to max — never report a width that exceeds frame_width_bits_minus_1.
+    auto bitstream = buildBitstream(1920, 1080, { { 4096, 4096 } }, /* OBU_FRAME_HEADER */ 3, 12, 12);
+    auto videoInfo = WebCore::createVideoInfoFromAV1Stream(bitstream.span());
+    ASSERT_TRUE(videoInfo);
+    EXPECT_EQ(static_cast<uint32_t>(videoInfo->size().width()), 1920u);
+    EXPECT_EQ(static_cast<uint32_t>(videoInfo->size().height()), 1080u);
+}
+
+TEST(AV1Utilities, CreateVideoInfo_NoSequenceHeaderReturnsNull)
+{
+    // A frame OBU on its own (no sequence header in the same buffer) should fail to produce
+    // a VideoInfo because the codec record cannot be reconstructed.
+    auto framePayload = buildKeyFrameHeaderPayload(1920, 1080, 12, 12, true);
+    auto frameOBU = wrapInOBU(/* OBU_FRAME_HEADER */ 3, framePayload.span());
+    auto videoInfo = WebCore::createVideoInfoFromAV1Stream(frameOBU.span());
+    EXPECT_FALSE(videoInfo);
+}
+
+}


### PR DESCRIPTION
#### 21d113853f62a0dcd232e9ba222529b7134e3969
<pre>
Add AV1 intra support for frame size overriding
<a href="https://rdar.apple.com/178436596">rdar://178436596</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316531">https://bugs.webkit.org/show_bug.cgi?id=316531</a>

Reviewed by NOBODY (OOPS!).

When an AV1 stream signals max_frame_width / max_frame_height in the sequence header
larger than the actual frame size and uses frame_size_override_flag = 1 on each frame to
carry the real dimensions, WebKit reports the max-frame size as the video format dimensions.

We fix this by doing the following:
- createVideoInfoFromAV1Stream now also locates the frame header OBU in the buffer;
  for KEY / INTRA_ONLY frames it reads frame_size_override_flag and, if set, returns the
  per-frame dimensions in place of the sequence-header max. parseSequenceHeaderOBU now
  returns an AV1SequenceHeaderInfo struct that carries the parser context required to
  walk uncompressed_header() up to frame_size() (frame_width_bits_minus_1,
  frame_id_numbers_present_flag, order_hint_bits, ...), and the full sequence header OBU
  bytes so callers can rebuild the av1C box for frames that arrive without an in-stream
  sequence header.
- Inter frames are still bailed on - frame_size_with_refs() depends on reference-frame
  state we don&apos;t track. The Garmin scenario relies on key frames for resolution changes,
  which is the typical pattern for AV1 dynamic resolution.
- WebRTCVideoDecoderVTBAV1 now caches an AV1SequenceHeaderInfo across decodeFrame calls
  and threads it into createVideoInfoFromAV1Stream, so inter packets that don&apos;t carry a
  sequence header can still produce a format description from the cached one.
  sequence header can still produce a format description from the cached one.

Drive-by: getSequenceHeaderOBU&apos;s `index + payloadSize &gt;= data.size()` is now `&gt;`, which
correctly accepts an OBU whose payload exactly fills the buffer; merged its body with
the new findOBU helper so OBU walking lives in one place.

We cover the fix with API tests.

Coauthored with Claude 4.7

Test: Tools/TestWebKitAPI/Tests/WebCore/AV1Utilities.cpp
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/AV1Utilities.cpp:
* Source/WebCore/platform/graphics/AV1Utilities.h:
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBAV1.mm:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/AV1Utilities.cpp: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbba480b2379ced866def5de249a70d867637c87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168838 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126545 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15cb30d7-818d-4e27-9c41-626438f0883c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170704 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131470 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92485 "1 flakes 10 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2146fd1-2623-4b99-b308-4d63a447711d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33924 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151745 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 6 api tests failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111974 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/782cc593-d158-43db-9853-5382e5b86fd0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32911 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31623 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26864 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180770 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139918 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42409 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139762 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43098 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28117 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106871 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35044 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114865 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41601 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6205 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40998 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41252 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41143 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->