### PR TITLE
AX: In rare circumstances, WebKit can loop infinitely downstream of updateOwnedChildrenIfNecessary(), causing stack overflow crashes

### DIFF
--- a/LayoutTests/accessibility/aria-owns-crash-after-subtree-update-expected.txt
+++ b/LayoutTests/accessibility/aria-owns-crash-after-subtree-update-expected.txt
@@ -1,0 +1,20 @@
+This tests that mixed DOM + aria-owns cycles do not cause stack-overflow recursion in updateOwnedChildrenIfNecessary().
+
+PASS: typeof t1a.childrenCount === 'number'
+PASS: typeof t2a.childrenCount === 'number'
+PASS: typeof t3self.childrenCount === 'number'
+PASS: typeof t4a.childrenCount === 'number'
+PASS: did not stack overflow.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+a
+b
+c
+child of t2-a
+b
+self
+a-mutated
+b
+c

--- a/LayoutTests/accessibility/aria-owns-crash-after-subtree-update.html
+++ b/LayoutTests/accessibility/aria-owns-crash-after-subtree-update.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<!-- Test 1: Three-element aria-owns cycle. -->
+<div role="group" id="t1-a" aria-owns="t1-b">a</div>
+<div role="group" id="t1-b" aria-owns="t1-c">b</div>
+<div role="group" id="t1-c" aria-owns="t1-a">c</div>
+
+<!-- Test 2: Mixed DOM + aria-owns: A's DOM child has aria-owns back to A. -->
+<div role="group" id="t2-a" aria-owns="t2-b">
+    <div role="group" id="t2-a-child" aria-owns="t2-a">child of t2-a</div>
+</div>
+<div role="group" id="t2-b" aria-owns="t2-a-child">b</div>
+
+<!-- Test 3: Self-owning element. -->
+<div role="group" id="t3-self" aria-owns="t3-self">self</div>
+
+<!-- Test 4: Live-region update scenario, matching a crash seen in the wild
+     (originating from _performLiveRegionUpdate). Mutate content after the
+     AX tree is built to set m_subtreeDirty across the ancestry, then re-query children. -->
+<div role="region" aria-live="polite" id="t4-region">
+    <div role="group" id="t4-a" aria-owns="t4-b">a</div>
+    <div role="group" id="t4-b" aria-owns="t4-c">b</div>
+    <div role="group" id="t4-c" aria-owns="t4-a">c</div>
+</div>
+
+<script>
+var output = "This tests that mixed DOM + aria-owns cycles do not cause stack-overflow recursion in updateOwnedChildrenIfNecessary().\n\n";
+
+if (window.accessibilityController) {
+    // Test 1: Three-element aria-owns cycle. Querying children must terminate.
+    var t1a = accessibilityController.accessibleElementById("t1-a");
+    output += expect("typeof t1a.childrenCount", "'number'");
+
+    // Test 2: Mixed DOM + aria-owns. Querying t2-a's children traverses both
+    // its DOM child and its aria-owns target.
+    var t2a = accessibilityController.accessibleElementById("t2-a");
+    output += expect("typeof t2a.childrenCount", "'number'");
+
+    // Test 3: Self-owning aria-owns.
+    var t3self = accessibilityController.accessibleElementById("t3-self");
+    output += expect("typeof t3self.childrenCount", "'number'");
+
+    // Test 4: Trigger live-region update by mutating content. This sets
+    // m_subtreeDirty across the ancestry.
+    document.getElementById("t4-a").textContent = "a-mutated";
+    var t4a = accessibilityController.accessibleElementById("t4-a");
+    output += expect("typeof t4a.childrenCount", "'number'");
+
+    output += "PASS: did not stack overflow.\n";
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -941,6 +941,8 @@ accessibility/clip-path-bounding-box.html [ Skip ]
 accessibility/first-letter-single-character.html [ Skip ]
 accessibility/table-cell-hit-test-not-column.html [ Skip ]
 
+accessibility/aria-owns-crash-after-subtree-update.html [ Skip ]
+
 # installImageOverlay is a no-op on platforms without IMAGE_ANALYSIS.
 accessibility/image-overlay-elements-presentational.html [ Skip ]
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -6307,7 +6307,7 @@ bool AXObjectCache::addRelation(Element& origin, Element& target, AXRelation rel
     AXLOG(makeString("origin: "_s, origin.debugDescription(), " target: "_s, target.debugDescription(), " relation "_s, static_cast<uint8_t>(relation)));
 
     if (!validRelation(origin, target, relation)) {
-        AX_ASSERT_NOT_REACHED();
+        // Skip invalid relations (which can be created with legitimate markup, e.g. self-referential aria-owns.
         return false;
     }
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -810,11 +810,20 @@ void AccessibilityNodeObject::clearChildren()
 
 void AccessibilityNodeObject::updateOwnedChildrenIfNecessary()
 {
-    bool didRemoveChild = false;
     auto ownedObjects = this->ownedObjects();
     if (ownedObjects.isEmpty())
         return;
 
+    // Tracks the objects whose owned children are currently being resolved, so a re-entrant
+    // call for an object already on the stack can bail instead of recursing forever.
+    static NeverDestroyed<HashSet<const AccessibilityNodeObject*>> objectsCurrentlyResolvingOwnedChildren;
+    if (!objectsCurrentlyResolvingOwnedChildren->add(this).isNewEntry)
+        return;
+    auto removeOnExit = makeScopeExit([&] {
+        objectsCurrentlyResolvingOwnedChildren->remove(this);
+    });
+
+    bool didRemoveChild = false;
     for (const auto& child : ownedObjects) {
         if (m_children.removeFirst(child)) {
             // If the child already exists as a DOM child, but is also in the owned objects, then


### PR DESCRIPTION
#### 5472527c2f962e2a7a9f6333bd29a122710d386e
<pre>
AX: In rare circumstances, WebKit can loop infinitely downstream of updateOwnedChildrenIfNecessary(), causing stack overflow crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=316542">https://bugs.webkit.org/show_bug.cgi?id=316542</a>
<a href="https://rdar.apple.com/172763724">rdar://172763724</a>

Reviewed by Dominic Mazzoni and Andres Gonzalez.

For a long while now, we have observed rare stack overflow crashes
originating from updateOwnedChildrenIfNecessary(). It&apos;s unclear how
these crashes are ocurring, since existing function relationCausesCycle
should (and does in all known situations) prevent an aria-owns
relationship from being established if it would cause a cycle.

The current theory is that these crashes happen when the tree is dirty and
in the process of being rebuilt after dynamic DOM changes (which may introduce
cycles that relationCausesCycle didn&apos;t and couldn&apos;t possibly have
checked for at relations-creation time). But I haven&apos;t been able to
construct markup that actually reproduces this, including the new layout
test, which passes with and without the newly added guard (described below).

The speculative fix taken by this commit is the addition of a per-traversal visited
set in updateOwnedChildrenIfNecessary, breaking if we encounter a node we&apos;ve already seen.

* LayoutTests/accessibility/aria-owns-crash-after-subtree-update-expected.txt: Added.
* LayoutTests/accessibility/aria-owns-crash-after-subtree-update.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::updateOwnedChildrenIfNecessary):

Canonical link: <a href="https://commits.webkit.org/314865@main">https://commits.webkit.org/314865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b8315c291816d616546dfc3ac1a6551ea9e7249

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176384 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3442152-2942-42b6-9b64-343578d7c037) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130170 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec061f1b-433a-4351-97cf-ea4f671368fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110687 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4dfdfbd5-5b97-4a58-9fa7-1112c94e1ab8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30255 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25123 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178927 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31824 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29777 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138567 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138448 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37302 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149853 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104654 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33697 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26730 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40096 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113177 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39493 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4828 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39638 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->