### PR TITLE
Use default member initializers for RenderFrameSet data members

### DIFF
--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 2000 Simon Hausmann <hausmann@kde.org>
  *           (C) 2000 Stefan Schimanski (1Stein@gmx.de)
- * Copyright (C) 2004, 2005, 2006, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
@@ -58,7 +58,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderFrameSet);
 
 RenderFrameSet::RenderFrameSet(HTMLFrameSetElement& frameSet, Style::ComputedStyle&& style)
     : RenderBox(Type::FrameSet, frameSet, WTF::move(style))
-    , m_isResizing(false)
 {
     ASSERT(isRenderFrameSet());
     setInline(false);
@@ -69,11 +68,6 @@ RenderFrameSet::~RenderFrameSet() = default;
 HTMLFrameSetElement& NODELETE RenderFrameSet::frameSetElement() const
 {
     return downcast<HTMLFrameSetElement>(nodeForNonAnonymous());
-}
-
-RenderFrameSet::GridAxis::GridAxis()
-    : m_splitBeingResized(noSplit)
-{
 }
 
 void RenderFrameSet::paintColumnBorder(const PaintInfo& paintInfo, const IntRect& borderRect)

--- a/Source/WebCore/rendering/RenderFrameSet.h
+++ b/Source/WebCore/rendering/RenderFrameSet.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 2000 Simon Hausmann <hausmann@kde.org>
- * Copyright (C) 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
@@ -81,15 +81,15 @@ private:
     class GridAxis {
         WTF_MAKE_NONCOPYABLE(GridAxis);
     public:
-        GridAxis();
+        GridAxis() = default;
         void resize(int);
 
         Vector<int> m_sizes;
         Vector<int> m_deltas;
         Vector<bool> m_preventResize;
         Vector<bool> m_allowBorder;
-        int m_splitBeingResized;
-        int m_splitResizeOffset;
+        int m_splitBeingResized { noSplit };
+        int m_splitResizeOffset { 0 };
     };
 
     ASCIILiteral renderName() const override { return "RenderFrameSet"_s; }
@@ -119,7 +119,7 @@ private:
     GridAxis m_rows;
     GridAxis m_cols;
 
-    bool m_isResizing;
+    bool m_isResizing { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 54090eb0904c1adfef296291012ad7800690cf2f
<pre>
Use default member initializers for RenderFrameSet data members
<a href="https://bugs.webkit.org/show_bug.cgi?id=316552">https://bugs.webkit.org/show_bug.cgi?id=316552</a>
<a href="https://rdar.apple.com/179024722">rdar://179024722</a>

Reviewed by Simon Fraser.

RenderFrameSet and its nested GridAxis spread member initialization across
hand-written constructor init lists. GridAxis::GridAxis() only initialized
m_splitBeingResized and omitted m_splitResizeOffset, leaving it uninitialized;
it happens to be assigned in startResizing() before its read in
continueResizing(), so there is no observable change, but the member was not
safely default-initialized.

Move the data members to default member initializers in the header so every
constructor stays in sync:

- GridAxis::m_splitBeingResized defaults to noSplit and m_splitResizeOffset to
  0, letting GridAxis() become = default.
- RenderFrameSet::m_isResizing defaults to false.

The GridAxis constructor definition and the RenderFrameSet m_isResizing init
list entry are dropped. No change in behavior.

* Source/WebCore/rendering/RenderFrameSet.cpp:
(WebCore::RenderFrameSet::RenderFrameSet):
(WebCore::RenderFrameSet::GridAxis::GridAxis): Deleted.
* Source/WebCore/rendering/RenderFrameSet.h:

Canonical link: <a href="https://commits.webkit.org/314766@main">https://commits.webkit.org/314766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e1a8adf5326b51791ffaad5a0bf5dd6acfad458

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176167 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ed4311e-b67d-4adc-86ab-40eb52da9308) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129979 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c012302f-707a-40c2-a448-bf2130ff7b10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110496 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23b3dbc2-c100-4618-abd8-4b9e8e45ea7f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31363 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30068 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24906 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141346 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178708 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31608 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138356 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138255 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37221 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41376 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104334 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33517 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26521 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39880 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112959 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39277 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4619 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39527 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->