### PR TITLE
[WebXR] WebGL extensions not enabled when using xrCompatible context creation attribute

### DIFF
--- a/Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp
+++ b/Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp
@@ -43,6 +43,11 @@ bool GraphicsContextGLTextureMapperAndroid::platformInitializeExtensions()
     if (!enableExtensionsImpl({ "GL_OES_EGL_image"_s }))
         return false;
 
+#if ENABLE(WEBXR)
+    if (contextAttributes().xrCompatible && !enableRequiredWebXRExtensionsImpl())
+        return false;
+#endif
+
     const auto& eglExtensions = PlatformDisplay::sharedDisplay().eglExtensions();
     return eglExtensions.KHR_image_base && eglExtensions.ANDROID_get_native_client_buffer && eglExtensions.ANDROID_image_native_buffer;
 }
@@ -104,6 +109,11 @@ bool GraphicsContextGLTextureMapperAndroid::enableRequiredWebXRExtensions()
     if (!makeContextCurrent())
         return false;
 
+    return enableRequiredWebXRExtensionsImpl();
+}
+
+bool GraphicsContextGLTextureMapperAndroid::enableRequiredWebXRExtensionsImpl()
+{
     return enableExtensionsImpl({
         "GL_OES_EGL_image"_s,
         "GL_OES_EGL_image_external"_s,

--- a/Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.h
+++ b/Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.h
@@ -40,6 +40,9 @@ private:
         : GraphicsContextGLTextureMapperANGLE(WTF::move(attributes))
     {
     }
+#if ENABLE(WEBXR)
+    bool enableRequiredWebXRExtensionsImpl();
+#endif
 
     bool platformInitializeExtensions() override;
 };

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
@@ -112,6 +112,11 @@ bool GraphicsContextGLTextureMapperGBM::platformInitializeExtensions()
     if (!enableExtensionsImpl({ "GL_OES_EGL_image"_s }))
         return false;
 
+#if ENABLE(WEBXR)
+    if (contextAttributes().xrCompatible && !enableRequiredWebXRExtensionsImpl())
+        return false;
+#endif
+
     const auto& eglExtensions = PlatformDisplay::sharedDisplay().eglExtensions();
     return eglExtensions.KHR_image_base && eglExtensions.EXT_image_dma_buf_import;
 }
@@ -305,6 +310,11 @@ bool GraphicsContextGLTextureMapperGBM::enableRequiredWebXRExtensions()
     if (!makeContextCurrent())
         return false;
 
+    return enableRequiredWebXRExtensionsImpl();
+}
+
+bool GraphicsContextGLTextureMapperGBM::enableRequiredWebXRExtensionsImpl()
+{
     return enableExtensionsImpl({
         "GL_OES_EGL_image"_s,
         "GL_OES_EGL_image_external"_s

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h
@@ -60,6 +60,9 @@ private:
     bool platformInitializeExtensions() override;
     bool reshapeDrawingBuffer() override;
     void prepareForDisplay() override;
+#if ENABLE(WEBXR)
+    bool enableRequiredWebXRExtensionsImpl();
+#endif
 
     void freeDrawingBuffers();
     bool bindNextDrawingBuffer();


### PR DESCRIPTION
#### df6bba12ff65e9a48e20fe19feec614836b48bde
<pre>
[WebXR] WebGL extensions not enabled when using xrCompatible context creation attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=316540">https://bugs.webkit.org/show_bug.cgi?id=316540</a>

Reviewed by Dan Glastonbury.

Whenever a XR experience requests a XR compatible canvas to a GL context
it must be ensured that all the required GL extensions are available.
That is done by the different implementations of
enabledRequiredWebXRExtensions().

The aforementioned call is the recommended way to create an XR
compatible canvas because it&apos;s asynchronous. However there is also the
possibility of creating them using the xrCompatible boolean flag at
creation time. If that method was used the required list of GL
extensions was not enforced. We must call
enableRequiredWebXRExtensions() also in that case.

* Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp:
(WebCore::GraphicsContextGLTextureMapperAndroid::platformInitializeExtensions):
(WebCore::GraphicsContextGLTextureMapperAndroid::enableRequiredWebXRExtensions):
(WebCore::GraphicsContextGLTextureMapperAndroid::enableRequiredWebXRExtensionsImpl):
* Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.h:
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp:
(WebCore::GraphicsContextGLTextureMapperGBM::platformInitializeExtensions):
(WebCore::GraphicsContextGLTextureMapperGBM::enableRequiredWebXRExtensions):
(WebCore::GraphicsContextGLTextureMapperGBM::enableRequiredWebXRExtensionsImpl):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h:

Canonical link: <a href="https://commits.webkit.org/315082@main">https://commits.webkit.org/315082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89fff28a3e5e20b378992222c3dd1013279c655d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176321 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124953 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130119 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91594 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150293 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110636 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31502 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30202 "Found 2 new API test failures: TestWebKitAPI.ResourceLoadStatistics.DataTaskIdentifierCollision, TestWebKitAPI.ProcessSwap.SessionStorage (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25060 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178862 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31761 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138505 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138395 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37443 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41529 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104549 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26655 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40033 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113114 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39430 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4753 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->