### PR TITLE
[GStreamer] Migrate MediaStream source element to PadProbeHandle

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -411,6 +411,8 @@ public:
         gst_pad_remove_probe(m_pad.get(), m_id);
     }
 
+    const GRefPtr<GstPad>& pad() const { return m_pad; }
+
 private:
     PadProbeHandle(const T& owner, GRefPtr<GstPad>&& pad, GstPadProbeType probeType, PadProbeCallback&& callback)
         : m_pad(WTF::move(pad))

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -37,6 +37,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/glib/GMallocString.h>
 
 #if USE(GSTREAMER_WEBRTC)
@@ -147,7 +148,7 @@ static void webkitMediaStreamSrcEnsureStreamCollectionPosted(WebKitMediaStreamSr
 
 
 class InternalSource final : public MediaStreamTrackPrivateObserver,
-    public RefCounted<InternalSource>,
+    public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<InternalSource>,
     public RealtimeMediaSourceObserver,
     public RealtimeMediaSource::AudioSampleObserver,
     public RealtimeMediaSource::VideoFrameObserver,
@@ -160,8 +161,8 @@ public:
         return adoptRef(*new InternalSource(parent, track, padName, consumerIsVideoPlayer));
     }
 
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     void replaceTrack(RefPtr<MediaStreamTrackPrivate>&& newTrack)
     {
@@ -212,12 +213,8 @@ public:
 
         auto incomingSource = static_cast<RealtimeIncomingSourceGStreamer*>(&trackSource);
         auto srcPad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
-        gst_pad_add_probe(srcPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_EVENT_UPSTREAM | GST_PAD_PROBE_TYPE_QUERY_UPSTREAM), reinterpret_cast<GstPadProbeCallback>(+[](GstPad* pad, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
-            auto weakSource = static_cast<ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>*>(userData);
-            auto incomingSource = weakSource->get();
-            if (!incomingSource)
-                return GST_PAD_PROBE_REMOVE;
-            auto src = adoptGRef(gst_pad_get_parent_element(pad));
+        m_incomingPadProbeHandle = PadProbeHandle<RealtimeIncomingSourceGStreamer>::create(*incomingSource, WTF::move(srcPad), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_EVENT_UPSTREAM | GST_PAD_PROBE_TYPE_QUERY_UPSTREAM), [](const auto& incomingSource, const auto& pad, auto info) -> GstPadProbeReturn {
+            auto src = adoptGRef(gst_pad_get_parent_element(pad.get()));
             if (GST_IS_QUERY(info->data)) {
                 switch (GST_QUERY_TYPE(GST_PAD_PROBE_INFO_QUERY(info))) {
                 case GST_QUERY_CAPS:
@@ -243,9 +240,7 @@ public:
                     return GST_PAD_PROBE_HANDLED;
             }
             return GST_PAD_PROBE_OK;
-        }), new ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer> { incomingSource }, reinterpret_cast<GDestroyNotify>(+[](gpointer data) {
-            delete static_cast<ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>*>(data);
-        }));
+        });
 #endif
     }
 
@@ -275,6 +270,9 @@ public:
 
         if (!m_track)
             return;
+
+        m_incomingPadProbeHandle = nullptr;
+
         auto& trackSource = m_track->source();
         if (trackSource.isIncomingAudioSource()) {
             auto& source = static_cast<RealtimeIncomingAudioSourceGStreamer&>(trackSource);
@@ -631,8 +629,7 @@ private:
             m_trackSource = &(m_track->source());
 
         auto pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
-        gst_pad_add_probe(pad.get(), GST_PAD_PROBE_TYPE_QUERY_UPSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
-            auto self = reinterpret_cast<InternalSource*>(userData);
+        m_upstreamQueryPadProbeHandle = PadProbeHandle<InternalSource>::create(*this, WTF::move(pad), GST_PAD_PROBE_TYPE_QUERY_UPSTREAM, [](const auto& self, const auto&, auto info) -> GstPadProbeReturn {
             auto query = GST_PAD_PROBE_INFO_QUERY(info);
             switch (GST_QUERY_TYPE(query)) {
 #if GST_CHECK_VERSION(1, 22, 0)
@@ -672,7 +669,7 @@ private:
                 break;
             }
             return GST_PAD_PROBE_OK;
-        }), this, nullptr);
+        });
 
         if (!trackSource.isIncomingAudioSource() && !trackSource.isIncomingVideoSource())
             return;
@@ -872,6 +869,40 @@ private:
     double m_totalAudioEnergy { 0 };
     unsigned m_audioSamplesCountSinceLastTotalEnergyCalculation { 0 };
     GUniquePtr<GstStructure> m_stats;
+#if USE(GSTREAMER_WEBRTC)
+    RefPtr<PadProbeHandle<RealtimeIncomingSourceGStreamer>> m_incomingPadProbeHandle;
+#endif
+    RefPtr<PadProbeHandle<InternalSource>> m_upstreamQueryPadProbeHandle;
+};
+
+class PadProbeData final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PadProbeData> {
+public:
+    static RefPtr<PadProbeData> create(GThreadSafeWeakPtr<GstElement>&& element, RealtimeMediaSource::Type sourceType, GRefPtr<GstStream>&& stream, GRefPtr<GstStreamCollection>&& collection)
+    {
+        return adoptRef(*new PadProbeData(WTF::move(element), sourceType, WTF::move(stream), WTF::move(collection)));
+    }
+
+    const GRefPtr<GstStream>& stream() const { return m_stream; }
+    [[nodiscard]] GRefPtr<GstElement> element() { return m_element.get(); }
+    [[nodiscard]] GRefPtr<GstStreamCollection> takeCollection()
+    {
+        GRefPtr<GstStreamCollection> result = WTF::move(m_collection);
+        return result;
+    }
+    RealtimeMediaSource::Type sourceType() const { return m_sourceType; }
+
+private:
+    PadProbeData(GThreadSafeWeakPtr<GstElement>&& element, RealtimeMediaSource::Type sourceType, GRefPtr<GstStream>&& stream, GRefPtr<GstStreamCollection>&& collection)
+        : m_element(WTF::move(element))
+        , m_sourceType(sourceType)
+        , m_stream(WTF::move(stream))
+        , m_collection(WTF::move(collection))
+    {
+    }
+    GThreadSafeWeakPtr<GstElement> m_element;
+    RealtimeMediaSource::Type m_sourceType;
+    GRefPtr<GstStream> m_stream;
+    GRefPtr<GstStreamCollection> m_collection;
 };
 
 struct _WebKitMediaStreamSrcPrivate {
@@ -885,6 +916,8 @@ struct _WebKitMediaStreamSrcPrivate {
     Atomic<unsigned> videoPadCounter;
     unsigned groupId;
     bool firstVideoSampleSeen { false };
+    Vector<RefPtr<PadProbeHandle<PadProbeData>>> probes;
+    Vector<RefPtr<PadProbeData>> probeData;
 };
 
 enum {
@@ -936,6 +969,16 @@ static void webkitMediaStreamSrcCleanup(WebKitMediaStreamSrc* self, const RefPtr
 
     GST_DEBUG_OBJECT(self, "Cleaning-up internal source element %" GST_PTR_FORMAT, appSrc);
     source->cleanUp();
+
+    auto appSrcPad = adoptGRef(gst_element_get_static_pad(appSrc, "src"));
+    self->priv->probes.removeFirstMatching([pad = WTF::move(appSrcPad)](auto& probe) -> bool {
+        return probe->pad() == pad;
+    });
+
+    const auto& stream = source->stream();
+    self->priv->probeData.removeFirstMatching([stream = GRefPtr(stream)](auto& data) -> bool {
+        return data->stream() == stream;
+    });
 
     gstElementLockAndSetState(appSrc, GST_STATE_NULL);
     gst_bin_remove(GST_BIN_CAST(self), appSrc);
@@ -1261,58 +1304,6 @@ static void webkitMediaStreamSrcEnsureStreamCollectionPosted(WebKitMediaStreamSr
     GST_DEBUG_OBJECT(self, "Stream collection posted");
 }
 
-struct ProbeData {
-    GThreadSafeWeakPtr<GstElement> element;
-    RealtimeMediaSource::Type sourceType;
-    GRefPtr<GstStream> stream;
-    GRefPtr<GstStreamCollection> collection;
-};
-WEBKIT_DEFINE_ASYNC_DATA_STRUCT(ProbeData);
-
-static GstPadProbeReturn webkitMediaStreamSrcPadProbeCb(GstPad* pad, GstPadProbeInfo* info, ProbeData* data)
-{
-    auto element = data->element.get();
-    if (!element)
-        return GST_PAD_PROBE_REMOVE;
-
-    [[maybe_unused]] WebKitMediaStreamSrc* self = WEBKIT_MEDIA_STREAM_SRC_CAST(element.get());
-
-    auto event = GST_PAD_PROBE_INFO_EVENT(info);
-    GST_DEBUG_OBJECT(self, "Event %" GST_PTR_FORMAT, event);
-    switch (GST_EVENT_TYPE(event)) {
-    case GST_EVENT_STREAM_START: {
-        if (!data->stream) [[unlikely]]
-            return GST_PAD_PROBE_OK;
-
-        GST_DEBUG_OBJECT(self, "Replacing stream-start event");
-        auto sequenceNumber = gst_event_get_seqnum(event);
-
-        auto streamStartEvent = adoptGRef(gst_event_new_stream_start(gst_stream_get_stream_id(data->stream.get())));
-        gst_event_set_group_id(streamStartEvent.get(), self->priv->groupId);
-        gst_event_set_stream(streamStartEvent.get(), data->stream.get());
-        gst_event_set_seqnum(streamStartEvent.get(), sequenceNumber);
-        gst_pad_probe_info_set_event(info, streamStartEvent.leakRef());
-        return GST_PAD_PROBE_OK;
-    }
-    case GST_EVENT_CAPS: {
-        if (data->collection) {
-            auto collection = WTF::move(data->collection);
-            GST_DEBUG_OBJECT(self, "Pushing stream-collection event");
-            gst_pad_push_event(pad, gst_event_new_stream_collection(collection.get()));
-            if (data->sourceType == RealtimeMediaSource::Type::Video) {
-                GST_DEBUG_OBJECT(self, "Requesting a key-frame");
-                gst_pad_send_event(pad, gst_video_event_new_upstream_force_key_unit(GST_CLOCK_TIME_NONE, TRUE, 1));
-            }
-        }
-        return GST_PAD_PROBE_OK;
-    }
-    default:
-        break;
-    }
-
-    return GST_PAD_PROBE_OK;
-}
-
 void webkitMediaStreamSrcAddTrack(WebKitMediaStreamSrc* self, MediaStreamTrackPrivate* track, bool consumerIsVideoPlayer)
 {
     ASCIILiteral sourceType;
@@ -1344,18 +1335,56 @@ void webkitMediaStreamSrcAddTrack(WebKitMediaStreamSrc* self, MediaStreamTrackPr
     self->priv->tracks.append(track);
 
     auto pad = adoptGRef(gst_element_get_static_pad(element, "src"));
-    auto data = createProbeData();
-    data->element.reset(GST_ELEMENT_CAST(self));
-    data->sourceType = track->source().type();
-    data->collection = webkitMediaStreamSrcCreateStreamCollection(self);
-    data->stream = stream;
+    auto collection = webkitMediaStreamSrcCreateStreamCollection(self);
+    RefPtr data = PadProbeData::create(GThreadSafeWeakPtr(GST_ELEMENT_CAST(self)), track->source().type(), GRefPtr(stream), WTF::move(collection));
 
     auto stickyStreamStartEvent = adoptGRef(gst_event_new_stream_start(gst_stream_get_stream_id(stream.get())));
     gst_event_set_group_id(stickyStreamStartEvent.get(), self->priv->groupId);
     gst_event_set_stream(stickyStreamStartEvent.get(), stream.get());
 
-    gst_pad_add_probe(pad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(webkitMediaStreamSrcPadProbeCb),
-        data, reinterpret_cast<GDestroyNotify>(destroyProbeData));
+    self->priv->probes.append(PadProbeHandle<PadProbeData>::create(*data, GRefPtr(pad), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, [](const auto& data, const auto& pad, auto info) -> GstPadProbeReturn {
+        auto element = data->element();
+        if (!element)
+            return GST_PAD_PROBE_REMOVE;
+
+        [[maybe_unused]] WebKitMediaStreamSrc* self = WEBKIT_MEDIA_STREAM_SRC_CAST(element.get());
+
+        auto event = GST_PAD_PROBE_INFO_EVENT(info);
+        GST_DEBUG_OBJECT(self, "Event %" GST_PTR_FORMAT, event);
+        switch (GST_EVENT_TYPE(event)) {
+        case GST_EVENT_STREAM_START: {
+            const auto& stream = data->stream();
+            if (!stream) [[unlikely]]
+                return GST_PAD_PROBE_OK;
+
+            GST_DEBUG_OBJECT(self, "Replacing stream-start event");
+            auto sequenceNumber = gst_event_get_seqnum(event);
+
+            auto streamStartEvent = adoptGRef(gst_event_new_stream_start(gst_stream_get_stream_id(stream.get())));
+            gst_event_set_group_id(streamStartEvent.get(), self->priv->groupId);
+            gst_event_set_stream(streamStartEvent.get(), stream.get());
+            gst_event_set_seqnum(streamStartEvent.get(), sequenceNumber);
+            gst_pad_probe_info_set_event(info, streamStartEvent.leakRef());
+            return GST_PAD_PROBE_OK;
+        }
+        case GST_EVENT_CAPS: {
+            if (auto collection = data->takeCollection()) {
+                GST_DEBUG_OBJECT(self, "Pushing stream-collection event");
+                gst_pad_push_event(pad.get(), gst_event_new_stream_collection(collection.get()));
+                if (data->sourceType() == RealtimeMediaSource::Type::Video) {
+                    GST_DEBUG_OBJECT(self, "Requesting a key-frame");
+                    gst_pad_send_event(pad.get(), gst_video_event_new_upstream_force_key_unit(GST_CLOCK_TIME_NONE, TRUE, 1));
+                }
+            }
+            return GST_PAD_PROBE_OK;
+        }
+        default:
+            break;
+        }
+
+        return GST_PAD_PROBE_OK;
+    }));
+    self->priv->probeData.append(WTF::move(data));
 
 #ifndef GST_DISABLE_GST_DEBUG
     auto objectPath = GMallocString::unsafeAdoptFromUTF8(gst_object_get_path_string(GST_OBJECT_CAST(self)));


### PR DESCRIPTION
#### 6a4f65a5bcc38e610c91fe957a47f5463242c70b
<pre>
[GStreamer] Migrate MediaStream source element to PadProbeHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=316551">https://bugs.webkit.org/show_bug.cgi?id=316551</a>

Reviewed by Xabier Rodriguez-Calvar.

Refactoring migrating from gst_pad_add_probe to PadProbeHandle.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(webkitMediaStreamSrcAddTrack):
(webkitMediaStreamSrcPadProbeCb): Deleted.

Canonical link: <a href="https://commits.webkit.org/315085@main">https://commits.webkit.org/315085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bf56920e8f96336d06d69c795bcc6acf377cdc7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177370 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125767 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130774 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151029 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111291 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26072 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179969 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32721 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139198 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139078 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37445 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42331 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105646 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34366 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40835 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114087 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40232 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5496 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->