### PR TITLE
[Web Platform Tests] Un-skip the back-forward-cache test suite

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -793,15 +793,10 @@ imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/loc
 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_replace_session_history.html [ Skip ] # timeout on all browsers
 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_assign.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/per-global.window.html [ Skip ]
-# bfcache is not enabled in WebKitTestRunner.
-imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache [ Skip ]
-imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pagereveal/order-in-bfcache-restore.html [ Skip ]
-imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pagereveal/order-in-bfcache-restore-iframe.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_3.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/history-traversal-navigates-multiple-frames.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/window-name-after-cross-origin-main-frame-navigation.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-user-click-during-load.html [ Skip ]
-imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-user-click-during-pageshow.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/prompt-and-unload-script-closeable.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/prompt/004.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-no-bfcache.https.html [ Skip ]
@@ -6147,7 +6142,6 @@ http/tests/webgpu [ Skip ]
 fast/text/install-font-style-recalc.html [ Failure ]
 
 # These tests have been timing out since their import.
-imported/w3c/web-platform-tests/web-locks/bfcache
 
 webkit.org/b/239533 [ Debug ] editing/inserting/insert-list-user-select-none-crash.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/broadcastchannel.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/broadcastchannel.window-expected.txt
@@ -1,0 +1,3 @@
+
+NOTRUN Ensure that open broadcastchannel does not block bfcache. BFCache not supported.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/dedicatedworker.tentative.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/dedicatedworker.tentative.window-expected.txt
@@ -1,0 +1,3 @@
+
+NOTRUN BroadcastChannel messages dispatched to dedicated worker in bfcache should be queued. BFCache not supported.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/broadcast-channel-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/broadcast-channel-expected.txt
@@ -1,0 +1,4 @@
+
+NOTRUN Eligibility (BroadcastChannel) Could have been BFCached but actually wasn't
+NOTRUN Eligibility (BroadcastChannel closed in the pagehide event) Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/dedicated-worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/dedicated-worker-expected.txt
@@ -1,0 +1,3 @@
+
+NOTRUN Eligibility: dedicated workers Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-1-expected.txt
@@ -1,0 +1,4 @@
+
+NOTRUN Eligibility (in-flight fetch): Header received before BFCache and body received when in BFCache Could have been BFCached but actually wasn't
+NOTRUN Eligibility (in-flight fetch): Header received before BFCache and body received after BFCache Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-2-expected.txt
@@ -1,0 +1,5 @@
+
+NOTRUN Eligibility (in-flight fetch): Header and body received when in BFCache Could have been BFCached but actually wasn't
+NOTRUN Eligibility (in-flight fetch): Header received when in BFCache and body received after BFCache Could have been BFCached but actually wasn't
+NOTRUN Eligibility (in-flight fetch): Header and body received after BFCache Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-cors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-cors-expected.txt
@@ -1,0 +1,4 @@
+
+NOTRUN Eligibility (in-flight fetch): CORS succeeded when in BFCache Could have been BFCached but actually wasn't
+NOTRUN Eligibility (in-flight fetch): CORS failed when in BFCache Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-redirects-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-redirects-expected.txt
@@ -1,0 +1,6 @@
+
+NOTRUN Eligibility (in-flight fetch): Redirect header received when in BFCache Could have been BFCached but actually wasn't
+NOTRUN Eligibility (in-flight fetch): Redirect header received when in BFCache w/ CSP passing Could have been BFCached but actually wasn't
+NOTRUN Eligibility (in-flight fetch): Cross-origin redirect header received when in BFCache Could have been BFCached but actually wasn't
+NOTRUN Eligibility (in-flight fetch): Cross-origin redirect header received when in BFCache w/ CSP failing Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/shared-worker-active-client.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/shared-worker-active-client.window-expected.txt
@@ -1,0 +1,3 @@
+
+NOTRUN Eligibility: shared workers with another active client in a separate window Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/shared-worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/shared-worker-expected.txt
@@ -1,0 +1,3 @@
+
+NOTRUN Eligibility: shared workers Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/events-expected.txt
@@ -1,0 +1,9 @@
+main frame - has 1 onunload handler(s)
+main frame - has 1 onunload handler(s)
+
+NOTRUN SameOrigin Could have been BFCached but actually wasn't
+NOTRUN SameSite Could have been BFCached but actually wasn't
+NOTRUN CrossSite Could have been BFCached but actually wasn't
+NOTRUN beforeunload Could have been BFCached but actually wasn't
+NOTRUN unload Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/focus-expected.txt
@@ -1,0 +1,3 @@
+
+NOTRUN Focus should be kept when page gets into and out of BFCache Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/pushstate.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/pushstate.https-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT back navigation to pushState()d page (in BFCache) Test timed out
-NOTRUN back navigation to pushState()d page (not in BFCache)
+NOTRUN back navigation to pushState()d page (in BFCache) Could have been BFCached but actually wasn't
+FAIL back navigation to pushState()d page (not in BFCache) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'navigator.keyboard.lock')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-client-postmessage.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-client-postmessage.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Client.postMessage while a controlled page is in BFCache
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-claim.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-claim.https-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Clients.claim() evicts pages that would be affected from BFCache Test timed out
+PASS Clients.claim() evicts pages that would be affected from BFCache
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-matchall.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-matchall.https-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Clients.matchAll() should not list pages in BFCache Test timed out
+NOTRUN Clients.matchAll() should not list pages in BFCache Could have been BFCached but actually wasn't
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-controlled-after-restore.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-controlled-after-restore.https-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Pages should remain controlled after restored from BFCache Test timed out
+NOTRUN Pages should remain controlled after restored from BFCache Could have been BFCached but actually wasn't
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-unregister.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-unregister.https-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Unregister service worker while a controlled page is in BFCache Test timed out
+PASS Unregister service worker while a controlled page is in BFCache
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/storage-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/storage-events-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Storage events should not be fired for BFCached pages after becoming active Test timed out
+NOTRUN Storage events should not be fired for BFCached pages after becoming active Could have been BFCached but actually wasn't
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/timers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/timers-expected.txt
@@ -1,0 +1,3 @@
+
+NOTRUN Timers should be paused when the page is in BFCache Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pagereveal/order-in-bfcache-restore-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pagereveal/order-in-bfcache-restore-expected.txt
@@ -1,0 +1,3 @@
+
+NOTRUN pagereveal event fires and in correct order on restoration from BFCache Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pagereveal/order-in-bfcache-restore-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pagereveal/order-in-bfcache-restore-iframe-expected.txt
@@ -1,0 +1,3 @@
+
+NOTRUN pagereveal event in iframe fires and in correct order on restoration from BFCache Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-user-click-during-pageshow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-user-click-during-pageshow-expected.txt
@@ -1,0 +1,6 @@
+
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT User click on <a> during the pageshow event must NOT replace Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https-expected.txt
@@ -1,0 +1,6 @@
+
+NOTRUN An immediately aborted lock on main thread should not prevent bfcache Could have been BFCached but actually wasn't
+NOTRUN An immediately aborted lock on a worker should not prevent bfcache Could have been BFCached but actually wasn't
+NOTRUN An immediately aborted lock on a nested worker should not prevent bfcache Could have been BFCached but actually wasn't
+NOTRUN An immediately aborted lock on a shared worker should not prevent bfcache Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS A held lock on the main thread must prevent bfcache
+PASS A held lock on a worker must prevent bfcache
+PASS A held lock on a nested worker must prevent bfcache
+PASS A held lock on a shared worker must prevent bfcache
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/release-across-thread.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/release-across-thread.tentative.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS A held lock on main thread must prevent bfcache even after worker releases locks
+PASS A held lock on worker must prevent bfcache even after main thread releases locks
+PASS A held lock on shared worker must prevent bfcache even after main thread releases locks
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/release.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/release.tentative.https-expected.txt
@@ -1,0 +1,6 @@
+
+NOTRUN A released lock on the main thread should not prevent bfcache Could have been BFCached but actually wasn't
+NOTRUN A released lock on a worker should not prevent bfcache Could have been BFCached but actually wasn't
+NOTRUN A released lock on a nested worker should not prevent bfcache Could have been BFCached but actually wasn't
+NOTRUN A released lock on a shared worker should not prevent bfcache Could have been BFCached but actually wasn't
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/sharedworker-multiple.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/sharedworker-multiple.tentative.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS A new held lock must prevent bfcache on all connected documents
+PASS An existing held lock must prevent bfcache on all connected documents
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-closed-webtransport-connection.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-closed-webtransport-connection.https.window-expected.txt
@@ -1,5 +1,0 @@
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Testing BFCache support for page with closed WebTransport connection. Test timed out
-

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-open-webtransport-connection.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/back-forward-cache-with-open-webtransport-connection.https.window-expected.txt
@@ -1,5 +1,0 @@
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Testing BFCache support for page with open WebTransport connection. Test timed out
-

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1310,3 +1310,8 @@ webkit.org/b/316577 http/tests/animations/threaded-animations-timeline-resumptio
 
 webkit.org/b/278719 fast/events/touch/touch-scaled-scrolled.html [ Failure Timeout ]
 webkit.org/b/317009 fast/events/mouse-events-on-textarea-resize.html [ Pass Failure ]
+
+webkit.org/b/316547 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/pushstate.https.html [ Failure ]
+webkit.org/b/316547 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-matchall.https.html [ Failure ]
+webkit.org/b/316547 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-controlled-after-restore.https.html [ Failure ]
+webkit.org/b/316547 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/storage-events.html [ Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1336,3 +1336,8 @@ webkit.org/b/252878 [ arm64 ] fast/frames/lots-of-objects.html [ Pass Timeout ]
 webkit.org/b/317021 [ arm64 ] fast/parser/elementstack-nesting-depth.html [ Pass Timeout ]
 
 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fires-for-repeat-key-ending-after-scroll-container-end-is-reached.html [ Skip ] # Different outputs
+
+webkit.org/b/316547 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/pushstate.https.html [ Failure ]
+webkit.org/b/316547 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-matchall.https.html [ Failure ]
+webkit.org/b/316547 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-controlled-after-restore.https.html [ Failure ]
+webkit.org/b/316547 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/storage-events.html [ Failure ]


### PR DESCRIPTION
#### d10ca156a7f1960d2f08d9fa3f72ae115c0af75d
<pre>
[Web Platform Tests] Un-skip the back-forward-cache test suite
<a href="https://bugs.webkit.org/show_bug.cgi?id=316547">https://bugs.webkit.org/show_bug.cgi?id=316547</a>
<a href="https://rdar.apple.com/179019949">rdar://179019949</a>

Reviewed by Sihui Liu.

The WPT back-forward-cache test suite was globally Skip&apos;d in
LayoutTests/TestExpectations with the comment &quot;bfcache is not enabled in
WebKitTestRunner.&quot; That comment is no longer accurate: BFCache works in
WebKitTestRunner under both default WebKit2 and --site-isolation, and the
runBfcacheTest helper that drives most of these tests degrades gracefully
to NOTRUN via assert_implements_optional in scenarios WebKit declines to
cache by design — notably popup-based scenarios, where the source page&apos;s
BrowsingContextGroup has multiple pages and
WebPageProxy::suspendCurrentPageIfPossible refuses to suspend the page.

Remove the Skip entries for:

  - imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache
  - .../history-traversal/pagereveal/order-in-bfcache-restore.html (and -iframe.html)
  - .../navigating-across-documents/replace-before-load/a-user-click-during-pageshow.html
  - imported/w3c/web-platform-tests/web-locks/bfcache

Refresh stale baselines that still expected timeout from before BFCache
worked, and add fresh baselines for tests that were previously unrun.

NOTRUN entries in the new baselines reflect intentional WebKit behavior
for popup-based runBfcacheTest scenarios.

The two webtransport BFCache tests (back-forward-cache-with-{open,closed}-
webtransport-connection.https.window.html) remain Skip&apos;d alongside the
rest of the WebTransport suite — WebTransport has a stub implementation
in WebKitTestRunner and these tests inherit the same flaky-timeout
behavior on mac and Linux.

Four tests (pushstate, service-worker-clients-matchall,
service-worker-controlled-after-restore, storage-events) produce
platform-specific output on wpe/gtk; mark them [ Failure ] in
platform/wpe/TestExpectations and platform/gtk/TestExpectations under
the same bug for follow-up rebaseline by a wpe/gtk contributor.

Tests pass under both default WebKit2 (mac) and --site-isolation.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/broadcastchannel.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/dedicatedworker.tentative.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/broadcast-channel-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/dedicated-worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-1-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-2-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-cors-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/inflight-fetch-redirects-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/shared-worker-active-client.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/eligibility/shared-worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/events-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/focus-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/pushstate.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-client-postmessage.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-claim.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-matchall.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-controlled-after-restore.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-unregister.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/storage-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/timers-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pagereveal/order-in-bfcache-restore-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pagereveal/order-in-bfcache-restore-iframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-user-click-during-pageshow-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/release-across-thread.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/release.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-locks/bfcache/sharedworker-multiple.tentative.https-expected.txt: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/315514@main">https://commits.webkit.org/315514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/690d30d02903fc33bbb3b7fc2bcd05dc4f24c575

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126997 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/50acd596-d95c-4458-be19-9dc9a10c38a0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131852 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48b47cb2-5f4d-4b12-8cc5-6a876a657f6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172244 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112356 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6679a186-72f1-4ae1-8675-38de68f0a669) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27341 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181241 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140309 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42863 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140147 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37705 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43552 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107484 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35416 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42062 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6602 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41455 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41710 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->