### PR TITLE
font-synthesis: Synthetic bold not applied for variable font with font-weight: normal

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-weight-3-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-weight-3-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>CSS reference file: synthetic bold for a variable font whose font-weight descriptor is normal</title>
+<!-- Based on font-slant-3-ref.html (the 'slnt' axis variant) by Jonathan Kew. -->
+<style>
+@font-face {
+  font-family: test;
+  /* Version of Inter subset with the variation axes stripped,
+     so the browser's synthetic bold should take effect. */
+  src: url(resources/Inter.no-var.subset.ttf);
+  font-style: normal;
+  font-weight: normal;
+  font-stretch: normal;
+}
+.test {
+  font: 32px/1.5 test;
+}
+</style>
+<body>
+<p>Test passes if the first line is normal weight and the following two lines are displayed with synthetic bold.</p>
+<div class="test" style="font-weight: normal">nt</div>
+<div class="test" style="font-weight: bold">nt</div>
+<div class="test" style="font-weight: 900">nt</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-weight-3-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-weight-3-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>CSS reference file: synthetic bold for a variable font whose font-weight descriptor is normal</title>
+<!-- Based on font-slant-3-ref.html (the 'slnt' axis variant) by Jonathan Kew. -->
+<style>
+@font-face {
+  font-family: test;
+  /* Version of Inter subset with the variation axes stripped,
+     so the browser's synthetic bold should take effect. */
+  src: url(resources/Inter.no-var.subset.ttf);
+  font-style: normal;
+  font-weight: normal;
+  font-stretch: normal;
+}
+.test {
+  font: 32px/1.5 test;
+}
+</style>
+<body>
+<p>Test passes if the first line is normal weight and the following two lines are displayed with synthetic bold.</p>
+<div class="test" style="font-weight: normal">nt</div>
+<div class="test" style="font-weight: bold">nt</div>
+<div class="test" style="font-weight: 900">nt</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-weight-3.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-weight-3.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>CSS test: synthetic bold for a variable font whose font-weight descriptor is normal</title>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz"/>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-weight-prop"/>
+<link rel="match" href="font-weight-3-ref.html"/>
+<meta name="assert" content="A variable font with a 'wght' axis but a font-weight:normal descriptor must use synthetic bold for bold requests, since the descriptor restricts the face to normal weight.">
+<!-- Based on font-slant-3.html (the 'slnt' axis variant) by Jonathan Kew. -->
+<style>
+@font-face {
+  font-family: test;
+  /* The font resource includes a 'wght' axis, but our font-weight descriptor
+     should prevent it being used to render bold styles. */
+  src: url(resources/Inter.var.subset.ttf);
+  font-style: normal;
+  font-weight: normal;
+  font-stretch: normal;
+}
+.test {
+  font-synthesis: weight;
+  font: 32px/1.5 test;
+}
+</style>
+<body>
+<p>Test passes if the first line is normal weight and the following two lines are displayed with synthetic bold.</p>
+<div class="test" style="font-weight: normal">nt</div>
+<div class="test" style="font-weight: bold">nt</div>
+<div class="test" style="font-weight: 900">nt</div>

--- a/Source/WebCore/platform/graphics/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontCustomPlatformData.h
@@ -115,9 +115,11 @@ public:
 
 inline bool computeSyntheticBold(bool hasWeightVariationAxis, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)
 {
-    if (hasWeightVariationAxis)
+    auto explicitlyDeclaredWeight = fontCreationContext.fontFaceCapabilities().weight;
+    // No explicit font-weight descriptor (auto): the variable font's wght axis handles weight, so don't synthesize.
+    if (hasWeightVariationAxis && !explicitlyDeclaredWeight)
         return false;
-    auto declaredWeightMax = fontCreationContext.fontFaceCapabilities().weight
+    auto declaredWeightMax = explicitlyDeclaredWeight
         .transform([](auto range) { return range.maximum; })
         .value_or(normalWeightValue());
     return fontDescription.hasAutoFontSynthesisWeight()


### PR DESCRIPTION
#### fc7afbc7e662cf0318706a9e66b2d684360b5cb6
<pre>
font-synthesis: Synthetic bold not applied for variable font with font-weight: normal
<a href="https://bugs.webkit.org/show_bug.cgi?id=316532">https://bugs.webkit.org/show_bug.cgi?id=316532</a>
<a href="https://rdar.apple.com/179001275">rdar://179001275</a>

Reviewed by Alan Baradlay.

After <a href="https://commits.webkit.org/314537@main">https://commits.webkit.org/314537@main</a>, synthetic bold was suppressed for
any variable font with a wght axis. This regressed faces that explicitly declare
a non-bold font-weight, notably font-weight: normal: the descriptor pins the face
to a weight the clamped axis cannot make bold, so synthesis is still needed.
Faces that declare a bold-capable weight (for example font-weight: 700) were
unaffected, since the axis already provides bold. Therefore only suppress
synthesis when the font-weight descriptor is auto, letting the variable axis own
the weight in that case.

Spec: <a href="https://drafts.csswg.org/css-fonts-4/#font-prop-desc">https://drafts.csswg.org/css-fonts-4/#font-prop-desc</a>
Resolution: <a href="https://github.com/w3c/csswg-drafts/issues/7999">https://github.com/w3c/csswg-drafts/issues/7999</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-weight-3-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-weight-3-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-weight-3.html: Added.
* Source/WebCore/platform/graphics/FontCustomPlatformData.h:
(WebCore::computeSyntheticBold):

Canonical link: <a href="https://commits.webkit.org/314814@main">https://commits.webkit.org/314814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87795a0e06f12d9080ed3556cd0aef1559751638

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176172 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/080052fe-5bbd-4c5a-a86c-40b6e729f556) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129986 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d030173-7d2a-4988-a9ec-7c2636f52b5b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110503 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37edeedd-7478-4255-8497-44aeb194ea05) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31365 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30073 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24911 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178713 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31613 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138361 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138260 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37265 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149651 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104339 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33520 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26526 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39885 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112964 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39282 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4624 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39532 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39426 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->