### PR TITLE
Parse and serialize scroll-state container queries

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5717,10 +5717,18 @@ imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-lay
 imported/w3c/web-platform-tests/css/css-conditional/container-queries/inline-size-bfc-floats.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-010.html [ ImageOnlyFailure ]
 
-# Scroll-state container queries (unsupported), enable parsing and computed-value tests only.
+# Scroll-state container queries (evaluation unsupported), enable parsing/serialization and computed-value tests only.
 imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state [ Skip ]
 imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/container-type-scroll-state-parsing.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/container-type-scroll-state-computed.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-parsing.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-serialization.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-parsing.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-serialization.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-parsing.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-serialization.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-parsing.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-serialization.html [ Pass ]
 
 webkit.org/b/279424 [ Debug ] imported/w3c/web-platform-tests/css/css-conditional/container-queries/svg-foreignobject-no-size-container.html [ Skip ] # Crash
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-parsing-expected.txt
@@ -1,4 +1,25 @@
 
-Harness Error (FAIL), message = Error: assert_implements: Basic support for scroll-state container queries required undefined
-
+PASS Query condition should be valid: scroll-state(scrollable)
+PASS Query condition should be valid: scroll-state(scrollable: none)
+PASS Query condition should be valid: scroll-state(scrollable: top)
+PASS Query condition should be valid: scroll-state(scrollable: left)
+PASS Query condition should be valid: scroll-state(scrollable: bottom)
+PASS Query condition should be valid: scroll-state(scrollable: right)
+PASS Query condition should be valid: scroll-state(scrollable: inline-start)
+PASS Query condition should be valid: scroll-state(scrollable: inline-end)
+PASS Query condition should be valid: scroll-state(scrollable: block-start)
+PASS Query condition should be valid: scroll-state(scrollable: block-end)
+PASS Query condition should be valid: scroll-state(scrollable: block)
+PASS Query condition should be valid: scroll-state(scrollable: x)
+PASS Query condition should be valid: scroll-state(scrollable: y)
+PASS Query condition should be valid: scroll-state(scrollable: inline)
+PASS Query condition should be valid: (scroll-state(scrollable: inline-end))
+PASS Query condition should be valid: scroll-state((scrollable: left))
+PASS Query condition should be valid: scroll-state(not ((scrollable: bottom) and (scrollable: right)))
+PASS Query condition should be valid: scroll-state((scrollable: left) or (scrollable: top))
+PASS Query condition should be valid but unknown: scroll-state(scrollable: auto)
+PASS Query condition should be valid but unknown: scroll-state(scrollable: true)
+PASS Query condition should be valid but unknown: scroll-state(style(scrollable: left))
+PASS Query condition should be valid but unknown: style(scroll-state(scrollable: left))
+PASS Query condition should be valid but unknown: scroll-state(scrollable:)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-serialization-expected.txt
@@ -1,4 +1,7 @@
 
-Harness Error (FAIL), message = Error: assert_implements: Basic support for scroll-state container queries required undefined
-
+PASS Normalize spaces
+FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(scrollable:    )" but got "scroll-state(scrollable: )"
+PASS Boolean context
+PASS Logical with 'or'
+PASS Not a scroll-state function with space before '('
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-parsing-expected.txt
@@ -1,4 +1,25 @@
 
-Harness Error (FAIL), message = Error: assert_implements: Basic support for scroll-state container queries required undefined
-
+PASS Query condition should be valid: scroll-state(scrolled)
+PASS Query condition should be valid: scroll-state(scrolled: none)
+PASS Query condition should be valid: scroll-state(scrolled: top)
+PASS Query condition should be valid: scroll-state(scrolled: left)
+PASS Query condition should be valid: scroll-state(scrolled: bottom)
+PASS Query condition should be valid: scroll-state(scrolled: right)
+PASS Query condition should be valid: scroll-state(scrolled: inline-start)
+PASS Query condition should be valid: scroll-state(scrolled: inline-end)
+PASS Query condition should be valid: scroll-state(scrolled: block-start)
+PASS Query condition should be valid: scroll-state(scrolled: block-end)
+PASS Query condition should be valid: scroll-state(scrolled: block)
+PASS Query condition should be valid: scroll-state(scrolled: x)
+PASS Query condition should be valid: scroll-state(scrolled: y)
+PASS Query condition should be valid: scroll-state(scrolled: inline)
+PASS Query condition should be valid: (scroll-state(scrolled: inline-end))
+PASS Query condition should be valid: scroll-state((scrolled: left))
+PASS Query condition should be valid: scroll-state(not ((scrolled: bottom) and (scrolled: right)))
+PASS Query condition should be valid: scroll-state((scrolled: left) or (scrolled: top))
+PASS Query condition should be valid but unknown: scroll-state(scrolled: auto)
+PASS Query condition should be valid but unknown: scroll-state(scrolled: true)
+PASS Query condition should be valid but unknown: scroll-state(style(scrolled: left))
+PASS Query condition should be valid but unknown: style(scroll-state(scrolled: left))
+PASS Query condition should be valid but unknown: scroll-state(scrolled:)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-serialization-expected.txt
@@ -1,4 +1,7 @@
 
-Harness Error (FAIL), message = Error: assert_implements: Basic support for scroll-state container queries required undefined
-
+PASS Normalize spaces
+FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(scrolled:    )" but got "scroll-state(scrolled: )"
+PASS Boolean context
+PASS Logical with 'or'
+PASS Not a scroll-state function with space before '('
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-parsing-expected.txt
@@ -1,4 +1,18 @@
 
-Harness Error (FAIL), message = Error: assert_implements: Basic support for scroll-state container queries required undefined
-
+PASS Query condition should be valid: scroll-state(snapped)
+PASS Query condition should be valid: scroll-state(snapped: x)
+PASS Query condition should be valid: scroll-state(snapped: y)
+PASS Query condition should be valid: scroll-state(snapped: none)
+PASS Query condition should be valid: scroll-state(snapped: block)
+PASS Query condition should be valid: scroll-state(snapped: inline)
+PASS Query condition should be valid: scroll-state(snapped: both)
+PASS Query condition should be valid: (scroll-state(snapped: block))
+PASS Query condition should be valid: scroll-state((snapped: inline))
+PASS Query condition should be valid: scroll-state(not ((snapped: inline) and (snapped: block)))
+PASS Query condition should be valid: scroll-state((snapped: x) or (snapped: y))
+PASS Query condition should be valid but unknown: scroll-state(snapped: auto)
+PASS Query condition should be valid but unknown: scroll-state(snapped: true)
+PASS Query condition should be valid but unknown: scroll-state(style(snapped: inline))
+PASS Query condition should be valid but unknown: style(scroll-state(snapped: inline))
+PASS Query condition should be valid but unknown: scroll-state(snapped:)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-serialization-expected.txt
@@ -1,4 +1,7 @@
 
-Harness Error (FAIL), message = Error: assert_implements: Basic support for scroll-state container queries required undefined
-
+PASS Normalize spaces
+FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(snapped:    )" but got "scroll-state(snapped: )"
+PASS Boolean context
+PASS Logical with 'or'
+PASS Not a scroll-state function with space before '('
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-parsing-expected.txt
@@ -1,4 +1,22 @@
 
-Harness Error (FAIL), message = Error: assert_implements: Basic support for scroll-state container queries required undefined
-
+PASS Query condition should be valid: scroll-state(stuck)
+PASS Query condition should be valid: scroll-state(stuck: none)
+PASS Query condition should be valid: scroll-state(stuck: top)
+PASS Query condition should be valid: scroll-state(stuck: left)
+PASS Query condition should be valid: scroll-state(stuck: bottom)
+PASS Query condition should be valid: scroll-state(stuck: right)
+PASS Query condition should be valid: scroll-state(stuck: block-start)
+PASS Query condition should be valid: scroll-state(stuck: block-end)
+PASS Query condition should be valid: scroll-state(stuck: inline-start)
+PASS Query condition should be valid: scroll-state(stuck: inline-end)
+PASS Query condition should be valid: (scroll-state(stuck: top))
+PASS Query condition should be valid: scroll-state((stuck: top))
+PASS Query condition should be valid: scroll-state(not ((stuck: top) and (stuck: bottom)))
+PASS Query condition should be valid: scroll-state((stuck: right) or (stuck: left))
+PASS Query condition should be valid but unknown: scroll-state(stuck: auto)
+PASS Query condition should be valid but unknown: scroll-state(stuck: true)
+PASS Query condition should be valid but unknown: scroll-state(style(stuck: top))
+PASS Query condition should be valid but unknown: style(scroll-state(stuck: top))
+PASS Query condition should be valid but unknown: scroll-state(stuck:)
+PASS Query condition should be valid but unknown: scroll-state(--foo)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-serialization-expected.txt
@@ -1,4 +1,7 @@
 
-Harness Error (FAIL), message = Error: assert_implements: Basic support for scroll-state container queries required undefined
-
+PASS Normalize spaces
+FAIL No value - invalid, serializes as <general-enclosed> assert_equals: expected "scroll-STate(stuck:    )" but got "scroll-state(stuck: )"
+PASS Boolean context
+PASS Logical with 'or'
+PASS Not a scroll-state function with space before '('
 

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -226,6 +226,22 @@ struct StyleFeatureSchema : public FeatureSchema {
     }
 };
 
+// Scroll-state query features: scroll-state(scrollable | scrolled | stuck | snapped [: <keyword>]).
+// https://drafts.csswg.org/css-conditional-5/#scroll-state-container
+struct ScrollStateFeatureSchema : public FeatureSchema {
+    ScrollStateFeatureSchema(const AtomString& name, FixedVector<CSSValueID>&& valueIdentifiers)
+        : FeatureSchema(name, FeatureSchema::Type::Discrete, FeatureSchema::ValueType::Identifier, { }, WTF::move(valueIdentifiers))
+    {
+    }
+
+    EvaluationResult evaluate(const MQ::Feature&, const FeatureEvaluationContext&) const override
+    {
+        // FIXME: Evaluate the actual scroll state. For now the feature is recognized and
+        // evaluates to false (no active scroll state); real evaluation is a follow-up.
+        return EvaluationResult::False;
+    }
+};
+
 // MARK: - Singleton readonly instances of FeatureSchemas
 
 static const WidthFeatureSchema& widthFeatureSchema()
@@ -270,6 +286,30 @@ static const StyleFeatureSchema& styleFeatureSchema()
     return schema;
 }
 
+static const ScrollStateFeatureSchema& scrollableFeatureSchema()
+{
+    static MainThreadNeverDestroyed<ScrollStateFeatureSchema> schema { "scrollable"_s, FixedVector<CSSValueID> { CSSValueNone, CSSValueTop, CSSValueRight, CSSValueBottom, CSSValueLeft, CSSValueBlockStart, CSSValueBlockEnd, CSSValueInlineStart, CSSValueInlineEnd, CSSValueBlock, CSSValueInline, CSSValueX, CSSValueY } };
+    return schema;
+}
+
+static const ScrollStateFeatureSchema& scrolledFeatureSchema()
+{
+    static MainThreadNeverDestroyed<ScrollStateFeatureSchema> schema { "scrolled"_s, FixedVector<CSSValueID> { CSSValueNone, CSSValueTop, CSSValueRight, CSSValueBottom, CSSValueLeft, CSSValueBlockStart, CSSValueBlockEnd, CSSValueInlineStart, CSSValueInlineEnd, CSSValueBlock, CSSValueInline, CSSValueX, CSSValueY } };
+    return schema;
+}
+
+static const ScrollStateFeatureSchema& stuckFeatureSchema()
+{
+    static MainThreadNeverDestroyed<ScrollStateFeatureSchema> schema { "stuck"_s, FixedVector<CSSValueID> { CSSValueNone, CSSValueTop, CSSValueRight, CSSValueBottom, CSSValueLeft, CSSValueBlockStart, CSSValueBlockEnd, CSSValueInlineStart, CSSValueInlineEnd } };
+    return schema;
+}
+
+static const ScrollStateFeatureSchema& snappedFeatureSchema()
+{
+    static MainThreadNeverDestroyed<ScrollStateFeatureSchema> schema { "snapped"_s, FixedVector<CSSValueID> { CSSValueNone, CSSValueX, CSSValueY, CSSValueBlock, CSSValueInline, CSSValueBoth } };
+    return schema;
+}
+
 // MARK: - Type erased exposed schemas
 
 const MQ::FeatureSchema& width()
@@ -305,6 +345,19 @@ const MQ::FeatureSchema& orientation()
 const MQ::FeatureSchema& style()
 {
     return styleFeatureSchema();
+}
+
+const MQ::FeatureSchema* scrollState(const AtomString& name)
+{
+    if (name == "scrollable"_s)
+        return &scrollableFeatureSchema();
+    if (name == "scrolled"_s)
+        return &scrolledFeatureSchema();
+    if (name == "stuck"_s)
+        return &stuckFeatureSchema();
+    if (name == "snapped"_s)
+        return &snappedFeatureSchema();
+    return nullptr;
 }
 
 Vector<const MQ::FeatureSchema*> allSchemas()

--- a/Source/WebCore/css/query/ContainerQueryFeatures.h
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.h
@@ -51,6 +51,10 @@ const MQ::FeatureSchema& aspectRatio();
 const MQ::FeatureSchema& orientation();
 const MQ::FeatureSchema& style();
 
+// Returns the scroll-state query feature schema for `name`
+// (scrollable/scrolled/stuck/snapped), or nullptr. Used inside scroll-state().
+const MQ::FeatureSchema* scrollState(const AtomString&);
+
 Vector<const MQ::FeatureSchema*> allSchemas();
 
 } // namespace Features

--- a/Source/WebCore/css/query/ContainerQueryParser.cpp
+++ b/Source/WebCore/css/query/ContainerQueryParser.cpp
@@ -71,13 +71,19 @@ std::optional<ContainerQuery> ContainerQueryParser::consumeContainerQuery(CSSPar
 
 bool ContainerQueryParser::isValidFunctionId(CSSValueID functionId)
 {
-    return functionId == CSSValueStyle;
+    return functionId == CSSValueStyle || functionId == CSSValueScrollState;
 }
 
 const MQ::FeatureSchema* ContainerQueryParser::schemaForFeatureName(const AtomString& name, const MediaQueryParserContext& context, State& state)
 {
     if (state.inFunctionId == CSSValueStyle)
         return &Features::style();
+
+    if (state.inFunctionId == CSSValueScrollState) {
+        if (!context.context.cssScrollStateContainerQueriesEnabled)
+            return nullptr;
+        return Features::scrollState(name);
+    }
 
     return GenericMediaQueryParser<ContainerQueryParser>::schemaForFeatureName(name, context, state);
 }


### PR DESCRIPTION
#### ccb3efd6af0b7e72d7d978ca749adf212e9dc1c6
<pre>
Parse and serialize scroll-state container queries
<a href="https://bugs.webkit.org/show_bug.cgi?id=316536">https://bugs.webkit.org/show_bug.cgi?id=316536</a>

Reviewed by Tim Nguyen.

Add parsing and serialization for the `@container scroll-state(...)` query
syntax. Four features are recognized inside scroll-state(): scrollable,
scrolled, stuck and snapped, in both the boolean (`scroll-state(stuck)`) and
keyword (`scroll-state(stuck: top)`) forms, gated by the existing
cssScrollStateContainerQueriesEnabled flag.

The features are resolved only inside scroll-state(), mirroring style(), so
they are not matched as bare features. Serialization is handled by the generic
machinery via the stored functionId. Evaluation is a placeholder returning
false; real evaluation against the container&apos;s scroll state is a follow-up.

The &quot;&lt;general-enclosed&gt; verbatim&quot; serialization subcase is left as a baked
failure, matching the pre-existing at-container-style-serialization baseline
(a generic media-query parser limitation, not specific to scroll-state).

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrollable-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-scrolled-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-snapped-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/scroll-state/at-container-stuck-serialization-expected.txt:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
(WebCore::CQ::Features::ScrollStateFeatureSchema::ScrollStateFeatureSchema):
(WebCore::CQ::Features::scrollableFeatureSchema):
(WebCore::CQ::Features::scrolledFeatureSchema):
(WebCore::CQ::Features::stuckFeatureSchema):
(WebCore::CQ::Features::snappedFeatureSchema):
(WebCore::CQ::Features::scrollable):
(WebCore::CQ::Features::scrolled):
(WebCore::CQ::Features::stuck):
(WebCore::CQ::Features::snapped):
(WebCore::CQ::Features::scrollStateFeatureSchema):
* Source/WebCore/css/query/ContainerQueryFeatures.h:
* Source/WebCore/css/query/ContainerQueryParser.cpp:
(WebCore::CQ::ContainerQueryParser::isValidFunctionId):
(WebCore::CQ::ContainerQueryParser::schemaForFeatureName):

Canonical link: <a href="https://commits.webkit.org/314890@main">https://commits.webkit.org/314890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85d171b7d47f045a765f606a335e0ab6930ffe4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176568 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130320 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110837 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30413 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25303 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179109 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32004 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138715 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138602 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149997 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104893 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25493 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33861 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26876 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113357 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39673 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4986 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39924 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->