### PR TITLE
[JSC] Promise combinator's array should get vector-hint based on iterable size

### DIFF
--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -169,6 +169,13 @@ static ALWAYS_INLINE bool canSkipIntermediatePromise(JSGlobalObject* globalObjec
     return isDefinitelyNonThenable(uncheckedDowncast<JSObject>(cell), globalObject);
 }
 
+static ALWAYS_INLINE unsigned vectorLengthHintForCombinator(JSValue iterable)
+{
+    if (!isJSArray(iterable))
+        return 0;
+    return std::min<unsigned>(uncheckedDowncast<JSArray>(iterable)->length(), MAX_STORAGE_VECTOR_LENGTH);
+}
+
 static JSObject* promiseRaceSlow(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue thisValue)
 {
     VM& vm = globalObject->vm();
@@ -371,7 +378,8 @@ static JSObject* promiseAllSlow(JSGlobalObject* globalObject, CallFrame* callFra
         cachedCall = &cachedCallHolder.value();
     }
 
-    JSArray* values = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), 0);
+    JSValue iterable = callFrame->argument(0);
+    JSArray* values = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 0, vectorLengthHintForCombinator(iterable));
     if (!values) [[unlikely]] {
         callReject(createOutOfMemoryError(globalObject));
         return promise;
@@ -381,7 +389,6 @@ static JSObject* promiseAllSlow(JSGlobalObject* globalObject, CallFrame* callFra
 
     uint64_t index = 0;
 
-    JSValue iterable = callFrame->argument(0);
     forEachInIterable(globalObject, iterable, [&](VM& vm, JSGlobalObject* globalObject, JSValue value) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -481,7 +488,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
         promise->reject(vm, exception);
     };
 
-    JSArray* values = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), 0);
+    JSValue iterable = callFrame->argument(0);
+    JSArray* values = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 0, vectorLengthHintForCombinator(iterable));
     if (!values) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         callReject();
@@ -493,7 +501,6 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
     uint64_t index = 0;
     JSFunction* onRejected = nullptr;
 
-    JSValue iterable = callFrame->argument(0);
     forEachInIterable(globalObject, iterable, [&](VM& vm, JSGlobalObject* globalObject, JSValue value) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -699,7 +706,8 @@ static JSObject* promiseAllSettledSlow(JSGlobalObject* globalObject, CallFrame* 
         cachedCall = &cachedCallHolder.value();
     }
 
-    JSArray* values = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), 0);
+    JSValue iterable = callFrame->argument(0);
+    JSArray* values = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 0, vectorLengthHintForCombinator(iterable));
     if (!values) [[unlikely]] {
         callReject(createOutOfMemoryError(globalObject));
         return promise;
@@ -709,7 +717,6 @@ static JSObject* promiseAllSettledSlow(JSGlobalObject* globalObject, CallFrame* 
 
     uint64_t index = 0;
 
-    JSValue iterable = callFrame->argument(0);
     forEachInIterable(globalObject, iterable, [&](VM& vm, JSGlobalObject* globalObject, JSValue value) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -814,7 +821,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
         promise->reject(vm, exception);
     };
 
-    JSArray* values = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), 0);
+    JSValue iterable = callFrame->argument(0);
+    JSArray* values = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 0, vectorLengthHintForCombinator(iterable));
     if (!values) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         callReject();
@@ -825,7 +833,6 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
 
     uint64_t index = 0;
 
-    JSValue iterable = callFrame->argument(0);
     forEachInIterable(globalObject, iterable, [&](VM& vm, JSGlobalObject* globalObject, JSValue value) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -1191,7 +1198,8 @@ static JSObject* promiseAnySlow(JSGlobalObject* globalObject, CallFrame* callFra
         cachedCall = &cachedCallHolder.value();
     }
 
-    JSArray* errors = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), 0);
+    JSValue iterable = callFrame->argument(0);
+    JSArray* errors = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 0, vectorLengthHintForCombinator(iterable));
     if (!errors) [[unlikely]] {
         callReject(createOutOfMemoryError(globalObject));
         return promise;
@@ -1201,7 +1209,6 @@ static JSObject* promiseAnySlow(JSGlobalObject* globalObject, CallFrame* callFra
 
     uint64_t index = 0;
 
-    JSValue iterable = callFrame->argument(0);
     forEachInIterable(globalObject, iterable, [&](VM& vm, JSGlobalObject* globalObject, JSValue value) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -1296,7 +1303,9 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
         promise->reject(vm, exception);
     };
 
-    JSArray* errors = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), 0);
+    JSValue resolve;
+    JSValue iterable = callFrame->argument(0);
+    JSArray* errors = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 0, vectorLengthHintForCombinator(iterable));
     if (!errors) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         callReject();
@@ -1307,8 +1316,6 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
 
     uint64_t index = 0;
 
-    JSValue resolve;
-    JSValue iterable = callFrame->argument(0);
     forEachInIterable(globalObject, iterable, [&](VM& vm, JSGlobalObject* globalObject, JSValue value) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 


### PR DESCRIPTION
#### c6900eb698938600bebd834b0409f4e7c5073527
<pre>
[JSC] Promise combinator&apos;s array should get vector-hint based on iterable size
<a href="https://bugs.webkit.org/show_bug.cgi?id=316548">https://bugs.webkit.org/show_bug.cgi?id=316548</a>
<a href="https://rdar.apple.com/179020924">rdar://179020924</a>

Reviewed by Marcus Plutowski.

Add vector-hint when creating an array for Promise combinators (e.g.
Promise.all) based on length of iterable. So this avoids repeated
extension of JSArray.

* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::vectorLengthHintForCombinator):
(JSC::promiseAllSlow):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::promiseAllSettledSlow):
(JSC::promiseAnySlow):

Canonical link: <a href="https://commits.webkit.org/314754@main">https://commits.webkit.org/314754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/128cb119f21039d0408e6037f0abc9ffde3b2e29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176157 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124370 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/286bc492-6330-49fb-a411-36ca92743725) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129970 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01c6ba0b-d031-4f93-9688-67ebb2bcc39f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110487 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8946517-f996-4c14-aa38-2f8b5115164b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30059 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24896 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159273 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178696 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/28006 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31599 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138344 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138244 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41366 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104324 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25438 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33506 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26513 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199787 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39870 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112949 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53722 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39267 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4611 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39517 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39411 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->